### PR TITLE
chore: moved backpack settings to use asset reference

### DIFF
--- a/Explorer/Assets/DCL/Backpack/BackpackSettings.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackSettings.cs
@@ -8,12 +8,12 @@ namespace DCL.Backpack
     public class BackpackSettings
     {
         [field: SerializeField]
-        public NftTypeIconSO CategoryIconsMapping { get; private set; }
+        public AssetReferenceT<NftTypeIconSO> CategoryIconsMapping { get; private set; }
 
         [field: SerializeField]
-        public NftTypeIconSO RarityBackgroundsMapping { get; private set; }
+        public AssetReferenceT<NftTypeIconSO> RarityBackgroundsMapping { get; private set; }
 
         [field: SerializeField]
-        public NFTColorsSO RarityColorMappings { get; private set; }
+        public AssetReferenceT<NFTColorsSO> RarityColorMappings { get; private set; }
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -49,8 +49,13 @@ namespace DCL.PluginSystem.Global
             navmapController = new NavmapController(navmapView: explorePanelView.GetComponentInChildren<NavmapView>(), mapRendererContainer.MapRenderer, placesAPIService, teleportController);
             await navmapController.InitialiseAssetsAsync(assetsProvisioner, ct);
 
+            (ProvidedAsset<NFTColorsSO> rarityColorMappings, ProvidedAsset<NftTypeIconSO> categoryIconsMapping, ProvidedAsset<NftTypeIconSO> rarityBackgroundsMapping) = await UniTask.WhenAll(
+                assetsProvisioner.ProvideMainAssetAsync(backpackSettings.RarityColorMappings, ct),
+                assetsProvisioner.ProvideMainAssetAsync(backpackSettings.CategoryIconsMapping, ct),
+                assetsProvisioner.ProvideMainAssetAsync(backpackSettings.RarityBackgroundsMapping, ct));
+
             SettingsController settingsController = new SettingsController(explorePanelView.GetComponentInChildren<SettingsView>());
-            BackpackControler backpackController = new BackpackControler(explorePanelView.GetComponentInChildren<BackpackView>(), backpackSettings.RarityBackgroundsMapping, backpackSettings.CategoryIconsMapping, backpackSettings.RarityColorMappings);
+            BackpackControler backpackController = new BackpackControler(explorePanelView.GetComponentInChildren<BackpackView>(), rarityBackgroundsMapping.Value, categoryIconsMapping.Value, rarityColorMappings.Value);
 
             mvcManager.RegisterController(new ExplorePanelController(viewFactoryMethod, navmapController, settingsController, backpackController));
 

--- a/Explorer/Assets/Scenes/DynamicSceneLoading.unity
+++ b/Explorer/Assets/Scenes/DynamicSceneLoading.unity
@@ -313,9 +313,21 @@ MonoBehaviour:
         m_SubObjectType: 
         m_EditorAssetChanged: 0
     <BackpackSettings>k__BackingField:
-      <CategoryIconsMapping>k__BackingField: {fileID: 11400000, guid: 4a2a7b610414b45c1b576946ce094877, type: 2}
-      <RarityBackgroundsMapping>k__BackingField: {fileID: 11400000, guid: 04a7ffcd277754f7c91237894604f522, type: 2}
-      <RarityColorMappings>k__BackingField: {fileID: 11400000, guid: 7491e2fb7fd484d2b8aed984dfc7c6ab, type: 2}
+      <CategoryIconsMapping>k__BackingField:
+        m_AssetGUID: 4a2a7b610414b45c1b576946ce094877
+        m_SubObjectName: 
+        m_SubObjectType: 
+        m_EditorAssetChanged: 0
+      <RarityBackgroundsMapping>k__BackingField:
+        m_AssetGUID: 04a7ffcd277754f7c91237894604f522
+        m_SubObjectName: 
+        m_SubObjectType: 
+        m_EditorAssetChanged: 0
+      <RarityColorMappings>k__BackingField:
+        m_AssetGUID: 7491e2fb7fd484d2b8aed984dfc7c6ab
+        m_SubObjectName: 
+        m_SubObjectType: 
+        m_EditorAssetChanged: 0
 --- !u!114 &234607244
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Changed reference type from scriptable object in `BackpackSettings` to `AssetReference` to avoid duplication of assets that are part of addressables.
Before:
![Screenshot 2023-12-20 133218](https://github.com/decentraland/unity-explorer/assets/7305682/40b027fe-1a3c-47af-bdd1-3dd22dafcd7c)

After:
![Screenshot 2023-12-20 161248](https://github.com/decentraland/unity-explorer/assets/7305682/b3fd68b6-7e29-4739-8367-0b284649f2e7)
