### PR TITLE
fix: prevent constant rebuild when label is changed

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -7,6 +7,8 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+  pull_request_target:
+    types:
       - labeled
   merge_group: {}
   push:
@@ -50,7 +52,10 @@ jobs:
     name: Prebuild
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (!github.event.pull_request.draft) || ${{ github.event.label.name == 'force-build' }}
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'force-build')
     outputs:
       commit_sha: ${{ steps.get_commit_sha.outputs.commit_sha }}
       options: ${{ steps.get_options.outputs.options }}


### PR DESCRIPTION
## What does this PR change?

**Changes:**

Remove 'labeled' from pull_request event types
Add pull_request_target event for 'force-build' label
Update prebuild job condition to handle pull_request_target

**Effects:**

Stops workflow triggers on every label change
Allows builds to be forced with 'force-build' label
Maintains existing build triggers for PR updates and pushes to main
Enables 'force-build' to work on fork PRs (via pull_request_target)