### PR TITLE
Fix: IndexOutOfRange for partition

### DIFF
--- a/Explorer/Assets/DCL/Roads/Systems/UnloadRoadSystem.cs
+++ b/Explorer/Assets/DCL/Roads/Systems/UnloadRoadSystem.cs
@@ -29,16 +29,15 @@ namespace DCL.Roads.Systems
         protected override void Update(float t)
         {
             UnloadRoadQuery(World);
-            World.Remove<RoadInfo, VisualSceneState, DeleteEntityIntention>(UnloadRoad_QueryDescription);
         }
 
         [Query]
         [All(typeof(DeleteEntityIntention), typeof(VisualSceneState))]
-        private void UnloadRoad(ref RoadInfo roadInfo, ref SceneDefinitionComponent sceneDefinitionComponent)
+        private void UnloadRoad(in Entity entity, ref RoadInfo roadInfo, ref SceneDefinitionComponent sceneDefinitionComponent)
         {
             roadInfo.Dispose(roadAssetPool);
             scenesCache.RemoveNonRealScene(sceneDefinitionComponent.Parcels);
+            World.Remove<RoadInfo, VisualSceneState, DeleteEntityIntention>(entity);
         }
-      
     }
 }

--- a/Explorer/Assets/Scripts/ECS/Prioritization/ScenesPartitioningUtils.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/ScenesPartitioningUtils.cs
@@ -132,7 +132,7 @@ namespace ECS.Prioritization
                 // mind that taking cosines is not cheap
                 // the same scene is counted as InFront
                 // If the bucket exceeds the maximum bucket array, we need to mark partition as dirty since we are out of range
-                partition.IsDirty = partition.Bucket != bucket || partition.IsBehind != isBehind || bucketIndex == SqrDistanceBuckets.Length || partition.RawSqrDistance == -1;
+                partition.IsDirty = partition.Bucket != bucket || partition.IsBehind != isBehind || bucketIndex == SqrDistanceBuckets.Length || partition.RawSqrDistance < 0;
                 partition.OutOfRange = minSqrMagnitude > UnloadingSqrDistance;
 
                 if (partition.IsDirty)


### PR DESCRIPTION
## What does this PR change?
fix #1181
fix #1193 

Issue was due to `World.Capacity` wasn't increased correctly when Adding or Creating new Entity. This change fixing it (for some reason)

## How to test the changes?

1. See mentioned bug-tickets 👆 repro steps are there

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

