### PR TITLE
fix: issue when cancelling asset bundle loading

### DIFF
--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/Systems/AssetsLoadingUtility.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/Systems/AssetsLoadingUtility.cs
@@ -34,7 +34,6 @@ namespace ECS.StreamableLoading.Common.Systems
                 ReportHub.Log(reportCategory, $"Starting loading {intention}\n{partition}, attempts left: {attemptCount}");
 
                 try { return await flow(intention, acquiredBudget, partition, ct); }
-
                 catch (UnityWebRequestException unityWebRequestException)
                 {
                     // we can't access web request here as it is disposed already
@@ -67,7 +66,7 @@ namespace ECS.StreamableLoading.Common.Systems
                         return null;
                     }
                 }
-                catch (Exception e) when (e is not OperationCanceledException)
+                catch (Exception e) when (e is not OperationCanceledException && e.InnerException is not OperationCanceledException)
                 {
                     // General exception
                     // conclude now, we can't do anything


### PR DESCRIPTION
## What does this PR change?

Added check for the internal exception and not only the exception when catching on the AssetLoadingUtility as it was masking intended cancellations as unexpected exceptions. 
I detected this issue happening when cancelling a wearable request, but it might have happened with other assets as well.

## How to test the changes?

Go to the backpack and try to equip a wearable you haven't equipped in this session yet, before it finishes loading, quickly unequip it. Nothing should break. 
Next time you try to equip the same wearable, it will try to load again the wearable and after a lil while it should be loaded correctly.
Previously, doing these steps would result on the wearable to be replaced by the default one for the duration of the session.

See video here ->
https://github.com/decentraland/unity-explorer/issues/933
