### PR TITLE
FIx: goerli droid not moving after first cycle

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweener.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweener.cs
@@ -15,9 +15,9 @@ namespace DCL.SDKComponents.Tween.Components
         protected T CurrentValue;
         protected TweenerCore<T, T, TU> core;
         protected abstract TweenerCore<T, T, TU> CreateTweener(T start, T end, float duration);
-        protected abstract (T, T) GetTweenValues(PBTween pbTween, Transform startTransform);
+        protected abstract (T, T) GetTweenValues(PBTween pbTween, SDKTransform sdkTransform, Transform startTransform);
         public abstract void SetResult(ref SDKTransform sdkTransform);
-        
+
         public void Play()
         {
             core.Play();
@@ -53,13 +53,12 @@ namespace DCL.SDKComponents.Tween.Components
             core.SetEase(ease).SetAutoKill(false).OnComplete(() => { Finished = true; }).Goto(tweenModelCurrentTime, isPlaying);
         }
 
-        public void Initialize(PBTween pbTween, Transform startTransform, float durationInSeconds)
+        public void Initialize(PBTween pbTween, SDKTransform sdkTransform, Transform startTransform, float durationInSeconds)
         {
             core?.Kill();
             Finished = false;
-            var tweenValues = GetTweenValues(pbTween, startTransform);
+            var tweenValues = GetTweenValues(pbTween, sdkTransform, startTransform);
             core = CreateTweener(tweenValues.Item1, tweenValues.Item2, durationInSeconds);
         }
-
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweenerImpl.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweenerImpl.cs
@@ -1,5 +1,4 @@
-﻿using CommunityToolkit.HighPerformance.Helpers;
-using CrdtEcsBridge.Components.Conversion;
+﻿using CrdtEcsBridge.Components.Conversion;
 using CrdtEcsBridge.Components.Transform;
 using DCL.ECSComponents;
 using DG.Tweening;
@@ -10,23 +9,25 @@ using UnityEngine;
 
 namespace DCL.SDKComponents.Tween.Components
 {
-
-    public abstract class Vector3Tweener : CustomTweener<Vector3, VectorOptions>
+    public class PositionTweener : CustomTweener<Vector3, VectorOptions>
     {
+        private Vector3 startScale;
+        private Quaternion startRotation;
+
         protected override TweenerCore<Vector3, Vector3, VectorOptions> CreateTweener(Vector3 start, Vector3 end, float duration)
         {
             return DOTween.To(() => CurrentValue, x => CurrentValue = x, end, duration);
         }
-    } 
-    
-    
-    public class PositionTweener : Vector3Tweener
-    {
-        protected override (Vector3, Vector3) GetTweenValues(PBTween pbTween, Transform startTransform)
+
+        protected override (Vector3, Vector3) GetTweenValues(PBTween pbTween, SDKTransform sdkTransform, Transform startTransform)
         {
-            var start = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Move.Start);
-            var end = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Move.End);
+            startScale = startTransform.localScale;
+            startRotation = startTransform.localRotation;
+
+            Vector3 start = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Move.Start);
+            Vector3 end = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Move.End);
             startTransform.localPosition = start;
+
             CurrentValue = start;
             return (start, end);
         }
@@ -34,15 +35,29 @@ namespace DCL.SDKComponents.Tween.Components
         public override void SetResult(ref SDKTransform sdkTransform)
         {
             sdkTransform.Position = CurrentValue;
+
+            sdkTransform.Rotation = startRotation;
+            sdkTransform.Scale = startScale;
         }
     }
 
-    public class ScaleTweener : Vector3Tweener
+    public class ScaleTweener : CustomTweener<Vector3, VectorOptions>
     {
-        protected override (Vector3, Vector3) GetTweenValues(PBTween pbTween, Transform startTransform)
+        private Vector3 startPosition;
+        private Quaternion startRotation;
+
+        protected override TweenerCore<Vector3, Vector3, VectorOptions> CreateTweener(Vector3 start, Vector3 end, float duration)
         {
-            var start = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Scale.Start);
-            var end = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Scale.End);
+            return DOTween.To(() => CurrentValue, x => CurrentValue = x, end, duration);
+        }
+
+        protected override (Vector3, Vector3) GetTweenValues(PBTween pbTween, SDKTransform sdkTransform, Transform startTransform)
+        {
+            startPosition = startTransform.localPosition;
+            startRotation = startTransform.localRotation;
+
+            Vector3 start = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Scale.Start);
+            Vector3 end = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Scale.End);
             startTransform.localScale = start;
             CurrentValue = start;
             return (start, end);
@@ -51,18 +66,30 @@ namespace DCL.SDKComponents.Tween.Components
         public override void SetResult(ref SDKTransform sdkTransform)
         {
             sdkTransform.Scale = CurrentValue;
-        }
 
