### PR TITLE
fix: third party wearables & emote urns and fixes on wearable resolving process

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesCache.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesCache.cs
@@ -19,10 +19,12 @@ namespace DCL.AvatarRendering.Emotes
         {
             if (!emotes.TryGetValue(urn, out emote))
             {
-                if (!emotes.TryGetValue(urn.ToLower(), out emote))
+                URN loweredUrn = urn.ToLower();
+
+                if (!emotes.TryGetValue(loweredUrn, out emote))
                     return false;
 
-                urn = urn.ToLower();
+                urn = loweredUrn;
             }
 
             UpdateListedCachePriority(urn);
@@ -53,8 +55,12 @@ namespace DCL.AvatarRendering.Emotes
                 URN urn = node.Value.key;
 
                 if (!emotes.TryGetValue(urn, out IEmote emote))
-                    if (emotes.TryGetValue(urn.ToLower(), out emote))
-                        urn = urn.ToLower();
+                {
+                    URN loweredUrn = urn.ToLower();
+
+                    if (emotes.TryGetValue(loweredUrn, out emote))
+                        urn = loweredUrn;
+                }
 
                 if (emote == null) continue;
                 if (!TryUnloadAllWearableAssets(emote)) continue;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesCache.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesCache.cs
@@ -71,12 +71,7 @@ namespace DCL.AvatarRendering.Emotes
         public bool TryGetOwnedNftRegistry(URN nftUrn, out IReadOnlyDictionary<URN, NftBlockchainOperationEntry> registry)
         {
             bool result = ownedNftsRegistry.TryGetValue(nftUrn, out Dictionary<URN, NftBlockchainOperationEntry> r);
-
-            if (!result)
-                ownedNftsRegistry.TryGetValue(nftUrn, out r);
-
             registry = r;
-
             return result;
         }
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/LoadEmotesByPointersSystem.cs
@@ -259,7 +259,7 @@ namespace DCL.AvatarRendering.Emotes
                 return;
             }
 
