### PR TITLE
fix: emotes again

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/EmotePlayer.cs
@@ -3,7 +3,9 @@ using DCL.Character.CharacterMotion.Components;
 using DCL.Optimization.Pools;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
+using UnityEngine.Pool;
 using Object = UnityEngine.Object;
 
 namespace DCL.AvatarRendering.Emotes
@@ -107,22 +109,18 @@ namespace DCL.AvatarRendering.Emotes
             references.animator = animator;
 
             RuntimeAnimatorController? rac = animator.runtimeAnimatorController;
-            AnimationClip[]? clips = rac.animationClips;
+            List<AnimationClip> uniqueClips = ListPool<AnimationClip>.Get();
 
-            if (clips.Length == 1)
-                references.avatarClip = clips[0];
+            foreach (AnimationClip clip in rac.animationClips)
+                if (!uniqueClips.Contains(clip))
+                    uniqueClips.Add(clip);
+
+            if (uniqueClips.Count == 1)
+                references.avatarClip = uniqueClips[0];
             else
-                foreach (AnimationClip animationClip in clips)
+            {
+                foreach (AnimationClip animationClip in uniqueClips)
                 {
-                    if (isLooping)
-                    {
-                        animationClip.wrapMode = WrapMode.Loop;
-                        // TODO move looping to the Asset Bundle Converter
-                        // AnimationClipSettings? settings = AnimationUtility.GetAnimationClipSettings(animationClip);
-                        // settings.loopTime = true;
-                        // AnimationUtility.SetAnimationClipSettings(animationClip, settings);
-                    }
-
                     if (animationClip.name.Contains("_avatar", StringComparison.OrdinalIgnoreCase))
                         references.avatarClip = animationClip;
 
@@ -132,6 +130,9 @@ namespace DCL.AvatarRendering.Emotes
                         references.propClipHash = Animator.StringToHash(animationClip.name);
                     }
                 }
+            }
+
+            ListPool<AnimationClip>.Release(uniqueClips);
 
             // some of our legacy emotes have unity events that we are not handling, so we disable that system to avoid further errors
             animator.fireEvents = false;


### PR DESCRIPTION
## What does this PR change?

Fix the issue with newer asset bundles having 2 states for the same clip, this added a new entry to the clip list, making the logic that detects extended emotes not work properly.

## How to test the changes?

- Equip and use non-embedded emotes with _no props_
- All other emotes should also work

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

