### PR TITLE
fix: emotes timeout when loading in the backpack

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
@@ -179,7 +179,6 @@ MonoBehaviour:
         - dontsee
         - hammer
         - handsair
-        - hands_in_the_air
         - hohoho
         - robot
         - snowfall


### PR DESCRIPTION
## What does this PR change?

Removed an already deleted embed emote from a secondary list

## How to test the changes?

- Emotes in the backpack should not take 30 seconds to load.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

