### PR TITLE
Fix/raycast issue

### DIFF
--- a/Explorer/Assets/DCL/Audio/Systems/InteractionsAudioSystem.cs
+++ b/Explorer/Assets/DCL/Audio/Systems/InteractionsAudioSystem.cs
@@ -15,7 +15,6 @@ namespace DCL.Audio.Systems
     [UpdateBefore(typeof(WritePointerEventResultsSystem))]
     public partial class InteractionsAudioSystem : BaseUnityLoopSystem
     {
-
         private readonly IInteractionsAudioConfigs interactionsAudioConfigs;
 
         private InteractionsAudioSystem(World world, IInteractionsAudioConfigs interactionsAudioConfigs) : base(world)
@@ -28,20 +27,22 @@ namespace DCL.Audio.Systems
             PlayAudioForPointerEventsQuery(World);
         }
 
-
         [Query]
         [None(typeof(DeleteEntityIntention))]
         private void PlayAudioForPointerEvents(ref PBPointerEvents pbPointerEvents)
         {
             AppendPointerEventResultsIntent intent = pbPointerEvents.AppendPointerEventResultsIntent;
+            int count = intent.ValidIndicesCount();
 
-            foreach (byte validIndex in intent.ValidIndices)
+            for (var i = 0; i < count; i++)
             {
+                byte validIndex = intent.ValidIndexAt(i);
                 PBPointerEvents.Types.Entry entry = pbPointerEvents.PointerEvents[validIndex];
 
                 if (entry.EventType == PointerEventType.PetDown)
                 {
                     PBPointerEvents.Types.Info info = entry.EventInfo;
+
                     switch (info.Button)
                     {
                         case InputAction.IaPointer:
@@ -57,6 +58,5 @@ namespace DCL.Audio.Systems
                 }
             }
         }
-
     }
 }

--- a/Explorer/Assets/DCL/Character/CharacterCamera/Tests/UpdateCursorInputSystemShould.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Tests/UpdateCursorInputSystemShould.cs
@@ -114,8 +114,7 @@ namespace DCL.CharacterCamera.Tests
         [TestCase(CursorStyle.Normal, false)]
         public void ChangeCursorStyleWhenHoveringOverSDKInteractable(CursorStyle cursorStyle, bool isAtDistance)
         {
-            world.Set(hoverEntity, new HoverStateComponent
-                { IsAtDistance = isAtDistance, IsHoverOver = false, HasCollider = true });
+            world.Set(hoverEntity, new HoverStateComponent(isAtDistance, null, true));
 
             world.Set(entity, new CursorComponent { CursorState = CursorState.Free });
             cursor.IsLocked().Returns(false);

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/HoverFeedbackComponent.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/HoverFeedbackComponent.cs
@@ -6,7 +6,7 @@ namespace DCL.Interaction.PlayerOriginated.Components
     /// <summary>
     ///     Holds the state to show/hide the hover canvas
     /// </summary>
-    public struct HoverFeedbackComponent
+    public readonly struct HoverFeedbackComponent
     {
         public readonly struct Tooltip
         {
@@ -23,19 +23,34 @@ namespace DCL.Interaction.PlayerOriginated.Components
         /// <summary>
         ///     Whether feedback should be shown
         /// </summary>
-        public bool Enabled => Tooltips.Count > 0;
+        public bool Enabled => tooltips.Count > 0;
+
+        public IReadOnlyList<Tooltip> Tooltips => tooltips;
 
         /// <summary>
         ///     Pre-allocated array with a maximum size for tooltips
         /// </summary>
-        public readonly List<Tooltip> Tooltips;
+        private readonly List<Tooltip> tooltips;
 
-        private int activeTooltipCount;
+        public void Add(in Tooltip tooltip)
+        {
+            tooltips.Add(tooltip);
+        }
+
+        public void Remove(in Tooltip tooltip)
+        {
+            tooltips.Remove(tooltip);
+        }
+
+        public void Clear()
+        {
+            tooltips.Clear();
+        }
 
         public HoverFeedbackComponent(int tooltipsCapacity) : this()
         {
             // tolerate the allocation as this components exists in a single instance in the global world
-            Tooltips = new List<Tooltip>(tooltipsCapacity);
+            tooltips = new List<Tooltip>(tooltipsCapacity);
         }
     }
 }

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/HoverStateComponent.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/HoverStateComponent.cs
@@ -7,9 +7,29 @@ namespace DCL.Interaction.PlayerOriginated.Components
         /// <summary>
         ///     Collider that was hit last frame
         /// </summary>
-        public Collider? LastHitCollider;
+        public Collider? LastHitCollider { get; private set; }
+        public bool HasCollider { get; private set; }
+
         public bool IsAtDistance;
-        public bool IsHoverOver;
-        public bool HasCollider;
+
+        public HoverStateComponent(bool isAtDistance, Collider? lastHitCollider, bool hasCollider)
+        {
+            IsAtDistance = isAtDistance;
+            LastHitCollider = lastHitCollider;
+            HasCollider = hasCollider;
+        }
+
+        public void AssignCollider(Collider collider)
+        {
+            LastHitCollider = collider;
+            HasCollider = true;
+        }
+
+        public void Clear()
+        {
+            LastHitCollider = null;
+            IsAtDistance = false;
+            HasCollider = false;
+        }
     }
 }

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/HoverStateComponent.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/HoverStateComponent.cs
@@ -19,10 +19,11 @@ namespace DCL.Interaction.PlayerOriginated.Components
             HasCollider = hasCollider;
         }
 
-        public void AssignCollider(Collider collider)
+        public void AssignCollider(Collider collider, bool isAtDistance)
         {
             LastHitCollider = collider;
             HasCollider = true;
+            IsAtDistance = isAtDistance;
         }
 
         public void Clear()

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/PlayerOriginRaycastResultForGlobalEntities.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/PlayerOriginRaycastResultForGlobalEntities.cs
@@ -16,6 +16,8 @@ namespace DCL.Interaction.PlayerOriginated.Components
         private RaycastHit unityRaycastHit;
         private Ray originRay;
 
