### PR TITLE
fix: unreliable sdk colliders initialization

### DIFF
--- a/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
@@ -30,6 +30,7 @@ namespace ECS.Unity.SceneBoundsChecker
         private readonly IPartitionComponent scenePartition;
         private readonly ParcelMathHelper.SceneGeometry sceneGeometry;
         private readonly IPhysicsTickProvider physicsTickEntity;
+        private Bounds auxiliaryBounds = new Bounds();
 
         /// <summary>
         ///     Throttle scheduling between fixed updates
@@ -72,9 +73,12 @@ namespace ECS.Unity.SceneBoundsChecker
             if (!primitiveCollider.SDKCollider.HasMoved())
                 return;
 
-            collider.enabled = true; // enable it to calculate
-            primitiveCollider.SDKCollider.ForceActiveBySceneBounds(collider.bounds.max.y <= sceneGeometry.Height
-                                                                    && sceneGeometry.CircumscribedPlanes.Intersects(collider.bounds));
+            // We use an auxiliary bounds object as Unity physics may take more than 1 frame to actually
+            // update the min-max of the collider bounds, leaving the collider disabled in the end...
+            auxiliaryBounds.center = collider.transform.position;
+            auxiliaryBounds.extents = collider.bounds.extents;
+            primitiveCollider.SDKCollider.ForceActiveBySceneBounds(auxiliaryBounds.max.y <= sceneGeometry.Height
+                                                                   && sceneGeometry.CircumscribedPlanes.Intersects(auxiliaryBounds));
         }
 
         [Query]
@@ -111,15 +115,15 @@ namespace ECS.Unity.SceneBoundsChecker
                     if (!sdkCollider.HasMoved())
                         continue;
 
-                    // Unity doesn't calculate bounds if the component is disabled
-                    sdkCollider.Collider.enabled = true; // enable it to calculate
-
-                    Bounds colliderBounds = sdkCollider.Collider.bounds;
+                    // We use an auxiliary bounds object as Unity physics may take more than 1 frame to actually
+                    // update the min-max of the collider bounds, leaving the collider disabled in the end...
+                    auxiliaryBounds.center = sdkCollider.Collider.transform.position;
+                    auxiliaryBounds.extents = sdkCollider.Collider.bounds.extents;
 
                     // While the collider remains inactive, the bounds will continue to be zero, causing incorrect calculations.
                     // Therefore, it is necessary to force the collider to be activated at least once
-                    sdkCollider.ForceActiveBySceneBounds(colliderBounds.extents == Vector3.zero
-                                                         || (colliderBounds.max.y <= sceneGeometry.Height && sceneGeometry.CircumscribedPlanes.Intersects(colliderBounds)));
+                    sdkCollider.ForceActiveBySceneBounds(auxiliaryBounds.extents == Vector3.zero
+                                                         || (auxiliaryBounds.max.y <= sceneGeometry.Height && sceneGeometry.CircumscribedPlanes.Intersects(auxiliaryBounds)));
 
                     // write the structure back
                     colliders[i] = sdkCollider;

--- a/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
@@ -73,8 +73,8 @@ namespace ECS.Unity.SceneBoundsChecker
             if (!primitiveCollider.SDKCollider.HasMoved())
                 return;
 
