### PR TITLE
fix: exception with POIs

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
@@ -1,7 +1,7 @@
 ﻿using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.Ipfs;
 using DCL.MapRenderer.Culling;
-using DCL.PlacesAPIService;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -49,8 +49,12 @@ namespace DCL.MapRenderer.MapLayers.PointsOfInterest
         {
             IReadOnlyList<string> pointsOfInterestCoordsAsync = await placesAPIService.GetPointsOfInterestCoordsAsync(cancellationToken);
             vectorCoords.Clear();
+
             foreach (var s in pointsOfInterestCoordsAsync)
-                vectorCoords.Add(IpfsHelper.DecodePointer(s));
+            {
+                try { vectorCoords.Add(IpfsHelper.DecodePointer(s)); }
+                catch (Exception e) { ReportHub.LogException(e, ReportCategory.TEXTURES); }
+            }
 
             using var placesByCoordsListAsync = await placesAPIService.GetPlacesByCoordsListAsync(vectorCoords, cancellationToken, true);
             // non-blocking retrieval of scenes of interest happens independently on the minimap rendering


### PR DESCRIPTION
## What does this PR change?

Found a weird exception, this fix should avoid the map not loading

![image](https://github.com/decentraland/unity-explorer/assets/7646450/a1f94bd7-6157-48f4-b9af-93d3e89d5aba)


## How to test the changes?

- minimap should load

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

