### PR TITLE
fix: remove spanish and italian languages

### DIFF
--- a/Explorer/Assets/AddressableAssetsData/AssetGroups/Localization-Locales.asset
+++ b/Explorer/Assets/AddressableAssetsData/AssetGroups/Localization-Locales.asset
@@ -23,18 +23,6 @@ MonoBehaviour:
     m_SerializedLabels:
     - Locale
     FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: f81b53a5818cc4be9ab33b5208f77a18
-    m_Address: Italian (it)
-    m_ReadOnly: 1
-    m_SerializedLabels:
-    - Locale
-    FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: b5f53d39d15e2495eba70a31c1e4148b
-    m_Address: Spanish (es)
-    m_ReadOnly: 1
-    m_SerializedLabels:
-    - Locale
-    FlaggedDuringContentUpdateRestriction: 0
   m_ReadOnly: 1
   m_Settings: {fileID: 11400000, guid: fc8a9d2b539788c47a5b305639fa8b34, type: 2}
   m_SchemaSet:

--- a/Explorer/Assets/AddressableAssetsData/Windows/addressables_content_state.bin.meta
+++ b/Explorer/Assets/AddressableAssetsData/Windows/addressables_content_state.bin.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 620e42c6d14e2874888cb4558dcccc0d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingScreen.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingScreen.asset
@@ -15,8 +15,6 @@ MonoBehaviour:
   m_SharedTableData: {fileID: 11400000, guid: 743a5a3b15e404426ab7c23cffec5d68, type: 2}
   m_Tables:
   - {fileID: 11400000, guid: 8812e0161b0a243b88f588a34592df12, type: 2}
-  - {fileID: 11400000, guid: 56eeae7714ca1459ab495301eae9c9af, type: 2}
-  - {fileID: 11400000, guid: 96b7969c6bd9b45c8a6feb5cc88da1dc, type: 2}
   m_Extensions: []
   m_Group: String Table
   references:


### PR DESCRIPTION
It fixes an error during the initialization because the spanish (or italian) languages didn't have its localization tables configured. The issue happened only for OS configured in spanish or italian.