### PR TITLE
Ignore special chars

### DIFF
--- a/Explorer/Assets/DCL/Chat/MessageBus/ChatMessage.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/ChatMessage.cs
@@ -28,5 +28,8 @@ namespace DCL.Chat
             SentByOwnUser = false;
             HasToAnimate = true;
         }
+
+        public static ChatMessage NewFromSystem(string message) =>
+            new (message, "System", string.Empty, true, false);
     }
 }

--- a/Explorer/Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs
@@ -57,7 +57,7 @@ namespace DCL.Chat.MessageBus
 
         private void SendFromSystem(string message)
         {
-            OnMessageAdded?.Invoke(new ChatMessage(message, "System", string.Empty, true, false));
+            OnMessageAdded?.Invoke(ChatMessage.NewFromSystem(message));
         }
 
         private void OriginOnOnMessageAdded(ChatMessage obj)

--- a/Explorer/Assets/DCL/Chat/MessageBus/IChatMessagesBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/IChatMessagesBus.cs
@@ -35,5 +35,8 @@ namespace DCL.Chat
 
         public static IChatMessagesBus WithCommands(this IChatMessagesBus messagesBus, IReadOnlyDictionary<Regex, Func<IChatCommand>> commandsFactory) =>
             new CommandsHandleChatMessageBus(messagesBus, commandsFactory);
+
+        public static IChatMessagesBus WithIgnoreSymbols(this IChatMessagesBus messagesBus) =>
+            new IgnoreWithSymbolsChatMessageBus(messagesBus);
     }
 }

--- a/Explorer/Assets/DCL/Chat/MessageBus/IgnoreWithSymbolsChatMessageBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/IgnoreWithSymbolsChatMessageBus.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+namespace DCL.Chat.MessageBus
+{
+    /// <summary>
+    /// Fast fix, should be replaced with a more robust solution.
+    /// </summary>
+    public class IgnoreWithSymbolsChatMessageBus : IChatMessagesBus
+    {
+        private readonly IChatMessagesBus origin;
+        private readonly ISet<char> forbiddenChars;
+
+        public IgnoreWithSymbolsChatMessageBus(IChatMessagesBus origin) : this(origin, new HashSet<char>
+        {
+            //strange ping pong messages from the previous client
+            '␐',
+            '␆',
+        }) { }
+
+        public IgnoreWithSymbolsChatMessageBus(IChatMessagesBus origin, ISet<char> forbiddenChars)
+        {
+            this.origin = origin;
+            this.forbiddenChars = forbiddenChars;
+            this.origin.OnMessageAdded += OriginOnOnMessageAdded;
+        }
+
+        private void OriginOnOnMessageAdded(ChatMessage obj)
+        {
+            if (Valid(obj.Message))
+                OnMessageAdded?.Invoke(obj);
+        }
+
+        public event Action<ChatMessage>? OnMessageAdded;
+
+        public void Send(string message)
+        {
+            if (Valid(message))
+                origin.Send(message);
+            else
+                OnMessageAdded?.Invoke(
+                    ChatMessage.NewFromSystem("Message with the special character is forbidden")
+                );
+        }
+
+        public void Dispose()
+        {
+            origin.OnMessageAdded -= OriginOnOnMessageAdded;
+            origin.Dispose();
+        }
+
+        private bool Valid(string message)
+        {
+            for (var i = 0; i < message.Length; i++)
+                if (forbiddenChars.Contains(message[i]))
+                    return false;
+
+            return true;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Chat/MessageBus/IgnoreWithSymbolsChatMessageBus.cs.meta
+++ b/Explorer/Assets/DCL/Chat/MessageBus/IgnoreWithSymbolsChatMessageBus.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 30020dfe39cf411eb93f5ebf41f6a82e
+timeCreated: 1715075934

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -280,6 +280,7 @@ namespace Global.Dynamic
 
             container.ChatMessagesBus = new MultiplayerChatMessagesBus(container.MessagePipesHub, container.ProfileRepository, new MessageDeduplication<double>())
                                        .WithSelfResend(identityCache, container.ProfileRepository)
+                                       .WithIgnoreSymbols()
                                        .WithCommands(chatCommandsFactory)
                                        .WithDebugPanel(debugBuilder);
 


### PR DESCRIPTION
Fixes the issue with chat symbols from the old renderer: ␐ and ␆

- prevent sending messages from the current renderer 
- ignores incoming messages with these symbols

Should be investigate further why it comes by the versioning system of protobuff packets