### PR TITLE
fix: errors in map init flow no longer breaks the full UI

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererChunkComponentsFactory.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererChunkComponentsFactory.cs
@@ -80,9 +80,9 @@ namespace DCL.MapRenderer.ComponentsFactory
                 CreateAtlasAsync(layers, configuration, coordsUtils, cullingController, cancellationToken),
                 CreateSatelliteAtlasAsync(layers, configuration, coordsUtils, cullingController, cancellationToken),
                 playerMarkerInstaller.InstallAsync(layers, zoomScalingLayers, configuration, coordsUtils, cullingController, mapSettings, assetsProvisioner, cancellationToken),
-                HandleTaskWithErrorHandling(sceneOfInterestMarkerInstaller.InstallAsync(layers, zoomScalingLayers, configuration, coordsUtils, cullingController, assetsProvisioner, mapSettings, placesAPIService, cancellationToken)),
-                HandleTaskWithErrorHandling(favoritesMarkersInstaller.InstallAsync(layers, zoomScalingLayers, configuration, coordsUtils, cullingController, placesAPIService, assetsProvisioner, mapSettings, cancellationToken)),
-                HandleTaskWithErrorHandling(hotUsersMarkersInstaller.InstallAsync(layers, configuration, coordsUtils, cullingController, assetsProvisioner, mapSettings, cancellationToken))
+                HandleTaskWithErrorHandlingAsync(sceneOfInterestMarkerInstaller.InstallAsync(layers, zoomScalingLayers, configuration, coordsUtils, cullingController, assetsProvisioner, mapSettings, placesAPIService, cancellationToken)),
+                HandleTaskWithErrorHandlingAsync(favoritesMarkersInstaller.InstallAsync(layers, zoomScalingLayers, configuration, coordsUtils, cullingController, placesAPIService, assetsProvisioner, mapSettings, cancellationToken)),
+                HandleTaskWithErrorHandlingAsync(hotUsersMarkersInstaller.InstallAsync(layers, configuration, coordsUtils, cullingController, assetsProvisioner, mapSettings, cancellationToken))
                 /* List of other creators that can be executed in parallel */);
 
             return new MapRendererComponents(configuration, layers, zoomScalingLayers, cullingController, cameraControllersPool);
@@ -98,7 +98,7 @@ namespace DCL.MapRenderer.ComponentsFactory
 
         //Some markers installers can fail due to network issues or APIs problems, we handle here the initialization errors to avoid
         //breaking the whole map rendering process as an error in the UniTask.WhenAll would stop the execution of the other tasks.
-        private async UniTask HandleTaskWithErrorHandling(UniTask task)
+        private async UniTask HandleTaskWithErrorHandlingAsync(UniTask task)
         {
             try
             {

--- a/Explorer/Assets/DCL/Navmap/NavmapController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapController.cs
@@ -44,7 +44,7 @@ namespace DCL.Navmap
         private readonly RectTransform rectTransform;
         private readonly SatelliteController satelliteController;
         private readonly StreetViewController streetViewController;
-        private readonly NavmapLocationController navmapLocationController;
+        private NavmapLocationController navmapLocationController;
         private readonly IRealmData realmData;
 
         private Vector2 lastParcelHovered;
@@ -58,11 +58,8 @@ namespace DCL.Navmap
             IMapRenderer mapRenderer,
             IPlacesAPIService placesAPIService,
             IWebRequestController webRequestController,
-            IMVCManager mvcManager,
             IWebBrowser webBrowser,
             DCLInput dclInput,
-            World world,
-            Entity playerEntity,
             IRealmNavigator realmNavigator,
             IRealmData realmData)
         {
@@ -81,7 +78,6 @@ namespace DCL.Navmap
             searchBarController.OnSearchTextChanged += floatingPanelController.HidePanel;
             satelliteController = new SatelliteController(navmapView.GetComponentInChildren<SatelliteView>(), this.navmapView.MapCameraDragBehaviorData, mapRenderer, webBrowser);
             streetViewController = new StreetViewController(navmapView.GetComponentInChildren<StreetViewView>(), this.navmapView.MapCameraDragBehaviorData, mapRenderer);
-            navmapLocationController = new NavmapLocationController(navmapView.LocationView, world, playerEntity);
 
             mapSections = new ()
             {
@@ -140,6 +136,11 @@ namespace DCL.Navmap
 
         public async UniTask InitialiseAssetsAsync(IAssetsProvisioner assetsProvisioner, CancellationToken ct) =>
             await searchBarController.InitialiseAssetsAsync(assetsProvisioner, ct);
+
+        public void InitialiseWorldDependencies(World world, Entity playerEntity)
+        {
+            navmapLocationController = new NavmapLocationController(navmapView.LocationView, world, playerEntity);
+        }
 
         private void OnResultClicked(string coordinates)
         {

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -145,13 +145,13 @@ namespace DCL.PluginSystem.Global
             settingsController = new SettingsController(explorePanelView.GetComponentInChildren<SettingsView>(), settingsMenuConfiguration.Value, generalAudioMixer.Value, realmPartitionSettings.Value, landscapeData.Value, qualitySettingsAsset.Value);
 
             exploreOpener = (await assetsProvisioner.ProvideMainAssetAsync(settings.PersistentExploreOpenerPrefab, ct: ct)).Value.GetComponent<PersistentExploreOpenerView>();
-
+            navmapController = new NavmapController(navmapView: explorePanelView.GetComponentInChildren<NavmapView>(), mapRendererContainer.MapRenderer, placesAPIService, webRequestController, webBrowser, dclInput, realmNavigator, realmData);
+            await navmapController.InitialiseAssetsAsync(assetsProvisioner, ct);
             ContinueInitialization? backpackInitialization = await backpackSubPlugin.InitializeAsync(settings.BackpackSettings, explorePanelView.GetComponentInChildren<BackpackView>(), ct);
 
             return (ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments) =>
             {
-                navmapController = new NavmapController(navmapView: explorePanelView.GetComponentInChildren<NavmapView>(), mapRendererContainer.MapRenderer, placesAPIService, webRequestController, mvcManager, webBrowser, dclInput, builder.World, arguments.PlayerEntity, realmNavigator, realmData);
-                navmapController.InitialiseAssetsAsync(assetsProvisioner, ct).Forget();
+                navmapController.InitialiseWorldDependencies(builder.World, arguments.PlayerEntity);
                 backpackInitialization.Invoke(ref builder, arguments);
 
                 mvcManager.RegisterController(new ExplorePanelController(viewFactoryMethod, navmapController, settingsController, backpackSubPlugin.backpackController!, arguments.PlayerEntity, builder.World,


### PR DESCRIPTION
## What does this PR change?

Fix #1198 
If an error occurs at places API level when initialising the map it no longer breaks the full flow for the map.

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Verify that minimap doesn't break

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