+        public Collider Collider => unityRaycastHit.collider;
+
         public PlayerOriginRaycastResultForGlobalEntities(RaycastHit unityRaycastHit) : this()
         {
             this.unityRaycastHit = unityRaycastHit;
@@ -45,10 +47,6 @@ namespace DCL.Interaction.PlayerOriginated.Components
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public GlobalColliderGlobalEntityInfo? GetEntityInfo() =>
             entityInfo;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Collider GetCollider() =>
-            unityRaycastHit.collider;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public RaycastHit GetRaycastHit() =>

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/PlayerOriginRaycastResultForSceneEntities.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/PlayerOriginRaycastResultForSceneEntities.cs
@@ -9,52 +9,43 @@ namespace DCL.Interaction.PlayerOriginated.Components
         /// <summary>
         ///     Collider is hit and it belongs to an entity
         /// </summary>
-        public bool IsValidHit => entityInfo.HasValue;
+        public bool IsValidHit => EntityInfo.HasValue;
 
         private float distance;
-        private GlobalColliderSceneEntityInfo? entityInfo;
-        private RaycastHit unityRaycastHit;
-        private Ray originRay;
 
-        public Collider Collider => unityRaycastHit.collider;
+        public readonly Collider Collider => RaycastHit.collider;
+
+        public RaycastHit RaycastHit { get; private set; }
+
+        public Ray OriginRay { get; private set; }
+
+        public GlobalColliderSceneEntityInfo? EntityInfo { get; private set; }
 
         public PlayerOriginRaycastResultForSceneEntities(RaycastHit unityRaycastHit) : this()
         {
-            this.unityRaycastHit = unityRaycastHit;
+            this.RaycastHit = unityRaycastHit;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Reset()
         {
-            unityRaycastHit = default(RaycastHit);
-            entityInfo = null;
+            RaycastHit = default(RaycastHit);
+            EntityInfo = null;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetRay(Ray ray)
         {
-            originRay = ray;
+            OriginRay = ray;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetupHit(RaycastHit hitInfo, GlobalColliderSceneEntityInfo sceneEntityInfo, float distance)
         {
-            unityRaycastHit = hitInfo;
-            this.entityInfo = sceneEntityInfo;
+            RaycastHit = hitInfo;
+            this.EntityInfo = sceneEntityInfo;
             this.distance = distance;
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public GlobalColliderSceneEntityInfo? GetEntityInfo() =>
-            entityInfo;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public RaycastHit GetRaycastHit() =>
-            unityRaycastHit;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Ray GetOriginRay() =>
-            originRay;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly float GetDistance() =>

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/PlayerOriginRaycastResultForSceneEntities.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Components/PlayerOriginRaycastResultForSceneEntities.cs
@@ -16,6 +16,8 @@ namespace DCL.Interaction.PlayerOriginated.Components
         private RaycastHit unityRaycastHit;
         private Ray originRay;
 
+        public Collider Collider => unityRaycastHit.collider;
+
         public PlayerOriginRaycastResultForSceneEntities(RaycastHit unityRaycastHit) : this()
         {
             this.unityRaycastHit = unityRaycastHit;
@@ -45,10 +47,6 @@ namespace DCL.Interaction.PlayerOriginated.Components
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public GlobalColliderSceneEntityInfo? GetEntityInfo() =>
             entityInfo;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Collider GetCollider() =>
-            unityRaycastHit.collider;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public RaycastHit GetRaycastHit() =>

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/InteractionInputUtilsShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/InteractionInputUtilsShould.cs
@@ -80,8 +80,8 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             resultsIntent.TryAppendHoverInput(PointerEventType.PetHoverEnter, entry, 3);
 
-            Assert.AreEqual(1, resultsIntent.ValidIndices.Length);
-            Assert.AreEqual(3, resultsIntent.ValidIndices[0]);
+            Assert.AreEqual(1, resultsIntent.ValidIndicesCount());
+            Assert.AreEqual(3, resultsIntent.ValidIndexAt(0));
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             resultsIntent.TryAppendHoverInput(PointerEventType.PetHoverEnter, entry, 3);
 
-            Assert.AreEqual(0, resultsIntent.ValidIndices.Length);
+            Assert.AreEqual(0, resultsIntent.ValidIndicesCount());
         }
 
         [Test]
@@ -123,8 +123,8 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             InteractionInputUtils.TryAppendButtonLikeInput(map, entry, 2, ref resultsIntent, new InteractionInputUtils.AnyInputInfo(true, false, false));
 
-            Assert.AreEqual(1, resultsIntent.ValidIndices.Length);
-            Assert.AreEqual(2, resultsIntent.ValidIndices[0]);
+            Assert.AreEqual(1, resultsIntent.ValidIndicesCount());
+            Assert.AreEqual(2, resultsIntent.ValidIndexAt(0));
 
             map.DidNotReceive().TryGetValue(Arg.Any<ECSComponents.InputAction>(), out Arg.Any<InputAction>());
         }
@@ -156,8 +156,8 @@ namespace DCL.Interaction.PlayerOriginated.Tests
             var resultsIntent = new AppendPointerEventResultsIntent();
             InteractionInputUtils.TryAppendButtonLikeInput(map, entry, 0, ref resultsIntent, default(InteractionInputUtils.AnyInputInfo));
 
-            Assert.AreEqual(1, resultsIntent.ValidIndices.Length);
-            Assert.AreEqual(0, resultsIntent.ValidIndices[0]);
+            Assert.AreEqual(1, resultsIntent.ValidIndicesCount());
+            Assert.AreEqual(0, resultsIntent.ValidIndexAt(0));
 
             entry = new PBPointerEvents.Types.Entry
             {
@@ -172,8 +172,8 @@ namespace DCL.Interaction.PlayerOriginated.Tests
             PressAndRelease(keyboard.bKey);
             InteractionInputUtils.TryAppendButtonLikeInput(map, entry, 1, ref resultsIntent, default(InteractionInputUtils.AnyInputInfo));
 
-            Assert.AreEqual(2, resultsIntent.ValidIndices.Length);
-            Assert.AreEqual(1, resultsIntent.ValidIndices[1]);
+            Assert.AreEqual(2, resultsIntent.ValidIndicesCount());
+            Assert.AreEqual(1, resultsIntent.ValidIndexAt(1));
         }
 
         private static (Keyboard, InputAction[]) CreateInput()

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/InteractionInputUtilsShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/InteractionInputUtilsShould.cs
@@ -78,7 +78,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
                 },
             };
 
-            InteractionInputUtils.TryAppendHoverInput(ref resultsIntent, PointerEventType.PetHoverEnter, entry, 3);
+            resultsIntent.TryAppendHoverInput(PointerEventType.PetHoverEnter, entry, 3);
 
             Assert.AreEqual(1, resultsIntent.ValidIndices.Length);
             Assert.AreEqual(3, resultsIntent.ValidIndices[0]);
@@ -99,7 +99,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
                 },
             };
 
