### PR TITLE
fix: loading screen timeouts at 30 seconds when changing realms

### DIFF
--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -101,9 +101,11 @@ namespace Global.Dynamic
                         await roomHub.StartAsync();
 
                         loadReport.ProgressCounter.Value = 1f;
+                        loadReport.CompletionSource.TrySetResult();
                     },
                     ct
                 );
+
             }
             catch (TimeoutException) { }
 
@@ -150,7 +152,8 @@ namespace Global.Dynamic
 
         private async UniTask GenerateWorldTerrainAsync(uint worldSeed, AsyncLoadProcessReport processReport, CancellationToken ct)
         {
-            if (!worldsTerrain.IsInitialized) return;
+            if (!worldsTerrain.IsInitialized)
+                return;
 
             await UniTask.WaitUntil(() => realmController.GlobalWorld.EcsWorld.Get<FixedScenePointers>(realmController.RealmEntity).AllPromisesResolved, cancellationToken: ct);
 


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/899

## How to test the changes?

- use `/world MetadyneLabs`
- Our loading screen should be fast and does not get stuck at 100%
- The custom loading screen from the scene should appear

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

