### PR TITLE
fix: the fetch api module was not working correctly

### DIFF
--- a/Explorer/Assets/StreamingAssets/Js/Init.js
+++ b/Explorer/Assets/StreamingAssets/Js/Init.js
@@ -60,7 +60,9 @@ globalThis.setImmediate = (fn) => Promise.resolve().then(fn)
 globalThis.require = require;
 globalThis.console = console;
 globalThis.WebSocket = require('~system/WebSocketApi').WebSocket;
-globalThis.fetch = require('~system/FetchApi').fetch;
+globalThis.fetch = async function executeFetch(url, init) {
+    return Promise.resolve(require('~system/FetchApi').fetch(url, init))
+}
 
 
 // disable WebAssembly


### PR DESCRIPTION
## What does this PR change?
The fetch js module was not receiving correctly its arguments and it was making all the POST requests from the scenes fail.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md