### PR TITLE
fix: Initialize Stars Buffer only once to prevent leaks

### DIFF
--- a/Explorer/Assets/DCL/SkyBox/Rendering/DCL_RenderPass_GenerateSkyBox.cs
+++ b/Explorer/Assets/DCL/SkyBox/Rendering/DCL_RenderPass_GenerateSkyBox.cs
@@ -165,7 +165,9 @@ namespace DCL.SkyBox.Rendering
                 StarsComputeShader = _StarsComputeShader;
                 CubemapTextureArray = _CubemapTextureArray;
 
-                starBuffer = new ComputeBuffer(9110, Unsafe.SizeOf<StarParam>(), ComputeBufferType.Structured, ComputeBufferMode.Immutable);
+                if (starBuffer == null || !starBuffer.IsValid())
+                    starBuffer = new ComputeBuffer(9110, Unsafe.SizeOf<StarParam>(), ComputeBufferType.Structured, ComputeBufferMode.Dynamic);
+
                 starBuffer.SetData(starList_ComputeBuffer);
             }
 
@@ -343,6 +345,7 @@ namespace DCL.SkyBox.Rendering
                 m_SkyBoxCubeMap_RTHandle?.Release();
                 m_StarBoxCubeMap_RTHandle?.Release();
                 CubemapTextureArray?.Release();
+                starBuffer?.Release();
             }
 
             private struct StarParam

--- a/Explorer/Assets/DCL/SkyBox/Rendering/DCL_RenderPass_GenerateSkyBox.cs
+++ b/Explorer/Assets/DCL/SkyBox/Rendering/DCL_RenderPass_GenerateSkyBox.cs
@@ -166,9 +166,10 @@ namespace DCL.SkyBox.Rendering
                 CubemapTextureArray = _CubemapTextureArray;
 
                 if (starBuffer == null || !starBuffer.IsValid())
-                    starBuffer = new ComputeBuffer(9110, Unsafe.SizeOf<StarParam>(), ComputeBufferType.Structured, ComputeBufferMode.Dynamic);
-
-                starBuffer.SetData(starList_ComputeBuffer);
+                {
+                    starBuffer = new ComputeBuffer(9110, Unsafe.SizeOf<StarParam>(), ComputeBufferType.Structured, ComputeBufferMode.Immutable);
+                    starBuffer.SetData(starList_ComputeBuffer);
+                }
             }
 
             // This method is called before executing the render pass.


### PR DESCRIPTION
Star Buffer was leaking every frame