### PR TITLE
fix: show naked avatar when wearables are empty at character preview

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
@@ -61,8 +61,6 @@ namespace DCL.CharacterPreview
 
         public UniTask UpdateAvatar(CharacterPreviewAvatarModel avatarModel, CancellationToken ct)
         {
-            if (avatarModel.Wearables == null || avatarModel.Wearables.Count <= 0) return UniTask.CompletedTask;
-
             ref AvatarShapeComponent avatarShape = ref globalWorld.Get<AvatarShapeComponent>(characterPreviewEntity);
 
             avatarShape.SkinColor = avatarModel.SkinColor;
@@ -74,12 +72,14 @@ namespace DCL.CharacterPreview
 
             avatarShape.WearablePromise = AssetPromise<WearablesResolution, GetWearablesByPointersIntention>.Create(
                 globalWorld,
-                WearableComponentsUtils.CreateGetWearablesByPointersIntention(avatarShape.BodyShape, avatarModel.Wearables, avatarModel.ForceRenderCategories),
+                WearableComponentsUtils.CreateGetWearablesByPointersIntention(avatarShape.BodyShape,
+                    avatarModel.Wearables ?? (IReadOnlyCollection<URN>)Array.Empty<URN>(), avatarModel.ForceRenderCategories),
                 PartitionComponent.TOP_PRIORITY
             );
 
             avatarShape.EmotePromise = EmotePromise.Create(globalWorld,
-                EmoteComponentsUtils.CreateGetEmotesByPointersIntention(avatarShape.BodyShape, ((IReadOnlyCollection<URN>) avatarModel.Emotes) ?? Array.Empty<URN>()),
+                EmoteComponentsUtils.CreateGetEmotesByPointersIntention(avatarShape.BodyShape,
+                    avatarModel.Emotes ?? (IReadOnlyCollection<URN>)Array.Empty<URN>()),
                 PartitionComponent.TOP_PRIORITY);
 
             avatarShape.IsDirty = true;


### PR DESCRIPTION
## What does this PR change?

Fixes #622 

## How to test the changes?

1. Follow issue steps
2. The avatar preview should be always visible either in the authentication screen or backpack

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

