### PR TITLE
fix: authentication urls & dApp avatar preview

### DIFF
--- a/Explorer/Assets/DCL/Web3/Authenticators/DappWeb3Authenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/DappWeb3Authenticator.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnityEngine;
 
 namespace DCL.Web3.Authenticators
 {
@@ -261,10 +262,23 @@ namespace DCL.Web3.Authenticators
 
             public Default(IWeb3IdentityCache identityCache)
             {
+#if !UNITY_EDITOR
+                string serverUrl = Debug.isDebugBuild
+                    ? "https://auth-api.decentraland.zone"
+                    : "https://auth-api.decentraland.org";
+
+                string signatureUrl = Debug.isDebugBuild
+                    ? "https://decentraland.zone/auth/requests"
+                    : "https://decentraland.org/auth/requests";
+#else
+                const string serverUrl = "https://auth-api.decentraland.org";
+                const string signatureUrl = "https://decentraland.org/auth/requests";
+#endif
+
                 var origin = new DappWeb3Authenticator(
                     new UnityAppWebBrowser(),
-                    "https://auth-api.decentraland.zone",
-                    "https://decentraland.zone/auth/requests",
+                    serverUrl,
+                    signatureUrl,
                     identityCache,
                     new HashSet<string>(
                         new[]

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.asset
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.asset
@@ -13,7 +13,6 @@ MonoBehaviour:
   m_Name: DynamicSceneLoaderSettings
   m_EditorClassIdentifier: 
   <StartPosition>k__BackingField: {x: 0, y: 0}
-  <SceneLoadRadius>k__BackingField: 4
   <StaticLoadPositions>k__BackingField: []
   <Realms>k__BackingField:
   - https://sdk-team-cdn.decentraland.org/ipfs/goerli-plaza-main
@@ -24,8 +23,10 @@ MonoBehaviour:
   - https://worlds-content-server.decentraland.org/world/yemel.dcl.eth
   - https://worlds-content-server.decentraland.org/world/MetadyneLabs.dcl.eth
   - http://127.0.0.1:8000
-  <AuthWebSocketUrl>k__BackingField: https://auth-api.decentraland.zone
-  <AuthSignatureUrl>k__BackingField: https://decentraland.zone/auth/requests
+  <AuthWebSocketUrl>k__BackingField: https://auth-api.decentraland.org
+  <AuthWebSocketUrlDev>k__BackingField: https://auth-api.decentraland.zone
+  <AuthSignatureUrl>k__BackingField: https://decentraland.org/auth/requests
+  <AuthSignatureUrlDev>k__BackingField: https://decentraland.zone/auth/requests
   <Web3WhitelistMethods>k__BackingField:
   - eth_sendTransaction
   - eth_getTransactionReceipt

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.cs
@@ -14,7 +14,9 @@ namespace Global.Dynamic
         [field: SerializeField] public List<int2> StaticLoadPositions { get; private set; }
         [field: SerializeField] public List<string> Realms { get; private set; }
         [field: SerializeField] public string AuthWebSocketUrl { get; private set; }
+        [field: SerializeField] public string AuthWebSocketUrlDev { get; private set; }
         [field: SerializeField] public string AuthSignatureUrl { get; private set; }
+        [field: SerializeField] public string AuthSignatureUrlDev { get; private set; }
         [field: SerializeField] public List<string> Web3WhitelistMethods { get; private set; }
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -11,7 +11,6 @@ using DCL.PluginSystem.Global;
 using DCL.Utilities;
 using DCL.Web3.Authenticators;
 using DCL.Web3.Identities;
-using DCL.WebRequests;
 using MVC;
 using System;
 using System.Collections.Generic;
@@ -110,9 +109,22 @@ namespace Global.Dynamic
                 identityCache = new ProxyIdentityCache(new MemoryWeb3IdentityCache(),
                     new PlayerPrefsIdentityProvider(new PlayerPrefsIdentityProvider.DecentralandIdentityWithNethereumAccountJsonSerializer()));
 
+#if !UNITY_EDITOR
+                string authServerUrl = Debug.isDebugBuild
+                    ? settings.AuthWebSocketUrlDev
+                    : settings.AuthWebSocketUrl;
+
+                string authSignatureUrl = Debug.isDebugBuild
+                    ? settings.AuthSignatureUrlDev
+                    : settings.AuthSignatureUrl;
+#else
+                string authServerUrl = settings.AuthWebSocketUrl;
+                string authSignatureUrl = settings.AuthSignatureUrl;
+#endif
+
                 web3VerifiedAuthenticator = new DappWeb3Authenticator(new UnityAppWebBrowser(),
-                    settings.AuthWebSocketUrl,
-                    settings.AuthSignatureUrl,
+                    authServerUrl,
+                    authSignatureUrl,
                     identityCache,
                     new HashSet<string>(settings.Web3WhitelistMethods));
 


### PR DESCRIPTION
Sets the authentication urls to `org` which is currently prod. Allows to set a secondary development url for development builds.

# Test steps

1. Open the app and follow the authentication process
2. When redirected to the web browser to sign the request observe that your avatar has your wearables
3. Continue through the authentication process, everything should keep working as expected