### PR TITLE
fix: missing scoped registry in package manager settings for animation sequencer package

### DIFF
--- a/Explorer/ProjectSettings/PackageManagerSettings.asset
+++ b/Explorer/ProjectSettings/PackageManagerSettings.asset
@@ -34,6 +34,7 @@ MonoBehaviour:
     - com.coffee.ui-particle
     - com.atteneder.draco
     - com.madsbangh.easybuttons
+    - com.brunomikoski
     m_IsDefault: 0
     m_Capabilities: 0
     m_ConfigSource: 4
@@ -42,6 +43,6 @@ MonoBehaviour:
   m_RegistryInfoDraft:
     m_Modified: 0
     m_ErrorMessage: 
-    m_UserModificationsInstanceId: -838
-    m_OriginalInstanceId: -840
+    m_UserModificationsInstanceId: -834
+    m_OriginalInstanceId: -838
   m_LoadAssets: 0


### PR DESCRIPTION
### WHY
Since [the commit](https://github.com/decentraland/unity-explorer/commit/ec5495c40662dc435b7b3f041c061e98f6075ee2) that adds the "Animation Sequencer" unity package in the unity project, I haven't been able to load the unity project at all (I use a macbook pro intel 2019).

It stays in the following frozen state forever:
<img width="448" alt="Screen Shot 2024-04-02 at 08 29 00" src="https://github.com/decentraland/unity-explorer/assets/1031741/388045fc-aa0f-44bb-8b10-027ed5442b8f">

### WHAT
Replicating the adding of the desired package from the previous commit to the one that added it, following [the package official instructions](https://github.com/brunomikoski/Animation-Sequencer#how-to-install) I saw that there was a "registry scope" step that modified the PackageManagerSettings file (`Explorer/ProjectSettings/PackageManagerSettings.asset`) and that change hadn't been pushed in [the original commit ](https://github.com/decentraland/unity-explorer/commit/ec5495c40662dc435b7b3f041c061e98f6075ee2).

So I added that change manually and now I can load the project again.