### PR TITLE
Fix: Handle Texture Promises on Materials properly

### DIFF
--- a/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/CreateMaterialSystemBase.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/CreateMaterialSystemBase.cs
@@ -23,7 +23,12 @@ namespace ECS.Unity.Materials.Systems
 
         protected void DestroyEntityReference(ref Promise? promise)
         {
-            promise?.Consume(World);
+            if (promise == null) return;
+            Promise promiseValue = promise.Value;
+            promiseValue.Consume(World);
+
+            // Write the value back as `promise.Value` produces a copy of the struct
+            promise = promiseValue;
         }
 
         protected bool TryGetTextureResult(ref Promise? promise, out StreamableLoadingResult<Texture2D> textureResult)
@@ -33,7 +38,12 @@ namespace ECS.Unity.Materials.Systems
             if (promise == null)
                 return true;
 
-            return promise.Value.TryGetResult(World, out textureResult);
+            Promise value = promise.Value;
+            bool result = value.TryGetResult(World, out textureResult);
+
+            // Write the value back as `promise.Value` produces a copy of the struct
+            promise = value;
+            return result;
         }
 
         protected static void TrySetTexture(Material material, ref StreamableLoadingResult<Texture2D> textureResult, int propId, in TextureComponent? textureComponent)


### PR DESCRIPTION
Continuation of #1555 

```
if (Equals(ref textureComponentValue, ref promise)
                    && promise!.Value.TryGetResult(World!, out var texture))
                {
                    // If data inside promise has not changed just reuse the same promise
                    // as creating and waiting for a new one can be expensive
                    promise = Promise.CreateFinalized(intention, texture);
                }
```
This branch was unreachable as `ReleaseMaterial.TryAddAbortIntention(World, ref promise);` was called before leading to the invalidation of the promise.

- It led to re-creation of the promise every time the material was changed even if the texture was not
- It could be a major bottleneck if materials on the scene are frequently changed, e.g. their colors

**I completely reverted that logic**

**The real issue**
`TryGetTextureResult` was operating on `Nullable.Value` which produces a copy and, thus, not reflected on the original promise so the result is not saved.
When all promises were resolved entities were deleted so if the result was not saved there was no source to take it from. Then the promise was re-used when the material changed, but it didn't contain a valid entity nor the result so it could be never finished. Ultimately it led to impossibility to signal the readiness of the material and display it on the renderer.


**How to QA:**
- Re-check NFT Museum