### PR TITLE
Fix: material system performance

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/StaticSettings.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/StaticSettings.cs
@@ -1,19 +1,13 @@
-﻿using Arch.SystemGroups;
-using Cysharp.Threading.Tasks;
-using DCL.AssetsProvision;
-using DCL.Character;
-using DCL.Diagnostics;
-using DCL.LOD;
+﻿using DCL.LOD;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.Prioritization;
 using System;
 using System.Collections.Generic;
 using DCL.Roads.Settings;
 using DCL.AvatarRendering;
-using DCL.MapRenderer;
-using System.Threading;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.Profiling;
 
 namespace DCL.PluginSystem.Global
 {
@@ -30,8 +24,20 @@ namespace DCL.PluginSystem.Global
         // Performance budgeting
         [field: Header("Performance Budgeting")] [field: Space]
         [field: SerializeField]
-        public int FrameTimeCap { get; private set; } = 33; // in [ms]. Table: 33ms ~ 30fps | 16ms ~ 60fps | 11ms ~ 90 fps | 8ms ~ 120fps
+        private int frameTimeCap = 33; // in [ms]. Table: 33ms ~ 30fps | 16ms ~ 60fps | 11ms ~ 90 fps | 8ms ~ 120fps
+        [SerializeField]
+        private int frameTimeCapDeepProfiler = 300;
 
+        public int FrameTimeCap
+        {
+            get
+            {
+                bool isDeepProfiling = Profiler.enabled && Profiler.enableBinaryLog;
+                return isDeepProfiling ? frameTimeCapDeepProfiler : frameTimeCap;
+            }
+        }
+
+        [field: Space]
         [field: SerializeField]
         public int ScenesLoadingBudget { get; private set; } = 100;
 

--- a/Explorer/Assets/DCL/PluginSystem/World/MaterialWorldPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MaterialWorldPlugin.cs
@@ -1,6 +1,5 @@
 ﻿using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
-using DCL.AssetsProvision;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.Optimization.Pools;
 using DCL.PluginSystem.World.Dependencies;
@@ -20,7 +19,7 @@ namespace DCL.PluginSystem.World
     public class MaterialsPlugin : IDCLWorldPlugin<MaterialsPlugin.Settings>
     {
         private readonly IPerformanceBudget capFrameTimeBudget;
-        private readonly IAssetsProvisioner assetsProvisioner;
+        private readonly MemoryBudget memoryBudgetProvider;
 
         private readonly IExtendedObjectPool<Texture2D> videoTexturePool;
 
@@ -30,13 +29,11 @@ namespace DCL.PluginSystem.World
         private DestroyMaterial destroyMaterial = null!;
 
         private int loadingAttemptsCount;
-        private readonly MemoryBudget memoryBudgetProvider;
 
-        public MaterialsPlugin(ECSWorldSingletonSharedDependencies sharedDependencies, IAssetsProvisioner assetsProvisioner, IExtendedObjectPool<Texture2D> videoTexturePool)
+        public MaterialsPlugin(ECSWorldSingletonSharedDependencies sharedDependencies, IExtendedObjectPool<Texture2D> videoTexturePool)
         {
             memoryBudgetProvider = sharedDependencies.MemoryBudget;
             capFrameTimeBudget = sharedDependencies.FrameTimeBudget;
-            this.assetsProvisioner = assetsProvisioner;
             this.videoTexturePool = videoTexturePool;
         }
 

--- a/Explorer/Assets/DCL/Utilities/DCLPhysics.cs
+++ b/Explorer/Assets/DCL/Utilities/DCLPhysics.cs
@@ -10,10 +10,13 @@ namespace DCL.Utilities
         /// <summary>
         /// Unity SphereCast with Debug gizmos.
         /// </summary>
-        public static bool SphereCast(Ray ray, float radius, out RaycastHit hitInfo, float maxDistance, int layerMask, QueryTriggerInteraction queryTriggerInteraction)
+        public static bool SphereCast(Ray ray, float radius, out RaycastHit hitInfo, float maxDistance, int layerMask,
+            QueryTriggerInteraction queryTriggerInteraction)
         {
             bool hasHit = Physics.SphereCast(ray, radius, out hitInfo, maxDistance, layerMask, queryTriggerInteraction);
-            if (Application.isEditor) DebugUtils.DrawRaycast(ray.origin, maxDistance, hasHit, hitInfo, radius);
+#if UNITY_EDITOR && DEBUG_RAYCAST
+            DebugUtils.DrawRaycast(ray.origin, maxDistance, hasHit, hitInfo, radius);
+#endif
             return hasHit;
         }
 
@@ -23,7 +26,9 @@ namespace DCL.Utilities
         public static bool Raycast(Ray ray, out RaycastHit hitInfo, float maxDistance, int layerMask, QueryTriggerInteraction queryTriggerInteraction)
         {
             bool hasHit = Physics.Raycast(ray, out hitInfo, maxDistance, layerMask, queryTriggerInteraction);
-            if (Application.isEditor) DebugUtils.DrawRaycast(ray.origin, maxDistance, hasHit, hitInfo, 0.1f);
+#if UNITY_EDITOR && DEBUG_RAYCAST
+            DebugUtils.DrawRaycast(ray.origin, maxDistance, hasHit, hitInfo, 0.1f);
+#endif
             return hasHit;
         }
     }

--- a/Explorer/Assets/Scripts/ECS/Unity/Materials/Components/MaterialTransparencyMode.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Materials/Components/MaterialTransparencyMode.cs
@@ -1,3 +1,6 @@
+using ECS.Unity.Textures.Components;
+using UnityEngine;
+
 namespace ECS.Unity.Materials.Components
 {
     public enum MaterialTransparencyMode : byte
@@ -7,5 +10,16 @@ namespace ECS.Unity.Materials.Components
         AlphaBlend = 2,
         AlphaTestAndAlphaBlend = 3,
         Auto = 4,
+    }
+
+    public static class MaterialTransparencyModeExtensions
+    {
+        public static void ResolveAutoMode(this ref MaterialTransparencyMode transparencyMode, in TextureComponent? alphaTexture, in Color albedoColor)
+        {
+            if (transparencyMode == MaterialTransparencyMode.Auto)
+                transparencyMode = alphaTexture != null || albedoColor.a < 1f
+                    ? MaterialTransparencyMode.AlphaBlend //AlphaBlend
+                    : MaterialTransparencyMode.Opaque; // Opaque
+        }
     }
 }

