### PR TITLE
fix: IsTerrainShown & Culling

### DIFF
--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -112,7 +112,7 @@ namespace DCL.Landscape
 
         public async UniTask ShowAsync(AsyncLoadProcessReport postRealmLoadReport)
         {
-            if (!isInitialized) return;
+            if (!isInitialized && !IsTerrainShown) return;
 
             if (rootGo != null)
                 rootGo.gameObject.SetActive(true);

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -112,7 +112,7 @@ namespace DCL.Landscape
 
         public async UniTask ShowAsync(AsyncLoadProcessReport postRealmLoadReport)
         {
-            if (!isInitialized && !IsTerrainShown) return;
+            if (!isInitialized) return;
 
             if (rootGo != null)
                 rootGo.gameObject.SetActive(true);

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -195,8 +195,8 @@ namespace Global.Dynamic
 
                     if (!genesisTerrain.IsTerrainGenerated)
                         await genesisTerrain.GenerateTerrainAsync(cancellationToken: ct);
-                    else
-                        await genesisTerrain.ShowAsync(landscapeLoadReport);
+
+                    await genesisTerrain.ShowAsync(landscapeLoadReport);
                 }
                 else
                 {


### PR DESCRIPTION
## What does this PR change?

After terrain is generated, the shown flag is not set and the terrain culling systems do not work leading to big performance drops:

Without:
![scenecullingbefore](https://github.com/decentraland/unity-explorer/assets/296469/0d7743bf-13a7-4a3b-97e9-eaa96f33eda8)

With:
![image](https://github.com/decentraland/unity-explorer/assets/296469/bbe689ce-be22-4dc1-a84a-32384708c5bd)


### How to test?

Please test the flow between worlds, and in and out of genesis city. Ensuring terrain is still shown and generated in all cases.

