### PR TITLE
fix: a weird case when the component is added and later removed from the scene root

### DIFF
--- a/Explorer/Assets/Scripts/SceneRunner/ECSWorld/ECSWorldFactory.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/ECSWorld/ECSWorldFactory.cs
@@ -100,7 +100,7 @@ namespace SceneRunner.ECSWorld
 
         private static PersistentEntities CreateReservedEntities(World world, ECSWorldInstanceSharedDependencies sharedDependencies)
         {
-            Entity sceneRootEntity = world.Create(new CRDTEntity(SpecialEntitiesID.SCENE_ROOT_ENTITY), new SceneRootComponent(), world);
+            Entity sceneRootEntity = world.Create(new CRDTEntity(SpecialEntitiesID.SCENE_ROOT_ENTITY), new SceneRootComponent(), RemovedComponents.CreateDefault());
             Entity playerEntity = world.Create(new CRDTEntity(SpecialEntitiesID.PLAYER_ENTITY), RemovedComponents.CreateDefault());
             Entity cameraEntity = world.Create(new CRDTEntity(SpecialEntitiesID.CAMERA_ENTITY), RemovedComponents.CreateDefault());
 


### PR DESCRIPTION
fixes #1431 (crash)

It does not fix colliders' movement as there is a separate issue for that.

P.S. Adding components to the scene root has no effect - it's hard to say what content creators wanted to achieve 🤷 

