### PR TITLE
fix: emote command subscription of the own player entity from the sdk

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/PlayerCRDTEntitiesHandlerSystem.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/PlayerCRDTEntitiesHandlerSystem.cs
@@ -41,6 +41,8 @@ namespace DCL.Multiplayer.SDK.Systems.GlobalWorld
             RemoveComponentQuery(World);
 
             AddRemotePlayerCRDTEntityQuery(World);
+
+            AddOwnPlayerCRDTEntityQuery(World);
         }
 
         [Query]
@@ -63,6 +65,27 @@ namespace DCL.Multiplayer.SDK.Systems.GlobalWorld
 
             Entity sceneWorldEntity = sceneEcsExecutor.World.Create();
             var crdtEntity = new CRDTEntity(crdtEntityId);
+
+            sceneEcsExecutor.World.Add(sceneWorldEntity, new PlayerSceneCRDTEntity(crdtEntity));
+
+            World.Add(entity, new PlayerCRDTEntity(crdtEntity, sceneFacade, sceneWorldEntity));
+        }
+
+        [Query]
+        [All(typeof(Profile), typeof(PlayerComponent))]
+        [None(typeof(PlayerCRDTEntity), typeof(DeleteEntityIntention))]
+        private void AddOwnPlayerCRDTEntity(in Entity entity, ref CharacterTransform characterTransform)
+        {
+            if (!scenesCache.TryGetByParcel(ParcelMathHelper.FloorToParcel(characterTransform.Transform.position), out ISceneFacade sceneFacade))
+                return;
+
+            if (sceneFacade.IsEmpty || !sceneFacade.SceneStateProvider.IsCurrent)
+                return;
+
+            SceneEcsExecutor sceneEcsExecutor = sceneFacade.EcsExecutor;
+
+            Entity sceneWorldEntity = sceneEcsExecutor.World.Create();
+            var crdtEntity = new CRDTEntity(SpecialEntitiesID.PLAYER_ENTITY);
 
             sceneEcsExecutor.World.Add(sceneWorldEntity, new PlayerSceneCRDTEntity(crdtEntity));
 

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/PlayerCRDTEntitiesHandlerSystem.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/PlayerCRDTEntitiesHandlerSystem.cs
@@ -93,7 +93,6 @@ namespace DCL.Multiplayer.SDK.Systems.GlobalWorld
         }
 
         [Query]
-        [None(typeof(PlayerComponent))]
         private void RemoveComponentOnOutsideCurrentScene(in Entity entity, ref CharacterTransform characterTransform, ref PlayerCRDTEntity playerCRDTEntity)
         {
             // Only target entities outside the current scene

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Tests/PlayerCRDTEntitiesHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Tests/PlayerCRDTEntitiesHandlerSystemShould.cs
@@ -1,5 +1,4 @@
 using Arch.Core;
-using CRDT;
 using CrdtEcsBridge.Components;
 using DCL.AvatarRendering.Emotes;
 using DCL.Character;
@@ -65,8 +64,9 @@ namespace DCL.Multiplayer.SDK.Tests
             world.Dispose();
         }
 
-        [Test]
-        public void SetupPlayerCRDTEntityForPlayerInsideScene()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetupPlayerCRDTEntityForPlayerInsideScene(bool isMainPlayer)
         {
             scene1Facade.SceneStateProvider.IsCurrent.Returns(true);
             scene2Facade.SceneStateProvider.IsCurrent.Returns(false);
@@ -75,6 +75,9 @@ namespace DCL.Multiplayer.SDK.Tests
             world.Add(entity, Profile.NewRandomProfile(FAKE_USER_ID),
                 new CharacterTransform(fakeCharacterUnityTransform)
             );
+
+            if (isMainPlayer)
+                world.Add(entity, new PlayerComponent());
 
             Assert.IsFalse(world.Has<PlayerCRDTEntity>(entity));
 
@@ -85,8 +88,9 @@ namespace DCL.Multiplayer.SDK.Tests
             Assert.AreEqual(playerCRDTEntity.CRDTEntity, scenePlayerCRDTEntity.CRDTEntity);
         }
 
-        [Test]
-        public void NotSetupPlayerCRDTEntityForPlayersOutsideScene()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void NotSetupPlayerCRDTEntityForPlayersOutsideScene(bool isMainPlayer)
         {
             scene1Facade.SceneStateProvider.IsCurrent.Returns(true);
             scene2Facade.SceneStateProvider.IsCurrent.Returns(false);
@@ -96,6 +100,9 @@ namespace DCL.Multiplayer.SDK.Tests
                 new CharacterTransform(fakeCharacterUnityTransform)
             );
 
