### PR TITLE
fix: looping emotes not being re-played on startup

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/CharacterEmoteSystem.cs
@@ -159,10 +159,7 @@ namespace DCL.AvatarRendering.Emotes
 
                     // the emote is still loading? dont remove the intent yet, wait for it
                     if (streamableAsset == null)
-                    {
-                        World.Remove<CharacterEmoteIntent>(entity);
                         return;
-                    }
 
                     var streamableAssetValue = streamableAsset.Value;
                     GameObject? mainAsset;
@@ -181,14 +178,13 @@ namespace DCL.AvatarRendering.Emotes
                         ReportHub.LogWarning(reportCategory, $"Emote {emote.Model.Asset.metadata.name} cant be played, AB version: {emote.ManifestResult?.Asset?.GetVersion()} should be >= 16");
 
                     emoteComponent.EmoteUrn = emoteId;
+                    World.Remove<CharacterEmoteIntent>(entity);
                 }
             }
             catch (Exception e)
             {
                 ReportHub.LogException(e, reportCategory);
             }
-
-            World.Remove<CharacterEmoteIntent>(entity);
         }
 
         // Every time the emote is looped we send a new message that should refresh the looping emotes on clients that didn't receive the initial message yet

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/RemoteEmotesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/RemoteEmotesSystem.cs
@@ -35,7 +35,11 @@ namespace DCL.AvatarRendering.Emotes
             // this using cleans up the intention list
             using (OwnedBunch<RemoteEmoteIntention> emoteIntentions = emotesMessageBus.EmoteIntentions())
             {
-                if (!emoteIntentions.Available()) return;
+                if (!emoteIntentions.Available())
+                {
+                    HashSetPool<RemoteEmoteIntention>.Release(savedIntentions);
+                    return;
+                }
 
                 foreach (RemoteEmoteIntention remoteEmoteIntention in emoteIntentions.Collection())
                 {

--- a/Explorer/Assets/DCL/Multiplayer/Emotes/IEmotesMessageBus.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Emotes/IEmotesMessageBus.cs
@@ -10,5 +10,7 @@ namespace DCL.Multiplayer.Emotes
         void Send(URN urn, bool loopCyclePassed, bool sendToSelfReplica);
 
         void OnPlayerRemoved(string walletId);
+
+        void SaveForRetry(RemoteEmoteIntention intention);
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Emotes/MultiplayerEmotesMessageBus.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Emotes/MultiplayerEmotesMessageBus.cs
@@ -101,5 +101,10 @@ namespace DCL.Multiplayer.Emotes
             using (sync.GetScope())
                 emoteIntentions.Add(new RemoteEmoteIntention(emoteURN, walletId));
         }
+
+        public void SaveForRetry(RemoteEmoteIntention intention)
+        {
+            emoteIntentions.Add(intention);
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/930
Since introducing the `RemoteEmoteIntention`, the system has been consuming the intent even before the Entity exists, so we need to save the intent until the entity exists.

## How to test the changes?

- Ask a friend to trigger an NFT emote with a loop.
- Log in to the place where your friend is.
- When his avatar appears, you should see it doing the emote. 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

