### PR TITLE
fix: crash on scenes that uses pointer events and highlighting

### DIFF
--- a/Explorer/Assets/DCL/Interaction/Systems/InteractionHighlightSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/InteractionHighlightSystem.cs
@@ -42,7 +42,6 @@ namespace DCL.Interaction.Systems
         [None(typeof(DeleteEntityIntention))]
         private void UpdateHighlights(ref HighlightComponent highlightComponent)
         {
-
             if (highlightComponent.CurrentEntityOrNull() != EntityReference.Null
                 && World.Has<DeleteEntityIntention>(highlightComponent.CurrentEntityOrNull()))
                 highlightComponent.Disable();
@@ -70,7 +69,15 @@ namespace DCL.Interaction.Systems
             List<Renderer> renderers = ListPool<Renderer>.Get();
             AddRenderersFromEntity(entity, renderers);
 
-            TransformComponent entityTransform = World!.Get<TransformComponent>(entity);
+            ref TransformComponent entityTransform = ref World.TryGetRef<TransformComponent>(entity, out bool containsTransform);
+
+            // Fixes a crash by trying to access the transform of an entity when is not available
+            if (!containsTransform)
+            {
+                ListPool<Renderer>.Release(renderers);
+                return;
+            }
+
             GetRenderersFromChildrenRecursive(ref entityTransform, renderers);
 
             foreach (Renderer renderer in renderers)
@@ -104,7 +111,15 @@ namespace DCL.Interaction.Systems
             List<Renderer> renderers = ListPool<Renderer>.Get();
             AddRenderersFromEntity(entity, renderers);
 
-            TransformComponent entityTransform = World!.Get<TransformComponent>(entity);
+            ref TransformComponent entityTransform = ref World.TryGetRef<TransformComponent>(entity, out bool containsTransform);
+
+            // Fixes a crash by trying to access the transform of an entity when is not available
+            if (!containsTransform)
+            {
+                ListPool<Renderer>.Release(renderers);
+                return;
+            }
+
             GetRenderersFromChildrenRecursive(ref entityTransform, renderers);
 
             foreach (Renderer renderer in renderers)
@@ -120,7 +135,9 @@ namespace DCL.Interaction.Systems
             {
                 AddRenderersFromEntity(child, list);
 
-                TransformComponent childTransform = World!.Get<TransformComponent>(child);
+                ref TransformComponent childTransform = ref World.TryGetRef<TransformComponent>(child, out bool containsTransform);
+                if (!containsTransform) continue;
+
                 GetRenderersFromChildrenRecursive(ref childTransform, list);
             }
         }


### PR DESCRIPTION
## What does this PR change?

Fixes #1077 

Fix applies for scenes that uses pointer events, like this:
```
PointerEvents.create(staticBase, {
  pointerEvents: [
    {
      eventType: PointerEventType.PET_DOWN,
      eventInfo: {
        showFeedback: false
      }
    }
  ]
})
```
Which in the client eventually ends up in the highlighting feature. This was making the client crash for entities which do not have a `TransformComponent`. The fix just checks that the required components exists in the entity.

## How to test the changes?

1. Follow issue steps
2. Check that the highlighting keeps working

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

