### PR TITLE
Fix: ClearScript `GetUserDataResponse` propagation

### DIFF
--- a/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
@@ -14,12 +14,12 @@ using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using Utility;
+using Utility.Multithreading;
 
 namespace DCL.Backpack
 {
     public class BackpackEquipStatusController : IDisposable
     {
-        private readonly Func<(World, Entity)> ecsContextProvider;
         private readonly IBackpackEventBus backpackEventBus;
         private readonly IEquippedEmotes equippedEmotes;
         private readonly IEquippedWearables equippedWearables;
@@ -27,8 +27,8 @@ namespace DCL.Backpack
         private readonly IWeb3IdentityCache web3IdentityCache;
         private readonly ICollection<string> forceRender;
 
-        private World? world;
-        private Entity? playerEntity;
+        private readonly World world;
+        private readonly Entity playerEntity;
         private CancellationTokenSource? publishProfileCts;
 
         public BackpackEquipStatusController(
@@ -37,14 +37,13 @@ namespace DCL.Backpack
             IEquippedWearables equippedWearables,
             ISelfProfile selfProfile,
             ICollection<string> forceRender,
-            Func<(World, Entity)> ecsContextProvider,
-            IWeb3IdentityCache web3IdentityCache
-        )
+            IWeb3IdentityCache web3IdentityCache,
+            World world,
+            Entity playerEntity)
         {
             this.backpackEventBus = backpackEventBus;
             this.equippedEmotes = equippedEmotes;
             this.equippedWearables = equippedWearables;
-            this.ecsContextProvider = ecsContextProvider;
             this.web3IdentityCache = web3IdentityCache;
             this.selfProfile = selfProfile;
             this.forceRender = forceRender;
@@ -57,6 +56,9 @@ namespace DCL.Backpack
             backpackEventBus.ChangeColorEvent += ChangeColor;
             backpackEventBus.ForceRenderEvent += SetForceRender;
             backpackEventBus.UnEquipAllEvent += UnEquipAll;
+
+            this.world = world;
+            this.playerEntity = playerEntity;
         }
 
         public void Dispose()
@@ -132,6 +134,7 @@ namespace DCL.Backpack
             {
                 var profile = await selfProfile.PublishAsync(ct);
                 // TODO: is it a single responsibility issue? perhaps we can move it elsewhere?
+                MultithreadingUtility.AssertMainThread(nameof(PublishProfileAsync), true);
                 UpdateAvatarInWorld(profile!);
             }
 
@@ -141,21 +144,14 @@ namespace DCL.Backpack
 
         private void UpdateAvatarInWorld(Profile profile)
         {
-            if (world == null || !playerEntity.HasValue)
-            {
-                (World? w, Entity e) = ecsContextProvider.Invoke();
-                world = w;
-                playerEntity = e;
-            }
-
             profile.IsDirty = true;
 
-            bool found = world.Has<Profile>(playerEntity.Value);
+            bool found = world.Has<Profile>(playerEntity);
 
             if (found)
-                world.Set(playerEntity.Value, profile);
+                world.Set(playerEntity, profile);
             else
-                world.Add(playerEntity.Value, profile);
+                world.Add(playerEntity, profile);
         }
     }
 }

