### PR TITLE
fix: remove land flash between login and loading screen

### DIFF
--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInitializationFlowController.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInitializationFlowController.cs
@@ -67,8 +67,7 @@ namespace DCL.UserInAppInitializationFlow
             if (showAuthentication)
                 await ShowAuthenticationScreenAsync(ct);
 
-            // Re-initialize feature flags since the user might have changed thus the data to be resolved
-            await InitializeFeatureFlagsAsync(ct);
+
 
             if (showLoading)
                 await loadingScreen.ShowWhileExecuteTaskAsync(parentLoadReport => LoadCharacterAndWorldAsync(parentLoadReport, world, playerEntity, ct), ct);
@@ -80,6 +79,9 @@ namespace DCL.UserInAppInitializationFlow
 
         private async UniTask LoadCharacterAndWorldAsync(AsyncLoadProcessReport parentLoadReport, World world, Entity playerEntity, CancellationToken ct)
         {
+            // Re-initialize feature flags since the user might have changed thus the data to be resolved
+            await InitializeFeatureFlagsAsync(ct);
+            
             Profile ownProfile = await selfProfile.ProfileOrPublishIfNotAsync(ct);
             parentLoadReport.SetProgress(loadingStatus.SetStage(ProfileLoaded));
 


### PR DESCRIPTION

## What does this PR change?

Fixes #1331 

Removes the flash of land between login and loading screen



## How to test the changes?

1. Login
2. Wait for the loading screen. No flash should appear

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

