### PR TITLE
fix: Introduce SafeDispose to make the destruction flow uninterruptible

### DIFF
--- a/Explorer/Assets/DCL/Utilities/DisposableUtils.cs
+++ b/Explorer/Assets/DCL/Utilities/DisposableUtils.cs
@@ -9,10 +9,7 @@ namespace DCL.Utilities
 
         public static void SafeDispose<T>(this T? disposable, ReportData reportData, Func<T, string>? exceptionMessageFactory = null) where T: IDisposable
         {
-            static string GetDefaultException(T disposable) =>
-                $"{disposable.GetType()}{DEFAULT_EXCEPTION}";
-
-            exceptionMessageFactory ??= GetDefaultException;
+            exceptionMessageFactory ??= static d => $"{d.GetType()}{DEFAULT_EXCEPTION}";
 
             try { disposable?.Dispose(); }
             catch (Exception e) { ReportHub.LogException(new Exception(exceptionMessageFactory(disposable!), e), reportData); }

--- a/Explorer/Assets/DCL/Utilities/DisposableUtils.cs
+++ b/Explorer/Assets/DCL/Utilities/DisposableUtils.cs
@@ -1,0 +1,21 @@
+using DCL.Diagnostics;
+using System;
+
+namespace DCL.Utilities
+{
+    public static class DisposableUtils
+    {
+        public const string DEFAULT_EXCEPTION = "'s thrown an exception on disposal.";
+
+        public static void SafeDispose<T>(this T? disposable, ReportData reportData, Func<T, string>? exceptionMessageFactory = null) where T: IDisposable
+        {
+            static string GetDefaultException(T disposable) =>
+                $"{disposable.GetType()}{DEFAULT_EXCEPTION}";
+
+            exceptionMessageFactory ??= GetDefaultException;
+
+            try { disposable?.Dispose(); }
+            catch (Exception e) { ReportHub.LogException(new Exception(exceptionMessageFactory(disposable!), e), reportData); }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Utilities/DisposableUtils.cs.meta
+++ b/Explorer/Assets/DCL/Utilities/DisposableUtils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 00e43a5bd1fd48819406b25222a73cc5
+timeCreated: 1707730709

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneFacade/Systems/LoadEmptySceneSystemLogic.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneFacade/Systems/LoadEmptySceneSystemLogic.cs
@@ -25,14 +25,14 @@ namespace ECS.SceneLifeCycle.Systems
         private readonly IEmptyScenesWorldFactory emptyScenesWorldFactory;
         private readonly URLAddress mappingURL;
 
-        private EmptyScenesWorld sharedWorld;
+        private EmptyScenesWorld? sharedWorld;
 
         /// <summary>
         ///     Indicates that mapping could not be loaded and the whole logic will be skipped
         /// </summary>
         public bool Inactive { get; private set; }
 
-        internal EmptySceneData emptySceneData { get; private set; }
+        internal EmptySceneData? emptySceneData { get; private set; }
 
         public LoadEmptySceneSystemLogic(
             IWebRequestController webRequestController,
@@ -70,7 +70,7 @@ namespace ECS.SceneLifeCycle.Systems
 
                     if (sharedWorld == null)
                     {
-                        sharedWorld = emptyScenesWorldFactory.Create(emptySceneData);
+                        sharedWorld = emptyScenesWorldFactory.Create(emptySceneData!);
                         sharedWorld.SystemGroupWorld.Initialize();
                     }
                 }
@@ -83,11 +83,11 @@ namespace ECS.SceneLifeCycle.Systems
 
             // pick one of available scenes randomly based on coordinates
             Vector2Int parcel = intent.DefinitionComponent.Parcels[0];
-            EmptySceneMapping choice = emptySceneData.Mappings[Mathf.Abs(parcel.GetHashCode()) % emptySceneData.Mappings.Count];
+            EmptySceneMapping choice = emptySceneData!.Mappings[Mathf.Abs(parcel.GetHashCode()) % emptySceneData.Mappings.Count];
 
             var emptyScene = EmptySceneFacade.Create(
-                new EmptySceneFacade.Args(sharedWorld.FakeEntitiesMap, sharedWorld.EcsWorld, choice, componentPoolsRegistry,
-                    ParcelMathHelper.GetPositionByParcelPosition(parcel), partition, sharedWorld.MutexSync));
+                new EmptySceneFacade.Args(sharedWorld!.FakeEntitiesMap, sharedWorld.EcsWorld, choice, componentPoolsRegistry,
+                    ParcelMathHelper.GetPositionByParcelPosition(parcel), new SceneShortInfo(parcel, "EMPTY SCENE"), partition, sharedWorld.MutexSync));
 
             return emptyScene;
         }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Tests/LoadEmptySceneSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Tests/LoadEmptySceneSystemShould.cs
@@ -3,6 +3,7 @@ using Arch.SystemGroups;
 using CommunicationData.URLHelpers;
 using CRDT;
 using CrdtEcsBridge.Components.Transform;
+using DCL.Diagnostics;
 using DCL.ECSComponents;
 using DCL.Ipfs;
 using DCL.Optimization.Pools;
@@ -114,7 +115,7 @@ namespace ECS.SceneLifeCycle.Tests
 
             var args = new EmptySceneFacade.Args(map, world,
                 new EmptySceneMapping { environment = new ContentDefinition { file = "file1" }, grass = new ContentDefinition { file = "file2" } },
-                pool, Vector3.one, partition, new MutexSync());
+                pool, Vector3.one, new SceneShortInfo(Vector2Int.zero, "EMPTY"), partition, new MutexSync());
 
             var facade = EmptySceneFacade.Create(args);
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/IRealmController.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/IRealmController.cs
@@ -25,6 +25,6 @@ namespace Global.Dynamic
         /// <summary>
         ///     Dispose everything on application quit
         /// </summary>
-        UniTask DisposeGlobalWorldAsync();
+        void DisposeGlobalWorld();
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -6,15 +6,19 @@ using DCL.AuthenticationScreenFlow;
 using DCL.AvatarRendering.Wearables;
 using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Browser;
+using DCL.Diagnostics;
 using DCL.PluginSystem;
 using DCL.PluginSystem.Global;
+using DCL.PluginSystem.World;
 using DCL.Profiles;
 using DCL.SceneLoadingScreens;
 using DCL.SkyBox;
+using DCL.Utilities;
 using DCL.Web3.Authenticators;
 using DCL.Web3.Identities;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -55,26 +59,27 @@ namespace Global.Dynamic
 
         private void OnDestroy()
         {
-            async UniTaskVoid DisposeAsync()
+            web3Authenticator.SafeDispose(ReportCategory.AUTHENTICATION);
+
+            if (dynamicWorldContainer != null)
             {
-                if (dynamicWorldContainer != null)
-                {
-                    foreach (IDCLGlobalPlugin plugin in dynamicWorldContainer.GlobalPlugins)
-                        plugin.Dispose();
+                foreach (IDCLGlobalPlugin plugin in dynamicWorldContainer.GlobalPlugins)
+                    plugin.SafeDispose(ReportCategory.ENGINE);
 
-                    if (globalWorld != null)
-                        await dynamicWorldContainer.RealmController.DisposeGlobalWorldAsync().SuppressCancellationThrow();
-                }
+                if (globalWorld != null)
+                    dynamicWorldContainer.RealmController.DisposeGlobalWorld();
 
-                dynamicWorldContainer?.Dispose();
-
-                await UniTask.SwitchToMainThread();
-
-                staticContainer?.Dispose();
-                web3Authenticator?.Dispose();
+                dynamicWorldContainer.SafeDispose(ReportCategory.ENGINE);
             }
 
-            DisposeAsync().Forget();
+            if (staticContainer != null)
+            {
+                // Exclude SharedPlugins as they were disposed as they were already disposed of as `GlobalPlugins`
+                foreach (IDCLPlugin worldPlugin in staticContainer.ECSWorldPlugins.Except<IDCLPlugin>(staticContainer.SharedPlugins))
+                    worldPlugin.SafeDispose(ReportCategory.ENGINE);
+
+                staticContainer.SafeDispose(ReportCategory.ENGINE);
+            }
         }
 
         private async UniTask InitializeFlowAsync(CancellationToken ct)

--- a/Explorer/Assets/Scripts/SceneRunner/EmptyScene/EmptySceneFacade.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/EmptyScene/EmptySceneFacade.cs
@@ -2,6 +2,7 @@
 using CRDT;
 using CrdtEcsBridge.Components.Transform;
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.ECSComponents;
 using DCL.Optimization.Pools;
 using DCL.Optimization.ThreadSafePool;
@@ -24,6 +25,8 @@ namespace SceneRunner.EmptyScene
 
         private Args args;
 
+        public SceneShortInfo Info => args.ShortInfo;
+
         internal Entity sceneRoot { get; private set; } = Entity.Null;
 
         //internal Entity grass { get; private set; } = Entity.Null;
@@ -31,10 +34,8 @@ namespace SceneRunner.EmptyScene
 
         private EmptySceneFacade() { }
 
-        public async UniTask DisposeAsync()
+        public void Dispose()
         {
-            await UniTask.SwitchToThreadPool();
-
             using (MutexSync.Scope _ = args.MutexSync.GetScope())
             {
                 // Remove from map
@@ -48,7 +49,13 @@ namespace SceneRunner.EmptyScene
 
             POOL.Release(this);
 
-            args = default;
+            args = default(Args);
+        }
+
+        public async UniTask DisposeAsync()
+        {
+            await UniTask.SwitchToThreadPool();
+            Dispose();
         }
 
         public UniTask StartUpdateLoopAsync(int targetFPS, CancellationToken ct)
@@ -129,6 +136,7 @@ namespace SceneRunner.EmptyScene
             public readonly EmptySceneMapping Mapping;
             public readonly IComponentPoolsRegistry ComponentPools;
             public readonly Vector3 BasePosition;
+            public readonly SceneShortInfo ShortInfo;
             public readonly IPartitionComponent ParentPartition;
             public readonly MutexSync MutexSync;
 
@@ -138,6 +146,7 @@ namespace SceneRunner.EmptyScene
                 EmptySceneMapping mapping,
                 IComponentPoolsRegistry componentPools,
                 Vector3 basePosition,
+                SceneShortInfo shortInfo,
                 IPartitionComponent parentPartition,
                 MutexSync mutexSync)
             {
@@ -146,6 +155,7 @@ namespace SceneRunner.EmptyScene
                 Mapping = mapping;
                 ComponentPools = componentPools;
                 BasePosition = basePosition;
+                ShortInfo = shortInfo;
                 ParentPartition = parentPartition;
                 MutexSync = mutexSync;
             }

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/ISceneFacade.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/ISceneFacade.cs
@@ -1,10 +1,14 @@
 ﻿using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
+using System;
 using System.Threading;
 
 namespace SceneRunner.Scene
 {
-    public interface ISceneFacade : IUniTaskAsyncDisposable
+    public interface ISceneFacade : IUniTaskAsyncDisposable, IDisposable
     {
+        SceneShortInfo Info { get; }
+
         /// <summary>
         ///     Start an update loop with a given FPS
         /// </summary>

--- a/Explorer/Assets/Scripts/SceneRunner/SceneFacade.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/SceneFacade.cs
@@ -5,6 +5,7 @@ using CrdtEcsBridge.OutgoingMessages;
 using CrdtEcsBridge.PoolsProviders;
 using CrdtEcsBridge.WorldSynchronizer;
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.Interaction.Utility;
 using Microsoft.ClearScript;
 using SceneRunner.ECSWorld;
@@ -36,6 +37,8 @@ namespace SceneRunner
 
         public ISceneData SceneData { get; }
 
+        public SceneShortInfo Info => SceneData.SceneShortInfo;
+
         public SceneFacade(
             ISceneRuntime runtimeInstance,
             ECSWorldFacade ecsWorldFacade,
@@ -62,6 +65,18 @@ namespace SceneRunner
             SceneData = sceneData;
         }
 
+        public void Dispose()
+        {
+            AssertMainThread(nameof(Dispose), true);
+
+            sceneStateProvider.State = SceneState.Disposing;
+            runtimeInstance.SetIsDisposing();
+
+            DisposeInternal();
+
+            sceneStateProvider.State = SceneState.Disposed;
+        }
+
         public void SetTargetFPS(int fps)
         {
             intervalMS = (int)(1000f / fps);
@@ -75,7 +90,7 @@ namespace SceneRunner
 
         public async UniTask StartUpdateLoopAsync(int targetFPS, CancellationToken ct)
         {
-            AssertIsNotMainThread(nameof(StartUpdateLoopAsync));
+            AssertMainThread(nameof(StartUpdateLoopAsync));
 
             if (sceneStateProvider.State != SceneState.NotStarted)
                 throw new ThreadStateException($"{nameof(StartUpdateLoopAsync)} is already started!");
@@ -99,7 +114,7 @@ namespace SceneRunner
                 return;
             }
 
-            AssertIsNotMainThread(nameof(SceneRuntimeImpl.StartScene));
+            AssertMainThread(nameof(SceneRuntimeImpl.StartScene));
 
             var stopWatch = new Stopwatch();
             var deltaTime = 0f;
@@ -128,7 +143,7 @@ namespace SceneRunner
 
                     sceneStateProvider.TickNumber++;
 
-                    AssertIsNotMainThread(nameof(SceneRuntimeImpl.UpdateScene));
+                    AssertMainThread(nameof(SceneRuntimeImpl.UpdateScene));
 
                     // Passing ct to Task.Delay allows to break the loop immediately
                     // as, otherwise, due to 0 or low FPS it can spin for much longer
@@ -141,7 +156,7 @@ namespace SceneRunner
                     // We can't use Thread.Sleep as EngineAPI is called on the same thread
                     // We can't use UniTask.Delay as this loop has nothing to do with the Unity Player Loop
                     await Task.Delay(sleepMS, ct);
-                    AssertIsNotMainThread(nameof(Task.Delay));
+                    AssertMainThread(nameof(Task.Delay));
                     deltaTime = stopWatch.ElapsedMilliseconds / 1000f;
                 }
             }
@@ -179,10 +194,10 @@ namespace SceneRunner
         /// </summary>
         [Conditional("UNITY_EDITOR")]
         [Conditional("DEBUG")]
-        private static void AssertIsNotMainThread(string funcName)
+        private static void AssertMainThread(string funcName, bool isMainThread = false)
         {
-            if (PlayerLoopHelper.IsMainThread)
-                throw new ThreadStateException($"Execution after calling {funcName} must be off the main thread");
+            if (PlayerLoopHelper.IsMainThread != isMainThread)
+                throw new ThreadStateException($"Execution after calling {funcName} must be {(isMainThread ? "on" : "off")} the main thread");
         }
 
         public void SetIsCurrent(bool isCurrent)
@@ -201,6 +216,13 @@ namespace SceneRunner
 
             await UniTask.SwitchToMainThread(PlayerLoopTiming.Initialization);
 
+            DisposeInternal();
+
+            sceneStateProvider.State = SceneState.Disposed;
+        }
+
+        private void DisposeInternal()
+        {
             runtimeInstance.Dispose();
             ecsWorldFacade.Dispose();
             crdtProtocol.Dispose();
@@ -210,8 +232,6 @@ namespace SceneRunner
             crdtMemoryAllocator.Dispose();
             sceneExceptionsHandler.Dispose();
             entityCollidersSceneCache.Dispose();
-
-            sceneStateProvider.State = SceneState.Disposed;
         }
     }
 }


