### PR TITLE
chore: sdk camera control test coverage

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/MainCameraPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MainCameraPlugin.cs
@@ -8,7 +8,6 @@ using DCL.Optimization.Pools;
 using DCL.PluginSystem.World.Dependencies;
 using DCL.ResourcesUnloading;
 using DCL.SDKComponents.CameraControl.MainCamera.Systems;
-using DCL.Utilities;
 using ECS.LifeCycle;
 using ECS.LifeCycle.Systems;
 using System;

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Systems/MainCameraSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Systems/MainCameraSystem.cs
@@ -66,6 +66,11 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Systems
 
             int virtualCameraCRDTEntity = (int)pbMainCamera.VirtualCameraEntity;
 
+            /*Debug.Log($"PRAVS -----------------");
+            Debug.Log($"PRAVS - mainCameraComponent.virtualCameraCRDTEntity: {mainCameraComponent.virtualCameraCRDTEntity}");
+            Debug.Log($"PRAVS - virtualCameraCRDTEntity: {virtualCameraCRDTEntity}");
+            Debug.Log($"PRAVS - mainCameraComponent.virtualCameraInstance?.enabled: {mainCameraComponent.virtualCameraInstance?.enabled}");*/
+
             // Cannot check by pbComponent.IsDirty since the VirtualCamera may not yet be on the target CRDTEntity
             // when the pbComponent is dirty and may have to be re-checked on subsequent updates...
             if (mainCameraComponent.virtualCameraCRDTEntity == virtualCameraCRDTEntity &&

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Systems/MainCameraSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Systems/MainCameraSystem.cs
@@ -51,6 +51,7 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Systems
         {
             SetupMainCameraQuery(World);
 
+            HandleActiveVirtualCameraDirtyStateQuery(World);
             HandleVirtualCameraChangeQuery(World);
             DisableVirtualCameraOnSceneLeaveQuery(World);
 
@@ -65,11 +66,6 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Systems
             if (entity != cameraEntity || !sceneStateProvider.IsCurrent) return;
 
             int virtualCameraCRDTEntity = (int)pbMainCamera.VirtualCameraEntity;
-
-            /*Debug.Log($"PRAVS -----------------");
-            Debug.Log($"PRAVS - mainCameraComponent.virtualCameraCRDTEntity: {mainCameraComponent.virtualCameraCRDTEntity}");
-            Debug.Log($"PRAVS - virtualCameraCRDTEntity: {virtualCameraCRDTEntity}");
-            Debug.Log($"PRAVS - mainCameraComponent.virtualCameraInstance?.enabled: {mainCameraComponent.virtualCameraInstance?.enabled}");*/
 
             // Cannot check by pbComponent.IsDirty since the VirtualCamera may not yet be on the target CRDTEntity
             // when the pbComponent is dirty and may have to be re-checked on subsequent updates...

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/MainCameraSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/MainCameraSystemShould.cs
@@ -9,7 +9,7 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
     public class MainCameraSystemShould : UnitySystemTestBase<MainCameraSystem>
     {
         [SetUp]
-        public async void Setup()
+        public void Setup()
         {
 
         }
@@ -35,6 +35,44 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
 
         [Test]
         public void UpdateOnVirtualCameraLookAtUpdateCorrectly()
+        {
+            /*uint lookAtEntity1 = 358;
+            var component = new PBVirtualCamera()
+            {
+                LookAtEntity = lookAtEntity1,
+                IsDirty = true
+            };
+            world.Add(entity, component);
+
+            system.Update(1f);
+            Assert.IsTrue(world.TryGet(entity, out VirtualCameraComponent vCamComponent));
+            Assert.AreEqual(vCamComponent.lookAtCRDTEntity, lookAtEntity1);
+
+            uint lookAtEntity2 = 666;
+            component.LookAtEntity = lookAtEntity2;
+            component.IsDirty = false;
+            world.Set(entity, component);
+
+            system.Update(1f);
+            Assert.IsTrue(world.TryGet(entity, out vCamComponent));
+            Assert.AreNotEqual(vCamComponent.lookAtCRDTEntity, lookAtEntity2);
+
+            component.IsDirty = true;
+            world.Set(entity, component);
+
+            system.Update(1f);
+            Assert.IsTrue(world.TryGet(entity, out vCamComponent));
+            Assert.AreEqual(vCamComponent.lookAtCRDTEntity, lookAtEntity2);*/
+        }
+
+        [Test]
+        public void UpdateCinemachineCorrectly()
+        {
+
+        }
+
+        [Test]
+        public void UpdateMainCameraTransformValuesCorrectly()
         {
 
         }

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/MainCameraSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/MainCameraSystemShould.cs
@@ -1,0 +1,54 @@
+using Arch.Core;
+using Cinemachine;
+using DCL.SDKComponents.CameraControl.MainCamera.Systems;
+using ECS.TestSuite;
+using NUnit.Framework;
+
+namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
+{
+    public class MainCameraSystemShould : UnitySystemTestBase<MainCameraSystem>
+    {
+        [SetUp]
+        public async void Setup()
+        {
+
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            // poolsRegistry.Dispose();
+            // Object.DestroyImmediate(virtualCamera.gameObject);
+        }
+
+        [Test]
+        public void SetupMainCameraComponentCorrectly()
+        {
+
+        }
+
+        [Test]
+        public void UpdateMainCameraCorrectly()
+        {
+
+        }
+
+        [Test]
+        public void UpdateOnVirtualCameraLookAtUpdateCorrectly()
+        {
+
+        }
+
+        [Test]
+        public void HandleComponentRemoveCorrectly()
+        {
+
+        }
+
+        [Test]
+        public void HandleEntityDestructionCorrectly()
+        {
+
+        }
+    }
+}

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/MainCameraSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/MainCameraSystemShould.cs
@@ -1,34 +1,178 @@
 using Arch.Core;
 using Cinemachine;
+using CRDT;
+using CrdtEcsBridge.Components;
+using DCL.CharacterCamera;
+using DCL.ECSComponents;
+using DCL.SDKComponents.CameraControl.MainCamera.Components;
 using DCL.SDKComponents.CameraControl.MainCamera.Systems;
+using ECS.Prioritization.Components;
 using ECS.TestSuite;
+using ECS.Unity.Transforms.Components;
+using NSubstitute;
 using NUnit.Framework;
+using SceneRunner.Scene;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
 {
     public class MainCameraSystemShould : UnitySystemTestBase<MainCameraSystem>
     {
+        private Entity mainCameraEntity;
+        private Entity virtualCameraEntity1;
+        private Entity virtualCameraEntity2;
+        private Entity globalWorldCameraEntity;
+        private ISceneStateProvider sceneStateProvider;
+        private IExposedCameraData cameraData;
+        private World globalWorld;
+        private Dictionary<CRDTEntity, Entity> entitiesMap = new Dictionary<CRDTEntity, Entity>();
+        private CinemachineBrain cinemachineBrain;
+        private CinemachineFreeLook sdkCinemachineCam1;
+        private CinemachineFreeLook sdkCinemachineCam2;
+        private CinemachineFreeLook defaultCinemachineCam;
+
         [SetUp]
         public void Setup()
         {
+            // Create 'main camera' entity
+            mainCameraEntity = world.Create(
+                PartitionComponent.TOP_PRIORITY,
+                new CRDTEntity(SpecialEntitiesID.CAMERA_ENTITY),
+                new TransformComponent(),
+                new PBMainCamera());
+            entitiesMap[SpecialEntitiesID.CAMERA_ENTITY] = mainCameraEntity;
 
+            // Create 'virtual camera' entities
+            sdkCinemachineCam1 = new GameObject("SDKVirtualCamera1").AddComponent<CinemachineFreeLook>();
+            sdkCinemachineCam1.enabled = false;
+            VirtualCameraComponent vCamComponent = new VirtualCameraComponent(sdkCinemachineCam1, -1);
+            CRDTEntity vCamCRDTEntity = new CRDTEntity(222);
+            virtualCameraEntity1 = world.Create(vCamCRDTEntity, vCamComponent,
+                new PBVirtualCamera()
+                {
+                    DefaultTransition = new CameraTransition() { Speed = 30 }
+                });
+            entitiesMap[vCamCRDTEntity] = virtualCameraEntity1;
+
+            sdkCinemachineCam2 = new GameObject("SDKVirtualCamera1").AddComponent<CinemachineFreeLook>();
+            sdkCinemachineCam2.enabled = false;
+            vCamComponent = new VirtualCameraComponent(sdkCinemachineCam2, -1);
+            vCamCRDTEntity = new CRDTEntity(223);
+            virtualCameraEntity2 = world.Create(vCamCRDTEntity, vCamComponent,
+                new PBVirtualCamera()
+                {
+                    DefaultTransition = new CameraTransition() { Time = 2.5f }
+                });
+            entitiesMap[vCamCRDTEntity] = virtualCameraEntity2;
+
+            globalWorld = World.Create();
+            globalWorldCameraEntity = globalWorld.Create(
+                new CRDTEntity(SpecialEntitiesID.CAMERA_ENTITY),
+                new CameraComponent { Mode = CameraMode.ThirdPerson }
+            );
+
+            sceneStateProvider = Substitute.For<ISceneStateProvider>();
+            sceneStateProvider.IsCurrent.Returns(true);
+
+            cinemachineBrain = new GameObject("CinemachineBrain").AddComponent<CinemachineBrain>();
+            defaultCinemachineCam = new GameObject("DefaultCinemachineCam").AddComponent<CinemachineFreeLook>();
+            defaultCinemachineCam.enabled = true;
+            cinemachineBrain.ManualUpdate();
+            Assert.AreSame(defaultCinemachineCam.gameObject, cinemachineBrain.ActiveVirtualCamera.VirtualCameraGameObject);
+
+            cameraData = Substitute.For<IExposedCameraData>();
+            cameraData.CinemachineBrain.Returns(cinemachineBrain);
+
+            system = new MainCameraSystem(world, mainCameraEntity, entitiesMap, sceneStateProvider, cameraData, globalWorld);
         }
 
         [TearDown]
         public void Teardown()
         {
-            // poolsRegistry.Dispose();
-            // Object.DestroyImmediate(virtualCamera.gameObject);
+            entitiesMap.Clear();
+            world.Dispose();
+            globalWorld.Dispose();
+            GameObject.DestroyImmediate(sdkCinemachineCam1.gameObject);
+            GameObject.DestroyImmediate(sdkCinemachineCam2.gameObject);
+            GameObject.DestroyImmediate(defaultCinemachineCam.gameObject);
+            GameObject.DestroyImmediate(cinemachineBrain.gameObject);
         }
 
         [Test]
         public void SetupMainCameraComponentCorrectly()
         {
+            // Do not set up if not current scene
+            sceneStateProvider.IsCurrent.Returns(false);
+            SystemUpdate();
+            Assert.IsFalse(world.Has<MainCameraComponent>(mainCameraEntity));
 
+            // Set up if current scene
+            sceneStateProvider.IsCurrent.Returns(true);
+            SystemUpdate();
+            Assert.IsTrue(world.Has<MainCameraComponent>(mainCameraEntity));
+
+            // Do not set up an entity that's not the main camera entity
+            var nonCameraEntity = world.Create(new PBMainCamera());
+            SystemUpdate();
+            Assert.IsFalse(world.Has<MainCameraComponent>(nonCameraEntity));
         }
 
         [Test]
-        public void UpdateMainCameraCorrectly()
+        public void UpdateCinemachineCameraCorrectly()
+        {
+            var mainCameraComponent = new MainCameraComponent();
+            world.Add(mainCameraEntity, mainCameraComponent);
+
+            SystemUpdate();
+            Assert.IsNull(world.Get<MainCameraComponent>(mainCameraEntity).virtualCameraInstance);
+            Assert.IsFalse(sdkCinemachineCam1.enabled);
+
+            // Set virtualCameraEntity1 as active vCam
+            var pbMainCameraComponent = new PBMainCamera() { VirtualCameraEntity = (uint)world.Get<CRDTEntity>(virtualCameraEntity1).Id };
+            world.Set(mainCameraEntity, pbMainCameraComponent);
+
+            SystemUpdate();
+            cinemachineBrain.ManualUpdate();
+            Assert.IsNotNull(world.Get<MainCameraComponent>(mainCameraEntity).virtualCameraInstance);
+            Assert.AreSame(sdkCinemachineCam1, world.Get<MainCameraComponent>(mainCameraEntity).virtualCameraInstance);
+            Assert.AreSame(sdkCinemachineCam1.gameObject, cinemachineBrain.ActiveVirtualCamera.VirtualCameraGameObject);
+            Assert.IsTrue(sdkCinemachineCam1.enabled);
+
+            // Release active vCam in MainCameraComponent
+            pbMainCameraComponent.VirtualCameraEntity = 0;
+            world.Set(mainCameraEntity, pbMainCameraComponent);
+
+            SystemUpdate();
+            Assert.IsFalse(sdkCinemachineCam1.enabled);
+            Assert.IsNull(world.Get<MainCameraComponent>(mainCameraEntity).virtualCameraInstance);
+            Assert.AreNotSame(sdkCinemachineCam1.gameObject, cinemachineBrain.ActiveVirtualCamera.VirtualCameraGameObject);
+
+            // Set virtualCameraEntity2 as active vCam
+            pbMainCameraComponent.VirtualCameraEntity = (uint)world.Get<CRDTEntity>(virtualCameraEntity2).Id;
+            world.Set(mainCameraEntity, pbMainCameraComponent);
+
+            SystemUpdate();
+            Assert.IsFalse(sdkCinemachineCam1.enabled);
+            Assert.IsTrue(sdkCinemachineCam2.enabled);
+            Assert.IsNotNull(world.Get<MainCameraComponent>(mainCameraEntity).virtualCameraInstance);
+            Assert.AreSame(sdkCinemachineCam2, world.Get<MainCameraComponent>(mainCameraEntity).virtualCameraInstance);
+            Assert.AreSame(sdkCinemachineCam2.gameObject, cinemachineBrain.ActiveVirtualCamera.VirtualCameraGameObject);
+
+            // Set virtualCameraEntity1 as active vCam again
+            pbMainCameraComponent.VirtualCameraEntity = (uint)world.Get<CRDTEntity>(virtualCameraEntity1).Id;
+            world.Set(mainCameraEntity, pbMainCameraComponent);
+
+            SystemUpdate();
+            Assert.IsFalse(sdkCinemachineCam2.enabled);
+            Assert.IsTrue(sdkCinemachineCam1.enabled);
+            Assert.IsNotNull(world.Get<MainCameraComponent>(mainCameraEntity).virtualCameraInstance);
+            Assert.AreSame(sdkCinemachineCam1, world.Get<MainCameraComponent>(mainCameraEntity).virtualCameraInstance);
+            Assert.AreSame(sdkCinemachineCam1.gameObject, cinemachineBrain.ActiveVirtualCamera.VirtualCameraGameObject);
+        }
+
+        [Test]
+        public void UpdateMainCameraTransformCorrectly()
         {
 
         }
@@ -66,13 +210,7 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
         }
 
         [Test]
-        public void UpdateCinemachineCorrectly()
-        {
-
-        }
-
-        [Test]
-        public void UpdateMainCameraTransformValuesCorrectly()
+        public void HandleEnterAndLeaveSceneCorrectly()
         {
 
         }
@@ -87,6 +225,12 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
         public void HandleEntityDestructionCorrectly()
         {
 
+        }
+
+        private void SystemUpdate()
+        {
+            system.Update(1f);
+            cinemachineBrain.ManualUpdate();
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/MainCameraSystemShould.cs.meta
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/MainCameraSystemShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3025ae1db1cb49ae88a9dfab38ef5e06
+timeCreated: 1725884874

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraSystemShould.cs
@@ -1,0 +1,102 @@
+using Arch.Core;
+using Cinemachine;
+using Cysharp.Threading.Tasks;
+using DCL.Optimization.Pools;
+using DCL.SDKComponents.CameraControl.MainCamera.Systems;
+using ECS.Prioritization.Components;
+using ECS.TestSuite;
+using NSubstitute;
+using NUnit.Framework;
+using SceneRunner.Scene;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
+{
+    public class VirtualCameraSystemShould : UnitySystemTestBase<VirtualCameraSystem>
+    {
+        private Entity entity;
+        // private TransformComponent entityTransformComponent;
+        private ISceneStateProvider sceneStateProvider;
+        private IComponentPoolsRegistry poolsRegistry;
+        private IComponentPool<CinemachineFreeLook> sdkVirtualCameraPool;
+
+        private CinemachineFreeLook virtualCamera;
+
+        [SetUp]
+        public async void Setup()
+        {
+            entity = world.Create(PartitionComponent.TOP_PRIORITY);
+            /*entityTransformComponent = AddTransformToEntity(entity);
+            entityTransformComponent.SetTransform(Vector3.one * 30, Quaternion.identity, Vector3.one);
+            world.Set(entity, entityTransformComponent);*/
+
+            // Setup system
+            sceneStateProvider = Substitute.For<ISceneStateProvider>();
+            sceneStateProvider.IsCurrent.Returns(true);
+
+            // CinemachineFreeLook virtualCameraPrefab = (await assetsProvisioner.ProvideMainAssetAsync(settings.VirtualCameraPrefab, ct: ct)).Value.GetComponent<CinemachineFreeLook>();
+            GameObject virtualCameraPrefabGO = await Addressables.LoadAssetAsync<GameObject>("SDKVirtualCamera");
+            virtualCamera = Object.Instantiate(virtualCameraPrefabGO.GetComponent<CinemachineFreeLook>());
+            poolsRegistry = new ComponentPoolsRegistry();
+            poolsRegistry.AddGameObjectPool(() => virtualCamera, onGet: virtualCam => virtualCam.enabled = false, onRelease: virtualCam => virtualCam.enabled = false);
+            sdkVirtualCameraPool = poolsRegistry.GetReferenceTypePool<CinemachineFreeLook>();
+
+            system = new VirtualCameraSystem(world, sdkVirtualCameraPool, sceneStateProvider);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            poolsRegistry.Dispose();
+            Object.DestroyImmediate(virtualCamera.gameObject);
+        }
+
+        [Test]
+        public void SetupVirtualCameraComponentCorrectly()
+        {
+
+        }
+
+        [Test]
+        public void UpdateVirtualCameraCorrectly()
+        {
+
+        }
+
+        [Test]
+        public void HandleComponentRemoveCorrectly()
+        {
+
+        }
+
+        [Test]
+        public void HandleEntityDestructionCorrectly()
+        {
+
+        }
+
+        /*[Test]
+        public void UpdateCinemachineCorrectly()
+        {
+
+        }
+
+        [Test]
+        public void UpdateMainCameraTransformValuesCorrectly()
+        {
+
+        }
+
+        [Test]
+        public void HandleMinimumLookAtDistanceCorrectly()
+        {
+
+        }*/
+
+        /*
+        - Active VCam updates
+        - Ignoring of LookAt with same VCam Entity or with MainCamera Entity
+        */
+    }
+}

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraSystemShould.cs
@@ -75,41 +75,6 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
             Assert.AreSame(vCamComponent.virtualCameraInstance, virtualCamera);
         }
 
-        /*[Test]
-        public async Task UpdateVirtualCameraComponentCorrectly()
-        {
-            // Workaround for Unity bug not awaiting async Setup correctly
-            await UniTask.WaitUntil(() => system != null);
-
-            uint lookAtEntity1 = 358;
-            var component = new PBVirtualCamera()
-            {
-                LookAtEntity = lookAtEntity1,
-                IsDirty = true
-            };
-            world.Add(entity, component);
-
-            system.Update(1f);
-            Assert.IsTrue(world.TryGet(entity, out VirtualCameraComponent vCamComponent));
-            Assert.AreEqual(vCamComponent.lookAtCRDTEntity, lookAtEntity1);
-
-            uint lookAtEntity2 = 666;
-            component.LookAtEntity = lookAtEntity2;
-            component.IsDirty = false;
-            world.Set(entity, component);
-
-            system.Update(1f);
-            Assert.IsTrue(world.TryGet(entity, out vCamComponent));
-            Assert.AreNotEqual(vCamComponent.lookAtCRDTEntity, lookAtEntity2);
-
-            component.IsDirty = true;
-            world.Set(entity, component);
-
-            system.Update(1f);
-            Assert.IsTrue(world.TryGet(entity, out vCamComponent));
-            Assert.AreEqual(vCamComponent.lookAtCRDTEntity, lookAtEntity2);
-        }*/
-
         [Test]
         public async Task HandleComponentRemoveCorrectly()
         {
@@ -152,18 +117,6 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
         }
 
         /*[Test]
-        public void UpdateCinemachineCorrectly()
-        {
-
-        }
-
-        [Test]
-        public void UpdateMainCameraTransformValuesCorrectly()
-        {
-
-        }
-
-        [Test]
         public void HandleMinimumLookAtDistanceCorrectly()
         {
 

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraSystemShould.cs
@@ -115,16 +115,5 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
             Assert.IsFalse(virtualCamera.enabled);
             Assert.AreEqual(sdkVirtualCameraPool.CountInactive, 1);
         }
-
-        /*[Test]
-        public void HandleMinimumLookAtDistanceCorrectly()
-        {
-
-        }*/
-
-        /*
-        - Active VCam updates
-        - Ignoring of LookAt with same VCam Entity or with MainCamera Entity
-        */
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraSystemShould.cs.meta
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraSystemShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a9b04fd3eb714ff7b5b4d7eb7e0c934c
+timeCreated: 1725884881

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraUtilsShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraUtilsShould.cs
@@ -1,0 +1,73 @@
+using Arch.Core;
+using CRDT;
+using CrdtEcsBridge.Components;
+using DCL.ECSComponents;
+using DCL.SDKComponents.CameraControl.MainCamera.Components;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
+{
+    public class VirtualCameraUtilsShould
+    {
+        private World world;
+        private Dictionary<CRDTEntity, Entity> entitiesMap = new Dictionary<CRDTEntity, Entity>();
+        private Entity entity1;
+        private Entity entity2;
+
+        [SetUp]
+        public void Setup()
+        {
+            world = World.Create();
+
+            // Populate entities map
+            CRDTEntity crdtEntity1 = new CRDTEntity(15);
+            entity1 = world.Create(crdtEntity1);
+            entitiesMap[crdtEntity1] = entity1;
+
+            CRDTEntity crdtEntity2 = new CRDTEntity(635);
+            entity2 = world.Create(crdtEntity2);
+            entitiesMap[crdtEntity2] = entity2;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            entitiesMap.Clear();
+            world.Dispose();
+        }
+
+        [Test]
+        public void FetchVirtualCameraComponentCorrectly()
+        {
+            world.Add<VirtualCameraComponent>(entity1);
+
+            Assert.IsTrue(VirtualCameraUtils.TryGetVirtualCameraComponent(world, entitiesMap, world.Get<CRDTEntity>(entity1).Id, out var vCamComponent));
+            Assert.IsFalse(VirtualCameraUtils.TryGetVirtualCameraComponent(world, entitiesMap, world.Get<CRDTEntity>(entity2).Id, out vCamComponent));
+        }
+
+        [Test]
+        public void FetchTargetLookAtCRDTEntityCorrectly()
+        {
+            int virtualCameraCRDTEntity = 189;
+
+            // Empty LookAt prop
+            PBVirtualCamera pbComponent = new PBVirtualCamera();
+            Assert.AreEqual(-1, VirtualCameraUtils.GetPBVirtualCameraLookAtCRDTEntity(pbComponent, virtualCameraCRDTEntity));
+
+            // Invalid LookAt values
+            pbComponent.LookAtEntity = SpecialEntitiesID.CAMERA_ENTITY;
+            Assert.AreEqual(-1, VirtualCameraUtils.GetPBVirtualCameraLookAtCRDTEntity(pbComponent, virtualCameraCRDTEntity));
+
+            pbComponent.LookAtEntity = (uint)virtualCameraCRDTEntity;
+            Assert.AreEqual(-1, VirtualCameraUtils.GetPBVirtualCameraLookAtCRDTEntity(pbComponent, virtualCameraCRDTEntity));
+
+            // Valid LookAt values
+            pbComponent.LookAtEntity = SpecialEntitiesID.PLAYER_ENTITY;
+            Assert.AreEqual(SpecialEntitiesID.PLAYER_ENTITY, VirtualCameraUtils.GetPBVirtualCameraLookAtCRDTEntity(pbComponent, virtualCameraCRDTEntity));
+
+            pbComponent.LookAtEntity = 627;
+            Assert.AreEqual(627, VirtualCameraUtils.GetPBVirtualCameraLookAtCRDTEntity(pbComponent, virtualCameraCRDTEntity));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraUtilsShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraUtilsShould.cs
@@ -1,10 +1,15 @@
 using Arch.Core;
+using Cinemachine;
 using CRDT;
 using CrdtEcsBridge.Components;
+using DCL.CharacterCamera;
 using DCL.ECSComponents;
 using DCL.SDKComponents.CameraControl.MainCamera.Components;
+using ECS.Unity.Transforms.Components;
+using NSubstitute;
 using NUnit.Framework;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
 {
@@ -13,7 +18,9 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
         private World world;
         private Dictionary<CRDTEntity, Entity> entitiesMap = new Dictionary<CRDTEntity, Entity>();
         private Entity entity1;
+        private GameObject crdtEntity1GO;
         private Entity entity2;
+        private GameObject crdtEntity2GO;
 
         [SetUp]
         public void Setup()
@@ -22,11 +29,17 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
 
             // Populate entities map
             CRDTEntity crdtEntity1 = new CRDTEntity(15);
-            entity1 = world.Create(crdtEntity1);
+            crdtEntity1GO = new GameObject("crdtEntity1");
+            crdtEntity1GO.transform.position = Vector3.one * 25f;
+            var crdtEntity1Transform = new TransformComponent(crdtEntity1GO);
+            entity1 = world.Create(crdtEntity1, crdtEntity1Transform);
             entitiesMap[crdtEntity1] = entity1;
 
             CRDTEntity crdtEntity2 = new CRDTEntity(635);
-            entity2 = world.Create(crdtEntity2);
+            crdtEntity2GO = new GameObject("crdtEntity2");
+            crdtEntity2GO.transform.position = Vector3.one * -56f;
+            var crdtEntity2Transform = new TransformComponent(crdtEntity2GO);
+            entity2 = world.Create(crdtEntity2, crdtEntity2Transform);
             entitiesMap[crdtEntity2] = entity2;
         }
 
@@ -35,6 +48,8 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
         {
             entitiesMap.Clear();
             world.Dispose();
+            GameObject.DestroyImmediate(crdtEntity1GO);
+            GameObject.DestroyImmediate(crdtEntity2GO);
         }
 
         [Test]
@@ -68,6 +83,131 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Tests
 
             pbComponent.LookAtEntity = 627;
             Assert.AreEqual(627, VirtualCameraUtils.GetPBVirtualCameraLookAtCRDTEntity(pbComponent, virtualCameraCRDTEntity));
+        }
+
+        [Test]
+        public void ConfigureCameraTransitionCorrectly()
+        {
+            // Setup
+            CinemachineBrain cinemachineBrain = new GameObject("CinemachineBrain").AddComponent<CinemachineBrain>();
+            IExposedCameraData exposedCameraData = Substitute.For<IExposedCameraData>();
+            exposedCameraData.CinemachineBrain.Returns(cinemachineBrain);
+            int virtualCamCRDTEntity = world.Get<CRDTEntity>(entity1).Id;
+
+            // Time = 0 transition
+            PBVirtualCamera pbComponent = new PBVirtualCamera()
+            {
+                DefaultTransition = new CameraTransition() { Time = 0 }
+            };
+            world.Add(entity1, pbComponent);
+            VirtualCameraUtils.ConfigureVirtualCameraTransition(
+                world,
+                entitiesMap,
+                exposedCameraData,
+                virtualCamCRDTEntity,
+                3);
+            Assert.AreEqual(CinemachineBlendDefinition.Style.Cut, cinemachineBrain.m_DefaultBlend.m_Style);
+
+            // Time = 2.78 transition
+            pbComponent.DefaultTransition = new CameraTransition() { Time = 2.78f };
+            world.Set(entity1, pbComponent);
+            VirtualCameraUtils.ConfigureVirtualCameraTransition(
+                world,
+                entitiesMap,
+                exposedCameraData,
+                virtualCamCRDTEntity,
+                20);
+            Assert.AreEqual(CinemachineBlendDefinition.Style.EaseInOut, cinemachineBrain.m_DefaultBlend.m_Style);
+            Assert.AreEqual(pbComponent.DefaultTransition.Time, cinemachineBrain.m_DefaultBlend.m_Time);
+
+            // Time = -1 transition
+            pbComponent.DefaultTransition = new CameraTransition() { Time = -1 };
+            world.Set(entity1, pbComponent);
+            VirtualCameraUtils.ConfigureVirtualCameraTransition(
+                world,
+                entitiesMap,
+                exposedCameraData,
+                virtualCamCRDTEntity,
+                68);
+            Assert.AreEqual(CinemachineBlendDefinition.Style.Cut, cinemachineBrain.m_DefaultBlend.m_Style);
+
+            // Speed = 0 transition
+            pbComponent.DefaultTransition = new CameraTransition() { Speed = 0 };
+            world.Add(entity1, pbComponent);
+            VirtualCameraUtils.ConfigureVirtualCameraTransition(
+                world,
+                entitiesMap,
+                exposedCameraData,
+                virtualCamCRDTEntity,
+                8);
+            Assert.AreEqual(CinemachineBlendDefinition.Style.Cut, cinemachineBrain.m_DefaultBlend.m_Style);
+
+            // Speed = 53 transition
+            pbComponent.DefaultTransition = new CameraTransition() { Speed = 53f };
+            world.Set(entity1, pbComponent);
+            float distanceBetweenCameras = 35;
+            VirtualCameraUtils.ConfigureVirtualCameraTransition(
+                world,
+                entitiesMap,
+                exposedCameraData,
+                virtualCamCRDTEntity,
+                distanceBetweenCameras);
+            Assert.AreEqual(CinemachineBlendDefinition.Style.EaseInOut, cinemachineBrain.m_DefaultBlend.m_Style);
+            Assert.AreEqual(VirtualCameraUtils.CalculateDistanceBlendTime(distanceBetweenCameras, pbComponent.DefaultTransition.Speed), cinemachineBrain.m_DefaultBlend.m_Time);
+
+            // Speed = -1 transition
+            pbComponent.DefaultTransition = new CameraTransition() { Speed = -1 };
+            world.Set(entity1, pbComponent);
+            VirtualCameraUtils.ConfigureVirtualCameraTransition(
+                world,
+                entitiesMap,
+                exposedCameraData,
+                virtualCamCRDTEntity,
+                4);
+            Assert.AreEqual(CinemachineBlendDefinition.Style.Cut, cinemachineBrain.m_DefaultBlend.m_Style);
+
+            // Cleanup
+            GameObject.DestroyImmediate(cinemachineBrain.gameObject);
+        }
+
+        [Test]
+        public void ConfigureCameraLookAtCorrectly()
+        {
+            // Setup
+            CinemachineFreeLook cinemachineCamera = new GameObject("CinemachineFreeLookCam").AddComponent<CinemachineFreeLook>();
+            var middleRigCamera = cinemachineCamera.GetRig(1);
+            VirtualCameraComponent component = new VirtualCameraComponent(cinemachineCamera, world.Get<CRDTEntity>(entity1).Id);
+
+            // LookAt entity1
+            VirtualCameraUtils.ConfigureCameraLookAt(world, entitiesMap, component);
+            Assert.AreSame(world.Get<TransformComponent>(entity1).Transform, cinemachineCamera.m_LookAt);
+            Assert.IsNotNull(middleRigCamera.GetCinemachineComponent<CinemachineHardLookAt>());
+            Assert.IsNull(middleRigCamera.GetCinemachineComponent<CinemachinePOV>());
+
+            // LookAt invalid entity
+            component.lookAtCRDTEntity = 998;
+            VirtualCameraUtils.ConfigureCameraLookAt(world, entitiesMap, component);
+            Assert.IsNull(cinemachineCamera.m_LookAt);
+            Assert.IsNotNull(middleRigCamera.GetCinemachineComponent<CinemachinePOV>());
+            Assert.IsNull(middleRigCamera.GetCinemachineComponent<CinemachineHardLookAt>());
+
+            // LookAt entity2
+            component.lookAtCRDTEntity = world.Get<CRDTEntity>(entity2).Id;
+            VirtualCameraUtils.ConfigureCameraLookAt(world, entitiesMap, component);
+            Assert.AreSame(world.Get<TransformComponent>(entity2).Transform, cinemachineCamera.m_LookAt);
+            Assert.IsNotNull(middleRigCamera.GetCinemachineComponent<CinemachineHardLookAt>());
+            Assert.IsNull(middleRigCamera.GetCinemachineComponent<CinemachinePOV>());
+
+            // LookAt entity1 after moving it too close to the camera
+            world.Get<TransformComponent>(entity1).Transform.position = cinemachineCamera.transform.position + (Vector3.one * 0.1f);
+            component.lookAtCRDTEntity = world.Get<CRDTEntity>(entity1).Id;
+            VirtualCameraUtils.ConfigureCameraLookAt(world, entitiesMap, component);
+            Assert.IsNull(cinemachineCamera.m_LookAt);
+            Assert.IsNotNull(middleRigCamera.GetCinemachineComponent<CinemachinePOV>());
+            Assert.IsNull(middleRigCamera.GetCinemachineComponent<CinemachineHardLookAt>());
+
+            // Cleanup
+            GameObject.DestroyImmediate(cinemachineCamera.gameObject);
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraUtilsShould.cs.meta
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Tests/VirtualCameraUtilsShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b065d630d5a340079c1e8d76f1fe5274
+timeCreated: 1725909035

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/VirtualCameraUtils.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/VirtualCameraUtils.cs
@@ -56,7 +56,7 @@ namespace DCL.SDKComponents.CameraControl.MainCamera
                 cameraData.CinemachineBrain!.m_DefaultBlend.m_Style = speedValue <= 0 ? CinemachineBlendDefinition.Style.Cut : CinemachineBlendDefinition.Style.EaseInOut;
 
                 // SPEED = 1 -> 1 meter per second
-                float blendTime = distanceBetweenCameras / speedValue;
+                float blendTime = CalculateDistanceBlendTime(distanceBetweenCameras, speedValue);
                 if (blendTime == 0)
                     cameraData.CinemachineBrain!.m_DefaultBlend.m_Style = CinemachineBlendDefinition.Style.Cut;
                 else
@@ -80,5 +80,8 @@ namespace DCL.SDKComponents.CameraControl.MainCamera
                 virtualCameraComponent.virtualCameraInstance.m_LookAt = null;
             }
         }
+
+        internal static float CalculateDistanceBlendTime(float distanceBetweenCameras, float speedValue) =>
+            distanceBetweenCameras / speedValue;
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/VirtualCameraUtils.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/VirtualCameraUtils.cs
@@ -40,7 +40,9 @@ namespace DCL.SDKComponents.CameraControl.MainCamera
 
         public static void ConfigureVirtualCameraTransition(in World world, in Dictionary<CRDTEntity,Entity> entitiesMap, IExposedCameraData cameraData, int virtualCamCRDTEntity, float distanceBetweenCameras)
         {
-            var pbVirtualCamera = world.Get<PBVirtualCamera>(entitiesMap[virtualCamCRDTEntity]);
+            if (!entitiesMap.TryGetValue(virtualCamCRDTEntity, out Entity vCamEntity)) return;
+
+            var pbVirtualCamera = world.Get<PBVirtualCamera>(vCamEntity);
 
             // Using custom blends array doesn't work because there's no direct way of getting the custom blend index,
             // and we would have to hardcode it...


### PR DESCRIPTION
Adds test coverage for the feature introduced at https://github.com/decentraland/unity-explorer/pull/1744