### PR TITLE
fix: skinned mesh renderer pointer interaction

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/Animator/Systems/AnimationPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Animator/Systems/AnimationPlayerSystem.cs
@@ -96,17 +96,20 @@ namespace DCL.SDKComponents.Animator.Systems
 
         private static void SetAnimationState(ICollection<SDKAnimationState> sdkAnimationStates, UAnimator animator, float dt)
         {
+            // TODO: we should have one state in each layer so we support weighting
+            // The current system does not support all expected cases from the SDK
             const int DEFAULT_LAYER_INDEX = 0;
 
             if (sdkAnimationStates.Count == 0)
                 return;
 
-            var isAnyAnimPlaying = false;
+            SDKAnimationState? possiblePlayingAnimation = null;
 
             foreach (SDKAnimationState sdkAnimationState in sdkAnimationStates)
-                isAnyAnimPlaying |= sdkAnimationState.Playing;
+                if (sdkAnimationState.Playing)
+                    possiblePlayingAnimation = sdkAnimationState;
 
-            if (!isAnyAnimPlaying)
+            if (possiblePlayingAnimation == null)
             {
                 // Reset to anim initial state
                 animator.CrossFade(animator.GetCurrentAnimatorStateInfo(DEFAULT_LAYER_INDEX).fullPathHash, 0f);
@@ -117,18 +120,16 @@ namespace DCL.SDKComponents.Animator.Systems
 
             animator.enabled = true;
 
-            foreach (SDKAnimationState sdkAnimationState in sdkAnimationStates)
-            {
-                if (!sdkAnimationState.Playing) continue;
+            SDKAnimationState currentAnimationState = possiblePlayingAnimation.Value;
 
-                animator.SetLayerWeight(DEFAULT_LAYER_INDEX, sdkAnimationState.Weight);
-                animator.SetBool(LOOP_PARAM, sdkAnimationState.Loop);
-                animator.speed = sdkAnimationState.Speed;
-                animator.SetTrigger(sdkAnimationState.Clip);
+            animator.SetLayerWeight(DEFAULT_LAYER_INDEX, currentAnimationState.Weight);
+            animator.SetBool(LOOP_PARAM, currentAnimationState.Loop);
+            animator.speed = currentAnimationState.Speed;
+            animator.SetTrigger(currentAnimationState.Clip);
 
-                if (sdkAnimationState.ShouldReset)
-                    animator.CrossFade(sdkAnimationState.Clip, 0f);
-            }
+            // TODO: support reset
+            // if (sdkAnimationState.ShouldReset)
+            //     animator.CrossFade(sdkAnimationState.Clip, 0f);
         }
     }
 }

--- a/Explorer/Assets/Scripts/ECS/Unity/CollidersUtility/EntityCollidersCacheExtensions.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/CollidersUtility/EntityCollidersCacheExtensions.cs
@@ -16,8 +16,8 @@ namespace DCL.Interaction.Utility
         {
             GltfContainerAsset asset = gltfContainerComponent.Promise.Result.Value.Asset;
 
-            if (asset.VisibleMeshesColliders != null)
-                cache.Associate(asset.VisibleMeshesColliders, new ColliderEntityInfo(entityReference, sdkEntity, gltfContainerComponent.VisibleMeshesCollisionMask));
+            if (asset.DecodedVisibleSDKColliders != null)
+                cache.Associate(asset.DecodedVisibleSDKColliders, new ColliderEntityInfo(entityReference, sdkEntity, gltfContainerComponent.VisibleMeshesCollisionMask));
 
             cache.Associate(asset.InvisibleColliders, new ColliderEntityInfo(entityReference, sdkEntity, gltfContainerComponent.InvisibleMeshesCollisionMask));
         }
@@ -36,8 +36,8 @@ namespace DCL.Interaction.Utility
 
         public static void Remove(this IEntityCollidersSceneCache cache, in GltfContainerAsset gltfContainerAsset)
         {
-            if (gltfContainerAsset.VisibleMeshesColliders != null)
-                cache.Remove(gltfContainerAsset.VisibleMeshesColliders);
+            if (gltfContainerAsset.DecodedVisibleSDKColliders != null)
+                cache.Remove(gltfContainerAsset.DecodedVisibleSDKColliders);
 
             cache.Remove(gltfContainerAsset.InvisibleColliders);
         }

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
@@ -108,16 +108,16 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
                 List<MeshFilter> list = meshFilterScope.Value;
                 instance.GetComponentsInChildren(true, list);
 
-                foreach (MeshFilter visibleMeshCollider in list)
+                foreach (MeshFilter meshFilter in list)
                 {
-                    GameObject go = visibleMeshCollider.gameObject;
+                    GameObject go = meshFilter.gameObject;
 
                     // Consider it a visible collider when it has a renderer on it
                     if (go.GetComponent<Renderer>())
-                        AddVisibleMeshCollider(result, go, visibleMeshCollider.sharedMesh);
+                        AddVisibleMeshCollider(result, go, meshFilter.sharedMesh);
                     else
                         // Gather invisible colliders
-                        CreateAndAddMeshCollider(result.InvisibleColliders, go, visibleMeshCollider.sharedMesh);
+                        CreateAndAddMeshCollider(result.InvisibleColliders, go, meshFilter.sharedMesh);
                 }
             }
 

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
@@ -147,7 +147,7 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
             });
         }
 
