### PR TITLE
chore: add scriptable object for dynamic scene loader settings

### DIFF
--- a/Explorer/Assets/Scenes/DynamicSceneLoading.unity
+++ b/Explorer/Assets/Scenes/DynamicSceneLoading.unity
@@ -146,13 +146,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 158563621}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &170878723
 GameObject:
@@ -185,7 +185,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1648087549}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -255,13 +254,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 234607240}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &234607243
 MonoBehaviour:
@@ -279,17 +278,8 @@ MonoBehaviour:
   scenePluginSettingsContainer: {fileID: 11400000, guid: 52a2a6abe420a8b4db9dc55df4b42e92, type: 2}
   uiToolkitRoot: {fileID: 1901323878}
   debugUiRoot: {fileID: 946305963}
-  StartPosition: {x: 0, y: 0}
-  SceneLoadRadius: 4
-  StaticLoadPositions: []
   realmLauncher: {fileID: 234607244}
-  realms:
-  - https://sdk-team-cdn.decentraland.org/ipfs/goerli-plaza-main
-  - https://sdk-team-cdn.decentraland.org/ipfs/streaming-world-main
-  - https://sdk-test-scenes.decentraland.zone
-  - https://peer.decentraland.org
-  - https://worlds-content-server.decentraland.org/world/olavra.dcl.eth
-  - https://worlds-content-server.decentraland.org/world/yemel.dcl.eth
+  settings: {fileID: 11400000, guid: 2e1d2c350e04ac3428300d032c5ee567, type: 2}
   dynamicSettings:
     <PopupCloserView>k__BackingField:
       m_AssetGUID: dbfb7e67a438449f9a887f820f733868
@@ -370,7 +360,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1648087549}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
@@ -445,7 +434,6 @@ RectTransform:
   m_Children:
   - {fileID: 619587374}
   m_Father: {fileID: 1382499186}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -485,7 +473,6 @@ RectTransform:
   m_Children:
   - {fileID: 1895623060}
   m_Father: {fileID: 1385343039}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -574,7 +561,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 527563491}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0.2}
@@ -706,13 +692,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!114 &705507996
 MonoBehaviour:
@@ -777,13 +763,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 946305962}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1277831541
 GameObject:
@@ -816,7 +802,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1431507216}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -960,13 +945,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1281082859}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1281082863
 MonoBehaviour:
@@ -1029,7 +1014,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1648087549}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1166,7 +1150,6 @@ RectTransform:
   m_Children:
   - {fileID: 527563491}
   m_Father: {fileID: 1385343039}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1294,7 +1277,6 @@ RectTransform:
   - {fileID: 603247677}
   - {fileID: 1382499186}
   m_Father: {fileID: 2095941040}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -1466,7 +1448,6 @@ RectTransform:
   - {fileID: 2095941040}
   - {fileID: 1277831542}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1506,7 +1487,6 @@ RectTransform:
   - {fileID: 446244953}
   - {fileID: 1335601610}
   m_Father: {fileID: 1895623060}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -1584,13 +1564,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1800558272}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1855600545
 GameObject:
@@ -1623,7 +1603,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2095941040}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -1698,7 +1677,6 @@ RectTransform:
   m_Children:
   - {fileID: 1648087549}
   m_Father: {fileID: 603247677}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -1745,13 +1723,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1901323877}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2042493840
 GameObject:
@@ -1784,7 +1762,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2095941040}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1923,7 +1900,6 @@ RectTransform:
   - {fileID: 1855600546}
   - {fileID: 1385343039}
   m_Father: {fileID: 1431507216}
-  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -2045,13 +2021,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2104274356}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &4363253906714060728
 PrefabInstance:
@@ -2130,3 +2106,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 402338b75b99c91409764700d1f00a6d, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 234607242}
+  - {fileID: 158563622}
+  - {fileID: 705507995}
+  - {fileID: 4363253906714060728}
+  - {fileID: 1800558273}
+  - {fileID: 1281082862}
+  - {fileID: 1901323879}
+  - {fileID: 946305964}
+  - {fileID: 1431507216}
+  - {fileID: 2104274357}

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoader.cs
@@ -4,9 +4,7 @@ using DCL.PluginSystem;
 using DCL.PluginSystem.Global;
 using DCL.Web3Authentication;
 using System;
