### PR TITLE
fix: movePlayerTo restricted action does not work

### DIFF
--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/RestrictedActionsApi/RestrictedActionsAPIWrapper.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/RestrictedActionsApi/RestrictedActionsAPIWrapper.cs
@@ -24,21 +24,21 @@ namespace SceneRuntime.Apis.Modules.RestrictedActionsApi
 
         [UsedImplicitly]
         public void MovePlayerTo(
-            int newRelativePositionX, int newRelativePositionY, int newRelativePositionZ)
+            double newRelativePositionX, double newRelativePositionY, double newRelativePositionZ)
         {
             api.TryMovePlayerTo(
-                new Vector3(newRelativePositionX, newRelativePositionY, newRelativePositionZ),
+                new Vector3((float)newRelativePositionX, (float)newRelativePositionY, (float)newRelativePositionZ),
                 null);
         }
 
         [UsedImplicitly]
         public void MovePlayerTo(
-            int newRelativePositionX, int newRelativePositionY, int newRelativePositionZ,
-            int cameraTargetX, int cameraTargetY, int cameraTargetZ)
+            double newRelativePositionX, double newRelativePositionY, double newRelativePositionZ,
+            double cameraTargetX, double cameraTargetY, double cameraTargetZ)
         {
             api.TryMovePlayerTo(
-                new Vector3(newRelativePositionX, newRelativePositionY, newRelativePositionZ),
-                new Vector3(cameraTargetX, cameraTargetY, cameraTargetZ));
+                new Vector3((float)newRelativePositionX, (float)newRelativePositionY, (float)newRelativePositionZ),
+                new Vector3((float)cameraTargetX, (float)cameraTargetY, (float)cameraTargetZ));
         }
 
         [UsedImplicitly]


### PR DESCRIPTION
## What does this PR change?
Fix #677 
Fix #1149 

![image](https://github.com/decentraland/unity-explorer/assets/64659061/5c0e4f58-b5f8-4d09-b4b7-0a15cf2577e2)

## How to test the changes?
1. Launch the explorer
2. Go to the beam area in the cafe
3. Check that the countdown appears
4. Check that after the countdown your avatar is teleported to the upper place of the scene

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md