### PR TITLE
fix: zero lookAt direction in multiplayer interpolation 

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Movement/Interpolation.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Interpolation.cs
@@ -30,16 +30,17 @@ namespace DCL.Multiplayer.Movement
                 transComp.Transform.position = intComp.End.position;
             }
 
-            LookAt(deltaTime, ref transComp, lookDirection, rotationSpeed, intComp.End.rotationY);
+            // Flattened to have ground plane direction only (XZ)
+            lookDirection.y = 0;
+
+            if (lookDirection != Vector3.zero)
+                LookAt(deltaTime, ref transComp, lookDirection, rotationSpeed, intComp.End.rotationY);
 
             return remainedDeltaTime;
         }
 
         private static void LookAt(float dt, ref CharacterTransform transComp, Vector3 direction, float rotationSpeed, float yRotation)
         {
-            // Flattened to have ground plane direction only (XZ)
-            direction.y = 0;
-
             var lookRotation = Quaternion.LookRotation(direction, Vector3.up);
             lookRotation.eulerAngles = new Vector3(lookRotation.eulerAngles.x, yRotation, lookRotation.eulerAngles.z);
             transComp.Transform.rotation = Quaternion.RotateTowards(transComp.Transform.rotation, lookRotation, rotationSpeed * dt);


### PR DESCRIPTION
## What does this PR change?

Adds a check to not pass zero vector into lookAt

## How to test the changes?

1. Launch the explorer
2. Verify remote players rotation is replicated as previously

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved character orientation in multiplayer by ensuring characters look only in the horizontal plane.
- **Bug Fixes**
	- Optimized control flow by preventing unnecessary calls to the look direction method when the direction is zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->