### PR TITLE
fix: toggle minimap when teleporting to same location

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/MinimapPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/MinimapPlugin.cs
@@ -8,6 +8,7 @@ using ECS;
 using Global.Dynamic;
 using MVC;
 using System.Threading;
+using ECS.SceneLifeCycle.Realm;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 
@@ -20,10 +21,11 @@ namespace DCL.PluginSystem.Global
         private readonly MapRendererContainer mapRendererContainer;
         private readonly IPlacesAPIService placesAPIService;
         private readonly IRealmData realmData;
+        private readonly IRealmNavigator realmNavigator;
         private readonly IChatMessagesBus chatMessagesBus;
 
         public MinimapPlugin(IAssetsProvisioner assetsProvisioner, IMVCManager mvcManager, MapRendererContainer mapRendererContainer, IPlacesAPIService placesAPIService,
-            IRealmData realmData, IChatMessagesBus chatMessagesBus)
+            IRealmData realmData, IChatMessagesBus chatMessagesBus, IRealmNavigator realmNavigator)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.mvcManager = mvcManager;
@@ -31,6 +33,7 @@ namespace DCL.PluginSystem.Global
             this.placesAPIService = placesAPIService;
             this.realmData = realmData;
             this.chatMessagesBus = chatMessagesBus;
+            this.realmNavigator = realmNavigator;
         }
 
         protected override async UniTask<ContinueInitialization?> InitializeInternalAsync(MinimapSettings settings, CancellationToken ct)
@@ -41,7 +44,7 @@ namespace DCL.PluginSystem.Global
             {
                 mvcManager.RegisterController(new MinimapController(MinimapController.CreateLazily(prefab, null),
                     mapRendererContainer.MapRenderer, mvcManager, placesAPIService, TrackPlayerPositionSystem.InjectToWorld(ref world),
-                    realmData, chatMessagesBus));
+                    realmData, chatMessagesBus, realmNavigator));
             };
         }
 

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
@@ -29,5 +29,8 @@ namespace ECS.SceneLifeCycle.Realm
         UniTask LoadTerrainAsync(AsyncLoadProcessReport loadReport, CancellationToken ct);
 
         UniTask SwitchMiscVisibilityAsync();
+
+        //True if the realm has changed to genesis
+        Action<bool> OnRealmChanged { get; set; }
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -342,8 +342,7 @@ namespace Global.Dynamic
                     wearableCatalog
                 ),
                 new ProfilePlugin(container.ProfileRepository, profileCache, staticContainer.CacheCleaner, new ProfileIntentionCache()),
-                new MapRendererPlugin(mapRendererContainer.MapRenderer),
-                new MinimapPlugin(staticContainer.AssetsProvisioner, container.MvcManager, mapRendererContainer, placesAPIService, staticContainer.RealmData, container.ChatMessagesBus),
+                new MapRendererPlugin(mapRendererContainer.MapRenderer), new MinimapPlugin(staticContainer.AssetsProvisioner, container.MvcManager, mapRendererContainer, placesAPIService, staticContainer.RealmData, container.ChatMessagesBus, realmNavigator),
                 new ChatPlugin(staticContainer.AssetsProvisioner, container.MvcManager, container.ChatMessagesBus, entityParticipantTable, nametagsData, dclInput, unityEventSystem),
                 new ExplorePanelPlugin(
                     staticContainer.AssetsProvisioner,

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -51,6 +51,8 @@ namespace Global.Dynamic
         private readonly ObjectProxy<Entity> cameraEntity;
         private readonly CameraSamplingData cameraSamplingData;
 
+        public Action<bool> OnRealmChanged { get; set; }
+        
         public RealmNavigator(
             ILoadingScreen loadingScreen,
             IMapRenderer mapRenderer,
@@ -265,12 +267,11 @@ namespace Global.Dynamic
         {
             bool isGenesis = !realmController.GetRealm().ScenesAreFixed;
 
-            // is NOT visible
-
-            // isVisible
+            OnRealmChanged?.Invoke(isGenesis);
             mapRenderer.SetSharedLayer(MapLayer.PlayerMarker, isGenesis);
             await satelliteFloor.SwitchVisibilityAsync(isGenesis);
             roadsPlugin.RoadAssetPool?.SwitchVisibility(isGenesis);
         }
+
     }
 }


### PR DESCRIPTION
## What does this PR change?

Toggles the minimap if you teleport to a world that has the same spawn point as the coordinate you left from

## How to test the changes?

1. Launch the explorer and DONT MOVE
2. Go to dclexperience
3. Go back to Genesis
4. Teleport a couple of times to check that the minimap toggles as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

