### PR TITLE
fix: strobe lights

### DIFF
--- a/Explorer/Assets/AddressableAssetsData/AssetGroups/Materials.asset
+++ b/Explorer/Assets/AddressableAssetsData/AssetGroups/Materials.asset
@@ -16,17 +16,7 @@ MonoBehaviour:
   m_Data:
     m_SerializedData: []
   m_GUID: 2fec862f89f4d0a459a47ad60d35dc5d
-  m_SerializeEntries:
-  - m_GUID: 0009549658aa1be40bbed401477fbd48
-    m_Address: ShapeMaterial
-    m_ReadOnly: 0
-    m_SerializedLabels: []
-    FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: 60d3d51407bdce5449781acd4ee86781
-    m_Address: BasicShapeMaterial
-    m_ReadOnly: 0
-    m_SerializedLabels: []
-    FlaggedDuringContentUpdateRestriction: 0
+  m_SerializeEntries: []
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: fc8a9d2b539788c47a5b305639fa8b34, type: 2}
   m_SchemaSet:

--- a/Explorer/Assets/DCL/PluginSystem/World/MaterialWorldPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MaterialWorldPlugin.cs
@@ -42,17 +42,15 @@ namespace DCL.PluginSystem.World
 
         public void Dispose() { }
 
-        public async UniTask InitializeAsync(Settings settings, CancellationToken ct)
+        public UniTask InitializeAsync(Settings settings, CancellationToken ct)
         {
-            // ProvidedAsset<Material> basicMatReference = await assetsProvisioner.ProvideMainAssetAsync(settings.basicMaterial, ct: ct);
-            // ProvidedAsset<Material> pbrMaterialReference = await assetsProvisioner.ProvideMainAssetAsync(settings.pbrMaterial, ct: ct);
-
             basicMatPool = new ObjectPool<Material>(() => new Material(settings.basicMaterial), actionOnDestroy: UnityObjectUtils.SafeDestroy, defaultCapacity: settings.PoolInitialCapacity, maxSize: settings.PoolMaxSize);
             pbrMatPool = new ObjectPool<Material>(() => new Material(settings.pbrMaterial), actionOnDestroy: UnityObjectUtils.SafeDestroy, defaultCapacity: settings.PoolInitialCapacity, maxSize: settings.PoolMaxSize);
 
             destroyMaterial = (in MaterialData data, Material material) => { (data.IsPbrMaterial ? pbrMatPool : basicMatPool).Release(material); };
 
             loadingAttemptsCount = settings.LoadingAttemptsCount;
+            return UniTask.CompletedTask;
         }
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in ECSWorldInstanceSharedDependencies sharedDependencies, in PersistentEntities persistentEntities, List<IFinalizeWorldSystem> finalizeWorldSystems, List<ISceneIsCurrentListener> sceneIsCurrentListeners)

