### PR TITLE
fix: Terrain was not set as shown on first start

### DIFF
--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -138,7 +138,7 @@ namespace DCL.Landscape
             }
         }
 
-        public async UniTask GenerateTerrainAsync(
+        public async UniTask GenerateTerrainAndShowAsync(
             uint worldSeed = 1,
             bool withHoles = true,
             bool hideTrees = false,
@@ -221,6 +221,7 @@ namespace DCL.Landscape
                     localCache.Save();
 
                 IsTerrainGenerated = true;
+                IsTerrainShown = true;
 
                 emptyParcels.Dispose();
                 ownedParcels.Dispose();

--- a/Explorer/Assets/DCL/Landscape/TerrainGeneratorTest.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGeneratorTest.cs
@@ -75,7 +75,7 @@ namespace DCL.Landscape
             {
                 gen = new TerrainGenerator(true, clearCache);
                 gen.Initialize(genData, ref emptyParcels, ref ownedParcels);
-                await gen.GenerateTerrainAsync(worldSeed, digHoles, hideTrees, hideDetails);
+                await gen.GenerateTerrainAndShowAsync(worldSeed, digHoles, hideTrees, hideDetails);
             }
 
             emptyParcels.Dispose();

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -196,6 +196,8 @@ namespace Global.Dynamic
                     if (!genesisTerrain.IsTerrainGenerated)
                         await genesisTerrain.GenerateTerrainAsync(cancellationToken: ct);
 
+                    if (ct.IsCancellationRequested) return;
+
                     await genesisTerrain.ShowAsync(landscapeLoadReport);
                 }
                 else

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -194,11 +194,9 @@ namespace Global.Dynamic
                     worldsTerrain.SwitchVisibility(false);
 
                     if (!genesisTerrain.IsTerrainGenerated)
-                        await genesisTerrain.GenerateTerrainAsync(cancellationToken: ct);
-
-                    if (ct.IsCancellationRequested) return;
-
-                    await genesisTerrain.ShowAsync(landscapeLoadReport);
+                        await genesisTerrain.GenerateTerrainAndShowAsync(cancellationToken: ct);
+                    else
+                        await genesisTerrain.ShowAsync(landscapeLoadReport);
                 }
                 else
                 {

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -195,8 +195,8 @@ namespace Global.Dynamic
 
                     if (!genesisTerrain.IsTerrainGenerated)
                         await genesisTerrain.GenerateTerrainAsync(cancellationToken: ct);
-                    else
-                        await genesisTerrain.ShowAsync(landscapeLoadReport);
+
+                    await genesisTerrain.ShowAsync(landscapeLoadReport);
                 }
                 else
                 {


### PR DESCRIPTION
## What does this PR change?

Added the missing TerrainShown flag when doing the GenerateTerrain + renamed method to GenerateTerrainAndShow so its clear that it also shows it. In the future we might wanna extract the show so we dont have GenerateAndShow and just Show methods in the RealmNavigator

## How to test the changes?

Previously there would be no "nature" sounds anywhere and the visual culling would not work. so every tree would be visible, even outside of players view cone.
Now it should work as expected.