### PR TITLE
Fix: inject destroy entity world

### DIFF
--- a/Explorer/Assets/Scripts/ECS/ComponentsPooling/Systems/ReleasePoolableComponentSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/ComponentsPooling/Systems/ReleasePoolableComponentSystem.cs
@@ -49,6 +49,7 @@ namespace ECS.ComponentsPooling.Systems
             public void Update(ref TProvider provider)
             {
                 poolsRegistry.GetPool(provider.PoolableComponentType).Release(provider.PoolableComponent);
+                provider.Dispose();
             }
 
         }

--- a/Explorer/Assets/Scripts/SceneRunner/ECSWorld/ECSWorldFactory.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/ECSWorld/ECSWorldFactory.cs
@@ -35,6 +35,7 @@ namespace SceneRunner.ECSWorld
             foreach (IECSWorldPlugin worldPlugin in plugins)
                 worldPlugin.InjectToWorld(ref builder, in sharedDependencies, finalizeWorldSystems);
 
+            DestroyEntitiesSystem.InjectToWorld(ref builder);
             finalizeWorldSystems.Add(ReleaseReferenceComponentsSystem.InjectToWorld(ref builder, componentPoolsRegistry));
             finalizeWorldSystems.Add(ReleaseRemovedComponentsSystem.InjectToWorld(ref builder));
 


### PR DESCRIPTION
The `DestroyEntitySystem` was not being injected, causing objects that were already released on the pool to be released again.