-            InteractionInputUtils.TryAppendHoverInput(ref resultsIntent, PointerEventType.PetHoverEnter, entry, 3);
+            resultsIntent.TryAppendHoverInput(PointerEventType.PetHoverEnter, entry, 3);
 
             Assert.AreEqual(0, resultsIntent.ValidIndices.Length);
         }

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/PlayerOriginatedRaycastSystemShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/PlayerOriginatedRaycastSystemShould.cs
@@ -74,7 +74,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResultForSceneEntities raycastResultForSceneEntities = ref playerInteractionEntity.PlayerOriginRaycastResultForSceneEntities;
             Assert.That(raycastResultForSceneEntities.IsValidHit, Is.True);
-            Assert.That(raycastResultForSceneEntities.GetCollider(), Is.EqualTo(collider));
+            Assert.That(raycastResultForSceneEntities.Collider, Is.EqualTo(collider));
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResultForSceneEntities raycastResultForSceneEntities = ref playerInteractionEntity.PlayerOriginRaycastResultForSceneEntities;
             Assert.That(raycastResultForSceneEntities.IsValidHit, Is.True);
-            Assert.That(raycastResultForSceneEntities.GetCollider(), Is.EqualTo(collider));
+            Assert.That(raycastResultForSceneEntities.Collider, Is.EqualTo(collider));
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResultForSceneEntities raycastResultForSceneEntities = ref playerInteractionEntity.PlayerOriginRaycastResultForSceneEntities;
             Assert.That(raycastResultForSceneEntities.IsValidHit, Is.False);
-            Assert.That(raycastResultForSceneEntities.GetCollider(), Is.Null);
+            Assert.That(raycastResultForSceneEntities.Collider, Is.Null);
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResultForSceneEntities raycastResultForSceneEntities = ref playerInteractionEntity.PlayerOriginRaycastResultForSceneEntities;
             Assert.That(raycastResultForSceneEntities.IsValidHit, Is.False);
-            Assert.That(raycastResultForSceneEntities.GetCollider(), Is.Null);
+            Assert.That(raycastResultForSceneEntities.Collider, Is.Null);
         }
     }
 }

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/PlayerOriginatedRaycastSystemShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/PlayerOriginatedRaycastSystemShould.cs
@@ -125,7 +125,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResultForSceneEntities raycastResultForSceneEntities = ref playerInteractionEntity.PlayerOriginRaycastResultForSceneEntities;
             Assert.That(raycastResultForSceneEntities.IsValidHit, Is.False);
-            Assert.That(raycastResultForSceneEntities.GetEntityInfo(), Is.Null);
+            Assert.That(raycastResultForSceneEntities.EntityInfo, Is.Null);
         }
 
         [Test]
@@ -166,7 +166,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             ref PlayerOriginRaycastResultForSceneEntities raycastResultForSceneEntities = ref playerInteractionEntity.PlayerOriginRaycastResultForSceneEntities;
             Assert.That(raycastResultForSceneEntities.IsValidHit, Is.False);
-            Assert.That(raycastResultForSceneEntities.GetEntityInfo(), Is.Null);
+            Assert.That(raycastResultForSceneEntities.EntityInfo, Is.Null);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/ProcessPointerEventsSystemShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/ProcessPointerEventsSystemShould.cs
@@ -62,8 +62,8 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             HoverFeedbackUtils.TryIssueLeaveHoverEventForPreviousEntity(in raycastResultForSceneEntities, in previousColliderSceneInfo);
 
-            Assert.That(pbPointerEvents.AppendPointerEventResultsIntent.ValidIndices.Length, Is.EqualTo(1));
-            Assert.That(pbPointerEvents.AppendPointerEventResultsIntent.ValidIndices[0], Is.EqualTo(0));
+            Assert.That(pbPointerEvents.AppendPointerEventResultsIntent.ValidIndicesCount(), Is.EqualTo(1));
+            Assert.That(pbPointerEvents.AppendPointerEventResultsIntent.ValidIndexAt(0), Is.EqualTo(0));
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             HoverFeedbackUtils.TryIssueLeaveHoverEventForPreviousEntity(in raycastResultForSceneEntities, in previousColliderSceneInfo);
 
-            Assert.That(pbPointerEvents.AppendPointerEventResultsIntent.ValidIndices.Length, Is.EqualTo(0));
+            Assert.That(pbPointerEvents.AppendPointerEventResultsIntent.ValidIndicesCount(), Is.EqualTo(0));
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
 
             HoverFeedbackUtils.TryIssueLeaveHoverEventForPreviousEntity(in raycastResultForSceneEntities, in previousColliderSceneInfo);
 
-            Assert.That(pbPointerEvents.AppendPointerEventResultsIntent.ValidIndices.Length, Is.EqualTo(0));
+            Assert.That(pbPointerEvents.AppendPointerEventResultsIntent.ValidIndicesCount(), Is.EqualTo(0));
         }
 
         private GlobalColliderSceneEntityInfo CreateColliderInfo() =>

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/WritePointerEventResultsSystemShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/WritePointerEventResultsSystemShould.cs
@@ -109,8 +109,8 @@ namespace DCL.Interaction.PlayerOriginated.Tests
                 },
             };
 
-            sdkEvents.AppendPointerEventResultsIntent.ValidIndices.Add(1);
-            sdkEvents.AppendPointerEventResultsIntent.ValidIndices.Add(3);
+            sdkEvents.AppendPointerEventResultsIntent.AddValidIndex(1);
+            sdkEvents.AppendPointerEventResultsIntent.AddValidIndex(3);
 
             var sdkEntity = new CRDTEntity(100);
 

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/HoverFeedbackUtils.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/HoverFeedbackUtils.cs
@@ -29,7 +29,7 @@ namespace DCL.Interaction.PlayerOriginated.Utility
 
                 if (!InteractionInputUtils.IsQualifiedByDistance(raycastResultForSceneEntities, info)) continue;
 
-                InteractionInputUtils.TryAppendHoverInput(ref pbPointerEvents.AppendPointerEventResultsIntent, type, pointerEvent, i);
+                pbPointerEvents.AppendPointerEventResultsIntent.TryAppendHoverInput(type, pointerEvent, i);
             }
         }
 

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/HoverFeedbackUtils.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/HoverFeedbackUtils.cs
@@ -69,7 +69,7 @@ namespace DCL.Interaction.PlayerOriginated.Utility
             }
 
             // Add the tooltip
