### PR TITLE
fix: disable shadow casting for very distant trees and disable wind for lod0+

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01 Variant.prefab
@@ -14,15 +14,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 80.45209
+      value: 512.8621
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.0000076293945
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -614.5084
+      value: 151.08856
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
       propertyPath: m_LocalRotation.w
@@ -52,6 +52,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -826304646921787292, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 6216ac33d8f9df848947beada2ae5d74, type: 2}
+    - target: {fileID: -826304646921787292, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: 586ed44f1ca988c4b886ff5cb85d2999, type: 2}
     - target: {fileID: 919132149155446097, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
       propertyPath: m_Name
       value: Tree01 Variant
@@ -72,6 +80,14 @@ PrefabInstance:
       propertyPath: m_LODs.Array.data[3].screenRelativeHeight
       value: 0.010651686
       objectReference: {fileID: 0}
+    - target: {fileID: 6860042754516746155, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 6216ac33d8f9df848947beada2ae5d74, type: 2}
+    - target: {fileID: 6860042754516746155, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: 586ed44f1ca988c4b886ff5cb85d2999, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01_Billboard_LOD3.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01_Billboard_LOD3.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
   - EFFECT_BILLBOARD
-  - _WINDQUALITY_FASTEST
+  - _WINDQUALITY_NONE
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -71,21 +71,21 @@ Material:
     m_Floats:
     - BACKFACE_NORMAL_MODE: 1
     - EFFECT_BILLBOARD: 1
-    - EFFECT_EXTRA_TEX: 0
+    - EFFECT_EXTRA_TEX: 1
     - _AlphaClipThreshold: 0.33
-    - _Glossiness: 0
+    - _Glossiness: 1
     - _HueVariationKwToggle: 1
-    - _Metallic: 0
+    - _Metallic: 1
     - _NormalMapKwToggle: 1
-    - _OldHueVarBehavior: 1
+    - _OldHueVarBehavior: 0
     - _QueueControl: 0
     - _QueueOffset: 0
-    - _SubsurfaceIndirect: 0.1
+    - _SubsurfaceIndirect: 0.25
     - _SubsurfaceKwToggle: 1
-    - _WINDQUALITY: 1
-    - _WindQuality: 1
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _HueVariationColor: {r: 0.92549026, g: 0.52156866, b: 0.07450981, a: 0.5019608}
-    - _SubsurfaceColor: {r: 0.9607844, g: 0.78823537, b: 0.454902, a: 1}
+    - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}
+    - _SubsurfaceColor: {r: 1, g: 1, b: 1, a: 1}
   m_BuildTextureStacks: []

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01_LOD0.mat
@@ -26,7 +26,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_NONE
+  - _WINDQUALITY_BEST
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -81,8 +81,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.25
     - _SubsurfaceKwToggle: 1
-    - _WINDQUALITY: 0
-    - _WindQuality: 0
+    - _WINDQUALITY: 4
+    - _WindQuality: 1
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01_LOD0.mat
@@ -26,7 +26,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_BEST
+  - _WINDQUALITY_NONE
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -70,21 +70,21 @@ Material:
     m_Floats:
     - BACKFACE_NORMAL_MODE: 1
     - EFFECT_BILLBOARD: 0
-    - EFFECT_EXTRA_TEX: 0
+    - EFFECT_EXTRA_TEX: 1
     - _AlphaClipThreshold: 0.33
     - _Glossiness: 0
     - _HueVariationKwToggle: 1
     - _Metallic: 0
-    - _NormalMapKwToggle: 0
-    - _OldHueVarBehavior: 1
+    - _NormalMapKwToggle: 1
+    - _OldHueVarBehavior: 0
     - _QueueControl: 0
     - _QueueOffset: 0
-    - _SubsurfaceIndirect: 0.1
+    - _SubsurfaceIndirect: 0.25
     - _SubsurfaceKwToggle: 1
-    - _WINDQUALITY: 4
-    - _WindQuality: 4
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _HueVariationColor: {r: 0.92549026, g: 0.52156854, b: 0.07450978, a: 0.5019608}
-    - _SubsurfaceColor: {r: 1, g: 0.88255084, b: 0.6556604, a: 1}
+    - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}
+    - _SubsurfaceColor: {r: 1, g: 1, b: 1, a: 1}
   m_BuildTextureStacks: []

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01_LOD_NoWind.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01_LOD_NoWind.mat
@@ -1,0 +1,90 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5736387525623791430
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Tree01_LOD_NoWind
+  m_Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - BACKFACE_NORMAL_MODE_MIRROR
+  - _WINDQUALITY_NONE
+  m_InvalidKeywords: []
+  m_LightmapFlags: 2
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 1
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ExtraTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: b94895fa5b1d36c42a211cb755e85d2e, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SubsurfaceTex:
+        m_Texture: {fileID: 2800000, guid: 63a489dbfbcc19e4290d597a42625d5e, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - BACKFACE_NORMAL_MODE: 1
+    - EFFECT_BILLBOARD: 0
+    - EFFECT_EXTRA_TEX: 1
+    - _AlphaClipThreshold: 0.33
+    - _Glossiness: 0
+    - _HueVariationKwToggle: 1
+    - _Metallic: 0
+    - _NormalMapKwToggle: 1
+    - _OldHueVarBehavior: 0
+    - _QueueControl: 0
+    - _QueueOffset: 0
+    - _SubsurfaceIndirect: 0.25
+    - _SubsurfaceKwToggle: 1
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}
+    - _SubsurfaceColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01_LOD_NoWind.mat.meta
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01_LOD_NoWind.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 586ed44f1ca988c4b886ff5cb85d2999
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Trunk_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Trunk_LOD0.mat
@@ -13,7 +13,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_NONE
+  - _WINDQUALITY_BEST
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -68,8 +68,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.25
     - _SubsurfaceKwToggle: 0
