### PR TITLE
fix: Bring back progress bar for landscape

### DIFF
--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -196,7 +196,7 @@ namespace Global.Dynamic
                     worldsTerrain.SwitchVisibility(false);
 
                     if (!genesisTerrain.IsTerrainGenerated)
-                        await genesisTerrain.GenerateTerrainAndShowAsync(cancellationToken: ct);
+                        await genesisTerrain.GenerateTerrainAndShowAsync(processReport : landscapeLoadReport, cancellationToken: ct);
                     else
                         await genesisTerrain.ShowAsync(landscapeLoadReport);
                 }


### PR DESCRIPTION
## What does this PR change?

In the `RealmNavigator` refator we lost the porgress in the terrain. Now its back

## How to test the changes?


1. Launch the explorer
2. Check that the load bar is not stuck in 28 while loading

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

