### PR TITLE
fix: Added tree overlap again

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Config/LandscapeAsset.cs
+++ b/Explorer/Assets/DCL/Landscape/Config/LandscapeAsset.cs
@@ -17,7 +17,12 @@ namespace DCL.Landscape.Config
         /// </summary>
         [Header("Settings when used as tree")]
         public ObjectRandomization randomization;
+
+        [Tooltip("This radius is being used for this asset to not overlap with the same asset type")]
         public float radius;
+
+        [Tooltip("This radius is being used for this asset to not overlap with other asset types, you might want to set this value a bit lower than radius for nicer results, since your trees might get no stones below it")]
+        public float secondaryRadius;
 
         [Header("Settings when used as detail")]
         public TerrainDetailSettings TerrainDetailSettings;

--- a/Explorer/Assets/DCL/Landscape/Data/Trees/Birch.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/Trees/Birch.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: 0, y: 0}
   radius: 7
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/Trees/Bush01.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/Trees/Bush01.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: -0.5, y: 0.5}
   radius: 2
+  secondaryRadius: 1
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/Trees/Bush02.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/Trees/Bush02.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: -0.5, y: 0.5}
   radius: 2
+  secondaryRadius: 1
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/Trees/Oak.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/Trees/Oak.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: 0, y: 0}
   radius: 15
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/Trees/Oak2.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/Trees/Oak2.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: 0, y: 0}
   radius: 15
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/Trees/Tree01.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/Trees/Tree01.asset
@@ -19,14 +19,15 @@ MonoBehaviour:
     randomRotationY: {x: 0, y: 360}
     randomRotationZ: {x: -5, y: 5}
     proportionalScale: 1
-    randomScale: {x: 1, y: 2}
+    randomScale: {x: 0.75, y: 1.25}
     randomScaleX: {x: 0, y: 0}
     randomScaleY: {x: 0, y: 0}
     randomScaleZ: {x: 0, y: 0}
     positionOffsetX: {x: 0, y: 0}
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: 0, y: 0}
-  radius: 18
+  radius: 10
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/Trees/Tree02.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/Trees/Tree02.asset
@@ -19,14 +19,15 @@ MonoBehaviour:
     randomRotationY: {x: 0, y: 360}
     randomRotationZ: {x: -5, y: 5}
     proportionalScale: 1
-    randomScale: {x: 1, y: 1}
+    randomScale: {x: 0.75, y: 1}
     randomScaleX: {x: 0, y: 0}
     randomScaleY: {x: 0, y: 0}
     randomScaleZ: {x: 0, y: 0}
     positionOffsetX: {x: 0, y: 0}
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: 0, y: 0}
-  radius: 18
+  radius: 10
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/Trees/Tree03.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/Trees/Tree03.asset
@@ -19,14 +19,15 @@ MonoBehaviour:
     randomRotationY: {x: 0, y: 360}
     randomRotationZ: {x: -5, y: 5}
     proportionalScale: 1
-    randomScale: {x: 1, y: 1}
+    randomScale: {x: 0.75, y: 1}
     randomScaleX: {x: 0, y: 0}
     randomScaleY: {x: 0, y: 0}
     randomScaleZ: {x: 0, y: 0}
     positionOffsetX: {x: 0, y: 0}
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: 0, y: 0}
-  radius: 35
+  radius: 13
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsTerrainData.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsTerrainData.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   terrainSize: 1
   chunkSize: 1
   heightScaleNerf: 0.25
-  seed: 97
+  seed: 380
   terrainHoleEdgeSize: 0.5
   minHeight: 0
   pondDepth: 0

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Bush01_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Bush01_W.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: -0.5, y: 0.5}
   radius: 2
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Bush02_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Bush02_W.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: -0.5, y: 0.5}
   radius: 2
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Noises/Bush02Noise_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Noises/Bush02Noise_W.asset
@@ -15,13 +15,13 @@ MonoBehaviour:
   settings:
     invert: 0
     normalize: 0
-    scale: 27.36
+    scale: 14.45
     octaves: 2
     persistance: 1
-    lacunarity: 7.1
+    lacunarity: 11.6
     seed: 26
     offset: {x: 0, y: 0}
-    cutoff: 0.5
+    cutoff: 0.42
     noiseType: 2
     baseValue: 0
     multiplyValue: 0

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Noises/OakCNoise_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Noises/OakCNoise_W.asset
@@ -15,17 +15,17 @@ MonoBehaviour:
   settings:
     invert: 0
     normalize: 1
-    scale: 30.41
+    scale: 8.75
     octaves: 2
     persistance: 1