-    - _WINDQUALITY: 0
-    - _WindQuality: 0
+    - _WINDQUALITY: 4
+    - _WindQuality: 1
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Trunk_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Trunk_LOD0.mat
@@ -13,7 +13,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_BEST
+  - _WINDQUALITY_NONE
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -26,7 +26,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _BumpMap:
-        m_Texture: {fileID: 2800000, guid: 346d93fe259b226469a3f7f582af428a, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _ExtraTex:
@@ -34,7 +34,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 0b70f380c04e1184389dc604167a5c01, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _SubsurfaceTex:
@@ -68,8 +68,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.25
     - _SubsurfaceKwToggle: 0
-    - _WINDQUALITY: 4
-    - _WindQuality: 4
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Trunk_LOD_NoWind.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Trunk_LOD_NoWind.mat
@@ -1,0 +1,90 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Trunk_LOD_NoWind
+  m_Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - BACKFACE_NORMAL_MODE_MIRROR
+  - _WINDQUALITY_NONE
+  m_InvalidKeywords: []
+  m_LightmapFlags: 2
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ExtraTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SubsurfaceTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - BACKFACE_NORMAL_MODE: 1
+    - EFFECT_BILLBOARD: 0
+    - EFFECT_EXTRA_TEX: 1
+    - _AlphaClipThreshold: 0.33
+    - _Glossiness: 0.2509804
+    - _HueVariationKwToggle: 1
+    - _Metallic: 0
+    - _NormalMapKwToggle: 1
+    - _OldHueVarBehavior: 0
+    - _QueueControl: 0
+    - _QueueOffset: 0
+    - _SubsurfaceIndirect: 0.25
+    - _SubsurfaceKwToggle: 0
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}
+    - _SubsurfaceColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &7196465453147827752
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Trunk_LOD_NoWind.mat.meta
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Trunk_LOD_NoWind.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6216ac33d8f9df848947beada2ae5d74
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02 Variant.prefab
@@ -14,15 +14,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1210.1542
+      value: 513.20306
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.5992652
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1870.1772
+      value: 127.74459
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
       propertyPath: m_LocalRotation.w
