### PR TITLE
fix: Avatar sfx issues

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Animation/AvatarAnimationEventsHandler.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Animation/AvatarAnimationEventsHandler.cs
@@ -47,6 +47,7 @@ namespace DCL.CharacterMotion.Animation
         public void AnimEvent_Jump()
         {
             var movementState = GetMovementState();
+            if (movementState == MovementKind.None) return;
 
             if (TryPlayAnimEventFX(lastJumpTime, jumpIntervalSeconds, centerBottomTransform, AvatarAnimationEventType.Jump,
                     movementState switch
@@ -62,6 +63,7 @@ namespace DCL.CharacterMotion.Animation
         public void AnimEvent_Land()
         {
             var movementState = GetMovementState();
+            if (movementState == MovementKind.None) return;
 
             if (TryPlayAnimEventFX(lastLandTime, landIntervalSeconds, centerBottomTransform, AvatarAnimationEventType.Land,
                     movementState switch
@@ -77,6 +79,7 @@ namespace DCL.CharacterMotion.Animation
             if (!AvatarAnimator.GetBool(AnimationHashes.GROUNDED)) return;
 
             var movementState = GetMovementState();
+            if (movementState == MovementKind.None) return;
 
             float interval = GetIntervalFor(movementState);
 
@@ -211,8 +214,7 @@ namespace DCL.CharacterMotion.Animation
                        {
                            (int)MovementKind.Run => MovementKind.Run,
                            (int)MovementKind.Jog => MovementKind.Jog,
-                           (int)MovementKind.Walk => MovementKind.Walk,
-                           _ => MovementKind.None,
+                           _ => MovementKind.Walk,
                        };
             }
 


### PR DESCRIPTION
## What does this PR change?

Basically when the AvatarAnimationEventsHandler class was refactored we didnt consider the different types of sounds that should be played (walk, land or jump) and also the movement threshold from the blend tree of the animator was returning the same value (None) both for valid and invalid cases.
This caused that first, all types of movement played always jump sounds and second that we had lingering sounds after walking because the blend tree was in a non 0 state returning None as movement type.
These fixes address both those issues.

## How to test the changes?

Just walk, jump and stomp around. SFX should play correctly now as well as particles.

Fixes (https://github.com/decentraland/unity-explorer/issues/1662)
