### PR TITLE
Fix : Disabled post processing on camera on character preview only for Mac

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewAvatarContainer.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewAvatarContainer.cs
@@ -2,6 +2,7 @@ using Cinemachine;
 using DG.Tweening;
 using System;
 using UnityEngine;
+using UnityEngine.Rendering.Universal;
 
 namespace DCL.CharacterPreview
 {
@@ -29,6 +30,14 @@ namespace DCL.CharacterPreview
             transform.position = new Vector3(0, 5000, 0);
             camera.targetTexture = targetTexture;
             rotationTarget.rotation = Quaternion.identity;
+
+#if UNITY_STANDALONE_OSX
+            camera.gameObject.TryGetComponent(out UniversalAdditionalCameraData cameraData);
+            if (cameraData)
+            {
+                cameraData.renderPostProcessing = false;
+            }
+#endif
         }
 
         public void SetCameraPosition(CharacterPreviewCameraPreset preset)

--- a/Explorer/Assets/DCL/Character/CharacterPreview/DCL.CharacterPreview.asmdef
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/DCL.CharacterPreview.asmdef
@@ -17,7 +17,7 @@
         "GUID:166b65e6dfc848bb9fb075f53c293a38",
         "GUID:9e314663ce958b746873cb22d57ede55",
         "GUID:007bff6000804d90ac597452fb69a4ee",
-        "GUID:800d01f252aedc243b320345c737f37c"
+        "GUID:15fc0a57446b3144c949da3e2b9737a9"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
As the title says, we are disabling PostProcessing for the CharacterPreview Standalone versions for Mac users, as it is not working correctly RN