@@ -52,6 +52,22 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -3898294048865169196, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: be2688536fdbd4c4b883cceff222ca00, type: 2}
+    - target: {fileID: -3898294048865169196, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: 91e0dafba65a0af41b73e806444da999, type: 2}
+    - target: {fileID: 660055678392721515, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: be2688536fdbd4c4b883cceff222ca00, type: 2}
+    - target: {fileID: 660055678392721515, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: 91e0dafba65a0af41b73e806444da999, type: 2}
     - target: {fileID: 919132149155446097, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
       propertyPath: m_Name
       value: Tree02 Variant

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02_Billboard_LOD3.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02_Billboard_LOD3.mat
@@ -14,7 +14,7 @@ Material:
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
   - EFFECT_BILLBOARD
-  - _WINDQUALITY_FASTEST
+  - _WINDQUALITY_NONE
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -69,8 +69,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.1
     - _SubsurfaceKwToggle: 1
-    - _WINDQUALITY: 1
-    - _WindQuality: 1
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 0.7686275, g: 0.4117647, b: 0.06666665, a: 0.5019608}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02_LOD0.mat
@@ -13,7 +13,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_NONE
+  - _WINDQUALITY_BEST
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -68,8 +68,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.1
     - _SubsurfaceKwToggle: 1
-    - _WINDQUALITY: 0
-    - _WindQuality: 0
+    - _WINDQUALITY: 4
+    - _WindQuality: 1
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 0.7686275, g: 0.41176474, b: 0.06666667, a: 0.5019608}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02_LOD0.mat
@@ -13,7 +13,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_BEST
+  - _WINDQUALITY_NONE
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -68,8 +68,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.1
     - _SubsurfaceKwToggle: 1
