### PR TITLE
fix: avoid deadlock if we cannot acquire the mutex

### DIFF
--- a/Explorer/Assets/Scripts/Utility/Multithreading/MutexSync.cs
+++ b/Explorer/Assets/Scripts/Utility/Multithreading/MutexSync.cs
@@ -1,6 +1,6 @@
-using DCL.Diagnostics;
 using System;
 using System.Threading;
+using UnityEngine;
 using UnityEngine.Profiling;
 
 namespace Utility.Multithreading
@@ -27,7 +27,7 @@ namespace Utility.Multithreading
             }
             else
             {
-                ReportHub.LogWarning(ReportCategory.ENGINE, $"MutexSync.Acquire: Failed to acquire mutex in the timeout {TIMEOUT}ms.");
+                Debug.LogWarning( $"MutexSync.Acquire: Failed to acquire mutex in the timeout {TIMEOUT}ms.");
             }
 
         }

--- a/Explorer/Assets/Scripts/Utility/Multithreading/MutexSync.cs
+++ b/Explorer/Assets/Scripts/Utility/Multithreading/MutexSync.cs
@@ -1,3 +1,4 @@
+using DCL.Diagnostics;
 using System;
 using System.Threading;
 using UnityEngine.Profiling;
@@ -7,6 +8,7 @@ namespace Utility.Multithreading
     public class MutexSync : IDisposable
     {
         private static readonly CustomSampler SAMPLER;
+        private const int TIMEOUT = 1000;
 
         private readonly Mutex mutex = new ();
 
@@ -19,13 +21,20 @@ namespace Utility.Multithreading
 
         public void Acquire()
         {
-            mutex.WaitOne();
-            Acquired = true;
+            if (mutex.WaitOne(TIMEOUT))
+            {
+                Acquired = true;
+            }
+            else
+            {
+                ReportHub.LogWarning(ReportCategory.ENGINE, $"MutexSync.Acquire: Failed to acquire mutex in the timeout {TIMEOUT}ms.");
+            }
+
         }
 
         public void Release()
         {
-            mutex.ReleaseMutex();
+            if(Acquired) mutex.ReleaseMutex();
             Acquired = false;
         }
 


### PR DESCRIPTION
## What does this PR change?

Attempts to avoid a deadlock situation with a timeout, the real problem must be investigated