### PR TITLE
fix: fixed emoji panel and emoji suggestion panel closing when clicking elsewhere

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -107,8 +107,9 @@ namespace DCL.Chat
             viewInstance.InputField.onSubmit.AddListener(OnSubmit);
             viewInstance.CloseChatButton.onClick.AddListener(CloseChat);
             viewInstance.LoopList.InitListView(0, OnGetItemByIndex);
-            emojiPanelController = new EmojiPanelController(viewInstance.EmojiPanel, emojiPanelConfiguration, emojiMappingJson, emojiSectionViewPrefab, emojiButtonPrefab);
+            emojiPanelController = new EmojiPanelController(viewInstance.EmojiPanel, emojiPanelConfiguration, emojiMappingJson, emojiSectionViewPrefab, emojiButtonPrefab, dclInput, eventSystem);
             emojiPanelController.OnEmojiSelected += AddEmojiToInput;
+            emojiPanelController.OnPanelClosedByClick += () => viewInstance.EmojiPanelButton.SetState(false);
 
             emojiSuggestionPanelController = new EmojiSuggestionPanel(viewInstance.EmojiSuggestionPanel, emojiSuggestionViewPrefab, dclInput);
             emojiSuggestionPanelController.OnEmojiSelected += AddEmojiFromSuggestion;

--- a/Explorer/Assets/DCL/EmojiPanel/EmojiPanelController.cs
+++ b/Explorer/Assets/DCL/EmojiPanel/EmojiPanelController.cs
@@ -1,9 +1,12 @@
 using Cysharp.Threading.Tasks;
+using DCL.Input;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
 using UnityEngine.UI;
 using Utility;
 using Object = UnityEngine.Object;
@@ -13,35 +16,45 @@ namespace DCL.Emoji
     public class EmojiPanelController
     {
         public event Action<string> OnEmojiSelected;
+        public event Action OnPanelClosedByClick;
+
         private readonly EmojiPanelView view;
         private readonly EmojiPanelConfigurationSO emojiPanelConfiguration;
         private readonly EmojiButton emojiButtonPrefab;
+        private readonly DCLInput dclInput;
         private readonly EmojiSectionView emojiSectionPrefab;
         private readonly EmojiSearchController emojiSearchController;
+        private readonly IEventSystem eventSystem;
 
         private readonly List<EmojiSectionView> emojiSectionViews = new ();
         public readonly Dictionary<string, EmojiData> EmojiNameMapping = new ();
         private readonly Dictionary<int, string> emojiValueMapping = new ();
         private readonly Dictionary<EmojiSectionName, RectTransform> sectionTransforms = new ();
         private readonly List<EmojiData> foundEmojis = new ();
+        private readonly Mouse device;
 
         private CancellationTokenSource cts = new ();
 
         private int startDec;
         private int endDec;
         private int emojiCode;
+        private IReadOnlyList<RaycastResult> raycastResults;
 
         public EmojiPanelController(
             EmojiPanelView view,
             EmojiPanelConfigurationSO emojiPanelConfiguration,
             TextAsset emojiMappingJson,
             EmojiSectionView emojiSectionPrefab,
-            EmojiButton emojiButtonPrefab)
+            EmojiButton emojiButtonPrefab,
+            DCLInput dclInput,
+            IEventSystem eventSystem)
         {
             this.view = view;
             this.emojiPanelConfiguration = emojiPanelConfiguration;
             this.emojiSectionPrefab = emojiSectionPrefab;
             this.emojiButtonPrefab = emojiButtonPrefab;
+            this.dclInput = dclInput;
+            this.eventSystem = eventSystem;
             emojiSearchController = new EmojiSearchController(view.SearchPanelView, view.EmojiSearchedContent, emojiButtonPrefab);
             emojiSearchController.OnSearchTextChanged += OnSearchTextChanged;
             emojiSearchController.OnEmojiSelected += emoji => OnEmojiSelected?.Invoke(emoji);
@@ -57,6 +70,31 @@ namespace DCL.Emoji
             view.OnEmojiFirstOpen += ConfigureEmojiSectionSizes;
             ConfigureEmojiSections();
             view.OnSectionSelected += OnSectionSelected;
+            view.OnEmojiPanelToggle += OnPanelToggle;
+            device = InputSystem.GetDevice<Mouse>();
+        }
+
+        private void OnPanelToggle(bool isActive)
+        {
+            if (isActive)
+                dclInput.UI.Click.performed += OnClick;
+            else
+                dclInput.UI.Click.performed -= OnClick;
+        }
+
+        private void OnClick(InputAction.CallbackContext obj)
+        {
+            raycastResults = eventSystem.RaycastAll(device.position.value);
+            var clickedOnPanel = false;
+            foreach (RaycastResult raycasted in raycastResults)
+                if (raycasted.gameObject == view.gameObject)
+                    clickedOnPanel = true;
+
+            if (!clickedOnPanel)
+            {
+                SetPanelVisibility(false);
+                OnPanelClosedByClick?.Invoke();
+            }
         }
 
         private void OnSearchTextChanged(string searchText)
