### PR TITLE
fix: There is no music at first spawn on Genesis Plaza

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/InterpolateCharacterSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/InterpolateCharacterSystem.cs
@@ -40,8 +40,8 @@ namespace DCL.CharacterMotion.Systems
         [Query]
         private void TeleportPlayer(in Entity entity, in CharacterController controller, ref CharacterPlatformComponent platformComponent, in PlayerTeleportIntent teleportIntent)
         {
-            if (teleportIntent.LoadReport != null && teleportIntent.LoadReport.CompletionSource.UnsafeGetStatus() == UniTaskStatus.Pending)
-                return;
+            if (teleportIntent.LoadReport == null || teleportIntent.LoadReport.CompletionSource.UnsafeGetStatus() != UniTaskStatus.Pending)
+                World.Remove<PlayerTeleportIntent>(entity);
 
             playerHasJustTeleported = true;
 
@@ -50,8 +50,6 @@ namespace DCL.CharacterMotion.Systems
 
             // Reset the current platform so we dont bounce back if we are touching the world plane
             platformComponent.CurrentPlatform = null;
-
-            World.Remove<PlayerTeleportIntent>(entity);
         }
 
         [Query]


### PR DESCRIPTION
…loading
Fix #1189 

## How to test the changes?
1. Launch the explorer on Genesis Plaza.
2. Check that the background music and waterfall sfx is on.
3. Go down through the beam and go up again.
4. Check that the background music and waterfall sfx is on again.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md
