### PR TITLE
feat: non-square resolution support

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayContainer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayContainer.cs
@@ -38,7 +38,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
                 // Check if the texture is present in the original material
                 var tex = originalMaterial.GetTexture(mapping.OriginalTextureID) as Texture2D;
                 if (tex)
-                    results[i] = mapping.Handler.SetTexture(targetMaterial, tex, tex.width);
+                    results[i] = mapping.Handler.SetTexture(targetMaterial, tex, new Vector2Int(tex.width, tex.height));
                 else
                    mapping.Handler.SetDefaultTexture(targetMaterial, mapping.DefaultFallbackResolution);
             }
@@ -55,7 +55,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
                 TextureArrayMapping mapping = mappings[i];
 
                 if (textures.TryGetValue(mapping.OriginalTextureID, out var texture))
-                    results[i] = mapping.Handler.SetTexture(targetMaterial, texture as Texture2D, texture.width);
+                    results[i] = mapping.Handler.SetTexture(targetMaterial, texture as Texture2D, new Vector2Int(texture.width, texture.height));
                 else
                     mapping.Handler.SetDefaultTexture(targetMaterial, mapping.DefaultFallbackResolution);
             }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayHandler.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayHandler.cs
@@ -15,7 +15,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
         internal readonly int arrayID;
         internal readonly int textureID;
 
-        private readonly Dictionary<int, TextureArraySlotHandler> handlersByResolution;
+        private readonly Dictionary<Vector2Int, TextureArraySlotHandler> handlersByResolution;
         private readonly int minArraySize;
         private readonly int initialCapacityForEachResolution;
         private readonly TextureFormat textureFormat;
@@ -38,13 +38,14 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             this.defaultTextures = defaultTextures;
             this.initialCapacityForEachResolution = initialCapacityForEachResolution;
 
-            handlersByResolution = new Dictionary<int, TextureArraySlotHandler>(defaultResolutions.Count);
+            handlersByResolution = new Dictionary<Vector2Int, TextureArraySlotHandler>(defaultResolutions.Count);
 
+            //Default resolutions are always squared
             for (var i = 0; i < defaultResolutions.Count; i++)
-                CreateHandler(defaultResolutions[i]);
+                CreateHandler(new Vector2Int(defaultResolutions[i], defaultResolutions[i]));
         }
 
-        private TextureArraySlotHandler CreateHandler(int resolution)
+        private TextureArraySlotHandler CreateHandler(Vector2Int resolution)
         {
             var slotHandler = new TextureArraySlotHandler(resolution, minArraySize, initialCapacityForEachResolution, textureFormat);
             handlersByResolution[resolution] = slotHandler;
@@ -59,10 +60,12 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             return slotHandler;
         }
 
-        internal TextureArraySlotHandler GetOrCreateSlotHandler(int resolution) =>
-            handlersByResolution.TryGetValue(resolution, out var slotHandler) ? slotHandler : CreateHandler(resolution);
+        internal TextureArraySlotHandler GetOrCreateSlotHandler(Vector2Int resolution)
+        {
+            return handlersByResolution.TryGetValue(resolution, out var slotHandler) ? slotHandler : CreateHandler(resolution);
+        }
 
-        public TextureArraySlot SetTexture(Material material, Texture2D texture, int resolution)
+        public TextureArraySlot SetTexture(Material material, Texture2D texture, Vector2Int resolution)
         {
             TextureArraySlot slot = GetOrCreateSlotHandler(resolution).GetNextFreeSlot();
             var mipLevel = 0;
@@ -77,13 +80,16 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             return slot;
         }
 
