### PR TITLE
chore: LOD group recalculation on distance change

### DIFF
--- a/Explorer/Assets/DCL/LOD/Components/SceneLODInfo.cs
+++ b/Explorer/Assets/DCL/LOD/Components/SceneLODInfo.cs
@@ -34,12 +34,18 @@ namespace DCL.LOD.Components
             };
         }
 
+        public void RecalculateLODDistances(float defaultFOV, float defaultLodBias, int loadingDistance)
+        {
+            var lods = metadata.LodGroup.GetLODs();
+            SetupLODRelativeHeights(lods, defaultFOV, defaultLodBias, loadingDistance);
+            metadata.LodGroup.SetLODs(lods);
+        }
+
         public void AddFailedLOD()
         {
             metadata.FailedLODs = SceneLODInfoUtils.SetLODResult(metadata.FailedLODs, CurrentLODLevelPromise);
             CurrentLODLevelPromise = byte.MaxValue;
         }
-
 
         public void AddSuccessLOD(GameObject instantiatedLOD, LODAsset lodAsset, float defaultFOV, float defaultLodBias, int loadingDistance)
         {
@@ -48,28 +54,26 @@ namespace DCL.LOD.Components
             instantiatedLOD.transform.SetParent(metadata.LodGroup.transform);
 
             instantiatedLOD.GetComponentsInChildren(true, TEMP_RENDERERS);
-            
+
             if (TEMP_RENDERERS.Count != 0)
-                RecalculateLODValues(defaultFOV, defaultLodBias, loadingDistance);
+            {
+                var lods = metadata.LodGroup.GetLODs();
+                SetupRenderers(lods, TEMP_RENDERERS, CurrentLODLevelPromise);
+                SetupLODRelativeHeights(lods, defaultFOV, defaultLodBias, loadingDistance);
+                metadata.LodGroup.SetLODs(lods);
+            }
 
             CurrentLODLevelPromise = byte.MaxValue;
         }
 
