### PR TITLE
Fix #1619 : fixed nullref on passport disposal

### DIFF
--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -38,7 +38,6 @@ namespace DCL.Passport
         private readonly IMVCManager mvcManager;
         private readonly ISelfProfile selfProfile;
         private readonly World world;
-        private readonly Entity playerEntity;
         private readonly IThumbnailProvider thumbnailProvider;
         private readonly DCLInput dclInput;
         private readonly IWebBrowser webBrowser;
@@ -48,7 +47,7 @@ namespace DCL.Passport
         private CancellationTokenSource characterPreviewLoadingCts;
         private PassportErrorsController passportErrorsController;
         private PassportCharacterPreviewController characterPreviewController;
-        private PassportProfileInfoController passportProfileInfoController;
+        private readonly PassportProfileInfoController passportProfileInfoController;
         private readonly List<IPassportModuleController> passportModules = new ();
 
         public event Action<string> PassportOpened;
@@ -84,11 +83,11 @@ namespace DCL.Passport
             this.mvcManager = mvcManager;
             this.selfProfile = selfProfile;
             this.world = world;
-            this.playerEntity = playerEntity;
             this.thumbnailProvider = thumbnailProvider;
             this.dclInput = dclInput;
             this.webBrowser = webBrowser;
             this.decentralandUrlsSource = decentralandUrlsSource;
+            passportProfileInfoController = new PassportProfileInfoController(selfProfile, world, playerEntity);
         }
 
         protected override void OnViewInstantiated()
@@ -96,12 +95,17 @@ namespace DCL.Passport
             Assert.IsNotNull(world);
             passportErrorsController = new PassportErrorsController(viewInstance.ErrorNotification);
             characterPreviewController = new PassportCharacterPreviewController(viewInstance.CharacterPreviewView, characterPreviewFactory, world, characterPreviewEventBus);
-            passportProfileInfoController = new PassportProfileInfoController(selfProfile, world, playerEntity, passportErrorsController);
             passportModules.Add(new UserBasicInfo_PassportModuleController(viewInstance.UserBasicInfoModuleView, chatEntryConfiguration, selfProfile, passportErrorsController));
             passportModules.Add(new UserDetailedInfo_PassportModuleController(viewInstance.UserDetailedInfoModuleView, mvcManager, selfProfile, viewInstance.AddLinkModal, passportErrorsController, passportProfileInfoController));
             passportModules.Add(new EquippedItems_PassportModuleController(viewInstance.EquippedItemsModuleView, world, rarityBackgrounds, rarityColors, categoryIcons, thumbnailProvider, webBrowser, decentralandUrlsSource, passportErrorsController));
 
+            passportProfileInfoController.PublishError += OnPublishError;
             passportProfileInfoController.OnProfilePublished += SetupPassportModules;
+        }
+
+        private void OnPublishError()
+        {
+            passportErrorsController.Show();
         }
 
         protected override void OnViewShow()
@@ -143,6 +147,8 @@ namespace DCL.Passport
             characterPreviewController?.Dispose();
 
             passportProfileInfoController.OnProfilePublished -= SetupPassportModules;
+            passportProfileInfoController.PublishError -= OnPublishError;
+
             foreach (IPassportModuleController module in passportModules)
                 module.Dispose();
         }

--- a/Explorer/Assets/DCL/Passport/PassportProfileInfoController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportProfileInfoController.cs
@@ -11,22 +11,20 @@ namespace DCL.Passport
     public class PassportProfileInfoController
     {
         public event Action<Profile>? OnProfilePublished;
+        public event Action PublishError;
 
         private readonly ISelfProfile selfProfile;
         private readonly World world;
         private readonly Entity playerEntity;
-        private readonly PassportErrorsController passportErrorsController;
 
         public PassportProfileInfoController(
             ISelfProfile selfProfile,
             World world,
-            Entity playerEntity,
-            PassportErrorsController passportErrorsController)
+            Entity playerEntity)
         {
             this.selfProfile = selfProfile;
             this.world = world;
             this.playerEntity = playerEntity;
-            this.passportErrorsController = passportErrorsController;
         }
 
         public async UniTask UpdateProfileAsync(CancellationToken ct)
@@ -49,7 +47,7 @@ namespace DCL.Passport
             catch (Exception e)
             {
                 const string ERROR_MESSAGE = "There was an error while trying to update your profile info. Please try again!";
-                passportErrorsController.Show();
+                PublishError?.Invoke();
                 ReportHub.LogError(ReportCategory.PROFILE, $"{ERROR_MESSAGE} ERROR: {e.Message}");
             }
         }

--- a/Explorer/Assets/DCL/PluginSystem/Global/PassportPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/PassportPlugin.cs
@@ -112,12 +112,6 @@ namespace DCL.PluginSystem.Global
             };
         }
 
-        public override void Dispose()
-        {
-            passportController?.Dispose();
-            base.Dispose();
-        }
-
         public class PassportSettings : IDCLPluginSettings
         {
             [field: Header(nameof(PassportPlugin) + "." + nameof(PassportSettings))]


### PR DESCRIPTION
## What does this PR change?

This PR fixes issue #1619
It removes a duplicated disposal flow of the passport controller and it improves the creation of passportProfileInfoController

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Verify that the player passports are working as expected (no major changes have been applied)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