--- a/Explorer/Assets/DCL/PluginSystem/World/MaterialWorldPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MaterialWorldPlugin.cs
@@ -44,11 +44,11 @@ namespace DCL.PluginSystem.World
 
         public async UniTask InitializeAsync(Settings settings, CancellationToken ct)
         {
-            ProvidedAsset<Material> basicMatReference = await assetsProvisioner.ProvideMainAssetAsync(settings.basicMaterial, ct: ct);
-            ProvidedAsset<Material> pbrMaterialReference = await assetsProvisioner.ProvideMainAssetAsync(settings.pbrMaterial, ct: ct);
+            // ProvidedAsset<Material> basicMatReference = await assetsProvisioner.ProvideMainAssetAsync(settings.basicMaterial, ct: ct);
+            // ProvidedAsset<Material> pbrMaterialReference = await assetsProvisioner.ProvideMainAssetAsync(settings.pbrMaterial, ct: ct);
 
-            basicMatPool = new ObjectPool<Material>(() => new Material(basicMatReference.Value), actionOnDestroy: UnityObjectUtils.SafeDestroy, defaultCapacity: settings.PoolInitialCapacity, maxSize: settings.PoolMaxSize);
-            pbrMatPool = new ObjectPool<Material>(() => new Material(pbrMaterialReference.Value), actionOnDestroy: UnityObjectUtils.SafeDestroy, defaultCapacity: settings.PoolInitialCapacity, maxSize: settings.PoolMaxSize);
+            basicMatPool = new ObjectPool<Material>(() => new Material(settings.basicMaterial), actionOnDestroy: UnityObjectUtils.SafeDestroy, defaultCapacity: settings.PoolInitialCapacity, maxSize: settings.PoolMaxSize);
+            pbrMatPool = new ObjectPool<Material>(() => new Material(settings.pbrMaterial), actionOnDestroy: UnityObjectUtils.SafeDestroy, defaultCapacity: settings.PoolInitialCapacity, maxSize: settings.PoolMaxSize);
 
             destroyMaterial = (in MaterialData data, Material material) => { (data.IsPbrMaterial ? pbrMatPool : basicMatPool).Release(material); };
 
@@ -71,11 +71,14 @@ namespace DCL.PluginSystem.World
         [Serializable]
         public class Settings : IDCLPluginSettings
         {
+            /// <summary>
+            /// replaced from Addressables, Being in Addressables caused a problem with strobe-lights because shaders were not being compiled
+            /// </summary>
             [field: SerializeField]
-            public AssetReferenceMaterial basicMaterial;
+            public Material basicMaterial = null!;
 
             [field: SerializeField]
-            public AssetReferenceMaterial pbrMaterial;
+            public Material pbrMaterial = null!;
             [field: Header(nameof(MaterialsPlugin) + "." + nameof(Settings))]
             [field: Space]
             [field: SerializeField]

--- a/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
+++ b/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
@@ -167,16 +167,8 @@ MonoBehaviour:
     - rid: 6784895267130048515
       type: {class: MaterialsPlugin/Settings, ns: DCL.PluginSystem.World, asm: DCL.Plugins}
       data:
-        basicMaterial:
-          m_AssetGUID: 60d3d51407bdce5449781acd4ee86781
-          m_SubObjectName: 
-          m_SubObjectType: 
-          m_EditorAssetChanged: 0
-        pbrMaterial:
-          m_AssetGUID: 0009549658aa1be40bbed401477fbd48
-          m_SubObjectName: 
-          m_SubObjectType: 
-          m_EditorAssetChanged: 0
+        basicMaterial: {fileID: 2100000, guid: 60d3d51407bdce5449781acd4ee86781, type: 2}
+        pbrMaterial: {fileID: 2100000, guid: 0009549658aa1be40bbed401477fbd48, type: 2}
         <LoadingAttemptsCount>k__BackingField: 6
         <PoolInitialCapacity>k__BackingField: 256
         <PoolMaxSize>k__BackingField: 2048

--- a/Explorer/ProjectSettings/GraphicsSettings.asset
+++ b/Explorer/ProjectSettings/GraphicsSettings.asset
@@ -42,6 +42,9 @@ GraphicsSettings:
   - {fileID: 4800000, guid: 6e9f244bbe8f40e38644cb9c55cf1a67, type: 3}
   m_PreloadedShaders:
   - {fileID: 20000000, guid: 29ff2a68595df104ab86d7589e04b702, type: 2}
+  - {fileID: 20000000, guid: 5108e1fd8995a4642b1032eb189390ae, type: 2}
+  - {fileID: 20000000, guid: 208c657bf63862c449775069ddb6a9d4, type: 2}
+  - {fileID: 20000000, guid: bced61a4141f5844f8f72cb24280f892, type: 2}
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_CustomRenderPipeline: {fileID: 11400000, guid: 362b7d6d8bc7d8a4caba9aa7515a5f6d, type: 2}
@@ -67,7 +70,7 @@ GraphicsSettings:
   m_LightsUseLinearIntensity: 1
   m_LightsUseColorTemperature: 1
   m_DefaultRenderingLayerMask: 1
-  m_LogWhenShaderIsCompiled: 0
+  m_LogWhenShaderIsCompiled: 1
   m_SRPDefaultSettings:
     UnityEngine.Rendering.Universal.UniversalRenderPipeline: {fileID: 11400000, guid: 98c3401a6c7f16348886ddfb07d6ced7, type: 2}
   m_LightProbeOutsideHullStrategy: 0


### PR DESCRIPTION
## What does this PR change?

Moves shape materials from addressables to the build
Being in Addressables caused a problem with strobe-lights because shaders were not being compiled and _EMISSION hadn't been propagated to renderer

It fixes
https://github.com/decentraland/unity-explorer/issues/1497#issue-2425588098
#1582
#796
#1500
#1101

## How to test the changes?

Follow the flow of the tickets

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