-using System.Collections.Generic;
 using System.Threading;
-using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.UIElements;
 using Utility;
@@ -24,13 +22,9 @@ namespace Global.Dynamic
         [Space]
         [SerializeField] private UIDocument uiToolkitRoot;
         [SerializeField] private UIDocument debugUiRoot;
-        [SerializeField] private Vector2Int StartPosition;
-        [SerializeField] [Obsolete] private int SceneLoadRadius = 4;
 
-        // If it's 0, it will load every parcel in the range
-        [SerializeField] private List<int2> StaticLoadPositions;
         [SerializeField] private RealmLauncher realmLauncher;
-        [SerializeField] private string[] realms;
+        [SerializeField] private DynamicSceneLoaderSettings settings;
         [SerializeField] private DynamicSettings dynamicSettings;
 
         private StaticContainer staticContainer;
@@ -40,7 +34,7 @@ namespace Global.Dynamic
 
         private void Awake()
         {
-            realmLauncher.Initialize(realms);
+            realmLauncher.Initialize(settings.Realms);
 
             InitializationFlowAsync(destroyCancellationToken).Forget();
         }
@@ -94,8 +88,8 @@ namespace Global.Dynamic
                     scenePluginSettingsContainer,
                     ct,
                     uiToolkitRoot,
-                    StaticLoadPositions,
-                    SceneLoadRadius,
+                    settings.StaticLoadPositions,
+                    settings.SceneLoadRadius,
                     dynamicSettings,
                     web3Authenticator);
 
@@ -155,7 +149,7 @@ namespace Global.Dynamic
 
             await UniTask.SwitchToMainThread();
 
-            Vector3 characterPos = ParcelMathHelper.GetPositionByParcelPosition(StartPosition);
+            Vector3 characterPos = ParcelMathHelper.GetPositionByParcelPosition(settings.StartPosition);
             characterPos.y = 1f;
 
             globalContainer.CharacterObject.Controller.transform.position = characterPos;

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.asset
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 51b5f8f4ed664a47a7204b6a65d2d742, type: 3}
+  m_Name: DynamicSceneLoaderSettings
+  m_EditorClassIdentifier: 
+  <StartPosition>k__BackingField: {x: 0, y: 0}
+  <SceneLoadRadius>k__BackingField: 4
+  <StaticLoadPositions>k__BackingField: []
+  <Realms>k__BackingField:
+  - https://sdk-team-cdn.decentraland.org/ipfs/goerli-plaza-main
+  - https://sdk-team-cdn.decentraland.org/ipfs/streaming-world-main
+  - https://sdk-test-scenes.decentraland.zone
+  - https://peer.decentraland.org
+  - https://worlds-content-server.decentraland.org/world/olavra.dcl.eth
+  - https://worlds-content-server.decentraland.org/world/yemel.dcl.eth

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.asset.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e1d2c350e04ac3428300d032c5ee567
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace Global.Dynamic
+{
+    [CreateAssetMenu(fileName = "DynamicSceneLoaderSettings", menuName = "SO/DynamicSceneLoaderSettings")]
+    public class DynamicSceneLoaderSettings : ScriptableObject
+    {
+        [field: SerializeField] public Vector2Int StartPosition { get; private set; }
+        [field: SerializeField] [Obsolete] public int SceneLoadRadius { get; private set; } = 4;
+
+        [Tooltip("If it's 0, it will load every parcel in the range")]
+        [field: SerializeField] public List<int2> StaticLoadPositions { get; private set; }
+        [field: SerializeField] public string[] Realms { get; private set; }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 51b5f8f4ed664a47a7204b6a65d2d742
+timeCreated: 1703081743


### PR DESCRIPTION
This pull request introduces a scriptable object that contains settings from `DynamicSceneLoader`.
This makes it easier to change settings without need to update the actual scene, and makes merge conflict resolve easier.
This will also allow us to have different presets of configuration files if we need. 

![Screenshot 2023-12-20 142348](https://github.com/decentraland/unity-explorer/assets/7305682/5b79a6b9-96b5-492f-a0fd-d69f89151aff)
