### PR TITLE
fix: AppArgs test and debug flag

### DIFF
--- a/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Text.RegularExpressions;
@@ -19,11 +20,13 @@ namespace Global.AppArgs
 
         public ApplicationParametersParser() : this(Environment.GetCommandLineArgs()) { }
 
-        public ApplicationParametersParser(string[] args)
+        public ApplicationParametersParser(string[] args) : this(true, args) { }
+
+        public ApplicationParametersParser(bool useInEditorFlags = true, params string[] args)
         {
             ParseApplicationParameters(args);
 
-            if (Application.isEditor)
+            if (useInEditorFlags && Application.isEditor)
                 AddAlwaysInEditorFlags();
         }
 
@@ -32,6 +35,9 @@ namespace Global.AppArgs
 
         public bool TryGetValue(string flagName, out string? value) =>
             appParameters.TryGetValue(flagName, out value);
+
+        public IEnumerable<string> Flags() =>
+            appParameters.Keys;
 
         private void AddAlwaysInEditorFlags()
         {

--- a/Explorer/Assets/Scripts/Global/AppArgs/IAppArgs.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/IAppArgs.cs
@@ -1,12 +1,16 @@
+using System.Collections.Generic;
+
 namespace Global.AppArgs
 {
     public interface IAppArgs
     {
-        public const string DEBUG_FLAG = "-debug";
+        public const string DEBUG_FLAG = "debug";
 
         bool HasFlag(string flagName);
 
         bool TryGetValue(string flagName, out string? value);
+
+        IEnumerable<string> Flags();
     }
 
     public static class AppArgsExtensions

--- a/Explorer/Assets/Scripts/Global/AppArgs/Tests.meta
+++ b/Explorer/Assets/Scripts/Global/AppArgs/Tests.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5e39e87a17df4a71806309ed9e1298ac
+timeCreated: 1724747358

--- a/Explorer/Assets/Scripts/Global/AppArgs/Tests/AppArgs.Tests.asmref
+++ b/Explorer/Assets/Scripts/Global/AppArgs/Tests/AppArgs.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/Scripts/Global/AppArgs/Tests/AppArgs.Tests.asmref.meta
+++ b/Explorer/Assets/Scripts/Global/AppArgs/Tests/AppArgs.Tests.asmref.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 30872d32e06b46419bd50cce890a8a26
+timeCreated: 1724747381

--- a/Explorer/Assets/Scripts/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/Tests/AppArgsTests.cs
@@ -1,0 +1,21 @@
+using NUnit.Framework;
+
+namespace Global.AppArgs.Tests
+{
+    public class AppArgsTest
+    {
+        [Test]
+        public void DebugArgFailTest()
+        {
+            IAppArgs args = new ApplicationParametersParser(false, "-debug");
+            Assert.False(args.HasDebugFlag(), $"flags in args: {string.Join(", ", args.Flags())}");
+        }
+
+        [Test]
+        public void DebugArgContainsTest()
+        {
+            IAppArgs args = new ApplicationParametersParser(false, "--debug");
+            Assert.True(args.HasDebugFlag(), $"flags in args: {string.Join(", ", args.Flags())}");
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/AppArgs/Tests/AppArgsTests.cs.meta
+++ b/Explorer/Assets/Scripts/Global/AppArgs/Tests/AppArgsTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d271992a069149f5856d40ce163f300b
+timeCreated: 1724747376


### PR DESCRIPTION
## What does this PR change?

Args keys are presented without '--' prefix
...

## How to test the changes?

1. Launch the explorer
2. Try with and without `--debug` flag 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

