### PR TITLE
fix: Each individual coordinate can be either an array or a plain value

### DIFF
--- a/Explorer/Assets/DCL/Ipfs/SceneMetadata.cs
+++ b/Explorer/Assets/DCL/Ipfs/SceneMetadata.cs
@@ -15,30 +15,30 @@ namespace DCL.Ipfs
         public List<SpawnPoint>? spawnPoints;
 
         [Serializable]
-        [JsonConverter(typeof(SpawnPointConverter))]
         public struct SpawnPoint
         {
             public string name;
 
             public bool @default;
 
-            [field: NonSerialized] public SinglePosition? SP { get; internal set; }
-            [field: NonSerialized] public MultiPosition? MP { get; internal set; }
+            public Position position;
 
             [Serializable]
-            public struct SinglePosition
+            public struct Position
             {
-                public float x;
-                public float y;
-                public float z;
+                public Coordinate x;
+                public Coordinate y;
+                public Coordinate z;
             }
 
-            [Serializable]
-            public struct MultiPosition
+            /// <summary>
+            /// Coordinates is either a single value or a list of values
+            /// </summary>
+            [JsonConverter(typeof(SpawnPointCoordinateConverter))]
+            public struct Coordinate
             {
-                public float[] x;
-                public float[] y;
-                public float[] z;
+                public float? SingleValue { get; internal set; }
+                public float[]? MultiValue { get; internal set; }
             }
         }
     }

--- a/Explorer/Assets/DCL/Ipfs/SpawnPointConverter.cs
+++ b/Explorer/Assets/DCL/Ipfs/SpawnPointConverter.cs
@@ -7,36 +7,20 @@ namespace DCL.Ipfs
     /// <summary>
     ///     Provides support for polymorphic definition of "position"
     /// </summary>
-    public class SpawnPointConverter : JsonConverter<SceneMetadata.SpawnPoint>
+    public class SpawnPointCoordinateConverter : JsonConverter<SceneMetadata.SpawnPoint.Coordinate>
     {
-        public override bool CanWrite => false;
-
-        public override void WriteJson(JsonWriter writer, SceneMetadata.SpawnPoint value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, SceneMetadata.SpawnPoint.Coordinate value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }
 
-        public override SceneMetadata.SpawnPoint ReadJson(JsonReader reader, Type objectType, SceneMetadata.SpawnPoint existingValue, bool hasExistingValue, JsonSerializer serializer)
+        public override SceneMetadata.SpawnPoint.Coordinate ReadJson(JsonReader reader, Type objectType, SceneMetadata.SpawnPoint.Coordinate existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            var jsonObject = JObject.Load(reader);
-            var spawnPoint = new SceneMetadata.SpawnPoint();
+            var token = JToken.Load(reader);
 
-            spawnPoint.name = jsonObject["name"].Value<string>();
-            JToken position = jsonObject["position"];
-
-            // Check if 'position' is an array or a single object
-            if (position["x"].Type == JTokenType.Array)
-            {
-                // Deserialize as MultiPosition
-                spawnPoint.MP = position.ToObject<SceneMetadata.SpawnPoint.MultiPosition>();
-            }
-            else
-            {
-                // Deserialize as SinglePosition
-                spawnPoint.SP = position.ToObject<SceneMetadata.SpawnPoint.SinglePosition>();
-            }
-
-            return spawnPoint;
+            return token.Type == JTokenType.Array
+                ? new SceneMetadata.SpawnPoint.Coordinate { MultiValue = token.ToObject<float[]>() }
+                : new SceneMetadata.SpawnPoint.Coordinate { SingleValue = token.ToObject<float>() };
         }
     }
 }

--- a/Explorer/Assets/DCL/ParcelsService/TeleportController.cs
+++ b/Explorer/Assets/DCL/ParcelsService/TeleportController.cs
@@ -158,30 +158,31 @@ namespace DCL.ParcelsService
 
         private static Vector3 GetOffsetFromSpawnPoint(SceneMetadata.SpawnPoint spawnPoint)
         {
-            if (spawnPoint.SP != null)
+            static float GetMidPoint(float[] coordArray)
             {
-                SceneMetadata.SpawnPoint.SinglePosition val = spawnPoint.SP.Value;
-                return new Vector3(val.x, val.y, val.z);
+                var sum = 0f;
+
+                for (var i = 0; i < coordArray.Length; i++)
+                    sum += (int)coordArray[i];
+
+                return sum / coordArray.Length;
             }
 
-            if (spawnPoint.MP != null)
+            static float? GetSpawnComponent(SceneMetadata.SpawnPoint.Coordinate coordinate)
             {
-                static float GetMidPoint(float[] coordArray)
-                {
-                    var sum = 0f;
+                if (coordinate.SingleValue != null)
+                    return coordinate.SingleValue.Value;
 
-                    for (var i = 0; i < coordArray.Length; i++)
-                        sum += (int)coordArray[i];
+                if (coordinate.MultiValue != null)
+                    return GetMidPoint(coordinate.MultiValue);
 
-                    return sum / coordArray.Length;
-                }
-
-                SceneMetadata.SpawnPoint.MultiPosition val = spawnPoint.MP.Value;
-                return new Vector3(GetMidPoint(val.x), GetMidPoint(val.y), GetMidPoint(val.z));
+                return null;
             }
 
-            // Center
-            return new Vector3(ParcelMathHelper.PARCEL_SIZE / 2f, 0, ParcelMathHelper.PARCEL_SIZE / 2f);
+            return new Vector3(
+                GetSpawnComponent(spawnPoint.position.x) ?? ParcelMathHelper.PARCEL_SIZE / 2f,
+                GetSpawnComponent(spawnPoint.position.y) ?? 0,
+                GetSpawnComponent(spawnPoint.position.z) ?? ParcelMathHelper.PARCEL_SIZE / 2f);
         }
 
         [Query]


### PR DESCRIPTION
Fixes inability to teleport to the spawn point. E.g. `(-9, 91)` coordinate