### PR TITLE
fix: Fixed issue with not found Entity when Raycasting

### DIFF
--- a/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
@@ -205,10 +205,11 @@ namespace DCL.Interaction.Raycast.Systems
 
                 Collider collider = hit.collider;
 
-                if (!TryGetQualifiedEntity(collider, collisionMask, out foundEntity)) continue;
-
                 if (closestQualifiedHit == null || hit.distance < closestQualifiedHit.Value.distance)
+                {
                     closestQualifiedHit = hit;
+                    TryGetQualifiedEntity(collider, collisionMask, out foundEntity);
+                }
             }
 
             if (closestQualifiedHit != null)

--- a/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
@@ -207,8 +207,7 @@ namespace DCL.Interaction.Raycast.Systems
 
                 if (closestQualifiedHit == null || hit.distance < closestQualifiedHit.Value.distance)
                 {
-                    closestQualifiedHit = hit;
-                    TryGetQualifiedEntity(collider, collisionMask, out foundEntity);
+                    if (TryGetQualifiedEntity(collider, collisionMask, out foundEntity)) { closestQualifiedHit = hit; }
                 }
             }
 

--- a/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
@@ -207,7 +207,11 @@ namespace DCL.Interaction.Raycast.Systems
 
                 if (closestQualifiedHit == null || hit.distance < closestQualifiedHit.Value.distance)
                 {
-                    if (TryGetQualifiedEntity(collider, collisionMask, out foundEntity)) { closestQualifiedHit = hit; }
+                    if (TryGetQualifiedEntity(collider, collisionMask, out CRDTEntity entity))
+                    {
+                        foundEntity = entity;
+                        closestQualifiedHit = hit;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes:
https://github.com/decentraland/unity-explorer/issues/1080

## What does this PR change?

Howdy dudes and dudettes, this little thing fixes an issue present when doing Raycasts that get the first hit. 
The issue was evident on the Advanced Range where an error triggered when shooting saying the SDK could not find an entity with a huge ID. This ID was -1 converted to uint.
Aaaand -1 is the default value given to the CRDTEntities in the ExecuteRaycastSystem xD
Basically, in TryGetQualifiedEntity we were overwritting the value of foundEntity with -1. Which normally would be OK if we didnt do it even when the raycast should be ignored xD
So we were first getting the Entity, overwritting the value of foundEntity (which when the entity did not qualify would be -1) and THEN checking if that hit should be considered or not. So, lets say we hit 3 things, the first one is good, so we say there is a closestQualifiedHit, but then the other 2 are not valid. We would say there is a valid hit, but send the wrong foundEntity, as we were overwritting it to -1.
Now, we only overwrite the value if the hit is closest, which makes sense xD

## How to test the changes?

The scene where I spotted this clearly is in the Advanced Shooting Range in Goerli, so, coords 83,-1.
So, just shoot the targets and there should be a decal of the shot + SFX and whatnot.

There might be other places where this was happening as well. I will add them to this ticket if I find them :)