### PR TITLE
fix: Implemented disabling shortcut input before game is loaded

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/InputPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/InputPlugin.cs
@@ -89,6 +89,7 @@ namespace DCL.PluginSystem.Global
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments)
         {
             InputMapComponent.Kind startingDisabledInputs = InputMapComponent.Kind.EmoteWheel;
+            startingDisabledInputs |= InputMapComponent.Kind.Shortcuts;
             builder.World.Create(new InputMapComponent(~startingDisabledInputs));
 
             ApplyInputMapsSystem.InjectToWorld(ref builder, dclInput);

--- a/Explorer/Assets/DCL/UI/MainUIContainer/MainUIController.cs
+++ b/Explorer/Assets/DCL/UI/MainUIContainer/MainUIController.cs
@@ -1,5 +1,6 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCL.Chat;
+using DCL.EmotesWheel;
 using DCL.Minimap;
 using DCL.SidebarBus;
 using DCL.UI.ConnectionStatusPanel;
@@ -54,6 +55,7 @@ namespace DCL.UI.MainUI
             mvcManager.ShowAsync(MinimapController.IssueCommand()).Forget();
             mvcManager.ShowAsync(ChatController.IssueCommand()).Forget();
             mvcManager.ShowAsync(ConnectionStatusPanelController.IssueCommand()).Forget();
+            mvcManager.ShowAsync(PersistentEmoteWheelOpenerController.IssueCommand()).Forget();
             showingSidebar = true;
         }
 

--- a/Explorer/Assets/DCL/UI/MainUIContainer/MainUi.asmdef
+++ b/Explorer/Assets/DCL/UI/MainUIContainer/MainUi.asmdef
@@ -12,7 +12,8 @@
         "GUID:ff9608d635a64a03a75efb8e221a9d57",
         "GUID:2f30d6e5229a74284acedda491abcc6e",
         "GUID:029c1c1b674aaae47a6841a0b89ad80e",
-        "GUID:c5db5ed4ea75a402dba1512abe9482ec"
+        "GUID:c5db5ed4ea75a402dba1512abe9482ec",
+        "GUID:01f7bfa188da76f4b8eedc875c66b334"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/Scripts/Global/Dynamic/Bootstraper.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/Bootstraper.cs
@@ -6,6 +6,8 @@ using DCL.DebugUtilities;
 using DCL.Diagnostics;
 using DCL.EmotesWheel;
 using DCL.FeatureFlags;
+using DCL.Input;
+using DCL.Input.Component;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Notifications.NewNotification;
 using DCL.PerformanceAndDiagnostics.DotNetLogging;
@@ -175,16 +177,14 @@ namespace Global.Dynamic
                 ct
             );
 
-            splashScreen.HideSplash();
             OpenDefaultUI(dynamicWorldContainer.MvcManager, ct);
+            splashScreen.HideSplash();
         }
 
         private static void OpenDefaultUI(IMVCManager mvcManager, CancellationToken ct)
         {
-            // TODO: all of these UIs should be part of a single canvas. We cannot make a proper layout by having them separately
-            mvcManager.ShowAsync(MainUIController.IssueCommand(), ct).Forget();
             mvcManager.ShowAsync(NewNotificationController.IssueCommand(), ct).Forget();
-            mvcManager.ShowAsync(PersistentEmoteWheelOpenerController.IssueCommand(), ct).Forget();
+            mvcManager.ShowAsync(MainUIController.IssueCommand(), ct).Forget();
         }
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -3,6 +3,8 @@ using Cysharp.Threading.Tasks;
 using DCL.Audio;
 using DCL.DebugUtilities;
 using DCL.Diagnostics;
+using DCL.Input;
+using DCL.Input.Component;
 using DCL.PluginSystem;
 using DCL.PluginSystem.Global;
 using DCL.SceneLoadingScreens.SplashScreen;
