### PR TITLE
Fix: revert "Stringify arguments so we avoid [Object object] (#1024)"

### DIFF
--- a/Explorer/Assets/StreamingAssets/Js/Init.js
+++ b/Explorer/Assets/StreamingAssets/Js/Init.js
@@ -3,7 +3,7 @@
 function require(moduleName) {
     const wrapped = UnityOpsApi.LoadAndEvaluateCode(moduleName);
 
-    if (!wrapped) return {};
+    if (!wrapped) return { };
 
     // create minimal context for the execution
     var module = {
@@ -19,28 +19,28 @@ function require(moduleName) {
         moduleName.substring(1),    // __filename
         moduleName.substring(0, 1)   // __dirname
     );
-
+	
     const logger = {
         error: (m) => console.error(m),
         warning: (m) => console.warning(m),
         log: (m) => console.log(m),
     }
-
+    
     Validates.registerBundle(module.exports, logger)
     Validates.registerLogs(module.exports, logger)
     //TODO implement later
     // Validates.registerIntegrationTests(module.exports, logger)
-
+    
     return module.exports;
 }
 
 const console = {
-    log: function (...args) { UnityOpsApi.Log("SceneLog: " + JSON.stringify(args)) },
-    info: function (...args) { UnityOpsApi.Log("SceneInfo: " + JSON.stringify(args)) },
-    debug: function (...args) { UnityOpsApi.Log("SceneDebug: " + JSON.stringify(args)) },
-    trace: function (...args) { UnityOpsApi.Log("SceneTrace: " + JSON.stringify(args)) },
-    warning: function (...args) { UnityOpsApi.Warning("SceneWarning: " + JSON.stringify(args)) },
-    error: function (...args) { UnityOpsApi.Error("SceneError: " + JSON.stringify(args)) },
+    log: function (...args) { UnityOpsApi.Log("SceneLog: " + args.join(' ')) },
+    info: function (...args) { UnityOpsApi.Log("SceneInfo: " + args.join(' ')) },
+    debug: function (...args) { UnityOpsApi.Log("SceneDebug: " + args.join(' ')) },
+    trace: function (...args) { UnityOpsApi.Log("SceneTrace: " + args.join(' ')) },
+    warning: function (...args) { UnityOpsApi.Warning("SceneWarning: " + args.join(' ')) },
+    error: function (...args) { UnityOpsApi.Error("SceneError: " + args.join(' ')) },
 }
 
 // NOTE: MetadyneLabs.dcl.eth introduced a dependency on Cannon.js, this library


### PR DESCRIPTION
This reverts commit 46b7e62e32b95c45bc1ebb3419135b6c6f6eafb6. since it produced a lot of js errors in `Goerli` realm

![image](https://github.com/decentraland/unity-explorer/assets/35366872/fc5b12ac-6ec1-48e5-857e-2764587af0e9)



