### PR TITLE
fix: nullref on DELETE crdt messages

### DIFF
--- a/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRDTMessagesProvider.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/OutgoingMessages/OutgoingCRDTMessagesProvider.cs
@@ -130,16 +130,18 @@ namespace CrdtEcsBridge.OutgoingMessages
                 for (var i = 0; i < messages.Count; i++)
                 {
                     PendingMessage pendingMessage = messages[i];
-
-                    IMemoryOwner<byte> memory = memoryAllocator.GetMemoryBuffer(pendingMessage.Message.CalculateSize());
-                    pendingMessage.Bridge.Serializer.SerializeInto(pendingMessage.Message, memory.Memory.Span);
+                    IMemoryOwner<byte> memory;
 
                     switch (pendingMessage.MessageType)
                     {
                         case CRDTMessageType.PUT_COMPONENT:
+                            memory = memoryAllocator.GetMemoryBuffer(pendingMessage.Message.CalculateSize());
+                            pendingMessage.Bridge.Serializer.SerializeInto(pendingMessage.Message, memory.Memory.Span);
                             processedMessages.Add(crdtProtocol.CreatePutMessage(pendingMessage.Entity, pendingMessage.Bridge.Id, memory));
                             break;
                         case CRDTMessageType.APPEND_COMPONENT:
+                            memory = memoryAllocator.GetMemoryBuffer(pendingMessage.Message.CalculateSize());
+                            pendingMessage.Bridge.Serializer.SerializeInto(pendingMessage.Message, memory.Memory.Span);
                             processedMessages.Add(crdtProtocol.CreateAppendMessage(pendingMessage.Entity, pendingMessage.Bridge.Id, pendingMessage.Timestamp, memory));
                             break;
                         case CRDTMessageType.DELETE_COMPONENT:


### PR DESCRIPTION
When memory is calculated at `GetSerializationSyncBlock()` we should do it only for `PUT` or `APPEND` messages, since in other cases like `DELETE` the `pendingMessage.Message` is null.

I was getting the following behaviour on scene that called the `IECSToCRDTWriter.DeleteMessage()` method, effectively breaking scenes execution with the nullref:

https://github.com/decentraland/unity-explorer/assets/1031741/67b3d330-e282-4fb5-8527-aef6fd18ab36

<img width="357" alt="Screenshot 2024-04-17 at 11 21 51 AM" src="https://github.com/decentraland/unity-explorer/assets/1031741/36a19410-c918-4275-9e93-52ca69943221">


