### PR TITLE
fix: SignedFetch does not work (II)

### DIFF
--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
@@ -45,7 +45,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                 {
                     body = body,
                     headers = deserializedHeaders ?? new Dictionary<string, string>(),
-                    method = method,
+                    method = string.IsNullOrEmpty(method) ? "get" : method,
                 },
             });
         }

--- a/Explorer/Assets/StreamingAssets/Js/Modules/SignedFetch.js
+++ b/Explorer/Assets/StreamingAssets/Js/Modules/SignedFetch.js
@@ -1,7 +1,7 @@
 module.exports.signedFetch = async function(message) {
-    let body
-    let headers
-    let method
+    let body = ''
+    let headers = ''
+    let method = ''
     if (message.init != undefined) {
         body = message.init.body ?? ''
         headers = JSON.stringify(message.init.headers)


### PR DESCRIPTION
## What does this PR change?
This is a complementary fix of https://github.com/decentraland/unity-explorer/pull/1186 that fixes the call to `SignedFetchWrap` when the params come empty from the JS side.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md