### PR TITLE
fix: added logic to stop emotes playing on the backpack

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animations/Animator/CharacterAnimator.controller
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animations/Animator/CharacterAnimator.controller
@@ -1074,6 +1074,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
+  - m_Name: EmoteStop
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -1238,6 +1244,7 @@ AnimatorState:
   - {fileID: 5221070625922526324}
   - {fileID: -6091293658042496824}
   - {fileID: 3255245744030989529}
+  - {fileID: 4154687653260660565}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -1378,8 +1385,8 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 3
-    m_ConditionEvent: MovementBlend
+  - m_ConditionMode: 1
+    m_ConditionEvent: EmoteStop
     m_EventTreshold: 0.1
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -4050450968213979288}
@@ -1474,6 +1481,31 @@ AnimatorStateTransition:
   m_TransitionOffset: 0
   m_ExitTime: 0.75
   m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &4154687653260660565
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 3
+    m_ConditionEvent: MovementBlend
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -4050450968213979288}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.96875
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
@@ -10,5 +10,6 @@ namespace DCL.AvatarRendering.Emotes
         public AnimationClip? EmoteClip;
         public EmoteReferences? CurrentEmoteReference;
         public int CurrentAnimationTag;
+        public bool StopEmote;
     }
 }

--- a/Explorer/Assets/DCL/Backpack/BackpackController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackController.cs
@@ -22,7 +22,6 @@ namespace DCL.Backpack
     {
         private readonly BackpackView view;
         private readonly BackpackCommandBus backpackCommandBus;
-        private readonly BackpackEventBus backpackEventBus;
         private readonly BackpackInfoPanelController emoteInfoPanelController;
         private readonly RectTransform rectTransform;
         private readonly AvatarController avatarController;
@@ -62,7 +61,6 @@ namespace DCL.Backpack
             this.playerEntity = playerEntity;
             this.backpackEmoteGridController = backpackEmoteGridController;
             this.emotesController = emotesController;
-            this.backpackEventBus = backpackEventBus;
 
             rectTransform = view.transform.parent.GetComponent<RectTransform>();
 

--- a/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
@@ -41,6 +41,7 @@ namespace DCL.Backpack.CharacterPreview
                     rotateEnabled = true;
                     panEnabled = true;
                     zoomEnabled = true;
+                    StopEmotes();
                     break;
                 case BackpackSections.Emotes:
                     inputEventBus.OnChangePreviewFocus(AvatarWearableCategoryEnum.Body);

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Components/AnimationHashes.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Components/AnimationHashes.cs
@@ -7,6 +7,7 @@ namespace DCL.Character.CharacterMotion.Components
         public static readonly int EMOTE = Animator.StringToHash("Emote");
         public static readonly int EMOTE_LOOP = Animator.StringToHash("EmoteLoop");
         public static readonly int EMOTE_RESET = Animator.StringToHash("EmoteForceRestart");
+        public static readonly int EMOTE_STOP = Animator.StringToHash("EmoteStop");
         public static readonly int MOVEMENT_BLEND = Animator.StringToHash("MovementBlend");
         public static readonly int GROUNDED = Animator.StringToHash("IsGrounded");
         public static readonly int JUMPING = Animator.StringToHash("IsJumping");

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
@@ -55,6 +55,7 @@ namespace DCL.CharacterPreview
                 globalWorld.Add(characterPreviewEntity, new DeleteEntityIntention());
             }
 
+            StopEmotes();
             characterPreviewContainerPool.Release(characterPreviewAvatarContainer);
             cameraController.Dispose();
         }
@@ -101,6 +102,12 @@ namespace DCL.CharacterPreview
         public void PlayEmote(string emoteId)
         {
             globalWorld.Add(characterPreviewEntity, new CharacterEmoteIntent { EmoteId = emoteId });
+        }
+
+        public void StopEmotes()
+        {
+            ref CharacterEmoteComponent emoteComponent = ref globalWorld.Get<CharacterEmoteComponent>(characterPreviewEntity);
+            emoteComponent.StopEmote = true;
         }
     }
 }

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
@@ -162,6 +162,7 @@ namespace DCL.CharacterPreview
                 previewController?.Dispose();
                 previewController = null;
                 initialized = false;
+
             }
         }
 
@@ -194,6 +195,11 @@ namespace DCL.CharacterPreview
             var spinner = view.Spinner;
             spinner.SetActive(true);
             return spinner;
+        }
+
+        public void StopEmotes()
+        {
+            previewController?.StopEmotes();
         }
 
         protected void PlayEmote(string emoteId) =>


### PR DESCRIPTION
## What does this PR change?

This fixes the issues caused by emotes not stopping playing when player either leaves the backpack or changes tabs.

## How to test the changes?

Go to the backpack/emotes section, play any emote (preferably a long one, like the dance) and then try:
* switching tabs to wearables -> the emote shoudl smoothly stop playing
* changing tabs inside explorer -> when returning to the backpack the preview should not be broken and the emote should not be playing
* closing the explore panel -> when opening the backpack again, the emote should not be playing and nothing should be broken.