### PR TITLE
fix: RemoteEntities threading access error

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Profiles/Entities/RemoteEntities.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/Entities/RemoteEntities.cs
@@ -103,16 +103,7 @@ namespace DCL.Multiplayer.Profiles.Entities
         {
             bool ContainsInRoom(IRoom room)
             {
-                foreach (string? identity in room.Participants.RemoteParticipantIdentities())
-                {
-                    if (identity != null
-                        && room.Participants.RemoteParticipant(identity) is { } participant
-                        && participant.Identity == wallet
-                       )
-                        return true;
-                }
-
-                return false;
+                return room.Participants.RemoteParticipant(wallet) != null;
             }
 
             return ContainsInRoom(roomHub.IslandRoom()) || ContainsInRoom(roomHub.SceneRoom());


### PR DESCRIPTION
## What does this PR change?

Removes iteration of not thread-safe collection

`InvalidOperationException: Collection was modified; enumeration operation may not execute.
System.Collections.Generic.Dictionary`2+KeyCollection+Enumerator[TKey,TValue].MoveNext () (at <606c2e0a56af495988c860a4ac613e74>:0)
DCL.Multiplayer.Profiles.Entities.RemoteEntities.<DoesStillExist>g__ContainsInRoom|15_0 (LiveKit.Rooms.IRoom room, DCL.Multiplayer.Profiles.Entities.RemoteEntities+<>c__DisplayClass15_0& ) (at Assets/DCL/Multiplayer/Profiles/Entities/RemoteEntities.cs:106)
DCL.Multiplayer.Profiles.Entities.RemoteEntities.DoesStillExist (System.String wallet) (at Assets/DCL/Multiplayer/Profiles/Entities/RemoteEntities.cs:118)
DCL.Multiplayer.Profiles.Entities.RemoteEntities.Remove (System.Collections.Generic.IReadOnlyCollection`1[T] list, Arch.Core.World world) (at Assets/DCL/Multiplayer/Profiles/Entities/RemoteEntities.cs:71)
DCL.Multiplayer.Profiles.Entities.RemoteEntitiesExtensions.Remove (DCL.Multiplayer.Profiles.Entities.IRemoteEntities remoteEntities, DCL.Multiplayer.Profiles.RemoveIntentions.IRemoveIntentions removeIntentions, Arch.Core.World world) (at Assets/DCL/Multiplayer/Profiles/Entities/IRemoteEntities.cs:36)
DCL.Multiplayer.Profiles.Systems.MultiplayerProfilesSystem.Update (System.Single t) (at Assets/DCL/Multiplayer/Profiles/Systems/MultiplayerProfilesSystem.cs:74)
ECS.Abstract.BaseUnityLoopSystem.Update (System.Single& t) (at Assets/Scripts/ECS/Abstract/BaseUnityLoopSystem.cs:29)
Rethrow as EcsSystemException: [ECS]: [MultiplayerProfilesSystem]
ECS.Abstract.BaseUnityLoopSystem.Update (System.Single& t) (at Assets/Scripts/ECS/Abstract/BaseUnityLoopSystem.cs:35)
Arch.SystemGroups.ExecutionNode`1[T].Update (T& t, System.Boolean throttle) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/ExecutionNode.cs:78)
Arch.SystemGroups.SystemGroup.Update (Arch.SystemGroups.UnityBridge.TimeProvider+Info& timeInfo) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/SystemGroup.cs:118)`

## How to test the changes?

1. Launch the explorer
2. Play Happy path, bring a peep and ask him to disconnect - see his avatar is removed after the disconnection

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