--- a/Explorer/Assets/DCL/LOD/Components/SceneLODInfoDebug.cs
+++ b/Explorer/Assets/DCL/LOD/Components/SceneLODInfoDebug.cs
@@ -50,7 +50,7 @@ namespace DCL.LOD
             foreach (var pair in FailedLODs)
             {
                 foreach (var t in pair.Value)
-                    Object.Destroy(t.gameObject);
+                    UnityObjectUtils.SafeDestroy(t.gameObject);
                 lods[pair.Key].renderers = Array.Empty<Renderer>();
             }
 

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Systems/SceneWorld/CleanUpAvatarPropagationComponentsSystem.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Systems/SceneWorld/CleanUpAvatarPropagationComponentsSystem.cs
@@ -1,0 +1,46 @@
+﻿using Arch.Core;
+using Arch.System;
+using Arch.SystemGroups;
+using DCL.Multiplayer.SDK.Components;
+using DCL.Profiles;
+using ECS.Abstract;
+using ECS.Groups;
+using ECS.LifeCycle.Systems;
+
+namespace DCL.Multiplayer.SDK.Systems.SceneWorld
+{
+    /// <summary>
+    ///     Components local to the client can't be cleaned-up via <see cref="ResetDirtyFlagSystem{T}" />
+    ///     as their clean-up should not be throttled. Otherwise, components are reported every frame
+    /// </summary>
+    [UpdateInGroup(typeof(CleanUpGroup))]
+    public partial class CleanUpAvatarPropagationComponentsSystem : BaseUnityLoopSystem
+    {
+        internal CleanUpAvatarPropagationComponentsSystem(World world) : base(world) { }
+
+        protected override void Update(float t)
+        {
+            ResetSDKProfileQuery(World);
+            ResetSceneCRDTEntityQuery(World);
+            ResetAvatarEmoteCommandComponentQuery(World);
+        }
+
+        [Query]
+        private void ResetSDKProfile(ref SDKProfile sdkProfile)
+        {
+            sdkProfile.IsDirty = false;
+        }
+
+        [Query]
+        private void ResetSceneCRDTEntity(ref PlayerSceneCRDTEntity crdtEntity)
+        {
+            crdtEntity.IsDirty = false;
+        }
+
+        [Query]
+        private void ResetAvatarEmoteCommandComponent(ref AvatarEmoteCommandComponent avatarEmoteCommandComponent)
+        {
+            avatarEmoteCommandComponent.IsDirty = false;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Systems/SceneWorld/CleanUpAvatarPropagationComponentsSystem.cs.meta
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Systems/SceneWorld/CleanUpAvatarPropagationComponentsSystem.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 418c657883d1474a87b6b186741e7709
+timeCreated: 1723471901

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Systems/SceneWorld/WriteAvatarEmoteCommandSystem.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Systems/SceneWorld/WriteAvatarEmoteCommandSystem.cs
@@ -1,7 +1,6 @@
 using Arch.Core;
 using Arch.System;
 using Arch.SystemGroups;
-using CRDT;
 using CrdtEcsBridge.ECSToCRDTWriter;
 using DCL.Diagnostics;
 using DCL.ECSComponents;

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Systems/SceneWorld/WriteSDKAvatarBaseSystem.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Systems/SceneWorld/WriteSDKAvatarBaseSystem.cs
@@ -1,6 +1,7 @@
 using Arch.Core;
 using Arch.System;
 using Arch.SystemGroups;
+using Arch.SystemGroups.Metadata;
 using CrdtEcsBridge.ECSToCRDTWriter;
 using DCL.Diagnostics;
 using DCL.ECSComponents;
@@ -10,6 +11,7 @@ using ECS.Abstract;
 using ECS.Groups;
 using ECS.LifeCycle.Components;
 using ECS.Unity.ColorComponent;
+using System;
 
 namespace DCL.Multiplayer.SDK.Systems.SceneWorld
 {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportHub.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportHub.cs
@@ -81,7 +81,7 @@ namespace DCL.Diagnostics
         public static void Verbose(ReportData reportData, string message, ReportHandler reportToHandlers = ReportHandler.All)
         {
 #if !UNITY_EDITOR && !VERBOSE_LOGS
-            if (!enforceVerboseLogs) return;
+            if (!enforceUnconditionalVerboseLogs) return;
 #endif
             Instance.Log(LogType.Log, reportData, message, null, reportToHandlers);
         }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Pools/GameObjectPool.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Pools/GameObjectPool.cs
@@ -37,6 +37,9 @@ namespace DCL.Optimization.Pools
 
         public void Release(T element)
         {
+            // If Application is quitting game objects can be already destroyed
+            if (UnityObjectUtils.IsQuitting) return;
+
             if (element == null)
             {
                 ReportHub.LogError(ReportCategory.ENGINE, $"Trying to release `null` reference of type {typeof(T).Name} to the pool");

--- a/Explorer/Assets/DCL/PluginSystem/Global/BackpackSubPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/BackpackSubPlugin.cs
@@ -30,24 +30,24 @@ namespace DCL.PluginSystem.Global
     {
         private readonly IAssetsProvisioner assetsProvisioner;
         private readonly IWearableCatalog wearableCatalog;
+        private readonly ISelfProfile selfProfile;
         private readonly IEquippedWearables equippedWearables;
         private readonly IEquippedEmotes equippedEmotes;
         private readonly IEmoteCache emoteCache;
         private readonly IReadOnlyCollection<URN> embeddedEmotes;
+        private readonly ICollection<string> forceRender;
         private readonly IRealmData realmData;
         private readonly DCLInput dclInput;
         private readonly IWeb3IdentityCache web3Identity;
         private readonly BackpackCommandBus backpackCommandBus;
         private readonly IBackpackEventBus backpackEventBus;
         private readonly ICharacterPreviewFactory characterPreviewFactory;
-        private readonly BackpackEquipStatusController backpackEquipStatusController;
         private readonly URLDomain assetBundleURL;
         private readonly IWebRequestController webRequestController;
         private readonly CharacterPreviewEventBus characterPreviewEventBus;
 
         private BackpackBusController? busController;
-        private Arch.Core.World? world;
-        private Entity? playerEntity;
+        private BackpackEquipStatusController? backpackEquipStatusController;
 
         internal BackpackController? backpackController { get; private set; }
 
@@ -73,10 +73,12 @@ namespace DCL.PluginSystem.Global
             this.web3Identity = web3Identity;
             this.characterPreviewFactory = characterPreviewFactory;
             this.wearableCatalog = wearableCatalog;
+            this.selfProfile = selfProfile;
             this.equippedWearables = equippedWearables;
             this.equippedEmotes = equippedEmotes;
             this.emoteCache = emoteCache;
             this.embeddedEmotes = embeddedEmotes;
+            this.forceRender = forceRender;
             this.realmData = realmData;
             this.dclInput = dclInput;
             this.assetBundleURL = assetBundleURL;
@@ -85,16 +87,6 @@ namespace DCL.PluginSystem.Global
 
             backpackCommandBus = new BackpackCommandBus();
             this.backpackEventBus = backpackEventBus;
-
-            backpackEquipStatusController = new BackpackEquipStatusController(
-                backpackEventBus,
-                equippedEmotes,
-                equippedWearables,
-                selfProfile,
-                forceRender,
-                ProvideEcsContext,
-                web3Identity
-            );
         }
 
         internal async UniTask<ContinueInitialization> InitializeAsync(
@@ -156,8 +148,8 @@ namespace DCL.PluginSystem.Global
 
             return (ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments args) =>
             {
-                world = builder.World!;
-                playerEntity = args.PlayerEntity;
+                Arch.Core.World world = builder.World!;
+                Entity playerEntity = args.PlayerEntity;
 
                 var thumbnailProvider = new ECSThumbnailProvider(realmData, builder.World, assetBundleURL, webRequestController);
 
@@ -177,6 +169,17 @@ namespace DCL.PluginSystem.Global
 
                 var backpackCharacterPreviewController = new BackpackCharacterPreviewController(view.CharacterPreviewView,
                     characterPreviewFactory, backpackEventBus, world, equippedEmotes, characterPreviewEventBus);
+
+                backpackEquipStatusController = new BackpackEquipStatusController(
+                    backpackEventBus,
+                    equippedEmotes,
+                    equippedWearables,
+                    selfProfile,
+                    forceRender,
+                    web3Identity,
+                    world,
+                    playerEntity
+                );
 
                 backpackController = new BackpackController(
                     view,
@@ -205,8 +208,5 @@ namespace DCL.PluginSystem.Global
             backpackController?.Dispose();
             backpackEquipStatusController?.Dispose();
         }
-
-        private (Arch.Core.World, Entity) ProvideEcsContext() =>
-            (world!, playerEntity!.Value);
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/World/MultiplayerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MultiplayerPlugin.cs
@@ -1,6 +1,7 @@
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.Multiplayer.SDK.Components;
+using DCL.Multiplayer.SDK.Systems.SceneWorld;
 using DCL.PluginSystem.World.Dependencies;
 using DCL.Profiles;
 using ECS.LifeCycle;
@@ -31,9 +32,7 @@ namespace DCL.PluginSystem.World
             WriteAvatarEquippedDataSystem.InjectToWorld(ref builder, sharedDependencies.EcsToCRDTWriter);
             WriteAvatarEmoteCommandSystem.InjectToWorld(ref builder, sharedDependencies.EcsToCRDTWriter, sharedDependencies.SceneStateProvider);
 
-            ResetDirtyFlagSystem<SDKProfile>.InjectToWorld(ref builder);
-            ResetDirtyFlagSystem<PlayerSceneCRDTEntity>.InjectToWorld(ref builder);
-            ResetDirtyFlagSystem<AvatarEmoteCommandComponent>.InjectToWorld(ref builder);
+            CleanUpAvatarPropagationComponentsSystem.InjectToWorld(ref builder);
         }
     }
 }

--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/UserIdentityApi/UserIdentityApiWrapper.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/UserIdentityApi/UserIdentityApiWrapper.cs
@@ -7,6 +7,7 @@ using SceneRunner.Scene.ExceptionsHandling;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using UnityEngine;
 using Utility;
 
 namespace SceneRuntime.Apis.Modules.UserIdentityApi
@@ -73,7 +74,7 @@ namespace SceneRuntime.Apis.Modules.UserIdentityApi
                 }
             }
 
-            return GetOwnUserDataAsync(lifeCycleCts.Token).ToDisconnectedPromise();
+            return GetOwnUserDataAsync(lifeCycleCts.Token).ContinueWith(JsonUtility.ToJson).ToDisconnectedPromise();
         }
     }
 }

