### PR TITLE
fix: Ring job overcalculating

### DIFF
--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -114,6 +114,9 @@ namespace Global.Dynamic
                         remoteEntities.ForceRemoveAll(world);
                         await roomHub.StopIfNotAsync();
 
+                        // By removing the CameraSamplingData, we stop the ring calculation
+                        world.Remove<CameraSamplingData>(cameraEntity.Object);
+
                         await ChangeRealmAsync(realm, ct);
                         parentLoadReport.SetProgress(RealFlowLoadingStatus.PROGRESS[ProfileLoaded]);
 
@@ -137,7 +140,8 @@ namespace Global.Dynamic
             }
             catch (TimeoutException)
             {
-                
+                if (!world.Has<CameraSamplingData>(cameraEntity.Object))
+                    world.Add(cameraEntity.Object, cameraSamplingData);
             }
 
             return true;
@@ -156,8 +160,7 @@ namespace Global.Dynamic
 
             // add camera sampling data to the camera entity to start partitioning
             Assert.IsTrue(cameraEntity.Configured);
-            if (!world.Has<CameraSamplingData>(cameraEntity.Object))
-                world.Add(cameraEntity.Object, cameraSamplingData);
+            world.Add(cameraEntity.Object, cameraSamplingData);
             await waitForSceneReadiness;
         }
 


### PR DESCRIPTION
## What does this PR change?

Fixes this
![image](https://github.com/decentraland/unity-explorer/assets/1999557/a5536624-31cf-4a3c-86c1-8a55e131f8db)


The ring jobs was still running when changing realms. This PR avoid that by removing the `CameraSamplingData` while changing realms

## How to test the changes?

1. Launch the explorer
2. Teleport back and forth between realms

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