-            hoverFeedbackComponent.Tooltips.Add(new HoverFeedbackComponent.Tooltip(pointerEventEntry.EventInfo.HoverText, pointerEventEntry.EventInfo.Button));
+            hoverFeedbackComponent.Add(new HoverFeedbackComponent.Tooltip(pointerEventEntry.EventInfo.HoverText, pointerEventEntry.EventInfo.Button));
             return true;
         }
     }

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/InteractionInputUtils.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/InteractionInputUtils.cs
@@ -72,7 +72,7 @@ namespace DCL.Interaction.PlayerOriginated.Utility
                     return;
             }
 
-            resultsIntent.ValidIndices.Add((byte)entryIndex);
+            resultsIntent.AddValidIndex((byte)entryIndex);
         }
 
         public static void TryAppendButtonAction(IReadOnlyDictionary<DCL.ECSComponents.InputAction, InputAction> sdkInputActionsMap, ref AppendPointerEventResultsIntent resultsIntent)
@@ -91,15 +91,12 @@ namespace DCL.Interaction.PlayerOriginated.Utility
         {
             if (inputAction.WasPressedThisFrame())
             {
-                resultsIntent.ValidInputActions.Add(ecsInputAction, PointerEventType.PetDown);
+                resultsIntent.AddInputAction(ecsInputAction, PointerEventType.PetDown);
                 return;
             }
 
             if (inputAction.WasReleasedThisFrame())
-            {
-                resultsIntent.ValidInputActions.Add(ecsInputAction, PointerEventType.PetUp);
-                return;
-            }
+                resultsIntent.AddInputAction(ecsInputAction, PointerEventType.PetUp);
         }
 
         public static void PrepareDefaultValues(this PBPointerEvents.Types.Info info)

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/InteractionInputUtils.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/InteractionInputUtils.cs
@@ -75,6 +75,14 @@ namespace DCL.Interaction.PlayerOriginated.Utility
             resultsIntent.ValidIndices.Add((byte)entryIndex);
         }
 
+        public static void TryAppendButtonAction(IReadOnlyDictionary<DCL.ECSComponents.InputAction, InputAction> sdkInputActionsMap, ref AppendPointerEventResultsIntent resultsIntent)
+        {
+            foreach (var input in sdkInputActionsMap)
+
+                // Add all inputs that were pressed/unpressed this frame
+                TryAppendButtonAction(input.Value!, input.Key, ref resultsIntent);
+        }
+
         /// <summary>
         ///     Handler Pointer Up and Pointer Down, check the corresponding input action if it was upped or downed this frame
         /// </summary>

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/InteractionInputUtils.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Utility/InteractionInputUtils.cs
@@ -32,21 +32,6 @@ namespace DCL.Interaction.PlayerOriginated.Utility
             !(raycastResultForSceneEntities.GetDistance() > info.MaxDistance);
 
         /// <summary>
-        ///     Adds hover input if the entry is qualified for listening to it
-        ///     <para>
-        ///         Entry is qualified if the expected Button is "Pointer" or "Any", and event type is corresponding "HoverEnter"/"HoverExit"
-        ///     </para>
-        /// </summary>
-        public static void TryAppendHoverInput(ref AppendPointerEventResultsIntent resultsIntent, PointerEventType? hoverEventType, in PBPointerEvents.Types.Entry entry, int entryIndex)
-        {
-            if (!hoverEventType.HasValue) return;
-
-            if (entry.EventType == hoverEventType.Value
-                && (entry.EventInfo.Button == ECSComponents.InputAction.IaPointer || entry.EventInfo.Button == ECSComponents.InputAction.IaAny))
-                resultsIntent.ValidIndices.Add((byte)entryIndex);
-        }
-
-        /// <summary>
         ///     Handler Pointer Up and Pointer Down, check the corresponding input action if it was upped or downed this frame
         /// </summary>
         public static void TryAppendButtonLikeInput(IReadOnlyDictionary<ECSComponents.InputAction, InputAction> sdkInputActionsMap,
@@ -108,7 +93,6 @@ namespace DCL.Interaction.PlayerOriginated.Utility
                 return;
             }
         }
-
 
         public static void PrepareDefaultValues(this PBPointerEvents.Types.Info info)
         {

--- a/Explorer/Assets/DCL/Interaction/Raycast/Components/HighlightComponent.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Components/HighlightComponent.cs
@@ -21,6 +21,14 @@ namespace DCL.Interaction.Raycast.Components
             this.nextEntity = nextEntity;
         }
 
+        public static HighlightComponent NewEntityHighlightComponent(bool isAtDistance, EntityReference entityRef) =>
+            new (
+                true,
+                isAtDistance,
+                entityRef,
+                entityRef
+            );
+
         public void Setup(bool atDistance, EntityReference newNextEntity)
         {
             isEnabled = true;

--- a/Explorer/Assets/DCL/Interaction/Raycast/Systems/InitializeRaycastSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Systems/InitializeRaycastSystem.cs
@@ -4,7 +4,6 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.Throttling;
 using DCL.ECSComponents;
 using DCL.Interaction.Raycast.Components;
-using DCL.Optimization.Pools;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
 using ECS.Unity.Transforms.Components;
@@ -15,19 +14,14 @@ namespace DCL.Interaction.Raycast.Systems
     [ThrottlingEnabled] // as we react on Scene Changes
     public partial class InitializeRaycastSystem : BaseUnityLoopSystem
     {
-        private readonly IComponentPool<PBRaycastResult> raycastComponentPool;
-
-        internal InitializeRaycastSystem(World world,
-            IComponentPool<PBRaycastResult> raycastComponentPool
-        ) : base(world)
+        internal InitializeRaycastSystem(World world) : base(world)
         {
-            this.raycastComponentPool = raycastComponentPool;
         }
 
         protected override void Update(float t)
         {
-            HandleChangedComponentQuery(World);
-            HandleNewComponentQuery(World);
+            HandleChangedComponentQuery(World!);
+            HandleNewComponentQuery(World!);
         }
 
         [Query]
@@ -36,7 +30,7 @@ namespace DCL.Interaction.Raycast.Systems
         private void HandleNewComponent(in Entity entity)
         {
             var comp = new RaycastComponent();
-            World.Add(entity, comp);
+            World!.Add(entity, comp);
         }
 
         [Query]

--- a/Explorer/Assets/DCL/Interaction/Raycast/Tests/InitializeRaycastSystemShould.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Tests/InitializeRaycastSystemShould.cs
@@ -2,9 +2,7 @@
 using DCL.ECSComponents;
 using DCL.Interaction.Raycast.Components;
 using DCL.Interaction.Raycast.Systems;
-using DCL.Optimization.Pools;
 using ECS.TestSuite;
-using NSubstitute;
 using NUnit.Framework;
 
 namespace DCL.Interaction.Raycast.Tests
@@ -14,32 +12,30 @@ namespace DCL.Interaction.Raycast.Tests
         [SetUp]
         public void Setup()
         {
-            IComponentPool<PBRaycastResult> pbRaycastResultPool = Substitute.For<IComponentPool<PBRaycastResult>>();
-
-            system = new InitializeRaycastSystem(world, pbRaycastResultPool);
+            system = new InitializeRaycastSystem(world!);
         }
 
         [Test]
         public void AddRaycastComponent()
         {
-            Entity e = world.Create(new PBRaycast());
+            Entity e = world!.Create(new PBRaycast());
             AddTransformToEntity(e);
 
-            system.Update(0);
+            system!.Update(0);
 
-            Assert.That(world.TryGet(e, out RaycastComponent raycastComponent), Is.True);
+            Assert.That(world!.TryGet(e, out RaycastComponent raycastComponent), Is.True);
             Assert.That(raycastComponent.Executed, Is.False);
         }
 
         [Test]
         public void RelaunchIfChangedToContinuous()
         {
-            Entity e = world.Create(new PBRaycast { Continuous = true, IsDirty = true }, new RaycastComponent { Executed = true });
+            Entity e = world!.Create(new PBRaycast { Continuous = true, IsDirty = true }, new RaycastComponent { Executed = true });
             AddTransformToEntity(e);
 
-            system.Update(0);
+            system!.Update(0);
 
-            Assert.That(world.Get<RaycastComponent>(e).Executed, Is.False);
+            Assert.That(world!.Get<RaycastComponent>(e).Executed, Is.False);
         }
     }
 }

