### PR TITLE
style: fix unique rarity background texture

### DIFF
--- a/Explorer/Assets/Textures/BackpackPanel/ItemRarityBackground/UniqueBackground.png
+++ b/Explorer/Assets/Textures/BackpackPanel/ItemRarityBackground/UniqueBackground.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e80e5cd0166b6f717d00fdeb9dc69b421a60f5acdf4489b8b5ded3d496f3bbb0
-size 38042
+oid sha256:f3dcac434c87030802fa2464d36b143bf3640e52806e3d9eb9cc8feecfb5e875
+size 138137


### PR DESCRIPTION
## What does this PR change?
This PR fixes the unique background texture which had a different size compared with the rest of the rarities, making it look smaller and broken regarding the mask and the rest of the items. 
<img width="878" alt="Screenshot 2024-08-13 at 12 19 16" src="https://github.com/user-attachments/assets/af85ad5c-e3be-4d95-bcca-7efdc08e157b">


## How to test the changes?

1. Launch the explorer
2. Explore your profile or someone else's profile with unique items (@NikkiFuego for eg)
3. Open the backpack and check that unique items are also fixed.
