### PR TITLE
fix: fetch requests content type not being sent

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/WebRequestHeadersInfo.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestHeadersInfo.cs
@@ -44,17 +44,18 @@ namespace DCL.WebRequests
             return this;
         }
 
-        /// <param name="key">Case sensitive key</param>
+        /// <param name="key">Case sensitive key or use bool for insensitive</param>
         /// <returns>Value of the key or not, if the key doesn't exist</returns>
-        public readonly string? HeaderOrNull(string key)
+        public readonly string? HeaderOrNull(string key, bool caseInsensitive = false)
         {
             if (values == null)
                 return null;
 
             foreach (WebRequestHeader header in values)
-                if (header.Name == key)
+            {
+                if (string.Equals(header.Name, key, caseInsensitive? StringComparison.InvariantCultureIgnoreCase : StringComparison.InvariantCulture))
                     return header.Value;
-
+            }
             return null;
         }
 

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/JsModulesImplementation/SimpleFetchApiImplementation.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/JsModulesImplementation/SimpleFetchApiImplementation.cs
@@ -4,6 +4,8 @@ using DCL.Diagnostics;
 using DCL.Utilities.Extensions;
 using DCL.WebRequests;
 using Microsoft.ClearScript;
+using Microsoft.ClearScript.V8;
+using Newtonsoft.Json;
 using SceneRuntime.Apis.Modules.FetchApi;
 using System;
 using System.Collections.Generic;
@@ -66,15 +68,15 @@ namespace CrdtEcsBridge.JsModulesImplementation
                 case RequestMethod.GET:
                     return await webController.GetAsync<GenerateResponseOp<GenericGetRequest>, object>(commonArguments, new GenerateResponseOp<GenericGetRequest>(), ct, ReportCategory.SCENE_FETCH_REQUEST, webRequestHeaders);
                 case RequestMethod.POST:
-                    string postContentType = webRequestHeaders.HeaderOrNull("content-type") ?? string.Empty;
+                    string postContentType = webRequestHeaders.HeaderOrNull("content-type", true) ?? string.Empty;
                     var postArguments = GenericPostArguments.Create(body, postContentType);
                     return await webController.PostAsync<GenerateResponseOp<GenericPostRequest>, object>(commonArguments, new GenerateResponseOp<GenericPostRequest>(), postArguments, ct, ReportCategory.SCENE_FETCH_REQUEST, webRequestHeaders);
                 case RequestMethod.PUT:
-                    string putContentType = webRequestHeaders.HeaderOrNull("content-type") ?? string.Empty;
+                    string putContentType = webRequestHeaders.HeaderOrNull("content-type", true) ?? string.Empty;
                     var putArguments = GenericPutArguments.Create(body, putContentType);
                     return await webController.PutAsync<GenerateResponseOp<GenericPutRequest>, object>(commonArguments, new GenerateResponseOp<GenericPutRequest>(), putArguments, ct, ReportCategory.SCENE_FETCH_REQUEST, webRequestHeaders);
                 case RequestMethod.PATCH:
-                    string patchContentType = webRequestHeaders.HeaderOrNull("content-type") ?? string.Empty;
+                    string patchContentType = webRequestHeaders.HeaderOrNull("content-type", true) ?? string.Empty;
                     var patchArguments = GenericPatchArguments.Create(body, patchContentType);
                     return await webController.PatchAsync<GenerateResponseOp<GenericPatchRequest>, object>(commonArguments, new GenerateResponseOp<GenericPatchRequest>(), patchArguments, ct, ReportCategory.SCENE_FETCH_REQUEST, webRequestHeaders);
                 case RequestMethod.HEAD: throw new NotImplementedException();
@@ -101,6 +103,9 @@ namespace CrdtEcsBridge.JsModulesImplementation
                 var requestStatus = (int)unityWebRequest.responseCode;
                 var requestStatusText = unityWebRequest.responseCode.ToString();
                 string requestUrl = unityWebRequest.url.EnsureNotNull();
+
+                object? jsonData = JsonConvert.DeserializeObject(responseData);
+                object reSerializedData = JsonConvert.SerializeObject(jsonData);
 
                 object result = new
                 {

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/JsModulesImplementation/SimpleFetchApiImplementation.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/JsModulesImplementation/SimpleFetchApiImplementation.cs
@@ -104,9 +104,6 @@ namespace CrdtEcsBridge.JsModulesImplementation
                 var requestStatusText = unityWebRequest.responseCode.ToString();
                 string requestUrl = unityWebRequest.url.EnsureNotNull();
 
-                object? jsonData = JsonConvert.DeserializeObject(responseData);
-                object reSerializedData = JsonConvert.SerializeObject(jsonData);
-
                 object result = new
                 {
                     headers = responseHeadersPropertyBag,


### PR DESCRIPTION
## What does this PR change?

Small fix caused by using case sensitive comparison for the content-type of the Fetch requests
