### PR TITLE
fix: audioClip count less than zero

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/LoadEmoteAudioClipSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/LoadEmoteAudioClipSystem.cs
@@ -17,7 +17,7 @@ using Utility.Multithreading;
 namespace DCL.AvatarRendering.Emotes
 {
     [UpdateInGroup(typeof(PresentationSystemGroup))]
-    [LogCategory(ReportCategory.AUDIO_SOURCES)]
+    [LogCategory(ReportCategory.SDK_AUDIO_SOURCES)]
     public partial class LoadEmoteAudioClipSystem : LoadSystemBase<AudioClip, GetAudioClipIntention>
     {
         private readonly IWebRequestController webRequestController;

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportCategory.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportCategory.cs
@@ -123,7 +123,7 @@
         /// <summary>
         ///     Everything related to Scenes audio source components
         /// </summary>
-        public const string AUDIO_SOURCES = nameof(AUDIO_SOURCES);
+        public const string SDK_AUDIO_SOURCES = nameof(SDK_AUDIO_SOURCES);
 
         /// <summary>
         ///     Everything related to Media streaming components such as PBAudioStream or PBVideoPlayer

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/AudioSourceLoadingGroup.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/AudioSourceLoadingGroup.cs
@@ -11,6 +11,6 @@ namespace DCL.SDKComponents.AudioSources
     /// </summary>
     [UpdateInGroup(typeof(SyncedPresentationSystemGroup))]
     [UpdateBefore(typeof(StreamableLoadingGroup))]
-    [LogCategory(ReportCategory.AUDIO_SOURCES)]
+    [LogCategory(ReportCategory.SDK_AUDIO_SOURCES)]
     public partial class SDKAudioSourceGroup { }
 }

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/AudioUtils.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/AudioUtils.cs
@@ -27,6 +27,11 @@ namespace DCL.SDKComponents.AudioSources
             cache.Dereference(component.ClipPromise.LoadingIntention, component.AudioSource.clip);
         }
 
