### PR TITLE
fix: put coordinates back into world minimap

### DIFF
--- a/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
+++ b/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
@@ -885,81 +885,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &2759377129377115971
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8763323205625865704}
-  - component: {fileID: 9206561807649397155}
-  - component: {fileID: 1636583966066412649}
-  m_Layer: 5
-  m_Name: WorldIcon
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &8763323205625865704
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2759377129377115971}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2505400538292533899}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -99, y: -10.1}
-  m_SizeDelta: {x: 16, y: 16}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &9206561807649397155
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2759377129377115971}
-  m_CullTransparentMesh: 1
---- !u!114 &1636583966066412649
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2759377129377115971}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.4}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: e95e9a04840de8642a118c78e3abd46c, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2977730809347555680
 GameObject:
   m_ObjectHideFlags: 0
@@ -2176,7 +2101,6 @@ RectTransform:
   - {fileID: 4897382332338837817}
   - {fileID: 8988245998127038548}
   - {fileID: 3996028225641499819}
-  - {fileID: 8763323205625865704}
   - {fileID: 742869874383310255}
   - {fileID: 4157932491952998570}
   - {fileID: 3093333061167999157}
@@ -2830,10 +2754,8 @@ MonoBehaviour:
   <objectsToActivateForGenesis>k__BackingField:
   - {fileID: 6047126784813902107}
   - {fileID: 4936345567603315831}
-  - {fileID: 8498749943120513715}
   <objectsToActivateForWorlds>k__BackingField:
   - {fileID: 591988185976572089}
-  - {fileID: 2759377129377115971}
 --- !u!95 &5048152786859444568
 Animator:
   serializedVersion: 5

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -199,9 +199,7 @@ namespace DCL.Minimap
                 catch (Exception) { viewInstance.placeNameText.text = "Unknown place"; }
                 finally
                 {
-                    viewInstance.placeCoordinatesText.text = realmData.ScenesAreFixed ?
-                        realmData.RealmName :
-                        playerParcelPosition.ToString().Replace("(", "").Replace(")", "");
+                    viewInstance.placeCoordinatesText.text = playerParcelPosition.ToString().Replace("(", "").Replace(")", "");
                 }
             }
         }


### PR DESCRIPTION
## What does this PR change?
Fix #1178 

![image](https://github.com/decentraland/unity-explorer/assets/64659061/443a665c-2eac-424d-b68a-e500a658e170)

## How to test the changes?
1. Launch the explorer
2. Go to a world
3. Observe the minimap keeps the coordinates and, when you move through the place, the coords change

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md