### PR TITLE
fix: weird tree generation and memory leaks

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Noises/Bush01Noise_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Noises/Bush01Noise_W.asset
@@ -15,13 +15,13 @@ MonoBehaviour:
   settings:
     invert: 0
     normalize: 0
-    scale: 8.78
-    octaves: 5
+    scale: 12.1
+    octaves: 3
     persistance: 1
-    lacunarity: 21.8
+    lacunarity: 18.8
     seed: 21
     offset: {x: 0, y: 0}
-    cutoff: 0.5
+    cutoff: 1.1
     noiseType: 2
     baseValue: 0
     multiplyValue: 0

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Noises/OakCNoise_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Noises/OakCNoise_W.asset
@@ -15,14 +15,14 @@ MonoBehaviour:
   settings:
     invert: 0
     normalize: 1
-    scale: 0.01
-    octaves: 1
+    scale: 30.41
+    octaves: 2
     persistance: 1
-    lacunarity: 1
-    seed: 30
+    lacunarity: 1.66
+    seed: 22
     offset: {x: 0, y: 0}
     cutoff: 0
-    noiseType: 2
+    noiseType: 1
     baseValue: 0
     multiplyValue: 1
     divideValue: 2

--- a/Explorer/Assets/DCL/Landscape/Worlds/WorldModel.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/WorldModel.cs
@@ -29,10 +29,10 @@ namespace DCL.Landscape
             foreach (int2 parcel in ownedParcels)
             {
                 if (parcel.x < minParcel.x) minParcel.x = parcel.x;
-                else if (parcel.x > maxParcel.x) maxParcel.x = parcel.x;
+                if (parcel.x > maxParcel.x) maxParcel.x = parcel.x;
 
                 if (parcel.y < minParcel.y) minParcel.y = parcel.y;
-                else if (parcel.y > maxParcel.y) maxParcel.y = parcel.y;
+                if (parcel.y > maxParcel.y) maxParcel.y = parcel.y;
             }
 
             return (minParcel, maxParcel);

--- a/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
@@ -4,6 +4,7 @@ using DCL.Landscape.Jobs;
 using DCL.Landscape.NoiseGeneration;
 using DCL.Landscape.Settings;
 using DCL.Landscape.Utils;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Unity.Collections;
@@ -15,7 +16,7 @@ using Utility;
 
 namespace DCL.Landscape
 {
-    public class WorldTerrainGenerator
+    public class WorldTerrainGenerator : IDisposable
     {
         private const string TERRAIN_OBJECT_NAME = "World Generated Terrain";
         private const float ROOT_VERTICAL_SHIFT = -0.001f; // fix for not clipping with scene (potential) floor
@@ -70,16 +71,7 @@ namespace DCL.Landscape
             if (!IsInitialized) return;
 
             if (rootGo != null)
-            {
-                if (!isVisible)
-                {
-                    emptyParcels.Dispose();
-                    emptyParcelsData.Dispose();
-                    emptyParcelsNeighborData.Dispose();
-                }
-
                 rootGo.gameObject.SetActive(isVisible);
-            }
         }
 
         public async UniTask GenerateTerrainAsync(NativeParallelHashSet<int2> ownedParcels, uint worldSeed = 1, CancellationToken cancellationToken = default)
@@ -125,6 +117,11 @@ namespace DCL.Landscape
 
             foreach (Terrain terrain in terrains)
                 terrain.enabled = true;
+
+            noiseGenCache.Dispose();
+            emptyParcelsNeighborData.Dispose();
+            emptyParcelsData.Dispose();
+            emptyParcels.Dispose();
         }
 
         private async UniTask GenerateTerrainDataAsync(ChunkModel chunkModel, TerrainModel terrainModel, uint worldSeed, CancellationToken cancellationToken)


### PR DESCRIPTION
## What does this PR change?

Changes this
![image](https://github.com/decentraland/unity-explorer/assets/7646450/d2c66a70-bb2d-4739-b018-e75b668a2665)

into this
![image](https://github.com/decentraland/unity-explorer/assets/7646450/d99db3d5-4ad2-4007-88b5-136364a0750d)

Also fixes all memory leaks caused by generating terrain in worlds.

## How to test the changes?

- `/goto goerli`
 - fly with F11
 - check that trees are no longer in weird patterns

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

