### PR TITLE
fix: scene ui parenting crash

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UITransform/UITransformParentingSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UITransform/UITransformParentingSystem.cs
@@ -47,7 +47,7 @@ namespace DCL.SDKComponents.SceneUI.Systems.UITransform
 
                 if (!exists)
                 {
-                    ReportHub.LogError(GetReportCategory(), $"Trying to remove an ${nameof(UITransformComponent)}'s child but no component has been found on entity {childEntity.Entity}");
+                    ReportHub.LogError(GetReportCategory(), $"Trying to unparent an ${nameof(UITransformComponent)}'s child but no component has been found on entity {childEntity.Entity}");
                     continue;
                 }
 


### PR DESCRIPTION
## What does this PR change?

Fixes #1089 

The UI system was performing parenting operations on entities that didnt have any `UITransformComponent`. The scene UI gets broken tho, but we avoid the client crash.

## How to test the changes?

1. Follow issue steps
2. Check that the UI on other scenes keeps working

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

