### PR TITLE
fix: wearables not loading because of missing AB dependency

### DIFF
--- a/Explorer/Assets/StreamingAssets/AssetBundles/Wearables/dcl/scene_ignore_windows
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/Wearables/dcl/scene_ignore_windows
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b75855225775af73a83582e9b1844cbd0356e7e0473837822096a3d4397e29b3
+size 207488

--- a/Explorer/Assets/StreamingAssets/AssetBundles/Wearables/dcl/scene_ignore_windows.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/Wearables/dcl/scene_ignore_windows.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: da68179a950fea646aa7dfbd370f1b51
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Before the fix:
![image](https://github.com/decentraland/unity-explorer/assets/7646450/67e3728b-9efc-4376-957c-107fec81c08b)
After the fix:
![image](https://github.com/decentraland/unity-explorer/assets/7646450/1b41e2c5-6f38-46a9-9a6e-9a67178f3dc6)
Used profile:
`0x9dB59920d3776c2d8A3aA0CbD7b16d81FcAb0A2b`