### PR TITLE
Chore: lod cleanup

### DIFF
--- a/.github/workflows/build-Windows-il2cpp.yml
+++ b/.github/workflows/build-Windows-il2cpp.yml
@@ -215,11 +215,6 @@ jobs:
           sshAgent: ${{ env.SSH_AUTH_SOCK }}
           allowDirtyBuild: true
 
-      - name: Download and Extract Zip File for LODS
-        run: |
-          Invoke-WebRequest -Uri "${{ secrets.LODS_URL }}" -OutFile "build/${{ matrix.targetPlatform }}/Decentraland_Data/StreamingAssets/AssetBundles/lods/lods.zip"
-        shell: pwsh
-
       # Upload artifact
       - name: Upload windows artifact
         uses: actions/upload-artifact@v4

--- a/Explorer/Assets/DCL/LOD/Systems/LODContainer.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/LODContainer.cs
@@ -53,6 +53,7 @@ namespace DCL.LOD.Systems
             RealmData realmData,
             TextureArrayContainerFactory textureArrayContainerFactory,
             DebugContainerBuilder debugBuilder,
+            bool lodEnabled,
             CancellationToken ct)
         {
             var container = new LODContainer(staticContainer.AssetsProvisioner);
@@ -75,7 +76,7 @@ namespace DCL.LOD.Systems
                     staticContainer.SingletonSharedDependencies.MemoryBudget,
                     staticContainer.SingletonSharedDependencies.FrameTimeBudget,
                     staticContainer.ScenesCache, debugBuilder, staticContainer.SceneReadinessReportQueue,
-                    visualSceneStateResolver, textureArrayContainerFactory, c.lodSettingsAsset.Value);
+                    visualSceneStateResolver, textureArrayContainerFactory, c.lodSettingsAsset.Value, lodEnabled);
 
                 return UniTask.CompletedTask;
             });

--- a/Explorer/Assets/DCL/LOD/Systems/LODPlugin.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/LODPlugin.cs
@@ -35,7 +35,7 @@ namespace DCL.PluginSystem.Global
         private readonly ISceneReadinessReportQueue sceneReadinessReportQueue;
         private readonly VisualSceneStateResolver visualSceneStateResolver;
         private readonly TextureArrayContainerFactory textureArrayContainerFactory;
-
+        private readonly bool lodEnabled;
         
         private IExtendedObjectPool<Material> lodMaterialPool;
         private ILODSettingsAsset lodSettingsAsset;
@@ -45,7 +45,7 @@ namespace DCL.PluginSystem.Global
         public LODPlugin(CacheCleaner cacheCleaner, RealmData realmData, IPerformanceBudget memoryBudget,
             IPerformanceBudget frameCapBudget, IScenesCache scenesCache, IDebugContainerBuilder debugBuilder,
             ISceneReadinessReportQueue sceneReadinessReportQueue, VisualSceneStateResolver visualSceneStateResolver, TextureArrayContainerFactory textureArrayContainerFactory,
-            ILODSettingsAsset lodSettingsAsset)
+            ILODSettingsAsset lodSettingsAsset, bool lodEnabled)
         {
             lodAssetsPool = new LODAssetsPool();
             cacheCleaner.Register(lodAssetsPool);
@@ -59,6 +59,7 @@ namespace DCL.PluginSystem.Global
             this.visualSceneStateResolver = visualSceneStateResolver;
             this.textureArrayContainerFactory = textureArrayContainerFactory;
             this.lodSettingsAsset = lodSettingsAsset;
+            this.lodEnabled = lodEnabled;
         }
 
         public UniTask Initialize(IPluginSettingsContainer container, CancellationToken ct)
@@ -76,10 +77,19 @@ namespace DCL.PluginSystem.Global
             
             ResolveVisualSceneStateSystem.InjectToWorld(ref builder, lodSettingsAsset, visualSceneStateResolver, realmData);
             UpdateVisualSceneStateSystem.InjectToWorld(ref builder, realmData, scenesCache, lodAssetsPool, lodSettingsAsset, visualSceneStateResolver);
