### PR TITLE
Fix: RoadInstantiatorSystem causes frame-rate spikes & Memory Allocations (#1917)

### DIFF
--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/-49,-51.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/-49,-51.prefab
@@ -10291,7 +10291,7 @@ GameObject:
   - component: {fileID: 3050132076008021636}
   m_Layer: 0
   m_Name: -49,-51
-  m_TagString: Undefined
+  m_TagString: LongRoad
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/-49,-51.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/-49,-51.prefab
@@ -10291,7 +10291,7 @@ GameObject:
   - component: {fileID: 3050132076008021636}
   m_Layer: 0
   m_Name: -49,-51
-  m_TagString: Untagged
+  m_TagString: Undefined
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/-51,-49.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/-51,-49.prefab
@@ -8019,7 +8019,7 @@ GameObject:
   - component: {fileID: 4147738518612072844}
   m_Layer: 0
   m_Name: -51,-49
-  m_TagString: Untagged
+  m_TagString: LongRoad
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/-70,-1.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/-70,-1.prefab
@@ -10023,7 +10023,7 @@ GameObject:
   - component: {fileID: 6627585916494459200}
   m_Layer: 0
   m_Name: -70,-1
-  m_TagString: Untagged
+  m_TagString: LongRoad
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/0,-69.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/0,-69.prefab
@@ -4540,7 +4540,7 @@ GameObject:
   - component: {fileID: 2233336176444780422}
   m_Layer: 0
   m_Name: 0,-69
-  m_TagString: Untagged
+  m_TagString: LongRoad
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/0,12.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/0,12.prefab
@@ -8696,7 +8696,7 @@ GameObject:
   - component: {fileID: 5681165076325503088}
   m_Layer: 0
   m_Name: 0,12
-  m_TagString: Untagged
+  m_TagString: LongRoad
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/13,0.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/13,0.prefab
@@ -2532,7 +2532,7 @@ GameObject:
   - component: {fileID: 8918454710814458933}
   m_Layer: 0
   m_Name: 13,0
-  m_TagString: Untagged
+  m_TagString: LongRoad
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/2,-51.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/2,-51.prefab
@@ -3437,7 +3437,7 @@ GameObject:
   - component: {fileID: 6935055516716160377}
   m_Layer: 0
   m_Name: 2,-51
-  m_TagString: Untagged
+  m_TagString: LongRoad
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/2,50.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/2,50.prefab
@@ -1818,7 +1818,7 @@ GameObject:
   - component: {fileID: 3811092461617926061}
   m_Layer: 0
   m_Name: 2,50
-  m_TagString: Untagged
+  m_TagString: LongRoad
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/50,-49.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/50,-49.prefab
@@ -8367,7 +8367,7 @@ GameObject:
   - component: {fileID: 4583215572633511121}
   m_Layer: 0
   m_Name: 50,-49
-  m_TagString: Untagged
+  m_TagString: LongRoad
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/50,2.prefab
+++ b/Explorer/Assets/DCL/Roads/Data/RoadAssets/LongRoad/50,2.prefab
@@ -2733,7 +2733,7 @@ GameObject:
   - component: {fileID: 3034092438606035892}
   m_Layer: 0
   m_Name: 50,2
-  m_TagString: Untagged
+  m_TagString: LongRoad
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Explorer/Assets/DCL/Roads/Pools/RoadAssetsPool.cs
+++ b/Explorer/Assets/DCL/Roads/Pools/RoadAssetsPool.cs
@@ -1,10 +1,6 @@
 using System;
 using System.Collections.Generic;
 using DCL.Optimization.PerformanceBudgeting;
-using DCL.Optimization.Pools;
-using Nethereum.ABI.Util;
-using System.Reflection;
-using Unity.VisualScripting.YamlDotNet.Core.Tokens;
 using UnityEngine;
 using UnityEngine.Pool;
 using Utility;

--- a/Explorer/Assets/DCL/Roads/Pools/RoadAssetsPool.cs
+++ b/Explorer/Assets/DCL/Roads/Pools/RoadAssetsPool.cs
@@ -24,7 +24,7 @@ namespace DCL.LOD
         /// <summary>
         /// When a pool is filled and more instances are required, this is the minimum amount to add to the pool.
         /// </summary>
-        private const int POOLS_MIN_NEW_INSTANCES = 20;
+        private const int POOLS_MIN_NEW_INSTANCES = 1;
 
         /// <summary>
         /// When a pool is filled and more instances are required, this is the maximum amount to add to the pool.

--- a/Explorer/Assets/DCL/Roads/Pools/RoadAssetsPool.cs
+++ b/Explorer/Assets/DCL/Roads/Pools/RoadAssetsPool.cs
@@ -95,18 +95,17 @@ namespace DCL.LOD
                     {
                         roadAssetPool.Release(precachedInstances[i]);
                     }
-
-                    Debug.Log("<color=red>INCREASED POOL (+" + extraInstances + "): " + key + "</color>");
                 }
 
