### PR TITLE
chore: Memory assertions

### DIFF
--- a/Explorer/Assets/Scripts/CRDT/AssemblyInfo.cs
+++ b/Explorer/Assets/Scripts/CRDT/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("CRDTTests")]
+[assembly: InternalsVisibleTo("PoolsProviders")]
+[assembly: InternalsVisibleTo("Engine.Tests")]

--- a/Explorer/Assets/Scripts/CRDT/CRDTTests/CRDTDeserializerShould.cs
+++ b/Explorer/Assets/Scripts/CRDT/CRDTTests/CRDTDeserializerShould.cs
@@ -19,14 +19,14 @@ namespace CRDT.CRDTTests
             64, 73, 15, 219, 64, 73, 15, 219
         };
 
-        private CRDTPooledMemoryAllocator crdtPooledMemoryAllocator;
+        private ICRDTMemoryAllocator memoryAllocator;
         private CRDTDeserializer deserializer;
 
         [SetUp]
         public void SetUp()
         {
-            crdtPooledMemoryAllocator = CRDTPooledMemoryAllocator.Create();
-            deserializer = new CRDTDeserializer(crdtPooledMemoryAllocator);
+            memoryAllocator = CRDTOriginalMemorySlicer.Create();
+            deserializer = new CRDTDeserializer(memoryAllocator);
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace CRDT.CRDTTests
                 new CRDTEntity(666),
                 1,
                 7666,
-                crdtPooledMemoryAllocator.GetMemoryBuffer(componentDataBytes)
+                memoryAllocator.GetMemoryBuffer(componentDataBytes)
             );
 
             TestInput(bytes, new[] { expectedMessage });
@@ -75,7 +75,7 @@ namespace CRDT.CRDTTests
                 new CRDTEntity(666),
                 1,
                 7666,
-                crdtPooledMemoryAllocator.GetMemoryBuffer(componentDataBytes)
+                memoryAllocator.GetMemoryBuffer(componentDataBytes)
             );
 
             TestInput(bytes, new[] { expectedMessage });
@@ -132,7 +132,7 @@ namespace CRDT.CRDTTests
 
             byte[] bytes = bytesMsgA.Concat(bytesMsgB).ToArray();
 
-            var expectedComponentHeader = new CRDTMessage(CRDTMessageType.PUT_COMPONENT, new CRDTEntity(666), 1, 7666, crdtPooledMemoryAllocator.GetMemoryBuffer(componentDataBytes));
+            var expectedComponentHeader = new CRDTMessage(CRDTMessageType.PUT_COMPONENT, new CRDTEntity(666), 1, 7666, memoryAllocator.GetMemoryBuffer(componentDataBytes));
 
             TestInput(bytes, new[] { expectedComponentHeader, expectedComponentHeader });
         }
@@ -251,14 +251,14 @@ namespace CRDT.CRDTTests
                     new CRDTEntity(666),
                     1,
                     7666,
-                    crdtPooledMemoryAllocator.GetMemoryBuffer(componentDataBytes)
+                    memoryAllocator.GetMemoryBuffer(componentDataBytes)
                 ),
                 new CRDTMessage(
                     CRDTMessageType.PUT_COMPONENT,
                     new CRDTEntity(666),
                     1,
                     7666,
-                    crdtPooledMemoryAllocator.GetMemoryBuffer(componentDataBytes)
+                    memoryAllocator.GetMemoryBuffer(componentDataBytes)
                 ),
                 new CRDTMessage(
                     CRDTMessageType.DELETE_COMPONENT,

--- a/Explorer/Assets/Scripts/CRDT/CRDTTests/CRDTTests.asmdef
+++ b/Explorer/Assets/Scripts/CRDT/CRDTTests/CRDTTests.asmdef
@@ -1,25 +1,27 @@
 {
-    "name": "CRDTTests",
-    "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner",
-        "CRDT"
-    ],
-    "includePlatforms": [
-        "Editor"
-    ],
-    "excludePlatforms": [],
-    "allowUnsafeCode": false,
-    "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll",
-        "Collections.Pooled.dll"
-    ],
-    "autoReferenced": false,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
-    ],
-    "versionDefines": [],
-    "noEngineReferences": false
+  "name": "CRDTTests",
+  "rootNamespace": "",
+  "references": [
+    "UnityEngine.TestRunner",
+    "UnityEditor.TestRunner",
+    "CRDT",
+    "Instrumentation",
+    "PoolsProviders"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": true,
+  "precompiledReferences": [
+    "nunit.framework.dll",
+    "Collections.Pooled.dll"
+  ],
+  "autoReferenced": false,
+  "defineConstraints": [
+    "UNITY_INCLUDE_TESTS"
+  ],
+  "versionDefines": [],
+  "noEngineReferences": false
 }

--- a/Explorer/Assets/Scripts/CRDT/CRDTTests/Protocol/ParsedCRDTTestFile.cs
+++ b/Explorer/Assets/Scripts/CRDT/CRDTTests/Protocol/ParsedCRDTTestFile.cs
@@ -59,7 +59,7 @@ namespace CRDT.CRDTTests.Protocol
             return (msg.ToCRDTMessage(memoryAllocator), reconciliationResult);
         }
 
-        internal static IEnumerable<CRDTMessage> InstructionToFinalStateMessages(TestFileInstruction instruction, CRDTPooledMemoryAllocator crdtPooledMemoryAllocator)
+        internal static IEnumerable<CRDTMessage> InstructionToFinalStateMessages(TestFileInstruction instruction, ICRDTMemoryAllocator crdtPooledMemoryAllocator)
         {
             CrdtJsonState finalState = null;
 
@@ -95,7 +95,7 @@ namespace CRDT.CRDTTests.Protocol
 
             CRDTProtocol.State state = new CRDTProtocol.State(
                 new PooledDictionary<int, int>(),
-                new PooledDictionary<int, PooledDictionary<CRDTEntity, CRDTProtocol.EntityComponentData>>(),
+                new Dictionary<int, Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData>>(),
                 new PooledDictionary<int, PooledDictionary<CRDTEntity, PooledList<CRDTProtocol.EntityComponentData>>>());
 
             foreach (var entityComponentData in finalState.components)
@@ -106,7 +106,7 @@ namespace CRDT.CRDTTests.Protocol
                 var realData = entityComponentData.ToEntityComponentData();
 
                 if (!state.lwwComponents.ContainsKey(componentId))
-                    state.lwwComponents.Add(componentId, new PooledDictionary<CRDTEntity, CRDTProtocol.EntityComponentData>());
+                    state.lwwComponents.Add(componentId, new Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData>());
 
                 state.lwwComponents[componentId].Add(new CRDTEntity(entityId), realData);
             }

