### PR TITLE
fix: Clipping Issue on Roads and Scenes from a Distance (#1790)

### DIFF
--- a/Explorer/Assets/DCL/Landscape/SatelliteFloor.cs
+++ b/Explorer/Assets/DCL/Landscape/SatelliteFloor.cs
@@ -13,7 +13,7 @@ namespace DCL.Landscape
         private const int CHUNK_SIZE = 40;
         private const int GENESIS_HALF_PARCEL_WIDTH = 150;
         private const int SATELLITE_MAP_RESOLUTION = 8;
-        private const float Z_FIGHT_THRESHOLD = 0.001f;
+        private const float Z_FIGHT_THRESHOLD = 0.005f;
 
         private static readonly int BASE_MAP = Shader.PropertyToID("_BaseMap");
 


### PR DESCRIPTION
The separation between the ground assets (roads) and the satellite view chunks has increased from 0.001 to 0.005 (satellite planes are now placed at Y=-0.005). It's the minimum distance to avoid Z-fighting.

## What does this PR change?

It moves the satellite view planes down to avoid z-fighting.

## How to test the changes?

1. Launch the explorer.
2. Go to a high place, like the tower where avatars are spawned.
3. Look at the horizon and move the camera, pay attention to roads that are far from you, there should not be any visual glitch on them.