### PR TITLE
fix: force to re-login if the identity will expire in 24hs or less

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -2,7 +2,6 @@ using Arch.Core;
 using Cysharp.Threading.Tasks;
 using DCL.Audio;
 using DCL.Browser;
-using DCL.Character.CharacterMotion.Components;
 using DCL.CharacterPreview;
 using DCL.Diagnostics;
 using DCL.FeatureFlags;
@@ -152,7 +151,10 @@ namespace DCL.AuthenticationScreenFlow
         {
             IWeb3Identity? storedIdentity = storedIdentityProvider.Identity;
 
-            if (storedIdentity is { IsExpired: false })
+            if (storedIdentity is { IsExpired: false }
+                // Force to re-login if the identity will expire in 24hs or less, so we mitigate the chances on
+                // getting the identity expired while in-world, provoking signed-fetch requests to fail
+                && storedIdentity.Expiration - DateTime.UtcNow > TimeSpan.FromDays(1))
             {
                 CancelLoginProcess();
                 loginCancellationToken = new CancellationTokenSource();


### PR DESCRIPTION
## What does this PR change?

Fixes #1625 

## How to test the changes?

1. Login
2. Quit DCL
3. Change your system date to 6 days into the future
4. Open DCL
5. In the authentication screen you should be requested to login again

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

