### PR TITLE
Fix: fixed backpack freeze

### DIFF
--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -110,7 +110,6 @@ namespace DCL.Backpack
             eventBus.SearchEvent += OnSearch;
             backpackSortController.OnSortChanged += OnSortChanged;
             backpackSortController.OnCollectiblesOnlyChanged += OnCollectiblesOnlyChanged;
-            pageSelectorController.SetActive(false);
         }
 
         public void Deactivate()

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -272,10 +272,7 @@ namespace DCL.Backpack
                 return;
 
             if (refreshPageSelector)
-            {
-                pageSelectorController.SetActive(false);
                 pageSelectorController.Configure(uniTaskAsync.Result.Value.Asset.TotalAmount, CURRENT_PAGE_SIZE);
-            }
 
             currentPageWearables = uniTaskAsync.Result.Value.Asset.Wearables;
 

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -110,6 +110,7 @@ namespace DCL.Backpack
             eventBus.SearchEvent += OnSearch;
             backpackSortController.OnSortChanged += OnSortChanged;
             backpackSortController.OnCollectiblesOnlyChanged += OnCollectiblesOnlyChanged;
+            pageSelectorController.SetActive(false);
         }
 
         public void Deactivate()
@@ -263,13 +264,19 @@ namespace DCL.Backpack
 
         private async UniTaskVoid AwaitWearablesPromiseAsync(ParamPromise wearablesPromise, bool refreshPageSelector, CancellationToken ct)
         {
+            if (refreshPageSelector)
+                pageSelectorController.SetActive(false);
+
             AssetPromise<WearablesResponse, GetWearableByParamIntention> uniTaskAsync = await wearablesPromise.ToUniTaskAsync(world, cancellationToken: ct);
 
             if (!uniTaskAsync.Result!.Value.Succeeded || ct.IsCancellationRequested)
                 return;
 
-            if(refreshPageSelector)
+            if (refreshPageSelector)
+            {
+                pageSelectorController.SetActive(false);
                 pageSelectorController.Configure(uniTaskAsync.Result.Value.Asset.TotalAmount, CURRENT_PAGE_SIZE);
+            }
 
             currentPageWearables = uniTaskAsync.Result.Value.Asset.Wearables;
 

--- a/Explorer/Assets/DCL/UI/PageSelector/PageSelectorController.cs
+++ b/Explorer/Assets/DCL/UI/PageSelector/PageSelectorController.cs
@@ -63,6 +63,11 @@ namespace DCL.UI
             OnSetPage?.Invoke(currentPage);
         }
 
+        public void SetActive(bool isActive)
+        {
+            view.gameObject.SetActive(isActive);
+        }
+
         public void Configure(int maxElements, int pageSize)
         {
             totalPages = (maxElements + pageSize - 1) / pageSize;


### PR DESCRIPTION
## What does this PR change?

This issue fixes the backpack freeze that happened when clicking the page selector when the first page was not loaded.
To solve this the page selector now is visible only after we retrieve properly the total pages count.

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open the backpack
3. Verify that the page selector is not visible before the first page loads
4. Verify this also when applying the category filters

PS: Keep in mind that if we open the backpack when other stuff is loading as soon as we join in game the requests will take longer, if instead we wait a while and then open the backpack it will be faster

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

