### PR TITLE
Fix: Prevent AssetPromise leak on cancellation

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarLoaderSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarLoaderSystemShould.cs
@@ -1,4 +1,5 @@
-﻿using CommunicationData.URLHelpers;
+﻿using Arch.Core;
+using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.AvatarRendering.AvatarShape.Systems;
 using DCL.AvatarRendering.Wearables;
@@ -108,7 +109,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             system.Update(0);
 
             ref AvatarShapeComponent avatarShapeComponent = ref world.Get<AvatarShapeComponent>(entity);
-            int originalPromiseVersion = avatarShapeComponent.WearablePromise.Entity.Entity.Id;
+            EntityReference originalPromise = avatarShapeComponent.WearablePromise.Entity;
 
             pbAvatarShape.BodyShape = BODY_SHAPE_FEMALE;
             pbAvatarShape.IsDirty = true;
@@ -117,7 +118,8 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
 
             //Assert
             //Should be different ids, because the promise was cancelled and a new one was created
-            Assert.AreNotEqual(avatarShapeComponent.WearablePromise.Entity.Entity.Id, originalPromiseVersion);
+            Assert.That(world.IsAlive(originalPromise), Is.False);
+            Assert.AreNotEqual(avatarShapeComponent.WearablePromise.Entity, originalPromise);
         }
     }
 }

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/AssetPromise.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/AssetPromise.cs
@@ -53,7 +53,7 @@ namespace ECS.StreamableLoading.Common
         /// <summary>
         ///     Returns the asset if the loading is finished
         /// </summary>
-        public  bool TryGetResult(World world, out StreamableLoadingResult<TAsset> result)
+        public bool TryGetResult(World world, out StreamableLoadingResult<TAsset> result)
         {
             if (Result.HasValue)
             {
@@ -88,8 +88,7 @@ namespace ECS.StreamableLoading.Common
                     ReportHub.LogError(ReportCategory.STREAMABLE_LOADING,
                         $"{nameof(TryGetResult)} was called before {nameof(TryConsume)} for {LoadingIntention.ToString()}, the flow is inconclusive and should be fixed!");
 
-                    world.Destroy(Entity);
-                    Entity = EntityReference.Null;
+                    DestroyEntity(world);
                     result = Result.Value;
                     return true;
                 }
@@ -102,8 +101,7 @@ namespace ECS.StreamableLoading.Common
             if (world.TryGet(Entity, out result))
             {
                 Result = result;
-                world.Destroy(Entity);
-                Entity = EntityReference.Null;
+                DestroyEntity(world);
                 return true;
             }
 
@@ -117,12 +115,11 @@ namespace ECS.StreamableLoading.Common
         {
             if (Entity == EntityReference.Null || !Entity.IsAlive(world)) return;
 
-            world.Destroy(Entity);
-            Entity = EntityReference.Null;
+            DestroyEntity(world);
         }
 
         /// <summary>
-        ///     Places <see cref="ForgetLoadingIntent" /> and nullifies the reference
+        ///     Cancel Cancellation Token Source and nullifies the reference
         /// </summary>
         /// <param name="world"></param>
         public void ForgetLoading(World world)
@@ -130,6 +127,12 @@ namespace ECS.StreamableLoading.Common
             if (Entity == EntityReference.Null || !Entity.IsAlive(world)) return;
 
             LoadingIntention.CancellationTokenSource.Cancel();
+            DestroyEntity(world);
+        }
+
+        private void DestroyEntity(World world)
+        {
+            world.Destroy(Entity);
             Entity = EntityReference.Null;
         }
 

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/Components/StreamableLoadingResult.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/Components/StreamableLoadingResult.cs
@@ -23,5 +23,8 @@ namespace ECS.StreamableLoading.Common.Components
         }
 
         public bool IsInitialized => Exception != null || Asset != null || Succeeded;
+
+        public override string ToString() =>
+            IsInitialized ? Succeeded ? Asset!.ToString() : Exception!.ToString() : "Not Initialized";
     }
 }

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/Components/StreamableLoadingState.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/Components/StreamableLoadingState.cs
@@ -1,6 +1,8 @@
 using DCL.Optimization.PerformanceBudgeting;
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Utility;
 
 namespace ECS.StreamableLoading.Common.Components
 {
@@ -47,6 +49,10 @@ namespace ECS.StreamableLoading.Common.Components
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetAllowed(IAcquiredBudget budget)
         {
+#if UNITY_EDITOR
+            if (Value is not Status.Forbidden && Value is not Status.NotStarted)
+                throw new InvalidOperationException($"Unexpected transition from \"{Value}\" to \"Allowed\"");
+#endif
             AcquiredBudget = budget;
             Value = Status.Allowed;
         }
@@ -56,7 +62,7 @@ namespace ECS.StreamableLoading.Common.Components
         {
 #if UNITY_EDITOR
             if (Value is Status.Finished)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException($"Unexpected transition from \"{Value}\" to \"Forbidden\"");
 #endif
             Value = Status.Forbidden;
         }
@@ -66,7 +72,7 @@ namespace ECS.StreamableLoading.Common.Components
         {
 #if UNITY_EDITOR
             if (Value is not Status.Allowed)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException($"Unexpected transition from \"{Value}\" to \"InProgress\"");
 #endif
             Value = Status.InProgress;
         }
@@ -76,7 +82,7 @@ namespace ECS.StreamableLoading.Common.Components
         {
 #if UNITY_EDITOR
             if (Value is not Status.InProgress)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException($"Unexpected transition from \"{Value}\" to \"Finished\"");
 #endif
             Value = Status.Finished;
         }
@@ -89,7 +95,7 @@ namespace ECS.StreamableLoading.Common.Components
         {
 #if UNITY_EDITOR
             if (Value is not Status.InProgress)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException($"Unexpected transition from \"{Value}\" to \"NotStarted\"");
 #endif
             Value = Status.NotStarted;
         }


### PR DESCRIPTION
Fixes #1791 

- When `ForgetLoading` was called it didn't lead to the entity deletion. Its rensobility was in `LoadSystemBase`. However, if the promise was not allowed by `DeferredLoadingSystem` that flow was not starting at all leading to entities leak with `OperationCancelledException`
- Now `ForgetLoading` removes the entity and the flow in `LoadSystemBase` handles removed entities safely

### Testing
- Ensure loading and unloading of assets, scenes, worlds, models all work as expected.