### PR TITLE
fix: When teleporting to a high terrain, the spawn point appears to be under it

### DIFF
--- a/Explorer/Assets/DCL/ParcelsService/TeleportController.cs
+++ b/Explorer/Assets/DCL/ParcelsService/TeleportController.cs
@@ -44,7 +44,7 @@ namespace DCL.ParcelsService
         {
             if (retrieveScene == null)
             {
-                AddTeleportIntentQuery(world, new PlayerTeleportIntent(ParcelMathHelper.GetPositionByParcelPosition(parcel), parcel));
+                AddTeleportIntentQuery(world, new PlayerTeleportIntent(ParcelMathHelper.GetPositionByParcelPosition(parcel, true), parcel));
                 loadReport.ProgressCounter.Value = 1f;
                 loadReport.CompletionSource.TrySetResult();
                 return null;
@@ -87,7 +87,7 @@ namespace DCL.ParcelsService
                 }
             }
             else
-                targetPosition = ParcelMathHelper.GetPositionByParcelPosition(parcel);
+                targetPosition = ParcelMathHelper.GetPositionByParcelPosition(parcel, true);
 
             await UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate);
 
@@ -109,7 +109,7 @@ namespace DCL.ParcelsService
         {
             if (retrieveScene == null)
             {
-                AddTeleportIntentQuery(world, new PlayerTeleportIntent(ParcelMathHelper.GetPositionByParcelPosition(parcel), parcel));
+                AddTeleportIntentQuery(world, new PlayerTeleportIntent(ParcelMathHelper.GetPositionByParcelPosition(parcel, true), parcel));
                 loadReport.ProgressCounter.Value = 1f;
                 loadReport.CompletionSource.TrySetResult();
                 return;

--- a/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
+++ b/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
@@ -8,7 +8,6 @@ namespace Utility
     public static class ParcelMathHelper
     {
         public const float PARCEL_SIZE = 16.0f;
-
         public const float SQR_PARCEL_SIZE = PARCEL_SIZE * PARCEL_SIZE;
 
         public static readonly SceneGeometry UNDEFINED_SCENE_GEOMETRY = new (
@@ -29,8 +28,18 @@ namespace Utility
         public static Vector3 GetSceneRelativePosition(Vector3 position, Vector3 scenePosition) =>
             position - scenePosition;
 
-        public static Vector3 GetPositionByParcelPosition(Vector2Int parcelPosition) =>
-            new (parcelPosition.x * PARCEL_SIZE, 0.0f, parcelPosition.y * PARCEL_SIZE);
+        public static Vector3 GetPositionByParcelPosition(Vector2Int parcelPosition, bool adaptYPositionToTerrain = false)
+        {
+            var position = new Vector3(parcelPosition.x * PARCEL_SIZE, 0.0f, parcelPosition.y * PARCEL_SIZE);
+
+            if (adaptYPositionToTerrain)
+            {
+                const float TERRAIN_HEIGHT_ADAPTATION_OFFSET = 2.0f;
+                position.y = Terrain.activeTerrain.SampleHeight(position) + TERRAIN_HEIGHT_ADAPTATION_OFFSET;
+            }
+
+            return position;
+        }
 
         /// <summary>
         ///     Creates scene geometry from multiple occupied parcels


### PR DESCRIPTION
## What does this PR change?
Fix #661 

## How to test the changes?
1. Launch the explorer.
2. Go to `-104,4`.
3. Check that your avatar is teleported ON the surface of the floor and not below.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md