### PR TITLE
polishment: diverse ux improvements

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/AuthenticationScreen.prefab
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/AuthenticationScreen.prefab
@@ -6379,7 +6379,35 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: f72622248e9201c45bae28303f6d713d, type: 2}
     - target: {fileID: 4598321510840604919, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4598321510840604919, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4598321510840604919, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4598321510840604919, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4598321510840604919, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 998
+      objectReference: {fileID: 0}
+    - target: {fileID: 4598321510840604919, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 998
+      objectReference: {fileID: 0}
+    - target: {fileID: 4598321510840604919, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
       propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4598321510840604919, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6064998454780672223, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
@@ -6412,11 +6440,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6064998454780672223, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 960
+      value: 997.35
       objectReference: {fileID: 0}
     - target: {fileID: 6064998454780672223, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 960
+      value: 997.35
       objectReference: {fileID: 0}
     - target: {fileID: 6064998454780672223, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6452,7 +6480,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6064998454780672223, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -517.35
+      value: -498.67
       objectReference: {fileID: 0}
     - target: {fileID: 6064998454780672223, guid: ef488299c2199b848ad0e35b6b5b019a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Explorer/Assets/DCL/Character/CharacterPreview/Assets/CharacterPreviewCameraSettings_LoadingScreen.asset
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/Assets/CharacterPreviewCameraSettings_LoadingScreen.asset
@@ -17,32 +17,19 @@ MonoBehaviour:
     - <verticalPosition>k__BackingField: {x: 0, y: -0.2, z: 0}
       <cameraFieldOfView>k__BackingField: 24
       <wearableCategoryEnum>k__BackingField: 4
-    <dragEnabled>k__BackingField: 0
-    <dragMovementModifier>k__BackingField: 0
-    <minVerticalOffset>k__BackingField: 0
-    <maxVerticalOffset>k__BackingField: 0
-    <scrollEnabled>k__BackingField: 0
-    <scrollModifier>k__BackingField: 0
-    <fieldOfViewThresholdForPanning>k__BackingField: 0
-    <fieldOfViewThresholdForReCentering>k__BackingField: 0
-    <fieldOfViewLimits>k__BackingField: {x: 0, y: 0}
+    <dragEnabled>k__BackingField: 1
+    <dragMovementModifier>k__BackingField: 0.3
+    <minVerticalOffset>k__BackingField: -0.84
+    <maxVerticalOffset>k__BackingField: 0.5
+    <scrollEnabled>k__BackingField: 1
+    <scrollModifier>k__BackingField: 6
+    <fieldOfViewThresholdForPanning>k__BackingField: 32
+    <fieldOfViewThresholdForReCentering>k__BackingField: 10
+    <fieldOfViewLimits>k__BackingField: {x: 40, y: 16}
     <rotationEnabled>k__BackingField: 1
     <rotationModifier>k__BackingField: 10
-  <cameraPositions>k__BackingField:
-  - <verticalPosition>k__BackingField: {x: 0, y: -0.2, z: 0}
-    <cameraFieldOfView>k__BackingField: 24
-    <wearableCategoryEnum>k__BackingField: 4
-  <dragEnabled>k__BackingField: 0
-  <dragMovementModifier>k__BackingField: 0.3
-  <minVerticalOffset>k__BackingField: -0.84
-  <maxVerticalOffset>k__BackingField: 0.5
-  <scrollEnabled>k__BackingField: 0
-  <scrollModifier>k__BackingField: 6
-  <fieldOfViewThresholdForPanning>k__BackingField: 18
-  <fieldOfViewThresholdForReCentering>k__BackingField: 10
-  <fieldOfViewLimits>k__BackingField: {x: 0, y: 0}
-  <rotationEnabled>k__BackingField: 0
-  <rotationModifier>k__BackingField: 10
   <cursorSettings>k__BackingField:
   - inputAction: 1
     cursorSprite: {fileID: 21300000, guid: d34aedda08e64344091b34deada8211e, type: 3}
+  - inputAction: 0
+    cursorSprite: {fileID: 21300000, guid: a0dd824ee2daadd46a4437a4e3145c9e, type: 3}

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewCameraController.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewCameraController.cs
@@ -103,7 +103,7 @@ namespace DCL.CharacterPreview
                     Vector3 rotation = characterPreviewAvatarContainer.rotationTarget.rotation.eulerAngles;
                     float rotationModifier = Time.deltaTime * cameraSettings.rotationModifier;
 
-                    rotation.y += pointerEventData.delta.x * rotationModifier;
+                    rotation.y -= pointerEventData.delta.x * rotationModifier;
                     var quaternion = Quaternion.Euler(rotation);
 
                     characterPreviewAvatarContainer.rotationTarget.rotation = quaternion;

--- a/Explorer/Assets/DCL/ExplorePanel/Assets/PersistentExploreOpener.prefab
+++ b/Explorer/Assets/DCL/ExplorePanel/Assets/PersistentExploreOpener.prefab
@@ -230,9 +230,9 @@ RectTransform:
   m_Father: {fileID: 816873455510436537}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -36, y: -36}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 313, y: -38.5}
   m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4787299909605144198


### PR DESCRIPTION
- The zoom & panning has been enabled on authentication screen so you can properly preview avatars that get out of screen
- Prevent avatar preview from clipping on the top on authentication screen
- Reverted direction of rotation on avatar preview
- Explore menu icon moved next to the map

# How to test?
- Go through the authentication screen
- Check your avatar is correctly previewed with no clipping
- Check you can zoom in/out with scroll and pan the camera dragging right click button
- Jump into the world
- Check the explore menu button is working as expected (next to the minimap)
- Quit the application through the system menu by clicking on your avatar's capsule. The app should close correctly without any crashes