### PR TITLE
fix: AvatarBase and AvatarEquippedData by correcting Profile.IsDirty reset

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarLoaderSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarLoaderSystem.cs
@@ -60,7 +60,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         {
             WearablePromise wearablePromise = CreateWearablePromise(profile, partition);
             EmotePromise emotePromise = CreateEmotePromise(profile, partition);
-            profile.IsDirty = false;
             World.Add(entity, new AvatarShapeComponent(profile.Name, profile.UserId, profile.Avatar.BodyShape, wearablePromise, emotePromise, profile.Avatar.SkinColor, profile.Avatar.HairColor, profile.Avatar.EyesColor));
         }
 
@@ -106,7 +105,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             avatarShapeComponent.EmotePromise = CreateEmotePromise(profile, partition);
             avatarShapeComponent.BodyShape = profile.Avatar.BodyShape;
             avatarShapeComponent.IsDirty = true;
-            profile.IsDirty = false;
         }
 
         private WearablePromise CreateWearablePromise(PBAvatarShape pbAvatarShape, PartitionComponent partition) =>

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/PlayerProfileDataPropagationSystem.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/PlayerProfileDataPropagationSystem.cs
@@ -1,7 +1,6 @@
 using Arch.Core;
 using Arch.System;
 using Arch.SystemGroups;
-using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.Diagnostics;
 using DCL.Multiplayer.SDK.Components;
 using DCL.Profiles;
@@ -10,13 +9,9 @@ using ECS.Groups;
 using ECS.LifeCycle.Components;
 using ECS.LifeCycle.Systems;
 using SceneRunner.Scene;