-        internal Texture2DArray GetDefaultTextureArray(int resolution) => GetOrCreateSlotHandler(resolution).arrays[DEFAULT_SLOT_INDEX];
+        internal Texture2DArray GetDefaultTextureArray(Vector2Int resolution)
+        {
+            return GetOrCreateSlotHandler(resolution).arrays[DEFAULT_SLOT_INDEX];
+        }
 
         public void SetDefaultTexture(Material material, int resolution)
         {
             // Default slot is always zero
-
-            var defaultSlotArray = GetDefaultTextureArray(resolution);
+            // Default textures are always squared
+            var defaultSlotArray = GetDefaultTextureArray(new Vector2Int(resolution, resolution));
 
             material.SetInteger(arrayID, DEFAULT_SLOT_INDEX);
             material.SetTexture(textureID, defaultSlotArray);

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayKey.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayKey.cs
@@ -6,12 +6,18 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
     public readonly struct TextureArrayKey : IEquatable<TextureArrayKey>
     {
         public readonly int Id;
-        public readonly int Resolution;
+        public readonly Vector2Int Resolution;
 
-        public TextureArrayKey(int id, int resolution)
+        public TextureArrayKey(int id, Vector2Int resolution)
         {
             Id = id;
             Resolution = resolution;
+        }
+
+        public TextureArrayKey(int id, int squareResolution)
+        {
+            Id = id;
+            Resolution = new Vector2Int(squareResolution, squareResolution);
         }
 
         public bool Equals(TextureArrayKey other) =>

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArraySlotHandler.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArraySlotHandler.cs
@@ -8,11 +8,11 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
         internal readonly List<Texture2DArray> arrays;
         internal readonly Stack<TextureArraySlot> freeSlots;
         private readonly int minArraySize;
-        private readonly int resolution;
+        private readonly Vector2Int resolution;
         private int nextFreeIndex;
         private TextureFormat textureFormat;
 
-        public TextureArraySlotHandler(int resolution, int minArraySize, int initialCapacity, TextureFormat textureFormat)
+        public TextureArraySlotHandler(Vector2Int resolution, int minArraySize, int initialCapacity, TextureFormat textureFormat)
         {
             this.minArraySize = minArraySize;
             this.resolution = resolution;
@@ -40,7 +40,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
 
         private Texture2DArray CreateTexture2DArray()
         {
-            var texture2DArray = new Texture2DArray(resolution, resolution, minArraySize, textureFormat, false, false);
+            var texture2DArray = new Texture2DArray(resolution.x, resolution.y, minArraySize, textureFormat, false, false);
             texture2DArray.filterMode = FilterMode.Bilinear;
             texture2DArray.wrapMode = TextureWrapMode.Repeat;
             texture2DArray.anisoLevel = 9;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/TextureArrayShouldBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/TextureArrayShouldBase.cs
@@ -60,7 +60,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             foreach (var textureArrayMapping in textureArrayContainer.mappings)
             {
                 Assert.AreEqual(TextureArrayHandler.DEFAULT_SLOT_INDEX, testTargetMaterial.GetInteger(textureArrayMapping.Handler.arrayID));
-                Assert.AreEqual(textureArrayMapping.Handler.GetDefaultTextureArray(TEST_RESOLUTION), testTargetMaterial.GetTexture(textureArrayMapping.Handler.textureID));
+                Assert.AreEqual(textureArrayMapping.Handler.GetDefaultTextureArray(new Vector2Int(TEST_RESOLUTION, TEST_RESOLUTION)), testTargetMaterial.GetTexture(textureArrayMapping.Handler.textureID));
             }
         }
 
@@ -78,7 +78,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
                 TextureArraySlot slotVal = slot.Value;
 
                 Assert.AreEqual(slotVal.UsedSlotIndex, 1);
-                Assert.AreEqual(slotVal.TextureArray, textureArrayContainer.mappings[i].Handler.GetOrCreateSlotHandler(TEST_RESOLUTION).arrays[0]);
+                Assert.AreEqual(slotVal.TextureArray, textureArrayContainer.mappings[i].Handler.GetOrCreateSlotHandler(new Vector2Int(TEST_RESOLUTION, TEST_RESOLUTION)).arrays[0]);
             }
         }
 
@@ -95,7 +95,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
 
                 slot.Value.FreeSlot();
 
-                Assert.AreEqual(textureArrayContainer.mappings[i].Handler.GetOrCreateSlotHandler(TEST_RESOLUTION).freeSlots.Count, 1);
+                Assert.AreEqual(textureArrayContainer.mappings[i].Handler.GetOrCreateSlotHandler(new Vector2Int(TEST_RESOLUTION, TEST_RESOLUTION)).freeSlots.Count, 1);
             }
 
             var replacedSlots = textureArrayContainer.SetTexturesFromOriginalMaterial(testSourceMaterial, testTargetMaterial);

--- a/Explorer/Assets/DCL/AvatarRendering/DemoScripts/Systems/InstantiateRandomAvatarsSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/DemoScripts/Systems/InstantiateRandomAvatarsSystem.cs
@@ -31,6 +31,7 @@ using ECS.Prioritization.Components;
 using ECS.StreamableLoading.Common.Components;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Pool;
 using Utility;