--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessOtherAvatarsInteractionSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessOtherAvatarsInteractionSystem.cs
@@ -71,10 +71,7 @@ namespace DCL.Interaction.Systems
                 return;
 
             currentProfileHovered = profile;
-
-            hoverStateComponent.AssignCollider(raycastResultForGlobalEntities.Collider);
-            hoverStateComponent.IsAtDistance = true;
-
+            hoverStateComponent.AssignCollider(raycastResultForGlobalEntities.Collider, isAtDistance: true);
             hoverFeedbackComponent.Add(viewProfileTooltip);
         }
 

--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessOtherAvatarsInteractionSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessOtherAvatarsInteractionSystem.cs
@@ -39,7 +39,7 @@ namespace DCL.Interaction.Systems
             this.dclInput = dclInput;
             this.mvcManager = mvcManager;
 
-            dclInput.Player.Pointer.performed += OpenPassport;
+            dclInput.Player.Pointer!.performed += OpenPassport;
         }
 
         protected override void Update(float t)
@@ -49,7 +49,7 @@ namespace DCL.Interaction.Systems
 
         public override void Dispose()
         {
-            dclInput.Player.Pointer.performed -= OpenPassport;
+            dclInput.Player.Pointer!.performed -= OpenPassport;
             base.Dispose();
         }
 
@@ -57,7 +57,7 @@ namespace DCL.Interaction.Systems
         private void ProcessRaycastResult(ref PlayerOriginRaycastResultForGlobalEntities raycastResultForGlobalEntities, ref HoverFeedbackComponent hoverFeedbackComponent, ref HoverStateComponent hoverStateComponent)
         {
             currentProfileHovered = null;
-            hoverFeedbackComponent.Tooltips.Remove(viewProfileTooltip);
+            hoverFeedbackComponent.Remove(viewProfileTooltip);
 
             bool canHover = !eventSystem.IsPointerOverGameObject();
             GlobalColliderGlobalEntityInfo? entityInfo = raycastResultForGlobalEntities.GetEntityInfo();
@@ -67,7 +67,7 @@ namespace DCL.Interaction.Systems
 
             EntityReference entityRef = entityInfo.Value.EntityReference;
 
-            if (!entityRef.IsAlive(World) || !World.TryGet(entityRef, out Profile? profile))
+            if (!entityRef.IsAlive(World!) || !World!.TryGet(entityRef, out Profile? profile))
                 return;
 
             currentProfileHovered = profile;
@@ -76,12 +76,12 @@ namespace DCL.Interaction.Systems
             hoverStateComponent.HasCollider = true;
             hoverStateComponent.IsAtDistance = true;
 
-            hoverFeedbackComponent.Tooltips.Add(viewProfileTooltip);
+            hoverFeedbackComponent.Add(viewProfileTooltip);
         }
 
         private void OpenPassport(UnityEngine.InputSystem.InputAction.CallbackContext context)
         {
-            if (context.control.IsPressed() || currentProfileHovered == null)
+            if (context.control!.IsPressed() || currentProfileHovered == null)
                 return;
 
             string userId = currentProfileHovered.UserId;

--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessOtherAvatarsInteractionSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessOtherAvatarsInteractionSystem.cs
@@ -72,8 +72,7 @@ namespace DCL.Interaction.Systems
 
             currentProfileHovered = profile;
 
-            hoverStateComponent.LastHitCollider = raycastResultForGlobalEntities.GetCollider();
-            hoverStateComponent.HasCollider = true;
+            hoverStateComponent.AssignCollider(raycastResultForGlobalEntities.Collider);
             hoverStateComponent.IsAtDistance = true;
 
             hoverFeedbackComponent.Add(viewProfileTooltip);

--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
@@ -72,8 +72,7 @@ namespace DCL.Interaction.Systems
                 if (candidateForHoverLeaveIsValid && newEntityWasHovered == false)
                     candidateForHoverLeaveIsValid = false;
 
-                pbPointerEvents!.AppendPointerEventResultsIntent.Initialize(raycastResultForSceneEntities.RaycastHit, raycastResultForSceneEntities.OriginRay);
-                bool isAtDistance = SetupPointerEvents(raycastResultForSceneEntities, ref hoverFeedbackComponent, pbPointerEvents, newEntityWasHovered);
+                bool isAtDistance = SetupPointerEvents(raycastResultForSceneEntities, ref hoverFeedbackComponent, pbPointerEvents!, newEntityWasHovered);
                 hoverStateComponent.AssignCollider(raycastResultForSceneEntities.Collider, isAtDistance);
                 HighlightNewEntity(entityInfo, isAtDistance);
             }