-    - _WINDQUALITY: 4
-    - _WindQuality: 4
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 0.7686275, g: 0.41176474, b: 0.06666667, a: 0.5019608}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02_LOD_NoWind.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02_LOD_NoWind.mat
@@ -1,0 +1,90 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Tree02_LOD_NoWind
+  m_Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - BACKFACE_NORMAL_MODE_MIRROR
+  - _WINDQUALITY_NONE
+  m_InvalidKeywords: []
+  m_LightmapFlags: 2
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 1
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ExtraTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 304e1a173fe129443a8e14730e33310b, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SubsurfaceTex:
+        m_Texture: {fileID: 2800000, guid: 97c622c908130b742b46f8b2a056d15a, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - BACKFACE_NORMAL_MODE: 1
+    - EFFECT_BILLBOARD: 0
+    - EFFECT_EXTRA_TEX: 0
+    - _AlphaClipThreshold: 0.33
+    - _Glossiness: 0
+    - _HueVariationKwToggle: 1
+    - _Metallic: 0
+    - _NormalMapKwToggle: 0
+    - _OldHueVarBehavior: 1
+    - _QueueControl: 0
+    - _QueueOffset: 0
+    - _SubsurfaceIndirect: 0.1
+    - _SubsurfaceKwToggle: 1
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _HueVariationColor: {r: 0.7686275, g: 0.41176474, b: 0.06666667, a: 0.5019608}
+    - _SubsurfaceColor: {r: 0.9921569, g: 0.9960785, b: 0.854902, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &7027227174819161736
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02_LOD_NoWind.mat.meta
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02_LOD_NoWind.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 91e0dafba65a0af41b73e806444da999
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Trunk_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Trunk_LOD0.mat
@@ -13,7 +13,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_BEST
+  - _WINDQUALITY_NONE
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -68,8 +68,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.25
     - _SubsurfaceKwToggle: 0
-    - _WINDQUALITY: 4
-    - _WindQuality: 4
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Trunk_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Trunk_LOD0.mat
@@ -13,7 +13,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_NONE
+  - _WINDQUALITY_BEST
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -68,8 +68,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.25
     - _SubsurfaceKwToggle: 0
-    - _WINDQUALITY: 0
-    - _WindQuality: 0
+    - _WINDQUALITY: 4
+    - _WindQuality: 1
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Trunk_LOD_NoWind.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Trunk_LOD_NoWind.mat
@@ -1,0 +1,90 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Trunk_LOD_NoWind
+  m_Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - BACKFACE_NORMAL_MODE_MIRROR
+  - _WINDQUALITY_NONE
+  m_InvalidKeywords: []
+  m_LightmapFlags: 2
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 2800000, guid: 346d93fe259b226469a3f7f582af428a, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ExtraTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 0b70f380c04e1184389dc604167a5c01, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SubsurfaceTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - BACKFACE_NORMAL_MODE: 1
+    - EFFECT_BILLBOARD: 0
+    - EFFECT_EXTRA_TEX: 1
+    - _AlphaClipThreshold: 0.33
+    - _Glossiness: 0.2509804
+    - _HueVariationKwToggle: 1
+    - _Metallic: 0
+    - _NormalMapKwToggle: 1
+    - _OldHueVarBehavior: 0
+    - _QueueControl: 0
+    - _QueueOffset: 0
+    - _SubsurfaceIndirect: 0.25
+    - _SubsurfaceKwToggle: 0
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}
+    - _SubsurfaceColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &4173447116808058116
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Trunk_LOD_NoWind.mat.meta
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Trunk_LOD_NoWind.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: be2688536fdbd4c4b883cceff222ca00
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03 Variant.prefab
@@ -14,15 +14,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 167.55455
+      value: 519.92065
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.0000009536743
+      value: 3.7279105
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1735.4667
+      value: 161.22261
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
       propertyPath: m_LocalRotation.w
@@ -52,6 +52,22 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -3133692548589481169, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 71a6827b73a416f4797633b9eda7a640, type: 2}
+    - target: {fileID: -3133692548589481169, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: 9033a1c43e10cb0439f54b71c37b37a8, type: 2}
+    - target: {fileID: -3109584156469848223, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 71a6827b73a416f4797633b9eda7a640, type: 2}
+    - target: {fileID: -3109584156469848223, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: 9033a1c43e10cb0439f54b71c37b37a8, type: 2}
     - target: {fileID: 919132149155446097, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
       propertyPath: m_Name
       value: Tree03 Variant

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03_Billboard_LOD3.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03_Billboard_LOD3.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
   - EFFECT_BILLBOARD
-  - _WINDQUALITY_FASTEST
+  - _WINDQUALITY_NONE
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -82,8 +82,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.1
     - _SubsurfaceKwToggle: 1
-    - _WINDQUALITY: 1
-    - _WindQuality: 1
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 0.18039212, g: 0.36470586, b: 0.6117647, a: 0.6509804}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03_LOD0.mat
@@ -13,7 +13,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_BEST
+  - _WINDQUALITY_NONE
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -68,8 +68,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.1
     - _SubsurfaceKwToggle: 1
-    - _WINDQUALITY: 4
-    - _WindQuality: 4
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 0.18039212, g: 0.36470586, b: 0.6117647, a: 0.6509804}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03_LOD0.mat
@@ -13,7 +13,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_NONE
+  - _WINDQUALITY_BEST
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -68,7 +68,7 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.1
     - _SubsurfaceKwToggle: 1