-    lacunarity: 1.66
+    lacunarity: 2.4
     seed: 22
     offset: {x: 0, y: 0}
     cutoff: 0
     noiseType: 1
     baseValue: 0
     multiplyValue: 1
-    divideValue: 2
+    divideValue: 2.63
   operations:
   - operation: 2
     noise: {fileID: 11400000, guid: f1828e41f6f44394c8807749fc57c5bd, type: 2}

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Noises/StoneNoise03_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Noises/StoneNoise03_W.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   settings:
     invert: 0
     normalize: 1
-    scale: 21.2
+    scale: 3
     octaves: 2
     persistance: 1
     lacunarity: 9.3
@@ -23,3 +23,6 @@ MonoBehaviour:
     offset: {x: 18.59, y: 0}
     cutoff: 0.75
     noiseType: 0
+    baseValue: 0
+    multiplyValue: 0
+    divideValue: 0

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Stone01_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Stone01_W.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
     positionOffsetY: {x: 0, y: 0}
     positionOffsetZ: {x: -0.5, y: 0.5}
   radius: 1
+  secondaryRadius: 1
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Stone02_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Stone02_W.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
     positionOffsetY: {x: 0, y: 0}
     positionOffsetZ: {x: -0.5, y: 0.5}
   radius: 1
+  secondaryRadius: 1
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Stone03_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Stone03_W.asset
@@ -27,6 +27,7 @@ MonoBehaviour:
     positionOffsetY: {x: 0, y: 0}
     positionOffsetZ: {x: -0.5, y: 0.5}
   radius: 1
+  secondaryRadius: 1
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Tree01_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Tree01_W.asset
@@ -19,14 +19,15 @@ MonoBehaviour:
     randomRotationY: {x: 0, y: 360}
     randomRotationZ: {x: -5, y: 5}
     proportionalScale: 1
-    randomScale: {x: 1, y: 2}
+    randomScale: {x: 0.75, y: 1.5}
     randomScaleX: {x: 0, y: 0}
     randomScaleY: {x: 0, y: 0}
     randomScaleZ: {x: 0, y: 0}
     positionOffsetX: {x: 0, y: 0}
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: 0, y: 0}
-  radius: 18
+  radius: 9
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Tree02_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Tree02_W.asset
@@ -19,14 +19,15 @@ MonoBehaviour:
     randomRotationY: {x: 0, y: 360}
     randomRotationZ: {x: -5, y: 5}
     proportionalScale: 1
-    randomScale: {x: 1, y: 1}
+    randomScale: {x: 0.75, y: 1.5}
     randomScaleX: {x: 0, y: 0}
     randomScaleY: {x: 0, y: 0}
     randomScaleZ: {x: 0, y: 0}
     positionOffsetX: {x: 0, y: 0}
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: 0, y: 0}
-  radius: 18
+  radius: 9
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Tree03_W.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/WorldsVairations/Tree03_W.asset
@@ -19,14 +19,15 @@ MonoBehaviour:
     randomRotationY: {x: 0, y: 360}
     randomRotationZ: {x: -5, y: 5}
     proportionalScale: 1
-    randomScale: {x: 1, y: 1}
+    randomScale: {x: 0.65, y: 0.75}
     randomScaleX: {x: 0, y: 0}
     randomScaleY: {x: 0, y: 0}
     randomScaleZ: {x: 0, y: 0}
     positionOffsetX: {x: 0, y: 0}
     positionOffsetY: {x: -0.1, y: -0.2}
     positionOffsetZ: {x: 0, y: 0}
-  radius: 35
+  radius: 10
+  secondaryRadius: 2
   TerrainDetailSettings:
     alignToGround: 100
     positionJitter: 50

--- a/Explorer/Assets/DCL/Landscape/Jobs/GenerateTreeInstancesJob.cs
+++ b/Explorer/Assets/DCL/Landscape/Jobs/GenerateTreeInstancesJob.cs
@@ -25,7 +25,7 @@ namespace DCL.Landscape.Jobs
         [ReadOnly] private NativeArray<float>.ReadOnly treeNoise;
         [ReadOnly] private ObjectRandomization treeRandomization;
         [ReadOnly] private readonly NativeParallelHashMap<int2, EmptyParcelNeighborData>.ReadOnly emptyParcelResult;
-        [ReadOnly] private readonly float treeRadius;
+        [ReadOnly] private readonly TreeRadiusPair treeRadius;
         [ReadOnly] private readonly int treeIndex;
         [ReadOnly] private readonly int chunkSize;
         [ReadOnly] private readonly int2 chunkMinParcel;
