### PR TITLE
fix: removed italian & spanish from localization settings

### DIFF
--- a/Explorer/Assets/AddressableAssetsData/AssetGroups/Localization-Locales.asset
+++ b/Explorer/Assets/AddressableAssetsData/AssetGroups/Localization-Locales.asset
@@ -23,18 +23,6 @@ MonoBehaviour:
     m_SerializedLabels:
     - Locale
     FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: f81b53a5818cc4be9ab33b5208f77a18
-    m_Address: Italian (it)
-    m_ReadOnly: 1
-    m_SerializedLabels:
-    - Locale
-    FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: b5f53d39d15e2495eba70a31c1e4148b
-    m_Address: Spanish (es)
-    m_ReadOnly: 1
-    m_SerializedLabels:
-    - Locale
-    FlaggedDuringContentUpdateRestriction: 0
   m_ReadOnly: 1
   m_Settings: {fileID: 11400000, guid: fc8a9d2b539788c47a5b305639fa8b34, type: 2}
   m_SchemaSet:


### PR DESCRIPTION
We dont provide any content for italian and spanish languages. This is bringing some issues since we require loadings tips to be available, but it crashes if you have your system on spanish or italian.
