### PR TITLE
chore: enable forward plus

### DIFF
--- a/Explorer/Assets/Rendering/ForwardRenderer - High.asset
+++ b/Explorer/Assets/Rendering/ForwardRenderer - High.asset
@@ -92,7 +92,7 @@ MonoBehaviour:
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1
-  m_RenderingMode: 0
+  m_RenderingMode: 2
   m_DepthPrimingMode: 0
   m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0

--- a/Explorer/Assets/Rendering/ForwardRenderer - Low.asset
+++ b/Explorer/Assets/Rendering/ForwardRenderer - Low.asset
@@ -73,7 +73,7 @@ MonoBehaviour:
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1
-  m_RenderingMode: 0
+  m_RenderingMode: 2
   m_DepthPrimingMode: 0
   m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0

--- a/Explorer/Assets/Rendering/ForwardRenderer - Medium.asset
+++ b/Explorer/Assets/Rendering/ForwardRenderer - Medium.asset
@@ -73,7 +73,7 @@ MonoBehaviour:
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1
-  m_RenderingMode: 0
+  m_RenderingMode: 2
   m_DepthPrimingMode: 0
   m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0


### PR DESCRIPTION
## What does this PR change?

Enables the forward plus rendering path.

## How to test the changes?

On both mac & windows everything should function as normal with no graphical differences between the existing versions.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