### PR DESCRIPTION
* The destruction flow made sync as it can't be executed asynchronously in an understandable manner
* `SafeDispose` catches an exception and logs it with additional information
* All plugins and scenes now are disposed of with safety

Example of the log with the inner exception:
```
NullReferenceException: Object reference not set to an instance of an object
  at DCL.CharacterPreview.CharacterPreviewController.Dispose () [0x00001] in D:\Decentraland\unity-explorer\Explorer\Assets\DCL\CharacterPreview\CharacterPreviewController.cs:42 
  at DCL.CharacterPreview.BackpackCharacterPreviewController.Dispose () [0x000a5] in D:\Decentraland\unity-explorer\Explorer\Assets\DCL\Backpack\BackpackCharacterPreviewController.cs:76 
  at DCL.Backpack.BackpackControler.Dispose () [0x00048] in D:\Decentraland\unity-explorer\Explorer\Assets\DCL\Backpack\BackpackControler.cs:106 
  at DCL.PluginSystem.Global.ExplorePanelPlugin.Dispose () [0x0000d] in D:\Decentraland\unity-explorer\Explorer\Assets\DCL\PluginSystem\Global\ExplorePanelPlugin.cs:106 
  at DCL.Utilities.DisposableUtils.SafeDispose[T] (T disposable, DCL.Diagnostics.ReportData reportData, System.Func`2[T,TResult] exceptionMessageFactory) [0x00015] in D:\Decentraland\unity-explorer\Explorer\Assets\DCL\Utilities\DisposableUtils.cs:17 
