### PR TITLE
fix: avatar invisible in backpack after changes

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarShapeComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarShapeComponent.cs
@@ -47,7 +47,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         {
             ID = id;
             Name = name;
-
+            IsVisible = true;
             InstantiatedWearables = new List<CachedWearable>();
         }
     }


### PR DESCRIPTION
## What does this PR change?

After we introduced a visibility optimization, avatar's in backpack and passport stopped rendering. 

This PR fixes that

## How to test the changes?

1. Launch the explorer
2. Go to the backpack, change wearables. The avatar should not dissapear
3. Check passports. Avatar should be there

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