@@ -65,6 +66,7 @@ namespace DCL.AvatarRendering.DemoScripts.Systems
         private int avatarIndex;
 
         private bool requestDone;
+        private int lastIndexInstantiated;
         private readonly AvatarRandomizerAsset avatarRandomizerAsset;
 
         internal InstantiateRandomAvatarsSystem(
@@ -91,6 +93,10 @@ namespace DCL.AvatarRendering.DemoScripts.Systems
                         .AddSingleButton("Destroy All Avatars", DestroyAllAvatars)
                         .AddSingleButton("Destroy Random Amount of Avatars", DestroyRandomAmountOfAvatars)
                         .AddSingleButton("Randomize Wearables of Avatars", RandomizeWearablesOfAvatars);
+
+            debugBuilder.AddWidget("Avatar Creator")
+                .AddStringFieldsWithConfirmation(3, "Instantiate Male", InstantiateMaleAvatar)
+                .AddStringFieldsWithConfirmation(3, "Instantiate Female", InstantiateFemaleAvatar);
         }
 
         public override void Initialize()
@@ -98,6 +104,22 @@ namespace DCL.AvatarRendering.DemoScripts.Systems
             camera = World.CacheCamera();
             defaultWearableState = World.CacheDefaultWearablesState();
             settings = World.CacheCharacterSettings();
+        }
+
+        private void InstantiateMaleAvatar(string[] urn)
+        {
+            var cameraPosition = camera.GetCameraComponent(World).Camera.transform.position;
+            CreateAvatar(settings.GetCharacterSettings(World), cameraPosition.x, cameraPosition.z, urn.Where(s => !string.IsNullOrEmpty(s)).ToList(),
+                BodyShape.MALE, lastIndexInstantiated, 1);
+            lastIndexInstantiated++;
+        }
+
+        private void InstantiateFemaleAvatar(string[] urn)
+        {
+            var cameraPosition = camera.GetCameraComponent(World).Camera.transform.position;
+            CreateAvatar(settings.GetCharacterSettings(World), cameraPosition.x, cameraPosition.z, urn.Where(s => !string.IsNullOrEmpty(s)).ToList(),
+                BodyShape.FEMALE, lastIndexInstantiated, 1);
+            lastIndexInstantiated++;
         }
 
         private void SetDebugViewActivity()

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Builders/BuilderExtensions.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Builders/BuilderExtensions.cs
@@ -43,6 +43,26 @@ namespace DCL.DebugUtilities
             return builder;
         }
 
+        public static DebugWidgetBuilder AddStringFieldsWithConfirmation(this DebugWidgetBuilder builder, int amountOfField, string buttonName, Action<string[]> onClick)
+        {
+            var bindings = new ElementBinding<string>[amountOfField];
+
+            for (int i = 0; i < amountOfField; i++)
+            {
+                var binding = new ElementBinding<string>("");
+                var textFieldDef = new DebugTextFieldDef(binding);
+                bindings[i] = binding;
+                builder.AddControl(null, textFieldDef);
+            }
+
+            var buttonDef = new DebugButtonDef(buttonName, () =>
+            {
+                onClick?.Invoke(Array.ConvertAll(bindings, x => x.Value));
+            });
+            builder.AddControl(null, buttonDef);
+            return builder;
+        }
+        
         public static DebugWidgetBuilder AddFloatField(this DebugWidgetBuilder builder, string labelName, ElementBinding<float> elementBinding)
         {
             var label = new DebugConstLabelDef(labelName);


### PR DESCRIPTION
Fixes #506 

- Introduces non square texture support in TextureArrayContainer
- Introduces a new debug feature to create avatars from build

**How to test**
Use the new Avatar Creator debug window to introduce this urn (urn:decentraland:matic:collections-v2:0x5969488f3b9cf9b12e5e9b51b3ff4077cd3d46ea:5). The avatar should have the correct texture

Before

![image](https://github.com/decentraland/unity-explorer/assets/1999557/02dccc76-d7e9-4f0e-a379-1acc740c131e)

After

![image](https://github.com/decentraland/unity-explorer/assets/1999557/fab59e29-34f1-4c85-80e9-9e2f53cf1731)

