### PR TITLE
fix: Badge Notification Flashing After Loading Screen

### DIFF
--- a/Explorer/Assets/DCL/Notifications/Animations/BadgeNotificationController.controller
+++ b/Explorer/Assets/DCL/Notifications/Animations/BadgeNotificationController.controller
@@ -99,6 +99,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: 5097936261188300192}
     m_Position: {x: 300, y: 150, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 7839850631817092266}
+    m_Position: {x: 30, y: 10, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: 2369239000654847258}
@@ -110,7 +113,7 @@ AnimatorStateMachine:
   m_EntryPosition: {x: 50, y: 160, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 5097936261188300192}
+  m_DefaultState: {fileID: 7839850631817092266}
 --- !u!1102 &5097936261188300192
 AnimatorState:
   serializedVersion: 6
@@ -132,6 +135,32 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 5476ca15f777e7f4590d33989c6428fe, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &7839850631817092266
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: InitialState
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 

--- a/Explorer/Assets/DCL/Notifications/Animations/BadgeNotificationHide.anim
+++ b/Explorer/Assets/DCL/Notifications/Animations/BadgeNotificationHide.anim
@@ -575,6 +575,27 @@ AnimationClip:
     classID: 114
     script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
     flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
   m_PPtrCurves: []
   m_SampleRate: 60
   m_WrapMode: 0
@@ -732,6 +753,15 @@ AnimationClip:
       attribute: 2334886179
       script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
       typeID: 114
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 0
+      attribute: 1574349066
+      script: {fileID: 0}
+      typeID: 225
       customType: 0
       isPPtrCurve: 0
       isIntCurve: 0
@@ -1546,6 +1576,27 @@ AnimationClip:
     path: ImageContainer/Image
     classID: 114
     script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
     flags: 0
   m_EulerEditorCurves:
   - serializedVersion: 2

--- a/Explorer/Assets/DCL/Notifications/NewNotification/Assets/NewNotificationPanel.prefab
+++ b/Explorer/Assets/DCL/Notifications/NewNotification/Assets/NewNotificationPanel.prefab
@@ -266,7 +266,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2617022527507825205, guid: 92a863669989e814d8f7d887933c491e, type: 3}
       propertyPath: m_Alpha
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2617022527507825205, guid: 92a863669989e814d8f7d887933c491e, type: 3}
       propertyPath: m_Interactable


### PR DESCRIPTION
## What does this PR change?
Fix #2011 

## How to test the changes?
1. Launch the explorer and log in.
2. Wait for the loading screen to complete and spawn in Genesis Plaza.
3. Check that the badge notification doesn't appear at the beginning.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new animation state for badge notifications, enhancing animation flow.
	- Enhanced animation capabilities with new serialized fields for more nuanced control over animations.

- **Bug Fixes**
	- Adjusted the alpha property of the notification panel, potentially improving visibility and user experience. 

- **Documentation**
	- Updated animation parameters and properties to reflect the latest changes in the animation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->