### PR TITLE
fix: interactions with GLTFs

### DIFF
--- a/Explorer/Assets/DCL/Interaction/Raycast/Components/HighlightComponent.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Components/HighlightComponent.cs
@@ -15,7 +15,7 @@ namespace DCL.Interaction.Raycast.Components
         private Material? materialOnUse;
 
         //Should be repooled
-        public readonly Dictionary<EntityReference, Material[]> OriginalMaterials;
+        public readonly Dictionary<Renderer, Material[]> OriginalMaterials;
 
         public HighlightComponent(bool isEnabled, bool isAtDistance, EntityReference currentEntity, EntityReference nextEntity) : this()
         {
@@ -23,7 +23,7 @@ namespace DCL.Interaction.Raycast.Components
             this.isAtDistance = isAtDistance;
             this.currentEntity = currentEntity;
             this.nextEntity = nextEntity;
-            OriginalMaterials = new Dictionary<EntityReference, Material[]>();
+            OriginalMaterials = new Dictionary<Renderer, Material[]>();
         }
 
         public void Setup(bool atDistance, EntityReference newNextEntity)

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/AssetPromise.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/AssetPromise.cs
@@ -80,7 +80,7 @@ namespace ECS.StreamableLoading.Common
         /// </summary>
         public bool TryConsume(World world, out StreamableLoadingResult<TAsset> result)
         {
-            Assert.IsFalse(Result.HasValue, ASSERTION_MESSAGE);
+            //Assert.IsFalse(Result.HasValue, ASSERTION_MESSAGE);
 
             result = default(StreamableLoadingResult<TAsset>);
 

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/AssetPromise.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/AssetPromise.cs
@@ -80,7 +80,7 @@ namespace ECS.StreamableLoading.Common
         /// </summary>
         public bool TryConsume(World world, out StreamableLoadingResult<TAsset> result)
         {
-            //Assert.IsFalse(Result.HasValue, ASSERTION_MESSAGE);
+            Assert.IsFalse(Result.HasValue, ASSERTION_MESSAGE);
 
             result = default(StreamableLoadingResult<TAsset>);
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -270,7 +270,7 @@ namespace Global.Dynamic
                             {
                                 InitialRealm.GenesisCity => IRealmNavigator.GENESIS_URL,
                                 InitialRealm.SDK => IRealmNavigator.SDK_TEST_SCENES_URL,
-                                InitialRealm.World => IRealmNavigator.WORLDS_DOMAIN + targetWorld,
+                                InitialRealm.World => IRealmNavigator.WORLDS_DOMAIN + "/" + targetWorld,
                                 InitialRealm.Localhost => IRealmNavigator.LOCALHOST,
                                 InitialRealm.Custom => customRealm,
                                 _ => startingRealm,


### PR DESCRIPTION
## What does this PR change?

Fixes [#703](https://github.com/decentraland/unity-explorer/issues/703)
Fixes #710 

- Removed assertion that was making some assets to not load randomly on the editor
- Fixed interaction highlight with GLTF's and also fixed a null reference caused by the same system
- Fixed the ability to start on a world from the MainSceneLoader

## How to test the changes?

- `/world dclexperience`
- Hover your cursor over interactables, you have the twitter buttons, the bot and downside you have some other characters that can be interacted with.
- Characters can be interacted and have an outline

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

