### PR TITLE
chore: update unity builder action

### DIFF
--- a/.github/workflows/build-Mac-il2cpp.yml
+++ b/.github/workflows/build-Mac-il2cpp.yml
@@ -99,7 +99,7 @@ jobs:
             !Explorer/Library/BuildPlayerData/**
           key: Library-Explorer-IL2CPP-${{ matrix.targetPlatform }}
           
-      - uses: decentraland/unity-builder@0.7
+      - uses: decentraland/unity-builder@0.9
         id: build
         timeout-minutes: 120
         env:

--- a/.github/workflows/build-Windows-il2cpp.yml
+++ b/.github/workflows/build-Windows-il2cpp.yml
@@ -150,7 +150,7 @@ jobs:
               ls
 
 
-      - uses: decentraland/unity-builder@0.8
+      - uses: decentraland/unity-builder@0.9
         id: build
         timeout-minutes: 120
         with:

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -435,7 +435,7 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "1b6ff73eccc95157197fed7d3609ad063b212709"
+      "hash": "8e1478ec9f8fe2f5fbe1249ceeb31cdc764d1465"
     },
     "io.sentry.unity": {
       "version": "https://github.com/getsentry/unity.git#1.6.0",


### PR DESCRIPTION
- bump unity-builder version to 0.9 which removes step for importing required packages, that are not used on alpha
- bumped hash for grass shader package, this includes fix for this error `Asset Packages/decentraland.grassshader/package.json has no meta file, but it's in an immutable folder. The asset will be ignored.`