### PR TITLE
fix: pooling reposition

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Pools/GameObjectPool.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Pools/GameObjectPool.cs
@@ -75,7 +75,7 @@ namespace DCL.Optimization.Pools
             GameObject gameObject;
             (gameObject = component.gameObject).SetActive(false);
             gameObject.name = DEFAULT_COMPONENT_NAME;
-            component.gameObject.transform.SetParent(parentContainer);
+            component.gameObject.transform.SetParent(parentContainer, false);
         }
     }
 }

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
@@ -90,7 +90,7 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
             if (UnityObjectUtils.IsQuitting) return;
 
             asset.Root.SetActive(false);
-            asset.Root.transform.SetParent(parentContainer);
+            asset.Root.transform.SetParent(parentContainer, false);
         }
 
         public void Unload(IPerformanceBudget frameTimeBudget, int maxUnloadAmount)


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/1076

## How to test the changes?

- After spawning go to a world like `/world kinerius`
- go back to Genesis with either `/goto 0,0` or pressing the minimap button
- Check that the texts on the boards have proper rotations

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

