### PR TITLE
fix: SignedFetch does not work

### DIFF
--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using UnityEngine;
 using Utility;
 using Utility.Times;
 
@@ -68,7 +67,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                     method ?? string.Empty
                 );
 
-                async Task<UniTask<FlatFetchResponse>> CreatePromise()
+                async Task<UniTask<FlatFetchResponse>> CreatePromiseAsync()
                 {
                     await UniTask.SwitchToMainThread();
                     return method switch
@@ -106,7 +105,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                            };
                 }
 
-                return CreatePromise().Result.ToDisconnectedPromise();
+                return CreatePromiseAsync().Result.ToDisconnectedPromise();
         }
 
         public void Dispose()

--- a/Explorer/Assets/StreamingAssets/Js/Modules/SignedFetch.js
+++ b/Explorer/Assets/StreamingAssets/Js/Modules/SignedFetch.js
@@ -1,5 +1,14 @@
-module.exports.signedFetch = async function(message) {    
-    return UnitySignedFetch.SignedFetch(message)
+module.exports.signedFetch = async function(message) {
+    let body
+    let headers
+    let method
+    if (message.init != undefined) {
+        body = message.init.body ?? ''
+        headers = JSON.stringify(message.init.headers)
+        method = message.init.method ?? ''
+    }
+    
+    return UnitySignedFetch.SignedFetch(message.url, body, headers, method)
 }
 
 module.exports.getHeaders = async function(message) {


### PR DESCRIPTION
## What does this PR change?
This PR fixes the `signedFetch failed: the object has no method named 'SignedFetch' that matches the specific arguments` error successfully.

If this "breaks" the signed fetch functionality is not easy to confirm right now since we can't even find a working example of signedFetch with unity-renderer.

I'd suggest moving forward with this fix and revisiting the `signedFetch` functionality in the future.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md