### PR TITLE
fix: AB request relaunched due to ignored cached

### DIFF
--- a/Explorer/Assets/DCL/CommunicationData/URLHelpers/URLAddress.cs
+++ b/Explorer/Assets/DCL/CommunicationData/URLHelpers/URLAddress.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace CommunicationData.URLHelpers
 {
@@ -45,5 +46,17 @@ namespace CommunicationData.URLHelpers
 
         public override string ToString() =>
             Value;
+
+
+        private static readonly string HTTP_STARTER = "https";
+        private static readonly string VALIDATION_PATTERN = "/v[0-9]+/";
+
+        public string GetCacheableURL()
+        {
+            if (Value.StartsWith(HTTP_STARTER))
+                return Regex.Replace(Value, VALIDATION_PATTERN, "/");
+
+            return Value;
+        }
     }
 }

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/Systems/LoadSystemBase.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/Systems/LoadSystemBase.cs
@@ -108,7 +108,7 @@ namespace ECS.StreamableLoading.Common.Systems
 
                 // if the request is cached wait for it
                 // If there is an ongoing request it means that the result is neither cached, nor failed
-                if (cache.OngoingRequests.SyncTryGetValue(intention.CommonArguments.URL, out UniTaskCompletionSource<StreamableLoadingResult<TAsset>?> cachedSource))
+                if (cache.OngoingRequests.SyncTryGetValue(intention.CommonArguments.URL.GetCacheableURL(), out var cachedSource))
                 {
                     // Release budget immediately, if we don't do it and load a lot of bundles with dependencies sequentially, it will be a deadlock
                     acquiredBudget.Release();
@@ -127,7 +127,7 @@ namespace ECS.StreamableLoading.Common.Systems
 
 
                 // If the given URL failed irrecoverably just return the failure
-                if (cache.IrrecoverableFailures.TryGetValue(intention.CommonArguments.URL, out StreamableLoadingResult<TAsset> failure))
+                if (cache.IrrecoverableFailures.TryGetValue(intention.CommonArguments.URL.GetCacheableURL(), out var failure))
                 {
                     result = failure;
                     return;
@@ -238,7 +238,7 @@ namespace ECS.StreamableLoading.Common.Systems
             var source = new UniTaskCompletionSource<StreamableLoadingResult<TAsset>?>(); //AutoResetUniTaskCompletionSource<StreamableLoadingResult<TAsset>?>.Create();
 
             // ReportHub.Log(GetReportCategory(), $"OngoingRequests.SyncAdd {intention.CommonArguments.URL}");
-            cache.OngoingRequests.SyncAdd(intention.CommonArguments.URL, source);
+            cache.OngoingRequests.SyncAdd(intention.CommonArguments.URL.GetCacheableURL(), source);
 
             var ongoingRequestRemoved = false;
 
@@ -293,7 +293,7 @@ namespace ECS.StreamableLoading.Common.Systems
                 if (!ongoingRequestRemoved)
                 {
                     // ReportHub.Log(GetReportCategory(), $"OngoingRequests.SyncRemove {intention.CommonArguments.URL}");
-                    cache.OngoingRequests.SyncRemove(intention.CommonArguments.URL);
+                    cache.OngoingRequests.SyncRemove(intention.CommonArguments.URL.GetCacheableURL());
                     ongoingRequestRemoved = true;
                 }
             }
@@ -307,7 +307,7 @@ namespace ECS.StreamableLoading.Common.Systems
 
         private StreamableLoadingResult<TAsset> SetIrrecoverableFailure(TIntention intention, StreamableLoadingResult<TAsset> failure)
         {
-            cache.IrrecoverableFailures.Add(intention.CommonArguments.URL, failure);
+            cache.IrrecoverableFailures.Add(intention.CommonArguments.URL.GetCacheableURL(), failure);
             return failure;
         }
 


### PR DESCRIPTION
## What does this PR change?

Fixes this

```
NullReferenceException: bafkreigfg4kkuhtqpoimp7cvi6xelsjzawxpuazlfq2c6oif6wtcac65ei_windows Asset Bundle is null: The AssetBundle 'https://ab-cdn.decentraland.org/v18/bafkreigfg4kkuhtqpoimp7cvi6xelsjzawxpuazlfq2c6oif6wtcac65ei_windows' can't be loaded because another AssetBundle with the same files is already loaded.
ECS.StreamableLoading.AssetBundles.LoadAssetBundleSystem.FlowInternalAsync (ECS.StreamableLoading.AssetBundles.GetAssetBundleIntention intention, DCL.Optimization.PerformanceBudgeting.IAcquiredBudget acquiredBudget, ECS.Prioritization.Components.IPartitionComponent partition,
```

An asset bundle dependency may reside in two different asset bundle manifest. This is the case for this asset bundle

![image](https://github.com/decentraland/unity-explorer/assets/1999557/5e197e02-58c0-4e0f-9273-1f0e36d85ca6)

This PR introduces a different way to cache URLs

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

No QA Required

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

