### PR TITLE
Fix: fixed text shape size to accept < 1 values as old renderer

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/TextShape/Component/TextShapeProperties.cs
+++ b/Explorer/Assets/DCL/SDKComponents/TextShape/Component/TextShapeProperties.cs
@@ -11,7 +11,7 @@ namespace DCL.SDKComponents.TextShape.Component
     {
         [Header("Font")]
         public Font font = Font.FSerif;
-        public bool fontAutoSize = true;
+        public bool fontAutoSize;
         public float fontSize = 10;
 
         [Header("Frame")]

--- a/Explorer/Assets/DCL/SDKComponents/TextShape/TMPProSdkExtensions.cs
+++ b/Explorer/Assets/DCL/SDKComponents/TextShape/TMPProSdkExtensions.cs
@@ -36,7 +36,7 @@ namespace DCL.SDKComponents.TextShape
             tmpText.text = textShape.Text;
 
             tmpText.color = textShape.TextColor?.ToUnityColor() ?? Color.white;
-            tmpText.fontSize = textShape.HasFontSize? (int)textShape.FontSize : 10; // in unity-renderer the default font size is 100
+            tmpText.fontSize = textShape.HasFontSize? textShape.FontSize : 10; // in unity-renderer the default font size is 100
             tmpText.richText = true;
             tmpText.overflowMode = TextOverflowModes.Overflow;
             tmpText.enableAutoSizing = textShape.HasFontAutoSize ? textShape.FontAutoSize : tmpText.fontSize == 0;


### PR DESCRIPTION
## What does this PR change?

This PR fixes the issue number #1521
Basically it changes the utils that process the TextShape components to allow font sizes smaller then 1, because TMPro accept this values and are commonly used in various scenes.
It also sets the base AutoSize value to false to be like the old renderer

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Enter the Surz scene using the /goto surz command in the chat.
3. Start the game.
4. Win a round.
5. Observe the "You win! Press E to keep playing" is correctly sized.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

