### PR TITLE
fix: doors

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/Animator/Systems/AnimationPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Animator/Systems/AnimationPlayerSystem.cs
@@ -118,12 +118,12 @@ namespace DCL.SDKComponents.Animator.Systems
                     continue;
                 }
 
-                animator.SetLayerWeight(layerIndex, sdkAnimationState.Weight);
                 animator.SetBool($"{name}_Enabled", sdkAnimationState.Playing);
                 animator.SetBool($"{name}_Loop", sdkAnimationState.Loop);
 
                 if (sdkAnimationState.Playing)
                 {
+                    animator.SetLayerWeight(layerIndex, sdkAnimationState.Weight);
                     animator.SetTrigger($"{name}_Trigger");
 
                     // Animators don't support speed by state, just a global speed
@@ -134,6 +134,12 @@ namespace DCL.SDKComponents.Animator.Systems
                     // This behaviour could bring unexpected results since it works differently than unity-renderer
                     // TODO: support reset
                     // sdkAnimationState.ShouldReset
+                }
+                else
+                {
+                    // Since animation states are now executed through layers, we need to force to 0 if the state is not playing
+                    // otherwise it overrides the current playing state
+                    animator.SetLayerWeight(layerIndex, 0f);
                 }
             }
         }


### PR DESCRIPTION
## What does this PR change?

Fixes #1376 
Fixes #1397 
Should also fix #1333 when the AB conversion is done on Metadyne (not yet done)

Depends on AB conversions from: https://github.com/decentraland/asset-bundle-converter/pull/100

The doors should stay at the last frame of its open animation when the state is `loop:false`. The new asset bundle converter avoids overriding bones when transitioning to `empty`, keeping the animation on its latest state.

## How to test the changes?

Clear asset bundles cache.
If affects the animation system, so all animations should work as expected.
Some of the scenes from goerli plaza:

door-wearable-scanner (76,-5)
sliding-doors (79,-9)
man-dancing (76,-3)
skeleton-king (74,-9)
zombie-chaser (78,-1)
shark (73,-8)
birds-tree (76,-9)
scene-emotes-green-tiles (77,-7)
swap-avatar (75,-7)
avatar-emotes (80,-1)
black-dogs (72,-9)
doge (80,-3)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