--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/UnityOpsApi.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/UnityOpsApi.cs
@@ -24,7 +24,7 @@ namespace SceneRuntime.Apis
         [UsedImplicitly]
         public void Log(string message)
         {
-            ReportHub.Log(new ReportData(ReportCategory.JAVASCRIPT, sceneShortInfo: sceneShortInfo), message);
+            ReportHub.Verbose(new ReportData(ReportCategory.JAVASCRIPT, sceneShortInfo: sceneShortInfo), message);
         }
 
         [UsedImplicitly]

--- a/Explorer/Assets/StreamingAssets/Js/Modules/UserIdentity.js
+++ b/Explorer/Assets/StreamingAssets/Js/Modules/UserIdentity.js
@@ -3,26 +3,7 @@ module.exports.getUserPublicKey = async function(message) {
 }
 
 module.exports.getUserData = async function(message) {
-    const result = await UnityUserIdentityApi.GetOwnUserData();
-    if (result.data == undefined) {
-        return result
-    }
-    
-    const data = result.data;
-    const avatar = data.avatar;
-    const wearables = Array(avatar.wearables.Count);
-    
-    for (let i = 0; i < avatar.wearables.Count; i++) {
-        wearables[i] = avatar.wearables[i];
-    }
-    
-    return {
-        data: {
-            ...data,
-            avatar: {
-                ...avatar,
-                wearables: wearables
-            }
-        }
-    };
+    const json = await UnityUserIdentityApi.GetOwnUserData();
+    const result = JSON.parse(json);
+    return result;
 }