+        public static void AddReferenceToAudioClip(this ref AudioSourceComponent component,IDereferencableCache<AudioClip, GetAudioClipIntention> cache)
+        {
+            cache.Add(component.ClipPromise.LoadingIntention, component.AudioSource.clip);
+        }
+
         public static bool TryCreateAudioClipPromise(World world, ISceneData sceneData, string pbAudioClipUrl, PartitionComponent partitionComponent, out Promise? assetPromise)
         {
             if (!sceneData.TryGetContentUrl(pbAudioClipUrl, out URLAddress audioClipUrl))
@@ -55,7 +60,7 @@ namespace DCL.SDKComponents.AudioSources
         {
             if (string.IsNullOrEmpty(url))
             {
-                ReportHub.LogError(ReportCategory.AUDIO_SOURCES, $"Cannot detect AudioType. UrlName doesn't contain file extension!. Setting to {AudioType.UNKNOWN.ToString()}");
+                ReportHub.LogError(ReportCategory.SDK_AUDIO_SOURCES, $"Cannot detect AudioType. UrlName doesn't contain file extension!. Setting to {AudioType.UNKNOWN.ToString()}");
                 return AudioType.UNKNOWN;
             }
 

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Components/AudioSourceComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Components/AudioSourceComponent.cs
@@ -1,8 +1,7 @@
-﻿using DCL.ECSComponents;
+﻿using DCL.Diagnostics;
 using System;
 using UnityEngine;
 using UnityEngine.Audio;
-using UnityEngine.Serialization;
 using Promise = ECS.StreamableLoading.Common.AssetPromise<UnityEngine.AudioClip, ECS.StreamableLoading.AudioClips.GetAudioClipIntention>;
 
 namespace DCL.SDKComponents.AudioSources
@@ -22,7 +21,6 @@ namespace DCL.SDKComponents.AudioSources
         {
             ClipPromise = promise;
             AudioClipUrl = audioClipUrl;
-            Debug.LogError($"AUDIOCLIP - AudioSourceCreated - {promise} - {audioClipUrl}");
 
             AudioSource = null;
             AudioSourceAssigned = false;
@@ -31,7 +29,6 @@ namespace DCL.SDKComponents.AudioSources
         public void SetAudioSource(AudioSource audioSource, AudioMixerGroup audioMixerGroup)
         {
             AudioSource = audioSource;
-            Debug.LogError($"AUDIOCLIP - AudioSource Set {audioSource.clip}");
 
             if (audioMixerGroup != null) { audioSource.outputAudioMixerGroup = audioMixerGroup; }
 

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Components/AudioSourceComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Components/AudioSourceComponent.cs
@@ -22,6 +22,7 @@ namespace DCL.SDKComponents.AudioSources
         {
             ClipPromise = promise;
             AudioClipUrl = audioClipUrl;
+            Debug.LogError($"AUDIOCLIP - AudioSourceCreated - {promise} - {audioClipUrl}");
 
             AudioSource = null;
             AudioSourceAssigned = false;
@@ -30,6 +31,7 @@ namespace DCL.SDKComponents.AudioSources
         public void SetAudioSource(AudioSource audioSource, AudioMixerGroup audioMixerGroup)
         {
             AudioSource = audioSource;
+            Debug.LogError($"AUDIOCLIP - AudioSource Set {audioSource.clip}");
 
             if (audioMixerGroup != null) { audioSource.outputAudioMixerGroup = audioMixerGroup; }
 

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/CleanUpAudioSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/CleanUpAudioSourceSystem.cs
@@ -15,7 +15,7 @@ using UnityEngine;
 namespace DCL.SDKComponents.AudioSources
 {
     [UpdateInGroup(typeof(CleanUpGroup))]
-    [LogCategory(ReportCategory.AUDIO_SOURCES)]
+    [LogCategory(ReportCategory.SDK_AUDIO_SOURCES)]
     [ThrottlingEnabled]
     public partial class CleanUpAudioSourceSystem : BaseUnityLoopSystem, IFinalizeWorldSystem
     {

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/StartAudioSourceLoadingSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/StartAudioSourceLoadingSystem.cs
@@ -16,7 +16,7 @@ namespace DCL.SDKComponents.AudioSources
     ///     Places a loading intention for audio clip that can be consumed by other systems in the pipeline.
     /// </summary>
     [UpdateInGroup(typeof(SDKAudioSourceGroup))]
-    [LogCategory(ReportCategory.AUDIO_SOURCES)]
+    [LogCategory(ReportCategory.SDK_AUDIO_SOURCES)]
     [ThrottlingEnabled]
     public partial class StartAudioSourceLoadingSystem : BaseUnityLoopSystem
     {

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
@@ -62,8 +62,15 @@ namespace DCL.SDKComponents.AudioSources
                 return;
 
             if (!audioSourceComponent.AudioSourceAssigned)
-                audioSourceComponent.SetAudioSource(audioSourcesPool.Get(), audioMixerGroup);
+            {
+                if (audioSourcesPool == null)
+                {
+                    var a = 1;
+                    return;
+                }
 
+                audioSourceComponent.SetAudioSource(audioSourcesPool.Get(), audioMixerGroup);
+            }
             audioSourceComponent.AudioSource.FromPBAudioSourceWithClip(sdkAudioSource, clip: promiseResult.Asset);
 
             // Reset isDirty as we just applied the PBAudioSource to the AudioSource

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/AudioClips/AudioClipData.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/AudioClips/AudioClipData.cs
@@ -34,8 +34,8 @@ namespace ECS.StreamableLoading.AudioClips
             if (referencesCount == 0)
                 ProfilingCounters.AudioClipsReferenced.Value++;
 
-            Debug.LogError($"AUDIOCLIP - Added a reference to - {AudioClip} - {referencesCount}");
             referencesCount++;
+
             LastUsedFrame = MultithreadingUtility.FrameCount;
         }
 
@@ -45,16 +45,15 @@ namespace ECS.StreamableLoading.AudioClips
 
             if (referencesCount < 0)
             {
-                Debug.LogError($"AUDIOCLIP NEGATIVE REF!! {AudioClip} {referencesCount}");
+                ReportHub.LogException(new Exception("Reference count of AudioClip should never be negative!"), ReportCategory.SDK_AUDIO_SOURCES);
+                //Assert.IsFalse(referencesCount < 0, "Reference count of AudioClip should never be negative!"); Leaving it commented for now :)
             }
-
-            //Assert.IsFalse(referencesCount < 0, "Reference count of AudioClip should never be negative!");
-                ReportHub.LogException(new Exception("Reference count of AudioClip should never be negative!"), ReportCategory.AUDIO);
 
             LastUsedFrame = MultithreadingUtility.FrameCount;
 
             if (referencesCount == 0)
                 ProfilingCounters.AudioClipsReferenced.Value--;
+
         }
 
         public bool CanBeDisposed() =>

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/AudioClips/AudioClipData.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/AudioClips/AudioClipData.cs
@@ -34,6 +34,7 @@ namespace ECS.StreamableLoading.AudioClips
             if (referencesCount == 0)
                 ProfilingCounters.AudioClipsReferenced.Value++;
 
+            Debug.LogError($"AUDIOCLIP - Added a reference to - {AudioClip} - {referencesCount}");
             referencesCount++;
             LastUsedFrame = MultithreadingUtility.FrameCount;
         }
@@ -42,7 +43,12 @@ namespace ECS.StreamableLoading.AudioClips
         {
             referencesCount--;
 
-            Assert.IsFalse(referencesCount < 0, "Reference count of AudioClip should never be negative!");
+            if (referencesCount < 0)
+            {
+                Debug.LogError($"AUDIOCLIP NEGATIVE REF!! {AudioClip} {referencesCount}");
+            }
+
+            //Assert.IsFalse(referencesCount < 0, "Reference count of AudioClip should never be negative!");
 
             LastUsedFrame = MultithreadingUtility.FrameCount;
 

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/AudioClips/AudioClipsCache.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/AudioClips/AudioClipsCache.cs
@@ -1,4 +1,5 @@
 ﻿using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.Profiling;
 using ECS.StreamableLoading.Cache;
@@ -35,7 +36,11 @@ namespace ECS.StreamableLoading.AudioClips
                 clipData.AddReference();
             else
             {
-                cache[key] = new AudioClipData(asset);
+                //Starting the count of references on 0 because this is created during the asset loading, but it isn't necessarily referenced by a component yet
+                //left the adding of references to be done manually by components when they are finally initialized so when we do the cleanup it properly removes
+                //referenced clips
+                cache[key] = new AudioClipData(asset, 0);
+
                 listedCache.Add((key, cache[key]));
             }
 
@@ -47,8 +52,7 @@ namespace ECS.StreamableLoading.AudioClips
             if (cache.TryGetValue(key, out AudioClipData? value))
             {
                 asset = value.AudioClip;
-                value.AddReference();
-                return true;
+                 return true;
             }
 
             asset = null;

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/AudioClips/LoadAudioClipSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/AudioClips/LoadAudioClipSystem.cs
@@ -14,7 +14,7 @@ using UnityEngine;
 namespace ECS.StreamableLoading.AudioClips
 {
     [UpdateInGroup(typeof(StreamableLoadingGroup))]
-    [LogCategory(ReportCategory.AUDIO_SOURCES)]
+    [LogCategory(ReportCategory.SDK_AUDIO_SOURCES)]
     public partial class LoadAudioClipSystem  : LoadSystemBase<AudioClip, GetAudioClipIntention>
     {
         private readonly IWebRequestController webRequestController;


### PR DESCRIPTION
## What does this PR change?

fixes: #459 

Changed a bit how references are added. Before we were depending on the audioClip loading to add the references, but this was not working correctly. Given that the cleanup is done by processing the AudioSourceComponents (not the clips themselves), I decided to add the reference adding into the AudioSourceComponent creation process, so we are sure to be adding the reference when the audioClip is finally referenced by the component. Otherwise it would not cleanup properly when disposing of all the components.

## How to test the changes?

Open the Plaza, jump to any other location far away. Nothing should break xD
Come back to plaza, jump to metadyne, jump back to plaza, nothing should break again.
Before, when jumping between these locations, we would get an assert Exception and it would break the whole flow.