### PR TITLE
fix: outdated colliders cache on gltf reconfiguration

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/GltfContainerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/GltfContainerPlugin.cs
@@ -57,7 +57,7 @@ namespace DCL.PluginSystem.World
             ReportGltfErrorsSystem.InjectToWorld(ref builder, globalDeps.ReportsHandlingSettings);
 
             // GLTF Container
-            LoadGltfContainerSystem.InjectToWorld(ref builder, buffer, sharedDependencies.SceneData);
+            LoadGltfContainerSystem.InjectToWorld(ref builder, buffer, sharedDependencies.SceneData, sharedDependencies.EntityCollidersSceneCache);
             FinalizeGltfContainerLoadingSystem.InjectToWorld(ref builder, persistentEntities.SceneRoot, globalDeps.FrameTimeBudget,
                 sharedDependencies.EntityCollidersSceneCache, sharedDependencies.SceneData, buffer);
 

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Tests/LoadGltfContainerSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Tests/LoadGltfContainerSystemShould.cs
@@ -1,26 +1,22 @@
-﻿using System;
-using Arch.Core;
+﻿using Arch.Core;
 using DCL.ECSComponents;
+using DCL.Interaction.Utility;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.Abstract;
 using ECS.Prioritization.Components;
-using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.Common;
-using ECS.StreamableLoading.Common.Components;
 using ECS.TestSuite;
 using ECS.Unity.GLTFContainer.Asset.Components;
 using ECS.Unity.GLTFContainer.Asset.Systems;
 using ECS.Unity.GLTFContainer.Asset.Tests;
 using ECS.Unity.GLTFContainer.Components;
 using ECS.Unity.GLTFContainer.Systems;
-using ECS.Unity.SceneBoundsChecker;
-using ECS.Unity.Transforms.Components;
 using NSubstitute;
 using NUnit.Framework;
+using SceneRunner.Scene;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using SceneRunner.Scene;
 using UnityEngine.TestTools;
 using Utility;
 
@@ -50,7 +46,7 @@ namespace ECS.Unity.GLTFContainer.Tests
                     x[1] = "";
                     return false;
                 });
-            system = new LoadGltfContainerSystem(world, eventBuffer = new EntityEventBuffer<GltfContainerComponent>(1), sceneData);
+            system = new LoadGltfContainerSystem(world, eventBuffer = new EntityEventBuffer<GltfContainerComponent>(1), sceneData, Substitute.For<IEntityCollidersSceneCache>());
             var budget = Substitute.For<IReleasablePerformanceBudget>();
             budget.TrySpendBudget().Returns(true);
             createGltfAssetFromAssetBundleSystem = new CreateGltfAssetFromAssetBundleSystem(world, budget, budget);

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Tests/LoadGltfContainerSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Tests/LoadGltfContainerSystemShould.cs
@@ -1,4 +1,5 @@
 ﻿using Arch.Core;
+using CRDT;
 using DCL.ECSComponents;
 using DCL.Interaction.Utility;
 using DCL.Optimization.PerformanceBudgeting;
@@ -106,7 +107,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             var e = world.Create(component, new PBGltfContainer
             {
                 Src = GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH
-            }, PartitionComponent.TOP_PRIORITY);
+            }, PartitionComponent.TOP_PRIORITY, new CRDTEntity());
             var transformComponent = AddTransformToEntity(e);
 
             ConfigureGltfContainerColliders.SetupColliders(ref component, result.Asset);
@@ -148,7 +149,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             var e = world.Create(component, new PBGltfContainer
             {
                 Src = GltfContainerTestResources.RENDERER_WITH_LEGACY_ANIM_NAME, IsDirty = true
-            }, PartitionComponent.TOP_PRIORITY);
+            }, PartitionComponent.TOP_PRIORITY, new CRDTEntity());
             AddTransformToEntity(e);
 
             system.Update(0);


### PR DESCRIPTION
## What does this PR change?

Fixes #1911 
Fixes #1910 

In the rat scape scene (metadynelabs's world) whenever you grab a Mirror Box, the GLTF container changes the collision layer. This update was not propagated into the colliders cache. The fix consists on updating the cache of colliders when the `PBGltfContainer` requests a reconfiguration, so the raycasts can be calculated properly with latest collider changes in the `ExecuteRaycastSystem`.


## How to test the changes?

1. Follow issue steps

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

