### PR TITLE
fix: preserve original json blob of the scenes

### DIFF
--- a/Explorer/Assets/DCL/Ipfs/DCL.Ipfs.asmdef
+++ b/Explorer/Assets/DCL/Ipfs/DCL.Ipfs.asmdef
@@ -8,7 +8,8 @@
         "GUID:8322ea9340a544c59ddc56d4793eac74",
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:5ab29fa8ae5769b49ab29e390caca7a4",
-        "GUID:4a12c0b1b77ec6b418a8d7bd5c925be3"
+        "GUID:4a12c0b1b77ec6b418a8d7bd5c925be3",
+        "GUID:166b65e6dfc848bb9fb075f53c293a38"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Ipfs/SceneMetadata.cs
+++ b/Explorer/Assets/DCL/Ipfs/SceneMetadata.cs
@@ -1,3 +1,4 @@
+using DCL.Utilities.Json;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -6,7 +7,7 @@ using UnityEngine;
 namespace DCL.Ipfs
 {
     [Serializable]
-    public class SceneMetadata
+    public class SceneMetadata : PreserveOriginalJson
     {
         public string main;
         public SceneMetadataScene scene;

--- a/Explorer/Assets/DCL/Utilities/Json.meta
+++ b/Explorer/Assets/DCL/Utilities/Json.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 76b42185ae594597aa0d286f4b9a5dab
+timeCreated: 1721217863

--- a/Explorer/Assets/DCL/Utilities/Json/IPreserveOriginalJson.cs
+++ b/Explorer/Assets/DCL/Utilities/Json/IPreserveOriginalJson.cs
@@ -1,0 +1,7 @@
+﻿namespace DCL.Utilities.Json
+{
+    public interface IPreserveOriginalJson
+    {
+        string OriginalJson { get; set; }
+    }
+}

--- a/Explorer/Assets/DCL/Utilities/Json/IPreserveOriginalJson.cs.meta
+++ b/Explorer/Assets/DCL/Utilities/Json/IPreserveOriginalJson.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e0c477d9d4154a4a975ff44ff6c1f61c
+timeCreated: 1721217896

--- a/Explorer/Assets/DCL/Utilities/Json/PreserveOriginalJson.cs
+++ b/Explorer/Assets/DCL/Utilities/Json/PreserveOriginalJson.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace DCL.Utilities.Json
+{
+    [JsonConverter(typeof(OriginalJsonContainerConverter))]
+    public abstract class PreserveOriginalJson : IPreserveOriginalJson
+    {
+        [JsonIgnore]
+        public string OriginalJson { get; set; }
+    }
+}

--- a/Explorer/Assets/DCL/Utilities/Json/PreserveOriginalJson.cs.meta
+++ b/Explorer/Assets/DCL/Utilities/Json/PreserveOriginalJson.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 999ef93872244161976e11b4737d7077
+timeCreated: 1721217918

--- a/Explorer/Assets/DCL/Utilities/Json/PreserveOriginalJsonConverter.cs
+++ b/Explorer/Assets/DCL/Utilities/Json/PreserveOriginalJsonConverter.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace DCL.Utilities.Json
+{
+    public class OriginalJsonContainerConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) =>
+            typeof(IPreserveOriginalJson).IsAssignableFrom(objectType);
+
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+
+            IPreserveOriginalJson result = (IPreserveOriginalJson)Activator.CreateInstance(objectType);
+            result.OriginalJson = jObject.ToString(Formatting.None);
+
+            serializer.Populate(jObject.CreateReader(), result);
+
+            return result;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var jObject = JObject.FromObject(value, serializer);
+
+            jObject.Remove("OriginalJson");
+
+            jObject.WriteTo(writer);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Utilities/Json/PreserveOriginalJsonConverter.cs.meta
+++ b/Explorer/Assets/DCL/Utilities/Json/PreserveOriginalJsonConverter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f83bd169ba3a4c8aa774051133bc071d
+timeCreated: 1721217990

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/JsModulesImplementation/RuntimeImplementation.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/JsModulesImplementation/RuntimeImplementation.cs
@@ -91,7 +91,7 @@ namespace CrdtEcsBridge.JsModulesImplementation
                 baseUrl: sceneData.SceneContent.ContentBaseUrl.Value,
                 urn: sceneData.SceneEntityDefinition.id,
                 content: sceneData.SceneEntityDefinition.content,
-                metadataJson: JsonConvert.SerializeObject(sceneData.SceneEntityDefinition.metadata)
+                metadataJson: sceneData.SceneEntityDefinition.metadata.OriginalJson
             );
     }
 }


### PR DESCRIPTION
## What does this PR change?

Preserves the original json data for when the scene creator requests it they are able to add any additional fields they want.

## How to test the changes?

Fixes #1235
Fixes #1289 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

