### PR TITLE
fix: missing map pin reference on EntryPoint GO in Main.unity

### DIFF
--- a/Explorer/Assets/Scenes/Main.unity
+++ b/Explorer/Assets/Scenes/Main.unity
@@ -535,7 +535,7 @@ MonoBehaviour:
         m_SubObjectType: 
         m_EditorAssetChanged: 0
       <PinMarker>k__BackingField:
-        m_AssetGUID: 
+        m_AssetGUID: e7d14406516774d91886b6b4d1a26a58
         m_SubObjectName: 
         m_SubObjectType: 
         m_EditorAssetChanged: 0


### PR DESCRIPTION
added missing/lost MapPin reference on EntryPoint GO in Main.unity