### PR TITLE
fix: panel closing on emoji suggestion press

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -127,7 +127,7 @@ namespace DCL.Chat
         private void OnChatViewPointerEnter() =>
             world.AddOrGet(cameraEntity, new CameraBlockerComponent());
 
-        private void AddEmojiFromSuggestion(string emojiCode)
+        private void AddEmojiFromSuggestion(string emojiCode, bool shouldClose)
         {
             if (viewInstance.InputField.text.Length >= MAX_MESSAGE_LENGTH)
                 return;
@@ -136,6 +136,8 @@ namespace DCL.Chat
             viewInstance.InputField.SetTextWithoutNotify(viewInstance.InputField.text.Replace(EMOJI_PATTERN_REGEX.Match(viewInstance.InputField.text).Value, emojiCode));
             viewInstance.InputField.stringPosition += emojiCode.Length;
             viewInstance.InputField.ActivateInputField();
+            if(shouldClose)
+                emojiSuggestionPanelController!.SetPanelVisibility(false);
         }
 
         private void OnToggleChatBubblesValueChanged(bool isToggled)

--- a/Explorer/Assets/DCL/EmojiPanel/EmojiSuggestionPanel.cs
+++ b/Explorer/Assets/DCL/EmojiPanel/EmojiSuggestionPanel.cs
@@ -126,6 +126,9 @@ namespace DCL.Emoji
 
         private void SetSelectedEmoji(int index)
         {
+            if (!view.gameObject.activeInHierarchy)
+                return;
+
             if (previouslySelected != null)
                 previouslySelected.SelectedBackground.SetActive(false);
 

--- a/Explorer/Assets/DCL/EmojiPanel/EmojiSuggestionPanel.cs
+++ b/Explorer/Assets/DCL/EmojiPanel/EmojiSuggestionPanel.cs
@@ -11,7 +11,7 @@ namespace DCL.Emoji
 {
     public class EmojiSuggestionPanel
     {
-        public event Action<string> OnEmojiSelected;
+        public event Action<string, bool> OnEmojiSelected;
 
         public bool IsActive { get; private set; }
 
@@ -45,7 +45,7 @@ namespace DCL.Emoji
         private void OnSubmit(InputAction.CallbackContext obj)
         {
             if (previouslySelected != null && IsActive)
-                OnEmojiSelected?.Invoke(previouslySelected.Emoji.text);
+                OnEmojiSelected?.Invoke(previouslySelected.Emoji.text, false);
         }
 
         private void OnArrowUp(InputAction.CallbackContext obj)
@@ -67,7 +67,7 @@ namespace DCL.Emoji
         private EmojiSuggestionView CreatePoolElement(EmojiSuggestionPanelView view, EmojiSuggestionView emojiSuggestion)
         {
             EmojiSuggestionView emojiSuggestionView = Object.Instantiate(emojiSuggestion, view.EmojiSuggestionContainer);
-            emojiSuggestionView.OnEmojiSelected += (emojiData) => OnEmojiSelected?.Invoke(emojiData);
+            emojiSuggestionView.OnEmojiSelected += (emojiData) => OnEmojiSelected?.Invoke(emojiData, true);
             return emojiSuggestionView;
         }
 


### PR DESCRIPTION
## What does this PR change?

Fixed issue when pressing an emoji with the mouse from the suggestion list broke the flow

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. In the chat use the suggestion panel
3. try to add emoji by pressing enter
4. try to add emoji by selecting with mouse

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

