### PR TITLE
feat: Implement `IEngineAPI`

### DIFF
--- a/Explorer/Assets/Scripts/CRDT/Protocol/Factory/ProcessedCRDTMessage.cs
+++ b/Explorer/Assets/Scripts/CRDT/Protocol/Factory/ProcessedCRDTMessage.cs
@@ -8,8 +8,8 @@ namespace CRDT.Protocol.Factory
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct ProcessedCRDTMessage
     {
-        internal readonly CRDTMessage message;
-        internal readonly int CRDTMessageDataLength;
+        public readonly CRDTMessage message;
+        public readonly int CRDTMessageDataLength;
 
         public ProcessedCRDTMessage(CRDTMessage message, int crdtMessageDataLength)
         {

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 56f2c3f3b11b437cb58a86743b6095ef
+timeCreated: 1683023620

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineAPIImplementation.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineAPIImplementation.cs
@@ -1,0 +1,160 @@
+﻿using CRDT.Deserializer;
+using CRDT.Protocol;
+using CRDT.Protocol.Factory;
+using CRDT.Serializer;
+using CrdtEcsBridge.OutgoingMessages;
+using CrdtEcsBridge.WorldSynchronizer;
+using Cysharp.Threading.Tasks;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace CrdtEcsBridge.Engine
+{
+    /// <summary>
+    /// Unique instance for each Scene Runtime
+    /// </summary>
+    public class EngineAPIImplementation : IEngineApi
+    {
+        private readonly IEngineAPIPoolsProvider poolsProvider;
+
+        private readonly ICRDTProtocol crdtProtocol;
+        private readonly ICRDTDeserializer crdtDeserializer;
+        private readonly ICRDTSerializer crdtSerializer;
+        private readonly ICrdtWorldSynchronizer crdtWorldSynchronizer;
+        private readonly IOutgoingCRTDMessagesProvider outgoingCrtdMessagesProvider;
+
+        private byte[] lastSerializationBuffer;
+
+        public EngineAPIImplementation(IEngineAPIPoolsProvider poolsProvider, ICRDTProtocol crdtProtocol, ICRDTDeserializer crdtDeserializer, ICRDTSerializer crdtSerializer, ICrdtWorldSynchronizer crdtWorldSynchronizer,
+            IOutgoingCRTDMessagesProvider outgoingCrtdMessagesProvider)
+        {
+            this.poolsProvider = poolsProvider;
+            this.crdtProtocol = crdtProtocol;
+            this.crdtDeserializer = crdtDeserializer;
+            this.crdtSerializer = crdtSerializer;
+            this.crdtWorldSynchronizer = crdtWorldSynchronizer;
+            this.outgoingCrtdMessagesProvider = outgoingCrtdMessagesProvider;
+        }
+
+        public async UniTask<byte[]> CrdtSendToRenderer(byte[] data)
+        {
+            // Called on the thread where the Scene Runtime is running (background thread)
+
+            ReleaseSerializationBuffer();
+
+            // Deserialize messages from the byte array
+            var messages = poolsProvider.GetDeserializationMessagesPool();
+
+            ReadOnlyMemory<byte> dataMemory = data;
+
+            // TODO add metrics to understand bottlenecks better
+            crdtDeserializer.DeserializeBatch(ref dataMemory, messages);
+
+            var worldSyncBuffer = crdtWorldSynchronizer.GetSyncCommandBuffer();
+
+            // Reconcile CRDT state
+            for (var i = 0; i < messages.Count; i++)
+            {
+                var message = messages[i];
+                var reconciliationResult = crdtProtocol.ProcessMessage(in message);
+
+                // TODO add metric to understand how many conflicts we have based on CRDTStateReconciliationResult
+
+                // Prepare the message to be synced with the ECS World
+                worldSyncBuffer.SyncCRDTMessage(in message, reconciliationResult.Effect);
+            }
+
+            // Deserialize messages on the main thread
+            worldSyncBuffer.FinalizeAndDeserialize();
+
+            // Return messages to the pool before switching to the main thread,
+            // it is a must because CRDT_MESSAGES_POOL is ThreadLocal
+            poolsProvider.ReleaseDeserializationMessagesPool(messages);
+
+            // before returning to the main thread serialize outgoing CRDT Messages
+            using (var outgoingMessagesSyncBlock = outgoingCrtdMessagesProvider.GetSerializationSyncBlock())
+            {
+                lastSerializationBuffer = poolsProvider.GetSerializedStateBytesPool(outgoingMessagesSyncBlock.GetPayloadLength());
+                SerializeOutgoingCRDTMessages(outgoingMessagesSyncBlock.Messages, lastSerializationBuffer.AsSpan());
+            }
+
+            // Now (unless we make ECS run on the background thread) we need to switch to the main thread
+            // before all systems start to update - in the beginning of the Player Loop
+            // TODO Validate if we can just launch and forget() without waiting
+            await UniTask.Yield(PlayerLoopTiming.Initialization);
+
+            // Apply changes to the ECS World on the main thread
+            crdtWorldSynchronizer.ApplySyncCommandBuffer(worldSyncBuffer);
+            return lastSerializationBuffer;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SerializeOutgoingCRDTMessages(IReadOnlyList<ProcessedCRDTMessage> outgoingMessages, Span<byte> span)
+        {
+            for (var i = 0; i < outgoingMessages.Count; i++)
+            {
+                var processedCRDTMessage = outgoingMessages[i];
+                crdtSerializer.Serialize(ref span, in processedCRDTMessage);
+            }
+        }
+
+        public UniTask<byte[]> CrdtGetState()
+        {
+            // Invoked on the background thread
+            // this method is called rarely but the memory impact is significant
+
+            ReleaseSerializationBuffer();
+
+            // Create CRDT Messages from the current state
+            // we know exactly how big the array should be
+            ProcessedCRDTMessage[] processedMessages = poolsProvider.GetSerializationCrdtMessagesPool(crdtProtocol.GetMessagesCount());
+
+            var currentStatePayloadLength = crdtProtocol.CreateMessagesFromTheCurrentState(processedMessages);
+
+            // Sync block ensures that no messages are added while they are being processed
+            // By the end of the block messages are flushed and adding is unblocked
+            using var outgoingMessagesSyncBlock = outgoingCrtdMessagesProvider.GetSerializationSyncBlock();
+
+            var outgoingCRDTMessagesPayloadLength = outgoingMessagesSyncBlock.GetPayloadLength();
+
+            var totalPayloadLength = currentStatePayloadLength + outgoingCRDTMessagesPayloadLength;
+
+            // We know exactly how many bytes we need to serialize
+            lastSerializationBuffer = poolsProvider.GetSerializedStateBytesPool(totalPayloadLength);
+
+            // Serialize the current state
+            var currentStateSpan = lastSerializationBuffer.AsSpan().Slice(currentStatePayloadLength);
+
+            for (var i = 0; i < processedMessages.Length; i++)
+                crdtSerializer.Serialize(ref currentStateSpan, in processedMessages[i]);
+
+            // Messages are serialized, we no longer need them in the managed form
+            poolsProvider.ReleaseSerializationCrdtMessagesPool(processedMessages);
+
+            // Serialize outgoing messages
+            SerializeOutgoingCRDTMessages(outgoingMessagesSyncBlock.Messages, lastSerializationBuffer.AsSpan().Slice(currentStatePayloadLength, outgoingCRDTMessagesPayloadLength));
+
+            // Return the buffer to the caller
+            return UniTask.FromResult(lastSerializationBuffer);
+        }
+
+        /// <summary>
+        /// When the state or outgoing messages processed by the Scene Runtime we can safely return them to the pool.
+        /// It is guaranteed by the sequential order of `CrdtSendToRenderer`/`CrdtGetState` calls
+        /// </summary>
+        private void ReleaseSerializationBuffer()
+        {
+            if (lastSerializationBuffer != null)
+            {
+                poolsProvider.ReleaseSerializedStateBytesPool(lastSerializationBuffer);
+                lastSerializationBuffer = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            ReleaseSerializationBuffer();
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineAPIImplementation.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineAPIImplementation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a7aebb4aa75341b5add4f85fc0a4881e
+timeCreated: 1683023651

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineAPIPoolsProvider.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineAPIPoolsProvider.cs
@@ -1,0 +1,55 @@
+using CRDT.Protocol;
+using CRDT.Protocol.Factory;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine.Pool;
+
+namespace CrdtEcsBridge.Engine
+{
+    public class EngineAPIPoolsProvider : IEngineAPIPoolsProvider
+    {
+        // CRDT Messages should not sync with other threads but be deserialized immediately instead
+        private static readonly ThreadLocal<IObjectPool<IList<CRDTMessage>>> CRDT_MESSAGES_POOL =
+            new (() => new ObjectPool<IList<CRDTMessage>>(
+
+                // just preallocate an array big enough
+                createFunc: () => new List<CRDTMessage>(256),
+                actionOnRelease: list => list.Clear()
+            ));
+
+        // This is accessed rarely but the memory footprint is huge so share it between different scenes
+        // Must be synchronized
+        private static readonly ArrayPool<ProcessedCRDTMessage> PROCESSED_CRDT_MESSAGES_POOL = ArrayPool<ProcessedCRDTMessage>.Create();
+
+        // This is accessed rarely but the memory footprint is huge so share it between different scenes
+        // Must be synchronized
+        private static readonly ArrayPool<byte> SERIALIZED_STATE_BYTES_POOL = ArrayPool<byte>.Create();
+
+        public IList<CRDTMessage> GetDeserializationMessagesPool() =>
+            CRDT_MESSAGES_POOL.Value.Get();
+
+        public void ReleaseDeserializationMessagesPool(IList<CRDTMessage> messages) =>
+            CRDT_MESSAGES_POOL.Value.Release(messages);
+
+        public ProcessedCRDTMessage[] GetSerializationCrdtMessagesPool(int size)
+        {
+            lock (PROCESSED_CRDT_MESSAGES_POOL) { return PROCESSED_CRDT_MESSAGES_POOL.Rent(size); }
+        }
+
+        public void ReleaseSerializationCrdtMessagesPool(ProcessedCRDTMessage[] messages)
+        {
+            lock (PROCESSED_CRDT_MESSAGES_POOL) { PROCESSED_CRDT_MESSAGES_POOL.Return(messages); }
+        }
+
+        public byte[] GetSerializedStateBytesPool(int size)
+        {
+            lock (SERIALIZED_STATE_BYTES_POOL) { return SERIALIZED_STATE_BYTES_POOL.Rent(size); }
+        }
+
+        public void ReleaseSerializedStateBytesPool(byte[] bytes)
+        {
+            lock (SERIALIZED_STATE_BYTES_POOL) { SERIALIZED_STATE_BYTES_POOL.Return(bytes); }
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineAPIPoolsProvider.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineAPIPoolsProvider.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 23ac77f5f1084b17ba6a873c5322305f
+timeCreated: 1683102961

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineImplementation.asmdef
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineImplementation.asmdef
@@ -1,0 +1,20 @@
+{
+  "name": "EngineImplementation",
+  "rootNamespace": "",
+  "references": [
+    "GUID:0b3eab7834a09c24ca4e84fe0d8a43ce",
+    "GUID:f51ebe6a0ceec4240a699833d6309b23",
+    "GUID:0f4c0f120707fb74497f5d581b9858f8",
+    "GUID:96825943f4e14954b5172da80fdee63d",
+    "GUID:40fef18dccdc4e119f7635452380fe9f"
+  ],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineImplementation.asmdef.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineImplementation.asmdef.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9f890bfbf13e43c481227c49a4e6cb11
+timeCreated: 1683023747

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/IEngineAPIPoolsProvider.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/IEngineAPIPoolsProvider.cs
@@ -1,0 +1,24 @@
+using CRDT.Protocol;
+using CRDT.Protocol.Factory;
+using System.Collections.Generic;
+
+namespace CrdtEcsBridge.Engine
+{
+    /// <summary>
+    /// Provides threads-synchronized pools for heavily-loaded bulk serialization and deserialization
+    /// </summary>
+    public interface IEngineAPIPoolsProvider
+    {
+        IList<CRDTMessage> GetDeserializationMessagesPool();
+
+        void ReleaseDeserializationMessagesPool(IList<CRDTMessage> messages);
+
+        ProcessedCRDTMessage[] GetSerializationCrdtMessagesPool(int size);
+
+        byte[] GetSerializedStateBytesPool(int size);
+
+        void ReleaseSerializationCrdtMessagesPool(ProcessedCRDTMessage[] messages);
+
+        void ReleaseSerializedStateBytesPool(byte[] bytes);
+    }
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/IEngineAPIPoolsProvider.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/IEngineAPIPoolsProvider.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 820b5ef919744a759e47674fa771e087
+timeCreated: 1683102920

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc4e329d56fa4504a9f9404306a98467
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests/EngineAPIImplementationShould.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests/EngineAPIImplementationShould.cs
@@ -1,0 +1,184 @@
+﻿using CRDT.Deserializer;
+using CRDT.Protocol;
+using CRDT.Protocol.Factory;
+using CRDT.Serializer;
+using CrdtEcsBridge.OutgoingMessages;
+using CrdtEcsBridge.WorldSynchronizer;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CrdtEcsBridge.Engine.Tests
+{
+    public class EngineAPIImplementationShould
+    {
+        private class CRDTSerializer : ICRDTSerializer
+        {
+            public void Serialize(ref Span<byte> destination, in ProcessedCRDTMessage processedMessage) { }
+        }
+
+        private static readonly byte[] OUTPUT = { 10, 20, 30, 20, 10, 0 };
+        private static readonly byte[] INPUT = { 0, 3, 5, 7, 10, 19, 20, 40, 76 };
+
+        private IEngineAPIPoolsProvider engineAPIPoolsProvider;
+        private ICRDTProtocol crdtProtocol;
+        private ICRDTDeserializer crdtDeserializer;
+        private ICRDTSerializer crdtSerializer;
+        private ICrdtWorldSynchronizer crdtWorldSynchronizer;
+        private IOutgoingCRTDMessagesProvider outgoingCrtdMessagesProvider;
+
+        private EngineAPIImplementation engineAPIImplementation;
+
+        private List<CRDTMessage> crdtMessages;
+        private List<ProcessedCRDTMessage> outgoingMessages;
+        private List<ProcessedCRDTMessage> crdtStateMessages;
+
+        private IWorldSyncCommandBuffer worldSyncCommandBuffer;
+        private Mutex mutex;
+
+        [SetUp]
+        public void SetUp()
+        {
+            mutex = new Mutex();
+
+            crdtMessages = new List<CRDTMessage>
+            {
+                new (CRDTMessageType.PUT_COMPONENT, 10, 100, 1, ReadOnlyMemory<byte>.Empty),
+                new (CRDTMessageType.APPEND_COMPONENT, 10, 123, 1, ReadOnlyMemory<byte>.Empty),
+                new (CRDTMessageType.DELETE_ENTITY, 12, 0, 0, ReadOnlyMemory<byte>.Empty),
+            };
+
+            outgoingMessages = new List<ProcessedCRDTMessage>
+            {
+                new (new (CRDTMessageType.APPEND_COMPONENT, 122, 100, 1, new byte[100]), 120)
+            };
+
+            crdtStateMessages = new List<ProcessedCRDTMessage>
+            {
+                new (new (CRDTMessageType.APPEND_COMPONENT, 33, 33, 1, new byte[100]), 120),
+                new (new (CRDTMessageType.APPEND_COMPONENT, 44, 33, 1, new byte[23]), 130),
+                new (new (CRDTMessageType.PUT_COMPONENT, 122, 33, 1, new byte[33]), 140),
+                new (new (CRDTMessageType.PUT_COMPONENT, 122, 1000, 1, new byte[44]), 10),
+            };
+
+            engineAPIImplementation = new EngineAPIImplementation(
+                engineAPIPoolsProvider = Substitute.For<IEngineAPIPoolsProvider>(),
+                crdtProtocol = Substitute.For<ICRDTProtocol>(),
+                crdtDeserializer = Substitute.For<ICRDTDeserializer>(),
+                crdtSerializer = new CRDTSerializer(),
+                crdtWorldSynchronizer = Substitute.For<ICrdtWorldSynchronizer>(),
+                outgoingCrtdMessagesProvider = Substitute.For<IOutgoingCRTDMessagesProvider>()
+            );
+
+            crdtDeserializer.When(d => d.DeserializeBatch(ref Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<IList<CRDTMessage>>()))
+                            .Do(c =>
+                             {
+                                 var list = c.ArgAt<IList<CRDTMessage>>(1);
+
+                                 foreach (var message in crdtMessages)
+                                     list.Add(message);
+                             });
+
+            crdtProtocol.ProcessMessage(Arg.Any<CRDTMessage>()).Returns(_ => new CRDTReconciliationResult(CRDTStateReconciliationResult.StateUpdatedData, CRDTReconciliationEffect.ComponentModified));
+
+            crdtProtocol.CreateMessagesFromTheCurrentState(Arg.Any<ProcessedCRDTMessage[]>())
+                        .Returns(c =>
+                         {
+                             crdtStateMessages.CopyTo(c.ArgAt<ProcessedCRDTMessage[]>(0));
+                             return crdtStateMessages.Aggregate(0, (acc, message) => acc + message.CRDTMessageDataLength);
+                         });
+
+            crdtProtocol.GetMessagesCount().Returns(crdtStateMessages.Count);
+
+            crdtWorldSynchronizer.GetSyncCommandBuffer().Returns(_ => worldSyncCommandBuffer = Substitute.For<IWorldSyncCommandBuffer>());
+
+            engineAPIPoolsProvider.GetDeserializationMessagesPool().Returns(_ => new List<CRDTMessage>());
+            engineAPIPoolsProvider.GetSerializedStateBytesPool(Arg.Any<int>()).Returns(c => new byte[c.Arg<int>()]);
+            engineAPIPoolsProvider.GetSerializationCrdtMessagesPool(Arg.Any<int>()).Returns(c => new ProcessedCRDTMessage[c.Arg<int>()]);
+
+            outgoingCrtdMessagesProvider.GetSerializationSyncBlock()
+                                        .Returns(_ =>
+                                         {
+                                             mutex.WaitOne();
+                                             return new OutgoingCRDTMessagesSyncBlock(outgoingMessages, mutex);
+                                         });
+        }
+
+        [Test]
+        public async Task CallDeserializeBatch()
+        {
+            await engineAPIImplementation.CrdtSendToRenderer(INPUT);
+
+            crdtDeserializer.Received(1).DeserializeBatch(ref Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<IList<CRDTMessage>>());
+        }
+
+        [Test]
+        public async Task MakeCallsInProperOrderCrdtSendToRenderer()
+        {
+            await engineAPIImplementation.CrdtSendToRenderer(INPUT);
+
+            Received.InOrder(() =>
+            {
+                engineAPIPoolsProvider.GetDeserializationMessagesPool();
+                crdtDeserializer.DeserializeBatch(ref Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<IList<CRDTMessage>>());
+                crdtWorldSynchronizer.GetSyncCommandBuffer();
+
+                for (var i = 0; i < crdtMessages.Count; i++)
+                {
+                    CRDTMessage crdtMessage = crdtMessages[i];
+                    crdtProtocol.ProcessMessage(crdtMessage);
+                    worldSyncCommandBuffer.SyncCRDTMessage(in crdtMessage, CRDTReconciliationEffect.ComponentModified);
+                }
+
+                worldSyncCommandBuffer.FinalizeAndDeserialize();
+                engineAPIPoolsProvider.ReleaseDeserializationMessagesPool(Arg.Any<IList<CRDTMessage>>());
+
+                outgoingCrtdMessagesProvider.GetSerializationSyncBlock();
+                engineAPIPoolsProvider.GetSerializedStateBytesPool(Arg.Any<int>());
+
+                // can't check Serialize, can't mock `Span<byte>`
+                crdtWorldSynchronizer.Received(1).ApplySyncCommandBuffer(worldSyncCommandBuffer);
+            });
+        }
+
+        [Test]
+        public async Task MakeCallsInProperOrderCrdtGetState()
+        {
+            var state = await engineAPIImplementation.CrdtGetState();
+
+            Received.InOrder(() =>
+            {
+                crdtProtocol.GetMessagesCount();
+                engineAPIPoolsProvider.GetSerializationCrdtMessagesPool(crdtStateMessages.Count);
+                crdtProtocol.CreateMessagesFromTheCurrentState(Arg.Any<ProcessedCRDTMessage[]>());
+                outgoingCrtdMessagesProvider.GetSerializationSyncBlock();
+                engineAPIPoolsProvider.GetSerializedStateBytesPool(400 + 120);
+                engineAPIPoolsProvider.ReleaseSerializationCrdtMessagesPool(Arg.Is<ProcessedCRDTMessage[]>(p => p.Length == crdtStateMessages.Count));
+            });
+
+            Assert.AreEqual(400 + 120, state.Length);
+        }
+
+        [Test]
+        public async Task ReleasePreviousBufferOnSend()
+        {
+            await engineAPIImplementation.CrdtSendToRenderer(INPUT);
+            await engineAPIImplementation.CrdtSendToRenderer(INPUT);
+
+            engineAPIPoolsProvider.Received(1).ReleaseSerializedStateBytesPool(Arg.Any<byte[]>());
+        }
+
+        [Test]
+        public async Task ReleasePreviousBufferOnGet()
+        {
+            await engineAPIImplementation.CrdtSendToRenderer(INPUT);
+            await engineAPIImplementation.CrdtGetState();
+
+            engineAPIPoolsProvider.Received(1).ReleaseSerializedStateBytesPool(Arg.Any<byte[]>());
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests/EngineAPIImplementationShould.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests/EngineAPIImplementationShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 11fcbd166544463e8cc325c821df434a
+timeCreated: 1683119026

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests/Tests.asmdef
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests/Tests.asmdef
@@ -1,0 +1,29 @@
+{
+  "name": "Engine.Tests",
+  "rootNamespace": "",
+  "references": [
+    "UnityEngine.TestRunner",
+    "UnityEditor.TestRunner",
+    "EngineImplementation",
+    "CRDT",
+    "WorldSynchronizer",
+    "OutgoingMessages",
+    "UniTask"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": true,
+  "precompiledReferences": [
+    "nunit.framework.dll",
+    "NSubstitute.dll"
+  ],
+  "autoReferenced": false,
+  "defineConstraints": [
+    "UNITY_INCLUDE_TESTS"
+  ],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests/Tests.asmdef.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b70b6a828666b7e41803d9b401ab9653
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8a6f313457484adebeeb03a916dc9764
+timeCreated: 1683106808

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/AssemblyInfo.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OutgoingMessages.Tests")]
+[assembly: InternalsVisibleTo("Engine.Tests")]

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/AssemblyInfo.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/AssemblyInfo.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 095ce71b94824427ac97eb654f42714f
+timeCreated: 1683111421

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/IOutgoingCRTDMessagesProvider.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/IOutgoingCRTDMessagesProvider.cs
@@ -1,0 +1,23 @@
+using CRDT.Protocol.Factory;
+
+namespace CrdtEcsBridge.OutgoingMessages
+{
+    /// <summary>
+    /// Provider of outgoing CRDT messages for the instance of Scene Runtime
+    /// </summary>
+    public interface IOutgoingCRTDMessagesProvider
+    {
+        /// <summary>
+        /// Add the message to the outgoing CRDT messages.
+        /// The call is blocked while the queue is being serialized from the background thread.
+        /// Before adding the message you must validate it against CRDT Protocol to ensure that no redundancies are pushed
+        /// </summary>
+        void AddMessage(ProcessedCRDTMessage processedCRDTMessage);
+
+        /// <summary>
+        /// Freeze the modification of the queue while it's being processed from the background thread
+        /// </summary>
+        /// <returns></returns>
+        OutgoingCRDTMessagesSyncBlock GetSerializationSyncBlock();
+    }
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/IOutgoingCRTDMessagesProvider.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/IOutgoingCRTDMessagesProvider.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 88613ae53d944492b1990eca79a2a902
+timeCreated: 1683104524

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRDTMessagesSyncBlock.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRDTMessagesSyncBlock.cs
@@ -1,0 +1,46 @@
+using CRDT.Protocol.Factory;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace CrdtEcsBridge.OutgoingMessages
+{
+    /// <summary>
+    /// Prevents modification to the outgoing CRDT messages while they being accessed from the background thread
+    /// </summary>
+    public readonly struct OutgoingCRDTMessagesSyncBlock : IDisposable
+    {
+        private readonly Mutex mutex;
+        private readonly List<ProcessedCRDTMessage> messages;
+
+        internal OutgoingCRDTMessagesSyncBlock(List<ProcessedCRDTMessage> messages, Mutex mutex)
+        {
+            this.messages = messages;
+            this.mutex = mutex;
+        }
+
+        public IReadOnlyList<ProcessedCRDTMessage> Messages => messages;
+
+        /// <summary>
+        /// Returns the total size of the payload of the outgoing CRDT Messages
+        /// </summary>
+        public int GetPayloadLength()
+        {
+            var length = 0;
+
+            for (var i = 0; i < messages.Count; i++)
+                length += messages[i].CRDTMessageDataLength;
+
+            return length;
+        }
+
+        /// <summary>
+        /// Flushes the outgoing CRDT messages and releases the mutex
+        /// </summary>
+        public void Dispose()
+        {
+            messages.Clear();
+            mutex.ReleaseMutex();
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRDTMessagesSyncBlock.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRDTMessagesSyncBlock.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a6f9136f20634f068beef6c9e1d37fe5
+timeCreated: 1683107930

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRTDMessagesProvider.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRTDMessagesProvider.cs
@@ -1,0 +1,48 @@
+using CRDT.Protocol.Factory;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Utility.ThreadSafePool;
+
+namespace CrdtEcsBridge.OutgoingMessages
+{
+    public class OutgoingCRTDMessagesProvider : IOutgoingCRTDMessagesProvider, IDisposable
+    {
+        internal const int START_POOL_CAPACITY = 8;
+
+        // All OutgoingCRTDMessagesProviders use this pool with a big initial capacity to prevent dynamic allocations
+        internal static readonly ThreadSafeListPool<ProcessedCRDTMessage> SHARED_POOL = new (64, START_POOL_CAPACITY);
+
+        private readonly List<ProcessedCRDTMessage> processedCRDTMessages;
+
+        private readonly Mutex mutex = new ();
+
+        public OutgoingCRTDMessagesProvider()
+        {
+            processedCRDTMessages = SHARED_POOL.Get();
+        }
+
+        internal IReadOnlyList<ProcessedCRDTMessage> ProcessedCRDTMessages => processedCRDTMessages;
+
+        public void AddMessage(ProcessedCRDTMessage processedCRDTMessage)
+        {
+            mutex.WaitOne();
+            processedCRDTMessages.Add(processedCRDTMessage);
+            mutex.ReleaseMutex();
+        }
+
+        public OutgoingCRDTMessagesSyncBlock GetSerializationSyncBlock()
+        {
+            mutex.WaitOne();
+
+            // Mutex will be released on block.Dispose()
+            return new OutgoingCRDTMessagesSyncBlock(processedCRDTMessages, mutex);
+        }
+
+        public void Dispose()
+        {
+            SHARED_POOL.Release(processedCRDTMessages);
+            mutex.Dispose();
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRTDMessagesProvider.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRTDMessagesProvider.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ddf99d6c7bfb449fa75644b4a4c59fc8
+timeCreated: 1683107826

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingMessages.asmdef
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingMessages.asmdef
@@ -1,0 +1,7 @@
+﻿{
+  "name": "OutgoingMessages",
+  "references": [
+    "GUID:0f4c0f120707fb74497f5d581b9858f8",
+    "GUID:fa7b3fdbb04d67549916da7bd2af58ab"
+  ]
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingMessages.asmdef.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingMessages.asmdef.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 40fef18dccdc4e119f7635452380fe9f
+timeCreated: 1683107939

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9689ce29b55ffc6418c07b9c2f41757b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingCRDTMessagesSyncBlockShould.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingCRDTMessagesSyncBlockShould.cs
@@ -1,0 +1,58 @@
+﻿using CRDT.Protocol;
+using CRDT.Protocol.Factory;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace CrdtEcsBridge.OutgoingMessages.Tests
+{
+    public class OutgoingCRDTMessagesSyncBlockShould
+    {
+        private OutgoingCRDTMessagesSyncBlock syncBlock;
+
+        private List<ProcessedCRDTMessage> messages;
+        private Mutex mutex;
+
+        [SetUp]
+        public void SetUp()
+        {
+            syncBlock = new OutgoingCRDTMessagesSyncBlock(
+                messages = new List<ProcessedCRDTMessage>
+                {
+                    new (new CRDTMessage(CRDTMessageType.PUT_COMPONENT, 100, 100, 0, ReadOnlyMemory<byte>.Empty), 30),
+                    new (new CRDTMessage(CRDTMessageType.DELETE_ENTITY, 123, 0, 0, ReadOnlyMemory<byte>.Empty), 60)
+                },
+                mutex = new Mutex()
+            );
+
+            mutex.WaitOne();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            mutex.Dispose();
+        }
+
+        [Test]
+        public void GetPayloadLength()
+        {
+            Assert.AreEqual(90, syncBlock.GetPayloadLength());
+        }
+
+        [Test]
+        public void ReleaseMutexOnDispose()
+        {
+            syncBlock.Dispose();
+            Assert.IsTrue(mutex.WaitOne(TimeSpan.FromSeconds(1)));
+        }
+
+        [Test]
+        public void ClearMessagesOnDispose()
+        {
+            syncBlock.Dispose();
+            CollectionAssert.IsEmpty(messages);
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingCRDTMessagesSyncBlockShould.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingCRDTMessagesSyncBlockShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7db3953b974644779a0e5448043aa2b7
+timeCreated: 1683111316

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingCRTDMessagesProviderShould.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingCRTDMessagesProviderShould.cs
@@ -1,0 +1,89 @@
+﻿using CRDT.Protocol;
+using CRDT.Protocol.Factory;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Debug = UnityEngine.Debug;
+
+namespace CrdtEcsBridge.OutgoingMessages.Tests
+{
+    public class OutgoingCRTDMessagesProviderShould
+    {
+        private OutgoingCRTDMessagesProvider provider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            provider = new OutgoingCRTDMessagesProvider();
+        }
+
+        [Test]
+        public void AddMessage()
+        {
+            var messages = new List<ProcessedCRDTMessage>
+            {
+                new (new (CRDTMessageType.PUT_COMPONENT, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 50),
+                new (new (CRDTMessageType.DELETE_ENTITY, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 12),
+                new (new (CRDTMessageType.APPEND_COMPONENT, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 34),
+                new (new (CRDTMessageType.DELETE_COMPONENT, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 77),
+            };
+
+            for (var i = 0; i < messages.Count; i++) { provider.AddMessage(messages[i]); }
+
+            CollectionAssert.AreEqual(messages, provider.ProcessedCRDTMessages);
+        }
+
+        [Test]
+        public void AddWaitForMutexRelease()
+        {
+            var messages = new List<ProcessedCRDTMessage>
+            {
+                new (new (CRDTMessageType.PUT_COMPONENT, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 50),
+                new (new (CRDTMessageType.DELETE_ENTITY, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 12),
+                new (new (CRDTMessageType.APPEND_COMPONENT, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 34),
+                new (new (CRDTMessageType.DELETE_COMPONENT, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 77),
+            };
+
+            void ThrottleInBackgroundThread()
+            {
+                using var s = provider.GetSerializationSyncBlock();
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+
+            var watch = new Stopwatch();
+            watch.Start();
+
+            ThreadPool.QueueUserWorkItem(_ => ThrottleInBackgroundThread());
+
+            Thread.Sleep(100);
+
+            for (var i = 0; i < messages.Count; i++) { provider.AddMessage(messages[i]); }
+
+            watch.Stop();
+
+            Assert.GreaterOrEqual(watch.Elapsed.TotalSeconds, 1);
+        }
+
+        [Test]
+        public void ReleaseToPoolOnDispose()
+        {
+            var messages = new List<ProcessedCRDTMessage>
+            {
+                new (new (CRDTMessageType.PUT_COMPONENT, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 50),
+                new (new (CRDTMessageType.DELETE_ENTITY, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 12),
+                new (new (CRDTMessageType.APPEND_COMPONENT, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 34),
+                new (new (CRDTMessageType.DELETE_COMPONENT, 10, 20, 20, ReadOnlyMemory<byte>.Empty), 77),
+            };
+
+            for (var i = 0; i < messages.Count; i++) { provider.AddMessage(messages[i]); }
+
+            provider.Dispose();
+
+            Assert.AreEqual(1, OutgoingCRTDMessagesProvider.SHARED_POOL.CountInactive);
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingCRTDMessagesProviderShould.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingCRTDMessagesProviderShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a01114bf03774dcaa04c2b3df2570f6f
+timeCreated: 1683112161

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingMessages.Tests.asmdef
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingMessages.Tests.asmdef
@@ -1,0 +1,26 @@
+{
+  "name": "OutgoingMessages.Tests",
+  "rootNamespace": "",
+  "references": [
+    "UnityEngine.TestRunner",
+    "UnityEditor.TestRunner",
+    "OutgoingMessages",
+    "CRDT",
+    "UniTask",
+    "Utility"
+  ],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": true,
+  "precompiledReferences": [
+    "nunit.framework.dll",
+    "NSubstitute.dll"
+  ],
+  "autoReferenced": false,
+  "defineConstraints": [
+    "UNITY_INCLUDE_TESTS"
+  ],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingMessages.Tests.asmdef.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingMessages.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2bb31c84c555c4743b14e5bce606637c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/CrdtEcsSynchronizer.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/CrdtEcsSynchronizer.cs
@@ -30,7 +30,7 @@ namespace CrdtEcsBridge.WorldSynchronizer
 
         public IReadOnlyDictionary<CRDTEntity, Entity> EntitiesMap => entitiesMap;
 
-        public WorldSyncCommandBuffer GetSyncCommandBuffer()
+        public IWorldSyncCommandBuffer GetSyncCommandBuffer()
         {
             if (commandBufferRented)
                 throw new InvalidOperationException("Command buffer is already rented");
@@ -39,7 +39,7 @@ namespace CrdtEcsBridge.WorldSynchronizer
             return new WorldSyncCommandBuffer(sdkComponentsRegistry);
         }
 
-        public void ApplySyncCommandBuffer(WorldSyncCommandBuffer syncCommandBuffer)
+        public void ApplySyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer)
         {
             syncCommandBuffer.Apply(world, reusableCommandBuffer, entitiesMap);
             commandBufferRented = false;

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/ICrdtWorldSynchronizer.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/ICrdtWorldSynchronizer.cs
@@ -9,17 +9,18 @@ namespace CrdtEcsBridge.WorldSynchronizer
     {
         /// <summary>
         /// Get the command buffer to fill it with the CRDT messages
-        /// Only one buffer can be rented at a time
+        /// Only one buffer can be rented at a time.
+        /// Can be called from the background thread
         /// </summary>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException">If the previous command buffer was not finalized the exception will be thrown</exception>
-        WorldSyncCommandBuffer GetSyncCommandBuffer();
+        IWorldSyncCommandBuffer GetSyncCommandBuffer();
 
         /// <summary>
         /// Should be called from the main thread to apply the changes to the ECS World
         /// Finalizes the command buffer and allows to rent it again.
         /// </summary>
         /// <param name="syncCommandBuffer"></param>
-        void ApplySyncCommandBuffer(WorldSyncCommandBuffer syncCommandBuffer);
+        void ApplySyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer);
     }
 }

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/IWorldSyncCommandBuffer.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/IWorldSyncCommandBuffer.cs
@@ -1,0 +1,36 @@
+using Arch.Core;
+using CRDT;
+using CRDT.Protocol;
+using System;
+using System.Collections.Generic;
+
+namespace CrdtEcsBridge.WorldSynchronizer
+{
+    /// <summary>
+    /// Merges CRDT Messages to their final state
+    /// to execute deserialize and execute them only once in the ECS World.
+    /// Can't be executed concurrently
+    /// </summary>
+    public interface IWorldSyncCommandBuffer : IDisposable
+    {
+        /// <summary>
+        /// Add messages in the order they are processed by CRDT
+        /// This sync function is for ECS syncing and it heavily relies on the proper result from the CRDT Protocol
+        /// </summary>
+        /// <returns>The last status corresponding to the (<see cref="CRDTMessage.EntityId"/>, <see cref="CRDTMessage.ComponentId"/>)</returns>
+        CRDTReconciliationEffect SyncCRDTMessage(in CRDTMessage message, CRDTReconciliationEffect reconciliationEffect);
+
+        /// <summary>
+        /// Resolves the final state of (entity, component) <br/>
+        /// Deserializes only the last state of the component <br/>
+        /// Should be called from the background thread <br/>
+        /// </summary>
+        void FinalizeAndDeserialize();
+
+        /// <summary>
+        /// Applies deserialized changes to the world.
+        /// Must be called on the thread where World is running
+        /// </summary>
+        void Apply(World world, Arch.Core.CommandBuffer.CommandBuffer commandBuffer, Dictionary<CRDTEntity, Entity> entitiesMap);
+    }
+}

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/IWorldSyncCommandBuffer.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/IWorldSyncCommandBuffer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 54400128899d4c1a9645731ddcc018bc
+timeCreated: 1683120422

--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/EngineApiWrapper.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/EngineApiWrapper.cs
@@ -9,6 +9,7 @@ using Microsoft.ClearScript.V8;
 public class EngineApiWrapper
 {
     private readonly IEngineApi api;
+
     public EngineApiWrapper(IEngineApi api)
     {
         this.api = api;

--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/IEngineApi.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/IEngineApi.cs
@@ -1,9 +1,16 @@
 ﻿using Cysharp.Threading.Tasks;
-using Microsoft.ClearScript.JavaScript;
+using System;
 
-public interface IEngineApi
+/// <summary>
+/// The contracts correspond directly to the JS-SDK-Toolchain and its transport API.
+/// They don't have Protobuf related stuff
+/// </summary>
+public interface IEngineApi : IDisposable
 {
+    /// <param name="data">A contiguous byte array of the CRDT Message</param>
+    /// <returns>A contiguous byte array of the CRDT Message representing the outgoing messages</returns>
     public UniTask<byte[]> CrdtSendToRenderer(byte[] data);
 
+    /// <returns>The full serialized CRDT State, A contiguous byte array of the CRDT Message</returns>
     public UniTask<byte[]> CrdtGetState();
 }

--- a/Explorer/Assets/Scripts/SceneRuntime/SceneRuntime.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/SceneRuntime.cs
@@ -2,9 +2,10 @@ using Cysharp.Threading.Tasks;
 using Microsoft.ClearScript;
 using Microsoft.ClearScript.JavaScript;
 using Microsoft.ClearScript.V8;
+using System;
 using System.Collections.Generic;
 
-public class SceneRuntime
+public class SceneRuntime : IDisposable
 {
     internal readonly V8ScriptEngine engine;
 
@@ -17,9 +18,11 @@ public class SceneRuntime
     // ResetableSource is an optimization to reduce 11kb of memory allocation per Update (reduces 15kb to 4kb per update)
     private readonly UniTaskResolverResetable resetableSource;
 
-    public SceneRuntime(string sourceCode, string jsInitCode, Dictionary<string,string> jsModules)
+    private IEngineApi engineApi;
+
+    public SceneRuntime(string sourceCode, string jsInitCode, Dictionary<string, string> jsModules)
     {
-        resetableSource  = new UniTaskResolverResetable();
+        resetableSource = new UniTaskResolverResetable();
         moduleLoader = new SceneModuleLoader();
         engine = V8EngineFactory.Create();
 
@@ -70,6 +73,8 @@ public class SceneRuntime
         return resetableSource.Task;
     }
 
+    public void Dispose()
+    {
+        engineApi?.Dispose();
+    }
 }
-
-

--- a/Explorer/Assets/Scripts/Utility/ThreadSafePool/ThreadSafeCollectionPool.cs
+++ b/Explorer/Assets/Scripts/Utility/ThreadSafePool/ThreadSafeCollectionPool.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace Utility.ThreadSafePool
+{
+    public abstract class ThreadSafeCollectionPool<TCollection, TItem> : ThreadSafeObjectPool<TCollection> where TCollection: class, ICollection<TItem>, new()
+    {
+        /// <summary>
+        /// Shared Collection Pool with default capacity
+        /// </summary>
+        public static readonly ThreadSafeObjectPool<TCollection> Shared = new (() => new TCollection(), actionOnRelease: c => c.Clear());
+
+        public ThreadSafeCollectionPool(int initialCapacity, int poolCapacity, Func<int, TCollection> createFunc) : base(() => createFunc(initialCapacity), actionOnRelease: c => c.Clear(), defaultCapacity: poolCapacity) { }
+    }
+}

--- a/Explorer/Assets/Scripts/Utility/ThreadSafePool/ThreadSafeCollectionPool.cs.meta
+++ b/Explorer/Assets/Scripts/Utility/ThreadSafePool/ThreadSafeCollectionPool.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 657badeec23a44e496e075fdca26d7af
+timeCreated: 1683107541

--- a/Explorer/Assets/Scripts/Utility/ThreadSafePool/ThreadSafeListPool.cs
+++ b/Explorer/Assets/Scripts/Utility/ThreadSafePool/ThreadSafeListPool.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Utility.ThreadSafePool
+{
+    public class ThreadSafeListPool<TItem> : ThreadSafeCollectionPool<List<TItem>, TItem>
+    {
+        public ThreadSafeListPool(int initialCapacity, int poolCapacity) : base(initialCapacity, poolCapacity, capacity => new List<TItem>(capacity)) { }
+    }
+}

--- a/Explorer/Assets/Scripts/Utility/ThreadSafePool/ThreadSafeListPool.cs.meta
+++ b/Explorer/Assets/Scripts/Utility/ThreadSafePool/ThreadSafeListPool.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dda88164bd794d9fab779c07cfb2f5ed
+timeCreated: 1683107603

--- a/Explorer/Assets/Scripts/Utility/ThreadSafePool/ThreadSafeObjectPool.cs
+++ b/Explorer/Assets/Scripts/Utility/ThreadSafePool/ThreadSafeObjectPool.cs
@@ -3,6 +3,10 @@ using UnityEngine.Pool;
 
 namespace Utility.ThreadSafePool
 {
+    /// <summary>
+    /// Represents a pool that can be shared between multiple threads
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     public class ThreadSafeObjectPool<T> : IObjectPool<T> where T: class
     {
         private IObjectPool<T> objectPoolImplementation;


### PR DESCRIPTION
Two methods of the interface are implemented:

- `UniTask<byte[]> CrdtSendToRenderer(byte[] data);` is called by the scene-runtime to send new messages to the renderer
- `UniTask<byte[]> CrdtGetState()` is invoked by scene-runtime, mainly at start-up to read the full CRDT state from the renderer

`EngineAPIImplementation` is virtually a hub layer for everything that was written before.

- Methods are invoked by the scene runtime on a background thread, so I took care of the basic synchronization
- It looks like both methods are not necessarily should be a `UniTask` as there is no real asynchronicity, later I will check how to get rid of `await UniTask.Yield(PlayerLoopTiming.Initialization)` in a safe manner
- Everything is heavily relying on pools: bigger chunks that are called more seldom are shared between threads whereas the smaller chunks that are needed more frequently belong to the thread exclusively. We will be using `ThreadPool` so ultimately even when the scene dies pools will be reused 