### PR TITLE
Fix/nametag is not dynamic with wearable bounds (#1683)

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -66,12 +66,18 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
         private bool disposed;
 
-        internal AvatarCustomSkinningComponent(int vertCount, Buffers buffers, List<MaterialSetup> materials, UnityEngine.ComputeShader computeShaderInstance)
+        /// <summary>
+        ///
+        /// </summary>
+        public Bounds LocalBounds { get; private set; }
+
+        internal AvatarCustomSkinningComponent(int vertCount, Buffers buffers, List<MaterialSetup> materials, UnityEngine.ComputeShader computeShaderInstance, Bounds localBounds)
         {
             this.vertCount = vertCount;
             this.buffers = buffers;
             this.materials = materials;
             this.computeShaderInstance = computeShaderInstance;
+            this.LocalBounds = localBounds;
             VertsOutRegion = default(FixedComputeBufferHandler.Slice);
 
             disposed = false;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using DCL.AvatarRendering.AvatarShape.Helpers;
 using DCL.Diagnostics;
+using NUnit.Framework;
 using Unity.Collections;
 using Unity.Mathematics;
 using UnityEngine;
@@ -29,9 +30,11 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
             AvatarCustomSkinningComponent.Buffers buffers = SetupComputeShader(meshesData, skinningShader, vertCount, boneCount);
             List<AvatarCustomSkinningComponent.MaterialSetup> materialSetups = SetupMeshRenderer(meshesData, avatarMaterialPool, avatarShapeComponent, facialFeatureTexture);
 
+            Bounds totalBounds =  CalculateLocalBoundsFromMeshes(meshesData);
+
             ListPool<MeshData>.Release(meshesData);
 
-            return new AvatarCustomSkinningComponent(vertCount, buffers, materialSetups, skinningShader);
+            return new AvatarCustomSkinningComponent(vertCount, buffers, materialSetups, skinningShader, totalBounds);
         }
         public override void ComputeSkinning(NativeArray<float4x4> bonesResult, ref AvatarCustomSkinningComponent skinning)
         {
@@ -219,6 +222,43 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
             for (var i = 0; i < skinningComponent.materials.Count; i++)
                 skinningComponent.materials[i].usedMaterial.SetInteger(ComputeShaderConstants.LAST_AVATAR_VERT_COUNT_ID, region.StartIndex);
+        }
+
+        /// <summary>
+        /// Checks the bounds of a list of meshes and computes the bounding box that contains them all.
+        /// </summary>
+        /// <param name="meshes">A list of meshes.</param>
+        /// <returns>A bounding box that contains all the meshes.</returns>
+        private static Bounds CalculateLocalBoundsFromMeshes(List<MeshData> meshes)
+        {
+            Vector3 maxCorner = new Vector3(float.MinValue, float.MinValue, float.MinValue);
+            Vector3 minCorner = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
+
+            for (int i = 0; i < meshes.Count; ++i)
+            {
+                Bounds meshBounds = meshes[i].Mesh.mesh.bounds;
+
+                if (maxCorner.x < meshBounds.max.x)
+                    maxCorner.x = meshBounds.max.x;
+
+                if (maxCorner.y < meshBounds.max.y)
+                    maxCorner.y = meshBounds.max.y;
+
+                if (maxCorner.z < meshBounds.max.z)
+                    maxCorner.z = meshBounds.max.z;
+
+                if (minCorner.x > meshBounds.min.x)
+                    minCorner.x = meshBounds.min.x;
+
+                if (minCorner.y > meshBounds.min.y)
+                    minCorner.y = meshBounds.min.y;
+
+                if (minCorner.z > meshBounds.min.z)
+                    minCorner.z = meshBounds.min.z;
+            }
+
+            Vector3 size = maxCorner - minCorner;
+            return new Bounds(minCorner + size * 0.5f, size);
         }
     }
 }

--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -144,11 +144,11 @@ namespace DCL.Nametags
             }
 
             // To test bounds:
