### PR TITLE
Fix: disabled systems gate (temporarily)

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenUpdaterSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenUpdaterSystem.cs
@@ -92,8 +92,7 @@ namespace DCL.SDKComponents.Tween.Systems
             World.Remove<SDKTweenComponent>(in HandleEntityDestruction_QueryDescription);
             World.Remove<SDKTweenComponent>(in HandleComponentRemoval_QueryDescription);
 
-            if (openSDKTransformPriorityGate)
-                systemsPriorityComponentsGate.Open<SDKTransform>();
+            // if (openSDKTransformPriorityGate) systemsPriorityComponentsGate.Open<SDKTransform>();
         }
 
         public void FinalizeComponents(in Query query)

--- a/Explorer/Assets/Scripts/ECS/Unity/Transforms/Systems/UpdateTransformSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Transforms/Systems/UpdateTransformSystem.cs
@@ -29,9 +29,9 @@ namespace ECS.Unity.Transforms.Systems
 
         protected override void Update(float _)
         {
-            if (systemsPriorityComponentsGate.IsOpen<SDKTransform>())
-                UpdateTransformQuery(World);
-            else if (!ecsGroupThrottler.ShouldThrottle(PARENT_GROUP_TYPE, new TimeProvider.Info()))
+            // if (systemsPriorityComponentsGate.IsOpen<SDKTransform>())
+                // UpdateTransformQuery(World);
+            // else if (!ecsGroupThrottler.ShouldThrottle(PARENT_GROUP_TYPE, new TimeProvider.Info()))
                 UpdateTransformQuery(World);
         }
 


### PR DESCRIPTION
## What does this PR change?
New gate for the UpdateTransform caused issue on GPlaza carousel

- disabled systems gate, before we fix it on GPlaza carousel

## How to test the changes?

1. Launch the explorer
2. Check the carousel on GPlaza works as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

