### PR TITLE
fix: player raycasting when panning camera

### DIFF
--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/PlayerOriginRaycastResult.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/PlayerOriginRaycastResult.cs
@@ -1,4 +1,5 @@
 using DCL.Interaction.Utility;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace DCL.Interaction.PlayerOriginated.Components
@@ -8,13 +9,57 @@ namespace DCL.Interaction.PlayerOriginated.Components
         /// <summary>
         ///     Collider is hit and it belongs to an entity
         /// </summary>
-        public bool IsValidHit => EntityInfo.HasValue;
-        public float Distance;
+        public bool IsValidHit => entityInfo.HasValue;
 
-        public GlobalColliderEntityInfo? EntityInfo;
+        private float distance;
+        private GlobalColliderEntityInfo? entityInfo;
+        private RaycastHit unityRaycastHit;
+        private Ray originRay;
 
-        public RaycastHit UnityRaycastHit;
+        public PlayerOriginRaycastResult(RaycastHit unityRaycastHit) : this()
+        {
+            this.unityRaycastHit = unityRaycastHit;
+        }
 
-        public Ray OriginRay;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Reset()
+        {
+            unityRaycastHit = default(RaycastHit);
+            entityInfo = null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetRay(Ray ray)
+        {
+            originRay = ray;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetupHit(RaycastHit hitInfo, GlobalColliderEntityInfo entityInfo, float distance)
+        {
+            unityRaycastHit = hitInfo;
+            this.entityInfo = entityInfo;
+            this.distance = distance;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public GlobalColliderEntityInfo GetEntityInfo() =>
+            entityInfo!.Value;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Collider GetCollider() =>
+            unityRaycastHit.collider;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public RaycastHit GetRaycastHit() =>
+            unityRaycastHit;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Ray GetOriginRay() =>
+            originRay;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly float GetDistance() =>
+            distance;
     }
 }

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/PlayerOriginRaycastResult.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/PlayerOriginRaycastResult.cs
@@ -43,8 +43,8 @@ namespace DCL.Interaction.PlayerOriginated.Components
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public GlobalColliderEntityInfo GetEntityInfo() =>
-            entityInfo!.Value;
+        public GlobalColliderEntityInfo? GetEntityInfo() =>
+            entityInfo;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Collider GetCollider() =>

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/InteractionInputUtilsShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/InteractionInputUtilsShould.cs
@@ -60,11 +60,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
         [Test]
         public void QualifyByDistance()
         {
-            Assert.IsTrue(InteractionInputUtils.IsQualifiedByDistance(new PlayerOriginRaycastResult
-            {
-                UnityRaycastHit = new RaycastHit
-                    { distance = 100 },
-            }, new PBPointerEvents.Types.Info { MaxDistance = 110 }));
+            Assert.IsTrue(InteractionInputUtils.IsQualifiedByDistance(new PlayerOriginRaycastResult(new RaycastHit { distance = 100 }), new PBPointerEvents.Types.Info { MaxDistance = 110 }));
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/PlayerOriginatedRaycastSystemShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/PlayerOriginatedRaycastSystemShould.cs
@@ -74,7 +74,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResult raycastResult = ref playerInteractionEntity.PlayerOriginRaycastResult;
             Assert.That(raycastResult.IsValidHit, Is.True);
-            Assert.That(raycastResult.UnityRaycastHit.collider, Is.EqualTo(collider));
+            Assert.That(raycastResult.GetCollider(), Is.EqualTo(collider));
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResult raycastResult = ref playerInteractionEntity.PlayerOriginRaycastResult;
             Assert.That(raycastResult.IsValidHit, Is.True);
-            Assert.That(raycastResult.UnityRaycastHit.collider, Is.EqualTo(collider));
+            Assert.That(raycastResult.GetCollider(), Is.EqualTo(collider));
         }
 
         [Test]
@@ -125,7 +125,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResult raycastResult = ref playerInteractionEntity.PlayerOriginRaycastResult;
             Assert.That(raycastResult.IsValidHit, Is.False);
-            Assert.That(raycastResult.EntityInfo, Is.Null);
+            Assert.That(raycastResult.GetEntityInfo(), Is.Null);
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResult raycastResult = ref playerInteractionEntity.PlayerOriginRaycastResult;
             Assert.That(raycastResult.IsValidHit, Is.False);
-            Assert.That(raycastResult.EntityInfo, Is.Null);
+            Assert.That(raycastResult.GetCollider(), Is.Null);
         }
 
         [Test]
