### PR TITLE
fix: avatar wearable bounds

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
@@ -194,6 +194,9 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
             MeshRenderer meshRenderer = go.AddComponent<MeshRenderer>();
             meshRenderer.renderingLayerMask = 2;
 
+            // TODO: make a more precise calculation of bounds
+            meshRenderer.localBounds = new Bounds(Vector3.zero, Vector3.one * 5f);
+
             Object.Destroy(skin);
             return (meshRenderer, filter);
         }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -26,6 +26,7 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         protected override void Update(float t)
         {
             UpdatePlayerFirstPersonQuery(World, camera.GetCameraComponent(World));
+            UpdateWearableRendererBoundsQuery(World);
         }
 
         [Query]
@@ -42,6 +43,19 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
                 case false when !shouldBeHidden:
                     Show(ref avatarShape);
                     break;
+            }
+        }
+
+        [Query]
+        private void UpdateWearableRendererBounds(ref AvatarShapeComponent avatarShape)
+        {
+            foreach (CachedWearable wearable in avatarShape.InstantiatedWearables)
+            {
+                foreach (Renderer renderer in wearable.Renderers)
+                {
+                    if (!renderer.enabled) continue;
+                    renderer.localBounds = new Bounds(Vector3.zero, Vector3.one * 5);
+                }
             }
         }
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -26,7 +26,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         protected override void Update(float t)
         {
             UpdatePlayerFirstPersonQuery(World, camera.GetCameraComponent(World));
-            UpdateWearableRendererBoundsQuery(World);
         }
 
         [Query]
@@ -43,19 +42,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
                 case false when !shouldBeHidden:
                     Show(ref avatarShape);
                     break;
-            }
-        }
-
-        [Query]
-        private void UpdateWearableRendererBounds(ref AvatarShapeComponent avatarShape)
-        {
-            foreach (CachedWearable wearable in avatarShape.InstantiatedWearables)
-            {
-                foreach (Renderer renderer in wearable.Renderers)
-                {
-                    if (!renderer.enabled) continue;
-                    renderer.localBounds = new Bounds(Vector3.zero, Vector3.one * 5);
-                }
             }
         }
 


### PR DESCRIPTION
Avatar's hands dissapear in front of camera frustrum. Bounds of the wearable's `MeshRenderer` has been expanded to avoid culling issues.