### PR TITLE
chore: Add SDK7 lods threshold

### DIFF
--- a/Explorer/Assets/DCL/LOD/Settings/ILODSettingsAsset.cs
+++ b/Explorer/Assets/DCL/LOD/Settings/ILODSettingsAsset.cs
@@ -9,6 +9,8 @@ namespace DCL.LOD
     {
         //Threshold for bucket partition (inclusive) 
         int[] LodPartitionBucketThresholds { get;  }
+        int SDK7LodThreshold { get; set;  }
+        
 
         //Texture array settings. Default resolutions and their default sizes
         TextureArrayResolutionDescriptor[] DefaultTextureArrayResolutionDescriptors { get;  }

--- a/Explorer/Assets/DCL/LOD/Settings/LODSettingsAsset.cs
+++ b/Explorer/Assets/DCL/LOD/Settings/LODSettingsAsset.cs
@@ -14,6 +14,8 @@ namespace DCL.LOD
             5
         };
 
+        [field: SerializeField] public int SDK7LodThreshold { get; set; } = 2;
+
         [field: SerializeField] public TextureArrayResolutionDescriptor[] DefaultTextureArrayResolutionDescriptors { get; set; } =
         {
             new (256, 500, 100), new (512, 100, 10), new (1024, 100, 10), new (2048, 25, 10), new (4096, 25, 10)

--- a/Explorer/Assets/DCL/LOD/Systems/LODDebugToolsSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/LODDebugToolsSystem.cs
@@ -43,6 +43,11 @@ namespace DCL.LOD.Systems
                 debugWidgetBuilder
                     .AddIntFieldWithConfirmation(lodSettingsAsset.LodPartitionBucketThresholds[i], $"LOD {i + 1} Threshold",  newValue => SetLOD(newValue, index));
             }
+
+            debugWidgetBuilder.AddIntFieldWithConfirmation(lodSettingsAsset.SDK7LodThreshold, "SDK 7 Threshold",  newValue =>
+            {
+                lodSettingsAsset.SDK7LodThreshold = newValue;
+            });
         }
 
         private void SetLOD(int newValue, int i)

--- a/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
@@ -30,7 +30,7 @@ namespace DCL.LOD
             else if (!sceneDefinitionComponent.IsSDK7) visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_LOD;
             else
             {
-                VisualSceneStateEnum candidateState = partition.Bucket < lodSettingsAsset.LodPartitionBucketThresholds[0]
+                var candidateState = partition.Bucket < lodSettingsAsset.SDK7LodThreshold
                     ? VisualSceneStateEnum.SHOWING_SCENE
                     : VisualSceneStateEnum.SHOWING_LOD;
 

--- a/Explorer/Assets/DCL/LOD/Tests/EditMode/ResolveVisualSceneStateSystemShould.cs
+++ b/Explorer/Assets/DCL/LOD/Tests/EditMode/ResolveVisualSceneStateSystemShould.cs
@@ -28,9 +28,10 @@ namespace DCL.LOD.Tests
             var lodSettings = Substitute.For<ILODSettingsAsset>();
             int[] bucketThresholds =
             {
-                2, 4
+                4, 8
             };
             lodSettings.LodPartitionBucketThresholds.Returns(bucketThresholds);
+            lodSettings.SDK7LodThreshold.Returns(2);
             var realmData = Substitute.For<IRealmData>();
             system = new ResolveVisualSceneStateSystem(world, lodSettings, new VisualSceneStateResolver(new HashSet<Vector2Int>
             {
@@ -87,8 +88,9 @@ namespace DCL.LOD.Tests
         }
 
         [Test]
-        [TestCase(0, VisualSceneStateEnum.SHOWING_SCENE)]
         [TestCase(5, VisualSceneStateEnum.SHOWING_LOD)]
+        [TestCase(3, VisualSceneStateEnum.SHOWING_LOD)]
+        [TestCase(0, VisualSceneStateEnum.SHOWING_SCENE)]
         public void AddDefaultSDK7SceneVisualState(byte bucket, VisualSceneStateEnum expectedVisualSceneState)
         {
             var partitionComponent = new PartitionComponent();

--- a/Explorer/Assets/DCL/LOD/Tests/EditMode/UpdateVisualSceneStateSystemShould.cs
+++ b/Explorer/Assets/DCL/LOD/Tests/EditMode/UpdateVisualSceneStateSystemShould.cs
@@ -27,8 +27,9 @@ public class UpdateVisualSceneStateSystemShould : UnitySystemTestBase<UpdateVisu
         var lodSettings = Substitute.For<ILODSettingsAsset>();
         int[] bucketThresholds =
         {
-            2, 4
+            4, 8
         };
+        lodSettings.SDK7LodThreshold.Returns(2);
         lodSettings.LodPartitionBucketThresholds.Returns(bucketThresholds);
 
         var scenesCahce = Substitute.For<IScenesCache>();


### PR DESCRIPTION
## What does this PR change?

Adds an SDK7 threshold to show LOD0 for SDK 7 scenes

## How to test the changes?


1. Launch the explorer
2. Enable LOD Debugging
3. There is a unicorn scene in one of the corners of genesis plaza
![image](https://github.com/decentraland/unity-explorer/assets/1999557/356be26b-e7c6-449c-8766-dae2bb975a2d)
4. When approaching, scene should change form green to yellow. Eventually, the scene dissapears and some floating cubes appear. This means that the real scene has loaded

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

