### PR TITLE
fix: force picking mode

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/SceneUIPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/SceneUIPlugin.cs
@@ -7,6 +7,7 @@ using DCL.Optimization.Pools;
 using DCL.PluginSystem.World.Dependencies;
 using DCL.SDKComponents.SceneUI.Classes;
 using DCL.SDKComponents.SceneUI.Components;
+using DCL.SDKComponents.SceneUI.Systems;
 using DCL.SDKComponents.SceneUI.Systems.UIBackground;
 using DCL.SDKComponents.SceneUI.Systems.UICanvasInformation;
 using DCL.SDKComponents.SceneUI.Systems.UIDropdown;
@@ -83,6 +84,7 @@ namespace DCL.PluginSystem.World
             UIDropdownReleaseSystem.InjectToWorld(ref builder, componentPoolsRegistry);
             UIPointerEventsSystem.InjectToWorld(ref builder, sharedDependencies.SceneStateProvider, sharedDependencies.EcsToCRDTWriter);
             UICanvasInformationSystem.InjectToWorld(ref builder, sharedDependencies.SceneStateProvider, sharedDependencies.EcsToCRDTWriter);
+            UIFixPbPointerEventsSystem.InjectToWorld(ref builder);
 
             finalizeWorldSystems.Add(ReleasePoolableComponentSystem<Label, UITextComponent>.InjectToWorld(ref builder, componentPoolsRegistry));
             finalizeWorldSystems.Add(ReleasePoolableComponentSystem<DCLImage, UIBackgroundComponent>.InjectToWorld(ref builder, componentPoolsRegistry));

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIFixPbPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIFixPbPointerEventsSystem.cs
@@ -1,0 +1,36 @@
+﻿using Arch.Core;
+using Arch.System;
+using Arch.SystemGroups;
+using CRDT;
+using DCL.Diagnostics;
+using DCL.ECSComponents;
+using DCL.SDKComponents.SceneUI.Systems.UITransform;
+using ECS.Abstract;
+using ECS.Groups;
+
+namespace DCL.SDKComponents.SceneUI.Systems
+{
+    [UpdateInGroup(typeof(SyncedSimulationSystemGroup))]
+    [UpdateBefore(typeof(UITransformUpdateSystem))]
+    [LogCategory(ReportCategory.SCENE_UI)]
+    public partial class UIFixPbPointerEventsSystem : BaseUnityLoopSystem
+    {
+        public UIFixPbPointerEventsSystem(World world) : base(world)
+        {
+        }
+
+        protected override void Update(float _)
+        {
+            FixPointerEventsQuery(World);
+        }
+
+        [Query]
+        private void FixPointerEvents(ref PBPointerEvents pbPointerEventsModel, ref PBUiTransform uiSdkTransformModel, ref CRDTEntity sdkEntity)
+        {
+            if (pbPointerEventsModel.IsDirty || uiSdkTransformModel.IsDirty)
+            {
+                uiSdkTransformModel.PointerFilter = PointerFilterMode.PfmBlock;
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIPointerEvents/UIPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIPointerEvents/UIPointerEventsSystem.cs
@@ -48,8 +48,6 @@ namespace DCL.SDKComponents.SceneUI.Systems.UIPointerEvents
                 uiTransformComponent.RegisterPointerCallbacks();
             }
 
-            uiTransformComponent.Transform.pickingMode = PickingMode.Position;
-
             sdkModel.IsDirty = false;
 
             if (uiTransformComponent.PointerEventTriggered == null)

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIPointerEvents/UIPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIPointerEvents/UIPointerEventsSystem.cs
@@ -45,9 +45,10 @@ namespace DCL.SDKComponents.SceneUI.Systems.UIPointerEvents
         {
             if (sdkModel.IsDirty)
             {
-                uiTransformComponent.Transform.pickingMode = PickingMode.Position;
                 uiTransformComponent.RegisterPointerCallbacks();
             }
+
+            uiTransformComponent.Transform.pickingMode = PickingMode.Position;
 
             sdkModel.IsDirty = false;
 


### PR DESCRIPTION
## What does this PR change?

Introduces a system to modify the pointer filtering as it is not enforced as part of SDK we must inject it into our system manually.

fixes #1233 
fixes #1483

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

