### PR TITLE
fix: interfering shortcuts on search bar & null profile on authentication

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -126,9 +126,17 @@ namespace DCL.AuthenticationScreenFlow
             {
                 CancelLoginProcess();
                 loginCancellationToken = new CancellationTokenSource();
-                await FetchProfileAsync(loginCancellationToken.Token);
 
-                SwitchState(ViewState.Finalize);
+                try
+                {
+                    await FetchProfileAsync(loginCancellationToken.Token);
+                    SwitchState(ViewState.Finalize);
+                }
+                catch (Exception e)
+                {
+                    ReportHub.LogException(e, new ReportData(ReportCategory.AUTHENTICATION));
+                    SwitchState(ViewState.Login);
+                }
             }
             else
                 SwitchState(ViewState.Login);

--- a/Explorer/Assets/DCL/Backpack/AvatarSection/AvatarController.cs
+++ b/Explorer/Assets/DCL/Backpack/AvatarSection/AvatarController.cs
@@ -23,12 +23,13 @@ namespace DCL.Backpack
             BackpackEventBus backpackEventBus,
             BackpackGridController backpackGridController,
             BackpackInfoPanelController backpackInfoPanelController,
-            IThumbnailProvider thumbnailProvider)
+            IThumbnailProvider thumbnailProvider,
+            DCLInput dclInput)
         {
             this.view = view;
             this.backpackInfoPanelController = backpackInfoPanelController;
             this.backpackGridController = backpackGridController;
-            new BackpackSearchController(view.backpackSearchBar, backpackCommandBus, backpackEventBus);
+            new BackpackSearchController(view.backpackSearchBar, backpackCommandBus, backpackEventBus, dclInput);
             slotsController = new BackpackSlotsController(slotViews, backpackCommandBus, backpackEventBus, rarityBackgrounds, thumbnailProvider);
 
             rectTransform = view.GetComponent<RectTransform>();

--- a/Explorer/Assets/DCL/Backpack/Backpack.asmdef
+++ b/Explorer/Assets/DCL/Backpack/Backpack.asmdef
@@ -25,7 +25,6 @@
         "GUID:101b8b6ebaf64668909b49c4b7a1420d",
         "GUID:e7751264a6735a942a64770d71eb49e0",
         "GUID:eec0964c48f6f4e40bc3ec2257ccf8c5",
-        "AvatarRendering.Emotes",
         "GUID:ac3295688c7c22745a96e6ac34718181"
     ],
     "includePlatforms": [],

--- a/Explorer/Assets/DCL/Backpack/Backpack.asmdef
+++ b/Explorer/Assets/DCL/Backpack/Backpack.asmdef
@@ -25,7 +25,8 @@
         "GUID:101b8b6ebaf64668909b49c4b7a1420d",
         "GUID:e7751264a6735a942a64770d71eb49e0",
         "GUID:eec0964c48f6f4e40bc3ec2257ccf8c5",
-        "AvatarRendering.Emotes"
+        "AvatarRendering.Emotes",
+        "GUID:ac3295688c7c22745a96e6ac34718181"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Backpack/BackpackController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackController.cs
@@ -57,7 +57,8 @@ namespace DCL.Backpack
             AvatarSlotView[] avatarSlotViews,
             EmotesController emotesController,
             BackpackCharacterPreviewController backpackCharacterPreviewController,
