### PR TITLE
style: reduce scene's name text box width in the mini map

### DIFF
--- a/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
+++ b/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
@@ -305,8 +305,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 1.7, y: 10.5}
-  m_SizeDelta: {x: 220, y: 20}
+  m_AnchoredPosition: {x: -6, y: 10.5}
+  m_SizeDelta: {x: 204, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &874412190483968444
 CanvasRenderer:


### PR DESCRIPTION
Currently, some scene names overlap the divider line that separates it from the menu button in the mini map.
This PR reduce the width of the scene's name text box to fix that aesthetic issue which happens with large names only.

Example bellow
<img width="389" alt="Screenshot 2024-01-30 at 15 56 32" src="https://github.com/decentraland/unity-explorer/assets/51088292/03e09e9b-8902-4309-96d3-9f76462bddd1">

### How to test?
Open the client. Then go to a scene with a very large name and check that the text component on the mini map is not touching the divider line anymore.