+            if (isMainPlayer)
+                world.Add(entity, new PlayerComponent());
+
             Assert.IsFalse(world.Has<PlayerCRDTEntity>(entity));
 
             system.Update(0);
@@ -103,8 +110,9 @@ namespace DCL.Multiplayer.SDK.Tests
             Assert.IsFalse(world.Has<PlayerCRDTEntity>(entity));
         }
 
-        [Test]
-        public void RemovePlayerCRDTEntityForPlayersLeavingScene()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void RemovePlayerCRDTEntityForPlayersLeavingScene(bool isMainPlayer)
         {
             scene1Facade.SceneStateProvider.IsCurrent.Returns(true);
             scene2Facade.SceneStateProvider.IsCurrent.Returns(false);
@@ -113,6 +121,9 @@ namespace DCL.Multiplayer.SDK.Tests
             world.Add(entity, Profile.NewRandomProfile(FAKE_USER_ID),
                 new CharacterTransform(fakeCharacterUnityTransform)
             );
+
+            if (isMainPlayer)
+                world.Add(entity, new PlayerComponent());
 
             Assert.IsFalse(world.Has<PlayerCRDTEntity>(entity));
 
@@ -130,8 +141,9 @@ namespace DCL.Multiplayer.SDK.Tests
             Assert.IsTrue(playerCRDTEntity.SceneFacade.EcsExecutor.World.Has<DeleteEntityIntention>(playerCRDTEntity.SceneWorldEntity));
         }
 
-        [Test]
-        public void RemovePlayerCRDTEntityForPlayersOnNoLongerCurrentScene()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void RemovePlayerCRDTEntityForPlayersOnNoLongerCurrentScene(bool isMainPlayer)
         {
             scene1Facade.SceneStateProvider.IsCurrent.Returns(true);
             scene2Facade.SceneStateProvider.IsCurrent.Returns(false);
@@ -140,6 +152,9 @@ namespace DCL.Multiplayer.SDK.Tests
             world.Add(entity, Profile.NewRandomProfile(FAKE_USER_ID),
                 new CharacterTransform(fakeCharacterUnityTransform)
             );
+
+            if (isMainPlayer)
+                world.Add(entity, new PlayerComponent());
 
             Assert.IsFalse(world.Has<PlayerCRDTEntity>(entity));
 
@@ -158,8 +173,9 @@ namespace DCL.Multiplayer.SDK.Tests
             Assert.IsTrue(playerCRDTEntity.SceneFacade.EcsExecutor.World.Has<DeleteEntityIntention>(playerCRDTEntity.SceneWorldEntity));
         }
 