-//#if UNITY_EDITOR
-//            Bounds avatarBounds = avatarSkinningComponent.LocalBounds;
-//            avatarBounds.center += characterTransform.Position;
-//            avatarBounds.DrawInEditor(Color.red);
-//#endif
+#if UNITY_EDITOR
+            Bounds avatarBounds = avatarSkinningComponent.LocalBounds;
+            avatarBounds.center += characterTransform.Position;
+            avatarBounds.DrawInEditor(Color.red);
+#endif
 
             UpdateTagPosition(nametagView, camera.Camera, characterTransform.Position + new Vector3(0.0f, avatarSkinningComponent.LocalBounds.max.y, 0.0f));
             UpdateTagTransparencyAndScale(nametagView, camera.Camera, characterTransform.Position);

--- a/Explorer/Assets/DCL/PluginSystem/DCL.Plugins.asmdef
+++ b/Explorer/Assets/DCL/PluginSystem/DCL.Plugins.asmdef
@@ -125,7 +125,8 @@
         "GUID:a285ec5e26824438b1b2ab8f22969298",
         "GUID:a0d83a4df040477894e767d4333169ec",
         "GUID:8baf705856414dad9a73b3f382f1bc8b",
-        "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b"
+        "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b",
+        "GUID:30e71cae72d2eb34584696878bc78813"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/Scripts/Utility/Editor/BoundsExtensions.cs
+++ b/Explorer/Assets/Scripts/Utility/Editor/BoundsExtensions.cs
@@ -1,0 +1,46 @@
+﻿using UnityEngine;
+
+namespace Utility.Editor
+{
+    public static class BoundsExtensions
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="bounds"></param>
+        /// <param name="color"></param>
+        public static void DrawInEditor(this Bounds bounds, Color color)
+        {
+            Vector3 halfSize = bounds.size * 0.5f;
+            Vector3[] bottomCorners = new Vector3[4]
+                    {
+                        new Vector3(bounds.center.x - halfSize.x, bounds.center.y - halfSize.y, bounds.center.z + halfSize.z),
+                        new Vector3(bounds.center.x + halfSize.x, bounds.center.y - halfSize.y, bounds.center.z + halfSize.z),
+                        new Vector3(bounds.center.x + halfSize.x, bounds.center.y - halfSize.y, bounds.center.z - halfSize.z),
+                        new Vector3(bounds.center.x - halfSize.x, bounds.center.y - halfSize.y, bounds.center.z - halfSize.z),
+                    };
+            Vector3[] topCorners = new Vector3[4]
+                    {
+                        new Vector3(bottomCorners[0].x, bottomCorners[0].y + bounds.size.y, bottomCorners[0].z),
+                        new Vector3(bottomCorners[1].x, bottomCorners[1].y + bounds.size.y, bottomCorners[1].z),
+                        new Vector3(bottomCorners[2].x, bottomCorners[2].y + bounds.size.y, bottomCorners[2].z),
+                        new Vector3(bottomCorners[3].x, bottomCorners[3].y + bounds.size.y, bottomCorners[3].z),
+                    };
+
+            Debug.DrawLine(bottomCorners[0], topCorners[0], color);
+            Debug.DrawLine(bottomCorners[1], topCorners[1], color);
+            Debug.DrawLine(bottomCorners[2], topCorners[2], color);
+            Debug.DrawLine(bottomCorners[3], topCorners[3], color);
+
+            Debug.DrawLine(bottomCorners[0], bottomCorners[1], color);
+            Debug.DrawLine(bottomCorners[1], bottomCorners[2], color);
+            Debug.DrawLine(bottomCorners[2], bottomCorners[3], color);
+            Debug.DrawLine(bottomCorners[3], bottomCorners[0], color);
+
+            Debug.DrawLine(topCorners[0], topCorners[1], color);
+            Debug.DrawLine(topCorners[1], topCorners[2], color);
+            Debug.DrawLine(topCorners[2], topCorners[3], color);
+            Debug.DrawLine(topCorners[3], topCorners[0], color);
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Utility/Editor/BoundsExtensions.cs.meta
+++ b/Explorer/Assets/Scripts/Utility/Editor/BoundsExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3839f5907d1645c9ac2a7168620546fc
+timeCreated: 1724938763


### PR DESCRIPTION
## What does this PR change?

It changes how the height of the nametags is calculated. Nametags will always be above the avatar, no matter what wearables are equipped.

## How to test the changes?

1. Launch the explorer
2. Change the wearables of the avatar, use different hats for example.
3. Meet other players and see how your nametags have different heights.

The name tag should move up or down depending on the height of the avatar.
