### PR TITLE
fix: large hiccup during loading, now its spread along the loading bar

### DIFF
--- a/Explorer/Assets/DCL/Landscape/TerrainFactory.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainFactory.cs
@@ -79,7 +79,7 @@ namespace DCL.Landscape
             return collider;
         }
 
-        public Terrain CreateTerrainObject(TerrainData terrainData, Transform parent, int2 at, Material material, bool drawTreesAndFoliage)
+        public Terrain CreateTerrainObject(TerrainData terrainData, Transform parent, int2 at, Material material)
         {
             Terrain terrain = Terrain.CreateTerrainGameObject(terrainData)
                                      .GetComponent<Terrain>();
@@ -89,7 +89,7 @@ namespace DCL.Landscape
             terrain.detailObjectDistance = 200;
             terrain.enableHeightmapRayTracing = false;
             terrain.drawHeightmap = true; // forced to true for the color map renderer
-            terrain.drawTreesAndFoliage = drawTreesAndFoliage;
+            terrain.drawTreesAndFoliage = true;
 
             terrain.transform.position = new Vector3(at.x, -terrainGenData.minHeight, at.y);
             terrain.transform.SetParent(parent, false);

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -198,7 +198,7 @@ namespace DCL.Landscape
             }
         }
 
-        private async Task ReEnableTerrainAsync(AsyncLoadProcessReport processReport)
+        private async UniTask ReEnableTerrainAsync(AsyncLoadProcessReport processReport)
         {
             foreach (Terrain terrain in terrains)
                 terrain.enabled = false;
@@ -206,8 +206,7 @@ namespace DCL.Landscape
             // we enable them one by one to avoid a super hiccup
             for (var i = 0; i < terrains.Count; i++)
             {
-                Terrain terrain = terrains[i];
-                terrain.enabled = true;
+                terrains[i].enabled = true;
                 if (processReport != null) processReport.ProgressCounter.Value = PROGRESS_COUNTER_DIG_HOLES + PROGRESS_SPAWN_TERRAIN + (i / terrainDataCount * PROGRESS_SPAWN_RE_ENABLE_TERRAIN);
                 await UniTask.Yield();
             }

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -30,9 +30,10 @@ namespace DCL.Landscape
         private const int CACHE_VERSION = 2;
 
         private const float PROGRESS_COUNTER_EMPTY_PARCEL_DATA = 0.1f;
-        private const float PROGRESS_COUNTER_TERRAIN_DATA = 0.6f;
-        private const float PROGRESS_COUNTER_DIG_HOLES = 0.75f;
+        private const float PROGRESS_COUNTER_TERRAIN_DATA = 0.3f;
+        private const float PROGRESS_COUNTER_DIG_HOLES = 0.5f;
         private const float PROGRESS_SPAWN_TERRAIN = 0.25f;
+        private const float PROGRESS_SPAWN_RE_ENABLE_TERRAIN = 0.25f;
         private readonly NoiseGeneratorCache noiseGenCache;
         private readonly ReportData reportData;
         private readonly TimeProfiler timeProfiler;
@@ -174,6 +175,9 @@ namespace DCL.Landscape
 
                     await TerrainGenerationUtils.AddColorMapRendererAsync(rootGo, terrains, factory);
 
+                    // waiting a frame to create the color map renderer created a new bug where some stones do not render properly, this should fix it
+                    await ReEnableTerrain(processReport);
+
                     if (processReport != null) processReport.ProgressCounter.Value = 1f;
                 }
             }
@@ -191,6 +195,21 @@ namespace DCL.Landscape
                     localCache.Save();
 
                 IsTerrainGenerated = true;
+            }
+        }
+
+        private async Task ReEnableTerrain(AsyncLoadProcessReport processReport)
+        {
+            foreach (Terrain terrain in terrains)
+                terrain.enabled = false;
+
+            // we enable them one by one to avoid a super hiccup
+            for (var i = 0; i < terrains.Count; i++)
+            {
+                Terrain terrain = terrains[i];
+                terrain.enabled = true;
+                if (processReport != null) processReport.ProgressCounter.Value = PROGRESS_COUNTER_DIG_HOLES + PROGRESS_SPAWN_TERRAIN + (i / terrainDataCount * PROGRESS_SPAWN_RE_ENABLE_TERRAIN);
+                await UniTask.Yield();
             }
         }
 
