### PR TITLE
fix: deterministic terrain generation

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Config/Editor/TerrainGeneratorTestEditor.cs
+++ b/Explorer/Assets/DCL/Landscape/Config/Editor/TerrainGeneratorTestEditor.cs
@@ -7,13 +7,24 @@ namespace DCL.Landscape.Config.Editor
     [CustomEditor(typeof(TerrainGeneratorTest))]
     public class TerrainGeneratorTestEditor : UnityEditor.Editor
     {
+        private TerrainGeneratorTest generatorTest;
+
         public override void OnInspectorGUI()
         {
+            var shouldDisable = false;
+            if (generatorTest != null)
+            {
+                var generator = generatorTest.GetGenerator();
+                shouldDisable = generator != null && !generator.IsTerrainGenerated();
+            }
+
+            GUI.enabled = !shouldDisable;
             if (GUILayout.Button("Generate"))
             {
-                TerrainGeneratorTest generator = (TerrainGeneratorTest)target;
-                generator.GenerateAsync().Forget();
+                this.generatorTest = (TerrainGeneratorTest)target;
+                this.generatorTest.GenerateAsync().Forget();
             }
+            GUI.enabled = true;
 
             base.OnInspectorGUI();
         }

--- a/Explorer/Assets/DCL/Landscape/Jobs/GenerateTreeInstancesJob.cs
+++ b/Explorer/Assets/DCL/Landscape/Jobs/GenerateTreeInstancesJob.cs
@@ -17,7 +17,7 @@ namespace DCL.Landscape.Jobs
     public struct GenerateTreeInstancesJob : IJobParallelFor
     {
         private NativeParallelHashMap<int2, TreeInstance>.ParallelWriter treeInstances;
-        private Random random;
+        private NativeArray<Random> randoms;
 
         [ReadOnly] private NativeArray<float>.ReadOnly treeNoise;
         [ReadOnly] private ObjectRandomization treeRandomization;
@@ -45,7 +45,7 @@ namespace DCL.Landscape.Jobs
             int offsetZ,
             int chunkSize,
             int chunkDensity,
-            ref Random random)
+            NativeArray<Random> randoms)
         {
             this.treeNoise = treeNoise;
             this.treeInstances = treeInstances;
@@ -57,7 +57,7 @@ namespace DCL.Landscape.Jobs
             this.offsetZ = offsetZ;
             this.chunkSize = chunkSize;
             this.chunkDensity = chunkDensity;
-            this.random = random;
+            this.randoms = randoms;
 
             UP = new int2(0, 1);
             RIGHT = new int2(1, 0);
@@ -71,6 +71,7 @@ namespace DCL.Landscape.Jobs
             int y = index % chunkDensity;
 
             float value = treeNoise[index];
+            var random = randoms[index];
 
             float3 randomness = treeRandomization.GetRandomizedPositionOffset(ref random) / chunkDensity;
             float3 positionWithinTheChunk = new float3((float)x / chunkDensity, 0, (float)y / chunkDensity) + randomness;

--- a/Explorer/Assets/DCL/Landscape/Jobs/SetupRandomForParallelJobs.cs
+++ b/Explorer/Assets/DCL/Landscape/Jobs/SetupRandomForParallelJobs.cs
@@ -1,0 +1,31 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Jobs;
+using Random = Unity.Mathematics.Random;
+
+namespace DCL.Landscape.Jobs
+{
+    [BurstCompile]
+    public struct SetupRandomForParallelJobs : IJob
+    {
+        private NativeArray<Random> randoms;
+        [ReadOnly] private readonly int seed;
+
+        public SetupRandomForParallelJobs(NativeArray<Random> randoms, int seed)
+        {
+            this.randoms = randoms;
+            this.seed = seed;
+        }
+
+        public void Execute()
+        {
+            int len = randoms.Length;
+
+            for (int i = 0; i < len; i++)
+            {
+                var random = new Random((uint)(seed + i));
+                randoms[i] = random;
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Landscape/Jobs/SetupRandomForParallelJobs.cs.meta
+++ b/Explorer/Assets/DCL/Landscape/Jobs/SetupRandomForParallelJobs.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6d97ed123b6445de9891885c634e5dd8
+timeCreated: 1709828631

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Jobs;
@@ -27,6 +28,9 @@ namespace DCL.Landscape
 {
     public class TerrainGenerator : ITerrainGenerator, IDisposable
     {
+        // increment this number if we want to force the users to generate a new terrain cache
+        private const int CACHE_VERSION = 1;
+
         private const float PROGRESS_COUNTER_EMPTY_PARCEL_DATA = 0.1f;
         private const float PROGRESS_COUNTER_TERRAIN_DATA = 0.6f;
         private const float PROGRESS_COUNTER_DIG_HOLES = 0.75f;
@@ -60,6 +64,7 @@ namespace DCL.Landscape
         private Transform ocean;
         private bool isTerrainGenerated;
         private bool showTerrainByDefault;
+        private uint worldSeed;
 
         public TerrainGenerator(TerrainGenerationData terrainGenData, ref NativeArray<int2> emptyParcels, ref NativeParallelHashSet<int2> ownedParcels, bool measureTime = false, bool forceCacheRegen = false)
         {
@@ -70,7 +75,7 @@ namespace DCL.Landscape
             noiseGenCache = new NoiseGeneratorCache();
             reportData = ReportCategory.LANDSCAPE;
             timeProfiler = new TimeProfiler(measureTime);
-            localCache = new TerrainGeneratorLocalCache(terrainGenData.seed, this.terrainGenData.chunkSize);
+            localCache = new TerrainGeneratorLocalCache(terrainGenData.seed, this.terrainGenData.chunkSize, CACHE_VERSION);
             terrains = new List<Terrain>();
         }
 
@@ -96,6 +101,7 @@ namespace DCL.Landscape
             AsyncLoadProcessReport processReport = null,
             CancellationToken cancellationToken = default)
         {
+            this.worldSeed = worldSeed;
             this.hideDetails = hideDetails;
             this.hideTrees = hideTrees;
             this.showTerrainByDefault = showTerrainByDefault;
@@ -163,6 +169,9 @@ namespace DCL.Landscape
                 await UniTask.Yield();
                 AddColorMapRenderer(rootGo);
 
+                // waiting a frame to create the color map renderer created a new bug where some stones do not render properly, this should fix it
+                await BugWorkaround();
+
                 if (processReport != null) processReport.ProgressCounter.Value = 1f;
 
                 timeProfiler.EndMeasure(t => ReportHub.Log(LogType.Log, reportData, $"Terrain generation was done in {t / 1000f:F2} seconds"));
@@ -181,6 +190,17 @@ namespace DCL.Landscape
 
                 isTerrainGenerated = true;
             }
+        }
+
+        private async Task BugWorkaround()
+        {
+            foreach (Terrain terrain in terrains)
+                terrain.enabled = false;
+
+            await UniTask.Yield();
+
+            foreach (Terrain terrain in terrains)
+                terrain.enabled = true;
         }
 
         private void SpawnMiscAsync()
@@ -717,6 +737,7 @@ namespace DCL.Landscape
                 var treeInstances = new NativeParallelHashMap<int2, TreeInstance>(chunkSize * chunkSize, Allocator.Persistent);
                 var treeInvalidationMap = new NativeParallelHashMap<int2, bool>(chunkSize * chunkSize, Allocator.Persistent);
                 var treeRadiusMap = new NativeHashMap<int, float>(terrainGenData.treeAssets.Length, Allocator.Persistent);
+                var treeParallelRandoms = new NativeArray<Random>(chunkSize * chunkSize, Allocator.Persistent);
 
                 try
                 {
@@ -734,8 +755,10 @@ namespace DCL.Landscape
                         var noiseDataPointer = new NoiseDataPointer(chunkSize, offsetX, offsetZ);
                         JobHandle generatorHandle = generator.Schedule(noiseDataPointer, instancingHandle);
 
-                        NativeArray<float> resultReference = generator.GetResult(noiseDataPointer);
+                        var randomizer = new SetupRandomForParallelJobs(treeParallelRandoms, (int)worldSeed);
+                        JobHandle randomizerHandle = randomizer.Schedule(generatorHandle);
 
+                        NativeArray<float> resultReference = generator.GetResult(noiseDataPointer);
                         var treeInstancesJob = new GenerateTreeInstancesJob(
                             resultReference.AsReadOnly(),
                             treeInstances.AsParallelWriter(),
@@ -747,9 +770,9 @@ namespace DCL.Landscape
                             offsetZ,
                             chunkSize,
                             chunkSize,
-                            ref random);
+                            treeParallelRandoms);
 
-                        instancingHandle = treeInstancesJob.Schedule(resultReference.Length, 32, generatorHandle);
+                        instancingHandle = treeInstancesJob.Schedule(resultReference.Length, 32, randomizerHandle);
                     }
 
                     await instancingHandle.ToUniTask(PlayerLoopTiming.Update).AttachExternalCancellation(cancellationToken);
@@ -786,6 +809,7 @@ namespace DCL.Landscape
                     treeInstances.Dispose();
                     treeInvalidationMap.Dispose();
                     treeRadiusMap.Dispose();
+                    treeParallelRandoms.Dispose();
                 }
             }
         }

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -170,7 +170,7 @@ namespace DCL.Landscape
                 AddColorMapRenderer(rootGo);
 
                 // waiting a frame to create the color map renderer created a new bug where some stones do not render properly, this should fix it
-                await BugWorkaround();
+                await BugWorkaroundAsync();
 
                 if (processReport != null) processReport.ProgressCounter.Value = 1f;
 
@@ -192,7 +192,7 @@ namespace DCL.Landscape
             }
         }
 
