### PR TITLE
fix: do not use cache

### DIFF
--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -60,12 +60,13 @@ def clone_current_target():
     new_target_name = f'{re.sub(r'^t_', '', os.getenv('TARGET'))}-{re.sub('[^A-Za-z0-9]+', '-', os.getenv('BRANCH_NAME'))}'.lower()
 
     # Generate request body
+    # Disabled cache for now as its not playing well with Unity and we delete builds anyway!
     body = generate_body(
         os.getenv('TARGET'),
         new_target_name,
         os.getenv('BRANCH_NAME'),
         os.getenv('BUILD_OPTIONS').split(','),
-        (os.getenv('USE_CACHE') == 'true' or os.getenv('USE_CACHE') == ''))
+        false)
 
     existing_target = get_target(new_target_name)
     

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -66,7 +66,7 @@ def clone_current_target():
         new_target_name,
         os.getenv('BRANCH_NAME'),
         os.getenv('BUILD_OPTIONS').split(','),
-        false)
+        False)
 
     existing_target = get_target(new_target_name)
     


### PR DESCRIPTION
## What does this PR change?

* Successful builds are deleted thus we do not have a cache for the previous build stored
* Caching is causing various issues with the mac build.
* Disable caching - lets see how fast the build runs.