-using UnityEngine;
 
 namespace DCL.Multiplayer.SDK.Systems.GlobalWorld
 {
-    // [UpdateInGroup(typeof(PresentationSystemGroup))]
-    // [UpdateAfter(typeof(PlayerCRDTEntitiesHandlerSystem))]
-    // [UpdateInGroup(typeof(SyncedPresentationSystemGroup))]
     [UpdateBefore(typeof(ResetDirtyFlagSystem<Profile>))]
     [UpdateInGroup(typeof(SyncedPostRenderingSystemGroup))]
     [LogCategory(ReportCategory.MULTIPLAYER_SDK_PLAYER_PROFILE_DATA)]

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/PlayerProfileDataPropagationSystem.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/PlayerProfileDataPropagationSystem.cs
@@ -6,14 +6,19 @@ using DCL.Diagnostics;
 using DCL.Multiplayer.SDK.Components;
 using DCL.Profiles;
 using ECS.Abstract;
+using ECS.Groups;
 using ECS.LifeCycle.Components;
+using ECS.LifeCycle.Systems;
 using SceneRunner.Scene;
 using UnityEngine;
 
 namespace DCL.Multiplayer.SDK.Systems.GlobalWorld
 {
-    [UpdateInGroup(typeof(PresentationSystemGroup))]
-    [UpdateAfter(typeof(PlayerCRDTEntitiesHandlerSystem))]
+    // [UpdateInGroup(typeof(PresentationSystemGroup))]
+    // [UpdateAfter(typeof(PlayerCRDTEntitiesHandlerSystem))]
+    // [UpdateInGroup(typeof(SyncedPresentationSystemGroup))]
+    [UpdateBefore(typeof(ResetDirtyFlagSystem<Profile>))]
+    [UpdateInGroup(typeof(SyncedPostRenderingSystemGroup))]
     [LogCategory(ReportCategory.MULTIPLAYER_SDK_PLAYER_PROFILE_DATA)]
     public partial class PlayerProfileDataPropagationSystem : BaseUnityLoopSystem
     {
@@ -26,26 +31,26 @@ namespace DCL.Multiplayer.SDK.Systems.GlobalWorld
 
         [Query]
         [None(typeof(DeleteEntityIntention))]
-        private void PropagateProfileToScene(Profile profile, ref PlayerCRDTEntity playerCRDTEntity)
+        private void PropagateProfileToScene(ref Profile profile, ref PlayerCRDTEntity playerCRDTEntity)
         {
-            SceneEcsExecutor sceneEcsExecutor = playerCRDTEntity.SceneFacade.EcsExecutor;
-
             if (playerCRDTEntity.IsDirty)
             {
-                profile.IsDirty = true;
-
-                // External world access should be always synchronized (Global World calls into Scene World)
-                using (sceneEcsExecutor.Sync.GetScope())
-                    sceneEcsExecutor.World.Add(playerCRDTEntity.SceneWorldEntity, profile);
-
+                SetSceneProfile(ref profile, ref playerCRDTEntity);
                 return;
             }
 
             if (!profile.IsDirty) return;
 
+            SetSceneProfile(ref profile, ref playerCRDTEntity);
+        }
+
+        private void SetSceneProfile(ref Profile profile, ref PlayerCRDTEntity playerCRDTEntity)
+        {
+            SceneEcsExecutor sceneEcsExecutor = playerCRDTEntity.SceneFacade.EcsExecutor;
+
             // External world access should be always synchronized (Global World calls into Scene World)
             using (sceneEcsExecutor.Sync.GetScope())
-                sceneEcsExecutor.World.Set(playerCRDTEntity.SceneWorldEntity, profile);
+                sceneEcsExecutor.World.Add(playerCRDTEntity.SceneWorldEntity, new Profile(profile.UserId, profile.Name, profile.Avatar));
         }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Tests/PlayerProfileDataPropagationSystemShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Tests/PlayerProfileDataPropagationSystemShould.cs
@@ -55,8 +55,10 @@ namespace DCL.Multiplayer.SDK.Tests
             system.Update(0);
 
             Assert.IsTrue(sceneWorld.TryGet(playerCRDTEntity.SceneWorldEntity, out Profile sceneEntityProfile));
+            Assert.AreNotSame(profile, sceneEntityProfile);
             Assert.AreEqual(profile.Name, sceneEntityProfile.Name);
-            Assert.AreEqual(profile, sceneEntityProfile);
+            Assert.AreEqual(profile.UserId, sceneEntityProfile.UserId);
+            Assert.AreEqual(profile.Avatar, sceneEntityProfile.Avatar);
 
             playerCRDTEntity.IsDirty = false;
             profile.IsDirty = true;
@@ -66,8 +68,10 @@ namespace DCL.Multiplayer.SDK.Tests
             system.Update(0);
 
             Assert.IsTrue(sceneWorld.TryGet(playerCRDTEntity.SceneWorldEntity, out sceneEntityProfile));
+            Assert.AreNotSame(profile, sceneEntityProfile);
             Assert.AreEqual(profile.Name, sceneEntityProfile.Name);
-            Assert.AreEqual(profile, sceneEntityProfile);
+            Assert.AreEqual(profile.UserId, sceneEntityProfile.UserId);
+            Assert.AreEqual(profile.Avatar, sceneEntityProfile.Avatar);
         }
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/Global/ProfilePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ProfilePlugin.cs
@@ -2,6 +2,7 @@ using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.Profiles;
 using DCL.ResourcesUnloading;
+using ECS.LifeCycle.Systems;
 using ECS.StreamableLoading.Cache;
 using System.Threading;
 using Utility.Multithreading;
@@ -40,6 +41,7 @@ namespace DCL.PluginSystem.Global
 
             LoadProfileSystem.InjectToWorld(ref builder, profileIntentionCache, mutexSync, profileRepository);
             ResolveProfilePictureSystem.InjectToWorld(ref builder);
+            ResetDirtyFlagSystem<Profile>.InjectToWorld(ref builder);
         }
     }
 }

--- a/Explorer/Assets/DCL/Profiles/Components/Profile.cs
+++ b/Explorer/Assets/DCL/Profiles/Components/Profile.cs
@@ -79,7 +79,7 @@ namespace DCL.Profiles
         /// <summary>
         ///     This flag can be moved elsewhere when the final flow is established
         /// </summary>
-        public bool IsDirty { get; set; }
+        public bool IsDirty { get; set; } = true;
 
         public IReadOnlyCollection<string>? Blocked => blocked;
         public IReadOnlyCollection<string>? Interests => interests;


### PR DESCRIPTION
The components `AvatarBase` and `AvatarEquippedData` stopped working recently, I found it's due to how we handle the `Profile.IsDirty`.

* `Profile` component `IsDirty` flag was being reset manually at `AvatarLoaderSystem`, now it's handled by the `ResetDirtyFlagSystem`.
* `Profile` component reference was being propagated as is into the current scene by `PlayerProfileDataPropagationSystem`, now it's being cloned whenever it changed and a different instance is used in the scene world (thus avoiding shared manipulation in different worlds, which was also a problem)

### QA INSTRUCTIONS
Please test that the backpack and wearables still work corretly with this branch