### PR TITLE
fix: add in renderqueue narrowing for OutlineDraw

### DIFF
--- a/Explorer/Assets/DCL/Rendering/Outline/OutlineDrawPass.cs
+++ b/Explorer/Assets/DCL/Rendering/Outline/OutlineDrawPass.cs
@@ -56,7 +56,7 @@ namespace DCL.Rendering.Avatar
                     // Create the draw settings, which configures a new draw call to the GPU
                     //CoreUtils.SetRenderTarget(cmd, renderingData.cameraData.renderer.cameraColorTargetHandle, renderingData.cameraData.renderer.cameraDepthTargetHandle, clearFlag: ClearFlag.None, clearColor: Color.black, miplevel: 0, cubemapFace: CubemapFace.Unknown, depthSlice: -1);
                     DrawingSettings drawSettings = CreateDrawingSettings(m_ShaderTagId, ref renderingData, renderingData.cameraData.defaultOpaqueSortFlags);
-                    m_FilteringSettings.renderQueueRange = new RenderQueueRange(0, 2449);
+                    m_FilteringSettings.renderQueueRange = new RenderQueueRange(0, 2000);
                     context.DrawRenderers(renderingData.cullResults, ref drawSettings, ref m_FilteringSettings);
                 }
 

--- a/Explorer/Assets/DCL/Rendering/Outline/OutlineDrawPass.cs
+++ b/Explorer/Assets/DCL/Rendering/Outline/OutlineDrawPass.cs
@@ -56,6 +56,7 @@ namespace DCL.Rendering.Avatar
                     // Create the draw settings, which configures a new draw call to the GPU
                     //CoreUtils.SetRenderTarget(cmd, renderingData.cameraData.renderer.cameraColorTargetHandle, renderingData.cameraData.renderer.cameraDepthTargetHandle, clearFlag: ClearFlag.None, clearColor: Color.black, miplevel: 0, cubemapFace: CubemapFace.Unknown, depthSlice: -1);
                     DrawingSettings drawSettings = CreateDrawingSettings(m_ShaderTagId, ref renderingData, renderingData.cameraData.defaultOpaqueSortFlags);
+                    m_FilteringSettings.renderQueueRange = new RenderQueueRange(0, 2449);
                     context.DrawRenderers(renderingData.cullResults, ref drawSettings, ref m_FilteringSettings);
                 }
 


### PR DESCRIPTION
Fixes https://github.com/decentraland/unity-explorer/issues/873

Load into Explorer and use the Avatar debug tool to load urn:decentraland:matic:collections-v2:0x5c440e07e702e2a5395098bc551d55d82264582a:0:50

The new test avatar loaded in should have wings and there should be no black box.

@Ludmilafantaniella should be able to test this easily as she found it. Thanks in advance.
