### PR TITLE
fix: Some assets on the environment overlaps the nametag (#1032)

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Assets/NametagObject.prefab
+++ b/Explorer/Assets/DCL/NameTags/Assets/NametagObject.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 6881943969416278642}
   - component: {fileID: 7915797373785868185}
   - component: {fileID: 317692783042627670}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: NametagObject
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -165,7 +165,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3805515542839986840}
   - component: {fileID: 4273700018563800502}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: VerifiedIcon
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -254,7 +254,7 @@ GameObject:
   - component: {fileID: 4776442481111019983}
   - component: {fileID: 7731930107436225423}
   - component: {fileID: 1264101715097455992}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: MessageContent
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -427,7 +427,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3767848672727676458}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: VerifiedIconParent
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -464,7 +464,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8746724036618754241}
   - component: {fileID: 620214271584746127}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: BubblePeak
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -553,7 +553,7 @@ GameObject:
   - component: {fileID: 8736261668784474907}
   - component: {fileID: 5473976778977378180}
   - component: {fileID: 4673612476327640102}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: Name
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -725,7 +725,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2772156915741177195}
   - component: {fileID: 2640253797295083812}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: Background
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Explorer/Assets/Rendering/ForwardRenderer - High.asset
+++ b/Explorer/Assets/Rendering/ForwardRenderer - High.asset
@@ -78,7 +78,8 @@ MonoBehaviour:
   - {fileID: 8512292912536760798}
   - {fileID: -3288772034090369892}
   - {fileID: -2448322177020252403}
-  m_RendererFeatureMap: 14e63e94147b3fe0de31d4cb4dbd21769cfccd7842ef5bd20d2fffa6f3cf05de
+  - {fileID: 1757973802043764545}
+  m_RendererFeatureMap: 14e63e94147b3fe0de31d4cb4dbd21769cfccd7842ef5bd20d2fffa6f3cf05de41ef42dbdb936518
   m_UseNativeRenderPass: 0
   postProcessData: {fileID: 11400000, guid: 3235692a041298c4f94f71909ca0b8a2, type: 2}
   xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
@@ -117,6 +118,48 @@ MonoBehaviour:
   m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0
   m_IntermediateTextureMode: 1
+--- !u!114 &1757973802043764545
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3d386ba5cd94485973aee1479b272e, type: 3}
+  m_Name: RenderNameTags
+  m_EditorClassIdentifier: 
+  m_Active: 1
+  settings:
+    passTag: RenderNameTags
+    Event: 500
+    filterSettings:
+      RenderQueueType: 1
+      LayerMask:
+        serializedVersion: 2
+        m_Bits: 32
+      PassNames: []
+    overrideMaterial: {fileID: 0}
+    overrideMaterialPassIndex: 0
+    overrideShader: {fileID: 0}
+    overrideShaderPassIndex: 0
+    overrideMode: 0
+    overrideDepthState: 0
+    depthCompareFunction: 4
+    enableWrite: 1
+    stencilSettings:
+      overrideStencilState: 0
+      stencilReference: 0
+      stencilCompareFunction: 8
+      passOperation: 0
+      failOperation: 0
+      zFailOperation: 0
+    cameraSettings:
+      overrideCamera: 0
+      restoreCamera: 1
+      offset: {x: 0, y: 0, z: 0, w: 0}
+      cameraFieldOfView: 60
 --- !u!114 &8512292912536760798
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/Rendering/ForwardRenderer - Low.asset
+++ b/Explorer/Assets/Rendering/ForwardRenderer - Low.asset
@@ -40,7 +40,8 @@ MonoBehaviour:
   - {fileID: 8138120187327749282}
   - {fileID: 2807433661055950781}
   - {fileID: 7172226581729682672}
-  m_RendererFeatureMap: 1bee3b731eab7ed8a21c1b593169f070bddfb6510a02f626f0a49c7413de8863
+  - {fileID: 5020021736804485952}
+  m_RendererFeatureMap: 1bee3b731eab7ed8a21c1b593169f070bddfb6510a02f626f0a49c7413de8863408bf8222cb3aa45
   m_UseNativeRenderPass: 0
   postProcessData: {fileID: 11400000, guid: 3235692a041298c4f94f71909ca0b8a2, type: 2}
   xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