@@ -84,8 +122,10 @@ namespace DCL.Emoji
             view.ScrollView.normalizedPosition = new Vector2(0, sectionPosition);
         }
 
-        public void SetPanelVisibility(bool isVisible) =>
+        public void SetPanelVisibility(bool isVisible)
+        {
             view.gameObject.SetActive(isVisible);
+        }
 
         private void ConfigureEmojiSectionSizes()
         {

--- a/Explorer/Assets/DCL/EmojiPanel/EmojiPanelView.cs
+++ b/Explorer/Assets/DCL/EmojiPanel/EmojiPanelView.cs
@@ -9,6 +9,7 @@ namespace DCL.Emoji
     public class EmojiPanelView : MonoBehaviour
     {
         public event Action<float, bool> OnSectionSelected;
+        public event Action<bool> OnEmojiPanelToggle;
 
         [field: SerializeField]
         public List<EmojiSectionToggle> EmojiSections { get; private set; }
@@ -39,6 +40,16 @@ namespace DCL.Emoji
 
             foreach (EmojiSectionToggle emojiSectionToggle in EmojiSections)
                 emojiSectionToggle.SectionToggle.onValueChanged.AddListener((isOn) => OnSectionSelected?.Invoke(emojiSectionToggle.SectionPosition, isOn));
+        }
+
+        private void OnEnable()
+        {
+            OnEmojiPanelToggle?.Invoke(true);
+        }
+
+        private void OnDisable()
+        {
+            OnEmojiPanelToggle?.Invoke(false);
         }
     }
 }

--- a/Explorer/Assets/DCL/EmojiPanel/EmojiPanelView.cs
+++ b/Explorer/Assets/DCL/EmojiPanel/EmojiPanelView.cs
@@ -9,7 +9,6 @@ namespace DCL.Emoji
     public class EmojiPanelView : MonoBehaviour
     {
         public event Action<float, bool> OnSectionSelected;
-        public event Action<bool> OnEmojiPanelToggle;
 
         [field: SerializeField]
         public List<EmojiSectionToggle> EmojiSections { get; private set; }
@@ -40,16 +39,6 @@ namespace DCL.Emoji
 
             foreach (EmojiSectionToggle emojiSectionToggle in EmojiSections)
                 emojiSectionToggle.SectionToggle.onValueChanged.AddListener((isOn) => OnSectionSelected?.Invoke(emojiSectionToggle.SectionPosition, isOn));
-        }
-
-        private void OnEnable()
-        {
-            OnEmojiPanelToggle?.Invoke(true);
-        }
-
-        private void OnDisable()
-        {
-            OnEmojiPanelToggle?.Invoke(false);
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

With this PR the emoji panel and the emoji suggestions panel can be closed by clicking anywhere

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open the emoji panel
3. Click anywhere to close it
4. Same for emoji suggestions panel

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