@@ -40,7 +40,7 @@ namespace DCL.Landscape.Jobs
             NativeParallelHashMap<int2, TreeInstance>.ParallelWriter treeInstances,
             NativeParallelHashMap<int2, EmptyParcelNeighborData>.ReadOnly emptyParcelResult,
             in ObjectRandomization treeRandomization,
-            float treeRadius,
+            TreeRadiusPair treeRadius,
             int treeIndex,
             in int2 chunkMinParcel,
             int chunkSize,
@@ -97,7 +97,7 @@ namespace DCL.Landscape.Jobs
             {
                 if(!emptyParcelResult.TryGetValue(parcel, out EmptyParcelNeighborData item)) return;
 
-                float radius = treeRadius * scale * value;
+                float radius = treeRadius.radius * scale * value;
 
                 // We check nearby boundaries (there has to be a simpler way)
                 bool u = CheckAssetPosition(item, parcel, parcelWorldPos, treeWorldPosition, up, 0, radius);

--- a/Explorer/Assets/DCL/Landscape/Jobs/InvalidateTreesJob.cs
+++ b/Explorer/Assets/DCL/Landscape/Jobs/InvalidateTreesJob.cs
@@ -9,21 +9,19 @@ namespace DCL.Landscape.Jobs
 {
     /// <summary>
     ///     This job's purpose is to invalidate trees that are too close to each other,
-    ///     running this in parallel would imply that all overlapping trees will be invalidated, so we get no trees as a result
     /// </summary>
-
-    //[BurstCompile]
+    [BurstCompile]
     public struct InvalidateTreesJob : IJobParallelFor
     {
         private readonly NativeParallelHashMap<int2, TreeInstance>.ReadOnly treeInstances;
-        private readonly NativeHashMap<int, float>.ReadOnly radius;
+        private readonly NativeHashMap<int, TreeRadiusPair>.ReadOnly radius;
         private NativeParallelHashMap<int2, bool>.ParallelWriter treeInvalidationMap;
         private readonly int mapSize;
 
         public InvalidateTreesJob(
             NativeParallelHashMap<int2, TreeInstance>.ReadOnly treeInstances,
             NativeParallelHashMap<int2, bool>.ParallelWriter treeInvalidationMap,
-            NativeHashMap<int, float>.ReadOnly radius,
+            NativeHashMap<int, TreeRadiusPair>.ReadOnly radius,
             int mapSize)
         {
             this.treeInstances = treeInstances;
@@ -42,25 +40,14 @@ namespace DCL.Landscape.Jobs
             if (!treeInstances.TryGetValue(key, out TreeInstance treeInstanceValue))
                 return;
 
-            float radiusWithScale = radius[treeInstanceValue.prototypeIndex] * treeInstanceValue.widthScale;
-            bool isValid = CheckAssetSpatialAvailability((int)math.ceil(radiusWithScale), key.x, key.y, treeInstanceValue.prototypeIndex, true);
+            TreeRadiusPair treeRadiusPair = radius[treeInstanceValue.prototypeIndex];
+            float radiusWithScale = treeRadiusPair.radius * treeInstanceValue.widthScale;
+            bool isValid = CheckAssetSpatialAvailability((int)math.ceil(radiusWithScale), treeRadiusPair.secondaryRadius, key.x, key.y, treeInstanceValue.prototypeIndex, true);
             treeInvalidationMap.TryAdd(key, !isValid);
         }
 
-        /*public void Execute()
-        {
-            foreach (KeyValue<int2,TreeInstance> treeInstance in treeInstances)
-            {
-                var key = treeInstance.Key;
-                TreeInstance treeInstanceValue = treeInstance.Value;
-
-                float radiusWithScale = radius[treeInstanceValue.prototypeIndex] * treeInstanceValue.widthScale;
-                bool isValid = CheckAssetSpatialAvailability((int)math.ceil(radiusWithScale), key.x, key.y, treeInstanceValue.prototypeIndex, true);
-                treeInvalidationMap.TryAdd(key, !isValid);
-            }
-        }*/
-
-        private bool CheckAssetSpatialAvailability(int intRadius, int x, int y, int prototypeIndex, bool recursive)
+        private bool CheckAssetSpatialAvailability(int intRadius, float secondaryRadius, int x, int y, int itemPrototypeIndex,
+            bool recursive)
         {
             var isValid = true;
             int index = x + (y * mapSize);
@@ -82,15 +69,35 @@ namespace DCL.Landscape.Jobs
                     if (!treeInstances.TryGetValue(pointer, out TreeInstance otherInstance))
                         continue;
 
+                    TreeRadiusPair treeRadiusPair = radius[otherInstance.prototypeIndex];
+                    float otherRadius = treeRadiusPair.secondaryRadius;
+
                     // if we want certain assets to not overlap with other types, we can do an overlap matrix like the collisions one and implement that logic here
-                    isValid = otherInstance.prototypeIndex != prototypeIndex;
+                    bool isPrototypeDifferent = otherInstance.prototypeIndex != itemPrototypeIndex;
+
+                    if (isPrototypeDifferent)
+                    {
+                        // we check the secondary radius of that asset to see if we overlap with it
+                        float sum = otherRadius + secondaryRadius;
+                        isValid = math.distancesq(new int2(x, y), pointer) > sum * sum;
+                    }
+                    else
+                        isValid = otherInstance.prototypeIndex != itemPrototypeIndex;
 
                     if (!recursive || isValid || index > pointerIndex)
                         continue;
 
                     // We do a recursive lookup to check if that asset is going to be invalid as well (specially made for IJobParallelFor)
-                    bool isOtherValid = CheckAssetSpatialAvailability(intRadius, pointer.x, pointer.y, prototypeIndex, false);
-                    isValid = !isOtherValid;
+                    if (isPrototypeDifferent)
+                    {
+                        bool isOtherValid = CheckAssetSpatialAvailability((int)math.ceil(treeRadiusPair.radius), otherRadius, pointer.x, pointer.y, otherInstance.prototypeIndex, false);
+                        isValid = !isOtherValid;
+                    }
+                    else
+                    {
+                        bool isOtherValid = CheckAssetSpatialAvailability(intRadius, secondaryRadius, pointer.x, pointer.y, otherInstance.prototypeIndex, false);
+                        isValid = !isOtherValid;
+                    }
                 }
             }
 

--- a/Explorer/Assets/DCL/Landscape/Jobs/TreeRadiusPair.cs
+++ b/Explorer/Assets/DCL/Landscape/Jobs/TreeRadiusPair.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace DCL.Landscape.Jobs
+{
+    [Serializable]
+    public struct TreeRadiusPair
+    {
+        public float radius;
+        public float secondaryRadius;
+    }
+}

--- a/Explorer/Assets/DCL/Landscape/Jobs/TreeRadiusPair.cs.meta
+++ b/Explorer/Assets/DCL/Landscape/Jobs/TreeRadiusPair.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d539809761184b25a8dde199c66abca0
+timeCreated: 1714138977

--- a/Explorer/Assets/DCL/Landscape/TerrainChunkDataGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainChunkDataGenerator.cs
@@ -180,7 +180,7 @@ namespace DCL.Landscape
 
                 var treeInstances = new NativeParallelHashMap<int2, TreeInstance>(chunkSize * chunkSize, Allocator.Persistent);
                 var treeInvalidationMap = new NativeParallelHashMap<int2, bool>(chunkSize * chunkSize, Allocator.Persistent);
-                var treeRadiusMap = new NativeHashMap<int, float>(terrainGenData.treeAssets.Length, Allocator.Persistent);
+                var treeRadiusMap = new NativeHashMap<int, TreeRadiusPair>(terrainGenData.treeAssets.Length, Allocator.Persistent);
                 var treeParallelRandoms = new NativeArray<Random>(chunkSize * chunkSize, Allocator.Persistent);
 
                 JobHandle instancingHandle = default;
@@ -194,7 +194,8 @@ namespace DCL.Landscape
                             LandscapeAsset treeAsset = terrainGenData.treeAssets[treeAssetIndex];
                             NoiseDataBase treeNoiseData = treeAsset.noiseData;
 
-                            treeRadiusMap.Add(treeAssetIndex, treeAsset.radius);
+                            var treeRadiusPair = new TreeRadiusPair { radius = treeAsset.radius, secondaryRadius = treeAsset.secondaryRadius };
+                            treeRadiusMap.Add(treeAssetIndex, treeRadiusPair);
 
                             INoiseGenerator generator = noiseGenCache.GetGeneratorFor(treeNoiseData, baseSeed);
                             var noiseDataPointer = new NoiseDataPointer(chunkSize, chunkMinParcel.x, chunkMinParcel.y);
@@ -210,7 +211,7 @@ namespace DCL.Landscape
                                 treeInstances.AsParallelWriter(),
                                 emptyParcelsNeighborData.AsReadOnly(),
                                 in treeAsset.randomization,
-                                treeAsset.radius,
+                                treeRadiusPair,
                                 treeAssetIndex,
                                 chunkMinParcel,
                                 chunkSize,

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -27,7 +27,7 @@ namespace DCL.Landscape
         private const string TERRAIN_OBJECT_NAME = "Generated Terrain";
 
         // increment this number if we want to force the users to generate a new terrain cache
-        private const int CACHE_VERSION = 2;
+        private const int CACHE_VERSION = 3;
 
         private const float PROGRESS_COUNTER_EMPTY_PARCEL_DATA = 0.1f;
         private const float PROGRESS_COUNTER_TERRAIN_DATA = 0.3f;
@@ -58,7 +58,6 @@ namespace DCL.Landscape
         private int processedTerrainDataCount;
         private int spawnedTerrainDataCount;
         private float terrainDataCount;
-        private bool showTerrainByDefault;
 
         private Transform rootGo;
         public Transform Ocean { get; private set; }
@@ -127,8 +126,6 @@ namespace DCL.Landscape
             CancellationToken cancellationToken = default)
         {
             if (!isInitialized) return;
-
-            this.showTerrainByDefault = showTerrainByDefault;
 
             this.hideDetails = hideDetails;
             this.hideTrees = hideTrees;

--- a/Explorer/Assets/DCL/Landscape/TerrainGeneratorTest.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGeneratorTest.cs
@@ -51,6 +51,12 @@ namespace DCL.Landscape
         [ContextMenu("Generate")]
         public async UniTask GenerateAsync()
         {
+            var worldLastTerrain = GameObject.Find("World Generated Terrain");
+            if (worldLastTerrain != null) DestroyImmediate(worldLastTerrain);
+
+            var lastTerrain = GameObject.Find("Generated Terrain");
+            if (lastTerrain != null) DestroyImmediate(lastTerrain);
+
             Log("Generate started");
             ownedParcels = parcelData.GetOwnedParcels();
             emptyParcels = parcelData.GetEmptyParcels();

--- a/Explorer/Assets/Scenes/InfiniteTerrain.unity
+++ b/Explorer/Assets/Scenes/InfiniteTerrain.unity
@@ -15,9 +15,9 @@ RenderSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 9
   m_Fog: 0
-  m_FogColor: {r: 0.8352941, g: 0.29178533, b: 0.48649436, a: 0.16862746}
-  m_FogMode: 1
-  m_FogDensity: 0.5
+  m_FogColor: {r: 0.8773585, g: 0.47592562, b: 0.47592562, a: 0.31764707}
+  m_FogMode: 2
+  m_FogDensity: 0.4
   m_LinearFogStart: 0
   m_LinearFogEnd: 0
   m_AmbientSkyColor: {r: 0.41429335, g: 0.49538925, b: 0.6603774, a: 1}
@@ -459,14 +459,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2ebb9ffde2df4ff4936c991393d7bcb7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clearCache: 0
-  worldSeed: 111
+  clearCache: 1
+  worldSeed: 372
   digHoles: 1
-  centerTerrain: 1
   hideTrees: 0
   hideDetails: 0
-  genData: {fileID: 11400000, guid: 073a968567df25b4988ecaf238256181, type: 2}
-  parcelData: {fileID: 11400000, guid: 45cecc148a9fbf148864f180a3dcdcc9, type: 2}
+  clearNoiseCacheForWorlds: 1
+  genData: {fileID: 11400000, guid: 409e3f2e0a395134cb4def3ba3747c39, type: 2}
+  parcelData: {fileID: 11400000, guid: 86bf0204cf3bb75429342452a2a460af, type: 2}
 --- !u!4 &1359845491
 Transform:
   m_ObjectHideFlags: 0

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -327,8 +327,8 @@
       }
     },
     "com.unity.render-pipelines.universal": {
-      "version": "14.0.10",
-      "depth": 1,
+      "version": "14.0.8",
+      "depth": 0,
       "source": "builtin",
       "dependencies": {
         "com.unity.mathematics": "1.2.1",
@@ -340,7 +340,7 @@
     },
     "com.unity.render-pipelines.universal-config": {
       "version": "14.0.9",
-      "depth": 2,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {
         "com.unity.render-pipelines.core": "14.0.9"
@@ -355,7 +355,7 @@
     },
     "com.unity.searcher": {
       "version": "4.9.2",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -379,7 +379,7 @@
     },
     "com.unity.shadergraph": {
       "version": "14.0.10",
-      "depth": 2,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {
         "com.unity.render-pipelines.core": "14.0.10",


### PR DESCRIPTION
## What does this PR change?

Solves [#692](https://github.com/decentraland/unity-explorer/issues/692)

- Fixed tree overlap
- Trees spawn with more different scales now, this enables putting smaller trees on smaller portions of terrain, so overall more trees should spawn on single empty parcels

## How to test the changes?

🌲 fly around and check the trees :) 🌳 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