-        private async Task BugWorkaround()
+        private async Task BugWorkaroundAsync()
         {
             foreach (Terrain terrain in terrains)
                 terrain.enabled = false;

--- a/Explorer/Assets/DCL/Landscape/TerrainGeneratorTest.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGeneratorTest.cs
@@ -20,11 +20,15 @@ namespace DCL.Landscape
 
         private NativeParallelHashSet<int2> ownedParcels;
         private NativeArray<int2> emptyParcels;
+        private TerrainGenerator gen;
 
         private void Start()
         {
             GenerateAsync().Forget();
         }
+
+        public TerrainGenerator GetGenerator() =>
+            gen;
 
         [ContextMenu("Generate")]
         public async UniTask GenerateAsync()
@@ -32,7 +36,7 @@ namespace DCL.Landscape
             ownedParcels = parcelData.GetOwnedParcels();
             emptyParcels = parcelData.GetEmptyParcels();
 
-            var gen = new TerrainGenerator(genData, ref emptyParcels, ref ownedParcels, true, clearCache);
+            gen = new TerrainGenerator(genData, ref emptyParcels, ref ownedParcels, true, clearCache);
             await gen.GenerateTerrainAsync(worldSeed, digHoles, centerTerrain, hideTrees, hideDetails, true);
 
             emptyParcels.Dispose();

--- a/Explorer/Assets/DCL/Landscape/Utils/TerrainGeneratorLocalCache.cs
+++ b/Explorer/Assets/DCL/Landscape/Utils/TerrainGeneratorLocalCache.cs
@@ -68,9 +68,9 @@ namespace DCL.Landscape.Utils
 
         private TerrainLocalCache() { }
 
-        public void SaveToFile(int seed, int chunkSize)
+        public void SaveToFile(int seed, int chunkSize, int version)
         {
-            string path = GetPath(seed, chunkSize);
+            string path = GetPath(seed, chunkSize, version);
 
             if (File.Exists(path))
                 File.Delete(path);
@@ -81,14 +81,14 @@ namespace DCL.Landscape.Utils
             formatter.Serialize(fileStream, this);
         }
 
-        private static string GetPath(int seed, int chunkSize) =>
-            Application.persistentDataPath + FILE_NAME + $"_{seed}_{chunkSize}.data";
+        private static string GetPath(int seed, int chunkSize, int version) =>
+            Application.persistentDataPath + FILE_NAME + $"_{seed}_{chunkSize}_v{version}.data";
 
-        public static async UniTask<TerrainLocalCache> LoadAsync(int seed, int chunkSize, bool force)
+        public static async UniTask<TerrainLocalCache> LoadAsync(int seed, int chunkSize, int version, bool force)
         {
             var localCache = new TerrainLocalCache();
 
-            string path = GetPath(seed, chunkSize);
+            string path = GetPath(seed, chunkSize, version);
 
             if (force && File.Exists(path))
                 File.Delete(path);
@@ -118,21 +118,23 @@ namespace DCL.Landscape.Utils
         private readonly bool isValid;
         private readonly int seed;
         private readonly int chunkSize;
+        private readonly int version;
 
-        public TerrainGeneratorLocalCache(int seed, int chunkSize)
+        public TerrainGeneratorLocalCache(int seed, int chunkSize, int version)
         {
             this.seed = seed;
             this.chunkSize = chunkSize;
+            this.version = version;
         }
 
         public async UniTask LoadAsync(bool force)
         {
-            localCache = await TerrainLocalCache.LoadAsync(seed, chunkSize, force);
+            localCache = await TerrainLocalCache.LoadAsync(seed, chunkSize, version, force);
         }
 
         public void Save()
         {
-            localCache.SaveToFile(seed, chunkSize);
+            localCache.SaveToFile(seed, chunkSize, version);
         }
 
         public bool IsValid() =>


### PR DESCRIPTION
# Description

Fixed trees & stones are not being deterministically placed at the same position on every client due to a race condition with `Random` usage in `IJobParallelFor` jobs.

The random is now being created for each chunk position using the seed and its index to be used during the parallel job, deterministically working for every seed.