-            UpdateSceneLODInfoSystem.InjectToWorld(ref builder, lodAssetsPool, lodSettingsAsset, memoryBudget,
-                frameCapBudget, scenesCache, sceneReadinessReportQueue, lodContainer.transform, lodTextureArrayContainer);
-            UnloadSceneLODSystem.InjectToWorld(ref builder, lodAssetsPool, scenesCache);
-            LODDebugToolsSystem.InjectToWorld(ref builder, debugBuilder, lodSettingsAsset, lodDebugContainer.transform);
+
+            if (lodEnabled)
+            {
+                UpdateSceneLODInfoSystem.InjectToWorld(ref builder, lodAssetsPool, lodSettingsAsset, memoryBudget,
+                    frameCapBudget, scenesCache, sceneReadinessReportQueue, lodContainer.transform, lodTextureArrayContainer);
+                UnloadSceneLODSystem.InjectToWorld(ref builder, lodAssetsPool, scenesCache);
+                LODDebugToolsSystem.InjectToWorld(ref builder, debugBuilder, lodSettingsAsset, lodDebugContainer.transform);
+            }
+            else
+            {
+                UpdateSceneLODInfoMockSystem.InjectToWorld(ref builder, sceneReadinessReportQueue);
+            }
+           
         }
 
         public void Dispose()

--- a/Explorer/Assets/DCL/LOD/Systems/LODUtils.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/LODUtils.cs
@@ -7,6 +7,7 @@ using DCL.Optimization.Pools;
 using ECS.SceneLifeCycle.SceneDefinition;
 using SceneRunner.Scene;
 using System.Linq;
+using ECS.SceneLifeCycle.Reporting;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
@@ -80,6 +81,19 @@ namespace DCL.LOD
             duplicatedMaterial.renderQueue = (int)RenderQueue.Transparent;
 
             duplicatedMaterial.color = new Color(duplicatedMaterial.color.r, duplicatedMaterial.color.g, duplicatedMaterial.color.b, setDefaultTransparency ? 0.8f : duplicatedMaterial.color.a);