@@ -141,6 +140,7 @@ namespace DCL.Interaction.Systems
         {
             var isAtDistance = false;
             var anyInputInfo = sdkInputActionsMap.Values.GatherAnyInputInfo();
+            pbPointerEvents.AppendPointerEventResultsIntent.Initialize(raycastResultForSceneEntities.RaycastHit, raycastResultForSceneEntities.OriginRay);
 
             for (var i = 0; i < pbPointerEvents.PointerEvents!.Count; i++)
             {

--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
@@ -73,8 +73,7 @@ namespace DCL.Interaction.Systems
                     candidateForHoverLeaveIsValid = false;
 
                 pbPointerEvents!.AppendPointerEventResultsIntent.Initialize(raycastResultForSceneEntities.RaycastHit, raycastResultForSceneEntities.OriginRay);
-                var anyInputInfo = sdkInputActionsMap.Values.GatherAnyInputInfo();
-                bool isAtDistance = SetupPointerEvents(raycastResultForSceneEntities, ref hoverFeedbackComponent, pbPointerEvents, anyInputInfo, newEntityWasHovered);
+                bool isAtDistance = SetupPointerEvents(raycastResultForSceneEntities, ref hoverFeedbackComponent, pbPointerEvents, newEntityWasHovered);
                 hoverStateComponent.AssignCollider(raycastResultForSceneEntities.Collider, isAtDistance);
                 HighlightNewEntity(entityInfo, isAtDistance);
             }
@@ -137,11 +136,11 @@ namespace DCL.Interaction.Systems
             in PlayerOriginRaycastResultForSceneEntities raycastResultForSceneEntities,
             ref HoverFeedbackComponent hoverFeedbackComponent,
             PBPointerEvents pbPointerEvents,
-            InteractionInputUtils.AnyInputInfo anyInputInfo,
             bool newEntityWasHovered
         )
         {
             var isAtDistance = false;
+            var anyInputInfo = sdkInputActionsMap.Values.GatherAnyInputInfo();
 
             for (var i = 0; i < pbPointerEvents.PointerEvents!.Count; i++)
             {

--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
@@ -66,8 +66,6 @@ namespace DCL.Interaction.Systems
             // Entity should be alive and contain PBPointerEvents component to be qualified for highlighting
             if (IsPointingOnEntity(in raycastResultForSceneEntities, out var entityInfo) && entityInfo.TryGetPointerEvents(out PBPointerEvents? pbPointerEvents))
             {
-                InteractionInputUtils.AnyInputInfo anyInputInfo = sdkInputActionsMap.Values.GatherAnyInputInfo();
-
                 bool newEntityWasHovered = NewEntityWasHovered(candidateForHoverLeaveIsValid, previousEntityInfo, entityInfo);
 
                 // Signal to stop issuing hover leave event for the previous entity as it's equal to the current one
@@ -75,6 +73,7 @@ namespace DCL.Interaction.Systems
                     candidateForHoverLeaveIsValid = false;
 
                 pbPointerEvents!.AppendPointerEventResultsIntent.Initialize(raycastResultForSceneEntities.RaycastHit, raycastResultForSceneEntities.OriginRay);
+                var anyInputInfo = sdkInputActionsMap.Values.GatherAnyInputInfo();
                 bool isAtDistance = SetupPointerEvents(raycastResultForSceneEntities, ref hoverFeedbackComponent, pbPointerEvents, anyInputInfo, newEntityWasHovered);
                 hoverStateComponent.AssignCollider(raycastResultForSceneEntities.Collider, isAtDistance);
                 HighlightNewEntity(entityInfo, isAtDistance);
@@ -144,10 +143,10 @@ namespace DCL.Interaction.Systems
         {
             var isAtDistance = false;
 
-            for (var i = 0; i < pbPointerEvents.PointerEvents.Count; i++)
+            for (var i = 0; i < pbPointerEvents.PointerEvents!.Count; i++)
             {
-                PBPointerEvents.Types.Entry pointerEvent = pbPointerEvents.PointerEvents[i];
-                PBPointerEvents.Types.Info info = pointerEvent.EventInfo;
+                PBPointerEvents.Types.Entry pointerEvent = pbPointerEvents.PointerEvents[i]!;
+                PBPointerEvents.Types.Info info = pointerEvent.EventInfo!;
 
                 info.PrepareDefaultValues();
 
@@ -156,7 +155,7 @@ namespace DCL.Interaction.Systems
 
                 // Try Append Hover Input
                 if (newEntityWasHovered)
-                    InteractionInputUtils.TryAppendHoverInput(ref pbPointerEvents.AppendPointerEventResultsIntent, PointerEventType.PetHoverEnter, pointerEvent, i);
+                    pbPointerEvents.AppendPointerEventResultsIntent.TryAppendHoverInput(PointerEventType.PetHoverEnter, pointerEvent, i);
 
                 // Try Append Hover Feedback
                 HoverFeedbackUtils.TryAppendHoverFeedback(sdkInputActionsMap, pointerEvent,
@@ -168,7 +167,7 @@ namespace DCL.Interaction.Systems
             foreach (var input in sdkInputActionsMap)
 
                 // Add all inputs that were pressed/unpressed this frame
-                InteractionInputUtils.TryAppendButtonAction(input.Value, input.Key, ref pbPointerEvents.AppendPointerEventResultsIntent);
+                InteractionInputUtils.TryAppendButtonAction(input.Value!, input.Key, ref pbPointerEvents.AppendPointerEventResultsIntent);
 
             return isAtDistance;
         }

--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
@@ -163,10 +163,8 @@ namespace DCL.Interaction.Systems
 
             if (!isAtDistance) return false;
 
-            foreach (var input in sdkInputActionsMap)
-
-                // Add all inputs that were pressed/unpressed this frame
-                InteractionInputUtils.TryAppendButtonAction(input.Value!, input.Key, ref pbPointerEvents.AppendPointerEventResultsIntent);
+            // Add all inputs that were pressed/unpressed this frame
+            InteractionInputUtils.TryAppendButtonAction(sdkInputActionsMap, ref pbPointerEvents.AppendPointerEventResultsIntent);
 
             return isAtDistance;
         }

--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
@@ -58,7 +58,7 @@ namespace DCL.Interaction.Systems
         private void ProcessRaycastResult(ref PlayerOriginRaycastResultForSceneEntities raycastResultForSceneEntities, ref HoverFeedbackComponent hoverFeedbackComponent, ref HoverStateComponent hoverStateComponent)
         {
             // Process all PBPointerEvents components to see if any of them is qualified
-            hoverFeedbackComponent.Tooltips.Clear();
+            hoverFeedbackComponent.Clear();
 
             bool candidateForHoverLeaveIsValid = TryGetPreviousEntityInfo(in hoverStateComponent, out GlobalColliderSceneEntityInfo previousEntityInfo);
             hoverStateComponent.LastHitCollider = null;

--- a/Explorer/Assets/DCL/Interaction/Utility/RaycastUtils.cs
+++ b/Explorer/Assets/DCL/Interaction/Utility/RaycastUtils.cs
@@ -68,6 +68,11 @@ namespace DCL.Interaction.Utility
             return true;
         }
 
+        public static void FillSDKRaycastHit(this RaycastHit target, Vector3 sceneRootPosition, AppendPointerEventResultsIntent intent, CRDTEntity crdtEntity)
+        {
+            target.FillSDKRaycastHit(sceneRootPosition, intent.RaycastHit, string.Empty, crdtEntity, intent.Ray.origin, intent.Ray.direction);
+        }
+
         public static void FillSDKRaycastHit(this RaycastHit target, Vector3 sceneRootPosition, in UnityEngine.RaycastHit unityHit, string colliderName, CRDTEntity crdtEntity,
             Vector3 globalOrigin,
             Vector3 direction)

--- a/Explorer/Assets/DCL/PluginSystem/World/InteractionPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/InteractionPlugin.cs
@@ -56,7 +56,7 @@ namespace DCL.PluginSystem.World
         {
             IComponentPool<PBRaycastResult>? raycastResultPool = sharedDependencies.ComponentPoolsRegistry.GetReferenceTypePool<PBRaycastResult>();
 
-            InitializeRaycastSystem.InjectToWorld(ref builder, raycastResultPool);
+            InitializeRaycastSystem.InjectToWorld(ref builder);
 
             sceneIsCurrentListeners.Add(
             ExecuteRaycastSystem.InjectToWorld(ref builder, sceneDeps.SceneData, raycastBudget, settings.RaycastBucketThreshold,

--- a/Explorer/Assets/DCL/PluginSystem/World/InteractionPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/InteractionPlugin.cs
@@ -10,6 +10,7 @@ using DCL.Optimization.PerformanceBudgeting;
 using DCL.Optimization.Pools;
 using DCL.PluginSystem.World.Dependencies;
 using DCL.Profiling;
+using DCL.Utilities.Extensions;
 using ECS.LifeCycle;
 using System;
 using System.Collections.Generic;
@@ -29,9 +30,9 @@ namespace DCL.PluginSystem.World
         private readonly IComponentPoolsRegistry poolsRegistry;
         private readonly IAssetsProvisioner assetsProvisioner;
 
-        private IReleasablePerformanceBudget raycastBudget;
-        private Settings settings;
-        private InteractionSettingsData interactionData;
+        private IReleasablePerformanceBudget raycastBudget = null!;
+        private Settings settings = null!;
+        private InteractionSettingsData interactionData = null!;
 
         public InteractionPlugin(ECSWorldSingletonSharedDependencies sharedDependencies, IProfilingProvider profilingProvider, IGlobalInputEvents globalInputEvents, IComponentPoolsRegistry poolsRegistry, IAssetsProvisioner assetsProvisioner)
         {
@@ -54,25 +55,36 @@ namespace DCL.PluginSystem.World
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in ECSWorldInstanceSharedDependencies sceneDeps,
             in PersistentEntities persistentEntities, List<IFinalizeWorldSystem> finalizeWorldSystems, List<ISceneIsCurrentListener> sceneIsCurrentListeners)
         {
-            IComponentPool<PBRaycastResult>? raycastResultPool = sharedDependencies.ComponentPoolsRegistry.GetReferenceTypePool<PBRaycastResult>();
+            IComponentPool<PBRaycastResult> raycastResultPool = sharedDependencies
+                                                               .ComponentPoolsRegistry
+                                                               .GetReferenceTypePool<PBRaycastResult>()
+                                                               .EnsureNotNull();
 
             InitializeRaycastSystem.InjectToWorld(ref builder);
 
             sceneIsCurrentListeners.Add(
-            ExecuteRaycastSystem.InjectToWorld(ref builder, sceneDeps.SceneData, raycastBudget, settings.RaycastBucketThreshold,
-                sharedDependencies.ComponentPoolsRegistry.GetReferenceTypePool<RaycastHit>(),
-                raycastResultPool,
-                sceneDeps.EntityCollidersSceneCache,
-                sceneDeps.EntitiesMap,
-                sceneDeps.EcsToCRDTWriter,
-                sceneDeps.SceneStateProvider)
+                ExecuteRaycastSystem.InjectToWorld(
+                    ref builder,
+                    sceneDeps.SceneData,
+                    raycastBudget,
+                    settings.RaycastBucketThreshold,
+                    sharedDependencies.ComponentPoolsRegistry.GetReferenceTypePool<RaycastHit>(),
+                    raycastResultPool,
+                    sceneDeps.EntityCollidersSceneCache,
+                    sceneDeps.EntitiesMap,
+                    sceneDeps.EcsToCRDTWriter,
+                    sceneDeps.SceneStateProvider
+                )
             );
 
-            WritePointerEventResultsSystem.InjectToWorld(ref builder, sceneDeps.SceneData,
+            WritePointerEventResultsSystem.InjectToWorld(
+                ref builder,
+                sceneDeps.SceneData,
                 sceneDeps.EcsToCRDTWriter,
                 sceneDeps.SceneStateProvider,
                 globalInputEvents,
-                poolsRegistry.GetReferenceTypePool<RaycastHit>());
+                poolsRegistry.GetReferenceTypePool<RaycastHit>()
+            );
 
             sceneIsCurrentListeners.Add(InteractionHighlightSystem.InjectToWorld(ref builder, interactionData,
                 sceneDeps.SceneStateProvider));

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/Components/ResetExtensions/PrimitivesInitializationExtensions.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/Components/ResetExtensions/PrimitivesInitializationExtensions.cs
@@ -1,5 +1,4 @@
 using Decentraland.Common;
-using System.Diagnostics.CodeAnalysis;
 
 namespace CrdtEcsBridge.Components.ResetExtensions
 {
@@ -11,7 +10,7 @@ namespace CrdtEcsBridge.Components.ResetExtensions
         public static void Reset(this Vector3 protoVector) =>
             protoVector.Set(UnityEngine.Vector3.zero);
 
-        public static void Set([NotNull] this Vector3 protoVector, UnityEngine.Vector3 unityVector)
+        public static void Set(this Vector3 protoVector, UnityEngine.Vector3 unityVector)
         {
             protoVector.X = unityVector.x;
             protoVector.Y = unityVector.y;

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/csc.rsp
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/csc.rsp.meta
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/csc.rsp.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1637982e75f042f09b254c8da52004fe
+timeCreated: 1721817261

--- a/Explorer/Assets/Scripts/ECS/Unity/CollidersUtility/GlobalColliderSceneEntityInfo.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/CollidersUtility/GlobalColliderSceneEntityInfo.cs
@@ -1,4 +1,7 @@
+using Arch.Core;
+using DCL.ECSComponents;
 using SceneRunner.Scene;
+using System.Diagnostics.Contracts;
 
 namespace DCL.Interaction.Utility
 {
@@ -14,6 +17,15 @@ namespace DCL.Interaction.Utility
         {
             EcsExecutor = ecsExecutor;
             ColliderSceneEntityInfo = colliderSceneEntityInfo;
+        }
+
+        [Pure]
+        public bool TryGetPointerEvents(out PBPointerEvents? pbPointerEvents)
+        {
+            World world = EcsExecutor.World;
+            EntityReference entityRef = ColliderSceneEntityInfo.EntityReference;
+            pbPointerEvents = null;
+            return entityRef.IsAlive(world) && world.TryGet(entityRef, out pbPointerEvents);
         }
     }
 }

--- a/Explorer/Assets/Scripts/ECS/Unity/CollidersUtility/GlobalColliderSceneEntityInfo.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/CollidersUtility/GlobalColliderSceneEntityInfo.cs
@@ -27,5 +27,9 @@ namespace DCL.Interaction.Utility
             pbPointerEvents = null;
             return entityRef.IsAlive(world) && world.TryGet(entityRef, out pbPointerEvents);
         }
+
+        public bool IsSameEntity(in GlobalColliderSceneEntityInfo other) =>
+            EcsExecutor.World == other.EcsExecutor.World
+            && ColliderSceneEntityInfo.EntityReference == other.ColliderSceneEntityInfo.EntityReference;
     }
 }

--- a/Explorer/Assets/Scripts/ProtobufPartialClasses/AppendPointerEventResultsIntent.cs
+++ b/Explorer/Assets/Scripts/ProtobufPartialClasses/AppendPointerEventResultsIntent.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Unity.Collections;
 using UnityEngine;
 
 namespace DCL.ECSComponents
@@ -25,40 +24,49 @@ namespace DCL.ECSComponents
         ///     <para>
         ///         The number of valid entries is limited to 64 elements (it's unlikely to be exceeded)
         ///     </para>
+        ///     <para>
+        ///         replaced to list because there was a bug with the fixed buffer
+        ///     </para>
         /// </summary>
-        private FixedList64Bytes<byte> validIndices;
+        private List<byte> validIndices;
 
         private Dictionary<InputAction, PointerEventType> validInputActions;
 
-        public void Initialize(UnityEngine.RaycastHit raycastHit, Ray ray)
+        public void Initialize()
         {
-            RaycastHit = raycastHit;
-            Ray = ray;
-            validIndices.Clear();
+            if (validIndices == null) validIndices = new List<byte>(64);
+            else validIndices.Clear();
 
             if (validInputActions == null) validInputActions = new ();
             else validInputActions.Clear();
         }
 
+        public void Initialize(UnityEngine.RaycastHit raycastHit, Ray ray)
+        {
+            RaycastHit = raycastHit;
+            Ray = ray;
+            Initialize();
+        }
+
         public void AddValidIndex(byte index)
         {
-            validIndices.Add(index);
+            validIndices!.Add(index);
         }
 
         public readonly byte ValidIndexAt(int at) =>
-            validIndices[at];
+            validIndices![at];
 
         public readonly int ValidIndicesCount() =>
-            validIndices.Length;
+            validIndices?.Count ?? 0;
 
         public void AddInputAction(InputAction ecsInputAction, PointerEventType pointerEventType)
         {
-            validInputActions.Add(ecsInputAction, pointerEventType);
+            validInputActions!.Add(ecsInputAction, pointerEventType);
         }
 
         public void Clear()
         {
-            validIndices.Clear();
+            validIndices?.Clear();
             validInputActions?.Clear();
         }
 

--- a/Explorer/Assets/Scripts/ProtobufPartialClasses/AppendPointerEventResultsIntent.cs
+++ b/Explorer/Assets/Scripts/ProtobufPartialClasses/AppendPointerEventResultsIntent.cs
@@ -33,8 +33,25 @@ namespace DCL.ECSComponents
             RaycastHit = raycastHit;
             Ray = ray;
             ValidIndices.Clear();
+
             if (ValidInputActions == null) ValidInputActions = new ();
             else ValidInputActions.Clear();
+        }
+
+        /// <summary>
+        ///     Adds hover input if the entry is qualified for listening to it
+        ///     <para>
+        ///         Entry is qualified if the expected Button is "Pointer" or "Any", and event type is corresponding "HoverEnter"/"HoverExit"
+        ///     </para>
+        /// </summary>
+        public void TryAppendHoverInput(PointerEventType? hoverEventType, in PBPointerEvents.Types.Entry entry, int entryIndex)
+        {
+            if (!hoverEventType.HasValue) return;
+
+            if (entry.EventType == hoverEventType.Value
+                && entry.EventInfo.Button is InputAction.IaPointer or InputAction.IaAny
+               )
+                ValidIndices.Add((byte)entryIndex);
         }
     }
 

--- a/Explorer/Assets/Scripts/ProtobufPartialClasses/csc.rsp
+++ b/Explorer/Assets/Scripts/ProtobufPartialClasses/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable

--- a/Explorer/Assets/Scripts/ProtobufPartialClasses/csc.rsp.meta
+++ b/Explorer/Assets/Scripts/ProtobufPartialClasses/csc.rsp.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d9f69180f03c406c97a2d7804fc34297
+timeCreated: 1721832412


### PR DESCRIPTION
## What does this PR change?

Fixes hover event propagation to Js side

- Refactor and decomposition of ProcessPointerEventsSystem for easy understanding
- GlobalColliderSceneEntityInfo comparing IsSameEntity Method
- AppendPointerEventResultsIntent encapsulation and FixedList64 is replaced to ordinary List due Unity's internal bug on cleaning. Sometimes it just won't work and it causes infinity sending of events that are not currently pressed 

## How to test the changes?

1. Follow the ticket https://github.com/decentraland/unity-explorer/issues/1505

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

