### PR TITLE
Chore: assets validation for missing refs

### DIFF
--- a/Explorer/Assets/DCL/Tests/Editor/ValidationTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/ValidationTests.cs
@@ -6,11 +6,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
+using UnityEditor;
 using UnityEngine;
 using static Utility.Tests.TestsCategories;
 
 namespace DCL.Tests.Editor
 {
+    [Category(VALIDATION)]
     public class ValidationTests
     {
         private static readonly HashSet<string> DEBUG_METHOD_NAMES = new () { "Log", "LogError", "LogWarning", "LogException" };
@@ -19,7 +22,6 @@ namespace DCL.Tests.Editor
         private readonly string[] excludedFileNames = { "JsonUtils.cs", "WorldSyncCommandBufferCollectionsPool.cs" };
         private readonly string[] fileNameExclusionKeywords = { "Test", "Sentry" };
 
-        [Category(VALIDATION)]
         [Test]
         public void ProjectShouldNotContainEmptyFolders()
         {
@@ -78,6 +80,47 @@ namespace DCL.Tests.Editor
                 Assert.IsEmpty(debugLogStatements, $"Debug usage found in file: {file}");
             }
         }
+
+        [Test]
+        public void CheckScriptableObjectsForMissingReferences()
+        {
+            IEnumerable<ScriptableObject> scriptableObjects = GetAllScriptableObjectsInFolder("Assets/DCL");
+
+            foreach (ScriptableObject scriptableObject in scriptableObjects)
+            {
+                if (!SerializationUtility.HasManagedReferencesWithMissingTypes(scriptableObject))
+                    continue;
+
+                ManagedReferenceMissingType[] missingTypes = SerializationUtility.GetManagedReferencesWithMissingTypes(scriptableObject);
+
+                var report = new StringBuilder();
+                var missingClasses = new HashSet<string>();
+
+                foreach (ManagedReferenceMissingType missingType in missingTypes)
+                    missingClasses.Add(MissingClassFullName(missingType));
+
+                foreach (string missingClass in missingClasses)
+                    report.Append("\t").Append(missingClass).AppendLine();
+
+                Assert.Fail($"Missing references found in the following ScriptableObjects:\n{string.Join("\n", scriptableObject)}, {report}");
+            }
+        }
+
+        private static string MissingClassFullName(ManagedReferenceMissingType missingType)
+        {
+            var description = new StringBuilder();
+
+            if (missingType.namespaceName.Length > 0)
+                description.Append(missingType.namespaceName).Append(".");
+
+            description.AppendFormat("{0}, {1}", missingType.className, missingType.assemblyName);
+            return description.ToString();
+        }
+
+        private static IEnumerable<ScriptableObject> GetAllScriptableObjectsInFolder(string folderPath) =>
+            AssetDatabase.FindAssets("t:Object", new[] { folderPath })
+                         .Select(guid => AssetDatabase.LoadAssetAtPath<ScriptableObject>(AssetDatabase.GUIDToAssetPath(guid)))
+                         .ToArray();
 
         private static bool IsDirectoryEmpty(string path) =>
             !Directory.EnumerateFileSystemEntries(path).Any();

--- a/Explorer/Assets/DCL/Tests/Editor/ValidationTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/ValidationTests.cs
@@ -82,7 +82,7 @@ namespace DCL.Tests.Editor
         }
 
         [Test]
-        public void CheckScriptableObjectsForMissingReferences()
+        public void CheckUnityObjectsForMissingReferences()
         {
             IEnumerable<ScriptableObject> scriptableObjects = GetAllScriptableObjectsInFolder("Assets/DCL");
 


### PR DESCRIPTION
Add validation test to check missing references in unity objects (static assets like prefabs or scriptable objects)