@@ -208,7 +210,7 @@ namespace Global.Dynamic
 
         private void RestoreShortcuts()
         {
-            staticContainer!.InputProxy.StrictObject.Shortcuts.Enable();
+            globalWorld!.EcsWorld.CacheInputMap().GetInputMapComponent(globalWorld.EcsWorld).Active |= InputMapComponent.Kind.Shortcuts;
         }
 
         [ContextMenu(nameof(ValidateSettingsAsync))]

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -170,6 +170,8 @@ namespace Global.Dynamic
 
                 await bootstrap.InitializeFeatureFlagsAsync(bootstrapContainer.IdentityCache!.Identity, bootstrapContainer.DecentralandUrlsSource, staticContainer!, ct);
 
+                DisableShortcuts();
+
                 if (await bootstrap.InitializePluginsAsync(staticContainer!, dynamicWorldContainer!, scenePluginSettingsContainer, globalPluginSettingsContainer, ct))
                 {
                     GameReports.PrintIsDead();
@@ -184,6 +186,8 @@ namespace Global.Dynamic
 
                 await bootstrap.LoadStartingRealmAsync(dynamicWorldContainer!, ct);
                 await bootstrap.UserInitializationAsync(dynamicWorldContainer!, globalWorld, playerEntity, splashScreen, ct);
+
+                RestoreShortcuts();
             }
             catch (OperationCanceledException)
             {
@@ -195,6 +199,16 @@ namespace Global.Dynamic
                 GameReports.PrintIsDead();
                 throw;
             }
+        }
+
+        private void DisableShortcuts()
+        {
+            staticContainer!.InputProxy.StrictObject.Shortcuts.Disable();
+        }
+
+        private void RestoreShortcuts()
+        {
+            staticContainer!.InputProxy.StrictObject.Shortcuts.Enable();
         }
 
         [ContextMenu(nameof(ValidateSettingsAsync))]

--- a/Explorer/Assets/Scripts/MVC/ControllerBase.cs
+++ b/Explorer/Assets/Scripts/MVC/ControllerBase.cs
@@ -50,7 +50,7 @@ namespace MVC
             State = ControllerState.ViewHidden;
         }
 
-        protected TView viewInstance { get; private set; }
+        protected TView? viewInstance { get; private set; }
 
         protected TInputData inputData { get; private set; }
 
@@ -97,6 +97,9 @@ namespace MVC
         public async UniTask HideViewAsync(CancellationToken ct)
         {
             State = ControllerState.ViewHidden;
+
+            //Ideally this should never happen but as HideViewAsync can be called at any point it means the controller might not have instantiated the view yet
+            if (viewInstance == null) return;
 
             for (var i = 0; i < modules?.Count; i++)
                 modules[i].OnViewHide();


### PR DESCRIPTION
## What does this PR change?

We were receiving some weird sentry errors related to showing or hiding views during game loading. Turns out that the shortcuts were enabled during loading, even before the world was initialized.
It meant players could try to open the explore panel at any point and it would trigger different errors depending on which shortcut was pressed.
So, I added a couple of lines to disable the shortcuts during initialization + added the shortcuts to the disabled inputs at start. 
Why? because we got 2 stages were inputs are registered. First before systems are started but after plugins are initialized (which is were the inputs are registered to open the explore panel, for example). So in that interval inputs are working (which is why we got the DisableShortcuts() method called before that in the MainSceneLoader.
Then, once systems are initialized, if the input is not excluded from the initial inputs, it will get re-enabled by the system.
Finally, after all the initialization process is done, we re-enable the shortcuts using the InputMapComponent so it gets properly updated with the active inputs.

I also took the opportunity to move the initialization of the PersistentEmoteWheelOpener into the MainUIController as it should have been from the start.

And I also added a line to avoid the errors on the OnHideView if the view isnt instantiated yet. As its a public method we cannot guarantee that the viewInstance exists when it is called. **Do we want a warning log there maybe? wdyt?**

## How to test the changes?

As soon as the explorer opens, try using any of the shortcuts to open the explore panel. They should not cause any error.

Its easier to compare with versions without this fix as using the shortcuts will cause errors to appear on the logs and might break the explore panel afterwards (not necessarily thou, but for sure you will get errors in the logs).

Should fix at least these ones:
https://github.com/decentraland/unity-explorer/issues/1719
https://github.com/decentraland/unity-explorer/issues/1722
https://github.com/decentraland/unity-explorer/issues/1802