### PR TITLE
chore: disable Landscape for local scene development

### DIFF
--- a/Explorer/Assets/Scripts/Global/Dynamic/Bootstraper.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/Bootstraper.cs
@@ -114,8 +114,8 @@ namespace Global.Dynamic
                     StaticLoadPositions = launchSettings.GetPredefinedParcels(),
                     Realms = settings.Realms,
                     StartParcel = startingParcel,
-                    EnableLandscape = enableLandscape,
-                    EnableLOD = enableLOD,
+                    EnableLandscape = enableLandscape && !localSceneDevelopment,
+                    EnableLOD = enableLOD && !localSceneDevelopment,
                     EnableAnalytics = EnableAnalytics, HybridSceneParams = launchSettings.CreateHybridSceneParams(startingParcel),
                     LocalSceneDevelopmentRealm = localSceneDevelopment ? launchSettings.GetStartingRealm() : string.Empty,
                     AppParameters = appParameters


### PR DESCRIPTION
### WHY
Currently, when connecting to a local scene, the genesis city landscape is being rendered and many of those meshes can clip with the actual local scene space.

Example:
![Screenshot 2024-07-31 152345](https://github.com/user-attachments/assets/9a966853-ce93-45a6-9efa-abf63be36a9e)

### WHAT
Dynamically disabled Landscape and LODs for Local Scene Development scenario.