@@ -166,7 +166,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResult raycastResult = ref playerInteractionEntity.PlayerOriginRaycastResult;
             Assert.That(raycastResult.IsValidHit, Is.False);
-            Assert.That(raycastResult.EntityInfo, Is.Null);
+            Assert.That(raycastResult.GetEntityInfo(), Is.Null);
         }
     }
 }

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/PlayerOriginatedRaycastSystemShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/PlayerOriginatedRaycastSystemShould.cs
@@ -168,5 +168,32 @@ namespace DCL.Interaction.PlayerOriginated.Tests
             Assert.That(raycastResult.IsValidHit, Is.False);
             Assert.That(raycastResult.GetEntityInfo(), Is.Null);
         }
+
+        [Test]
+        public void DoNotRaycastWhenPanningCamera()
+        {
+            var colliderGo = new GameObject(nameof(PlayerOriginatedRaycastSystemShould));
+            colliderGo.transform.ResetLocalTRS();
+            colliderGo.transform.localPosition = new Vector3(0, 0, 10);
+            colliderGo.layer = PhysicsLayers.DEFAULT_LAYER;
+            BoxCollider collider = colliderGo.AddComponent<BoxCollider>();
+            collider.size = Vector3.one;
+
+            entityCollidersGlobalCache.TryGetEntity(collider, out Arg.Any<GlobalColliderEntityInfo>())
+                                      .Returns(x =>
+                                       {
+                                           x[1] = new GlobalColliderEntityInfo();
+                                           return true;
+                                       });
+
+            ref CursorComponent cc = ref world.Get<CursorComponent>(cameraEntity);
+            cc.CursorState = CursorState.Panning;
+
+            system.Update(0);
+
+            ref PlayerOriginRaycastResult raycastResult = ref playerInteractionEntity.PlayerOriginRaycastResult;
+            Assert.That(raycastResult.IsValidHit, Is.False);
+            Assert.That(raycastResult.GetCollider(), Is.Null);
+        }
     }
 }

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/ProcessPointerEventsSystemShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/ProcessPointerEventsSystemShould.cs
@@ -58,12 +58,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             previousColliderInfo.EcsExecutor.World.Add(previousColliderInfo.ColliderEntityInfo.EntityReference, pbPointerEvents);
 
-            var raycastResult = new PlayerOriginRaycastResult
-            {
-                UnityRaycastHit = new RaycastHit
-                    { distance = 99 },
-                Distance = 99,
-            };
+            PlayerOriginRaycastResult raycastResult = GetRaycastAt(99);
 
             HoverFeedbackUtils.TryIssueLeaveHoverEventForPreviousEntity(in raycastResult, in previousColliderInfo);
 
@@ -89,12 +84,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             previousColliderInfo.EcsExecutor.World.Add(previousColliderInfo.ColliderEntityInfo.EntityReference, pbPointerEvents);
 
-            var raycastResult = new PlayerOriginRaycastResult
-            {
-                UnityRaycastHit = new RaycastHit
-                    { distance = 150 },
-                Distance = 150,
-            };
+            PlayerOriginRaycastResult raycastResult = GetRaycastAt(150);
 
             HoverFeedbackUtils.TryIssueLeaveHoverEventForPreviousEntity(in raycastResult, in previousColliderInfo);
 
@@ -108,12 +98,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             // Don't add PBPointerEvents component
 
-            var raycastResult = new PlayerOriginRaycastResult
-            {
-                UnityRaycastHit = new RaycastHit
-                    { distance = 50 },
-                Distance = 50,
-            };
+            PlayerOriginRaycastResult raycastResult = GetRaycastAt(50);
 
             HoverFeedbackUtils.TryIssueLeaveHoverEventForPreviousEntity(in raycastResult, in previousColliderInfo);
 
@@ -138,12 +123,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             previousColliderInfo.EcsExecutor.World.Add(previousColliderInfo.ColliderEntityInfo.EntityReference, pbPointerEvents);
 