-        private void RecalculateLODValues(float defaultFOV, float defaultLodBias, int loadingDistance)
+        private void SetupLODRelativeHeights(UnityEngine.LOD[] lods, float defaultFOV, float defaultLodBias, int loadingDistance)
         {
             int loadedLODAmount = SceneLODInfoUtils.LODCount(metadata.SuccessfullLODs);
-            var lods = metadata.LodGroup.GetLODs();
-
-            var renderers = LODGroupPoolUtils.RENDERER_ARRAY_POOL.Rent(TEMP_RENDERERS.Count);
-            TEMP_RENDERERS.CopyTo(renderers);
-            lods[CurrentLODLevelPromise].renderers = renderers;
+            CalculateCullRelativeHeight(defaultFOV, defaultLodBias, loadingDistance);
             
             if (loadedLODAmount == 1)
             {
-                //We only have to make this calculations for the first LOD (assuming they have the same bounds)
-                CalculateCullRelativeHeight(lods[CurrentLODLevelPromise].renderers, TEMP_RENDERERS.Count, defaultFOV, defaultLodBias, loadingDistance);
-                
-                if (CurrentLODLevelPromise == 0)
+                if (SceneLODInfoUtils.HasLODResult(metadata.SuccessfullLODs, 0))
                 {
                     //LOD0 is ready to be shown. Therefore, the relative percentage should be the cull percentage
                     lods[0].screenRelativeTransitionHeight = metadata.CullRelativeHeightPercentage;
@@ -88,46 +92,40 @@ namespace DCL.LOD.Components
                 lods[0].screenRelativeTransitionHeight = (1 - metadata.CullRelativeHeightPercentage) / 2 + metadata.CullRelativeHeightPercentage;
                 lods[1].screenRelativeTransitionHeight = metadata.CullRelativeHeightPercentage;
             }
-            metadata.LodGroup.SetLODs(lods);
         }
 
-        private void CalculateCullRelativeHeight(Renderer[] lodRenderers, int renderersLength, float defaultFOV, float defaultLodBias, int loadingDistance)
+
+        private void SetupRenderers(UnityEngine.LOD[] lods, List<Renderer> renderersToSetup, int lodToSetup)
+        {
+            var renderers = LODGroupPoolUtils.RENDERER_ARRAY_POOL.Rent(TEMP_RENDERERS.Count);
+            renderersToSetup.CopyTo(renderers);
+            lods[lodToSetup].renderers = renderers;
+
+            CalculateLODBounds(lods[lodToSetup].renderers, renderersToSetup.Count);
+        }
+
+        private void CalculateLODBounds(Renderer[] lodRenderers, int renderersCount)
         {
             var mergedBounds = lodRenderers[0].bounds;
 
             // Encapsulate the bounds of the remaining renderers
-            for (int i = 1; i < renderersLength; i++)
-            {
+            for (int i = 1; i < renderersCount; i++)
                 mergedBounds.Encapsulate(lodRenderers[i].bounds);
-            }
 
+            //Object size required to be the largest of the 3 axis
+            metadata.LodGroup.size = Mathf.Max(Mathf.Max(mergedBounds.size.x, mergedBounds.size.y), mergedBounds.size.z);
+        }
+
+        private void CalculateCullRelativeHeight(float defaultFOV, float defaultLodBias, int loadingDistance)
+        {
             //The cull distance is at loading distance - 1 parcel for some space buffer
             //(It should first load, and then cull in)
             float cullDistance = (loadingDistance - 1) * ParcelMathHelper.PARCEL_SIZE;
-
-            //Object size required to be the largest of the 3 axis
-            float maxExtents = Mathf.Max(Mathf.Max(mergedBounds.extents.x, mergedBounds.extents.y), mergedBounds.extents.z);
-            //We set the bounds of the LODGroup
-            metadata.LodGroup.size = maxExtents;
-
             float halfFov = defaultFOV / 2.0f * Mathf.Deg2Rad;
             float tanValue = Mathf.Tan(halfFov);
-            metadata.CullRelativeHeightPercentage = Mathf.Clamp(CalculateScreenRelativeCullHeight(tanValue, cullDistance, maxExtents, defaultLodBias), 0.02f, 0.999f);
-            metadata.LODChangeRelativeDistance = CalculateLODChangeRelativeHeight(tanValue, maxExtents, defaultLodBias);
-        }
-
-        //This will give us the percent of the screen in which the object will be culled when being at (unloadingDistance - 1) parcel
-        private float CalculateScreenRelativeCullHeight(float tanValue, float distance, float objectSize, float defaultLODBias)
-        {
-            return objectSize / ((distance + objectSize) * tanValue) * defaultLODBias;
-        }
-
-        //This will give us the distance at which the LOD change should occur if we consider the percentage at the middle between 
-        //cull distance and 100% of the screen
-        private float CalculateLODChangeRelativeHeight(float tanValue, float objectSize, float defaultLodBias)
-        {
-            float halfDistancePercentage = ((1 - metadata.CullRelativeHeightPercentage) / 2 + metadata.CullRelativeHeightPercentage) / defaultLodBias;
-            return objectSize / (halfDistancePercentage * tanValue) - objectSize;
+            float size = metadata.LodGroup.size;
+            metadata.CullRelativeHeightPercentage = Mathf.Clamp(SceneLODInfoUtils.CalculateScreenRelativeCullHeight(tanValue, cullDistance + size / 2, size / 2, defaultLodBias), 0.02f, 0.999f);
+            metadata.LODChangeRelativeDistance = SceneLODInfoUtils.CalculateLODChangeRelativeHeight(metadata.CullRelativeHeightPercentage, tanValue, metadata.LodGroup.size / 2, defaultLodBias);
         }
 
         public bool HasLOD(byte lodForAcquisition)

--- a/Explorer/Assets/DCL/LOD/Components/SceneLODInfoUtils.cs
+++ b/Explorer/Assets/DCL/LOD/Components/SceneLODInfoUtils.cs
@@ -25,5 +25,20 @@
         {
             return (currentLoadLOD & (1 << lodLevel)) != 0;
         }
+
+        //This will give us the percent of the screen in which the object will be culled when being at (unloadingDistance - 1) parcel
+        public static float CalculateScreenRelativeCullHeight(float tanValue, float distanceToCenter, float objectExtents, float defaultLODBias)
+        {
+            return objectExtents / (distanceToCenter * tanValue) * defaultLODBias;
+        }
+
+        //This will give us the distance at which the LOD change should occur if we consider the percentage at the middle between 
+        //cull distance and 100% of the screen
+        public static float CalculateLODChangeRelativeHeight(float cullRelativeHeightPercentage, float tanValue, float objectExtents, float defaultLodBias)
+        {
+            float halfDistancePercentage = ((1 - cullRelativeHeightPercentage) / 2 + cullRelativeHeightPercentage) / defaultLodBias;
+            return objectExtents / (halfDistancePercentage * tanValue) - objectExtents;
+        }
+        
     }
 }

