### PR TITLE
Fix/unity cloud queue

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - feat/unity-cloud-build
   workflow_dispatch:
     inputs:
       profile:

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -30,7 +30,7 @@ on:
         type: boolean
       version:
         description: 'Override for build version to use'
-        required: true
+        required: false
         default: ''
         type: string
   workflow_call:

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -36,39 +36,58 @@ def get_target(target):
 # So we *always* create a new target, no matter what
 # by appending the commit's SHA
 def clone_current_target():
-    body = get_target(os.getenv('TARGET'))
+    def generate_body(template_target, name, branch, options, cache):
+        body = get_target(template_target)
+
+        body['name'] = new_name
+        body['settings']['scm']['branch'] = branch
+        body['settings']['advanced']['unity']['playerExporter']['buildOptions'] = options
+
+        # Copy cache check
+        if cache:
+            body['settings']['buildTargetCopyCache'] = template_target
+        else:
+            if 'buildTargetCopyCache' in body['settings']:
+                del body['settings']['buildTargetCopyCache']
+
+        retun body
+
     # Set target name based on branch
     new_target_name = f'{re.sub(r'^t_', '', os.getenv('TARGET'))}-{re.sub('[^A-Za-z0-9]+', '-', os.getenv('BRANCH_NAME'))}'
-    # Ensure a new target:
+    # Append commit SHA to target:
     new_target_name = f'{new_target_name}_{os.getenv('COMMIT_SHA')}'
 
-    body['name'] = new_target_name
-    body['settings']['scm']['branch'] = os.getenv('BRANCH_NAME')
-    body['settings']['advanced']['unity']['playerExporter']['buildOptions'] = os.getenv('BUILD_OPTIONS').split(',')
-
-    # Copy cache check
-    use_cache = os.getenv('USE_CACHE')
-    if use_cache == 'true' or use_cache == '':
-        body['settings']['buildTargetCopyCache'] = os.getenv('TARGET')
-    else:
-        if 'buildTargetCopyCache' in body['settings']:
-            del body['settings']['buildTargetCopyCache']
+    # Generate request body
+    body = generate_body(
+        os.getenv('TARGET'),
+        new_target_name,
+        os.getenv('BRANCH_NAME'),
+        os.getenv('BUILD_OPTIONS').split(','),
+        (os.getenv('USE_CACHE') == 'true' or os.getenv('USE_CACHE') == ''))
 
     # Check if the target already exists (re-use of a branch)
     if 'error' in get_target(new_target_name):
         # Create new
         response = requests.post(f'{URL}/buildtargets', headers=HEADERS, json=body)
     else:
-        # Update existing
-        response = requests.put(f'{URL}/buildtargets/{new_target_name}', headers=HEADERS, json=body)
+        # Check if it's in use
+        if get_any_running_builds(new_target_name, False):
+            print(f'Target "{new_target_name} has running builds! Creating a variant using a timestamp..."')
+
+            new_target_name = f'{new_target_name}_{int(time.time())}'
+            body['name'] = new_target_name
+            response = requests.post(f'{URL}/buildtargets', headers=HEADERS, json=body)
+        else:
+            # Update existing
+            response = requests.put(f'{URL}/buildtargets/{new_target_name}', headers=HEADERS, json=body)
 
     if response.status_code == 200 or response.status_code == 201:
+        # Override target ENV
         os.environ['TARGET'] = new_target_name
     elif response.status_code == 500 and 'Build target name already in use for this project!' in response.text:
         print('Target failed to clone as it already exists! Possible race condition with another build')
-        print('BuildOptions may not be set correctly if the created target has different settings already set!')
-        print('Ignoring error and continuing...')
-        os.environ['TARGET'] = new_target_name
+        print('Retrying flow from start...')
+        clone_current_target()
     else:
         print('Target failed to clone with status code:', response.status_code)
         print('Response body:', response.text)
@@ -222,8 +241,8 @@ def delete_build(id):
         print('Response body:', response.text)
         sys.exit(1)
 