-        protected override TweenerCore<Vector3, Vector3, VectorOptions> CreateTweener(Vector3 start, Vector3 end, float duration)
-        {
-            return DOTween.To(() => CurrentValue,
-                x => CurrentValue = x,
-                end, duration);
+            sdkTransform.Position = startPosition;
+            sdkTransform.Rotation = startRotation;
         }
     }
 
     public class RotationTweener : CustomTweener<Quaternion, NoOptions>
     {
+        private Vector3 startPosition;
+        private Vector3 startScale;
+
+        protected override (Quaternion, Quaternion) GetTweenValues(PBTween pbTween, SDKTransform sdkTransform, Transform startTransform)
+        {
+            Quaternion start = PrimitivesConversionExtensions.PBQuaternionToUnityQuaternion(pbTween.Rotate.Start);
+            Quaternion end = PrimitivesConversionExtensions.PBQuaternionToUnityQuaternion(pbTween.Rotate.End);
+            startTransform.localRotation = start;
+
+            startPosition = startTransform.localPosition;
+            startScale = startTransform.localScale;
+
+            CurrentValue = start;
+            return (start, end);
+        }
+
         protected override TweenerCore<Quaternion, Quaternion, NoOptions> CreateTweener(Quaternion start, Quaternion end, float duration)
         {
             return DOTween.To(PureQuaternionPlugin.Plug(), () => CurrentValue,
@@ -70,18 +97,12 @@ namespace DCL.SDKComponents.Tween.Components
                 end, duration);
         }
 
-        protected override (Quaternion, Quaternion) GetTweenValues(PBTween pbTween, Transform startTransform)
-        {
-            var start = PrimitivesConversionExtensions.PBQuaternionToUnityQuaternion(pbTween.Rotate.Start);
-            var end = PrimitivesConversionExtensions.PBQuaternionToUnityQuaternion(pbTween.Rotate.End);
-            startTransform.localRotation = start;
-            CurrentValue = start;
-            return (start, end);
-        }
-
         public override void SetResult(ref SDKTransform sdkTransform)
         {
             sdkTransform.Rotation = CurrentValue;
+
+            sdkTransform.Position = startPosition;
+            sdkTransform.Scale = startScale;
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/ICustomTweener.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/ICustomTweener.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using CRDT;
-using CrdtEcsBridge.Components.Transform;
+﻿using CrdtEcsBridge.Components.Transform;
 using DCL.ECSComponents;
 using DG.Tweening;
 using UnityEngine;
@@ -17,15 +15,7 @@ namespace DCL.SDKComponents.Tween.Components
         bool IsFinished();
         bool IsActive();
 
-        void Initialize(PBTween pbTween, Transform startTransform, float durationInSeconds);
+        void Initialize(PBTween pbTween, SDKTransform sdkTransform, Transform startTransform, float durationInSeconds);
         void SetResult(ref SDKTransform sdkTransform);
-
-    }
-
-    public struct TweenResult
-    {
-        public Vector3 Position;
-        public Quaternion Rotation;
-        public Vector3 Scale;
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/TweenerPool.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/TweenerPool.cs
@@ -1,4 +1,5 @@
-﻿using DCL.ECSComponents;
+﻿using CrdtEcsBridge.Components.Transform;
+using DCL.ECSComponents;
 using UnityEngine;
 using UnityEngine.Pool;
 
@@ -17,7 +18,7 @@ namespace DCL.SDKComponents.Tween.Components
             scaleTweenersPool = new ObjectPool<ScaleTweener>(() => new ScaleTweener());
         }
 
-        public ICustomTweener GetTweener(PBTween pbTween, Transform entityTransform, float durationInSeconds)
+        public ICustomTweener GetTweener(PBTween pbTween, SDKTransform sdkTransform, Transform entityTransform, float durationInSeconds)
         {
             ICustomTweener tweener = null;
             switch (pbTween.ModeCase)
@@ -33,7 +34,7 @@ namespace DCL.SDKComponents.Tween.Components
                     break;
             }
 
-            tweener!.Initialize(pbTween, entityTransform, durationInSeconds);
+            tweener!.Initialize(pbTween, sdkTransform, entityTransform, durationInSeconds);
             return tweener;
         }
 

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenUpdaterSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenUpdaterSystem.cs
@@ -201,10 +201,9 @@ namespace DCL.SDKComponents.Tween.Systems
 
             ReturnTweenToPool(ref sdkTweenComponent);
 
-            if (!EASING_FUNCTIONS_MAP.TryGetValue(tweenModel.EasingFunction, out Ease ease))
-                ease = Linear;
+            Ease ease = EASING_FUNCTIONS_MAP.GetValueOrDefault(tweenModel.EasingFunction, Linear);
 
-            sdkTweenComponent.CustomTweener = tweenerPool.GetTweener(tweenModel, entityTransform, durationInSeconds);
+            sdkTweenComponent.CustomTweener = tweenerPool.GetTweener(tweenModel, sdkTransform, entityTransform, durationInSeconds);
             sdkTweenComponent.CustomTweener.DoTween(ease, tweenModel.CurrentTime * durationInSeconds, isPlaying);
         }
 


### PR DESCRIPTION
## What does this PR change?
Fix #1476 

It was an issue with pooling of SDKTransform, that was rewriting not-tweened transform value by default. That caused the trigger (controlled from JS side) being in wrong place after final Tween rotation. 

Fix: cached all starting Transform fields value and pass them each time together with the respective Tweened field value

## How to test the changes?

1. Check related issue

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

