### PR TITLE
fix: cleaning up unity target on PR closure

### DIFF
--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -7,26 +7,25 @@ on:
 
 jobs:
   handle-pr-closure:
-    name: Handle PR Closure
+    name: Clean Up Unity Cloud Target
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Check if PR is merged
-        id: check_if_merged
-        run: echo "PR_MERGED=${{ github.event.pull_request.merged }}" >> $GITHUB_ENV
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12.3
 
-      - name: Delete Unity Cloud target if merged
-        if: env.PR_MERGED == 'true'
-        env:
-          API_KEY: ${{ secrets.UNITY_CLOUD_API_KEY }}
-          ORG_ID: ${{ secrets.UNITY_CLOUD_ORG_ID }}
-          PROJECT_ID: ${{ secrets.UNITY_CLOUD_PROJECT_ID }}
-        run: python -u scripts/cloudbuild/build.py --delete
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/cloudbuild/requirements.txt
 
-      - name: Delete Unity Cloud target if closed without merging
-        if: env.PR_MERGED != 'true'
+      - name: Delete Unity Cloud target
         env:
           API_KEY: ${{ secrets.UNITY_CLOUD_API_KEY }}
           ORG_ID: ${{ secrets.UNITY_CLOUD_ORG_ID }}


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
Fixing workflow that is supposed to remove the target on unity cloud when the PR is closed

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