-        [Test]
-        public void RemovePlayerCRDTEntityForOnPlayersDisconnection()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void RemovePlayerCRDTEntityForOnPlayersDisconnection(bool isMainPlayer)
         {
             scene1Facade.SceneStateProvider.IsCurrent.Returns(true);
             scene2Facade.SceneStateProvider.IsCurrent.Returns(false);
@@ -168,6 +184,9 @@ namespace DCL.Multiplayer.SDK.Tests
             world.Add(entity, Profile.NewRandomProfile(FAKE_USER_ID),
                 new CharacterTransform(fakeCharacterUnityTransform)
             );
+
+            if (isMainPlayer)
+                world.Add(entity, new PlayerComponent());
 
             Assert.IsFalse(world.Has<PlayerCRDTEntity>(entity));
 
@@ -193,6 +212,7 @@ namespace DCL.Multiplayer.SDK.Tests
             fakeCharacterUnityTransform.position = Vector3.one;
 
             world.Add(entity, Profile.NewRandomProfile(FAKE_USER_ID),
+                new PlayerComponent(),
                 new CharacterTransform(fakeCharacterUnityTransform)
             );
 
@@ -201,7 +221,7 @@ namespace DCL.Multiplayer.SDK.Tests
             system.Update(0);
 
             Assert.IsTrue(world.TryGet(entity, out PlayerCRDTEntity playerCRDTEntity));
-            Assert.AreEqual(SpecialEntitiesID.OTHER_PLAYER_ENTITIES_FROM, playerCRDTEntity.CRDTEntity.Id);
+            Assert.AreEqual(SpecialEntitiesID.PLAYER_ENTITY, playerCRDTEntity.CRDTEntity.Id);
 
             // Add 2 more players
             Entity entity2 = world.Create(Profile.NewRandomProfile(FAKE_USER_ID),
@@ -210,7 +230,7 @@ namespace DCL.Multiplayer.SDK.Tests
             system.Update(0);
 
             Assert.IsTrue(world.TryGet(entity2, out playerCRDTEntity));
-            Assert.AreEqual(SpecialEntitiesID.OTHER_PLAYER_ENTITIES_FROM + 1, playerCRDTEntity.CRDTEntity.Id);
+            Assert.AreEqual(SpecialEntitiesID.OTHER_PLAYER_ENTITIES_FROM, playerCRDTEntity.CRDTEntity.Id);
 
             Entity entity3 = world.Create(Profile.NewRandomProfile(FAKE_USER_ID),
                 new CharacterTransform(fakeCharacterUnityTransform));
@@ -218,7 +238,7 @@ namespace DCL.Multiplayer.SDK.Tests
             system.Update(0);
 
             Assert.IsTrue(world.TryGet(entity3, out playerCRDTEntity));
-            Assert.AreEqual(SpecialEntitiesID.OTHER_PLAYER_ENTITIES_FROM + 2, playerCRDTEntity.CRDTEntity.Id);
+            Assert.AreEqual(SpecialEntitiesID.OTHER_PLAYER_ENTITIES_FROM + 1, playerCRDTEntity.CRDTEntity.Id);
 
             // "Disconnect" 2nd player
             world.Add(entity2, new DeleteEntityIntention());
@@ -231,38 +251,6 @@ namespace DCL.Multiplayer.SDK.Tests
             system.Update(0);
 
             Assert.IsTrue(world.TryGet(entity4, out playerCRDTEntity));
-            Assert.AreEqual(SpecialEntitiesID.OTHER_PLAYER_ENTITIES_FROM + 1, playerCRDTEntity.CRDTEntity.Id);
-        }
-
-        [Test]
-        public void IgnoreMainPlayer()
-        {
-            scene1Facade.SceneStateProvider.IsCurrent.Returns(true);
-            scene2Facade.SceneStateProvider.IsCurrent.Returns(false);
-
-            // Add main player
-            fakeMainCharacterUnityTransform.position = Vector3.one;
-
-            world.Add(entity, Profile.NewRandomProfile(FAKE_USER_ID),
-                new CharacterTransform(fakeMainCharacterUnityTransform),
-                new PlayerComponent(),
-                new CRDTEntity(SpecialEntitiesID.PLAYER_ENTITY)
-            );
-
-            // Add another player
-            fakeCharacterUnityTransform.position = Vector3.one;
-
-            Entity entity2 = world.Create(Profile.NewRandomProfile(FAKE_USER_ID),
-                new CharacterTransform(fakeCharacterUnityTransform));
-
-            Assert.IsFalse(world.Has<PlayerCRDTEntity>(entity));
-            Assert.IsFalse(world.Has<PlayerCRDTEntity>(entity2));
-
-            system.Update(0);
-
-            Assert.IsFalse(world.TryGet(entity, out PlayerCRDTEntity playerCRDTEntity));
-
-            Assert.IsTrue(world.TryGet(entity2, out playerCRDTEntity));
             Assert.AreEqual(SpecialEntitiesID.OTHER_PLAYER_ENTITIES_FROM, playerCRDTEntity.CRDTEntity.Id);
         }
     }


### PR DESCRIPTION
## What does this PR change?

Fixes #1523 

`PBAvatarEmoteCommand` was not being sent through crdt because it was lacking of required components: `PlayerSceneCRDTEntity` & `AvatarEmoteCommandComponent`.

## Solution

The solution consists in processing the OWN player so the `PlayerSceneCRDTEntity` is added to the to the scene's entity with `CRDTEntity: SpecialEntitiesID.PLAYER_ENTITY`, since the scene code (js side) subscribes to this special entity id. The flow will finally end up sending the `PBAvatarEmoteCommand` here: https://github.com/decentraland/unity-explorer/blob/2fffa9e337798c8e6aadecc7363fd17582f6fb73/Explorer/Assets/DCL/Multiplayer/SDK/Systems/SceneWorld/WriteAvatarEmoteCommandSystem.cs#L49
Since the local `CharacterEmoteIntent` player is applied to the own global player entity here: https://github.com/decentraland/unity-explorer/blob/69637139f62d1ccdd07c515c7e7bc5cb8c9af6ca/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/UpdateEmoteInputSystem.cs#L100
It is needed to add the `PlayerCRDTEntity` to the global player's entity so the `AvatarEmoteCommandComponent` can be later propagated into the scene's entity here: https://github.com/decentraland/unity-explorer/blob/69637139f62d1ccdd07c515c7e7bc5cb8c9af6ca/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/AvatarEmoteCommandPropagationSystem.cs#L33

## How to test the changes?

1. Follow issue steps
2. The clap meter should work as expected, either with one or many players
3. Get out of the scene
4. Re-enter the scene
5. The clap meter should work as expected, either with one or many players
6. Go to scene Genesis 65,-125
7. Play an emote
8. Confirm that the "onPlayerExpression" Text Shape appears and has the ID of the emote you play. Check that triggering different emotes updates that text

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