--- a/Explorer/Assets/DCL/LOD/Systems/CalculateLODBiasSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/CalculateLODBiasSystem.cs
@@ -24,8 +24,8 @@ namespace DCL.LOD.Systems
 
         protected override void Update(float t)
         {
-            float newHeight = Mathf.Tan(((defaultFOV - camera.GetCameraFovComponent(World).AdditiveFov) * 0.5f) * Mathf.Deg2Rad);
-            QualitySettings.lodBias = defaultLodBias * (defaultHeight / newHeight);
+            float newHeight = Mathf.Tan(camera.GetCameraComponent(World).Camera.fieldOfView * 0.5f * Mathf.Deg2Rad);
+            QualitySettings.lodBias = defaultLodBias * (newHeight / defaultHeight);
         }
 
         public override void Initialize()
@@ -33,7 +33,7 @@ namespace DCL.LOD.Systems
             camera = World.CacheCamera();
             defaultFOV = camera.GetCameraComponent(World).Camera.fieldOfView;
             defaultLodBias = QualitySettings.lodBias;
-            defaultHeight = Mathf.Tan((defaultFOV * 0.5f) * Mathf.Deg2Rad);
+            defaultHeight = Mathf.Tan(defaultFOV * 0.5f * Mathf.Deg2Rad);
         }
     }
 }

--- a/Explorer/Assets/DCL/LOD/Systems/LODPlugin.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/LODPlugin.cs
@@ -90,6 +90,7 @@ namespace DCL.PluginSystem.Global
             if (lodEnabled)
             {
                 CalculateLODBiasSystem.InjectToWorld(ref builder);
+                RecalculateLODDistanceSystem.InjectToWorld(ref builder, partitionSettings);
                 InitializeSceneLODInfoSystem.InjectToWorld(ref builder, lodCache, lodLevels, lodGroupPool, lodCacheParent);
                 UpdateSceneLODInfoSystem.InjectToWorld(ref builder, lodSettingsAsset, scenesCache, sceneReadinessReportQueue, decentralandUrlsSource);
                 InstantiateSceneLODInfoSystem.InjectToWorld(ref builder, frameCapBudget, memoryBudget, scenesCache, sceneReadinessReportQueue, lodTextureArrayContainer, partitionSettings);

--- a/Explorer/Assets/DCL/LOD/Systems/RecalculateLODDistanceSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/RecalculateLODDistanceSystem.cs
@@ -1,0 +1,60 @@
+﻿using Arch.Core;
+using Arch.System;
+using Arch.SystemGroups;
+using Arch.SystemGroups.Metadata;
+using DCL.CharacterCamera;
+using DCL.LOD.Components;
+using ECS.Abstract;
+using ECS.Prioritization;
+using ECS.SceneLifeCycle;
+using UnityEngine;
+
+namespace DCL.LOD.Systems
+{
+    [UpdateInGroup(typeof(RealmGroup))]
+    public partial class RecalculateLODDistanceSystem : BaseUnityLoopSystem
+    {
+        public IRealmPartitionSettings realmPartitionSettingsAsset;
+        private float defaultFOV;
+        private float defaultLodBias;
+
+        public RecalculateLODDistanceSystem(World world, IRealmPartitionSettings realmPartitionSettingsAsset) : base(world)
+        {
+            this.realmPartitionSettingsAsset = realmPartitionSettingsAsset;
+            realmPartitionSettingsAsset.OnMaxLoadingDistanceInParcelsChanged += RecalculateLODDistance;
+        }
+
+        public override void Initialize()
+        {
+            defaultFOV = World.CacheCamera().GetCameraComponent(World).Camera.fieldOfView;
+            defaultLodBias = QualitySettings.lodBias;
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            realmPartitionSettingsAsset.OnMaxLoadingDistanceInParcelsChanged -= RecalculateLODDistance;
+        }
+
+        private void RecalculateLODDistance(int obj)
+        {
+            RecalculateSceneLODDistanceQuery(World);
+        }
+
+        [Query]
+        public void RecalculateSceneLODDistance(ref SceneLODInfo sceneLODInfo)
+        {
+            // Not yet initialized
+            if (string.IsNullOrEmpty(sceneLODInfo.id))
+                return;
+
+            if (SceneLODInfoUtils.LODCount(sceneLODInfo.metadata.SuccessfullLODs) > 0)
+                sceneLODInfo.RecalculateLODDistances(defaultFOV, defaultLodBias, realmPartitionSettingsAsset.MaxLoadingDistanceInParcels);
+        }
+
+
+        protected override void Update(float t)
+        {
+        }
+    }
+}

--- a/Explorer/Assets/DCL/LOD/Systems/RecalculateLODDistanceSystem.cs.meta
+++ b/Explorer/Assets/DCL/LOD/Systems/RecalculateLODDistanceSystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 022c8dfffa514687967134904886a988
+timeCreated: 1722967060

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/IRealmPartitionSettings.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/IRealmPartitionSettings.cs
@@ -1,4 +1,5 @@
-﻿using ECS.Prioritization.Components;
+﻿using System;
+using ECS.Prioritization.Components;
 
 namespace ECS.Prioritization
 {
@@ -47,5 +48,7 @@ namespace ECS.Prioritization
         /// </summary>
         /// <returns>FPS</returns>
         int GetSceneUpdateFrequency(in PartitionComponent partition);
+
+        Action<int>? OnMaxLoadingDistanceInParcelsChanged { get; set; }
     }
 }

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettingsAsset.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettingsAsset.cs
@@ -8,7 +8,6 @@ namespace ECS.Prioritization
     [CreateAssetMenu(menuName = "Create Realm Partition Settings", fileName = "RealmPartitionSettings", order = 0)]
     public class RealmPartitionSettingsAsset : ScriptableObject, IRealmPartitionSettings
     {
-        public Action<int>? OnMaxLoadingDistanceInParcelsChanged;
 
         [SerializeField] private int[] fpsBuckets = { 30, 20, 10, 5, 0 };
         [SerializeField] private int behindFps = 1;
@@ -18,6 +17,8 @@ namespace ECS.Prioritization
         [field: SerializeField]
         public float AggregateAngleTolerance { get; private set; }
 
+        public Action<int>? OnMaxLoadingDistanceInParcelsChanged { get; set; }
+        
         public int MaxLoadingDistanceInParcels
         {
             get => Mathf.Min(maxLoadingDistanceInParcels, ParcelMathJobifiedHelper.RADIUS_HARD_LIMIT);
@@ -60,5 +61,6 @@ namespace ECS.Prioritization
             int bucketFps = fpsBuckets[Mathf.Clamp(partition.Bucket, 0, fpsBuckets.Length - 1)];
             return partition.IsBehind ? Mathf.Min(bucketFps, behindFps) : bucketFps;
         }
+
     }
 }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneFacade/SceneLODInfoExtensions.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneFacade/SceneLODInfoExtensions.cs
