### PR TITLE
fix: World channel volume does not work in the build

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/AudioSourcesPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AudioSourcesPlugin.cs
@@ -9,6 +9,7 @@ using DCL.SDKComponents.AudioSources;
 using DCL.WebRequests;
 using ECS.LifeCycle;
 using ECS.StreamableLoading.AudioClips;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
@@ -60,12 +61,12 @@ namespace DCL.PluginSystem.World
         public async UniTask InitializeAsync(AudioSourcesPluginSettings settings, CancellationToken ct) =>
             audioMixer = (await assetsProvisioner.ProvideMainAssetAsync(settings.GeneralAudioMixer, ct)).Value;
 
+        [Serializable]
         public class AudioSourcesPluginSettings : IDCLPluginSettings
         {
             [field: Header(nameof(AudioSourcesPlugin) + "." + nameof(AudioSourcesPluginSettings))]
             [field: Space]
-            [field: SerializeField]
-            public AssetReferenceT<AudioMixer> GeneralAudioMixer { get; private set; }
+            [field: SerializeField] internal AssetReferenceT<AudioMixer> GeneralAudioMixer;
         }
 
     }

--- a/Explorer/Assets/DCL/PluginSystem/World/AudioSourcesPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AudioSourcesPlugin.cs
@@ -11,6 +11,7 @@ using ECS.StreamableLoading.AudioClips;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.AddressableAssets;
 using UnityEngine.Audio;
 
 namespace DCL.PluginSystem.World
@@ -52,18 +53,15 @@ namespace DCL.PluginSystem.World
         public void Dispose()
         { }
 
-        public UniTask InitializeAsync(AudioSourcesPluginSettings settings, CancellationToken ct)
-        {
-            audioMixerGroup = settings.AudioMixerGroup;
-            return new UniTask();
-        }
+        public async UniTask InitializeAsync(AudioSourcesPluginSettings settings, CancellationToken ct) =>
+            audioMixerGroup = await settings.AudioMixerGroup.LoadAssetAsync<AudioMixerGroup>();
 
         public class AudioSourcesPluginSettings : IDCLPluginSettings
         {
             [field: Header(nameof(AudioSourcesPlugin) + "." + nameof(AudioSourcesPluginSettings))]
             [field: Space]
             [field: SerializeField]
-            public AudioMixerGroup AudioMixerGroup;
+            public AssetReference AudioMixerGroup;
         }
 
     }

--- a/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
+++ b/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
@@ -32,7 +32,7 @@ MonoBehaviour:
     - rid: 758312499805421571
       type: {class: AudioSourcesPlugin/AudioSourcesPluginSettings, ns: DCL.PluginSystem.World, asm: DCL.Plugins}
       data:
-        <GeneralAudioMixer>k__BackingField:
+        GeneralAudioMixer:
           m_AssetGUID: e38b0fb061d7ffa47b54d89ecd483bd2
           m_SubObjectName: 
           m_SubObjectType: 

--- a/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
+++ b/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
@@ -32,11 +32,10 @@ MonoBehaviour:
     - rid: 758312499805421571
       type: {class: AudioSourcesPlugin/AudioSourcesPluginSettings, ns: DCL.PluginSystem.World, asm: DCL.Plugins}
       data:
-        AudioMixerGroup:
+        <GeneralAudioMixer>k__BackingField:
           m_AssetGUID: e38b0fb061d7ffa47b54d89ecd483bd2
-          m_SubObjectName: World
-          m_SubObjectType: UnityEditor.Audio.AudioMixerGroupController, UnityEditor.CoreModule,
-            Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+          m_SubObjectName: 
+          m_SubObjectType: 
           m_EditorAssetChanged: 0
     - rid: 758312842344792066
       type: {class: InteractionsAudioPlugin/PluginSettings, ns: DCL.PluginSystem.Global, asm: DCL.Plugins}

--- a/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
+++ b/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
@@ -32,7 +32,12 @@ MonoBehaviour:
     - rid: 758312499805421571
       type: {class: AudioSourcesPlugin/AudioSourcesPluginSettings, ns: DCL.PluginSystem.World, asm: DCL.Plugins}
       data:
-        AudioMixerGroup: {fileID: -6220823946282331284, guid: e38b0fb061d7ffa47b54d89ecd483bd2, type: 2}
+        AudioMixerGroup:
+          m_AssetGUID: e38b0fb061d7ffa47b54d89ecd483bd2
+          m_SubObjectName: World
+          m_SubObjectType: UnityEditor.Audio.AudioMixerGroupController, UnityEditor.CoreModule,
+            Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+          m_EditorAssetChanged: 0
     - rid: 758312842344792066
       type: {class: InteractionsAudioPlugin/PluginSettings, ns: DCL.PluginSystem.Global, asm: DCL.Plugins}
       data:
