### PR TITLE
fix: enumerable alloc

### DIFF
--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
@@ -59,6 +59,8 @@ namespace SceneRunner.Scene
         public bool Contains(string hash) =>
             ignoreConvertedFiles || convertedFiles.Contains(hash);
 
+        public bool TryGet(string hash, out string convertedFile) => convertedFiles.TryGetValue(hash, out convertedFile);
+
         public URLAddress GetAssetBundleURL(string hash) =>
             assetBundlesBaseUrl.Append(new URLPath($"{version}/{hash}"));
 

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifestExtensions.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifestExtensions.cs
@@ -1,22 +1,11 @@
-﻿using JetBrains.Annotations;
-using System;
-
-namespace SceneRunner.Scene
+﻿namespace SceneRunner.Scene
 {
     public static class SceneAssetBundleManifestExtensions
     {
         public static string FixCapitalization(this SceneAssetBundleManifest? sceneAssetBundleManifest, string hash)
         {
             if (sceneAssetBundleManifest == null) return hash;
-
-            // TODO iterator allocation
-            foreach (string convertedFile in sceneAssetBundleManifest.ConvertedFiles)
-            {
-                if (string.Compare(hash, convertedFile, StringComparison.OrdinalIgnoreCase) == 0)
-                    return convertedFile;
-            }
-
-            return hash;
+            return sceneAssetBundleManifest.TryGet(hash, out string convertedFile) ? convertedFile : hash;
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Handles the todo, preventing the allocation and moves the string comparison to the existing HashSet/

## How to test the changes?

Ensure models, scenes and wearables all work as normal in worlds and genesis.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to safely retrieve converted files associated with a hash, enhancing error handling and usability.
  
- **Bug Fixes**
  - Improved the efficiency of the file name capitalization method by streamlining the logic, resulting in better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->