### PR TITLE
Fix: Nametag is jittery and detaching from the avatar (#1664)

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -3,12 +3,11 @@ using Arch.System;
 using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.AvatarRendering.AvatarShape.Components;
-using DCL.AvatarRendering.AvatarShape.Systems;
 using DCL.Character.Components;
 using DCL.CharacterCamera;
+using DCL.CharacterMotion.Systems;
 using DCL.Chat;
 using DCL.Diagnostics;
-using DCL.Multiplayer.Profiles.Systems;
 using DCL.Profiles;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
@@ -20,8 +19,7 @@ using UnityEngine.Pool;
 namespace DCL.Nametags
 {
     [UpdateInGroup(typeof(PresentationSystemGroup))]
-    [UpdateAfter(typeof(MultiplayerProfilesSystem))]
-    [UpdateAfter(typeof(AvatarInstantiatorSystem))]
+    [UpdateAfter(typeof(InterpolateCharacterSystem))]
     [LogCategory(ReportCategory.AVATAR)]
     public partial class NametagPlacementSystem : BaseUnityLoopSystem
     {


### PR DESCRIPTION
## What does this PR change?

It changes the order of execution of the system NametagPlacementSystem.

## How to test the changes?

1. Launch the explorer
2. Move the avatar.

The name tag must not jitter.