-            IThumbnailProvider thumbnailProvider)
+            IThumbnailProvider thumbnailProvider,
+            DCLInput dclInput)
         {
             this.view = view;
             this.backpackCommandBus = backpackCommandBus;
@@ -78,7 +79,8 @@ namespace DCL.Backpack
                 backpackEventBus,
                 gridController,
                 wearableInfoPanelController,
-                thumbnailProvider);
+                thumbnailProvider,
+                dclInput);
 
             backpackSections = new Dictionary<BackpackSections, ISection>
             {

--- a/Explorer/Assets/DCL/Backpack/BackpackSearchController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackSearchController.cs
@@ -11,20 +11,33 @@ namespace DCL.Backpack
         private const int SEARCH_AWAIT_TIME = 1000;
         private readonly SearchBarView view;
         private readonly IBackpackCommandBus commandBus;
+        private readonly DCLInput dclInput;
 
-        private CancellationTokenSource cts;
+        private CancellationTokenSource? searchCancellationToken;
 
-        public BackpackSearchController(SearchBarView view, IBackpackCommandBus commandBus, IBackpackEventBus backpackEventBus)
+        public BackpackSearchController(SearchBarView view,
+            IBackpackCommandBus commandBus,
+            IBackpackEventBus backpackEventBus,
+            DCLInput dclInput)
         {
             this.view = view;
             this.commandBus = commandBus;
+            this.dclInput = dclInput;
 
             backpackEventBus.SearchEvent += OnSearchEvent;
 
+            view.inputField.onSelect.AddListener(DisableShortcutsInput);
+            view.inputField.onDeselect.AddListener(RestoreInput);
             view.inputField.onValueChanged.AddListener(OnValueChanged);
             view.clearSearchButton.onClick.AddListener(ClearSearch);
             view.clearSearchButton.gameObject.SetActive(false);
         }
+
+        private void RestoreInput(string text) =>
+            dclInput.Shortcuts.Enable();
+
+        private void DisableShortcutsInput(string text) =>
+            dclInput.Shortcuts.Disable();
 
         private void OnSearchEvent(string searchString)
         {
@@ -42,14 +55,13 @@ namespace DCL.Backpack
         {
             view.clearSearchButton.gameObject.SetActive(!string.IsNullOrEmpty(searchText));
 
-            cts.SafeCancelAndDispose();
-            cts = new CancellationTokenSource();
-            AwaitAndSendSearchAsync(searchText).Forget();
+            searchCancellationToken = searchCancellationToken.SafeRestart();
+            AwaitAndSendSearchAsync(searchText, searchCancellationToken.Token).Forget();
         }
 
-        private async UniTaskVoid AwaitAndSendSearchAsync(string searchText)
+        private async UniTaskVoid AwaitAndSendSearchAsync(string searchText, CancellationToken ct)
         {
-            await UniTask.Delay(SEARCH_AWAIT_TIME, cancellationToken: cts.Token);
+            await UniTask.Delay(SEARCH_AWAIT_TIME, cancellationToken: ct);
             commandBus.SendCommand(new BackpackSearchCommand(searchText));
         }
     }

--- a/Explorer/Assets/DCL/PluginSystem/Global/BackpackSubPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/BackpackSubPlugin.cs
@@ -34,6 +34,7 @@ namespace DCL.PluginSystem.Global
         private readonly IEmoteCache emoteCache;
         private readonly IReadOnlyCollection<URN> embeddedEmotes;
         private readonly IRealmData realmData;
+        private readonly DCLInput dclInput;
         private readonly IWeb3IdentityCache web3Identity;
         private readonly BackpackCommandBus backpackCommandBus;
         private readonly BackpackEventBus backpackEventBus;
@@ -57,7 +58,8 @@ namespace DCL.PluginSystem.Global
             IEmoteCache emoteCache,
             IReadOnlyCollection<URN> embeddedEmotes,
             ICollection<string> forceRender,
-            IRealmData realmData
+            IRealmData realmData,
+            DCLInput dclInput
         )
         {
             this.assetsProvisioner = assetsProvisioner;
@@ -69,6 +71,7 @@ namespace DCL.PluginSystem.Global
             this.emoteCache = emoteCache;
             this.embeddedEmotes = embeddedEmotes;
             this.realmData = realmData;
+            this.dclInput = dclInput;
 
             backpackCommandBus = new BackpackCommandBus();
             backpackEventBus = new BackpackEventBus();
@@ -173,7 +176,8 @@ namespace DCL.PluginSystem.Global
                     avatarView.GetComponentsInChildren<AvatarSlotView>().EnsureNotNull(),
                     emotesController,
                     backpackCharacterPreviewController,
-                    thumbnailProvider
+                    thumbnailProvider,
+                    dclInput
                 );
             };
         }

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -22,7 +22,6 @@ using DCL.Web3.Authenticators;
 using DCL.Web3.Identities;
 using DCL.WebRequests;
 using ECS;
-using ECS.Prioritization;
 using ECS.SceneLifeCycle.Realm;
 using Global.Dynamic;
 using MVC;
@@ -32,7 +31,6 @@ using System.Threading;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.Audio;
-using UnityEngine.InputSystem;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 namespace DCL.PluginSystem.Global
@@ -132,7 +130,8 @@ namespace DCL.PluginSystem.Global
                 emoteCache,
                 settings.EmbeddedEmotesAsURN(),
                 forceRender,
-                realmData
+                realmData,
+                dclInput
             );
 
             ExplorePanelView panelViewAsset = (await assetsProvisioner.ProvideMainAssetValueAsync(settings.ExplorePanelPrefab, ct: ct)).GetComponent<ExplorePanelView>();

--- a/Explorer/Assets/DCL/Profiles/Repository/RealmProfileRepository.cs
+++ b/Explorer/Assets/DCL/Profiles/Repository/RealmProfileRepository.cs
@@ -98,11 +98,11 @@ namespace DCL.Profiles
                 URLAddress url = Url(id, version);
                 var response = webRequestController.GetAsync(new CommonArguments(url), ct, ignoreErrorCodes: IWebRequestController.IGNORE_NOT_FOUND);
 
-                using GetProfileJsonRootDto root = await response.CreateFromNewtonsoftJsonAsync<GetProfileJsonRootDto>(
+                using GetProfileJsonRootDto? root = await response.CreateFromNewtonsoftJsonAsync<GetProfileJsonRootDto>(
                     createCustomExceptionOnFailure: (exception, text) => new ProfileParseException(id, version, text, exception),
                     serializerSettings: SERIALIZER_SETTINGS);
 
-                var profileDto = root.FirstProfileDto();
+                var profileDto = root?.FirstProfileDto();
 
                 if (profileDto is null)
                     return null;


### PR DESCRIPTION
## What does this PR change?

Fixes #976 

Also fixes a problem when the profile cannot be solved on the authentication flow.

## How to test the changes?

1. Follow issue steps
2. Check that the shortcuts (I, M, Tab, B, etc) are restored as expected when going back to world or changing screens

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

