### PR TITLE
Fix: blocked chat input on explore panel open

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -107,7 +107,6 @@ namespace DCL.Chat
             viewInstance.InputField.onValueChanged.AddListener(OnInputChanged);
             viewInstance.InputField.onSelect.AddListener(OnInputSelected);
             viewInstance.InputField.onDeselect.AddListener(OnInputDeselected);
-            viewInstance.InputField.onSubmit.AddListener(OnSubmit);
             viewInstance.CloseChatButton.onClick.AddListener(CloseChat);
             viewInstance.LoopList.InitListView(0, OnGetItemByIndex);
             emojiPanelController = new EmojiPanelController(viewInstance.EmojiPanel, emojiPanelConfiguration, emojiMappingJson, emojiSectionViewPrefab, emojiButtonPrefab);
@@ -120,8 +119,8 @@ namespace DCL.Chat
 
             viewInstance.ChatBubblesToggle.Toggle.onValueChanged.AddListener(OnToggleChatBubblesValueChanged);
             viewInstance.ChatBubblesToggle.Toggle.SetIsOnWithoutNotify(nametagsData.showChatBubbles);
-            dclInput.UI.Submit.performed += OnSubmitAction;
             OnToggleChatBubblesValueChanged(nametagsData.showChatBubbles);
+            OnFocus();
         }
 
         protected override void OnViewShow()
@@ -388,6 +387,20 @@ namespace DCL.Chat
 
             viewInstance.CharacterCounter.SetCharacterCount(inputText.Length);
             viewInstance.StopChatEntriesFadeout();
+        }
+
+        protected override void OnBlur()
+        {
+            viewInstance.InputField.onSubmit.RemoveAllListeners();
+            dclInput.UI.Submit.performed -= OnSubmitAction;
+            viewInstance.InputField.DeactivateInputField();
+
+        }
+
+        protected override void OnFocus()
+        {
+            viewInstance.InputField.onSubmit.AddListener(OnSubmit);
+            dclInput.UI.Submit.performed += OnSubmitAction;
         }
 
         private void HandleEmojiSearch(string inputText)


### PR DESCRIPTION
## What does this PR change?

Fix #858 avoid chat to detect input when explore panel is open

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Chat
3. Open the explore panel
4. Verify you cannot chat
5. Close the explore panel
6. Verify you can chat correctly again

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

