### PR TITLE
Fix/livekit versioning fix

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Connections/DCL.Multiplayer.Connections.asmdef
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/DCL.Multiplayer.Connections.asmdef
@@ -14,7 +14,8 @@
     "GUID:166b65e6dfc848bb9fb075f53c293a38",
     "GUID:006c0e0a70294dbba8a4cbcfb77e1f7d",
     "GUID:e0eedfa2deb9406daf86fd8368728e39",
-    "GUID:3640f3c0b42946b0b8794a1ed8e06ca5"
+    "GUID:3640f3c0b42946b0b8794a1ed8e06ca5",
+    "GUID:d414ef88f3b15f746a4b97636b50dfb4"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Messaging/Hubs/MessagePipesHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Messaging/Hubs/MessagePipesHub.cs
@@ -10,12 +10,10 @@ namespace DCL.Multiplayer.Connections.Messaging.Hubs
         private readonly IMessagePipe scenePipe;
         private readonly IMessagePipe islandPipe;
 
-        public MessagePipesHub(IRoomHub roomHub, IMultiPool multiPool, IMemoryPool memoryPool) : this(
-            new MessagePipe(roomHub.SceneRoom().DataPipe, multiPool, memoryPool).WithLog("Scene"),
-            new MessagePipe(roomHub.IslandRoom().DataPipe, multiPool, memoryPool).WithLog("Island")
-            )
-        {
-        }
+        public MessagePipesHub(IRoomHub roomHub, IMultiPool sendingMultiPool, IMultiPool receivingMultiPool, IMemoryPool memoryPool) : this(
+            new MessagePipe(roomHub.SceneRoom().DataPipe, sendingMultiPool, receivingMultiPool, memoryPool).WithLog("Scene"),
+            new MessagePipe(roomHub.IslandRoom().DataPipe, sendingMultiPool, receivingMultiPool, memoryPool).WithLog("Island")
+        ) { }
 
         public MessagePipesHub(IMessagePipe scenePipe, IMessagePipe islandPipe)
         {

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Messaging/MessageWrap.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Messaging/MessageWrap.cs
@@ -1,3 +1,4 @@
+using CrdtEcsBridge.Components;
 using Cysharp.Threading.Tasks;
 using DCL.Multiplayer.Connections.Pools;
 using Decentraland.Kernel.Comms.Rfc4;
@@ -53,7 +54,7 @@ namespace DCL.Multiplayer.Connections.Messaging
                 return;
 
             using var packetWrap = multiPool.TempResource<Packet>();
-            packetWrap.value.ClearMessage();
+            packetWrap.value.ClearProtobufComponent();
             packetWrap.value.ProtocolVersion = supportedVersion;
             WritePayloadToPacket(packetWrap.value);
             using MemoryWrap memory = memoryPool.Memory(packetWrap.value);

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Messaging/Pipe/MessagePipe.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Messaging/Pipe/MessagePipe.cs
@@ -1,3 +1,4 @@
+using CrdtEcsBridge.Components;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.Typing;
@@ -36,7 +37,7 @@ namespace DCL.Multiplayer.Connections.Messaging.Pipe
             new MessageParser<Packet>(() =>
             {
                 var packet = receivingMultiPool.Get<Packet>();
-                packet.ClearMessage();
+                packet.ClearProtobufComponent();
                 return packet;
             }),
             100

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -224,7 +224,9 @@ namespace Global.Dynamic
             var satelliteView = new SatelliteFloor();
             var landscapePlugin = new LandscapePlugin(satelliteView, genesisTerrain, worldsTerrain, assetsProvisioner, debugBuilder, container.MapRendererContainer.TextureContainer, staticContainer.WebRequestsContainer.WebRequestController, dynamicWorldParams.EnableLandscape);
 
-            var multiPool = new DCLMultiPool();
+            Func<IMultiPool> multiPoolFactory = () => new DCLMultiPool();
+
+            var multiPool = multiPoolFactory();
             var memoryPool = new ArrayMemoryPool(ArrayPool<byte>.Shared!);
             container.RealFlowLoadingStatus = new RealFlowLoadingStatus();
 
@@ -268,7 +270,7 @@ namespace Global.Dynamic
                 container.localSceneDevelopmentController = new LocalSceneDevelopmentController(container.reloadSceneController, dynamicWorldParams.LocalSceneDevelopmentRealm);
 
             container.RoomHub = localSceneDevelopment ? NullRoomHub.INSTANCE : new RoomHub(archipelagoIslandRoom, gateKeeperSceneRoom);
-            container.MessagePipesHub = new MessagePipesHub(container.RoomHub, multiPool, memoryPool);
+            container.MessagePipesHub = new MessagePipesHub(container.RoomHub, multiPoolFactory()!, multiPoolFactory()!, memoryPool);
 
             var entityParticipantTable = new EntityParticipantTable();
 


### PR DESCRIPTION
## What does this PR change?

For some reason generated method ClearMessage won't clear protocolVersion's field
Not it's separated by 2 pools, it also increases performance

Additionally MessagePipe got rid off unnecessary string allocations on message routing

## How to test the changes?

Follow the ticket: https://github.com/decentraland/unity-explorer/issues/1717

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