--- a/Explorer/Assets/Scripts/CRDT/Deserializer/CRDTDeserializer.cs
+++ b/Explorer/Assets/Scripts/CRDT/Deserializer/CRDTDeserializer.cs
@@ -17,9 +17,6 @@ namespace CRDT.Deserializer
             this.crdtPooledMemoryAllocator = crdtPooledMemoryAllocator;
         }
 
-        void ICRDTDeserializer.DeserializeBatch(ref ReadOnlyMemory<byte> memory, IList<CRDTMessage> messages) =>
-            DeserializeBatch(ref memory, messages);
-
         public void DeserializeBatch(ref ReadOnlyMemory<byte> memory, IList<CRDTMessage> messages)
         {
             // While we have a header to read

--- a/Explorer/Assets/Scripts/CRDT/Deserializer/ICRDTDeserializer.cs
+++ b/Explorer/Assets/Scripts/CRDT/Deserializer/ICRDTDeserializer.cs
@@ -5,13 +5,13 @@ using System.Collections.Generic;
 namespace CRDT.Deserializer
 {
     /// <summary>
-    /// CRDT Deserializer acts as a thread-safe singleton:
-    /// it does not contain a state and does not rely on pools under the hood
+    ///     CRDT Deserializer acts as a thread-safe singleton:
+    ///     it does not contain a state and does not rely on pools under the hood
     /// </summary>
     public interface ICRDTDeserializer
     {
-       /// <summary>
-        /// Deserializes a batch of messages into individual <see cref="CRDTMessage"/>s
+        /// <summary>
+        ///     Deserializes a batch of messages into individual <see cref="CRDTMessage" />s
         /// </summary>
         /// <param name="memory">An original byte array to parse messages from</param>
         /// <param name="messages">The target list to fit all messages</param>

--- a/Explorer/Assets/Scripts/CRDT/Memory/Tests/CRDTPooledMemoryAllocatorShould.cs
+++ b/Explorer/Assets/Scripts/CRDT/Memory/Tests/CRDTPooledMemoryAllocatorShould.cs
@@ -1,0 +1,77 @@
+using Instrumentation;
+using NUnit.Framework;
+using System;
+using System.Buffers;
+using System.Reflection;
+
+namespace CRDT.Memory.Tests
+{
+    [TestFixture]
+    public class CRDTPooledMemoryAllocatorShould
+    {
+        private const int TOLERATED_INSTANCE_OVERHEAD = 100;
+
+        private static readonly MethodInfo SELECT_BUCKET_INDEX = Type.GetType("System.Buffers.Utilities").GetMethod("SelectBucketIndex", BindingFlags.NonPublic | BindingFlags.Static);
+        private static readonly MethodInfo GET_MAX_SIZE_FOR_BUCKET = Type.GetType("System.Buffers.Utilities").GetMethod("GetMaxSizeForBucket", BindingFlags.NonPublic | BindingFlags.Static);
+
+        [SetUp]
+        public void SetUp()
+        {
+            allocator = CRDTPooledMemoryAllocator.Create();
+        }
+
+        private CRDTPooledMemoryAllocator allocator;
+
+        [Test]
+        public void AllocateOnColdRun([Values(128, 1024, 8096, 256 * 1024, 512 * 1024, 1024 * 1024)] int size)
+        {
+            var poolAllocationSize = (int)GET_MAX_SIZE_FOR_BUCKET.Invoke(null, new object[] { (int)SELECT_BUCKET_INDEX.Invoke(null, new object[] { size }) });
+
+            MemoryStat.Debug.GC_ALLOCATED_IN_FRAME.Check(
+                () => allocator.GetMemoryBuffer(size),
+                value => { Assert.AreEqual(poolAllocationSize, value, TOLERATED_INSTANCE_OVERHEAD); });
+        }
+
+        [Test]
+        public void AllocateIfSizeExceedsTheMaximum()
+        {
+            int oversize = CRDTPooledMemoryAllocator.POOL_MAX_ARRAY_LENGTH + 1;
+
+            var data = new byte[oversize];
+            var random = new Random();
+            random.NextBytes(data);
+            IMemoryOwner<byte> allocation = allocator.GetMemoryBuffer(data);
+
+            for (var i = 0; i < 100; i++)
+            {
+                MemoryStat.Debug.GC_ALLOCATED_IN_FRAME.Check(
+                    () =>
+                    {
+                        allocation.Dispose();
+                        allocation = allocator.GetMemoryBuffer(data);
+                    },
+                    value => Assert.AreEqual(oversize, value, TOLERATED_INSTANCE_OVERHEAD));
+            }
+        }
+
+        [Test]
+        public void NotAllocateOnHotRun([Values(128, 1024, 8096, 256 * 1024, 512 * 1024, 1024 * 1024)] int size)
+        {
+            var data = new byte[size];
+            var random = new Random();
+            random.NextBytes(data);
+            IMemoryOwner<byte> allocation = allocator.GetMemoryBuffer(data);
+
+            for (var i = 0; i < 100; i++)
+            {
+                MemoryStat.Debug.GC_ALLOCATED_IN_FRAME.Check(
+                    () =>
+                    {
+                        allocation.Dispose();
+                        allocation = allocator.GetMemoryBuffer(data);
+                    },
+                    Assert.Zero);
+            }
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/CRDT/Memory/Tests/CRDTPooledMemoryAllocatorShould.cs.meta
+++ b/Explorer/Assets/Scripts/CRDT/Memory/Tests/CRDTPooledMemoryAllocatorShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a7b93f8190a5462d9d64f5a0fb2134e4
+timeCreated: 1684251276

--- a/Explorer/Assets/Scripts/CRDT/Memory/Tests/MemoryAllocatorShould.cs
+++ b/Explorer/Assets/Scripts/CRDT/Memory/Tests/MemoryAllocatorShould.cs
@@ -1,49 +1,30 @@
-using CRDT.Memory;
 using NUnit.Framework;
 using System;
 using System.Buffers;
 using UnityEngine.Profiling;
 
-public class MemoryAllocatorShould
+namespace CRDT.Memory.Tests
 {
-    [TestCase(1000)]
-    [TestCase(10000)]
-    [TestCase(100000)]
-    public void PoolNotAllocating(int arraySize)
+    public class MemoryAllocatorShould
     {
-        var crdtPooledMemoryAllocator = CRDTPooledMemoryAllocator.Create();
-
-        var data = new byte[arraySize];
-        var random = new Random();
-        random.NextBytes(data);
-        IMemoryOwner<byte> allocation = crdtPooledMemoryAllocator.GetMemoryBuffer(data);
-
-        for (var i = 0; i < 100; i++)
+        [TestCase(1000)]
+        [TestCase(10000)]
+        [TestCase(100000)]
+        public void OriginalMemorySlicerAllocating(int arraySize)
         {
-            Profiler.BeginSample($"Debug: CRDT Pooled Memory {arraySize}");
-            allocation.Dispose();
-            allocation = crdtPooledMemoryAllocator.GetMemoryBuffer(data);
-            Profiler.EndSample();
-        }
-    }
+            var originalMemorySlicer = CRDTOriginalMemorySlicer.Create();
+            var data = new byte[arraySize];
+            var random = new Random();
+            random.NextBytes(data);
+            IMemoryOwner<byte> allocation = originalMemorySlicer.GetMemoryBuffer(data);
 
-    [TestCase(1000)]
-    [TestCase(10000)]
-    [TestCase(100000)]
-    public void OriginalMemorySlicerAllocating(int arraySize)
-    {
-        var originalMemorySlicer = CRDTOriginalMemorySlicer.Create();
-        var data = new byte[arraySize];
-        var random = new Random();
-        random.NextBytes(data);
-        IMemoryOwner<byte> allocation = originalMemorySlicer.GetMemoryBuffer(data);
-
-        for (var i = 0; i < 100; i++)
-        {
-            Profiler.BeginSample($"Debug: CRDT Memory Slicer {arraySize}");
-            allocation.Dispose();
-            allocation = originalMemorySlicer.GetMemoryBuffer(data);
-            Profiler.EndSample();
+            for (var i = 0; i < 100; i++)
+            {
+                Profiler.BeginSample($"Debug: CRDT Memory Slicer {arraySize}");
+                allocation.Dispose();
+                allocation = originalMemorySlicer.GetMemoryBuffer(data);
+                Profiler.EndSample();
+            }
         }
     }
 }

--- a/Explorer/Assets/Scripts/CRDT/Memory/Tests/MemoryAllocatorTests.asmdef
+++ b/Explorer/Assets/Scripts/CRDT/Memory/Tests/MemoryAllocatorTests.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "CRDT"
+        "CRDT",
+        "Instrumentation"
     ],
     "includePlatforms": [
         "Editor"
@@ -14,7 +15,8 @@
     "overrideReferences": true,
     "precompiledReferences": [
         "nunit.framework.dll",
-        "Collections.Pooled.dll"
+        "Collections.Pooled.dll",
+        "System.Runtime.CompilerServices.Unsafe.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Explorer/Assets/Scripts/CRDT/Protocol/ICRDTProtocolPoolsProvider.cs
+++ b/Explorer/Assets/Scripts/CRDT/Protocol/ICRDTProtocolPoolsProvider.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace CRDT.Protocol
+{
+    public interface ICRDTProtocolPoolsProvider
+    {
+        internal Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData> GetCrdtLWWComponentsInner();
+
+        internal void ReleaseCrdtLWWComponentsInner(Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData> dictionary);
+
+        internal Dictionary<int, Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData>> GetCrdtLWWComponentsOuter();
+
+        internal void ReleaseCrdtLWWComponentsOuter(Dictionary<int, Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData>> dictionary);
+    }
+}

--- a/Explorer/Assets/Scripts/CRDT/Protocol/ICRDTProtocolPoolsProvider.cs.meta
+++ b/Explorer/Assets/Scripts/CRDT/Protocol/ICRDTProtocolPoolsProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7c9f1e35288d41a8b16fb736a96d8423
+timeCreated: 1684269609

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/ComponentWriter/Tests/ECSToCRDTWriterShould.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/ComponentWriter/Tests/ECSToCRDTWriterShould.cs
@@ -4,6 +4,7 @@ using CRDT.Protocol;
 using CRDT.Protocol.Factory;
 using CrdtEcsBridge.Components;
 using CrdtEcsBridge.OutgoingMessages;
+using CrdtEcsBridge.PoolsProviders;
 using DCL.ECS7;
 using DCL.ECSComponents;
 using NSubstitute;
@@ -41,7 +42,7 @@ namespace CrdtEcsBridge.ECSToCRDTWriter.Tests
         public void AddMessageToProtocol()
         {
             //Arrange
-            ICRDTProtocol crdtProtocol = new CRDTProtocol();
+            ICRDTProtocol crdtProtocol = new CRDTProtocol(InstancePoolsProvider.Create());
             IOutgoingCRTDMessagesProvider outgoingCRDTMessageProvider = Substitute.For<IOutgoingCRTDMessagesProvider>();
 
             var sdkComponentRegistry = new SDKComponentsRegistry();

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/ComponentWriter/Tests/ECSToCRDTWriterTests.asmdef
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/ComponentWriter/Tests/ECSToCRDTWriterTests.asmdef
@@ -1,29 +1,30 @@
 {
-    "name": "ECSToCRDTWriter.Tests",
-    "rootNamespace": "",
-    "references": [
-        "GUID:0f4c0f120707fb74497f5d581b9858f8",
-        "GUID:40fef18dccdc4e119f7635452380fe9f",
-        "GUID:3c7b57a14671040bd8c549056adc04f5",
-        "GUID:34936d3bba0aaec4588ec487fda270bc",
-        "GUID:5d54b27c5050b7b4ba77b8eb20337fb1",
-        "GUID:f95f5feadbbe2f9448969f3a23470e3d"
-    ],
-    "includePlatforms": [
-        "Editor"
-    ],
-    "excludePlatforms": [],
-    "allowUnsafeCode": false,
-    "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll",
-        "NSubstitute.dll",
-        "Google.Protobuf.dll"
-    ],
-    "autoReferenced": false,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
-    ],
-    "versionDefines": [],
-    "noEngineReferences": false
+  "name": "ECSToCRDTWriter.Tests",
+  "rootNamespace": "",
+  "references": [
+    "GUID:0f4c0f120707fb74497f5d581b9858f8",
+    "GUID:40fef18dccdc4e119f7635452380fe9f",
+    "GUID:3c7b57a14671040bd8c549056adc04f5",
+    "GUID:34936d3bba0aaec4588ec487fda270bc",
+    "GUID:5d54b27c5050b7b4ba77b8eb20337fb1",
+    "GUID:f95f5feadbbe2f9448969f3a23470e3d",
+    "GUID:f46e65eba0ab46d084015ff77e7e2ad5"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": true,
+  "precompiledReferences": [
+    "nunit.framework.dll",
+    "NSubstitute.dll",
+    "Google.Protobuf.dll"
+  ],
+  "autoReferenced": false,
+  "defineConstraints": [
+    "UNITY_INCLUDE_TESTS"
+  ],
+  "versionDefines": [],
+  "noEngineReferences": false
 }

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineAPIImplementation.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineAPIImplementation.cs
@@ -3,6 +3,7 @@ using CRDT.Protocol;
 using CRDT.Protocol.Factory;
 using CRDT.Serializer;
 using CrdtEcsBridge.OutgoingMessages;
+using CrdtEcsBridge.PoolsProviders;
 using CrdtEcsBridge.WorldSynchronizer;
 using Cysharp.Threading.Tasks;
 using SceneRuntime.Apis.Modules;
@@ -66,7 +67,6 @@ namespace CrdtEcsBridge.Engine
 
             deserializeBatchSampler.Begin();
 
-            // TODO add metrics to understand bottlenecks better
             crdtDeserializer.DeserializeBatch(ref dataMemory, messages);
 
             deserializeBatchSampler.End();

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineImplementation.asmdef
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/EngineImplementation.asmdef
@@ -8,7 +8,8 @@
     "GUID:96825943f4e14954b5172da80fdee63d",
     "GUID:40fef18dccdc4e119f7635452380fe9f",
     "GUID:fa7b3fdbb04d67549916da7bd2af58ab",
-    "GUID:f46e65eba0ab46d084015ff77e7e2ad5"
+    "GUID:f46e65eba0ab46d084015ff77e7e2ad5",
+    "GUID:921b4473535d45e4ba7e8b38fb8ca385"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests/EngineAPIImplementationShould.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Engine/Tests/EngineAPIImplementationShould.cs
@@ -4,6 +4,7 @@ using CRDT.Protocol;
 using CRDT.Protocol.Factory;
 using CRDT.Serializer;
 using CrdtEcsBridge.OutgoingMessages;
+using CrdtEcsBridge.PoolsProviders;
 using CrdtEcsBridge.WorldSynchronizer;
 using NSubstitute;
 using NUnit.Framework;

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingCRTDMessagesProviderShould.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingCRTDMessagesProviderShould.cs
@@ -101,7 +101,7 @@ namespace CrdtEcsBridge.OutgoingMessages.Tests
 
             provider.Dispose();
 
-            Assert.AreEqual(1, OutgoingCRTDMessagesProvider.SHARED_POOL.CountInactive);
+            Assert.GreaterOrEqual(OutgoingCRTDMessagesProvider.SHARED_POOL.CountInactive, 1);
         }
     }
 }

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingMessages.Tests.asmdef
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/Tests/OutgoingMessages.Tests.asmdef
@@ -7,7 +7,8 @@
     "OutgoingMessages",
     "CRDT",
     "UniTask",
-    "Utility"
+    "Utility",
+    "Instrumentation"
   ],
   "includePlatforms": [
     "Editor"

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/AssemblyInfo.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CRDTTests")]

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/AssemblyInfo.cs.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/AssemblyInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c26c5b144f4144d2ae191fe7e7bdfa21
+timeCreated: 1684270514

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/IInstancePoolsProvider.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/IInstancePoolsProvider.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace CrdtEcsBridge.Engine
+namespace CrdtEcsBridge.PoolsProviders
 {
     /// <summary>
     ///     Provides single threaded pools dedicated to a single scene instance

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/ISharedPoolsProvider.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/ISharedPoolsProvider.cs
@@ -1,6 +1,6 @@
 using CRDT.Protocol.Factory;
 
-namespace CrdtEcsBridge.Engine
+namespace CrdtEcsBridge.PoolsProviders
 {
     /// <summary>
     /// Provides threads-synchronized pools for heavily-loaded bulk serialization and deserialization

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/InstancePoolsProvider.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/InstancePoolsProvider.cs
@@ -1,5 +1,6 @@
-﻿using CRDT.Protocol;
-using CrdtEcsBridge.Engine;
+﻿using CRDT;
+using CRDT.Protocol;
+using DCL.ECS7;
 using System.Buffers;
 using System.Collections.Generic;
 using UnityEngine.Pool;
@@ -7,28 +8,48 @@ using Utility.ThreadSafePool;
 
 namespace CrdtEcsBridge.PoolsProviders
 {
-    public class InstancePoolsProvider : IInstancePoolsProvider
+    public class InstancePoolsProvider : IInstancePoolsProvider, ICRDTProtocolPoolsProvider
     {
+        internal const int DESERIALIZATION_LIST_CAPACITY = 256;
+
+        /// <summary>
+        ///     It should be slightly greater or equal to the number of <see cref="ComponentID" />'s
+        /// </summary>
+        internal const int CRDT_LWW_COMPONENTS_OUTER_CAPACITY = 32;
+
+        /// <summary>
+        ///     It refers to the entities for each component, just cap it at some number that is unlikely to reach on average
+        /// </summary>
+        internal const int CRDT_LWW_COMPONENTS_INNER_CAPACITY = 512;
+
         /// <summary>
         ///     Reuse pools when the scene is disposed
         /// </summary>
         private static readonly ThreadSafeObjectPool<InstancePoolsProvider> POOL =
             new (() => new InstancePoolsProvider());
 
+        private readonly IObjectPool<Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData>> crdtLWWComponentsInnerPool =
+            new ObjectPool<Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData>>(
+                createFunc: () => new Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData>(CRDT_LWW_COMPONENTS_INNER_CAPACITY, CRDTEntityComparer.INSTANCE),
+                actionOnRelease: dictionary => dictionary.Clear(),
+                defaultCapacity: CRDT_LWW_COMPONENTS_OUTER_CAPACITY,
+                maxSize: CRDT_LWW_COMPONENTS_OUTER_CAPACITY
+            );
+
+        private readonly Dictionary<int, Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData>> crdtLWWComponentsOuter =
+            new (CRDT_LWW_COMPONENTS_OUTER_CAPACITY);
+
         private readonly IObjectPool<IList<CRDTMessage>> crdtMessagesPool = new ObjectPool<IList<CRDTMessage>>(
 
             // just preallocate an array big enough
-            createFunc: () => new List<CRDTMessage>(256),
+            createFunc: () => new List<CRDTMessage>(DESERIALIZATION_LIST_CAPACITY),
             actionOnRelease: list => list.Clear()
         );
 
-        private readonly ArrayPool<byte> crdtRawDataPool = ArrayPool<byte>.Create(16_777_216, 8); // 16 MB, 8 buckets, if the requested array is more than 16 mb than a new instance is simply returned
+        private readonly ArrayPool<byte> crdtRawDataPool = ArrayPool<byte>.Create(16 * 1024 * 1024, 8); // 16 MB, 8 buckets, if the requested array is more than 16 mb than a new instance is simply returned
 
         // Forbid creating instances of this class outside of the pool
         private InstancePoolsProvider() { }
-
-        public static InstancePoolsProvider Create() =>
-            POOL.Get();
 
         public void Dispose()
         {
@@ -50,5 +71,20 @@ namespace CrdtEcsBridge.PoolsProviders
         {
             crdtMessagesPool.Release(messages);
         }
+
+        Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData> ICRDTProtocolPoolsProvider.GetCrdtLWWComponentsInner() =>
+            crdtLWWComponentsInnerPool.Get();
+
+        void ICRDTProtocolPoolsProvider.ReleaseCrdtLWWComponentsInner(Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData> dictionary) =>
+            crdtLWWComponentsInnerPool.Release(dictionary);
+
+        Dictionary<int, Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData>> ICRDTProtocolPoolsProvider.GetCrdtLWWComponentsOuter() =>
+            crdtLWWComponentsOuter;
+
+        void ICRDTProtocolPoolsProvider.ReleaseCrdtLWWComponentsOuter(Dictionary<int, Dictionary<CRDTEntity, CRDTProtocol.EntityComponentData>> dictionary) =>
+            dictionary.Clear();
+
+        public static InstancePoolsProvider Create() =>
+            POOL.Get();
     }
 }

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/PoolsProviders.asmdef
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/PoolsProviders.asmdef
@@ -2,6 +2,7 @@
   "name": "PoolsProviders",
   "references": [
     "GUID:fa7b3fdbb04d67549916da7bd2af58ab",
-    "GUID:0f4c0f120707fb74497f5d581b9858f8"
+    "GUID:0f4c0f120707fb74497f5d581b9858f8",
+    "GUID:3c7b57a14671040bd8c549056adc04f5"
   ]
 }

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/SharedPoolsProvider.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/SharedPoolsProvider.cs
@@ -1,7 +1,7 @@
 using CRDT.Protocol.Factory;
 using System.Buffers;
 
-namespace CrdtEcsBridge.Engine
+namespace CrdtEcsBridge.PoolsProviders
 {
     public class SharedPoolsProvider : ISharedPoolsProvider
     {

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/BatchState.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/BatchState.cs
@@ -1,24 +1,14 @@
 using CRDT.Protocol;
 using CrdtEcsBridge.Components;
-using Utility.ThreadSafePool;
 
 namespace CrdtEcsBridge.WorldSynchronizer
 {
     internal class BatchState
     {
-        internal static readonly ThreadSafeObjectPool<BatchState> POOL = new (
-            () => new BatchState(),
-            actionOnRelease: state => state.deserializationTarget = null,
-
-            // Omit checking collections, it is a hot path on the main thread
-            collectionCheck: false);
-
         internal CRDTMessage crdtMessage;
         internal ReconciliationState reconciliationState;
         internal SDKComponentBridge sdkComponentBridge;
 
         internal object deserializationTarget;
-
-        private BatchState() { }
     }
 }

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/Tests/CrdtWorldSynchronizerShould.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/Tests/CrdtWorldSynchronizerShould.cs
@@ -1,5 +1,6 @@
 ﻿using Arch.Core;
 using CrdtEcsBridge.Components;
+using Instrumentation;
 using NSubstitute;
 using NUnit.Framework;
 using System;
@@ -21,6 +22,21 @@ namespace CrdtEcsBridge.WorldSynchronizer.Tests
         {
             var cb = crdtWorldSynchronizer.GetSyncCommandBuffer();
             Assert.Throws<TimeoutException>(() => crdtWorldSynchronizer.GetSyncCommandBuffer());
+        }
+
+        [Test]
+        public void TolerateWorldSyncBufferAllocation()
+        {
+            // Warm up
+            // If we don't warm up static constructor will be called and screw up the test
+            IWorldSyncCommandBuffer worldSyncCommandBuffer = crdtWorldSynchronizer.GetSyncCommandBuffer();
+            worldSyncCommandBuffer.FinalizeAndDeserialize();
+            crdtWorldSynchronizer.ApplySyncCommandBuffer(worldSyncCommandBuffer);
+
+            // Tolerate 128 bytes allocation
+            MemoryStat.Debug.GC_ALLOCATED_IN_FRAME.Check(
+                () => crdtWorldSynchronizer.GetSyncCommandBuffer(),
+                value => Assert.Less(value, 128));
         }
 
         [Test]

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/Tests/WorldSynchronizer.Tests.asmdef
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/Tests/WorldSynchronizer.Tests.asmdef
@@ -1,33 +1,34 @@
 {
-    "name": "WorldSynchronizer.Tests",
-    "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner",
-        "WorldSynchronizer",
-        "SDKComponentsRegistry",
-        "CRDT",
-        "ECS",
-        "ComponentSerialization",
-        "ComponentsPooling",
-        "Utility",
-        "UniTask"
-    ],
-    "includePlatforms": [
-        "Editor"
-    ],
-    "excludePlatforms": [],
-    "allowUnsafeCode": false,
-    "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll",
-        "Arch.dll",
-        "NSubstitute.dll"
-    ],
-    "autoReferenced": false,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
-    ],
-    "versionDefines": [],
-    "noEngineReferences": false
+  "name": "WorldSynchronizer.Tests",
+  "rootNamespace": "",
+  "references": [
+    "UnityEngine.TestRunner",
+    "UnityEditor.TestRunner",
+    "WorldSynchronizer",
+    "SDKComponentsRegistry",
+    "CRDT",
+    "ECS",
+    "ComponentSerialization",
+    "ComponentsPooling",
+    "Utility",
+    "UniTask",
+    "Instrumentation"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": true,
+  "precompiledReferences": [
+    "nunit.framework.dll",
+    "Arch.dll",
+    "NSubstitute.dll"
+  ],
+  "autoReferenced": false,
+  "defineConstraints": [
+    "UNITY_INCLUDE_TESTS"
+  ],
+  "versionDefines": [],
+  "noEngineReferences": false
 }

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/WorldSyncCommandBuffer.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/WorldSyncCommandBuffer.cs
@@ -131,7 +131,7 @@ namespace CrdtEcsBridge.WorldSynchronizer
 
                     // the first and the last are the same
                     // take the component from the pool
-                    var batchState = BatchState.POOL.Get();
+                    BatchState batchState = collectionsPool.GetBatchState();
                     batchState.crdtMessage = message;
                     batchState.reconciliationState = new (reconciliationEffect, reconciliationEffect);
                     batchState.sdkComponentBridge = sdkComponentBridge;
@@ -182,7 +182,7 @@ namespace CrdtEcsBridge.WorldSynchronizer
                 if (!containsAnyChanges)
                 {
                     foreach (BatchState batchState in componentsBatch.Values)
-                        BatchState.POOL.Release(batchState);
+                        collectionsPool.ReleaseBatchState(batchState);
 
                     componentsBatch.Clear();
                 }
@@ -256,7 +256,7 @@ namespace CrdtEcsBridge.WorldSynchronizer
         private void ReleaseBatchStateDictionary(Dictionary<int, BatchState> inner)
         {
             foreach (BatchState batchState in inner.Values)
-                BatchState.POOL.Release(batchState);
+                collectionsPool.ReleaseBatchState(batchState);
 
             collectionsPool.ReleaseInnerDictionary(inner);
         }

--- a/Explorer/Assets/Scripts/ECS/ComponentsPooling/ComponentPool.cs
+++ b/Explorer/Assets/Scripts/ECS/ComponentsPooling/ComponentPool.cs
@@ -6,9 +6,6 @@ namespace ECS.ComponentsPooling
 {
     public class ComponentPool<T> : IComponentPool<T> where T: class, new()
     {
-        /// <summary>
-        /// It is not thread-safe
-        /// </summary>
         private readonly ThreadSafeObjectPool<T> objectPool;
 
         public ComponentPool(Action<T> onGet = null, Action<T> onRelease = null)

--- a/Explorer/Assets/Scripts/Global/SceneSharedContainer.cs
+++ b/Explorer/Assets/Scripts/Global/SceneSharedContainer.cs
@@ -1,7 +1,6 @@
-using CRDT.Deserializer;
 using CRDT.Serializer;
 using CrdtEcsBridge.Components;
-using CrdtEcsBridge.Engine;
+using CrdtEcsBridge.PoolsProviders;
 using SceneRunner.ECSWorld;
 using SceneRunner.Scene;
 using SceneRuntime.Factory;

--- a/Explorer/Assets/Scripts/Instrumentation.meta
+++ b/Explorer/Assets/Scripts/Instrumentation.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 31b8db766a324efb81d95bb823911c16
+timeCreated: 1684138044

--- a/Explorer/Assets/Scripts/Instrumentation/Instrumentation.asmdef
+++ b/Explorer/Assets/Scripts/Instrumentation/Instrumentation.asmdef
@@ -1,0 +1,3 @@
+{
+  "name": "Instrumentation"
+}

--- a/Explorer/Assets/Scripts/Instrumentation/Instrumentation.asmdef.meta
+++ b/Explorer/Assets/Scripts/Instrumentation/Instrumentation.asmdef.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 921b4473535d45e4ba7e8b38fb8ca385
+timeCreated: 1684138262

--- a/Explorer/Assets/Scripts/Instrumentation/MemoryStat.cs
+++ b/Explorer/Assets/Scripts/Instrumentation/MemoryStat.cs
@@ -1,0 +1,120 @@
+using Unity.Profiling;
+
+namespace Instrumentation
+{
+    /// <summary>
+    ///     Memory stats that is possible to track by <see cref="ProfilerRecorder" /> <br />
+    ///     See https://docs.unity3d.com/2022.2/Documentation/Manual/ProfilerMemory.html
+    /// </summary>
+    public static class MemoryStat
+    {
+        /// <summary>
+        ///     The .NET runtime imposes a minimum object size, which is 12 bytes on a 32-bit system and 24 bytes on a 64-bit system.
+        ///     Even if the class has no fields, the object will still occupy at least this minimum size.
+        /// </summary>
+        public const int MINIMUM_OBJECT_SIZE = 24;
+
+        public static readonly ProfilerCategory CATEGORY = ProfilerCategory.Memory;
+
+        private static ProfilerStat FromStatName(string statName) =>
+            new (CATEGORY, statName);
+
+        /// <summary>
+        ///     Stats available in Release builds
+        /// </summary>
+        public static class Release
+        {
+            /// <summary>
+            ///     The length of the Total Committed Memory bar indicates the total amount of memory that Unity’s Memory Manager system tracked,
+            ///     how much of that it used, and how much memory isn’t tracked through this system.
+            /// </summary>
+            public static readonly ProfilerStat TOTAL_COMMITTED_MEMORY = FromStatName("System Used Memory");
+
+            /// <summary>
+            ///     Indicates the total amount of memory that Unity uses and tracks
+            /// </summary>
+            public static readonly ProfilerStat TOTAL_USED_MEMORY = FromStatName("Total Used Memory");
+
+            /// <summary>
+            ///     The amount of memory that Unity reserves for tracking purposes and pool allocations
+            /// </summary>
+            public static readonly ProfilerStat TOTAL_RESERVED_MEMORY = FromStatName("Total Reserved Memory");
+
+            /// <summary>
+            ///     The used heap size and total heap size that managed code uses.
+            /// </summary>
+            public static readonly ProfilerStat GC_USED_MEMORY = FromStatName("GC Used Memory");
+
+            /// <summary>
+            ///     The used heap size and total heap size that managed code uses.
+            /// </summary>
+            public static readonly ProfilerStat GC_RESERVED_MEMORY = FromStatName("GC Reserved Memory");
+
+            /// <summary>
+            ///     The Audio system’s estimated memory usage.
+            /// </summary>
+            public static readonly ProfilerStat AUDIO_USED_MEMORY = FromStatName("Audio Used Memory");
+
+            /// <summary>
+            ///     The Audio system’s estimated memory usage.
+            /// </summary>
+            public static readonly ProfilerStat AUDIO_RESERVED_MEMORY = FromStatName("Audio Reserved Memory");
+
+            /// <summary>
+            ///     The Video system’s estimated memory usage.
+            /// </summary>
+            public static readonly ProfilerStat VIDEO_USED_MEMORY = FromStatName("Video Used Memory");
+
+            /// <summary>
+            ///     The Video system’s estimated memory usage.
+            /// </summary>
+            public static readonly ProfilerStat VIDEO_RESERVED_MEMORY = FromStatName("Video Reserved Memory");
+        }
+
+        /// <summary>
+        ///     Stats available in Debug builds and Editor only
+        /// </summary>
+        public static class Debug
+        {
+            /// <summary>
+            ///     Displays the amount of object instances of the types of Assets that commonly take up a high percentage of the memory
+            ///     (Textures, Meshes, Materials, Animation Clips), together with their accumulated sizes in memory (Assets, GameObjects, Scene Objects).
+            /// </summary>
+            public static readonly ProfilerStat OBJECT_COUNT = FromStatName("Object Count");
+            /// <summary>
+            ///     The total count of loaded textures and memory they use.
+            /// </summary>
+            public static readonly ProfilerStat TEXTURE_COUNT = FromStatName("Texture Count");
+            /// <summary>
+            ///     The total count of loaded textures and memory they use.
+            /// </summary>
+            public static readonly ProfilerStat TEXTURE_MEMORY = FromStatName("Texture Memory");
+            /// <summary>
+            ///     The total count of loaded meshes and memory they use.
+            /// </summary>
+            public static readonly ProfilerStat MESH_COUNT = FromStatName("Mesh Count");
+            /// <summary>
+            ///     The total count of loaded meshes and memory they use.
+            /// </summary>
+            public static readonly ProfilerStat MESH_MEMORY = FromStatName("Mesh Memory");
+            /// <summary>
+            ///     The total count of loaded materials and memory they use.
+            /// </summary>
+            public static readonly ProfilerStat MATERIAL_COUNT = FromStatName("Material Count");
+            /// <summary>
+            ///     The total count of loaded materials and memory they use.
+            /// </summary>
+            public static readonly ProfilerStat MATERIAL_MEMORY = FromStatName("Material Memory");
+
+            /// <summary>
+            ///     Displays the amount of managed allocations in the selected frame
+            /// </summary>
+            public static readonly ProfilerStat GC_ALLOCATED_IN_FRAME_COUNT = FromStatName("GC Allocation In Frame Count");
+
+            /// <summary>
+            ///     Displays the total size in bytes of managed allocations in the selected frame
+            /// </summary>
+            public static readonly ProfilerStat GC_ALLOCATED_IN_FRAME = FromStatName("GC Allocated In Frame");
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Instrumentation/MemoryStat.cs.meta
+++ b/Explorer/Assets/Scripts/Instrumentation/MemoryStat.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cb84bfb4609849bfa431bb184c31449d
+timeCreated: 1684138085

--- a/Explorer/Assets/Scripts/Instrumentation/ProfilerContainer.cs
+++ b/Explorer/Assets/Scripts/Instrumentation/ProfilerContainer.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using Unity.Profiling;
+
+namespace Instrumentation
+{
+    public class ProfilerContainer : IDisposable
+    {
+        public readonly struct AutoScope : IDisposable
+        {
+            public ProfilerRecorder Recorder { get; }
+
+            public AutoScope(ProfilerRecorder recorder)
+            {
+                Recorder = recorder;
+                recorder.Start();
+            }
+
+            public void Dispose()
+            {
+                Recorder.Stop();
+            }
+        }
+
+        private readonly Dictionary<string, ProfilerRecorder> recorders;
+
+        public ProfilerContainer(int recordsInitialCapacity = 3)
+        {
+            recorders = new Dictionary<string, ProfilerRecorder>(recordsInitialCapacity);
+        }
+
+        public AutoScope Scope(ProfilerCategory category, string statName, string funcName)
+        {
+            // Create ProfilerRecorder if it was not created before
+            if (!recorders.TryGetValue(funcName, out ProfilerRecorder recorder))
+                recorders[funcName] = recorder
+                    = new ProfilerRecorder(category, statName, 0, ProfilerRecorderOptions.WrapAroundWhenCapacityReached | ProfilerRecorderOptions.CollectOnlyOnCurrentThread);
+
+            return new AutoScope(recorder);
+        }
+
+        public AutoScope Scope(ProfilerStat stat, string funcName) =>
+            Scope(stat.Category, stat.StatName, funcName);
+
+        /// <summary>
+        ///     Create a new temporary scope with a new <see cref="ProfilerRecorder" />
+        /// </summary>
+        public static AutoScope Scope(ProfilerStat stat, int profilerCapacity = 1) =>
+            new (stat.CreateRecorder(profilerCapacity));
+
+        public void Dispose()
+        {
+            foreach (ProfilerRecorder recorder in recorders.Values)
+                recorder.Dispose();
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Instrumentation/ProfilerContainer.cs.meta
+++ b/Explorer/Assets/Scripts/Instrumentation/ProfilerContainer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 09e068a4894a45c5a8413b21209c5120
+timeCreated: 1684152965

--- a/Explorer/Assets/Scripts/Instrumentation/ProfilerStat.cs
+++ b/Explorer/Assets/Scripts/Instrumentation/ProfilerStat.cs
@@ -1,0 +1,19 @@
+using Unity.Profiling;
+
+namespace Instrumentation
+{
+    public readonly struct ProfilerStat
+    {
+        public readonly ProfilerCategory Category;
+        public readonly string StatName;
+
+        public ProfilerStat(ProfilerCategory category, string statName)
+        {
+            Category = category;
+            StatName = statName;
+        }
+
+        public static implicit operator ProfilerStat((ProfilerCategory, string) tuple) =>
+            new (tuple.Item1, tuple.Item2);
+    }
+}

--- a/Explorer/Assets/Scripts/Instrumentation/ProfilerStat.cs.meta
+++ b/Explorer/Assets/Scripts/Instrumentation/ProfilerStat.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e2dacf5175c44648833d23a54c0b3f93
+timeCreated: 1684248912

--- a/Explorer/Assets/Scripts/Instrumentation/ProfilerStatExtensions.cs
+++ b/Explorer/Assets/Scripts/Instrumentation/ProfilerStatExtensions.cs
@@ -1,0 +1,34 @@
+﻿using JetBrains.Annotations;
+using System;
+using Unity.Profiling;
+
+namespace Instrumentation
+{
+    public static class ProfilerStatExtensions
+    {
+        public static void Check(this in ProfilerStat profilerStat, [NotNull] Action @delegate, [NotNull] Action<long> checkFunc)
+        {
+            ProfilerContainer.AutoScope scope;
+
+            // the same samplers are shared
+            // so we need to adjust the current value if the same sampler was already called
+            long valueOnStart;
+
+            using (scope = ProfilerContainer.Scope(profilerStat))
+            {
+                valueOnStart = scope.Recorder.CurrentValue;
+                @delegate();
+            }
+
+            try { checkFunc(scope.Recorder.CurrentValue - valueOnStart); }
+            finally
+            {
+                scope.Recorder.Reset();
+                scope.Recorder.Dispose();
+            }
+        }
+
+        public static ProfilerRecorder CreateRecorder(this in ProfilerStat stat, int profilerCapacity = 0) =>
+            new (stat.Category, stat.StatName, profilerCapacity, ProfilerRecorderOptions.Default | ProfilerRecorderOptions.CollectOnlyOnCurrentThread);
+    }
+}

--- a/Explorer/Assets/Scripts/Instrumentation/ProfilerStatExtensions.cs.meta
+++ b/Explorer/Assets/Scripts/Instrumentation/ProfilerStatExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d1f61ac0a9ef49d4a28ee5254f83f865
+timeCreated: 1684254272

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneFacade.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneFacade.cs
@@ -1,7 +1,7 @@
 ﻿using CRDT.Memory;
 using CRDT.Protocol;
-using CrdtEcsBridge.Engine;
 using CrdtEcsBridge.OutgoingMessages;
+using CrdtEcsBridge.PoolsProviders;
 using CrdtEcsBridge.WorldSynchronizer;
 using Cysharp.Threading.Tasks;
 using SceneRunner.ECSWorld;

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneFactory.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneFactory.cs
@@ -43,9 +43,9 @@ namespace SceneRunner.Scene
         public async UniTask<ISceneFacade> CreateScene(string jsCodeUrl, CancellationToken ct)
         {
             // Per scene instance dependencies
-            var crdtProtocol = new CRDTProtocol();
             var outgoingCrtdMessagesProvider = new OutgoingCRTDMessagesProvider();
             var instancePoolsProvider = InstancePoolsProvider.Create();
+            var crdtProtocol = new CRDTProtocol(instancePoolsProvider);
             var crdtMemoryAllocator = CRDTPooledMemoryAllocator.Create();
             var crdtDeserializer = new CRDTDeserializer(crdtMemoryAllocator);
 

--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/EngineApiWrapper.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/EngineApiWrapper.cs
@@ -1,4 +1,4 @@
-﻿using CrdtEcsBridge.Engine;
+﻿using CrdtEcsBridge.PoolsProviders;
 using JetBrains.Annotations;
 using Microsoft.ClearScript.JavaScript;
 using System;

--- a/Explorer/Assets/Scripts/SceneRuntime/Factory/SceneRuntimeFactory.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Factory/SceneRuntimeFactory.cs
@@ -1,5 +1,5 @@
 using AssetManagement.JsCodeResolver;
-using CrdtEcsBridge.Engine;
+using CrdtEcsBridge.PoolsProviders;
 using Cysharp.Threading.Tasks;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;

--- a/Explorer/Assets/Scripts/SceneRuntime/Factory/Tests/SceneRuntimeFactory.Tests.asmdef
+++ b/Explorer/Assets/Scripts/SceneRuntime/Factory/Tests/SceneRuntimeFactory.Tests.asmdef
@@ -1,30 +1,31 @@
 {
-  "name": "SceneRuntimeFactory.Tests",
-  "rootNamespace": "",
-  "references": [
-    "UnityEngine.TestRunner",
-    "UnityEditor.TestRunner",
-    "SceneRuntime",
-    "UniTask",
-    "SceneRuntimeFactory",
-    "PoolsProviders"
-  ],
-  "includePlatforms": [
-    "Editor"
-  ],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": true,
-  "precompiledReferences": [
-    "nunit.framework.dll",
-    "NSubstitute.dll",
-    "ClearScript.Core.dll",
-    "ClearScript.V8.dll"
-  ],
-  "autoReferenced": false,
-  "defineConstraints": [
-    "UNITY_INCLUDE_TESTS"
-  ],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "SceneRuntimeFactory.Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "SceneRuntime",
+        "UniTask",
+        "SceneRuntimeFactory",
+        "PoolsProviders",
+        "CRDT"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "NSubstitute.dll",
+        "ClearScript.Core.dll",
+        "ClearScript.V8.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Explorer/Assets/Scripts/SceneRuntime/Factory/Tests/SceneRuntimeFactoryShould.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Factory/Tests/SceneRuntimeFactoryShould.cs
@@ -1,4 +1,4 @@
-using CrdtEcsBridge.Engine;
+using CrdtEcsBridge.PoolsProviders;
 using Cysharp.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;

--- a/Explorer/Assets/Scripts/SceneRuntime/SceneRuntime.asmdef
+++ b/Explorer/Assets/Scripts/SceneRuntime/SceneRuntime.asmdef
@@ -1,18 +1,19 @@
 {
-  "name": "SceneRuntime",
-  "rootNamespace": "",
-  "references": [
-    "UniTask",
-    "Utility",
-    "PoolsProviders"
-  ],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": false,
-  "precompiledReferences": [],
-  "autoReferenced": true,
-  "defineConstraints": [],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "SceneRuntime",
+    "rootNamespace": "",
+    "references": [
+        "UniTask",
+        "Utility",
+        "PoolsProviders",
+        "CRDT"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Explorer/Assets/Scripts/SceneRuntime/SceneRuntimeImpl.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/SceneRuntimeImpl.cs
@@ -1,4 +1,4 @@
-using CrdtEcsBridge.Engine;
+using CrdtEcsBridge.PoolsProviders;
 using Cysharp.Threading.Tasks;
 using Microsoft.ClearScript;
 using Microsoft.ClearScript.JavaScript;

--- a/Explorer/Assets/Scripts/SceneRuntime/Tests/SceneRuntime.Tests.asmdef
+++ b/Explorer/Assets/Scripts/SceneRuntime/Tests/SceneRuntime.Tests.asmdef
@@ -1,28 +1,29 @@
 {
-  "name": "SceneRuntime.Tests",
-  "rootNamespace": "",
-  "references": [
-    "UnityEngine.TestRunner",
-    "UnityEditor.TestRunner",
-    "SceneRuntime",
-    "UniTask",
-    "SceneRuntimeFactory",
-    "PoolsProviders"
-  ],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": true,
-  "precompiledReferences": [
-    "nunit.framework.dll",
-    "NSubstitute.dll",
-    "ClearScript.Core.dll",
-    "ClearScript.V8.dll"
-  ],
-  "autoReferenced": false,
-  "defineConstraints": [
-    "UNITY_INCLUDE_TESTS"
-  ],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "SceneRuntime.Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "SceneRuntime",
+        "UniTask",
+        "SceneRuntimeFactory",
+        "PoolsProviders",
+        "CRDT"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "NSubstitute.dll",
+        "ClearScript.Core.dll",
+        "ClearScript.V8.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Explorer/Assets/Scripts/SceneRuntime/Tests/SceneRuntimeShould.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Tests/SceneRuntimeShould.cs
@@ -1,4 +1,4 @@
-using CrdtEcsBridge.Engine;
+using CrdtEcsBridge.PoolsProviders;
 using Cysharp.Threading.Tasks;
 using JetBrains.Annotations;
 using NSubstitute;


### PR DESCRIPTION
Together with Unity support, we found a way to profile allocations for a specific code region:
1. Create a `ProfileRecorder` with a memory stat
2. `Start` and `Stop` manually
3. Read `CurrentValue` instead of `LastValue` to access the raw metric value

I applied this technique to assert hot regions with the following metrics:

- GC Allocation In Frame Count
- GC Allocated In Frame