### PR TITLE
fix: avoid stacking trigger if the animation is playing

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/Animator/Systems/AnimationPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Animator/Systems/AnimationPlayerSystem.cs
@@ -124,7 +124,17 @@ namespace DCL.SDKComponents.Animator.Systems
                 if (sdkAnimationState.Playing)
                 {
                     animator.SetLayerWeight(layerIndex, sdkAnimationState.Weight);
-                    animator.SetTrigger($"{name}_Trigger");
+
+                    bool isAnimationAlreadyPlaying = animator.GetCurrentAnimatorStateInfo(layerIndex).IsName(name);
+
+                    // This check fixes a border case that happens on sdk-goerli-plaza pirate island (78,7) with opening the chest the first time.
+                    // The AB converter sets the first clip in the animator to play as default, since it is required by the sdk definitions.
+                    // The scene first asks to play another clip (not the default one).
+                    // Eventually the scene finally decides to play the default clip, but it was already playing since it was never modified.
+                    // So the trigger gets enabled and makes the execution play twice (after it finishes), although is set to loop:false
+                    // The fix consists on avoid triggering the animation if it is already playing, to avoid stacking the trigger.
+                    if (!isAnimationAlreadyPlaying)
+                        animator.SetTrigger($"{name}_Trigger");
 
                     // Animators don't support speed by state, just a global speed
                     animator.speed = sdkAnimationState.Speed;


### PR DESCRIPTION
## What does this PR change?

Fixes #1465 

The AB converter sets the first clip in the animator to play as default, since it is required by the sdk definitions. The scene first asks to play another clip (not the default one). Eventually the scene finally decides to play the default clip, but it was already playing since it was never modified. So the trigger gets enabled and makes the execution play twice (after it finishes), although is set to loop:false
The fix consists on avoid triggering the animation if it is already playing, to avoid stacking the trigger.

## How to test the changes?

1. Follow issue steps
2. The chest should play the open animation only once
3. Its worth to also check that other scenes keep working:

sliding-doors (79,-9)
manDancing (76,-3)
skeleton-king (74,-9)
zombie-chaser (78,-1)
shark (73,-8)
birds-tree (76,-9)
scene-emotes-green-tiles (77,-7)
swap-avatar (75,-7)
swap-avatar-advanced (76,-7)
avatar-emotes (80,-1)
black-dogs (72,-9)
doge (80,-3)
metadyne (metadynelabs.dcl.eth)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