-                string log = "RoadAssetPoolDictionary\nTAKING: " + key + "\n";
+                // Debug: Uncomment this to know the content of the pools
+                //string log = "RoadAssetPoolDictionary\nTAKING: " + key + "\n";
 
-                foreach (KeyValuePair<string,IObjectPool<Transform>> keyValuePair in roadAssetPoolDictionary)
-                {
-                    log += keyValuePair.Key + ": " + (keyValuePair.Value as ObjectPool<Transform>).CountAll + " (" + (keyValuePair.Value as ObjectPool<Transform>).CountActive + ")\n";
-                }
+                //foreach (KeyValuePair<string,IObjectPool<Transform>> keyValuePair in roadAssetPoolDictionary)
+                //{
+                //    log += keyValuePair.Key + ": " + (keyValuePair.Value as ObjectPool<Transform>).CountAll + " (" + (keyValuePair.Value as ObjectPool<Transform>).CountActive + ")\n";
+                //}
 
-                Debug.Log(log);
+                //Debug.Log(log);
 
                 roadAsset = roadAssetPool.Get();
 
@@ -119,8 +118,6 @@ namespace DCL.LOD
 
         public void Release(string key, Transform asset)
         {
-            Debug.Log("<color=yellow>RELEASE: " + key + "</color>");
-
             if (roadAssetPoolDictionary.TryGetValue(key, out IObjectPool<Transform> roadAssetPool))
                 roadAssetPool.Release(asset);
             else
@@ -129,8 +126,6 @@ namespace DCL.LOD
 
         public void Unload(IPerformanceBudget frameTimeBudgetProvider, int maxUnloadAmount)
         {
-            Debug.Log("<color=cyan>UNLOAD!!!!!!!!!!!</color>");
-
             var unloadedAmount = 0;
 
             if (!frameTimeBudgetProvider.TrySpendBudget()) return;

--- a/Explorer/Assets/DCL/Roads/Systems/RoadInstantiatorSystem.cs
+++ b/Explorer/Assets/DCL/Roads/Systems/RoadInstantiatorSystem.cs
@@ -13,6 +13,7 @@ using ECS.Abstract;
 using ECS.LifeCycle.Components;
 using ECS.Prioritization.Components;
 using ECS.SceneLifeCycle;
+using ECS.SceneLifeCycle.Components;
 using ECS.SceneLifeCycle.Reporting;
 using ECS.SceneLifeCycle.SceneDefinition;
 using UnityEngine;
@@ -43,6 +44,7 @@ namespace DCL.Roads.Systems
 
         protected override void Update(float t)
         {
+            //ReleaseRoadQuery(World);
             InstantiateRoadQuery(World);
         }
 
@@ -50,6 +52,7 @@ namespace DCL.Roads.Systems
         [None(typeof(DeleteEntityIntention))]
         private void InstantiateRoad(ref RoadInfo roadInfo, ref SceneDefinitionComponent sceneDefinitionComponent, ref PartitionComponent partitionComponent)
         {
+            // Helpful info: RoadInfos are added in ResolveSceneStateByIncreasingRadiusSystem.CreatePromisesFromOrderedData
             if (!roadInfo.IsDirty) return;
 
             if (partitionComponent.IsBehind) return;
@@ -79,11 +82,29 @@ namespace DCL.Roads.Systems
             }
             roadInfo.IsDirty = false;
 
-            
+
             //In case this is a road teleport destination, we need to release the loading screen
             LODUtils.ReportSDK6SceneLoaded(sceneDefinitionComponent, sceneReadinessReportQueue, scenesCache);
         }
 
+        // [Query]
+        // [All(typeof(VisualSceneState))]
+        // [None(typeof(DeleteEntityIntention))]
+        // private void ReleaseRoad(Entity entity, ref RoadInfo roadInfo, ref SceneDefinitionComponent sceneDefinitionComponent, ref PartitionComponent partitionComponent)
+        // {
+        //     //if (!roadInfo.IsDirty) return;
+        //
+        //     if (!partitionComponent.IsBehind) return;
+        //
+        //     if (roadInfo.CurrentKey == null) return;
+        //
+        //     roadAssetPool.Release(roadInfo.CurrentKey, roadInfo.CurrentAsset);
+        //
+        //     roadInfo.CurrentKey = null;
+        //     roadInfo.CurrentAsset = null;
+        //
+        //     roadInfo.IsDirty = true;
+        // }
 
     }
 }

