### PR TITLE
fix: Clicking on Equip a emote does not play it

### DIFF
--- a/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackBusController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackBusController.cs
@@ -177,7 +177,7 @@ namespace DCL.Backpack.BackpackBus
             }
 
             backpackEventBus.SendUnEquipEmote(slot, equippedEmotes.EmoteInSlot(slot));
-            backpackEventBus.SendEquipEmote(slot, emote);
+            backpackEventBus.SendEquipEmote(slot, emote, command.IsManuallyEquipped);
         }
 
         private void HandleUnEquipWearableCommand(BackpackUnEquipWearableCommand command)

--- a/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackCommand.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackCommand.cs
@@ -20,11 +20,13 @@ namespace DCL.Backpack.BackpackBus
     {
         public readonly string Id;
         public readonly int? Slot;
+        public readonly bool IsManuallyEquipped; // It will be true when the user manually equip an emote from the emotes grid
 
-        public BackpackEquipEmoteCommand(string id, int? slot = null)
+        public BackpackEquipEmoteCommand(string id, int? slot, bool isManuallyEquipped)
         {
             Id = id;
             Slot = slot;
+            IsManuallyEquipped = isManuallyEquipped;
         }
     }
 

--- a/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackEventBus.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackEventBus.cs
@@ -13,7 +13,7 @@ namespace DCL.Backpack.BackpackBus
         public event Action<IWearable>? SelectWearableEvent;
         public event Action<IWearable>? EquipWearableEvent;
         public event Action<IWearable>? UnEquipWearableEvent;
-        public event Action<int, IEmote>? EquipEmoteEvent;
+        public event Action<int, IEmote, bool>? EquipEmoteEvent;
         public event Action<int, IEmote?>? UnEquipEmoteEvent;
         public event Action<int>? EmoteSlotSelectEvent;
         public event Action<IEmote>? SelectEmoteEvent;
@@ -60,8 +60,8 @@ namespace DCL.Backpack.BackpackBus
         public void SendUnEquipEmote(int slot, IEmote? emote) =>
             UnEquipEmoteEvent?.Invoke(slot, emote);
 
-        public void SendEquipEmote(int slot, IEmote emote) =>
-            EquipEmoteEvent?.Invoke(slot, emote);
+        public void SendEquipEmote(int slot, IEmote emote, bool isManuallyEquipped) =>
+            EquipEmoteEvent?.Invoke(slot, emote, isManuallyEquipped);
 
         public void SendEmoteSelect(IEmote emote) =>
             SelectEmoteEvent?.Invoke(emote);

--- a/Explorer/Assets/DCL/Backpack/BackpackBus/IBackpackEventBus.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackBus/IBackpackEventBus.cs
@@ -13,7 +13,7 @@ namespace DCL.Backpack.BackpackBus
         public event Action<IWearable> SelectWearableEvent;
         public event Action<IWearable> EquipWearableEvent;
         public event Action<IWearable> UnEquipWearableEvent;
-        public event Action<int, IEmote> EquipEmoteEvent;
+        public event Action<int, IEmote, bool> EquipEmoteEvent;
         public event Action<int, IEmote?> UnEquipEmoteEvent;
         public event Action<int> EmoteSlotSelectEvent;
         public event Action<IEmote> SelectEmoteEvent;
@@ -45,7 +45,7 @@ namespace DCL.Backpack.BackpackBus
 
         void SendUnEquipEmote(int slot, IEmote? emote);
 
-        void SendEquipEmote(int slot, IEmote emote);
+        void SendEquipEmote(int slot, IEmote emote, bool isManuallyEquipped);
 
         public void SendEmoteSelect(IEmote emote);
 

--- a/Explorer/Assets/DCL/Backpack/BackpackController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackController.cs
@@ -185,7 +185,7 @@ namespace DCL.Backpack
             {
                 URN avatarEmote = avatar.Emotes[i];
                 if (avatarEmote.IsNullOrEmpty()) continue;
-                backpackCommandBus.SendCommand(new BackpackEquipEmoteCommand(avatarEmote.Shorten(), i));
+                backpackCommandBus.SendCommand(new BackpackEquipEmoteCommand(avatarEmote.Shorten(), i, false));
             }
 
             isAvatarLoaded = true;

--- a/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
@@ -79,7 +79,7 @@ namespace DCL.Backpack
             forceRender.Clear();
         }
 
-        private void EquipEmote(int slot, IEmote emote)
+        private void EquipEmote(int slot, IEmote emote, bool _)
         {
             equippedEmotes.EquipEmote(slot, emote);
         }

--- a/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
@@ -152,7 +152,7 @@ namespace DCL.Backpack.CharacterPreview
             OnModelUpdated();
         }
 
-        private void OnEmoteEquipped(int slot, IEmote emote)
+        private void OnEmoteEquipped(int slot, IEmote emote, bool isManuallyEquipped)
         {
             previewAvatarModel.Emotes ??= new HashSet<URN>();
 
@@ -161,6 +161,9 @@ namespace DCL.Backpack.CharacterPreview
             previewAvatarModel.Emotes.Add(urn);
 
             OnModelUpdated();
+
+            if (isManuallyEquipped)
+                PlayEmote(urn);
         }
 
         private void OnEmoteSlotSelected(int slot)

--- a/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
@@ -266,7 +266,7 @@ namespace DCL.Backpack.EmotesSection
             commandBus.SendCommand(new BackpackUnEquipEmoteCommand(itemId));
 
         private void EquipItem(string itemId) =>
-            commandBus.SendCommand(new BackpackEquipEmoteCommand(itemId));
+            commandBus.SendCommand(new BackpackEquipEmoteCommand(itemId, null, true));
 
         private void OnFilterCategory(string category)
         {
@@ -336,7 +336,7 @@ namespace DCL.Backpack.EmotesSection
             backpackItemView.EquippedSlotLabel.gameObject.SetActive(false);
         }
 
-        private void OnEquip(int slot, IEmote emote)
+        private void OnEquip(int slot, IEmote emote, bool _)
         {
             if (!usedPoolItems.TryGetValue(emote.GetUrn(), out BackpackEmoteGridItemView backpackItemView)) return;
             backpackItemView.IsEquipped = true;

--- a/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteSlotsController.cs
+++ b/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteSlotsController.cs
@@ -77,7 +77,7 @@ namespace DCL.Backpack.EmotesSection
             avatarSlotView.BackgroundRarity.enabled = false;
         }
 
-        private void EquipInSlot(int slot, IEmote emote)
+        private void EquipInSlot(int slot, IEmote emote, bool _)
         {
             EmoteSlotContainerView avatarSlotView = avatarSlots[slot].Item1;
             CancellationTokenSource cts = avatarSlots[slot].Item2;


### PR DESCRIPTION
## What does this PR change?
Fix #1164 

## How to test the changes?
1. Launch the explorer.
2. Go to the Backpack -> Emotes section.
3. Equip an emote in a slot.
4. Check that the equipped emote is played in the avatar preview.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md