-    - _WINDQUALITY: 0
+    - _WINDQUALITY: 4
     - _WindQuality: 0
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03_LOD_NoWind.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03_LOD_NoWind.mat
@@ -1,0 +1,90 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Tree03_LOD_NoWind
+  m_Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - BACKFACE_NORMAL_MODE_MIRROR
+  - _WINDQUALITY_NONE
+  m_InvalidKeywords: []
+  m_LightmapFlags: 2
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 1
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ExtraTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 6f6096e1998574240b2b6bcbcc295616, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SubsurfaceTex:
+        m_Texture: {fileID: 2800000, guid: cf10d1dfd4612b247909d9b13aa23eaa, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - BACKFACE_NORMAL_MODE: 1
+    - EFFECT_BILLBOARD: 0
+    - EFFECT_EXTRA_TEX: 1
+    - _AlphaClipThreshold: 0.33
+    - _Glossiness: 0
+    - _HueVariationKwToggle: 1
+    - _Metallic: 0
+    - _NormalMapKwToggle: 0
+    - _OldHueVarBehavior: 1
+    - _QueueControl: 0
+    - _QueueOffset: 0
+    - _SubsurfaceIndirect: 0.1
+    - _SubsurfaceKwToggle: 1
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _HueVariationColor: {r: 0.18039212, g: 0.36470586, b: 0.6117647, a: 0.6509804}
+    - _SubsurfaceColor: {r: 0.5568628, g: 0.9803922, b: 0.8117648, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &4157037057963930545
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03_LOD_NoWind.mat.meta
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03_LOD_NoWind.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9033a1c43e10cb0439f54b71c37b37a8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Trunk_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Trunk_LOD0.mat
@@ -13,7 +13,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_BEST
+  - _WINDQUALITY_NONE
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -68,8 +68,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.25
     - _SubsurfaceKwToggle: 0
-    - _WINDQUALITY: 4
-    - _WindQuality: 4
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Trunk_LOD0.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Trunk_LOD0.mat
@@ -13,7 +13,7 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - BACKFACE_NORMAL_MODE_MIRROR
-  - _WINDQUALITY_NONE
+  - _WINDQUALITY_BEST
   m_InvalidKeywords: []
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 1
@@ -68,8 +68,8 @@ Material:
     - _QueueOffset: 0
     - _SubsurfaceIndirect: 0.25
     - _SubsurfaceKwToggle: 0
-    - _WINDQUALITY: 0
-    - _WindQuality: 0
+    - _WINDQUALITY: 4
+    - _WindQuality: 1
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Trunk_LOD_NoWind.mat
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Trunk_LOD_NoWind.mat
@@ -1,0 +1,90 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Trunk_LOD_NoWind
+  m_Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - BACKFACE_NORMAL_MODE_MIRROR
+  - _WINDQUALITY_NONE
+  m_InvalidKeywords: []
+  m_LightmapFlags: 2
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 2800000, guid: 346d93fe259b226469a3f7f582af428a, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ExtraTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 0b70f380c04e1184389dc604167a5c01, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SubsurfaceTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - BACKFACE_NORMAL_MODE: 1
+    - EFFECT_BILLBOARD: 0
+    - EFFECT_EXTRA_TEX: 1
+    - _AlphaClipThreshold: 0.33
+    - _Glossiness: 0.2509804
+    - _HueVariationKwToggle: 1
+    - _Metallic: 0
+    - _NormalMapKwToggle: 1
+    - _OldHueVarBehavior: 0
+    - _QueueControl: 0
+    - _QueueOffset: 0
+    - _SubsurfaceIndirect: 0.25
+    - _SubsurfaceKwToggle: 0
+    - _WINDQUALITY: 0
+    - _WindQuality: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _HueVariationColor: {r: 1, g: 0.5, b: 0, a: 0.1}
+    - _SubsurfaceColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &5983946713358790996
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Trunk_LOD_NoWind.mat.meta
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Trunk_LOD_NoWind.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71a6827b73a416f4797633b9eda7a640
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?

* All trees were previously casting shadows, even billboards
* The same for wind, it was affecting all trees (or rather the calculation was being ran) for trees in the distance.

Before:
![image](https://github.com/user-attachments/assets/e3d78691-510c-449a-86f8-24fc7f604d19)
![image](https://github.com/user-attachments/assets/896b1cd5-3b0f-4c93-b5dd-d516c1d1e15e)


After:
![image](https://github.com/user-attachments/assets/50403bce-c3a0-4190-8b3a-f544b2a43e6a)
![image](https://github.com/user-attachments/assets/68ab2f95-9a3a-4c95-a4c0-b93561ca5890)


## How to test the changes?

* Verify there are no obvious visual differences between the trees
* Verify the wind still works for the close trees

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

