### PR TITLE
Chore: allow goto commands to have spaces for coordinates

### DIFF
--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
@@ -34,8 +34,7 @@ namespace Global.Dynamic.ChatCommands
             { "test", IRealmNavigator.TEST_SCENES_URL },
         };
 
-        public static readonly Regex REGEX = new ($@"^/({COMMAND_WORLD}|{COMMAND_GOTO})\s+((?!-?\d+,-?\d+$).+?)(?:\s+(-?\d+),(-?\d+))?$", RegexOptions.Compiled);
-
+        public static readonly Regex REGEX = new ($@"^/({COMMAND_WORLD}|{COMMAND_GOTO})\s+((?!-?\d+\s*,\s*-?\d+$).+?)(?:\s+(-?\d+)\s*,\s*(-?\d+))?$", RegexOptions.Compiled);
         private readonly URLDomain worldDomain = URLDomain.FromString(IRealmNavigator.WORLDS_DOMAIN);
 
         private readonly Dictionary<string, URLAddress> worldAddressesCaches = new ();

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/GoToChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/GoToChatCommand.cs
@@ -16,8 +16,7 @@ namespace Global.Dynamic.ChatCommands
         private const string COMMAND_GOTO_LOCAL = "goto-local";
         private const string PARAMETER_RANDOM = "random";
 
-        public static readonly Regex REGEX = new ($@"^/({COMMAND_GOTO}|{COMMAND_GOTO_LOCAL})\s+(?:(-?\d+),(-?\d+)|{PARAMETER_RANDOM})$", RegexOptions.Compiled);
-
+        public static readonly Regex REGEX = new ($@"^/({COMMAND_GOTO}|{COMMAND_GOTO_LOCAL})\s+(?:(-?\d+)\s*,\s*(-?\d+)|{PARAMETER_RANDOM})$", RegexOptions.Compiled);
         private readonly IRealmNavigator realmNavigator;
 
         private int x;


### PR DESCRIPTION
## What does this PR change?
 Close #1562 

- extends REGEX equations to allow white spaces

## How to test the changes?

1. Launch the explorer
2. Try different variations of commands with coordinates and different spaces between coordinates, like:
```
/goto 10,20
/goto -5 , -10
/goto -5,-10
```
3. same with `/goto-local`
4. as well for world command:
```
/world genesis 10,20
/goto goerli 77 ,-3

```
## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

