### PR TITLE
fix: emote not being cancelled properly / audio not looping

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller
@@ -266,6 +266,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-6524115072652598266
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsFalling
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8066956773360497299}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.1
+  m_TransitionOffset: 0
+  m_ExitTime: 0.96875
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1107 &-6379408151363090636
 AnimatorStateMachine:
   serializedVersion: 6
@@ -283,16 +308,16 @@ AnimatorStateMachine:
     m_Position: {x: 600, y: 120, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 8575394270154567395}
-    m_Position: {x: 600, y: 240, z: 0}
+    m_Position: {x: 600, y: 0, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6383020052979447455}
-    m_Position: {x: 370, y: 310, z: 0}
+    m_Position: {x: 600, y: 230, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6626008193833255465}
-    m_Position: {x: 70, y: 200, z: 0}
+    m_Position: {x: 190, y: 240, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6121015139752552625}
-    m_Position: {x: 123, y: 324, z: 0}
+    m_Position: {x: 320, y: 300, z: 0}
   m_ChildStateMachines:
   - serializedVersion: 1
     m_StateMachine: {fileID: -2772301717899763986}
@@ -312,7 +337,7 @@ AnimatorStateMachine:
     second:
     - {fileID: -3841805562703951377}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 860, y: 130, z: 0}
+  m_AnyStatePosition: {x: 870, y: 130, z: 0}
   m_EntryPosition: {x: 30, y: 120, z: 0}
   m_ExitPosition: {x: 560, y: 440, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
@@ -2160,6 +2185,7 @@ AnimatorState:
   - {fileID: 1208421492764531611}
   - {fileID: -7991627196901748505}
   - {fileID: -484170803430907027}
+  - {fileID: -6524115072652598266}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller
@@ -299,7 +299,7 @@ AnimatorStateMachine:
     m_Position: {x: 320, y: 0, z: 0}
   - serializedVersion: 1
     m_StateMachine: {fileID: -674502226139900387}
-    m_Position: {x: 600, y: 10, z: 0}
+    m_Position: {x: 110, y: 0, z: 0}
   m_AnyStateTransitions:
   - {fileID: 5808146676334510174}
   - {fileID: -779795832300552295}
@@ -1276,6 +1276,7 @@ AnimatorState:
   - {fileID: -6091293658042496824}
   - {fileID: 3255245744030989529}
   - {fileID: 4154687653260660565}
+  - {fileID: 3741932110912549041}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -1469,6 +1470,31 @@ AnimatorTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 1
+--- !u!1101 &3741932110912549041
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsFalling
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8066956773360497299}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.1
+  m_TransitionOffset: 0
+  m_ExitTime: 0.96875
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &4007857039343994343
 AnimatorStateTransition:
   m_ObjectHideFlags: 1

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
@@ -11,5 +11,12 @@ namespace DCL.AvatarRendering.Emotes
         public EmoteReferences? CurrentEmoteReference;
         public int CurrentAnimationTag;
         public bool StopEmote;
+
+        public void Reset()
+        {
+            EmoteClip = null;
+            EmoteLoop = false;
+            CurrentEmoteReference = null;
+        }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
@@ -1,5 +1,4 @@
 using CommunicationData.URLHelpers;
