### PR TITLE
fix: removed negative size on box collider on the pot in the streets

### DIFF
--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/RoadRedesign/PotTree.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/RoadRedesign/PotTree.prefab
@@ -518,5 +518,5 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 2.2, y: -0.02, z: 2.2}
+  m_Size: {x: 2.2, y: 0.02, z: 2.2}
   m_Center: {x: 0, y: 0.71, z: 0}


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Updated prefab `PotTree` to remove this warning:

```
BoxCollider does not support negative scale or size.
The effective box size has been forced positive and is likely to give unexpected collision geometry.
If you absolutely need to use negative scaling you can use the convex MeshCollider. Scene hierarchy path "ROAD_ASSET_POOL/Crossroads_A(Clone)/*SCENEROOT*/Scene/PotTree"
```

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Go the the roads
3. The warning should not be visible in the console in editor or the log file.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

