### PR TITLE
fix: do not reset UI background  image and colour on creation

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Utils/UiElementUtils.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Utils/UiElementUtils.cs
@@ -130,9 +130,6 @@ namespace DCL.SDKComponents.SceneUI.Utils
                 visualElementToSetup.style.left = new Length(model.PositionLeft, GetUnit(model.PositionLeftUnit));
             else
                 visualElementToSetup.style.left = StyleKeyword.Null;
-
-            visualElementToSetup.style.backgroundImage = new StyleBackground(StyleKeyword.Null);
-            visualElementToSetup.style.backgroundColor = new StyleColor(StyleKeyword.None);
         }
 
         public static void SetupLabel(ref Label labelToSetup, ref PBUiText model, ref UITransformComponent uiTransformComponent)


### PR DESCRIPTION
## What does this PR change?

fixes #1150
fixes #1265

Scenes constantly re-create the UI as part of the flow and there is no reason to reset the background.