@@ -167,9 +172,6 @@ MonoBehaviour:
         <LoadingAttemptsCount>k__BackingField: 6
         <PoolInitialCapacity>k__BackingField: 256
         <PoolMaxSize>k__BackingField: 2048
-    - rid: 7387084847885844480
-      type: {class: DynamicWorldSettings, ns: Global.Dynamic, asm: DCL.Plugins}
-      data: 
     - rid: 7615904969758605314
       type: {class: NFTShapePluginSettings, ns: DCL.PluginSystem.Global, asm: DCL.Plugins}
       data:

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
@@ -32,11 +32,11 @@ namespace DCL.SDKComponents.AudioSources
         private readonly ISceneData sceneData;
         private readonly ISceneStateProvider sceneStateProvider;
         private readonly IStreamableCache<AudioClip, GetAudioClipIntention> cache;
-        private readonly AudioMixerGroup audioMixerGroup;
+        private readonly AudioMixer audioMixer;
 
         internal UpdateAudioSourceSystem(World world, ISceneData sceneData, ISceneStateProvider sceneStateProvider, IStreamableCache<AudioClip, GetAudioClipIntention> cache, IComponentPoolsRegistry poolsRegistry,
             IPerformanceBudget frameTimeBudgetProvider,
-            IPerformanceBudget memoryBudgetProvider, AudioMixerGroup audioMixerGroup) : base(world)
+            IPerformanceBudget memoryBudgetProvider, AudioMixer audioMixer) : base(world)
         {
             this.world = world;
             this.sceneData = sceneData;
@@ -44,7 +44,7 @@ namespace DCL.SDKComponents.AudioSources
             this.frameTimeBudgetProvider = frameTimeBudgetProvider;
             this.memoryBudgetProvider = memoryBudgetProvider;
             this.cache = cache;
-            this.audioMixerGroup = audioMixerGroup;
+            this.audioMixer = audioMixer;
 
             audioSourcesPool = poolsRegistry.GetReferenceTypePool<AudioSource>().EnsureNotNull();
         }
@@ -64,7 +64,11 @@ namespace DCL.SDKComponents.AudioSources
                 return;
 
             if (audioSourceComponent.AudioSourceAssigned == false)
-                audioSourceComponent.SetAudioSource(audioSourcesPool.Get()!, audioMixerGroup);
+            {
+                var worldGroup = audioMixer.FindMatchingGroups("World");
+                if (worldGroup.Length > 0)
+                    audioSourceComponent.SetAudioSource(audioSourcesPool.Get()!, worldGroup[0]);
+            }
 
             audioSourceComponent.AudioSource!.FromPBAudioSourceWithClip(sdkAudioSource, clip: promiseResult.Asset);
 

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
@@ -65,9 +65,11 @@ namespace DCL.SDKComponents.AudioSources
 
             if (audioSourceComponent.AudioSourceAssigned == false)
             {
-                var worldGroup = audioMixer.FindMatchingGroups("World");
-                if (worldGroup.Length > 0)
-                    audioSourceComponent.SetAudioSource(audioSourcesPool.Get()!, worldGroup[0]);
+                AudioMixerGroup[]? worldGroup = null;
+                if (audioMixer != null)
+                    worldGroup = audioMixer.FindMatchingGroups("World");
+
+                audioSourceComponent.SetAudioSource(audioSourcesPool.Get()!, (worldGroup is { Length: > 0 } ? worldGroup[0] : null)!);
             }
 
             audioSourceComponent.AudioSource!.FromPBAudioSourceWithClip(sdkAudioSource, clip: promiseResult.Asset);

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
@@ -32,7 +32,7 @@ namespace DCL.SDKComponents.AudioSources
         private readonly ISceneData sceneData;
         private readonly ISceneStateProvider sceneStateProvider;
         private readonly IStreamableCache<AudioClip, GetAudioClipIntention> cache;
