### PR TITLE
chore: UpdateAudioSourceSystem optimization 

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/AudioSourcesPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AudioSourcesPlugin.cs
@@ -50,7 +50,7 @@ namespace DCL.PluginSystem.World
         {
             StartAudioSourceLoadingSystem.InjectToWorld(ref builder, sharedDependencies.SceneData, frameTimeBudgetProvider);
             LoadAudioClipSystem.InjectToWorld(ref builder, audioClipsCache, webRequestController);
-            UpdateAudioSourceSystem.InjectToWorld(ref builder, sharedDependencies.SceneData, sharedDependencies.SceneStateProvider, audioClipsCache, componentPoolsRegistry, frameTimeBudgetProvider, memoryBudgetProvider, audioMixer);
+            sceneIsCurrentListeners.Add(UpdateAudioSourceSystem.InjectToWorld(ref builder, sharedDependencies.SceneData, audioClipsCache, componentPoolsRegistry, frameTimeBudgetProvider, memoryBudgetProvider, audioMixer));
 
             finalizeWorldSystems.Add(CleanUpAudioSourceSystem.InjectToWorld(ref builder, audioClipsCache, componentPoolsRegistry));
         }

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
@@ -60,8 +60,10 @@ namespace DCL.SDKComponents.AudioSources
         private void CreateAudioSource(ref PBAudioSource sdkAudioSource, ref AudioSourceComponent audioSourceComponent, ref TransformComponent entityTransform)
         {
             if (audioSourceComponent.ClipPromise.IsConsumed
-                || !audioSourceComponent.ClipPromise.TryConsume(World!, out var promiseResult)
                 || NoBudget())
+                return;
+
+            if (!audioSourceComponent.ClipPromise.TryConsume(World!, out var promiseResult))
                 return;
 
             if (audioSourceComponent.AudioSourceAssigned == false)

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
@@ -59,9 +59,9 @@ namespace DCL.SDKComponents.AudioSources
         [Query]
         private void CreateAudioSource(ref PBAudioSource sdkAudioSource, ref AudioSourceComponent audioSourceComponent, ref TransformComponent entityTransform)
         {
-            if (NoBudget()
-                || audioSourceComponent.ClipPromise.IsConsumed
-                || !audioSourceComponent.ClipPromise.TryConsume(World!, out StreamableLoadingResult<AudioClip> promiseResult))
+            if (audioSourceComponent.ClipPromise.IsConsumed
+                || !audioSourceComponent.ClipPromise.TryConsume(World!, out var promiseResult)
+                || NoBudget())
                 return;
 
             if (audioSourceComponent.AudioSourceAssigned == false)

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Tests/UpdateAudioSourceSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Tests/UpdateAudioSourceSystemShould.cs
@@ -53,11 +53,8 @@ namespace DCL.SDKComponents.AudioSources.Tests
             IPerformanceBudget budgetProvider = Substitute.For<IPerformanceBudget>();
             budgetProvider.TrySpendBudget().Returns(true);
 
-            ISceneStateProvider sceneStateProvider = Substitute.For<ISceneStateProvider>();
-            sceneStateProvider.IsCurrent.Returns(true);
-
             IStreamableCache<AudioClip, GetAudioClipIntention> cache = Substitute.For<IStreamableCache<AudioClip, GetAudioClipIntention>>();
-            return new UpdateAudioSourceSystem(world, ECSTestUtils.SceneDataSub(), sceneStateProvider, cache, poolsRegistry, budgetProvider, budgetProvider, null);
+            return new UpdateAudioSourceSystem(world, ECSTestUtils.SceneDataSub(), cache, poolsRegistry, budgetProvider, budgetProvider, null);
         }
 
         [Test]


### PR DESCRIPTION
## What does this PR change?

1. Makes the volume setter to 0 event based instead of checking it every frame. When a scene is changed, the audio sources volumes should go to 0
2. `frameTimeBudgetProvider.TrySpendBudget()` was pilling up and causing an overhead. Moved the conditional around, so its not the first thing to check

Goes from this

![image](https://github.com/user-attachments/assets/e20a67cd-8856-4a65-9b86-8aebfa6a9b51)

to this

![image](https://github.com/user-attachments/assets/7b82354e-3189-4c07-878e-c02d41fcdf2a)


## How to test the changes?

1. Check audios are fine in Genesis Plaza or in other scene you know there are audios at
2. Go between scenes and check that you don't have invading sounds from other scenes

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