+        }
+
+        public static void CheckSceneReadiness(ISceneReadinessReportQueue sceneReadinessReportQueue, SceneDefinitionComponent sceneDefinitionComponent)
+        {
+            if (sceneReadinessReportQueue.TryDequeue(sceneDefinitionComponent.Parcels, out var reports))
+            {
+                for (int i = 0; i < reports!.Value.Count; i++)
+                {
+                    var report = reports.Value[i];
+                    report.ProgressCounter.Value = 1f;
+                    report.CompletionSource.TrySetResult();
+                }
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/LOD/Systems/UpdateSceneLODInfoMockSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/UpdateSceneLODInfoMockSystem.cs
@@ -1,0 +1,51 @@
+﻿using Arch.Core;
+using Arch.System;
+using Arch.SystemGroups;
+using DCL.Diagnostics;
+using DCL.LOD.Components;
+using ECS.Abstract;
+using ECS.LifeCycle.Components;
+using ECS.Prioritization.Components;
+using ECS.SceneLifeCycle;
+using ECS.SceneLifeCycle.Components;
+using ECS.SceneLifeCycle.Reporting;
+using ECS.SceneLifeCycle.SceneDefinition;
+
+namespace DCL.LOD.Systems
+{
+    [UpdateInGroup(typeof(RealmGroup))]
+    [LogCategory(ReportCategory.LOD)]
+    public partial class UpdateSceneLODInfoMockSystem : BaseUnityLoopSystem
+    {
+        private readonly ISceneReadinessReportQueue sceneReadinessReportQueue;
+
+
+        public UpdateSceneLODInfoMockSystem(World world, ISceneReadinessReportQueue sceneReadinessReportQueue) : base(world)
+        {
+            this.sceneReadinessReportQueue = sceneReadinessReportQueue;
+        }
+
+        protected override void Update(float t)
+        {
+            UpdateLODLevelQuery(World);
+            UnloadLODQuery(World);
+        }
+
+        [Query]
+        [All(typeof(SceneLODInfo), typeof(PartitionComponent))]
+        [None(typeof(DeleteEntityIntention))]
+        private void UpdateLODLevel(SceneDefinitionComponent sceneDefinitionComponent)
+        {
+            //If LODs are not enabled, we can consider the scene as ready,
+            //and check scene readiness so not to block the loading screen
+            LODUtils.CheckSceneReadiness(sceneReadinessReportQueue, sceneDefinitionComponent);
+        }
+
+        [Query]
+        [All(typeof(DeleteEntityIntention))]
+        private void UnloadLOD(in Entity entity, ref SceneLODInfo sceneLODInfo, ref SceneDefinitionComponent sceneDefinitionComponent)
+        {
+            World.Remove<SceneLODInfo, VisualSceneState, DeleteEntityIntention>(entity);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/LOD/Systems/UpdateSceneLODInfoMockSystem.cs.meta
+++ b/Explorer/Assets/DCL/LOD/Systems/UpdateSceneLODInfoMockSystem.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0b8366ccc5c74ba88a2424377b83402c
+timeCreated: 1714044847

--- a/Explorer/Assets/DCL/LOD/Systems/UpdateSceneLODInfoSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/UpdateSceneLODInfoSystem.cs
@@ -108,7 +108,7 @@ namespace DCL.LOD.Systems
 
                 sceneLODInfo.SetCurrentLOD(newLod);
                 scenesCache.Add(sceneLODInfo, sceneDefinitionComponent.Parcels);
-                CheckSceneReadiness(sceneDefinitionComponent);
+                LODUtils.CheckSceneReadiness(sceneReadinessReportQueue, sceneDefinitionComponent);
                 sceneLODInfo.IsDirty = false;
             }
         }
@@ -158,7 +158,7 @@ namespace DCL.LOD.Systems
                 //If its cached, no need to make a new promise
                 sceneLODInfo.SetCurrentLOD(cachedAsset);
                 sceneLODInfo.IsDirty = false;
-                CheckSceneReadiness(sceneDefinitionComponent);
+                LODUtils.CheckSceneReadiness(sceneReadinessReportQueue, sceneDefinitionComponent);
             }
             else
             {
@@ -178,17 +178,5 @@ namespace DCL.LOD.Systems
             }
         }
 
-        private void CheckSceneReadiness(SceneDefinitionComponent sceneDefinitionComponent)
-        {
-            if (sceneReadinessReportQueue.TryDequeue(sceneDefinitionComponent.Parcels, out var reports))
-            {
-                for (int i = 0; i < reports!.Value.Count; i++)
-                {
-                    var report = reports.Value[i];
-                    report.ProgressCounter.Value = 1f;
-                    report.CompletionSource.TrySetResult();
-                }
-            }
-        }
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -148,7 +148,7 @@ namespace Global.Dynamic
 
                 // Init other containers
                 container.DefaultTexturesContainer = await DefaultTexturesContainer.CreateAsync(settingsContainer, staticContainer.AssetsProvisioner, ct).ThrowOnFail();
-                container.LODContainer = await LODContainer.CreateAsync(staticContainer, settingsContainer, realmData, container.DefaultTexturesContainer.TextureArrayContainerFactory, container.DebugContainer.Builder, ct).ThrowOnFail();
+                container.LODContainer = await LODContainer.CreateAsync(staticContainer, settingsContainer, realmData, container.DefaultTexturesContainer.TextureArrayContainerFactory, container.DebugContainer.Builder, dynamicWorldParams.EnableLOD, ct).ThrowOnFail();
                 container.AudioPlaybackContainer = await AudioPlaybackContainer.CreateAsync(settingsContainer, staticContainer.AssetsProvisioner, ct).ThrowOnFail();
             }
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldParams.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldParams.cs
@@ -27,5 +27,7 @@ namespace Global.Dynamic
         public List<string> Realms { get; init; }
         public Vector2Int StartParcel { get; init; }
         public bool EnableLandscape { get; init; }
+        public bool EnableLOD { get; init; }
+
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -38,6 +38,8 @@ namespace Global.Dynamic
         [SerializeField] private bool showAuthentication;
         [SerializeField] private bool showLoading;
         [SerializeField] private bool enableLandscape;
+        [SerializeField] private bool enableLOD;
+
 
         [Header("References")]
         [SerializeField] private PluginSettingsContainer globalPluginSettingsContainer = null!;
@@ -109,6 +111,8 @@ namespace Global.Dynamic
             showSplash = true;
             showAuthentication = true;
             showLoading = true;
+            enableLOD = true;
+            
 #endif
 
             //enableLandscape = true;
@@ -187,7 +191,7 @@ namespace Global.Dynamic
                         StaticLoadPositions = settings.StaticLoadPositions,
                         Realms = settings.Realms,
                         StartParcel = startingParcel,
-                        EnableLandscape = shouldEnableLandscape,
+                        EnableLandscape = shouldEnableLandscape, EnableLOD = enableLOD
                     }, ct
                 );
 


### PR DESCRIPTION
## What does this PR change?

- Adds the Enable LOD toggle in Main scene. By default, is off. This will be enabled by default when not development build.
- Removes LOD_3 embedded files in build to avoid creating such big files


## How to test the changes?

In Editor,

1. Try with and without the Enable LOD toggle. Walk around and check that behaviour is as expected. 
2. If you dont have lods and landscape enabled, the loading should be super fast

In Build,

1. Check that LODs load correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

