### PR TITLE
fix: clean up of UI background component

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/MediaPlayerComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/MediaPlayerComponent.cs
@@ -23,7 +23,6 @@ namespace DCL.SDKComponents.MediaStream
 
         public MediaPlayer PoolableComponent => MediaPlayer;
         public Type PoolableComponentType => typeof(MediaPlayer);
-        public AudioOutput AudioOutput;
 
         public bool IsPlaying => MediaPlayer.Control.IsPlaying();
         public float CurrentTime => (float)MediaPlayer.Control.GetCurrentTime();

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Classes/DCLImage.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Classes/DCLImage.cs
@@ -63,6 +63,7 @@ namespace DCL.SDKComponents.SceneUI.Classes
 
         public void Dispose()
         {
+            texture2D = null;
             canvas.generateVisualContent -= OnGenerateVisualContent;
 
             // Reset overriden styles

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Components/UIBackgroundComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Components/UIBackgroundComponent.cs
@@ -14,9 +14,12 @@ namespace DCL.SDKComponents.SceneUI.Components
         DCLImage IPoolableComponentProvider<DCLImage>.PoolableComponent => Image;
         Type IPoolableComponentProvider<DCLImage>.PoolableComponentType => typeof(DCLImage);
 
+        public bool IsDisposed { get; private set; }
+
         public void Dispose()
         {
-            Image.Dispose();
+            IsDisposed = true;
+            Image = null;
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIBackground/UIBackgroundReleaseSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIBackground/UIBackgroundReleaseSystem.cs
@@ -7,15 +7,13 @@ using DCL.ECSComponents;
 using DCL.Optimization.Pools;
 using DCL.SDKComponents.SceneUI.Classes;
 using DCL.SDKComponents.SceneUI.Components;
-using DCL.SDKComponents.SceneUI.Groups;
 using ECS.Abstract;
 using ECS.Groups;
 using ECS.LifeCycle.Components;
 
 namespace DCL.SDKComponents.SceneUI.Systems.UIBackground
 {
-    [UpdateInGroup(typeof(SyncedSimulationSystemGroup))]
-    [UpdateBefore(typeof(SceneUIComponentInstantiationGroup))]
+    [UpdateInGroup(typeof(CleanUpGroup))]
     [LogCategory(ReportCategory.SCENE_UI)]
     [ThrottlingEnabled]
     public partial class UIBackgroundReleaseSystem : BaseUnityLoopSystem
@@ -31,6 +29,7 @@ namespace DCL.SDKComponents.SceneUI.Systems.UIBackground
         {
             HandleEntityDestructionQuery(World);
             HandleUIBackgroundRemovalQuery(World);
+
             World.Remove<UIBackgroundComponent>(in HandleUIBackgroundRemoval_QueryDescription);
         }
 
@@ -52,8 +51,11 @@ namespace DCL.SDKComponents.SceneUI.Systems.UIBackground
                 uiBackgroundComponent.TexturePromise = null;
             }
 
-            if (componentPool != null)
-                componentPool.Release(uiBackgroundComponent.Image);
+            if (!uiBackgroundComponent.IsDisposed)
+            {
+                componentPool?.Release(uiBackgroundComponent.Image);
+                uiBackgroundComponent.Dispose();
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Utils/UiElementUtils.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Utils/UiElementUtils.cs
@@ -153,7 +153,7 @@ namespace DCL.SDKComponents.SceneUI.Utils
             }
         }
 
-        public static void SetupDCLImage(ref DCLImage imageToSetup, ref PBUiBackground model, Texture2D texture = null)
+        public static void SetupFromSdkModel(this DCLImage imageToSetup, ref PBUiBackground model, Texture2D texture = null)
         {
             imageToSetup.Color = model.GetColor();
             imageToSetup.Slices = model.GetBorder();


### PR DESCRIPTION
## What does this PR change?
fix #1384 
fix #1380

- removed reference from DCLImage on UIBackground disposal
- moved Releasing system to CleanUp ECS group
- minor clean-ups

## How to test the changes?
Check steps in #1384 and in #1380

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

