### PR TITLE
fix: change to reliable packets only temporarily

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Movement/Systems/MultiplayerMovementMessageBus.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Systems/MultiplayerMovementMessageBus.cs
@@ -7,6 +7,7 @@ using DCL.Multiplayer.Connections.Messaging.Hubs;
 using DCL.Multiplayer.Connections.Messaging.Pipe;
 using DCL.Multiplayer.Profiles.Tables;
 using Decentraland.Kernel.Comms.Rfc4;
+using LiveKit.Proto;
 using System;
 using System.Threading;
 using UnityEngine;
@@ -64,7 +65,7 @@ namespace DCL.Multiplayer.Movement.Systems
         {
             var messageWrap = messagePipe.NewMessage<Decentraland.Kernel.Comms.Rfc4.Movement>();
             WriteToProto(message, messageWrap.Payload);
-            messageWrap.SendAndDisposeAsync(cancellationTokenSource.Token).Forget();
+            messageWrap.SendAndDisposeAsync(cancellationTokenSource.Token, DataPacketKind.KindReliable).Forget();
         }
 
         private static void WriteToProto(NetworkMovementMessage message, Decentraland.Kernel.Comms.Rfc4.Movement movement)

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/BroadcastProfiles/ProfileBroadcast.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/BroadcastProfiles/ProfileBroadcast.cs
@@ -5,6 +5,7 @@ using DCL.Multiplayer.Connections.Messaging.Pipe;
 using DCL.Profiles;
 using DCL.Profiles.Self;
 using Decentraland.Kernel.Comms.Rfc4;
+using LiveKit.Proto;
 using System.Threading;
 
 namespace DCL.Multiplayer.Profiles.BroadcastProfiles
@@ -42,7 +43,7 @@ namespace DCL.Multiplayer.Profiles.BroadcastProfiles
                 Profile? profile = await selfProfile.ProfileAsync(ct);
                 MessageWrap<AnnounceProfileVersion> message = messagePipe.NewMessage<AnnounceProfileVersion>();
                 message.Payload.ProfileVersion = (uint)(profile?.Version ?? CURRENT_PROFILE_VERSION);
-                message.SendAndDisposeAsync(ct).Forget();
+                message.SendAndDisposeAsync(ct, DataPacketKind.KindReliable).Forget();
             }
 
             GetProfileVersionThenSendAsync(cancellationTokenSource.Token).Forget();

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/JsModulesImplementation/Communications/CommunicationControllerHub.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/JsModulesImplementation/Communications/CommunicationControllerHub.cs
@@ -4,6 +4,7 @@ using DCL.Multiplayer.Connections.Messaging.Hubs;
 using DCL.Multiplayer.Connections.Messaging.Pipe;
 using Decentraland.Kernel.Comms.Rfc4;
 using Google.Protobuf;
+using LiveKit.Proto;
 using System;
 using System.Threading;
 
@@ -44,7 +45,7 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
             MessageWrap<Scene> sceneMessage = messagePipe.NewMessage<Scene>();
             sceneMessage.Payload.Data = ByteString.CopyFrom(message);
             sceneMessage.Payload.SceneId = sceneId;
-            sceneMessage.SendAndDisposeAsync(ct).Forget();
+            sceneMessage.SendAndDisposeAsync(ct, DataPacketKind.KindReliable).Forget();
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Temporarily updates livekit to only use reliable packets.