### PR TITLE
Fix: fixed scene placement by introducing a new scene transform parent

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/TransformsPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/TransformsPlugin.cs
@@ -2,6 +2,7 @@
 using DCL.CharacterCamera;
 using DCL.Optimization.Pools;
 using DCL.PluginSystem.World.Dependencies;
+using Decentraland.Common;
 using ECS.ComponentsPooling.Systems;
 using ECS.LifeCycle;
 using ECS.Unity.Systems;
@@ -10,6 +11,8 @@ using ECS.Unity.Transforms.Systems;
 using System.Collections.Generic;
 using UnityEngine;
 using Utility;
+using Quaternion = UnityEngine.Quaternion;
+using Vector3 = UnityEngine.Vector3;
 
 namespace DCL.PluginSystem.World
 {
@@ -56,24 +59,28 @@ namespace DCL.PluginSystem.World
         private void CreateReservedTransforms(ArchSystemsWorldBuilder<Arch.Core.World> builder,
             ECSWorldInstanceSharedDependencies sharedDependencies, PersistentEntities persistentEntities)
         {
-            Transform sceneRootTransform = GetNewTransform(sharedDependencies);
-            sceneRootTransform.name = $"{sharedDependencies.SceneData.SceneShortInfo.BaseParcel}_{sharedDependencies.SceneData.SceneShortInfo.Name}";
+            Transform sceneRootContainerTransform = GetNewTransform(position: sharedDependencies.SceneData.Geometry.BaseParcelPosition);
+            sceneRootContainerTransform.name = $"{sharedDependencies.SceneData.SceneShortInfo.BaseParcel}_{sharedDependencies.SceneData.SceneShortInfo.Name}_Container";
+            builder.World.Create(new TransformComponent(sceneRootContainerTransform));
+
+            Transform sceneRootTransform = GetNewTransform(sceneRootContainerTransform);
+            sceneRootTransform.name = $"{sharedDependencies.SceneData.SceneShortInfo.BaseParcel}_{sharedDependencies.SceneData.SceneShortInfo.Name}_SceneRoot";
             builder.World.Add(persistentEntities.SceneRoot, new TransformComponent(sceneRootTransform));
 
-            Transform playerTransform = GetNewTransform(sharedDependencies, sceneRootTransform);
+            Transform playerTransform = GetNewTransform(sceneRootTransform);
             playerTransform.name = $"{sharedDependencies.SceneData.SceneShortInfo.BaseParcel} PLAYER_ENTITY";
             builder.World.Add(persistentEntities.Player, new TransformComponent(playerTransform));
 
-            Transform cameraTransform = GetNewTransform(sharedDependencies, sceneRootTransform);
+            Transform cameraTransform = GetNewTransform(sceneRootTransform);
             cameraTransform.name = $"{sharedDependencies.SceneData.SceneShortInfo.BaseParcel} CAMERA_ENTITY";
             builder.World.Add(persistentEntities.Camera, new TransformComponent(cameraTransform));
         }
 
-        private Transform GetNewTransform(ECSWorldInstanceSharedDependencies sharedDependencies, Transform? transform = null)
+        private Transform GetNewTransform(Transform? transform = null, Vector3 position = default)
         {
             Transform sceneRootTransform = transformPool.Get();
             sceneRootTransform.SetParent(transform);
-            sceneRootTransform.position = sharedDependencies.SceneData.Geometry.BaseParcelPosition;
+            sceneRootTransform.localPosition = position;
             sceneRootTransform.rotation = Quaternion.identity;
             sceneRootTransform.localScale = Vector3.one;
             return sceneRootTransform;

--- a/Explorer/Assets/Scripts/ECS/Unity/Transforms/Systems/UpdateTransformSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Transforms/Systems/UpdateTransformSystem.cs
@@ -9,6 +9,7 @@ using ECS.Abstract;
 using ECS.Groups;
 using ECS.Unity.Transforms.Components;
 using System;
+using UnityEngine;
 
 namespace ECS.Unity.Transforms.Systems
 {
@@ -40,6 +41,7 @@ namespace ECS.Unity.Transforms.Systems
         {
             if (sdkTransform.IsDirty)
             {
+                Debug.Log("transformComponent " + transformComponent.Transform.name + " pos " + sdkTransform.Position);
                 transformComponent.SetTransform(sdkTransform.Position, sdkTransform.Rotation, sdkTransform.Scale);
                 sdkTransform.IsDirty = false;
             }

--- a/Explorer/Assets/Scripts/ECS/Unity/Transforms/Systems/UpdateTransformSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Transforms/Systems/UpdateTransformSystem.cs
@@ -9,7 +9,6 @@ using ECS.Abstract;
 using ECS.Groups;
 using ECS.Unity.Transforms.Components;
 using System;
-using UnityEngine;
 
 namespace ECS.Unity.Transforms.Systems
 {
@@ -41,7 +40,6 @@ namespace ECS.Unity.Transforms.Systems
         {
             if (sdkTransform.IsDirty)
             {
-                Debug.Log("transformComponent " + transformComponent.Transform.name + " pos " + sdkTransform.Position);
                 transformComponent.SetTransform(sdkTransform.Position, sdkTransform.Rotation, sdkTransform.Scale);
                 sdkTransform.IsDirty = false;
             }


### PR DESCRIPTION
## What does this PR change?

Fix #1757
This PR introduces a new transform as a parent to the scene root transform.
The reason is that creators have access to the scene root transform and can change the rotation and the position (it is something allowed by SDK on purpose), causing the scene to be in weird places in some cases, for example by changing the rotation of the scene the position was being set to 0,0,0.
With this PR we place the scene correctly on the client and then still allow creators to manually change the scene root position but in relation to the world space

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Go to wilderness (-24, 92)
3. Verify that the scene is visible, unlike before
4. Check other sdk7 scenes

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