--- a/Explorer/Assets/Scripts/ECS/Unity/Materials/Components/ShouldInstanceMaterialComponent.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Materials/Components/ShouldInstanceMaterialComponent.cs
@@ -1,0 +1,7 @@
+namespace ECS.Unity.Materials.Components
+{
+    public struct ShouldInstanceMaterialComponent
+    {
+
+    }
+}

--- a/Explorer/Assets/Scripts/ECS/Unity/Materials/Components/ShouldInstanceMaterialComponent.cs.meta
+++ b/Explorer/Assets/Scripts/ECS/Unity/Materials/Components/ShouldInstanceMaterialComponent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dd8b614711d04f7785d301d679d08087
+timeCreated: 1723805025

--- a/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/CreateMaterialSystemBase.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/CreateMaterialSystemBase.cs
@@ -1,6 +1,7 @@
 using Arch.Core;
 using ECS.Abstract;
 using ECS.StreamableLoading.Common.Components;
+using ECS.Unity.Materials.Components;
 using ECS.Unity.Textures.Components;
 using UnityEngine;
 using UnityEngine.Pool;
@@ -20,6 +21,14 @@ namespace ECS.Unity.Materials.Systems
 
         protected Material CreateNewMaterialInstance() =>
             materialsPool.Get();
+
+        protected void DestroyEntityReferencesForPromises(ref MaterialComponent materialComponent)
+        {
+            DestroyEntityReference(ref materialComponent.AlbedoTexPromise);
+            DestroyEntityReference(ref materialComponent.EmissiveTexPromise);
+            DestroyEntityReference(ref materialComponent.AlphaTexPromise);
+            DestroyEntityReference(ref materialComponent.BumpTexPromise);
+        }
 
         protected void DestroyEntityReference(ref Promise? promise)
         {

--- a/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/CreatePBRMaterialSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/CreatePBRMaterialSystem.cs
@@ -99,18 +99,9 @@ namespace ECS.Unity.Materials.Systems
         public static void SetUpTransparency(Material material, MaterialTransparencyMode transparencyMode,
             in TextureComponent? alphaTexture, Color albedoColor, float alphaTest)
         {
-            if (transparencyMode == MaterialTransparencyMode.Auto)
-            {
-                if (alphaTexture != null || albedoColor.a < 1f) //AlphaBlend
-                {
-                    transparencyMode = MaterialTransparencyMode.AlphaBlend;
-                }
-                else // Opaque
-                {
-                    transparencyMode = MaterialTransparencyMode.Opaque;
-                }
-            }
+            transparencyMode.ResolveAutoMode(alphaTexture, albedoColor);
 
+            // ReSharper disable once SwitchStatementMissingSomeEnumCasesNoDefault
             switch (transparencyMode)
             {
                 case MaterialTransparencyMode.Opaque:

--- a/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/CreatePBRMaterialSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/CreatePBRMaterialSystem.cs
@@ -32,7 +32,8 @@ namespace ECS.Unity.Materials.Systems
         }
 
         [Query]
-        private void Handle(ref MaterialComponent materialComponent)
+        [All(typeof(ShouldInstanceMaterialComponent))]
+        private void Handle(Entity entity, ref MaterialComponent materialComponent)
         {
             if (!materialComponent.Data.IsPbrMaterial)
                 return;
@@ -42,10 +43,10 @@ namespace ECS.Unity.Materials.Systems
 
             // if there are no textures to load we can construct a material right away
             if (materialComponent.Status == StreamableLoading.LifeCycle.LoadingInProgress)
-                ConstructMaterial(ref materialComponent);
+                ConstructMaterial(entity, ref materialComponent);
         }
 
-        private void ConstructMaterial(ref MaterialComponent materialComponent)
+        private void ConstructMaterial(Entity entity, ref MaterialComponent materialComponent)
         {
             // Check if all promises are finished
             // Promises are finished if: all of their entities are invalid, no promises at all, or the result component exists
@@ -69,6 +70,8 @@ namespace ECS.Unity.Materials.Systems
                 TrySetTexture(materialComponent.Result, ref bumpResult, ShaderUtils.BumpMap, in materialComponent.Data.Textures.BumpTexture);
 
                 DestroyEntityReferencesForPromises(ref materialComponent);
+
+                World!.Remove<ShouldInstanceMaterialComponent>(entity);
 
                 // TODO It is super expensive and allocates 500 KB every call, the changes must be made in the common library
                 // SRPBatchingHelper.OptimizeMaterial(materialComponent.Result);

--- a/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/CreatePBRMaterialSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/CreatePBRMaterialSystem.cs
@@ -68,10 +68,7 @@ namespace ECS.Unity.Materials.Systems
                 TrySetTexture(materialComponent.Result, ref alphaResult, ShaderUtils.AlphaTexture, in materialComponent.Data.Textures.AlphaTexture);
                 TrySetTexture(materialComponent.Result, ref bumpResult, ShaderUtils.BumpMap, in materialComponent.Data.Textures.BumpTexture);
 
-                DestroyEntityReference(ref materialComponent.AlbedoTexPromise);
-                DestroyEntityReference(ref materialComponent.EmissiveTexPromise);
-                DestroyEntityReference(ref materialComponent.AlphaTexPromise);
-                DestroyEntityReference(ref materialComponent.BumpTexPromise);
+                DestroyEntityReferencesForPromises(ref materialComponent);
 
                 // TODO It is super expensive and allocates 500 KB every call, the changes must be made in the common library
                 // SRPBatchingHelper.OptimizeMaterial(materialComponent.Result);

--- a/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/StartMaterialsLoadingSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Materials/Systems/StartMaterialsLoadingSystem.cs
@@ -76,6 +76,7 @@ namespace ECS.Unity.Materials.Systems
             materialComponent.Status = StreamableLoading.LifeCycle.LoadingInProgress;
 
             World.Set(entity, StartNewMaterialLoad(entity, materialComponent, in prevTextureData, partitionComponent));
+            World.AddOrGet(entity, new ShouldInstanceMaterialComponent());
         }
 
         private void InvalidatePrbInequality(ref MaterialComponent materialComponent, ref MaterialData materialData)
@@ -108,6 +109,7 @@ namespace ECS.Unity.Materials.Systems
             materialComponent.Status = StreamableLoading.LifeCycle.LoadingInProgress;
 
             World.Add(entity, materialComponent);
+            World.Add(entity, new ShouldInstanceMaterialComponent());
         }
 
         private MaterialData CreateMaterialData(in PBMaterial material)

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -233,7 +233,10 @@ namespace Global.Dynamic
         {
             AssetPromise<SceneEntityDefinition, GetSceneDefinition>[] promises = await realmController.WaitForFixedScenePromisesAsync(ct);
 
-            if (!promises.Any(p => p.Result!.Value.Asset!.metadata.scene.DecodedParcels.Contains(parcelToTeleport)))
+            if (!promises.Any(p =>
+                    p.Result.HasValue
+                    && (p.Result.Value.Asset?.metadata.scene.DecodedParcels.Contains(parcelToTeleport) ?? false)
+                ))
                 parcelToTeleport = promises[0].Result!.Value.Asset!.metadata.scene.DecodedBase;
 
             WaitForSceneReadiness? waitForSceneReadiness = await teleportController.TeleportToSceneSpawnPointAsync(parcelToTeleport, processReport, ct);

--- a/Explorer/Assets/Scripts/Global/StaticContainer.cs
+++ b/Explorer/Assets/Scripts/Global/StaticContainer.cs
@@ -196,7 +196,7 @@ namespace Global
                 new BillboardPlugin(exposedGlobalDataContainer.ExposedCameraData),
                 new NFTShapePlugin(decentralandUrlsSource, container.assetsProvisioner, sharedDependencies.FrameTimeBudget, componentsContainer.ComponentPoolsRegistry, container.WebRequestsContainer.WebRequestController, container.CacheCleaner),
                 new TextShapePlugin(sharedDependencies.FrameTimeBudget, container.CacheCleaner, componentsContainer.ComponentPoolsRegistry),
-                new MaterialsPlugin(sharedDependencies, container.assetsProvisioner, videoTexturePool),
+                new MaterialsPlugin(sharedDependencies, videoTexturePool),
                 textureResolvePlugin,
                 new AssetsCollidersPlugin(sharedDependencies, container.PhysicsTickProvider),
                 new AvatarShapePlugin(container.GlobalWorldProxy),


### PR DESCRIPTION
## What does this PR change?

The performance impact was caused by iterating on each material even if there are no changes. ShouldInstanceMaterialComponent is introduced to filter only MaterialComponents that require an update

Performance impact reduced by 4-5 times in Editor
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/78546eaa-fbf0-413d-85f8-64435b001300">


Minors:
- DEBUG_RAYCAST for raycast debugging scenarions, reduce a performance impact
- MaterialsPlugin remove unused field
- A new additional frame budget property for deep profiling
- AutoResolve method
- DestroyEntityReferencesForPromises method
- Fixes null ref:
`
NullReferenceException: Object reference not set to an instance of an object
Global.Dynamic.RealmNavigator+<>c__DisplayClass29_0.<TeleportToWorldSpawnPointAsync>b__0 (ECS.StreamableLoading.Common.AssetPromise`2[TAsset,TLoadingIntention] p) (at Assets/Scripts/Global/Dynamic/RealmNavigator.cs:236)
System.Linq.Enumerable.Any[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate) (at <d858330b72074e379bd4579acacf4927>:0)
Global.Dynamic.RealmNavigator.TeleportToWorldSpawnPointAsync (UnityEngine.Vector2Int parcelToTeleport, DCL.AsyncLoadReporting.AsyncLoadProcessReport processReport, System.Threading.CancellationToken ct) (at Assets/Scripts/Global/Dynamic/RealmNavigator.cs:236)
`

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Play happy path and watch for objects with materials that are changing in realtime

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

