### PR TITLE
fix: remove entities dependency

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Jobs/UpdateBoundariesCullingJob.cs
+++ b/Explorer/Assets/DCL/Landscape/Jobs/UpdateBoundariesCullingJob.cs
@@ -2,12 +2,13 @@
 using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
+using UnityEngine;
 
 namespace DCL.Landscape.Jobs
 {
     public struct VisibleBounds
     {
-        public AABB Bounds;
+        public Bounds Bounds;
         public bool IsVisible;
         public bool IsAtDistance;
         public bool IsDirty;
@@ -41,7 +42,7 @@ namespace DCL.Landscape.Jobs
 
             if (isVisible)
             {
-                float sqrDist = terrain.Bounds.DistanceSq(cameraPosition);
+                float sqrDist = terrain.Bounds.SqrDistance(cameraPosition);
                 isAtDistance = sqrDist < detailDistanceSqr;
             }
 
@@ -54,7 +55,7 @@ namespace DCL.Landscape.Jobs
 
         // got this one from https://forum.unity.com/threads/managed-version-of-geometryutility-testplanesaabb.473575/
         // thanks kind internet fellow :)
-        private bool TestPlanesAABB(AABB bounds)
+        private bool TestPlanesAABB(Bounds bounds)
         {
             for (var i = 0; i < cameraPlanes.Length; i++)
             {
@@ -62,7 +63,7 @@ namespace DCL.Landscape.Jobs
                 float3 planeNormal = plane.xyz;
                 float planeDistance = plane.w;
                 float3 normalSign = math.sign(planeNormal);
-                float3 testPoint = bounds.Center + (bounds.Extents * normalSign);
+                float3 testPoint = new float3(bounds.center) + (bounds.extents * normalSign);
 
                 float dot = math.dot(testPoint, planeNormal);
 

--- a/Explorer/Assets/DCL/Landscape/Systems/LandscapeMiscCullingSystem.cs
+++ b/Explorer/Assets/DCL/Landscape/Systems/LandscapeMiscCullingSystem.cs
@@ -125,10 +125,10 @@ namespace DCL.Landscape.Systems
 
                     var cliffsBoundary = new VisibleBounds
                     {
-                        Bounds = new AABB
+                        Bounds = new Bounds()
                         {
-                            Center = bounds.center,
-                            Extents = bounds.extents + Vector3.one,
+                            center = bounds.center,
+                            extents = bounds.extents + Vector3.one,
                         },
                     };
 
@@ -157,10 +157,10 @@ namespace DCL.Landscape.Systems
 
                 waterBoundaries[i] = new VisibleBounds
                 {
-                    Bounds = new AABB
+                    Bounds = new Bounds()
                     {
-                        Center = bounds.center,
-                        Extents = bounds.extents + Vector3.one,
+                        center = bounds.center,
+                        extents = bounds.extents + Vector3.one,
                     },
                 };
             }

--- a/Explorer/Assets/DCL/Landscape/Systems/LandscapeTerrainCullingSystem.cs
+++ b/Explorer/Assets/DCL/Landscape/Systems/LandscapeTerrainCullingSystem.cs
@@ -92,10 +92,10 @@ namespace DCL.Landscape.Systems
 
                 terrainVisibilities[i] = new VisibleBounds
                 {
-                    Bounds = new AABB
+                    Bounds = new Bounds
                     {
-                        Center = bounds.center,
-                        Extents = bounds.extents,
+                        center = bounds.center,
+                        extents = bounds.extents,
                     },
                 };
             }

--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -18,7 +18,6 @@
     "com.unity.code-analysis": "0.1.2-preview",
     "com.unity.collab-proxy": "2.4.4",
     "com.unity.collections": "2.1.4",
-    "com.unity.entities": "1.0.16",
     "com.unity.feature.development": "1.0.1",
     "com.unity.ide.rider": "3.0.31",
     "com.unity.inputsystem": "1.7.0",


### PR DESCRIPTION
## What does this PR change?
Removes unnecessary unity entities dependency.

Before:
![image](https://github.com/user-attachments/assets/53346672-f4b5-4bbf-83ef-7e3523ef8856)

After:
![image](https://github.com/user-attachments/assets/a36ca262-f8fe-400b-b2c1-4af965a6b0bd)


## How to test the changes?

- Ensure the landscape works as normal in genesis and worlds
- Performance is the same or better

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