-            // We use an auxiliary bounds object as Unity physics may take more than 1 frame to actually
-            // update the min-max of the collider bounds, leaving the collider disabled in the end...
+            // We use an auxiliary bounds object as Unity physics may take at least an extra frame to
+            // actually update the min-max of the collider bounds, leaving the collider disabled in the end...
             auxiliaryBounds.center = collider.transform.position;
             auxiliaryBounds.extents = collider.bounds.extents;
             primitiveCollider.SDKCollider.ForceActiveBySceneBounds(auxiliaryBounds.max.y <= sceneGeometry.Height
@@ -115,8 +115,8 @@ namespace ECS.Unity.SceneBoundsChecker
                     if (!sdkCollider.HasMoved())
                         continue;
 
-                    // We use an auxiliary bounds object as Unity physics may take more than 1 frame to actually
-                    // update the min-max of the collider bounds, leaving the collider disabled in the end...
+                    // We use an auxiliary bounds object as Unity physics may take at least an extra frame to
+                    // actually update the min-max of the collider bounds, leaving the collider disabled in the end...
                     auxiliaryBounds.center = sdkCollider.Collider.transform.position;
                     auxiliaryBounds.extents = sdkCollider.Collider.bounds.extents;
 

--- a/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/Tests/ColliderBoundsCheckerShould.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/Tests/ColliderBoundsCheckerShould.cs
@@ -45,7 +45,7 @@ namespace ECS.Unity.SceneBoundsChecker.Tests
         {
             scenePartition.Bucket.Returns((byte)(CheckColliderBoundsSystem.BUCKET_THRESHOLD + 1));
 
-            collider.center = new Vector3(-50, 0, -50);
+            collider.transform.position = new Vector3(-50, 0, -50);
             collider.size = Vector3.one;
 
             var component = new PrimitiveColliderComponent();
@@ -66,7 +66,7 @@ namespace ECS.Unity.SceneBoundsChecker.Tests
         [Test]
         public void DisableColliderOutOfBounds()
         {
-            collider.center = new Vector3(-50, 0, -50);
+            collider.transform.position = new Vector3(-50, 0, -50);
             collider.size = Vector3.one;
 
             var component = new PrimitiveColliderComponent();
@@ -74,6 +74,7 @@ namespace ECS.Unity.SceneBoundsChecker.Tests
 
             component.SDKCollider.IsActiveByEntity = true;
             collider.enabled = true;
+
             //Simulate movement
             collider.transform.position += Vector3.one * 0.01f;
 
@@ -87,7 +88,7 @@ namespace ECS.Unity.SceneBoundsChecker.Tests
         [Test]
         public void KeepColliderWithinBounds()
         {
-            collider.center = new Vector3(-20, 0, -20);
+            collider.transform.position = new Vector3(-20, 0, -20);
             collider.size = Vector3.one;
 
             var component = new PrimitiveColliderComponent();
@@ -108,7 +109,7 @@ namespace ECS.Unity.SceneBoundsChecker.Tests
         [Test]
         public void DisableColliderOutOfVerticalBounds()
         {
-            collider.center = new Vector3(0, 50, 0);
+            collider.transform.position = new Vector3(0, 50, 0);
             collider.size = Vector3.one;
 
             var component = new PrimitiveColliderComponent();
@@ -129,7 +130,7 @@ namespace ECS.Unity.SceneBoundsChecker.Tests
         [Test]
         public void KeepColliderWithinVerticalBounds()
         {
-            collider.center = new Vector3(0, 20, 0);
+            collider.transform.position = new Vector3(0, 20, 0);
             collider.size = Vector3.one;
 
             var component = new PrimitiveColliderComponent();


### PR DESCRIPTION
### WHY

We observed that randomly an object with a PointerEvents component started with its collider disabled.

By debugging we discovered that since [a recent optimization introduced](https://github.com/decentraland/unity-explorer/pull/1759) that makes the`CheckColliderBoundsSystem` run only once, this problem came to light.

What is happening is that sometimes/randomly during [this line](https://github.com/decentraland/unity-explorer/blob/00a8d6a6c077fe9f25f07a2397ee67204edf21bf/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs#L76) the `collider.bounds.max` and `collider.bounds.min` is not completely updated by Unity (it holds values at 0,0,0; probably needs an extra frame or more to finish updating it) so the SDK collider ends up disabled in the end. And with the recent optimization since that system won't check again, it will stay disabled forever.

The problem can be seen in the following video in which I reload the scene several times and the cube entity that has an SDK MeshCollider for its PointerEvent component sometimes starts enabled (as it should) and sometimes not...

https://github.com/user-attachments/assets/fc716b8b-fa96-449e-a89a-4056cbba43d2

And in this other video we can see how the `collider.bounds` `min` and `max` values are not representing the real bounds, since we can see its `transform` being correctly positioned away from `0,0,0`

https://github.com/user-attachments/assets/f22aae25-9e10-467c-a7e8-c6851a7bfad8

### WHAT

Introduced an `auxiliaryBounds` variable to configure it when needed using the already accessible information on the collider, removing our dependency on Unity's physics engine.