### PR TITLE
chore: Just added info about parcels and height to scene bounds gizmo

### DIFF
--- a/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/GizmosDrawSceneBounds.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/GizmosDrawSceneBounds.cs
@@ -19,6 +19,12 @@ namespace ECS.Unity.SceneBoundsChecker
         private Color pickedColor;
         private Vector3 center;
         private Vector3 size;
+        private int parcelCount;
+        private float sceneHeight;
+
+#if UNITY_EDITOR
+        private GUIStyle labelStyle = new();
+#endif
 
         public override void OnInitialize()
         {
@@ -26,11 +32,16 @@ namespace ECS.Unity.SceneBoundsChecker
             // so it's possible to distinguish between different scenes
             pickedColor = RANDOM_COLORS[Mathf.Abs(SceneData.SceneShortInfo.BaseParcel.GetHashCode()) % RANDOM_COLORS.Length];
 
-            float sceneHeight = SceneData.Geometry.Height;
+            parcelCount = SceneData.Parcels.Count;
+            sceneHeight = SceneData.Geometry.Height;
             ParcelMathHelper.SceneCircumscribedPlanes planes = SceneData.Geometry.CircumscribedPlanes;
 
             center = new Vector3(planes.MinX + ((planes.MaxX - planes.MinX) / 2), sceneHeight / 2, planes.MinZ + ((planes.MaxZ - planes.MinZ) / 2));
             size = new Vector3(planes.MaxX - planes.MinX, sceneHeight, planes.MaxZ - planes.MinZ);
+
+#if UNITY_EDITOR
+            labelStyle.normal.textColor = pickedColor;
+#endif
         }
 
         public override void OnDrawGizmosSelected()
@@ -41,6 +52,11 @@ namespace ECS.Unity.SceneBoundsChecker
             Gizmos.DrawWireCube(center, size);
 
             Gizmos.color = color;
+
+#if UNITY_EDITOR
+            Vector3 gizmoUpperCornerPosition = center + size * 0.5f + new Vector3(0.0f, 0.5f, 0.0f);
+            UnityEditor.Handles.Label(gizmoUpperCornerPosition, $"Parcels: {parcelCount} -> Height: {sceneHeight}", labelStyle);
+#endif
         }
     }
 }


### PR DESCRIPTION
The colored bounding box now shows the number of parcels of the selected scene and the height limit calculated for it, in meters, at one of the corners of the box.

## What does this PR change?

It adds visual debug information about a selected scene when its gizmo is visible.

## How to test the changes?

1. Launch the explorer in Unity.
2. Select the Genesis plaza scene, which has a component that draws a gizmo of the bounding box.
3. Check that the info appears in one of its upper corners.