-        private readonly AudioMixer audioMixer;
+        private readonly AudioMixerGroup[] worldGroup;
 
         internal UpdateAudioSourceSystem(World world, ISceneData sceneData, ISceneStateProvider sceneStateProvider, IStreamableCache<AudioClip, GetAudioClipIntention> cache, IComponentPoolsRegistry poolsRegistry,
             IPerformanceBudget frameTimeBudgetProvider,
@@ -44,9 +44,11 @@ namespace DCL.SDKComponents.AudioSources
             this.frameTimeBudgetProvider = frameTimeBudgetProvider;
             this.memoryBudgetProvider = memoryBudgetProvider;
             this.cache = cache;
-            this.audioMixer = audioMixer;
 
             audioSourcesPool = poolsRegistry.GetReferenceTypePool<AudioSource>().EnsureNotNull();
+
+            if (audioMixer != null)
+                worldGroup = audioMixer.FindMatchingGroups("World");
         }
 
         protected override void Update(float t)
@@ -64,13 +66,7 @@ namespace DCL.SDKComponents.AudioSources
                 return;
 
             if (audioSourceComponent.AudioSourceAssigned == false)
-            {
-                AudioMixerGroup[]? worldGroup = null;
-                if (audioMixer != null)
-                    worldGroup = audioMixer.FindMatchingGroups("World");
-
                 audioSourceComponent.SetAudioSource(audioSourcesPool.Get()!, (worldGroup is { Length: > 0 } ? worldGroup[0] : null)!);
-            }
 
             audioSourceComponent.AudioSource!.FromPBAudioSourceWithClip(sdkAudioSource, clip: promiseResult.Asset);
 

--- a/Explorer/Assets/Scripts/Global/StaticContainer.cs
+++ b/Explorer/Assets/Scripts/Global/StaticContainer.cs
@@ -210,7 +210,7 @@ namespace Global
                 new AvatarAttachPlugin(container.MainPlayerAvatarBaseProxy, componentsContainer.ComponentPoolsRegistry),
                 new PrimitivesRenderingPlugin(sharedDependencies),
                 new VisibilityPlugin(),
-                new AudioSourcesPlugin(sharedDependencies, container.WebRequestsContainer.WebRequestController, container.CacheCleaner),
+                new AudioSourcesPlugin(sharedDependencies, container.WebRequestsContainer.WebRequestController, container.CacheCleaner, container.assetsProvisioner),
                 assetBundlePlugin, new GltfContainerPlugin(sharedDependencies, container.CacheCleaner, container.SceneReadinessReportQueue, container.SingletonSharedDependencies.SceneAssetLock),
                 new InteractionPlugin(sharedDependencies, profilingProvider, exposedGlobalDataContainer.GlobalInputEvents, componentsContainer.ComponentPoolsRegistry, container.assetsProvisioner),
                 new SceneUIPlugin(sharedDependencies, container.assetsProvisioner, container.InputBlock),

--- a/Explorer/Assets/Scripts/Global/Tests/PlayMode/Integration Tests World Container.asset
+++ b/Explorer/Assets/Scripts/Global/Tests/PlayMode/Integration Tests World Container.asset
@@ -36,7 +36,11 @@ MonoBehaviour:
     - rid: 758312634468794373
       type: {class: AudioSourcesPlugin/AudioSourcesPluginSettings, ns: DCL.PluginSystem.World, asm: DCL.Plugins}
       data:
-        AudioMixerGroup: {fileID: -6220823946282331284, guid: e38b0fb061d7ffa47b54d89ecd483bd2, type: 2}
+        GeneralAudioMixer:
+          m_AssetGUID: e38b0fb061d7ffa47b54d89ecd483bd2
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_EditorAssetChanged: 0
     - rid: 758312881421549570
       type: {class: InteractionsAudioPlugin/PluginSettings, ns: DCL.PluginSystem.Global, asm: DCL.Plugins}
       data:


### PR DESCRIPTION
## What does this PR change?
Fix #1395 

The "World" channel volume of our `GeneralAudioMixer` was not working in the build. None of the scenes audios was being attended to the WORLD volumen in the Settings Menu.

![image](https://github.com/decentraland/unity-explorer/assets/64659061/90d245cc-185f-4b71-ada5-df6b7b0e65bb)

Now it works correctly.

## How to test the changes?
1. Go to the top side of Genesis Plaza.
2. Check that you hear the background music.
3. Go to the Settings Menu -> audio section.
4. Modify the WORLD SFX slider to set it as 0.
5. Notice that the genesis plaza background music is being affected.
6. Do the same test with the sound of the doors in the floor below when they open.
7. Do the same test with other scenes/worlds (for example MetadyneLabs) and check that the scene audio is attending the volume that we set in the Settings Menu.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md