@@ -98,6 +99,48 @@ MonoBehaviour:
     NormalsSensitivity: 1
     ColorSensitivity: 0.5
     OutlineColor: {r: 1, g: 1, b: 1, a: 0.5}
+--- !u!114 &5020021736804485952
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3d386ba5cd94485973aee1479b272e, type: 3}
+  m_Name: RenderNameTags
+  m_EditorClassIdentifier: 
+  m_Active: 1
+  settings:
+    passTag: RenderNameTags
+    Event: 500
+    filterSettings:
+      RenderQueueType: 1
+      LayerMask:
+        serializedVersion: 2
+        m_Bits: 32
+      PassNames: []
+    overrideMaterial: {fileID: 0}
+    overrideMaterialPassIndex: 0
+    overrideShader: {fileID: 0}
+    overrideShaderPassIndex: 0
+    overrideMode: 0
+    overrideDepthState: 0
+    depthCompareFunction: 4
+    enableWrite: 1
+    stencilSettings:
+      overrideStencilState: 0
+      stencilReference: 0
+      stencilCompareFunction: 8
+      passOperation: 0
+      failOperation: 0
+      zFailOperation: 0
+    cameraSettings:
+      overrideCamera: 0
+      restoreCamera: 1
+      offset: {x: 0, y: 0, z: 0, w: 0}
+      cameraFieldOfView: 60
 --- !u!114 &7172226581729682672
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/Rendering/ForwardRenderer - Medium.asset
+++ b/Explorer/Assets/Rendering/ForwardRenderer - Medium.asset
@@ -40,7 +40,8 @@ MonoBehaviour:
   - {fileID: 2784079933934147183}
   - {fileID: 3276125648839237000}
   - {fileID: 2152243025009476847}
-  m_RendererFeatureMap: 228dedc75e290e946f167000f309a32688dd9b82eb22772def8400d0a04dde1d
+  - {fileID: 1798844783772877419}
+  m_RendererFeatureMap: 228dedc75e290e946f167000f309a32688dd9b82eb22772def8400d0a04dde1d6bc2d8d6ccc7f618
   m_UseNativeRenderPass: 0
   postProcessData: {fileID: 11400000, guid: 3235692a041298c4f94f71909ca0b8a2, type: 2}
   xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
@@ -79,6 +80,48 @@ MonoBehaviour:
   m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0
   m_IntermediateTextureMode: 1
+--- !u!114 &1798844783772877419
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3d386ba5cd94485973aee1479b272e, type: 3}
+  m_Name: RenderNameTags
+  m_EditorClassIdentifier: 
+  m_Active: 1
+  settings:
+    passTag: RenderNameTags
+    Event: 500
+    filterSettings:
+      RenderQueueType: 1
+      LayerMask:
+        serializedVersion: 2
+        m_Bits: 32
+      PassNames: []
+    overrideMaterial: {fileID: 0}
+    overrideMaterialPassIndex: 0
+    overrideShader: {fileID: 0}
+    overrideShaderPassIndex: 0
+    overrideMode: 0
+    overrideDepthState: 0
+    depthCompareFunction: 4
+    enableWrite: 1
+    stencilSettings:
+      overrideStencilState: 0
+      stencilReference: 0
+      stencilCompareFunction: 8
+      passOperation: 0
+      failOperation: 0
+      zFailOperation: 0
+    cameraSettings:
+      overrideCamera: 0
+      restoreCamera: 1
+      offset: {x: 0, y: 0, z: 0, w: 0}
+      cameraFieldOfView: 60
 --- !u!114 &2152243025009476847
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Added the same renderer feature to each renderer, Render Objects, which forces all geometry in the UI layer to render after the Transparent queue. The NametagObject prefab now has the UI layer instead of Default.

## What does this PR change?

It forces nametags to render after all transparent objects.

## How to test the changes?

1. Launch the explorer
2. Go to the basketball court, next to the Genesis plaza (ro to any other place where there are objects with transparencies).
3. Name tags should appear over everything at any moment.