### PR TITLE
Always report cloud logs

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -168,17 +168,21 @@ jobs:
             !build/**/*_BurstDebugInformation_DoNotShip
           if-no-files-found: error
 
+      # Will run always (even if failing)
       - name: Upload cloud logs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}_unity_log
           path: unity_cloud_log.log
           if-no-files-found: error
 
+      # Will run always (even if failing)
       - name: Print cloud logs
+        if: always()
         run: cat unity_cloud_log.log
 
-      # Will run on cancel or timeout
+      # Will run on cancel or timeout only
       - name: Cancel Unity Cloud build
         if: ${{ cancelled() }}
         env:

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -204,7 +204,7 @@ def download_artifact(id):
     try:
         artifact_url = response_json['links']['download_primary']['href']
     except KeyError:
-        print(f'Failed to locate build artifacts with ID {id} - Nothing to download')
+        print(f'Failed to locate any build artifacts - Nothing to download')
         return
 
     download_dir = 'build'
@@ -332,8 +332,7 @@ download_artifact(id)
 download_log(id)
 
 if not build_healthy:
-    print(f'For help, check the downloaded logs (if any) or go to https://cloud.unity.com/ and search for target "{os.getenv('TARGET')}" and build ID "{id}"')
-    print('Build unhealthy, failing script execution...')
+    print(f'Build unhealthy - check the downloaded logs or go to https://cloud.unity.com/ and search for target "{os.getenv('TARGET')}" and build ID "{id}"')
     sys.exit(1)
 
 # Cleanup (only if build is healthy)


### PR DESCRIPTION
Download & print Unity cloud logs in GitHub actions regardless of the build result