### PR TITLE
fix: Hide 3 dots menu from Minimap

### DIFF
--- a/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
+++ b/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
@@ -2575,7 +2575,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2527284913796384215
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2869,7 +2869,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1219915090820484222, guid: 9feb3014d432e432c9848c4aa8766a0d, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1314242413491555740, guid: 9feb3014d432e432c9848c4aa8766a0d, type: 3}
       propertyPath: m_Colors.m_PressedColor.b


### PR DESCRIPTION
## What does this PR change?
Fix #978 

## How to test the changes?
1. Launch the explorer
2. Check that the 3 points button doesn't appear in the Minimap anymore.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md