### PR TITLE
fix: default text wrapping

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Utils/UiElementUtils.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Utils/UiElementUtils.cs
@@ -194,6 +194,7 @@ namespace DCL.SDKComponents.SceneUI.Utils
             elementStyle.position = new StyleEnum<Position>(Position.Absolute);
             elementStyle.justifyContent = new StyleEnum<Justify>(Justify.Center);
             elementStyle.alignItems = new StyleEnum<Align>(Align.Center);
+            elementStyle.whiteSpace = new StyleEnum<WhiteSpace>(WhiteSpace.Normal);
         }
 
         public static void ReleaseUIElement(VisualElement visualElement) =>


### PR DESCRIPTION
## What does this PR change?

fixes #1309 

Protocol doesn't appear to have a white-space wrapping option, default to normal instead of no-wrap to avoid the force of the no-wrap. I also think the scene is incorrectly trying to wrap the text itself, I've reached out to @nearnshaw 