-            var raycastResult = new PlayerOriginRaycastResult
-            {
-                UnityRaycastHit = new RaycastHit
-                    { distance = 50 },
-                Distance = 50,
-            };
+            PlayerOriginRaycastResult raycastResult = GetRaycastAt(50);
 
             world.Destroy(previousColliderInfo.ColliderEntityInfo.EntityReference);
 
@@ -155,5 +135,12 @@ namespace DCL.Interaction.PlayerOriginated.Tests
         private GlobalColliderEntityInfo CreateColliderInfo() =>
             new (new SceneEcsExecutor(world, new MutexSync()),
                 new ColliderEntityInfo(world.Reference(world.Create(new CRDTEntity(123))), 123, ColliderLayer.ClPhysics));
+
+        private static PlayerOriginRaycastResult GetRaycastAt(float distance)
+        {
+            var raycastResult = new PlayerOriginRaycastResult();
+            raycastResult.SetupHit(new RaycastHit { distance = distance }, default(GlobalColliderEntityInfo), distance);
+            return raycastResult;
+        }
     }
 }

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/InteractionInputUtils.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/InteractionInputUtils.cs
@@ -29,7 +29,7 @@ namespace DCL.Interaction.PlayerOriginated.Utility
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsQualifiedByDistance(in PlayerOriginRaycastResult raycastResult, PBPointerEvents.Types.Info info) =>
-            !(raycastResult.Distance > info.MaxDistance);
+            !(raycastResult.GetDistance() > info.MaxDistance);
 
         /// <summary>
         ///     Adds hover input if the entry is qualified for listening to it

--- a/Explorer/Assets/DCL/Interaction/Systems/PlayerOriginatedRaycastSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/PlayerOriginatedRaycastSystem.cs
@@ -55,29 +55,29 @@ namespace DCL.Interaction.PlayerOriginated.Systems
         [Query]
         private void RaycastFromCamera(ref CameraComponent camera, in CursorComponent cursorComponent)
         {
+            ref PlayerOriginRaycastResult raycastResult = ref playerInteractionEntity.PlayerOriginRaycastResult;
+
+            if (cursorComponent.CursorState == CursorState.Panning)
+            {
+                raycastResult.Reset();
+                return;
+            }
+
             Ray ray = CreateRay(in camera, in cursorComponent);
 
             // we are interested in one hit only
-
             bool hasHit = Physics.Raycast(ray, out RaycastHit hitInfo, maxRaycastDistance, PhysicsLayers.PLAYER_ORIGIN_RAYCAST_MASK);
-            ref PlayerOriginRaycastResult raycastResult = ref playerInteractionEntity.PlayerOriginRaycastResult;
 
-            raycastResult.OriginRay = ray;
+            raycastResult.SetRay(ray);
 
             if (hasHit && collidersGlobalCache.TryGetEntity(hitInfo.collider, out GlobalColliderEntityInfo entityInfo))
             {
-                raycastResult.UnityRaycastHit = hitInfo;
-                raycastResult.EntityInfo = entityInfo;
-
-                raycastResult.Distance =
-                    camera.Mode == CameraMode.FirstPerson
-                        ? hitInfo.distance
-                        : Vector3.Distance(hitInfo.point, camera.PlayerFocus.position);
+                float distance = camera.Mode == CameraMode.FirstPerson ? hitInfo.distance : Vector3.Distance(hitInfo.point, camera.PlayerFocus.position);
+                raycastResult.SetupHit(hitInfo, entityInfo, distance);
             }
             else
             {
-                raycastResult.UnityRaycastHit = default(RaycastHit);
-                raycastResult.EntityInfo = null;
+                raycastResult.Reset();
             }
         }
 

