### PR TITLE
fix: When teleporting to a high terrain, the spawn point appears to be under it (part 2)

### DIFF
--- a/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
+++ b/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
@@ -35,11 +35,14 @@ namespace Utility
             if (adaptYPositionToTerrain)
             {
                 const float TERRAIN_HEIGHT_ADAPTATION_OFFSET = 2.0f;
-                position.y = Terrain.activeTerrain.SampleHeight(position) + TERRAIN_HEIGHT_ADAPTATION_OFFSET;
+                position.y = GetNearestSurfaceHeight(position) + TERRAIN_HEIGHT_ADAPTATION_OFFSET;
             }
 
             return position;
         }
+
+        private static float GetNearestSurfaceHeight(Vector3 position) =>
+            Physics.Raycast(position + (Vector3.up * 100), Vector3.down, out RaycastHit hit) ? hit.point.y : position.y;
 
         /// <summary>
         ///     Creates scene geometry from multiple occupied parcels


### PR DESCRIPTION
## What does this PR change?
This is the second part of https://github.com/decentraland/unity-explorer/pull/720
Fix #661 

## How to test the changes?
1. Launch the explorer.
2. Go to coordinates where the terrain is elevated (for example: `-104,4`, `-73,-85` or `-144,-106`).
3. Check that your avatar is teleported ON the surface of the floor and not below.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md