### PR DESCRIPTION
### Fixes #1678 

**Reason:**
During the resolution of `GetUserDataResponse` promise the stack is overflowed. I traced it down to the following:

```
  System.StackOverflowException: The requested operation caused a stack overflow.
  at (wrapper managed-to-native) System.Object.__icall_wrapper_ves_icall_array_new_specific(intptr,int)
  at System.RuntimeType.GetFields_internal (System.String name, System.Reflection.BindingFlags bindingAttr, System.RuntimeType+MemberListType listType, System.RuntimeType reflectedType) [0x0002f] in <b11ba2a8fbf24f219f7cc98532a11304>:0 
  at System.RuntimeType.GetFieldCandidates (System.String name, System.Reflection.BindingFlags bindingAttr, System.Boolean allowPrefixLookup) [0x0000f] in <b11ba2a8fbf24f219f7cc98532a11304>:0 
  at System.RuntimeType.GetFields (System.Reflection.BindingFlags bindingAttr) [0x00000] in <b11ba2a8fbf24f219f7cc98532a11304>:0 
  at Microsoft.ClearScript.Util.TypeHelpers.GetScriptableFields (System.Type type, System.Reflection.BindingFlags bindFlags, System.Type accessContext, Microsoft.ClearScript.ScriptAccess defaultAccess) [0x00014] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.Util.TypeHelpers.GetScriptableField (System.Type type, System.String name, System.Reflection.BindingFlags bindFlags, System.Type accessContext, Microsoft.ClearScript.ScriptAccess defaultAccess) [0x0005b] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.HostItem.GetHostProperty (System.String name, System.Reflection.BindingFlags invokeFlags, System.Object[] args, System.Object[] bindArgs, System.Boolean includeBoundMembers, System.Boolean& isCacheable) [0x003ec] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.HostItem.InvokeHostMember (System.String name, System.Reflection.BindingFlags invokeFlags, System.Object[] args, System.Object[] bindArgs, System.Boolean& isCacheable) [0x0030a] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.HostItem.InvokeMember (System.String name, System.Reflection.BindingFlags invokeFlags, System.Object[] args, System.Object[] bindArgs, System.Globalization.CultureInfo culture, System.Boolean bypassTunneling, System.Boolean& isCacheable) [0x00126] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.HostItem+<>c__DisplayClass147_0.<InvokeReflectMember>b__0 () [0x0011b] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.ScriptEngine.HostInvoke[T] (System.Func`1[TResult] func) [0x00000] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.HostItem.HostInvoke[T] (System.Func`1[TResult] func) [0x0000c] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.HostItem.InvokeReflectMember (System.String name, System.Reflection.BindingFlags invokeFlags, System.Object[] wrappedArgs, System.Globalization.CultureInfo culture, System.String[] namedParams, System.Boolean& isCacheable) [0x0003f] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.HostItem.Microsoft.ClearScript.Util.IDynamic.GetProperty (System.String name, System.Boolean& isCacheable, System.Object[] args) [0x0000d] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.V8.V8ProxyHelpers.GetHostObjectProperty (System.Object obj, System.String name, System.Boolean& isCacheable) [0x0000d] in <a1cbb75d8b5a46e59f09b9c70b8cb688>:0 
  at Microsoft.ClearScript.V8.V8ProxyHelpers.GetHostObjectProperty (System.IntPtr pObject, System.String name, System.Boolean& isCacheable) [0x00006] in <a1cbb75d8b5a46e59f09b9c70b8cb688>:0 
  at Microsoft.ClearScript.V8.SplitProxy.V8SplitProxyManaged.GetHostObjectNamedPropertyWithCacheability (System.IntPtr pObject, Microsoft.ClearScript.V8.SplitProxy.StdString+Ptr pName, Microsoft.ClearScript.V8.SplitProxy.V8Value+Ptr pValue, System.Boolean& isCacheable) [0x00008] in <a1cbb75d8b5a46e59f09b9c70b8cb688>:0 
  at (wrapper native-to-managed) Microsoft.ClearScript.V8.SplitProxy.V8SplitProxyManaged.GetHostObjectNamedPropertyWithCacheability(intptr,Microsoft.ClearScript.V8.SplitProxy.StdString/Ptr,Microsoft.ClearScript.V8.SplitProxy.V8Value/Ptr,byte&)
  at (wrapper managed-to-native) Microsoft.ClearScript.V8.SplitProxy.V8SplitProxyNative+Impl_Windows_X64.V8Object_InvokeMethod(Microsoft.ClearScript.V8.SplitProxy.V8Object/Handle,Microsoft.ClearScript.V8.SplitProxy.StdString/Ptr,Microsoft.ClearScript.V8.SplitProxy.StdV8ValueArray/Ptr,Microsoft.ClearScript.V8.SplitProxy.V8Value/Ptr)
  at Microsoft.ClearScript.V8.SplitProxy.V8SplitProxyNative+Impl_Windows_X64.Microsoft.ClearScript.V8.SplitProxy.IV8SplitProxyNative.V8Object_InvokeMethod (Microsoft.ClearScript.V8.SplitProxy.V8Object+Handle hObject, System.String name, System.Object[] args) [0x00027] in <a1cbb75d8b5a46e59f09b9c70b8cb688>:0 
  at Microsoft.ClearScript.V8.SplitProxy.V8ObjectImpl+<>c__DisplayClass27_0.<InvokeMethod>b__0 (Microsoft.ClearScript.V8.SplitProxy.IV8SplitProxyNative instance) [0x0000c] in <a1cbb75d8b5a46e59f09b9c70b8cb688>:0 
  at Microsoft.ClearScript.V8.SplitProxy.V8SplitProxyNative.Invoke[T] (System.Func`2[T,TResult] func) [0x0001c] in <a1cbb75d8b5a46e59f09b9c70b8cb688>:0 
  at Microsoft.ClearScript.V8.SplitProxy.V8ObjectImpl.InvokeMethod (System.String name, System.Object[] args) [0x00005] in <a1cbb75d8b5a46e59f09b9c70b8cb688>:0 
  at Microsoft.ClearScript.V8.V8ScriptItem+<>c__DisplayClass10_0.<InvokeMethod>b__0 () [0x00027] in <a1cbb75d8b5a46e59f09b9c70b8cb688>:0 
  at Microsoft.ClearScript.ScriptEngine.ScriptInvokeInternal[T] (System.Func`1[TResult] func) [0x00012] in <67e84edf6c9745c9b58de9459a07bd5c>:0 
  at Microsoft.ClearScript.V8.V8ScriptEngine+<>c__DisplayClass127_0`1[T].<ScriptInvoke>b__0 () [0x00000] in <a1cbb75d8b5a46e59f09b9c70b8cb688>:0 
  at Microsoft.ClearScript.V8.SplitProxy.V8SplitProxyManaged.InvokeHostAction (System.IntPtr pAction) [0x00006] in <a1cbb75d8b5a46e59f09b9c70b8cb688>:0 
```

Unfortunately the whole stack between native and managed jumps is not preserved so it's impossible to evaluate the whoel calls chain.

That code corresponds to fields access of a marshalled object:
- It's super performance and memory unfriendly, unfortunately ClearScript has not optimized the reflection path
- The marshalled object is passed by ref within JS code so every time its fields are accessed it leads to marshalling
- Unfortunately I could not narrow down to the exact field access that was causing an exception but it was within `GetUserDataResponse` structure

The impact of this and the stack length is shown below:

![Screenshot 2024-08-13 190415](https://github.com/user-attachments/assets/cf69de5d-cdc2-46c2-8c05-d1cf426c67f1)

**Solution:**
- Serialize and Deserialize `GetUserDataResponse` instead of marshalling
- The object deserialized is native to JS and does not require marshalling removing the corresponding impact

### Other issues

- Fixed Repetitive propagation of the changed profile/avatar data as the system resetting its dirtiness was bound to the scene loop
- Fixed Debug logs, put them back under the conditional compilation and introduced a separated method to log unconditionally for very specific circumstances (local scene development) 