### PR TITLE
Fix #739 : fixed chat bubble message cutout on certain length

### DIFF
--- a/Explorer/Assets/DCL/NameTags/NametagView.cs
+++ b/Explorer/Assets/DCL/NameTags/NametagView.cs
@@ -231,7 +231,7 @@ namespace DCL.Nametags
         private float CalculatePreferredWidth(string messageContent)
         {
             if(Username.preferredWidth + chatBubbleConfiguration.nametagMarginOffsetWidth + (isClaimedName ? VerifiedIcon.sizeDelta.x : 0) > MessageContent.preferredWidth)
-                return Username.preferredWidth + chatBubbleConfiguration.nametagMarginOffsetWidth;
+                return Username.preferredWidth + chatBubbleConfiguration.nametagMarginOffsetWidth + (isClaimedName ? VerifiedIcon.sizeDelta.x : 0);
 
             if(MessageContent.GetPreferredValues(messageContent, MaxWidth, 0).x < MaxWidth)
                 return MessageContent.GetPreferredValues(messageContent, MaxWidth, 0).x;


### PR DESCRIPTION
## What does this PR change?

Fixes issue #739 

...

## How to test the changes?


1. Launch the explorer
2. send messages of different lengths
3. verify the chat bubble never cuts out any text

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