@@ -14,7 +14,10 @@ namespace DCL.LOD
             ILODCache lodCache,
                                                                 World world)
         {
-            lodCache.Release(sceneLODInfo.id, sceneLODInfo.metadata);
+            //Only try to release SceneLODInfo that has been initialized
+            if (!string.IsNullOrEmpty(sceneLODInfo.id))
+                lodCache.Release(sceneLODInfo.id, sceneLODInfo.metadata);
+            
             sceneLODInfo.Dispose(world);
             scenesCache.RemoveNonRealScene(parcels);
         }


### PR DESCRIPTION
## What does this PR change?

1. Adds a system that allows to recalculate relative transition heights on all LODs when `MaxParcelLoadingDistance` changes
2. When scrolling the camera (not running) the fov also changed. This PR adjusts that scenario, so the `LODBias` is correctly calculated.
3. Potentially fixes #1660. If the `SceneLODInfo` has not been initialized, there is nothing to dispose or release to pool


On top of that, it makes a refactor to `SceneLODInfo`. Divides the  `RecalculateLODValues` into two methods, `SetupRenderers` and `SetupLODRelativeHeights`. In that way, I can now update the distances without modifying the renderers 

## How to test the changes?

1. Launch the explorer
2. Walk around the worlds and see lods dither in/out. There should be no popping
3. Run around. LODS should dither in/out just the same
4. Same occurs when zooming the camera out
5. Finally, try changing the distance settings. If you move it up, the LODs loaded should stay longer. The other way around (move it down and LODs should disappear sooner) should work as well


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

