### PR TITLE
Chore: launcher ids in Explorer analytics

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/Systems/ApplyCinemachineCameraInputSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Systems/ApplyCinemachineCameraInputSystem.cs
@@ -19,17 +19,18 @@ namespace DCL.CharacterCamera.Systems
     public partial class ApplyCinemachineCameraInputSystem : BaseUnityLoopSystem
     {
         private readonly DCLInput input;
-        private bool isFreeCameraAllowed;
+        private readonly bool isFreeCameraAllowed;
 
         internal ApplyCinemachineCameraInputSystem(World world, DCLInput input, bool isFreeCameraAllowed) : base(world)
         {
             this.input = input;
+            this.isFreeCameraAllowed = isFreeCameraAllowed;
         }
 
         protected override void Update(float t)
         {
-            ApplyQuery(World, t);
-            ForceLookAtQuery(World);
+            ApplyQuery(World!, t);
+            ForceLookAtQuery(World!);
         }
 
         [Query]

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
@@ -15,16 +15,12 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
         private readonly IAnalyticsService analytics;
         public AnalyticsConfiguration Configuration { get; }
 
-        public AnalyticsController(IAnalyticsService analyticsService, AnalyticsConfiguration configuration, string launcherAnonymousId, string sessionId)
+        public AnalyticsController(IAnalyticsService analyticsService, AnalyticsConfiguration configuration, LauncherTraits launcherTraits)
         {
             analytics = analyticsService;
             Configuration = configuration;
 
-            analytics.AddPlugin(new StaticCommonTraitsPlugin(new LauncherTraits
-            {
-                LauncherAnonymousId = launcherAnonymousId,
-                SessionId = sessionId,
-            }));
+            analytics.AddPlugin(new StaticCommonTraitsPlugin(launcherTraits));
 
             analytics.Track(AnalyticsEvents.General.SYSTEM_INFO_REPORT, new JsonObject
             {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
@@ -20,7 +20,11 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
             analytics = analyticsService;
             Configuration = configuration;
 
-            analytics.AddPlugin(new StaticCommonTraitsPlugin(launcherAnonymousId, sessionId));
+            analytics.AddPlugin(new StaticCommonTraitsPlugin(new LauncherTraits
+            {
+                LauncherAnonymousId = launcherAnonymousId,
+                SessionId = sessionId,
+            }));
 
             analytics.Track(AnalyticsEvents.General.SYSTEM_INFO_REPORT, new JsonObject
             {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
@@ -15,12 +15,12 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
         private readonly IAnalyticsService analytics;
         public AnalyticsConfiguration Configuration { get; }
 
-        public AnalyticsController(IAnalyticsService analyticsService, AnalyticsConfiguration configuration)
+        public AnalyticsController(IAnalyticsService analyticsService, AnalyticsConfiguration configuration, string launcherAnonymousId, string sessionId)
         {
             analytics = analyticsService;
             Configuration = configuration;
 
-            analytics.AddPlugin(new StaticCommonTraitsPlugin());
+            analytics.AddPlugin(new StaticCommonTraitsPlugin(launcherAnonymousId, sessionId));
 
             analytics.Track(AnalyticsEvents.General.SYSTEM_INFO_REPORT, new JsonObject
             {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/StaticCommonTraitsPlugin.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/StaticCommonTraitsPlugin.cs
@@ -16,10 +16,10 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
         public override PluginType Type => PluginType.Enrichment;
 
-        public StaticCommonTraitsPlugin(string launcherAnonymousId, string sessionId)
+        public StaticCommonTraitsPlugin(LauncherTraits launcherTraits)
         {
-            this.sessionId = !string.IsNullOrEmpty(this.sessionId) ? sessionId : SystemInfo.deviceUniqueIdentifier + DateTime.Now.ToString("yyyyMMddHHmmssfff");
-            this.launcherAnonymousId = launcherAnonymousId;
+            this.sessionId = !string.IsNullOrEmpty(launcherTraits.SessionId) ? launcherTraits.SessionId : SystemInfo.deviceUniqueIdentifier + DateTime.Now.ToString("yyyyMMddHHmmssfff");
+            this.launcherAnonymousId = launcherTraits.LauncherAnonymousId;
         }
 
         public override TrackEvent Track(TrackEvent trackEvent)
@@ -33,5 +33,11 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
             return trackEvent;
         }
+    }
+
+    public struct LauncherTraits
+    {
+        public string LauncherAnonymousId;
+        public string SessionId;
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/StaticCommonTraitsPlugin.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/StaticCommonTraitsPlugin.cs
@@ -7,17 +7,26 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
     public class StaticCommonTraitsPlugin : EventPlugin
     {
         private readonly string dclRendererType = SystemInfo.deviceType.ToString(); // Desktop, Console, Handeheld (Mobile), Unknown
-        private readonly string sessionID = SystemInfo.deviceUniqueIdentifier + DateTime.Now.ToString("yyyyMMddHHmmssfff");
         private readonly string rendererVersion = Application.version;
         private readonly string runtime = Application.isEditor? "editor" : Debug.isDebugBuild ? "debug" : "release";
         private readonly string os = SystemInfo.operatingSystem;
 
+        private readonly string sessionId;
+        private readonly string launcherAnonymousId;
+
         public override PluginType Type => PluginType.Enrichment;
+
+        public StaticCommonTraitsPlugin(string launcherAnonymousId, string sessionId)
+        {
+            this.sessionId = !string.IsNullOrEmpty(this.sessionId) ? sessionId : SystemInfo.deviceUniqueIdentifier + DateTime.Now.ToString("yyyyMMddHHmmssfff");
+            this.launcherAnonymousId = launcherAnonymousId;
+        }
 
         public override TrackEvent Track(TrackEvent trackEvent)
         {
             trackEvent.Context["dcl_renderer_type"] = dclRendererType;
-            trackEvent.Context["session_id"] = sessionID;
+            trackEvent.Context["session_id"] = sessionId;
+            trackEvent.Context["launcher_anonymous_id"] = launcherAnonymousId;
             trackEvent.Context["renderer_version"] = rendererVersion;
             trackEvent.Context["runtime"] = runtime;
             trackEvent.Context["operating_system"] = os;

--- a/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
@@ -44,15 +44,13 @@ namespace Global.AppArgs
             var deepLinkFound = false;
             string lastKeyStored = string.Empty;
 
-            for (int i = 0; i < cmdArgs.Length; i++)
+            foreach (string arg in cmdArgs)
             {
-                string arg = cmdArgs[i];
-
                 if (arg.StartsWith("--"))
                 {
                     if (arg.Length > 2)
                     {
-                        lastKeyStored = arg[2..];
+                        lastKeyStored = arg.Substring(2);
                         appParameters[lastKeyStored] = string.Empty;
                     }
                     else

--- a/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
@@ -36,8 +36,7 @@ namespace Global.AppArgs
         private void AddAlwaysInEditorFlags()
         {
             foreach ((string? key, string? value) in ALWAYS_IN_EDITOR)
-                if (appParameters.ContainsKey(key) == false)
-                    appParameters[key] = value;
+                appParameters.TryAdd(key, value);
         }
 
         private void ParseApplicationParameters(string[] cmdArgs)
@@ -53,7 +52,7 @@ namespace Global.AppArgs
                 {
                     if (arg.Length > 2)
                     {
-                        lastKeyStored = arg.Substring(2);
+                        lastKeyStored = arg[2..];
                         appParameters[lastKeyStored] = string.Empty;
                     }
                     else

--- a/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
@@ -106,7 +106,10 @@ namespace Global.Dynamic
             {
                 IAnalyticsService service = CreateAnalyticsService(analyticsConfig);
 
-                var analyticsController = new AnalyticsController(service, analyticsConfig);
+                appArgs.TryGetValue("launcher_anonymous_id", out string? launcherAnonymousId);
+                appArgs.TryGetValue("session_id", out string? sessionId);
+
+                var analyticsController = new AnalyticsController(service, analyticsConfig, launcherAnonymousId!, sessionId!);
 
                 return (new BootstrapAnalyticsDecorator(coreBootstrap, analyticsController), analyticsController);
             }

--- a/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
@@ -109,7 +109,13 @@ namespace Global.Dynamic
                 appArgs.TryGetValue("launcher_anonymous_id", out string? launcherAnonymousId);
                 appArgs.TryGetValue("session_id", out string? sessionId);
 
-                var analyticsController = new AnalyticsController(service, analyticsConfig, launcherAnonymousId!, sessionId!);
+                LauncherTraits launcherTraits = new LauncherTraits
+                {
+                    LauncherAnonymousId = launcherAnonymousId!,
+                    SessionId = sessionId!,
+                };
+
+                var analyticsController = new AnalyticsController(service, analyticsConfig, launcherTraits);
 
                 return (new BootstrapAnalyticsDecorator(coreBootstrap, analyticsController), analyticsController);
             }


### PR DESCRIPTION
## What does this PR change?

we want to have same session_id and anonymous_id in both Launcher and Explorer. I just forward them from application cmd arguments.

Note: we cannot override Sentis `anonymous_id `, thus we introduce new one

## How to test the changes?

1. Launch the explorer
2. Verify it launches :) 