### PR TITLE
fix: Launcher stuck at loading screen (experimental PR - do NOT merge)

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/MultiplayerMovementPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/MultiplayerMovementPlugin.cs
@@ -41,9 +41,14 @@ namespace DCL.PluginSystem.Global
 
         public void Dispose()
         {
-            multiplayerMovementDebug.Dispose();
-            messageBus.Dispose();
-            settings.Dispose();
+            if (multiplayerMovementDebug != null)
+                multiplayerMovementDebug.Dispose();
+
+            if (messageBus != null)
+                messageBus.Dispose();
+
+            if (settings.Value != null)
+                settings.Dispose();
         }
 
         public async UniTask InitializeAsync(MultiplayerCommunicationSettings settings, CancellationToken ct)


### PR DESCRIPTION
## What does this PR change?
When getting into the launcher of DCL, the user gets stuck at the loading screen and never finish loading.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the safety of resource disposal in the multiplayer movement functionality, preventing potential runtime errors related to null references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->