### PR TITLE
fix: Avoid tag and page creation if build fails

### DIFF
--- a/.github/workflows/create-page-release-weekly.yml
+++ b/.github/workflows/create-page-release-weekly.yml
@@ -6,9 +6,10 @@ on:
     types:
       - completed
 
-jobs:
+jobs:  
   get-info:
     name: Get Info
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -27,6 +28,7 @@ jobs:
         
   generate-release-info:
     name: Generate release info
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: get-info


### PR DESCRIPTION
## What does this PR change?

Adds if to avoid running tag and page creation if build fails

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