@@ -224,7 +243,7 @@ namespace DCL.Landscape
                 cancellationToken.ThrowIfCancellationRequested();
 
                 terrains.Add(
-                    factory.CreateTerrainObject(chunkModel.TerrainData, rootGo.transform, chunkModel.MinParcel * parcelSize, terrainGenData.terrainMaterial, showTerrainByDefault));
+                    factory.CreateTerrainObject(chunkModel.TerrainData, rootGo.transform, chunkModel.MinParcel * parcelSize, terrainGenData.terrainMaterial));
 
                 await UniTask.Yield();
                 spawnedTerrainDataCount++;

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -176,7 +176,7 @@ namespace DCL.Landscape
                     await TerrainGenerationUtils.AddColorMapRendererAsync(rootGo, terrains, factory);
 
                     // waiting a frame to create the color map renderer created a new bug where some stones do not render properly, this should fix it
-                    await ReEnableTerrain(processReport);
+                    await ReEnableTerrainAsync(processReport);
 
                     if (processReport != null) processReport.ProgressCounter.Value = 1f;
                 }
@@ -198,7 +198,7 @@ namespace DCL.Landscape
             }
         }
 
-        private async Task ReEnableTerrain(AsyncLoadProcessReport processReport)
+        private async Task ReEnableTerrainAsync(AsyncLoadProcessReport processReport)
         {
             foreach (Terrain terrain in terrains)
                 terrain.enabled = false;

--- a/Explorer/Assets/DCL/Landscape/Utils/TerrainGenerationUtils.cs
+++ b/Explorer/Assets/DCL/Landscape/Utils/TerrainGenerationUtils.cs
@@ -26,21 +26,6 @@ namespace DCL.Landscape
             grassColorMap.bounds.center = new Vector3(grassColorMap.bounds.center.x, 0, grassColorMap.bounds.center.z);
 
             colorMapRenderer.Render();
-
-            // waiting a frame to create the color map renderer created a new bug where some stones do not render properly, this should fix it
-            await BugWorkaroundAsync();
-            return;
-
-            async UniTask BugWorkaroundAsync()
-            {
-                foreach (Terrain terrain in terrains)
-                    terrain.enabled = false;
-
-                await UniTask.Yield();
-
-                foreach (Terrain terrain in terrains)
-                    terrain.enabled = true;
-            }
         }
 
         public static void ExtractEmptyParcels(TerrainModel terrainModel, ref NativeList<int2> emptyParcels, ref NativeParallelHashSet<int2> ownedParcels)

--- a/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
@@ -103,9 +103,18 @@ namespace DCL.Landscape
 
             // Generate Terrain GameObjects
             foreach (ChunkModel chunkModel in terrainModel.ChunkModels)
-                terrains.Add(factory.CreateTerrainObject(chunkModel.TerrainData, rootGo, chunkModel.MinParcel * parcelSize, terrainGenData.terrainMaterial, true));
+                terrains.Add(factory.CreateTerrainObject(chunkModel.TerrainData, rootGo, chunkModel.MinParcel * parcelSize, terrainGenData.terrainMaterial));
 
             await TerrainGenerationUtils.AddColorMapRendererAsync(rootGo, terrains, factory);
+
+            // waiting a frame to create the color map renderer created a new bug where some stones do not render properly, this should fix it
+            foreach (Terrain terrain in terrains)
+                terrain.enabled = false;
+
+            await UniTask.Yield();
+
+            foreach (Terrain terrain in terrains)
+                terrain.enabled = true;
         }
 
         private async UniTask GenerateTerrainDataAsync(ChunkModel chunkModel, TerrainModel terrainModel, uint worldSeed, CancellationToken cancellationToken)


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/563
Spreads along frames the re-enabling of terrain to fix a bug with the ColormapRenderer

## How to test the changes?

The loading screen should not get stuck at 92% for some seconds, instead, it should be spread out and the wait at 92% should be lower.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