--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
@@ -70,7 +70,7 @@ namespace DCL.Interaction.Systems
 
             if (raycastResult.IsValidHit && canHover)
             {
-                GlobalColliderEntityInfo entityInfo = raycastResult.EntityInfo.Value;
+                GlobalColliderEntityInfo entityInfo = raycastResult.GetEntityInfo();
 
                 InteractionInputUtils.AnyInputInfo anyInputInfo = sdkInputActionsMap.Values.GatherAnyInputInfo();
 
@@ -83,7 +83,7 @@ namespace DCL.Interaction.Systems
                     // Entity should be alive and contain PBPointerEvents component to be qualified
                     if (entityRef.IsAlive(world) && world.TryGet(entityRef, out PBPointerEvents pbPointerEvents))
                     {
-                        hoverStateComponent.LastHitCollider = raycastResult.UnityRaycastHit.collider;
+                        hoverStateComponent.LastHitCollider = raycastResult.GetCollider();
                         hoverStateComponent.HasCollider = true;
 
                         bool newEntityWasHovered = !candidateForHoverLeaveIsValid
@@ -93,7 +93,7 @@ namespace DCL.Interaction.Systems
                         if (candidateForHoverLeaveIsValid && !newEntityWasHovered)
                             candidateForHoverLeaveIsValid = false;
 
-                        pbPointerEvents!.AppendPointerEventResultsIntent.Initialize(raycastResult.UnityRaycastHit, raycastResult.OriginRay);
+                        pbPointerEvents!.AppendPointerEventResultsIntent.Initialize(raycastResult.GetRaycastHit(), raycastResult.GetOriginRay());
 
                         bool isAtDistance = SetupPointerEvents(raycastResult, ref hoverFeedbackComponent, pbPointerEvents, anyInputInfo, newEntityWasHovered);
 

--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
@@ -11,6 +11,7 @@ using DCL.Interaction.PlayerOriginated.Utility;
 using DCL.Interaction.Raycast.Components;
 using DCL.Interaction.Utility;
 using ECS.Abstract;
+using SceneRunner.Scene;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -29,7 +30,6 @@ namespace DCL.Interaction.Systems
         internal ProcessPointerEventsSystem(World world,
             IReadOnlyDictionary<InputAction, UnityEngine.InputSystem.InputAction> sdkInputActionsMap,
             IEntityCollidersGlobalCache entityCollidersGlobalCache,
-
             IEventSystem eventSystem) : base(world)
         {
             this.sdkInputActionsMap = sdkInputActionsMap;
@@ -67,18 +67,20 @@ namespace DCL.Interaction.Systems
             hoverStateComponent.IsAtDistance = false;
 
             bool canHover = !eventSystem.IsPointerOverGameObject();
+            GlobalColliderEntityInfo? entityInfo = raycastResult.GetEntityInfo();
 
-            if (raycastResult.IsValidHit && canHover)
+            if (raycastResult.IsValidHit && canHover && entityInfo != null)
             {
-                GlobalColliderEntityInfo entityInfo = raycastResult.GetEntityInfo();
+                SceneEcsExecutor ecsExecutor = entityInfo.Value.EcsExecutor;
+                ColliderEntityInfo colliderInfo = entityInfo.Value.ColliderEntityInfo;
 
                 InteractionInputUtils.AnyInputInfo anyInputInfo = sdkInputActionsMap.Values.GatherAnyInputInfo();
 
                 // External world access should be always synchronized (Global World calls into Scene World)
-                using (entityInfo.EcsExecutor.Sync.GetScope())
+                using (ecsExecutor.Sync.GetScope())
                 {
-                    World world = entityInfo.EcsExecutor.World;
-                    EntityReference entityRef = entityInfo.ColliderEntityInfo.EntityReference;
+                    World world = ecsExecutor.World;
+                    EntityReference entityRef = colliderInfo.EntityReference;
 
                     // Entity should be alive and contain PBPointerEvents component to be qualified
                     if (entityRef.IsAlive(world) && world.TryGet(entityRef, out PBPointerEvents pbPointerEvents))
@@ -101,10 +103,7 @@ namespace DCL.Interaction.Systems
 
                         int count = world.CountEntities(highlightQuery);
 
-                        if (count > 0)
-                        {
-                            SetupHighlightComponentQuery(world, isAtDistance, entityRef);
-                        }
+                        if (count > 0) { SetupHighlightComponentQuery(world, isAtDistance, entityRef); }
                         else
                         {
                             world.Create(


### PR DESCRIPTION
## What does this PR change?

Fixes #709 
Also did a slight refactor

## How to test the changes?

- Go to `dclexperience` world
- Pan the camera near an interactable, while panning the intractability should be disabled

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

