### PR TITLE
Feat: frame timing manager

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Builders/BuilderExtensions.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Builders/BuilderExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using DCL.DebugUtilities.UIBindings;
 using System;
-using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace DCL.DebugUtilities

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/PerformanceBottleneckDetector.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/PerformanceBottleneckDetector.cs
@@ -14,15 +14,19 @@ namespace DCL.Profiling
         }
 
         private const float K_NEAR_FULL_FRAME_TIME_THRESHOLD_PERCENT = 0.2f;
-
         private readonly FrameTiming[] frameTimings = new FrameTiming[1];
 
-        public PerformanceBottleneck Capture()
+        public FrameTiming FrameTiming => frameTimings[0];
+
+        public bool TryCapture()
         {
             FrameTimingManager.CaptureFrameTimings();
             uint numFrames = FrameTimingManager.GetLatestTimings((uint)frameTimings.Length, frameTimings);
-            return numFrames <= 0 ? PerformanceBottleneck.INDETERMINATE : DetermineBottleneck(frameTimings[0]);
+            return numFrames > 0;
         }
+
+        public PerformanceBottleneck DetermineBottleneck() =>
+            DetermineBottleneck(frameTimings[0]);
 
         private static PerformanceBottleneck DetermineBottleneck(FrameTiming timing)
         {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/PerformanceBottleneckDetector.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/PerformanceBottleneckDetector.cs
@@ -1,0 +1,59 @@
+﻿using UnityEngine;
+
+namespace DCL.Profiling
+{
+    public class PerformanceBottleneckDetector
+    {
+        public enum PerformanceBottleneck
+        {
+            INDETERMINATE, // Cannot be determined
+            PRESENT_LIMITED, // Limited by presentation (vsync or framerate cap)
+            CPU, // Limited by CPU (main and/or render thread)
+            GPU, // Limited by GPU
+            BALANCED, // Limited by both CPU and GPU, i.e. well balanced
+        }
+
+        private const float K_NEAR_FULL_FRAME_TIME_THRESHOLD_PERCENT = 0.2f;
+
+        private readonly FrameTiming[] frameTimings = new FrameTiming[1];
+
+        public PerformanceBottleneck Capture()
+        {
+            FrameTimingManager.CaptureFrameTimings();
+            uint numFrames = FrameTimingManager.GetLatestTimings((uint)frameTimings.Length, frameTimings);
+            return numFrames <= 0 ? PerformanceBottleneck.INDETERMINATE : DetermineBottleneck(frameTimings[0]);
+        }
+
+        private static PerformanceBottleneck DetermineBottleneck(FrameTiming timing)
+        {
+            if (timing.gpuFrameTime == 0)
+                return PerformanceBottleneck.INDETERMINATE;
+
+            double fullFrameTime = timing.cpuFrameTime + timing.gpuFrameTime;
+            double fullFrameTimeWithMargin = (1.0 - K_NEAR_FULL_FRAME_TIME_THRESHOLD_PERCENT) * fullFrameTime;
+
+            // GPU time is close to frame time, CPU times are not
+            if (timing.gpuFrameTime > fullFrameTimeWithMargin &&
+                timing.cpuMainThreadFrameTime < fullFrameTimeWithMargin &&
+                timing.cpuRenderThreadFrameTime < fullFrameTimeWithMargin)
+                return PerformanceBottleneck.GPU;
+
+            // One of the CPU times is close to frame time, GPU is not
+            if (timing.gpuFrameTime < fullFrameTimeWithMargin &&
+                (timing.cpuMainThreadFrameTime > fullFrameTimeWithMargin || timing.cpuRenderThreadFrameTime > fullFrameTimeWithMargin))
+                return PerformanceBottleneck.CPU;
+
+            // Check if we're limited by vsync or target frame rate
+            if (timing.syncInterval > 0)
+            {
+                // None of the times are close to frame time
+                if (timing.gpuFrameTime < fullFrameTimeWithMargin &&
+                    timing.cpuMainThreadFrameTime < fullFrameTimeWithMargin &&
+                    timing.cpuRenderThreadFrameTime < fullFrameTimeWithMargin)
+                    return PerformanceBottleneck.PRESENT_LIMITED;
+            }
+
+            return PerformanceBottleneck.BALANCED;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/PerformanceBottleneckDetector.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/PerformanceBottleneckDetector.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 175d08428471447eb2f92b99733a3449
+timeCreated: 1724059536


### PR DESCRIPTION
## What does this PR change?

Add support for FrameTimingManager to detect performance bottleneck.


## How to test the changes?

1. Launch the explorer
2. Go to /debug -> performance
3. Enable "Enable Bottleneck detector" checkbox
4. Observe frame timings below it being updated
5. Disable checkbox and verify frame timings are not updated anymore

Note: Frame timings below  "Enable Bottleneck detector" checkbox can differ from the FPS value showed above due to the 4 frames delay needed for `FrameTimingManager` internal calculations

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