--- a/Explorer/Assets/DCL/Roads/Systems/RoadInstantiatorSystem.cs
+++ b/Explorer/Assets/DCL/Roads/Systems/RoadInstantiatorSystem.cs
@@ -44,7 +44,6 @@ namespace DCL.Roads.Systems
 
         protected override void Update(float t)
         {
-            //ReleaseRoadQuery(World);
             InstantiateRoadQuery(World);
         }
 
@@ -86,25 +85,5 @@ namespace DCL.Roads.Systems
             //In case this is a road teleport destination, we need to release the loading screen
             LODUtils.ReportSDK6SceneLoaded(sceneDefinitionComponent, sceneReadinessReportQueue, scenesCache);
         }
-
-        // [Query]
-        // [All(typeof(VisualSceneState))]
-        // [None(typeof(DeleteEntityIntention))]
-        // private void ReleaseRoad(Entity entity, ref RoadInfo roadInfo, ref SceneDefinitionComponent sceneDefinitionComponent, ref PartitionComponent partitionComponent)
-        // {
-        //     //if (!roadInfo.IsDirty) return;
-        //
-        //     if (!partitionComponent.IsBehind) return;
-        //
-        //     if (roadInfo.CurrentKey == null) return;
-        //
-        //     roadAssetPool.Release(roadInfo.CurrentKey, roadInfo.CurrentAsset);
-        //
-        //     roadInfo.CurrentKey = null;
-        //     roadInfo.CurrentAsset = null;
-        //
-        //     roadInfo.IsDirty = true;
-        // }
-
     }
 }

--- a/Explorer/Assets/DCL/Roads/Systems/UnloadRoadSystem.cs
+++ b/Explorer/Assets/DCL/Roads/Systems/UnloadRoadSystem.cs
@@ -37,6 +37,7 @@ namespace DCL.Roads.Systems
         [All(typeof(DeleteEntityIntention), typeof(VisualSceneState))]
         private void UnloadRoad(ref RoadInfo roadInfo, ref SceneDefinitionComponent sceneDefinitionComponent)
         {
+            // Helpful info: DeleteEntityIntention is added as component in ResolveSceneStateByIncreasingRadiusSystem.StartUnloading
             roadInfo.Dispose(roadAssetPool);
             scenesCache.RemoveNonRealScene(sceneDefinitionComponent.Parcels);
         }

--- a/Explorer/ProjectSettings/TagManager.asset
+++ b/Explorer/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - LongRoad
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## What does this PR change?

It changes how the pools for road asset instances are used. Now some instances are cached in advance when the player enters DCL to reduce the chance of needing to instantiate more while walking around. FPS should not be affected after a short period of activity.

## How to test the changes?

1. Launch the explorer (stay in Genesis plaza world)
2. Move the camera and go for a walk with the avatar.

You may notice some hiccups every now and then. We may need to tweak the constants used by the system to know how many instances to create every time a pool is full, in such a way that it does not occur too often, they are less noticeable and they do not occupy too much memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new tag "LongRoad" for better categorization of road assets within the game environment.
	- Enhanced the management of road asset pools for improved performance and resource optimization based on demand.

- **Bug Fixes**
	- Updated existing game objects from "Untagged" to "LongRoad" for accurate identification and interaction within the game.

- **Documentation**
	- Added comments in relevant systems to clarify functionality and integration of components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->