### PR TITLE
fix: Medium quality settings gives invisible terrain

### DIFF
--- a/Explorer/Assets/DCL/Quality/Quality Settings.asset
+++ b/Explorer/Assets/DCL/Quality/Quality Settings.asset
@@ -134,7 +134,7 @@ MonoBehaviour:
       chunkCullDistance: 1000
   - volumeProfile: {fileID: -4880458653563171804}
     fogSettings:
-      m_Fog: 1
+      m_Fog: 0
       m_FogColor: {r: 0.8773585, g: 0.47592562, b: 0.47592562, a: 0.31764707}
       m_FogMode: 2
       m_FogDensity: 0.4

--- a/Explorer/ProjectSettings/QualitySettings.asset
+++ b/Explorer/ProjectSettings/QualitySettings.asset
@@ -4,7 +4,7 @@
 QualitySettings:
   m_ObjectHideFlags: 0
   serializedVersion: 5
-  m_CurrentQuality: 2
+  m_CurrentQuality: 1
   m_QualitySettings:
   - serializedVersion: 3
     name: Low
@@ -79,7 +79,7 @@ QualitySettings:
     useLegacyDetailDistribution: 1
     vSyncCount: 0
     realtimeGICPUUsage: 25
-    lodBias: 0.3
+    lodBias: 1.2
     maximumLODLevel: 0
     enableLODCrossFade: 1
     streamingMipmapsActive: 1
@@ -96,9 +96,9 @@ QualitySettings:
     customRenderPipeline: {fileID: 11400000, guid: c7655666771b41447aa2994cf82e2fc7, type: 2}
     terrainQualityOverrides: 0
     terrainPixelError: 1
-    terrainDetailDensityScale: 1
+    terrainDetailDensityScale: 0.7
     terrainBasemapDistance: 1000
-    terrainDetailDistance: 80
+    terrainDetailDistance: 150
     terrainTreeDistance: 5000
     terrainBillboardStart: 50
     terrainFadeLength: 5
@@ -128,7 +128,7 @@ QualitySettings:
     useLegacyDetailDistribution: 1
     vSyncCount: 0
     realtimeGICPUUsage: 25
-    lodBias: 0.3
+    lodBias: 2
     maximumLODLevel: 0
     enableLODCrossFade: 1
     streamingMipmapsActive: 1
@@ -147,7 +147,7 @@ QualitySettings:
     terrainPixelError: 1
     terrainDetailDensityScale: 1
     terrainBasemapDistance: 1000
-    terrainDetailDistance: 80
+    terrainDetailDistance: 300
     terrainTreeDistance: 5000
     terrainBillboardStart: 50
     terrainFadeLength: 5


### PR DESCRIPTION
## What does this PR change?
Fix #691 

## How to test the changes?
1. Launch the explorer.
2. Change the quality preset to "Medium" from the Settnigs Menu.
3. Observe everything in the graphics looks as expected.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md