### PR TITLE
fix: ensure audio loads on bg thread

### DIFF
--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 01.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 02.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 03.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 03.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 04.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 04.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 05.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 05.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 06.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 06.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 07.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Clothes Rustle - Short 07.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Blow Kiss 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Blow Kiss 01.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Blow Kiss 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Blow Kiss 02.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Blow Kiss 03.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Blow Kiss 03.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 01.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 02.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 03.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 03.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 04.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 04.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 05.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 05.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 06.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 06.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 07.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 07.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 08.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Clap 08.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Throw Money 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Throw Money 01.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Throw Money 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Throw Money 02.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Throw Money 03.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Throw Money 03.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Throw Money 04.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Throw Money 04.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Throw Money 05.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Expression - Throw Money 05.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Jump 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Jump 01.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Jump 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Jump 02.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Jump 03.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Jump 03.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Land 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Land 01.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Land 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Land 02.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Light 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Light 01.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Light 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Light 02.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Light 03.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Light 03.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Light 04.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Light 04.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 01.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 02.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 03.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 03.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 04.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 04.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 05.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 05.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 06.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 06.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 07.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 07.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 08.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Run 08.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Slide 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Slide 01.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Slide 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Slide 02.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Slide 03.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Slide 03.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 01.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 02.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 03.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 03.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 04.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 04.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 05.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 05.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 06.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 06.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 07.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 07.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 

--- a/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 08.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Old Renderer/Avatar SFX/Avatar - Footstep - Walk 08.wav.meta
@@ -15,7 +15,7 @@ AudioImporter:
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  loadInBackground: 0
+  loadInBackground: 1
   ambisonic: 0
   3D: 1
   userData: 


### PR DESCRIPTION
## What does this PR change?

Set in-game audio to load on bg thread.

Before:

![audio-foot-step-slow](https://github.com/user-attachments/assets/7bd069ee-7461-4e2c-a37b-f632db27c281)

After:
![image](https://github.com/user-attachments/assets/8d12c65b-88f2-4fc3-885d-1b498eb6748b)



## How to test the changes?

1. Ensure all avatar sounds work as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

