### PR TITLE
fix: feet ik offset

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Settings/CharacterControllerSettings.asset
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Settings/CharacterControllerSettings.asset
@@ -132,14 +132,18 @@ MonoBehaviour:
   <FOVIncreaseSpeed>k__BackingField: 15
   <FOVDecreaseSpeed>k__BackingField: 20
   <FeetIKHipsPullMaxDistance>k__BackingField: 0.6
-  <FeetIKSphereSize>k__BackingField: 0.1
+  <FeetIKSphereSize>k__BackingField: 0.08
   <IKWeightSpeed>k__BackingField: 10
   <IKPositionSpeed>k__BackingField: 10
   <FeetIKVerticalAngleLimits>k__BackingField: {x: -30, y: 50}
   <FeetIKTwistAngleLimits>k__BackingField: {x: -30, y: 15}
+  <FeetIKLeftOffset>k__BackingField: {x: 0, y: 0, z: 0}
+  <FeetIKRightOffset>k__BackingField: {x: 0, y: 0, z: 0.08}
+  <FeetIKLeftRotationOffset>k__BackingField: {x: 0, y: -5.35, z: 0}
+  <FeetIKRightRotationOffset>k__BackingField: {x: 0, y: 6.39, z: 0}
   <FeetHeightCorrection>k__BackingField: 0.08
   <FeetHeightDisableIkDistance>k__BackingField: 0.1
-  <HipsHeightCorrection>k__BackingField: 0.05
+  <HipsHeightCorrection>k__BackingField: 0
   <HandsIKWallHitDistance>k__BackingField: 0.5
   <HandsIKWeightSpeed>k__BackingField: 5
   <HandsIKElbowOffset>k__BackingField: {x: 0.256, y: 0.9800129, z: -0.4610018}

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Settings/CharacterControllerSettings.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Settings/CharacterControllerSettings.cs
@@ -71,6 +71,10 @@ namespace DCL.CharacterMotion.Settings
         [field: SerializeField] public Vector2 FeetIKVerticalAngleLimits { get; set; } = new (-50, 20);
         [field: SerializeField] public Vector2 FeetIKTwistAngleLimits { get; set; } = new (-30, 15);
 
+        [field: SerializeField] public Vector3 FeetIKLeftOffset { get; set; }
+        [field: SerializeField] public Vector3 FeetIKRightOffset { get; set; }
+        [field: SerializeField] public Vector3 FeetIKLeftRotationOffset { get; set; }
+        [field: SerializeField] public Vector3 FeetIKRightRotationOffset { get; set; }
         [field: SerializeField] public float FeetHeightCorrection { get; set; } = 0.08f;
         [field: SerializeField] public float FeetHeightDisableIkDistance { get; set; } = 0.1f;
         [field: SerializeField] public float HipsHeightCorrection { get; set; } = 0.05f;

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Settings/ICharacterControllerSettings.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Settings/ICharacterControllerSettings.cs
@@ -50,6 +50,10 @@ namespace DCL.CharacterMotion.Settings
         float IKPositionSpeed { get; set; }
         Vector2 FeetIKVerticalAngleLimits { get; set; }
         Vector2 FeetIKTwistAngleLimits { get; set; }
+        Vector3 FeetIKLeftOffset { get; set; }
+        Vector3 FeetIKRightOffset { get; set; }
+        Vector3 FeetIKLeftRotationOffset { get; set; }
+        Vector3 FeetIKRightRotationOffset { get; set; }
         float HandsIKWallHitDistance { get; set; }
         float HandsIKWeightSpeed { get; set; }
         Vector3 HandsIKElbowOffset { get; set; }

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/FeetIKSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/FeetIKSystem.cs
@@ -105,8 +105,8 @@ namespace DCL.CharacterMotion.Systems
                              && !disableByPlatform; // disable IK on moving platforms
 
             // First: Raycast down from right/left constraints and update IK targets
