### PR TITLE
fix: Set default visibility to true for text mesh preo

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/TextShape/System/InstantiateTextShapeSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/TextShape/System/InstantiateTextShapeSystem.cs
@@ -56,7 +56,8 @@ namespace DCL.SDKComponents.TextShape.System
 
             World.Add(entity, component);
 
-            // Issue an event so it will be grabbed by visibility system
+            // IF there is a visibility component, it will set it invisible in the visibility system
+            textMeshPro.enabled = true;
             changedTextMeshes.Add(entity, component);
         }
     }


### PR DESCRIPTION
## What does this PR change?

When getting TMP from the pool, we should set the default visibility to true. IF there is a `VisibilityComponent` on the entity, that one will turn it off. But if there isnt, by default it should be on

## How to test the changes?

Recomendation: In Debug Menu, in Landscape setting, move the load raidus to 1.

Clear local asset bundle cache
Go to Goerli
Go to the zombie scene (78,-1). The health billboard above zombies should look at you, and go down when you click it. The zombie should dissapear when reaching 0

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