-            if (promise.TryConsume(World, out StreamableLoadingResult<EmotesDTOList> promiseResult))
+            if (promise.SafeTryConsume(World, out StreamableLoadingResult<EmotesDTOList> promiseResult))
             {
                 if (!promiseResult.Succeeded)
                 {
@@ -296,7 +296,7 @@ namespace DCL.AvatarRendering.Emotes
                 return;
             }
 
-            if (promise.TryConsume(World, out StreamableLoadingResult<SceneAssetBundleManifest> result))
+            if (promise.SafeTryConsume(World, out StreamableLoadingResult<SceneAssetBundleManifest> result))
             {
                 emote.ManifestResult = result;
                 emote.IsLoading = false;
@@ -315,7 +315,7 @@ namespace DCL.AvatarRendering.Emotes
                 return;
             }
 
-            if (promise.TryConsume(World, out StreamableLoadingResult<AssetBundleData> result))
+            if (promise.SafeTryConsume(World, out StreamableLoadingResult<AssetBundleData> result))
             {
                 if (result.Succeeded)
                 {
@@ -403,7 +403,7 @@ namespace DCL.AvatarRendering.Emotes
 
             if (promise.IsConsumed) return;
 
-            if (!promise.TryConsume(World, out StreamableLoadingResult<AudioClip> result))
+            if (!promise.SafeTryConsume(World, out StreamableLoadingResult<AudioClip> result))
                 return;
 
             if (result.Succeeded)

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/Wearable.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/Wearable.cs
@@ -51,7 +51,10 @@ namespace DCL.AvatarRendering.Wearables.Components
 
         public void ResolveDTO(StreamableLoadingResult<WearableDTO> result)
         {
-            Assert.IsTrue(!WearableDTO.IsInitialized || !WearableDTO.Succeeded);
+            // This assert breaks the wearable resolving process when not on the happy path
+            // Makes sense to be able to update the dto of the wearable
+            // Assert.IsTrue(!WearableDTO.IsInitialized || !WearableDTO.Succeeded);
+
             WearableDTO = result;
 
             if (!result.Succeeded) return;

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/Wearable.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/Wearable.cs
@@ -51,9 +51,7 @@ namespace DCL.AvatarRendering.Wearables.Components
 
         public void ResolveDTO(StreamableLoadingResult<WearableDTO> result)
         {
-            // This assert breaks the wearable resolving process when not on the happy path
-            // Makes sense to be able to update the dto of the wearable
-            // Assert.IsTrue(!WearableDTO.IsInitialized || !WearableDTO.Succeeded);
+            Assert.IsTrue(!WearableDTO.IsInitialized || !WearableDTO.Succeeded);
 
             WearableDTO = result;
 

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/IWearableCatalog.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/IWearableCatalog.cs
@@ -21,9 +21,9 @@ namespace DCL.AvatarRendering.Wearables.Helpers
         /// <summary>
         ///     Adds an empty wearable to the catalog.
         /// </summary>
-        /// <param name="loadingIntentionPointer">The loading intention pointer.</param>
+        /// <param name="urn">The loading intention pointer.</param>
         /// <param name="qualifiedForUnloading">Determines if the wearable should be unloaded when memory is full</param>
-        void AddEmptyWearable(string loadingIntentionPointer, bool qualifiedForUnloading = true);
+        void AddEmptyWearable(URN urn, bool qualifiedForUnloading = true);
 
         /// <summary>
         ///     Attempts to retrieve a wearable from the catalog.

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableCatalog.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableCatalog.cs
@@ -101,11 +101,15 @@ namespace DCL.AvatarRendering.Wearables.Helpers
         {
             for (LinkedListNode<(string key, long lastUsedFrame)> node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
             {
-                string urn = node.Value.key;
+                URN urn = node.Value.key;
 
                 if (!wearablesCache.TryGetValue(urn, out IWearable wearable))
-                    if (wearablesCache.TryGetValue(urn.ToLower(), out wearable))
-                        urn = urn.ToLower();
+                {
+                    URN loweredUrn = urn.ToLower();
+
+                    if (wearablesCache.TryGetValue(loweredUrn, out wearable))
+                        urn = loweredUrn;
+                }
 
                 if (wearable == null) continue;
                 if (!TryUnloadAllWearableAssets(wearable)) continue;

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableCatalog.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableCatalog.cs
@@ -2,7 +2,6 @@
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.StreamableLoading.Common.Components;
-using System;
 using System.Collections.Generic;
 using Utility.Multithreading;
 
@@ -10,19 +9,8 @@ namespace DCL.AvatarRendering.Wearables.Helpers
 {
     public partial class WearableCatalog : IWearableCatalog
     {
-        private class StringIgnoreCaseEqualityComparer : IEqualityComparer<string>
-        {
-            public static StringIgnoreCaseEqualityComparer Default { get; } = new ();
-
-            public bool Equals(string x, string y) =>
-                string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
-
-            public int GetHashCode(string obj) =>
-                StringComparer.OrdinalIgnoreCase.GetHashCode(obj);
-        }
-
-        private readonly LinkedList<(string key, long lastUsedFrame)> listedCacheKeys = new ();
-        private readonly Dictionary<string, LinkedListNode<(string key, long lastUsedFrame)>> cacheKeysDictionary = new (new Dictionary<string, LinkedListNode<(string key, long lastUsedFrame)>>(), StringIgnoreCaseEqualityComparer.Default);
+        private readonly LinkedList<(URN key, long lastUsedFrame)> listedCacheKeys = new ();
+        private readonly Dictionary<URN, LinkedListNode<(URN key, long lastUsedFrame)>> cacheKeysDictionary = new (new Dictionary<URN, LinkedListNode<(URN key, long lastUsedFrame)>>(), URNIgnoreCaseEqualityComparer.Default);
         private readonly Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>> ownedNftsRegistry = new (new Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>>(), URNIgnoreCaseEqualityComparer.Default);
 
         internal Dictionary<URN, IWearable> wearablesCache { get; } = new (new Dictionary<URN, IWearable>(), URNIgnoreCaseEqualityComparer.Default);
@@ -80,9 +68,9 @@ namespace DCL.AvatarRendering.Wearables.Helpers
             return null;
         }
 
-        private void UpdateListedCachePriority(string @for)
+        private void UpdateListedCachePriority(URN @for)
         {
-            if (cacheKeysDictionary.TryGetValue(@for, out LinkedListNode<(string key, long lastUsedFrame)> node))
+            if (cacheKeysDictionary.TryGetValue(@for, out LinkedListNode<(URN key, long lastUsedFrame)> node))
             {
                 node.Value = (@for, MultithreadingUtility.FrameCount);
 
@@ -94,7 +82,7 @@ namespace DCL.AvatarRendering.Wearables.Helpers
 
         public void Unload(IPerformanceBudget frameTimeBudget)
         {
-            for (LinkedListNode<(string key, long lastUsedFrame)> node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
+            for (LinkedListNode<(URN key, long lastUsedFrame)> node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
             {
                 URN urn = node.Value.key;
 

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableCatalog.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableCatalog.cs
@@ -15,7 +15,7 @@ namespace DCL.AvatarRendering.Wearables.Helpers
             public static StringIgnoreCaseEqualityComparer Default { get; } = new ();
 
             public bool Equals(string x, string y) =>
-                x.Equals(y);
+                string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
 
             public int GetHashCode(string obj) =>
                 StringComparer.OrdinalIgnoreCase.GetHashCode(obj);

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableCatalog.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableCatalog.cs
@@ -13,25 +13,25 @@ namespace DCL.AvatarRendering.Wearables.Helpers
         private readonly Dictionary<string, LinkedListNode<(string key, long lastUsedFrame)>> cacheKeysDictionary = new ();
         private readonly Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>> ownedNftsRegistry = new ();
 
-        internal Dictionary<string, IWearable> wearablesCache { get; } = new ();
+        internal Dictionary<URN, IWearable> wearablesCache { get; } = new ();
 
         public IWearable GetOrAddWearableByDTO(WearableDTO wearableDto, bool qualifiedForUnloading = true) =>
             TryGetWearable(wearableDto.metadata.id, out IWearable existingWearable)
                 ? existingWearable
                 : AddWearable(wearableDto.metadata.id, new Wearable(new StreamableLoadingResult<WearableDTO>(wearableDto)), qualifiedForUnloading);
 
-        public void AddEmptyWearable(string loadingIntentionPointer, bool qualifiedForUnloading = true)
+        public void AddEmptyWearable(URN urn, bool qualifiedForUnloading = true)
         {
-            AddWearable(loadingIntentionPointer, new Wearable(), qualifiedForUnloading);
+            AddWearable(urn, new Wearable(), qualifiedForUnloading);
         }
 
-        internal IWearable AddWearable(string loadingIntentionPointer, IWearable wearable, bool qualifiedForUnloading)
+        internal IWearable AddWearable(URN urn, IWearable wearable, bool qualifiedForUnloading)
         {
-            wearablesCache.Add(loadingIntentionPointer, wearable);
+            wearablesCache.Add(urn, wearable);
 
             if (qualifiedForUnloading)
-                cacheKeysDictionary[loadingIntentionPointer] =
-                    listedCacheKeys.AddLast((loadingIntentionPointer, MultithreadingUtility.FrameCount));
+                cacheKeysDictionary[urn] =
+                    listedCacheKeys.AddLast((urn, MultithreadingUtility.FrameCount));
 
             return wearable;
         }

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/ResolveWearableByPointerSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/ResolveWearableByPointerSystem.cs
@@ -192,7 +192,11 @@ namespace DCL.AvatarRendering.Wearables.Systems
                 {
                     foreach (WearableDTO assetEntity in promiseResult.Asset.Value)
                     {
-                        wearableCatalog.TryGetWearable(assetEntity.metadata.id, out IWearable component);
+                        if (!wearableCatalog.TryGetWearable(assetEntity.metadata.id, out IWearable component))
+                        {
+                            ReportHub.LogError(new ReportData(GetReportCategory()), $"Cannot finalize wearable DTO: {assetEntity.metadata.id}");
+                            continue;
+                        }
 
                         component.ResolveDTO(new StreamableLoadingResult<WearableDTO>(assetEntity));
                         component.IsLoading = false;

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/ResolveWearableByPointerSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/ResolveWearableByPointerSystem.cs
@@ -177,7 +177,7 @@ namespace DCL.AvatarRendering.Wearables.Systems
                 return;
             }
 
-            if (promise.TryConsume(World, out StreamableLoadingResult<WearablesDTOList> promiseResult))
+            if (promise.SafeTryConsume(World, out StreamableLoadingResult<WearablesDTOList> promiseResult))
             {
                 if (!promiseResult.Succeeded)
                 {
@@ -222,7 +222,7 @@ namespace DCL.AvatarRendering.Wearables.Systems
                 return;
             }
 
-            if (promise.TryConsume(World, out StreamableLoadingResult<SceneAssetBundleManifest> result))
+            if (promise.SafeTryConsume(World, out StreamableLoadingResult<SceneAssetBundleManifest> result))
             {
                 if (result.Succeeded)
                     wearable.ManifestResult = result;
@@ -245,7 +245,7 @@ namespace DCL.AvatarRendering.Wearables.Systems
                 return;
             }
 
-            if (promise.TryConsume(World, out StreamableLoadingResult<AssetBundleData> result))
+            if (promise.SafeTryConsume(World, out StreamableLoadingResult<AssetBundleData> result))
             {
                 // every asset in the batch is mandatory => if at least one has already failed set the default wearables
                 if (result.Succeeded && !AnyAssetHasFailed(wearable, bodyShape))

--- a/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackBusController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackBusController.cs
@@ -98,7 +98,16 @@ namespace DCL.Backpack.BackpackBus
                 return;
             }
 
-            string? category = wearable.GetCategory();
+            string? category = null;
+
+            try
+            {
+                category = wearable.GetCategory();
+            }
+            catch (Exception)
+            {
+                // Sometimes the wearable has no available category thus asking for it provokes NRE
+            }
 
             if (category == null)
             {

--- a/Explorer/Assets/DCL/Backpack/BackpackController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackController.cs
@@ -151,7 +151,7 @@ namespace DCL.Backpack
             view.TipsPanelDeselectable.gameObject.SetActive(!view.TipsPanelDeselectable.gameObject.activeInHierarchy);
         }
 
-        private async UniTaskVoid AwaitForProfileAsync(CancellationTokenSource cts)
+        private async UniTaskVoid AwaitForProfileAsync(CancellationToken ct)
         {
             isAvatarLoaded = false;
 
@@ -164,7 +164,7 @@ namespace DCL.Backpack
             backpackCharacterPreviewController.Initialize(avatar);
 
             if (!avatarShapeComponent.WearablePromise.IsConsumed)
-                await avatarShapeComponent.WearablePromise.ToUniTaskAsync(world, cancellationToken: cts.Token);
+                await avatarShapeComponent.WearablePromise.ToUniTaskAsync(world, cancellationToken: ct);
 
             backpackCommandBus.SendCommand(new BackpackHideCommand(avatar.ForceRender));
             backpackCommandBus.SendCommand(new BackpackEquipWearableCommand(avatar.BodyShape.Value));
@@ -184,8 +184,8 @@ namespace DCL.Backpack
 
         public void Activate()
         {
-            profileLoadingCts = new CancellationTokenSource();
-            AwaitForProfileAsync(profileLoadingCts).Forget();
+            profileLoadingCts = profileLoadingCts.SafeRestart();
+            AwaitForProfileAsync(profileLoadingCts.Token).Forget();
 
             backpackSections[currentSection].Activate();
 

--- a/Explorer/Assets/DCL/Backpack/BackpackController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackController.cs
@@ -153,6 +153,8 @@ namespace DCL.Backpack
 
         private async UniTaskVoid AwaitForProfileAsync(CancellationToken ct)
         {
+            if (ct.IsCancellationRequested) return;
+
             isAvatarLoaded = false;
 
             world.TryGet(playerEntity, out AvatarShapeComponent avatarShapeComponent);
@@ -165,6 +167,8 @@ namespace DCL.Backpack
 
             if (!avatarShapeComponent.WearablePromise.IsConsumed)
                 await avatarShapeComponent.WearablePromise.ToUniTaskAsync(world, cancellationToken: ct);
+
+            if (ct.IsCancellationRequested) return;
 
             backpackCommandBus.SendCommand(new BackpackHideCommand(avatar.ForceRender));
             backpackCommandBus.SendCommand(new BackpackEquipWearableCommand(avatar.BodyShape.Value));

--- a/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
+++ b/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
@@ -40,6 +40,9 @@ namespace CommunicationData.URLHelpers
         public override string ToString() =>
             urn;
 
+        public URN ToLower() =>
+            urn.ToLower();
+
         public URLAddress ToUrlOrEmpty(URLAddress baseUrl)
         {
             string currentUrn = this.urn;

--- a/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
+++ b/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
@@ -1,5 +1,6 @@
 using DCL.Diagnostics;
 using System;
+using System.Collections.Generic;
 
 namespace CommunicationData.URLHelpers
 {
@@ -32,7 +33,12 @@ namespace CommunicationData.URLHelpers
             Equals(other.urn);
 
         public bool Equals(string other) =>
-            urn == other;
+            // Ignore case of all urn since the server returns urns with lower case or upper case representing the same content on different endpoints
+            // For example a wearable in the profile (/lambdas/profiles/:address):
+            // urn:decentraland:matic:collections-thirdparty:dolcegabbana-disco-drip:0x4bD77619a75C8EdA181e3587339E7011DA75bF0E:2a424e9c-c6fb-4783-99ed-63d260d90ed2
+            // The same wearable in the content server (/content/entities/active):
+            // urn:decentraland:matic:collections-thirdparty:dolcegabbana-disco-drip:0x4bd77619a75c8eda181e3587339e7011da75bf0e:2a424e9c-c6fb-4783-99ed-63d260d90ed2
+            string.Equals(urn, other, StringComparison.OrdinalIgnoreCase);
 
         public override bool Equals(object obj) =>
             obj is URN other && Equals(other);
@@ -94,7 +100,7 @@ namespace CommunicationData.URLHelpers
         }
 
         public override int GetHashCode() =>
-            urn != null ? urn.GetHashCode() : 0;
+            urn != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(urn) : 0;
 
         public URN Shorten()
         {
@@ -138,5 +144,16 @@ namespace CommunicationData.URLHelpers
 
         private bool IsThirdPartyCollection() =>
             !string.IsNullOrEmpty(urn) && urn.Contains(THIRD_PARTY_PART_ID);
+    }
+
+    public class URNIgnoreCaseEqualityComparer : IEqualityComparer<URN>
+    {
+        public static URNIgnoreCaseEqualityComparer Default { get; } = new ();
+
+        public bool Equals(URN x, URN y) =>
+            x.Equals(y);
+
+        public int GetHashCode(URN obj) =>
+            obj.GetHashCode();
     }
 }

--- a/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
+++ b/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
@@ -5,7 +5,8 @@ namespace CommunicationData.URLHelpers
 {
     public readonly struct URN
     {
-        public const int SHORTEN_URN_PARTS = 6;
+        private const int SHORTEN_URN_PARTS = 6;
+        private const string THIRD_PARTY_PART_ID = "collections-thirdparty";
 
         private readonly string urn;
 
@@ -95,6 +96,8 @@ namespace CommunicationData.URLHelpers
         public URN Shorten()
         {
             if (string.IsNullOrEmpty(urn)) return urn;
+            // Third party collections do not include the tokenId and have 7 parts, so we must keep all of them
+            if (IsThirdPartyCollection()) return urn;
 
             int index = -1;
 
@@ -109,6 +112,9 @@ namespace CommunicationData.URLHelpers
 
         public bool IsExtended()
         {
+            // Third party collections do not apply to shortened/extended rules
+            if (IsThirdPartyCollection()) return false;
+
             var count = 0;
 
             foreach (char c in urn)
@@ -126,5 +132,8 @@ namespace CommunicationData.URLHelpers
 
         public static implicit operator URN(string urn) =>
             new (urn);
+
+        private bool IsThirdPartyCollection() =>
+            !string.IsNullOrEmpty(urn) && urn.Contains(THIRD_PARTY_PART_ID);
     }
 }

--- a/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
+++ b/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
@@ -46,9 +46,6 @@ namespace CommunicationData.URLHelpers
         public override string ToString() =>
             urn;
 
-        public URN ToLower() =>
-            urn.ToLower();
-
         public URLAddress ToUrlOrEmpty(URLAddress baseUrl)
         {
             string currentUrn = this.urn;

--- a/Explorer/Assets/DCL/Profiles/DataModels/ProfileJsonDto.cs
+++ b/Explorer/Assets/DCL/Profiles/DataModels/ProfileJsonDto.cs
@@ -91,9 +91,7 @@ namespace DCL.Profiles
             List<string> forceRenderCategories = forceRenderPool.Get();
 
             foreach (string w in wearables)
-                // The profile endpoint could return wearables with CAPS, but entities/active endpoint lowers everything
-                // In order to avoid cache misses thus errors building the avatar, we lower all the wearables
-                wearableUrns.Add(w.ToLower());
+                wearableUrns.Add(w);
 
             avatar.forceRender.Clear();
 
@@ -111,9 +109,7 @@ namespace DCL.Profiles
             avatar.BodyShape = BodyShape.FromStringSafe(bodyShape);
 
             foreach (EmoteJsonDto emoteJsonDto in emotes)
-                // The profile endpoint could return emotes with CAPS, but entities/active endpoint lowers everything
-                // In order to avoid cache misses thus errors building the avatar, we lower all the emotes
-                avatar.emotes[emoteJsonDto.slot] = emoteJsonDto.urn.ToLower();
+                avatar.emotes[emoteJsonDto.slot] = emoteJsonDto.urn;
 
             avatar.FaceSnapshotUrl = URLAddress.FromString(snapshots!.face256);
             avatar.BodySnapshotUrl = URLAddress.FromString(snapshots.body);

--- a/Explorer/Assets/DCL/Profiles/DataModels/ProfileJsonDto.cs
+++ b/Explorer/Assets/DCL/Profiles/DataModels/ProfileJsonDto.cs
@@ -91,7 +91,9 @@ namespace DCL.Profiles
             List<string> forceRenderCategories = forceRenderPool.Get();
 
             foreach (string w in wearables)
-                wearableUrns.Add(w);
+                // The profile endpoint could return wearables with CAPS, but entities/active endpoint lowers everything
+                // In order to avoid cache misses thus errors building the avatar, we lower all the wearables
+                wearableUrns.Add(w.ToLower());
 
             avatar.forceRender.Clear();
 
@@ -109,7 +111,9 @@ namespace DCL.Profiles
             avatar.BodyShape = BodyShape.FromStringSafe(bodyShape);
 
             foreach (EmoteJsonDto emoteJsonDto in emotes)
-                avatar.emotes[emoteJsonDto.slot] = emoteJsonDto.urn;
+                // The profile endpoint could return emotes with CAPS, but entities/active endpoint lowers everything
+                // In order to avoid cache misses thus errors building the avatar, we lower all the emotes
+                avatar.emotes[emoteJsonDto.slot] = emoteJsonDto.urn.ToLower();
 
             avatar.FaceSnapshotUrl = URLAddress.FromString(snapshots!.face256);
             avatar.BodySnapshotUrl = URLAddress.FromString(snapshots.body);


### PR DESCRIPTION
## What does this PR change?

Third party wearables and emotes were not working due its urn structure.
TP do not include the tokenId and has 7 parts, so we must not shorten them. Example: `urn:decentraland:matic:collections-thirdparty:dolcegabbana-disco-drip:0x4bd77619a75c8eda181e3587339e7011da75bf0e:2a424e9c-c6fb-4783-99ed-63d260d90ed2`.

Also, some TPW wearable urns comes in UPPER CASE, but `entities/active` endpoint gets everything lowered provoking cache misses in the content. This change makes the urns case-insensitive.
Finally added some safe checks on resolving wearables so the avatars do not fail when a DTO is not resolved.

## How to test the changes?

1. Equip a third party wearable and/or emote into your avatar
2. Check that works as expected
3. Go to the backpack, change some wearables, keeping the TPW
4. Check that the avatar is updated in-world
5. You will not be able to equip TPW since we do not support the filters in the backpack yet. You will have to equip it through the old renderer.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