-def get_any_running_builds_on_current_target(trueOnError = True):
-    response = requests.delete(f'{URL}/buildtargets/{os.getenv('TARGET')}/builds?buildStatus=created,queued,sentToBuilder,started,restarted', headers=HEADERS)
+def get_any_running_builds(target, trueOnError = True):
+    response = requests.delete(f'{URL}/buildtargets/{target}/builds?buildStatus=created,queued,sentToBuilder,started,restarted', headers=HEADERS)
 
     if response.status_code == 200:
         response_json = response.json()
@@ -272,6 +291,9 @@ else:
     # Clone current target
     # This will clone the current $TARGET and replace the value in $TARGET with it
     # Also sets the branch to $BRANCH_NAME
+    #
+    # If the target already exists, it will check if it has running builds on it
+    # If it has running builds, a new target will be created with an added timestamp (Unity can't queue)
     clone_current_target()
 
     # Set ENVs (Parameters)
@@ -303,7 +325,7 @@ download_artifact(id)
 download_log(id)
 
 # Cleanup
-if get_any_running_builds_on_current_target():
+if get_any_running_builds(os.getenv('TARGET')):
     delete_build(id)
 else:
     # Deleting the parent target also removes all builds

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -50,7 +50,7 @@ def clone_current_target():
             if 'buildTargetCopyCache' in body['settings']:
                 del body['settings']['buildTargetCopyCache']
 
-        retun body
+        return body
 
     # Set target name based on branch
     new_target_name = f'{re.sub(r'^t_', '', os.getenv('TARGET'))}-{re.sub('[^A-Za-z0-9]+', '-', os.getenv('BRANCH_NAME'))}'

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -39,7 +39,7 @@ def clone_current_target():
     def generate_body(template_target, name, branch, options, cache):
         body = get_target(template_target)
 
-        body['name'] = new_name
+        body['name'] = name
         body['settings']['scm']['branch'] = branch
         body['settings']['advanced']['unity']['playerExporter']['buildOptions'] = options
 

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -242,7 +242,7 @@ def delete_build(id):
         sys.exit(1)
 
 def get_any_running_builds(target, trueOnError = True):
-    response = requests.delete(f'{URL}/buildtargets/{target}/builds?buildStatus=created,queued,sentToBuilder,started,restarted', headers=HEADERS)
+    response = requests.get(f'{URL}/buildtargets/{target}/builds?buildStatus=created,queued,sentToBuilder,started,restarted', headers=HEADERS)
 
     if response.status_code == 200:
         response_json = response.json()


### PR DESCRIPTION
Targets will remain as they where, where we have a single target "template" for each OS (Windows, Mac) (@T_Whatever) that is then used when a build is created, to generate a clone that uses the branch and commit name (windows64_branch_12345fa)

If for some reason two builds are scheduled to use the same target, the second build will instead use (windows64_branch_12345fa_TIMESTAMP) to avoid a collision / error with the Unity API

This will only happen in situations where the target is being used at the same time, but not when re-using builds

This will still allow cases where a job fails, and we want to do some manual changes (like disabling cache) and then re-run the job - this will then find that the target already exists, but is not in use, so it will use the already created target with the manual changes applied to it (without the timestamp)

Possible issues:

The only corner case that this could cause is that you need to make sure to always modify targets without a timestamp (on re-runs), even if the job failed / your changes should be applied to a job that used a timestamped target, because that it's just temporary, and the next run will use the normal non-timestamped target

Of course, don't re-run jobs more than once at a time, or the timestamp will happen again

And if somehow (this shouldn't happen) a non-timestamp target built fine, but a timestamped target didn't the original (non-timestamp) target will be auto-removed, so in that specific case you wouldn't be able to do any changes to it - but again, this really shouldn't be possible without some major issue on Unity's side, as the commits should be identical

Also fixes:
- Wrong method for build status request
- Required version params
- Removed old branch trigger