-            ApplyLegIK(rightLegConstraint, rightLegConstraint.forward, avatarBase.RightLegIKTarget, ref feetIKComponent.Right, settings, dt, settings.FeetIKVerticalAngleLimits, settings.FeetIKTwistAngleLimits);
-            ApplyLegIK(leftLegConstraint, leftLegConstraint.forward, avatarBase.LeftLegIKTarget, ref feetIKComponent.Left, settings, dt, settings.FeetIKVerticalAngleLimits, new Vector2(settings.FeetIKTwistAngleLimits.y, settings.FeetIKTwistAngleLimits.x));
+            ApplyLegIK(rightLegConstraint, rightLegConstraint.forward, avatarBase.RightLegIKTarget, ref feetIKComponent.Right, settings, dt, settings.FeetIKVerticalAngleLimits, settings.FeetIKTwistAngleLimits, settings.FeetIKRightOffset, settings.FeetIKRightRotationOffset);
+            ApplyLegIK(leftLegConstraint, leftLegConstraint.forward, avatarBase.LeftLegIKTarget, ref feetIKComponent.Left, settings, dt, settings.FeetIKVerticalAngleLimits, new Vector2(settings.FeetIKTwistAngleLimits.y, settings.FeetIKTwistAngleLimits.x), settings.FeetIKLeftOffset, settings.FeetIKLeftRotationOffset);
 
             // Second: Calculate IK feet weight based on the constrained local-Y
             ApplyIKWeight(avatarBase.RightLegIK, rightLegConstraint.localPosition, ref feetIKComponent.Right, isEnabled, settings, dt);
@@ -168,7 +168,8 @@ namespace DCL.CharacterMotion.Systems
             ref FeetIKComponent.FeetComponent feetComponent,
             ICharacterControllerSettings settings,
             float dt,
-            Vector2 verticalLimits, Vector2 twistLimits)
+            Vector2 verticalLimits, Vector2 twistLimits,
+            Vector3 positionOffset, Vector3 rotationOffset)
         {
             float pullDist = settings.FeetIKHipsPullMaxDistance;
             Vector3 origin = legConstraintPosition.position;
@@ -180,20 +181,22 @@ namespace DCL.CharacterMotion.Systems
 
             if (Physics.SphereCast(rayOrigin, settings.FeetIKSphereSize, rayDirection, out RaycastHit hitInfo, rayDistance, PhysicsLayers.CHARACTER_ONLY_MASK))
             {
+                Vector3 targetPosition = hitInfo.point + positionOffset;
                 // lerp towards the target position
-                legIKTarget.position = Vector3.MoveTowards(legIKTarget.position, hitInfo.point, settings.IKPositionSpeed * dt);
+                legIKTarget.position = Vector3.MoveTowards(legIKTarget.position, targetPosition, settings.IKPositionSpeed * dt);
                 var rotationCorrection = Quaternion.FromToRotation(Vector3.up, hitInfo.normal);
                 legConstraintForward.y = 0;
                 Quaternion targetRotation = rotationCorrection * Quaternion.LookRotation(legConstraintForward, Vector3.up);
 
                 // we first apply the rotation
                 legIKTarget.rotation = targetRotation;
+                legIKTarget.eulerAngles += rotationOffset;
 
                 // then we limit the angles using the local rotations
                 ApplyRotationLimit(legIKTarget, verticalLimits, twistLimits);
 
                 feetComponent.IsGrounded = true;
-                feetComponent.IsInsideMesh = hitInfo.point.y > origin.y;
+                feetComponent.IsInsideMesh = targetPosition.y > origin.y;
                 feetComponent.Distance = settings.FeetHeightCorrection + hitInfo.distance - pullDist - legConstraintPosition.localPosition.y;
                 return;
             }


### PR DESCRIPTION
## What does this PR change?

Added an offset to the Feet IK so the feet look more relaxed just like how they are with the Idle pose
Fixed offset that made the feet be over the ground level

Without IK:
![image](https://github.com/decentraland/unity-explorer/assets/7646450/a044aa4e-b13e-46b9-b20c-d5c8ec84f8f7)
![image](https://github.com/decentraland/unity-explorer/assets/7646450/a618584d-a1da-446c-bb19-5177dd8830ca)

Before with IK:
![image](https://github.com/decentraland/unity-explorer/assets/7646450/5bedd4f3-edc6-4aca-bb2c-ab84a1802072)
![image](https://github.com/decentraland/unity-explorer/assets/7646450/7a83c39b-b1d5-49f1-8792-d553019f799a)

Now with IK:
![image](https://github.com/decentraland/unity-explorer/assets/7646450/cd8a48aa-4231-493a-929d-3024c83b0083)
![image](https://github.com/decentraland/unity-explorer/assets/7646450/7a869865-db27-4d50-af61-e8e44e81b3f2)

## How to test the changes?

- Just watch your feet

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