Rethrow as AggregateException: DCL.PluginSystem.Global.ExplorePanelPlugin's thrown an exception on disposal. (Object reference not set to an instance of an object)

UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
DCL.Diagnostics.DebugLogReportHandler:LogExceptionInternal(Exception, ReportData, Object) (at Assets\DCL\PerformanceAndDiagnostics\Diagnostics\ReportsHandling\Handlers\DebugLogReportHandler.cs:98)
DCL.Diagnostics.ReportHandlerBase:LogException(Exception, ReportData, Object) (at Assets\DCL\PerformanceAndDiagnostics\Diagnostics\ReportsHandling\Handlers\ReportHandlerBase.cs:49)
DCL.Diagnostics.ReportHubLogger:LogException(Exception, ReportData, ReportHandler) (at Assets\DCL\PerformanceAndDiagnostics\Diagnostics\ReportsHandling\ReportHubLogger.cs:120)
DCL.Diagnostics.ReportHub:LogException(Exception, ReportData, ReportHandler) (at Assets\DCL\PerformanceAndDiagnostics\Diagnostics\ReportsHandling\ReportHub.cs:118)
DCL.Utilities.DisposableUtils:SafeDispose(IDCLGlobalPlugin, ReportData, Func`2) (at Assets\DCL\Utilities\DisposableUtils.cs:18)
Global.Dynamic.MainSceneLoader:OnDestroy() (at Assets\Scripts\Global\Dynamic\MainSceneLoader.cs:67)
```