### PR TITLE
Fix various exceptions connected to Disposal

### DIFF
--- a/Explorer/Assets/Scripts/AssetManagement/CodeResolver/WebJsCodeProvider.cs
+++ b/Explorer/Assets/Scripts/AssetManagement/CodeResolver/WebJsCodeProvider.cs
@@ -8,7 +8,7 @@ namespace AssetManagement.JsCodeResolver
     {
         public async UniTask<string> GetJsCodeAsync(string url, CancellationToken cancellationToken = default)
         {
-            var request = UnityWebRequest.Get(url);
+            using var request = UnityWebRequest.Get(url);
 
             await request.SendWebRequest().WithCancellation(cancellationToken);
 

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Components/SDKComponentsRegistry.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Components/SDKComponentsRegistry.cs
@@ -1,15 +1,14 @@
 ﻿using Google.Protobuf;
 using System;
 using System.Collections.Generic;
+using Utility.Pool;
 
 namespace CrdtEcsBridge.Components
 {
     public class SDKComponentsRegistry : ISDKComponentsRegistry
     {
-        private const int INITIAL_CAPACITY = 30;
-
-        private readonly Dictionary<int, SDKComponentBridge> bridges = new (INITIAL_CAPACITY);
-        private readonly Dictionary<Type, SDKComponentBridge> bridgeByType = new (INITIAL_CAPACITY);
+        private readonly Dictionary<int, SDKComponentBridge> bridges = new (PoolConstants.SDK_COMPONENT_TYPES_COUNT);
+        private readonly Dictionary<Type, SDKComponentBridge> bridgeByType = new (PoolConstants.SDK_COMPONENT_TYPES_COUNT);
 
         public SDKComponentsRegistry Add(SDKComponentBridge bridge)
         {

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRTDMessagesProvider.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRTDMessagesProvider.cs
@@ -1,17 +1,15 @@
 using CRDT.Protocol.Factory;
-using System;
 using System.Collections.Generic;
 using System.Threading;
+using Utility.Pool;
 using Utility.ThreadSafePool;
 
 namespace CrdtEcsBridge.OutgoingMessages
 {
     public class OutgoingCRTDMessagesProvider : IOutgoingCRTDMessagesProvider
     {
-        internal const int START_POOL_CAPACITY = 8;
-
         // All OutgoingCRTDMessagesProviders use this pool with a big initial capacity to prevent dynamic allocations
-        internal static readonly ThreadSafeListPool<ProcessedCRDTMessage> SHARED_POOL = new (64, START_POOL_CAPACITY);
+        internal static readonly ThreadSafeListPool<ProcessedCRDTMessage> SHARED_POOL = new (64, PoolConstants.SCENES_COUNT);
 
         private readonly List<ProcessedCRDTMessage> processedCRDTMessages;
 

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/WorldSyncCommandBufferCollectionsPool.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/WorldSynchronizer/WorldSyncCommandBufferCollectionsPool.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.Pool;
+using Utility.Pool;
 using Utility.ThreadSafePool;
 
 namespace CrdtEcsBridge.WorldSynchronizer
@@ -15,7 +16,7 @@ namespace CrdtEcsBridge.WorldSynchronizer
     internal class WorldSyncCommandBufferCollectionsPool : IDisposable
     {
         private static readonly ThreadSafeObjectPool<WorldSyncCommandBufferCollectionsPool> POOL = new (
-            () => new WorldSyncCommandBufferCollectionsPool());
+            () => new WorldSyncCommandBufferCollectionsPool(), defaultCapacity: PoolConstants.SCENES_COUNT);
 
         private Dictionary<CRDTEntity, Dictionary<int, BatchState>> mainDictionary = new (1024, CRDTEntityComparer.INSTANCE);
         private List<CRDTEntity> deletedEntities = new (256);

--- a/Explorer/Assets/Scripts/ECS/ComponentsPooling/UnityComponentPool.cs
+++ b/Explorer/Assets/Scripts/ECS/ComponentsPooling/UnityComponentPool.cs
@@ -53,7 +53,7 @@ namespace ECS.ComponentsPooling
 
         private void HandleRelease(T component)
         {
-            if (component == null)
+            if (component == null || UnityObjectUtils.IsQuitting)
                 return;
 
             onRelease?.Invoke(component);

--- a/Explorer/Assets/Scripts/ECS/ECS.asmdef
+++ b/Explorer/Assets/Scripts/ECS/ECS.asmdef
@@ -1,19 +1,20 @@
 {
-    "name": "ECS",
-    "rootNamespace": "",
-    "references": [
-        "GUID:fa7b3fdbb04d67549916da7bd2af58ab",
-        "GUID:08b2edf8f14cdd3408988fd7746b749c",
-        "GUID:3c7b57a14671040bd8c549056adc04f5",
-        "GUID:101b8b6ebaf64668909b49c4b7a1420d"
-    ],
-    "includePlatforms": [],
-    "excludePlatforms": [],
-    "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+  "name": "ECS",
+  "rootNamespace": "",
+  "references": [
+    "GUID:fa7b3fdbb04d67549916da7bd2af58ab",
+    "GUID:08b2edf8f14cdd3408988fd7746b749c",
+    "GUID:3c7b57a14671040bd8c549056adc04f5",
+    "GUID:101b8b6ebaf64668909b49c4b7a1420d",
+    "GUID:286980af24684da6acc1caa413039811"
+  ],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
 }

--- a/Explorer/Assets/Scripts/ECS/Groups/SyncedGroup.cs
+++ b/Explorer/Assets/Scripts/ECS/Groups/SyncedGroup.cs
@@ -1,5 +1,6 @@
 using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
+using SceneRunner.Scene;
 using Utility.Multithreading;
 
 namespace ECS.Groups
@@ -7,53 +8,66 @@ namespace ECS.Groups
     [UpdateInGroup(typeof(InitializationSystemGroup))]
     public partial class SyncedInitializationSystemGroup : SyncedGroup
     {
-        public SyncedInitializationSystemGroup(MutexSync mutexSync) : base(mutexSync) { }
+        public SyncedInitializationSystemGroup(MutexSync mutexSync, ISceneStateProvider sceneStateProvider) : base(mutexSync, sceneStateProvider) { }
     }
 
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial class SyncedSimulationSystemGroup : SyncedGroup
     {
-        public SyncedSimulationSystemGroup(MutexSync mutexSync) : base(mutexSync) { }
+        public SyncedSimulationSystemGroup(MutexSync mutexSync, ISceneStateProvider sceneStateProvider) : base(mutexSync, sceneStateProvider) { }
     }
 
     [UpdateInGroup(typeof(PresentationSystemGroup))]
     public partial class SyncedPresentationSystemGroup : SyncedGroup
     {
-        public SyncedPresentationSystemGroup(MutexSync mutexSync) : base(mutexSync) { }
+        public SyncedPresentationSystemGroup(MutexSync mutexSync, ISceneStateProvider sceneStateProvider) : base(mutexSync, sceneStateProvider) { }
     }
 
     [UpdateInGroup(typeof(PostRenderingSystemGroup))]
     public partial class SyncedPostRenderingSystemGroup : SyncedGroup
     {
-        public SyncedPostRenderingSystemGroup(MutexSync mutexSync) : base(mutexSync) { }
+        public SyncedPostRenderingSystemGroup(MutexSync mutexSync, ISceneStateProvider sceneStateProvider) : base(mutexSync, sceneStateProvider) { }
     }
 
     /// <summary>
-    ///     Group synchronized by mutex, unique instance for each world
+    ///     <para>Group is:</para>
+    ///     <para>Synchronized by mutex so no changes to the ECS World can be made from Systems and CRDT Bridge simultaneously;</para>
+    ///     <para>Preventing systems from running if the scene is disposing (and thus Unity objects may be already destroyed, especially critical on application exit)</para>
     /// </summary>
     public abstract class SyncedGroup : CustomGroupBase<float>
     {
         private readonly MutexSync mutexSync;
+        private readonly ISceneStateProvider sceneStateProvider;
 
-        protected SyncedGroup(MutexSync mutexSync)
+        protected SyncedGroup(MutexSync mutexSync, ISceneStateProvider sceneStateProvider)
         {
             this.mutexSync = mutexSync;
+            this.sceneStateProvider = sceneStateProvider;
         }
 
         public override void BeforeUpdate(in float t, bool throttle)
         {
+            if (sceneStateProvider.State != SceneState.Running)
+                return;
+
             using MutexSync.Scope scope = mutexSync.GetScope();
             BeforeUpdateInternal(in t, throttle);
         }
 
         public override void Update(in float t, bool throttle)
         {
+            if (sceneStateProvider.State != SceneState.Running)
+                return;
+
             using MutexSync.Scope scope = mutexSync.GetScope();
             UpdateInternal(in t, throttle);
         }
 
         public override void AfterUpdate(in float t, bool throttle)
         {
+            if (sceneStateProvider.State != SceneState.Running)
+                return;
+
             using MutexSync.Scope scope = mutexSync.GetScope();
             AfterUpdateInternal(in t, throttle);
         }

--- a/Explorer/Assets/Scripts/ECS/LifeCycle/Components/RemovedComponents.cs
+++ b/Explorer/Assets/Scripts/ECS/LifeCycle/Components/RemovedComponents.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine.Pool;
+using Utility.Pool;
+using Utility.ThreadSafePool;
 
 namespace ECS.LifeCycle.Components
 {
     public struct RemovedComponents : IDisposable
     {
+        private static readonly ThreadSafeHashSetPool<Type> POOL = new (PoolConstants.SDK_COMPONENT_TYPES_COUNT, PoolConstants.SCENES_COUNT);
+
         public readonly HashSet<Type> Set;
 
         private RemovedComponents(HashSet<Type> defaultHashSet)
@@ -17,9 +20,9 @@ namespace ECS.LifeCycle.Components
             Set.Remove(typeof(T));
 
         public static RemovedComponents CreateDefault() =>
-            new (HashSetPool<Type>.Get());
+            new (POOL.Get());
 
         public void Dispose() =>
-            HashSetPool<Type>.Release(Set);
+            POOL.Release(Set);
     }
 }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
@@ -56,9 +56,13 @@ namespace ECS.SceneLifeCycle.SceneDefinition
 
             bodyBuilder.Append("]}");
 
-            var request = UnityWebRequest.Post(intention.CommonArguments.URL, bodyBuilder.ToString(), "application/json");
-            await request.SendWebRequest().WithCancellation(ct);
-            string text = request.downloadHandler.text;
+            string text;
+
+            using (var request = UnityWebRequest.Post(intention.CommonArguments.URL, bodyBuilder.ToString(), "application/json"))
+            {
+                await request.SendWebRequest().WithCancellation(ct);
+                text = request.downloadHandler.text;
+            }
 
             await UniTask.SwitchToThreadPool();
 

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionSystem.cs
@@ -28,11 +28,16 @@ namespace ECS.SceneLifeCycle.SceneDefinition
 
         protected override async UniTask<StreamableLoadingResult<IpfsTypes.SceneEntityDefinition>> FlowInternal(GetSceneDefinition intention, IAcquiredBudget acquiredBudget, IPartitionComponent partition, CancellationToken ct)
         {
-            var wr = UnityWebRequest.Get(intention.CommonArguments.URL);
-            await wr.SendWebRequest().WithCancellation(ct);
+            string text;
 
-            // Get text on the main thread
-            string text = wr.downloadHandler.text;
+            using (var wr = UnityWebRequest.Get(intention.CommonArguments.URL))
+            {
+                await wr.SendWebRequest().WithCancellation(ct);
+
+                // Get text on the main thread
+                text = wr.downloadHandler.text;
+            }
+
             await UniTask.SwitchToThreadPool();
 
             IpfsTypes.SceneEntityDefinition sceneEntityDefinition = JsonUtility.FromJson<IpfsTypes.SceneEntityDefinition>(text);

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneFacade/Systems/LoadSceneSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneFacade/Systems/LoadSceneSystem.cs
@@ -61,7 +61,7 @@ namespace ECS.SceneLifeCycle
             // Repeat loop for this request only
             async UniTask<StreamableLoadingResult<string>> InnerFlow(SubIntention subIntention, IAcquiredBudget acquiredBudget, IPartitionComponent partition, CancellationToken ct)
             {
-                UnityWebRequest wr = await UnityWebRequest.Get(subIntention.CommonArguments.URL).SendWebRequest().WithCancellation(ct);
+                using UnityWebRequest wr = await UnityWebRequest.Get(subIntention.CommonArguments.URL).SendWebRequest().WithCancellation(ct);
                 return new StreamableLoadingResult<string>(wr.downloadHandler.text);
             }
 
@@ -112,7 +112,7 @@ namespace ECS.SceneLifeCycle
             // Repeat loop for this request only
             async UniTask<StreamableLoadingResult<string>> InnerFlow(SubIntention subIntention, IAcquiredBudget acquiredBudget, IPartitionComponent partition, CancellationToken ct)
             {
-                UnityWebRequest wr = await UnityWebRequest.Get(subIntention.CommonArguments.URL).SendWebRequest().WithCancellation(ct);
+                using UnityWebRequest wr = await UnityWebRequest.Get(subIntention.CommonArguments.URL).SendWebRequest().WithCancellation(ct);
                 return new StreamableLoadingResult<string>(wr.downloadHandler.text);
             }
 

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
@@ -54,6 +54,7 @@ namespace ECS.SceneLifeCycle.Systems
                 async UniTaskVoid RunOnThreadPool()
                 {
                     await UniTask.SwitchToThreadPool();
+                    if (destroyCancellationToken.IsCancellationRequested) return;
 
                     // Provide basic Thread Pool synchronization context
                     SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/Systems/AssetsLoadingUtility.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/Systems/AssetsLoadingUtility.cs
@@ -6,7 +6,6 @@ using ECS.StreamableLoading.Common.Components;
 using ECS.StreamableLoading.DeferredLoading.BudgetProvider;
 using System;
 using System.Threading;
-using UnityEngine.Networking;
 
 namespace ECS.StreamableLoading.Common.Systems
 {
@@ -37,26 +36,26 @@ namespace ECS.StreamableLoading.Common.Systems
 
                 catch (UnityWebRequestException unityWebRequestException)
                 {
-                    UnityWebRequest webRequest = unityWebRequestException.UnityWebRequest;
+                    // we can't access web request here as it is disposed already
 
                     // no more sources left
                     if (intention.CommonArguments.PermittedSources == AssetSource.NONE)
                     {
-                        ReportHub.LogError(reportCategory, $"Exception occured on loading {typeof(TAsset)} from {webRequest.url}");
+                        ReportHub.LogError(reportCategory, $"Exception occured on loading {typeof(TAsset)} from {intention.ToString()}");
                         ReportHub.LogException(unityWebRequestException, reportCategory);
                     }
                     else
                     {
-                        ReportHub.Log(reportCategory, $"Exception occured on loading {typeof(TAsset)} from {webRequest.url}.\n"
+                        ReportHub.Log(reportCategory, $"Exception occured on loading {typeof(TAsset)} from {intention.ToString()}.\n"
                                                       + $"Trying sources: {intention.CommonArguments.PermittedSources}");
                     }
 
                     // Decide if we can repeat or not
                     --attemptCount;
 
-                    bool isIrrecoverableError = !webRequest.IsServerError();
+                    bool isIrrecoverableError = !unityWebRequestException.IsServerError();
 
-                    if (attemptCount <= 0 || webRequest.IsAborted() || isIrrecoverableError)
+                    if (attemptCount <= 0 || unityWebRequestException.IsAborted() || isIrrecoverableError)
                     {
                         if (intention.CommonArguments.PermittedSources == AssetSource.NONE)
 

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Textures/LoadTextureSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Textures/LoadTextureSystem.cs
@@ -22,7 +22,7 @@ namespace ECS.StreamableLoading.Textures
 
         protected override async UniTask<StreamableLoadingResult<Texture2D>> FlowInternal(GetTextureIntention intention, IAcquiredBudget acquiredBudget, IPartitionComponent partition, CancellationToken ct)
         {
-            UnityWebRequest webRequest = UnityWebRequestTexture.GetTexture(intention.CommonArguments.URL, !intention.IsReadable);
+            using UnityWebRequest webRequest = UnityWebRequestTexture.GetTexture(intention.CommonArguments.URL, !intention.IsReadable);
             await webRequest.SendWebRequest().WithCancellation(ct);
             Texture2D tex = DownloadHandlerTexture.GetContent(webRequest);
             tex.wrapMode = intention.WrapMode;

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/WebRequestUtils.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/WebRequestUtils.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using ECS.StreamableLoading.Common.Components;
 using UnityEngine.Networking;
 
@@ -12,13 +13,13 @@ namespace ECS.StreamableLoading
             // Add more as needed
         }
 
-        public static bool IsServerError(this UnityWebRequest request) =>
-            request is { responseCode: >= 500 and < 600 };
+        public static bool IsServerError(this UnityWebRequestException exception) =>
+            exception is { ResponseCode: >= 500 and < 600 };
 
-        public static bool IsTimedOut(this UnityWebRequest request) =>
-            request is { error: "Request timeout" };
+        public static bool IsTimedOut(this UnityWebRequestException exception) =>
+            exception is { Error: "Request timeout" };
 
-        public static bool IsAborted(this UnityWebRequest request) =>
-            request is { result: UnityWebRequest.Result.ConnectionError or UnityWebRequest.Result.ProtocolError, error: "Request aborted" or "User Aborted" };
+        public static bool IsAborted(this UnityWebRequestException exception) =>
+            exception is { Result: UnityWebRequest.Result.ConnectionError or UnityWebRequest.Result.ProtocolError, Error: "Request aborted" or "User Aborted" };
     }
 }

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Tests/GltfContainerTestResources.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Tests/GltfContainerTestResources.cs
@@ -22,7 +22,7 @@ namespace ECS.Unity.GLTFContainer.Asset.Tests
 
         internal async UniTask<StreamableLoadingResult<AssetBundleData>> LoadAssetBundle(string hash)
         {
-            UnityWebRequest wr = UnityWebRequestAssetBundle.GetAssetBundle($"{TEST_FOLDER}{hash}");
+            using UnityWebRequest wr = UnityWebRequestAssetBundle.GetAssetBundle($"{TEST_FOLDER}{hash}");
             await wr.SendWebRequest();
             assetBundle = DownloadHandlerAssetBundle.GetContent(wr);
             return new StreamableLoadingResult<AssetBundleData>(new AssetBundleData(assetBundle, null, assetBundle.LoadAllAssets<GameObject>()));

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoader.cs
@@ -1,12 +1,10 @@
 ﻿using Cysharp.Threading.Tasks;
 using Diagnostics.ReportsHandling;
 using ECS.Prioritization;
-using SceneRunner.ECSWorld.Plugins;
 using System.Collections.Generic;
 using System.Threading;
 using Unity.Mathematics;
 using UnityEngine;
-using UnityEngine.Networking;
 using UnityEngine.Profiling;
 using Utility;
 
@@ -45,10 +43,7 @@ namespace Global.Dynamic
                 if (globalWorld == null)
                     return;
 
-                if (dynamicWorldContainer != null)
-                    await dynamicWorldContainer.RealmController.UnloadCurrentRealm(globalWorld);
-
-                globalWorld.Dispose();
+                await dynamicWorldContainer.RealmController.DisposeGlobalWorld(globalWorld).SuppressCancellationThrow();
             }
 
             DisposeAsync().Forget();

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -16,7 +16,7 @@ namespace Global.Dynamic
             IReadOnlyList<int2> staticLoadPositions, int sceneLoadRadius) =>
             new ()
             {
-                RealmController = new RealmController(sceneLoadRadius, staticLoadPositions, staticContainer.CameraSamplingData),
+                RealmController = new RealmController(sceneLoadRadius, staticLoadPositions),
                 GlobalWorldFactory = new GlobalWorldFactory(in staticContainer, realmPartitionSettings, staticContainer.CameraSamplingData, new RealmSamplingData()),
             };
     }

--- a/Explorer/Assets/Scripts/Global/Dynamic/IRealmController.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/IRealmController.cs
@@ -5,8 +5,19 @@ namespace Global.Dynamic
 {
     public interface IRealmController
     {
+        /// <summary>
+        ///     Unload the current realm and load the new one
+        /// </summary>
         UniTask SetRealm(GlobalWorld globalWorld, string realm, CancellationToken ct);
 
+        /// <summary>
+        ///     Gracefully unload the current realm
+        /// </summary>
         UniTask UnloadCurrentRealm(GlobalWorld globalWorld);
+
+        /// <summary>
+        ///     Dispose everything on application quit
+        /// </summary>
+        UniTask DisposeGlobalWorld(GlobalWorld globalWorld);
     }
 }

--- a/Explorer/Assets/Scripts/SceneRunner/ECSWorld/ECSWorldFactory.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/ECSWorld/ECSWorldFactory.cs
@@ -32,10 +32,12 @@ namespace SceneRunner.ECSWorld
             this.cameraSamplingData = cameraSamplingData;
         }
 
-        public ECSWorldFacade CreateWorld(in ECSWorldInstanceSharedDependencies sharedDependencies,
-            in ISystemGroupsUpdateGate systemGroupsUpdateGate,
-            in IPartitionComponent scenePartition)
+        public ECSWorldFacade CreateWorld(in ECSWorldFactoryArgs args)
         {
+            ISystemGroupsUpdateGate systemGroupsUpdateGate = args.SystemGroupsUpdateGate;
+            ECSWorldInstanceSharedDependencies sharedDependencies = args.SharedDependencies;
+            IPartitionComponent scenePartition = args.ScenePartition;
+
             // Worlds uses Pooled Collections under the hood so the memory impact is minimized
             var world = World.Create();
 
@@ -50,10 +52,10 @@ namespace SceneRunner.ECSWorld
                 sharedDependencies.SceneExceptionsHandler);
 
             builder
-               .InjectCustomGroup(new SyncedInitializationSystemGroup(sharedDependencies.MutexSync))
-               .InjectCustomGroup(new SyncedSimulationSystemGroup(sharedDependencies.MutexSync))
-               .InjectCustomGroup(new SyncedPresentationSystemGroup(sharedDependencies.MutexSync))
-               .InjectCustomGroup(new SyncedPostRenderingSystemGroup(sharedDependencies.MutexSync));
+               .InjectCustomGroup(new SyncedInitializationSystemGroup(sharedDependencies.MutexSync, args.SceneStateProvider))
+               .InjectCustomGroup(new SyncedSimulationSystemGroup(sharedDependencies.MutexSync, args.SceneStateProvider))
+               .InjectCustomGroup(new SyncedPresentationSystemGroup(sharedDependencies.MutexSync, args.SceneStateProvider))
+               .InjectCustomGroup(new SyncedPostRenderingSystemGroup(sharedDependencies.MutexSync, args.SceneStateProvider));
 
             var finalizeWorldSystems = new List<IFinalizeWorldSystem>(32);
 

--- a/Explorer/Assets/Scripts/SceneRunner/ECSWorld/ECSWorldFactoryArgs.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/ECSWorld/ECSWorldFactoryArgs.cs
@@ -1,0 +1,22 @@
+﻿using CrdtEcsBridge.UpdateGate;
+using ECS.Prioritization.Components;
+using SceneRunner.Scene;
+
+namespace SceneRunner.ECSWorld
+{
+    public readonly struct ECSWorldFactoryArgs
+    {
+        public readonly ECSWorldInstanceSharedDependencies SharedDependencies;
+        public readonly ISystemGroupsUpdateGate SystemGroupsUpdateGate;
+        public readonly IPartitionComponent ScenePartition;
+        public readonly ISceneStateProvider SceneStateProvider;
+
+        public ECSWorldFactoryArgs(ECSWorldInstanceSharedDependencies sharedDependencies, ISystemGroupsUpdateGate systemGroupsUpdateGate, IPartitionComponent scenePartition, ISceneStateProvider sceneStateProvider)
+        {
+            SharedDependencies = sharedDependencies;
+            SystemGroupsUpdateGate = systemGroupsUpdateGate;
+            ScenePartition = scenePartition;
+            SceneStateProvider = sceneStateProvider;
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/SceneRunner/ECSWorld/ECSWorldFactoryArgs.cs.meta
+++ b/Explorer/Assets/Scripts/SceneRunner/ECSWorld/ECSWorldFactoryArgs.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4f8815341c304248ad375c584512e6a2
+timeCreated: 1689774568

--- a/Explorer/Assets/Scripts/SceneRunner/ECSWorld/IECSWorldFactory.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/ECSWorld/IECSWorldFactory.cs
@@ -1,6 +1,3 @@
-using CrdtEcsBridge.UpdateGate;
-using ECS.Prioritization.Components;
-
 namespace SceneRunner.ECSWorld
 {
     public interface IECSWorldFactory
@@ -8,6 +5,6 @@ namespace SceneRunner.ECSWorld
         /// <summary>
         /// Create a new instance of the ECS world, all its systems and attach them to the player loop
         /// </summary>
-        ECSWorldFacade CreateWorld(in ECSWorldInstanceSharedDependencies sharedDependencies, in ISystemGroupsUpdateGate systemGroupsUpdateGate, in IPartitionComponent scenePartition);
+        ECSWorldFacade CreateWorld(in ECSWorldFactoryArgs args);
     }
 }

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/ExceptionsHandling/SceneExecutionException.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/ExceptionsHandling/SceneExecutionException.cs
@@ -12,11 +12,6 @@ namespace SceneRunner.Scene.ExceptionsHandling
         private readonly ReportData reportData;
         private string messagePrefix;
 
-        internal SceneExecutionException(Exception[] innerExceptions, ReportData reportData) : base(innerExceptions)
-        {
-            this.reportData = reportData;
-        }
-
         internal SceneExecutionException(IEnumerable<Exception> innerExceptions, ReportData reportData) : base(innerExceptions)
         {
             this.reportData = reportData;

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/Scene.asmdef
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/Scene.asmdef
@@ -1,22 +1,19 @@
 {
-  "name": "SceneRunner.Scene",
-  "rootNamespace": "",
-  "references": [
-    "GUID:f51ebe6a0ceec4240a699833d6309b23",
-    "GUID:0f4c0f120707fb74497f5d581b9858f8",
-    "GUID:d414ef88f3b15f746a4b97636b50dfb4",
-    "GUID:96825943f4e14954b5172da80fdee63d",
-    "GUID:8322ea9340a544c59ddc56d4793eac74",
-    "GUID:fa7b3fdbb04d67549916da7bd2af58ab",
-    "GUID:101b8b6ebaf64668909b49c4b7a1420d"
-  ],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": true,
-  "overrideReferences": false,
-  "precompiledReferences": [],
-  "autoReferenced": true,
-  "defineConstraints": [],
-  "versionDefines": [],
-  "noEngineReferences": false
+    "name": "SceneRunner.Scene",
+    "rootNamespace": "",
+    "references": [
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
+        "GUID:8322ea9340a544c59ddc56d4793eac74",
+        "GUID:fa7b3fdbb04d67549916da7bd2af58ab",
+        "GUID:101b8b6ebaf64668909b49c4b7a1420d"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Explorer/Assets/Scripts/SceneRunner/SceneFacade.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/SceneFacade.cs
@@ -89,41 +89,48 @@ namespace SceneRunner
             var stopWatch = new Stopwatch();
             var deltaTime = 0f;
 
-            while (true)
+            try
             {
-                if (ct.IsCancellationRequested)
+                while (true)
                 {
-                    completionSource.TrySetCanceled();
-                    break;
+                    if (ct.IsCancellationRequested)
+                    {
+                        completionSource.TrySetCanceled();
+                        break;
+                    }
+
+                    if (sceneStateProvider.State != SceneState.Running)
+                    {
+                        completionSource.TrySetResult();
+                        break;
+                    }
+
+                    stopWatch.Restart();
+
+                    // We can't guarantee that the thread is preserved between updates
+                    await runtimeInstance.UpdateScene(deltaTime);
+
+                    AssertIsNotMainThread(nameof(SceneRuntimeImpl.UpdateScene));
+
+                    // Passing ct to Task.Delay allows to break the loop immediately
+                    // as, otherwise, due to 0 or low FPS it can spin for much longer
+
+                    // Support scene freeze (0 FPS, int.MinValue)
+                    while (intervalMS < 0)
+
+                        // Just idle, don't do anything, need to wait for an actual value
+                        await Task.Delay(10, ct);
+
+                    int sleepMS = Math.Max(intervalMS - (int)stopWatch.ElapsedMilliseconds, 0);
+
+                    // We can't use Thread.Sleep as EngineAPI is called on the same thread
+                    // We can't use UniTask.Delay as this loop has nothing to do with the Unity Player Loop
+                    await Task.Delay(sleepMS, ct);
+                    AssertIsNotMainThread(nameof(Task.Delay));
+                    deltaTime = stopWatch.ElapsedMilliseconds / 1000f;
                 }
-
-                if (sceneStateProvider.State != SceneState.Running)
-                {
-                    completionSource.TrySetResult();
-                    break;
-                }
-
-                stopWatch.Restart();
-
-                // We can't guarantee that the thread is preserved between updates
-                await runtimeInstance.UpdateScene(deltaTime);
-
-                AssertIsNotMainThread(nameof(SceneRuntimeImpl.UpdateScene));
-
-                // Support scene freeze (0 FPS, int.MinValue)
-                while (intervalMS < 0)
-
-                    // Just idle, don't do anything, need to wait for an actual value
-                    await Task.Delay(10);
-
-                var sleepMS = Math.Max(intervalMS - (int)stopWatch.ElapsedMilliseconds, 0);
-
-                // We can't use Thread.Sleep as EngineAPI is called on the same thread
-                // We can't use UniTask.Delay as this loop has nothing to do with the Unity Player Loop
-                await Task.Delay(sleepMS); // No CancellationToken -> Cancel gracefully
-                AssertIsNotMainThread(nameof(Task.Delay));
-                deltaTime = stopWatch.ElapsedMilliseconds / 1000f;
             }
+            catch (OperationCanceledException) { completionSource.TrySetCanceled(); }
         }
 
         /// <summary>

--- a/Explorer/Assets/Scripts/SceneRunner/SceneFactory.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/SceneFactory.cs
@@ -79,7 +79,7 @@ namespace SceneRunner
 
             string rawSceneJsonPath = fullPath + SCENE_JSON_FILE_NAME;
 
-            var request = UnityWebRequest.Get(rawSceneJsonPath);
+            using var request = UnityWebRequest.Get(rawSceneJsonPath);
             await request.SendWebRequest().WithCancellation(ct);
 
             IpfsTypes.SceneMetadata sceneMetadata = JsonUtility.FromJson<IpfsTypes.SceneMetadata>(request.downloadHandler.text);
@@ -117,12 +117,14 @@ namespace SceneRunner
             /* Pass dependencies here if they are needed by the systems */
             var instanceDependencies = new ECSWorldInstanceSharedDependencies(sceneData, ecsToCrdtWriter, entitiesMap, exceptionsHandler, ecsMutexSync);
 
-            ECSWorldFacade ecsWorldFacade = ecsWorldFactory.CreateWorld(in instanceDependencies, systemGroupThrottler, in partitionProvider);
+            ECSWorldFacade ecsWorldFacade = ecsWorldFactory.CreateWorld(new ECSWorldFactoryArgs(instanceDependencies, systemGroupThrottler, partitionProvider, sceneStateProvider));
             ecsWorldFacade.Initialize();
 
             // Create an instance of Scene Runtime on the thread pool
             sceneData.TryGetMainScriptUrl(out string sceneCodeUrl);
             SceneRuntimeImpl sceneRuntime = await sceneRuntimeFactory.CreateByPath(sceneCodeUrl, instancePoolsProvider, ct, SceneRuntimeFactory.InstantiationBehavior.SwitchToThreadPool);
+
+            ct.ThrowIfCancellationRequested();
 
             var crdtWorldSynchronizer = new CRDTWorldSynchronizer(ecsWorldFacade.EcsWorld, sdkComponentsRegistry, entityFactory, entitiesMap);
 

--- a/Explorer/Assets/Scripts/SceneRunner/Tests/SceneFacadeShould.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Tests/SceneFacadeShould.cs
@@ -7,7 +7,6 @@ using CRDT.Serializer;
 using CrdtEcsBridge.Components;
 using CrdtEcsBridge.Engine;
 using CrdtEcsBridge.OutgoingMessages;
-using CrdtEcsBridge.UpdateGate;
 using CrdtEcsBridge.WorldSynchronizer;
 using Cysharp.Threading.Tasks;
 using ECS.LifeCycle;
@@ -53,7 +52,7 @@ namespace SceneRunner.Tests
 
             ecsWorldFactory = Substitute.For<IECSWorldFactory>();
 
-            ecsWorldFactory.CreateWorld(in Arg.Any<ECSWorldInstanceSharedDependencies>(), Arg.Any<ISystemGroupsUpdateGate>(), in Arg.Any<IPartitionComponent>())
+            ecsWorldFactory.CreateWorld(in Arg.Any<ECSWorldFactoryArgs>())
                            .Returns(_ =>
                             {
                                 var world = World.Create();

--- a/Explorer/Assets/Scripts/SceneRunner/Tests/SceneFactoryShould.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Tests/SceneFactoryShould.cs
@@ -3,7 +3,6 @@ using CRDT.Deserializer;
 using CRDT.Serializer;
 using CrdtEcsBridge.Components;
 using CrdtEcsBridge.Engine;
-using CrdtEcsBridge.UpdateGate;
 using Cysharp.Threading.Tasks;
 using ECS.Prioritization.Components;
 using NSubstitute;
@@ -43,7 +42,7 @@ namespace SceneRunner.Tests
             sceneRuntimeFactory = new SceneRuntimeFactory();
 
             ecsWorldFactory = Substitute.For<IECSWorldFactory>();
-            ecsWorldFactory.CreateWorld(Arg.Any<ECSWorldInstanceSharedDependencies>(), Arg.Any<ISystemGroupsUpdateGate>(), in Arg.Any<IPartitionComponent>()).Returns(ecsWorldFacade);
+            ecsWorldFactory.CreateWorld(in Arg.Any<ECSWorldFactoryArgs>()).Returns(ecsWorldFacade);
 
             sharedPoolsProvider = Substitute.For<ISharedPoolsProvider>();
             crdtSerializer = Substitute.For<ICRDTSerializer>();

--- a/Explorer/Assets/Scripts/Utility/Pool/PoolConstants.cs
+++ b/Explorer/Assets/Scripts/Utility/Pool/PoolConstants.cs
@@ -6,5 +6,20 @@ namespace Utility.Pool
         ///     Initial capacity of pools that should exist per scene context
         /// </summary>
         public const int SCENES_COUNT = 50;
+
+        /// <summary>
+        ///     The maximum number of scenes before everything explodes according to our expectations
+        /// </summary>
+        public const int SCENES_MAX_CAPACITY = 300;
+
+        /// <summary>
+        ///     Initial capacity of pools connected to the total number of entities per scene
+        /// </summary>
+        public const int ENTITIES_COUNT_PER_SCENE = 2000;
+
+        /// <summary>
+        ///     initial capacity of pools and collections that exist per SDK component type
+        /// </summary>
+        public const int SDK_COMPONENT_TYPES_COUNT = 30;
     }
 }


### PR DESCRIPTION
* Dispose Web Requests so they don't crash on assembly reload
* Ensure that the global scenes and worlds do not run after dispose has started
* Convert RemovedComponents to ThreadSafePool so it can be disposed and acquired simultaneously