-        private static void CreateAndAddMeshCollider(List<SDKCollider> results, GameObject go, Mesh mesh, bool checkGameObjectNaming = true)
+        private static void CreateAndAddMeshCollider(List<SDKCollider> results, GameObject go, Mesh mesh)
         {
             // Asset Bundle converter creates Colliders during the processing in some cases
             Collider collider = go.GetComponent<Collider>();
@@ -161,7 +161,7 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
                 return;
             }
 
-            if (checkGameObjectNaming && !IsNamedAsCollider(go))
+            if (!IsNamedAsCollider(go))
                 return;
 
             MeshCollider newCollider = go.AddComponent<MeshCollider>();

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
@@ -130,9 +130,6 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
                 {
                     GameObject go = skinnedMeshRenderer.gameObject;
 
-                    // Gather invisible colliders
-                    // CreateAndAddMeshCollider(result.InvisibleColliders, go, skinnedMeshRenderer.sharedMesh, false);
-
                     // Always considered as visible collider
                     AddVisibleMeshCollider(result, go, skinnedMeshRenderer.sharedMesh);
                 }

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Tests/CleanUpGltfContainerSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Tests/CleanUpGltfContainerSystemShould.cs
@@ -39,7 +39,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             c.Promise = AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(world, new GetGltfContainerAssetIntention("1", new CancellationTokenSource()), PartitionComponent.TOP_PRIORITY);
             var asset = GltfContainerAsset.Create(new GameObject(), null);
 
-            asset.VisibleMeshesColliders = new List<SDKCollider> { new (), new () };
+            asset.DecodedVisibleSDKColliders = new List<SDKCollider> { new (), new () };
             world.Add(c.Promise.Entity, new StreamableLoadingResult<GltfContainerAsset>(asset));
             c.State = LoadingState.Finished;
 

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
@@ -132,8 +132,8 @@ namespace ECS.Unity.GLTFContainer.Tests
             component = world.Get<GltfContainerComponent>(e);
             GltfContainerAsset promiseAsset = component.Promise.Result.Value.Asset;
 
-            Assert.That(promiseAsset.VisibleMeshesColliders.Count, Is.EqualTo(196));
-            Assert.That(promiseAsset.VisibleMeshesColliders.All(c => c.Collider.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
+            Assert.That(promiseAsset.DecodedVisibleSDKColliders.Count, Is.EqualTo(196));
+            Assert.That(promiseAsset.DecodedVisibleSDKColliders.All(c => c.Collider.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
         }
 
         [Test]
@@ -161,7 +161,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             Assert.That(promiseAsset.InvisibleColliders.All(c => c.Collider.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
 
             // No visible colliders created
-            Assert.That(promiseAsset.VisibleMeshesColliders, Is.Null);
+            Assert.That(promiseAsset.DecodedVisibleSDKColliders, Is.Null);
         }
     }
 }

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Tests/ResetGltfContainerSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Tests/ResetGltfContainerSystemShould.cs
@@ -45,7 +45,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             var c = new GltfContainerComponent();
             c.Promise = AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(world, new GetGltfContainerAssetIntention("1", new CancellationTokenSource()), PartitionComponent.TOP_PRIORITY);
             var asset = GltfContainerAsset.Create(new GameObject(), null);
-            asset.VisibleMeshesColliders = new List<SDKCollider> { new () };
+            asset.DecodedVisibleSDKColliders = new List<SDKCollider> { new () };
             world.Add(c.Promise.Entity, new StreamableLoadingResult<GltfContainerAsset>(asset));
             c.State = LoadingState.Finished;
 
@@ -69,7 +69,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             c.Promise = AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(world, new GetGltfContainerAssetIntention("1", new CancellationTokenSource()), PartitionComponent.TOP_PRIORITY);
 
             var asset = GltfContainerAsset.Create(new GameObject(), null);
-            asset.VisibleMeshesColliders = new List<SDKCollider> { new () };
+            asset.DecodedVisibleSDKColliders = new List<SDKCollider> { new () };
 
             world.Add(c.Promise.Entity, new StreamableLoadingResult<GltfContainerAsset>(asset));
             c.State = LoadingState.Finished;

--- a/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
@@ -87,8 +87,8 @@ namespace ECS.Unity.SceneBoundsChecker
             // Process all colliders
 
             // Visible meshes colliders are created on demand
-            if (asset.VisibleMeshesColliders != null)
-                ProcessColliders(asset.VisibleMeshesColliders);
+            if (asset.DecodedVisibleSDKColliders != null)
+                ProcessColliders(asset.DecodedVisibleSDKColliders);
 
             ProcessColliders(asset.InvisibleColliders);
             return;


### PR DESCRIPTION
## What does this PR change?

Fixes #752 
Fixes the interaction with the dog of #1261 
Partially fixes the interaction of #1087 

Fixes the pointer interactions with objects in the SDK configured like [this](https://github.com/decentraland/sdk7-goerli-plaza/blob/5dde0e08f5e369200d04506d1978c419fea3f3ff/Shark-animation/src/index.ts#L53) by supporting colliders for `SkinnedMeshRenderer` (which was previously ignored).

In order to fix the shark, we need to make animations weighted by layer so the bite and the swim can be played simultaneously. Will do it in another pr so this one does not grow too much.

## How to test the changes?

1. Follow issue steps
2. Check that the pointer interaction works
3. The bite animation will not work yet
4. Go around the scenes and check that the colliders and pointer interactions are still working as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