-using UnityEngine;
 
 namespace DCL.AvatarRendering.Emotes
 {
@@ -7,16 +6,15 @@ namespace DCL.AvatarRendering.Emotes
     {
         public URN EmoteUrn;
         public bool EmoteLoop;
-        public AnimationClip? EmoteClip;
         public EmoteReferences? CurrentEmoteReference;
         public int CurrentAnimationTag;
         public bool StopEmote;
 
         public void Reset()
         {
-            EmoteClip = null;
             EmoteLoop = false;
             CurrentEmoteReference = null;
+            StopEmote = false;
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/CharacterEmoteSystem.cs
@@ -67,20 +67,14 @@ namespace DCL.AvatarRendering.Emotes
         [All(typeof(DeleteEntityIntention))]
         private void CancelEmotesByDeletion(ref CharacterEmoteComponent emoteComponent, in IAvatarView avatarView)
         {
-            EmoteReferences? emoteReference = emoteComponent.CurrentEmoteReference;
-
-            if (emoteReference != null)
-                StopEmote(ref emoteComponent, emoteReference, avatarView);
+            StopEmote(ref emoteComponent, avatarView);
         }
 
         [Query]
         [All(typeof(PlayerTeleportIntent))]
         private void CancelEmotesByTeleportIntention(ref CharacterEmoteComponent emoteComponent, in IAvatarView avatarView)
         {
-            EmoteReferences? emoteReference = emoteComponent.CurrentEmoteReference;
-
-            if (emoteReference != null)
-                StopEmote(ref emoteComponent, emoteReference, avatarView);
+            StopEmote(ref emoteComponent, avatarView);
         }
 
         // looping emotes and cancelling emotes by tag depend on tag change, this query alone is the one that updates that value at the ond of the update
@@ -113,7 +107,7 @@ namespace DCL.AvatarRendering.Emotes
 
             if (wantsToCancelEmote)
             {
-                StopEmote(ref emoteComponent, emoteReference, avatarView);
+                StopEmote(ref emoteComponent, avatarView);
                 return;
             }
 
@@ -121,7 +115,7 @@ namespace DCL.AvatarRendering.Emotes
             bool isOnAnotherTag = animatorCurrentStateTag != AnimationHashes.EMOTE && animatorCurrentStateTag != AnimationHashes.EMOTE_LOOP;
 
             if (isOnAnotherTag)
-                StopEmote(ref emoteComponent, emoteReference, avatarView);
+                StopEmote(ref emoteComponent, avatarView);
         }
 
         // when moving or jumping we detect the emote cancellation and we take care of getting rid of the emote props and sounds
@@ -136,17 +130,18 @@ namespace DCL.AvatarRendering.Emotes
 
             if (!canEmoteBeCancelled) return;
 
-            EmoteReferences? emoteReference = emoteComponent.CurrentEmoteReference;
-            if (emoteReference == null) return;
-
-            StopEmote(ref emoteComponent, emoteReference, avatarView);
+            StopEmote(ref emoteComponent, avatarView);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void StopEmote(ref CharacterEmoteComponent emoteComponent, EmoteReferences emoteReference, IAvatarView avatarView)
+        private void StopEmote(ref CharacterEmoteComponent emoteComponent, IAvatarView avatarView)
         {
-            avatarView.SetAnimatorTrigger(AnimationHashes.EMOTE_STOP);
-            emotePlayer.Stop(emoteReference);
+            if (emoteComponent.CurrentEmoteReference != null)
+            {
+                emotePlayer.Stop(emoteComponent.CurrentEmoteReference);
+                avatarView.SetAnimatorTrigger(AnimationHashes.EMOTE_STOP);
+            }
+
             emoteComponent.Reset();
         }
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/EmotePlayer.cs
@@ -84,6 +84,7 @@ namespace DCL.AvatarRendering.Emotes
                 audioSource.spatialize = isSpatial;
                 audioSource.spatialBlend = isSpatial ? 1 : 0;
                 audioSource.transform.position = avatarTransform.position;
+                audioSource.loop = isLooping;
                 audioSource.Play();
                 emoteReferences.audioSource = audioSource;
             }


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/1034
Fixes https://github.com/decentraland/unity-explorer/issues/1196
Fixes https://github.com/decentraland/unity-explorer/issues/1194 and https://github.com/decentraland/unity-explorer/issues/791

## How to test the changes?

### Test case https://github.com/decentraland/unity-explorer/issues/1034
- Use a looping emote with props
- Without canceling it, teleport to another location or switch realms
- Your character should spawn without doing any emote

### Test case https://github.com/decentraland/unity-explorer/issues/1196 (HARD TO REPRO)
- Amidst the chaos of users playing emotes and disappearing or teleporting around, all avatars should spawn and move without emote props that weren't properly returned to the pool. 

### Test case https://github.com/decentraland/unity-explorer/issues/1194
- Equip and play a looping emote that also has a looping audio clip
- The audio clip should keep playing forever

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

