### PR TITLE
fix: interactions from outside scenes

### DIFF
--- a/Explorer/Assets/DCL/Interaction/Systems/InteractionHighlightSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/InteractionHighlightSystem.cs
@@ -13,6 +13,7 @@ using ECS.Unity.GLTFContainer.Asset.Components;
 using ECS.Unity.GLTFContainer.Components;
 using ECS.Unity.PrimitiveRenderer.Components;
 using ECS.Unity.Transforms.Components;
+using SceneRunner.Scene;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Pool;
@@ -27,14 +28,18 @@ namespace DCL.Interaction.Systems
     public partial class InteractionHighlightSystem : BaseUnityLoopSystem
     {
         private readonly InteractionSettingsData settingsData;
+        private readonly ISceneStateProvider sceneStateProvider;
 
-        internal InteractionHighlightSystem(World world, InteractionSettingsData settingsData) : base(world)
+        internal InteractionHighlightSystem(World world, InteractionSettingsData settingsData, ISceneStateProvider sceneStateProvider) : base(world)
         {
             this.settingsData = settingsData;
+            this.sceneStateProvider = sceneStateProvider;
         }
 
         protected override void Update(float t)
         {
+            if (!sceneStateProvider.IsCurrent) return;
+
             UpdateHighlightsQuery(World);
         }
 

--- a/Explorer/Assets/DCL/Interaction/Systems/WritePointerEventResultsSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/WritePointerEventResultsSystem.cs
@@ -51,6 +51,8 @@ namespace DCL.Interaction.PlayerOriginated.Systems
 
         protected override void Update(float t)
         {
+            if (!sceneStateProvider.IsCurrent) return;
+
             var messageSent = false;
             WriteResultsQuery(World, sceneData.Geometry.BaseParcelPosition, ref messageSent);
 

--- a/Explorer/Assets/DCL/PluginSystem/World/InteractionPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/InteractionPlugin.cs
@@ -72,7 +72,7 @@ namespace DCL.PluginSystem.World
                 globalInputEvents,
                 poolsRegistry.GetReferenceTypePool<RaycastHit>());
 
-            InteractionHighlightSystem.InjectToWorld(ref builder, interactionData);
+            InteractionHighlightSystem.InjectToWorld(ref builder, interactionData, sceneDeps.SceneStateProvider);
         }
 
         [Serializable]


### PR DESCRIPTION
### WHY
User interactions are being tracked and processed on scenes that are not the current scene, this consumes performance and may affect the "starting state" of a scene once the user reached that scene.

### WHAT
Added a simple current scene check on the system that writes into CRDT the user input values + the interactables highlighting system

### TESTING

There is a scene in **goerli-plaza 82,1** that has the following interactions:
* Re-spawn balls in the air when pressing E
* Highlight balls even at long distance
* Move balls by clicking them on close distance

Those interactions are working when triggered from outside the scene and that shouldn't be the case, here's a video displaying those 3 being triggered from outside the scene:

https://github.com/decentraland/unity-explorer/assets/1031741/cc295b8c-30ca-4150-b13b-141b48563280

Please check that with this fix those interactions are only availble when you are inside the scene.
