### PR TITLE
fix: Unable to Select 'High' Graphics Quality

### DIFF
--- a/Explorer/Assets/DCL/Quality/Quality Settings.asset
+++ b/Explorer/Assets/DCL/Quality/Quality Settings.asset
@@ -224,7 +224,7 @@ MonoBehaviour:
     lensFlareEnabled: 0
     lensFlareComponent: {fileID: 2726953631672280614, guid: 91fed6d77ceea8246b3d136a8e67a12c, type: 3}
     environmentSettings:
-      sceneLoadRadius: 150
+      sceneLoadRadius: 80
       lod1Threshold: 2
       lod2Threshold: 4
       terrainLODBias: 250


### PR DESCRIPTION
## What does this PR change?
Fix #896 

## How to test the changes?
1. Launch the explorer.
2. Open Settings Menu.
3. Select the 'High' quality option.
4. Observe that the preset keeps as 'High' and not as 'Custom'.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md