### PR TITLE
fix: duplicated emote

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/EmbeddedEmotes/EmbeddedEmotes.asset
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/EmbeddedEmotes/EmbeddedEmotes.asset
@@ -130,24 +130,11 @@ MonoBehaviour:
       hides: []
       removesDefaultHiding: []
       loop: 1
-  - id: hands_in_the_air
-    name: hands_in_the_air
-    audioClip: {fileID: 0}
-    thumbnail: {fileID: 21300000, guid: 5d9d324d9b1257f4cbeed858807c2c06, type: 3}
-    prefab: {fileID: 8771091787928289351, guid: 1367a4cc5c746844995474c692ce506f, type: 3}
-    entity:
-      representations: []
-      category: 
-      tags: []
-      replaces: []
-      hides: []
-      removesDefaultHiding: []
-      loop: 0
   - id: handsair
     name: handsair
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 5d9d324d9b1257f4cbeed858807c2c06, type: 3}
-    prefab: {fileID: 8018143466885850673, guid: 425469edfdeba472c907877cc4c364c3, type: 3}
+    prefab: {fileID: 8771091787928289351, guid: 1367a4cc5c746844995474c692ce506f, type: 3}
     entity:
       representations: []
       category: 


### PR DESCRIPTION
## What does this PR change?

- Removed` hands_in_the_air emote` since it failed to be equipped and it was a duplicate of `handsinair`

## How to test the changes?

- Check that you have only one version of `handsinair` and that you can equip it and use it (it has confetti! 🥳) 
## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

