### PR TITLE
fix: deep link parsing macos patch

### DIFF
--- a/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Text.RegularExpressions;
@@ -93,9 +92,15 @@ namespace Global.AppArgs
                 appParameters[uriQueryKey] = uriQuery.Get(uriQueryKey);
             }
 
-            // Patch for WinOS sometimes affecting the 'realm' parameter in deep links putting a '/' at the end
-            if (appParameters.TryGetValue(REALM_PARAM, out string? realmParamValue) && realmParamValue.EndsWith('/'))
-                appParameters[REALM_PARAM] = realmParamValue.Remove(realmParamValue.Length - 1);
+            if (appParameters.TryGetValue(REALM_PARAM, out string? realmParamValue))
+            {
+                // Patch for WinOS sometimes affecting the 'realm' parameter in deep links putting a '/' at the end
+                if (realmParamValue.EndsWith('/'))
+                    appParameters[REALM_PARAM] = realmParamValue.Remove(realmParamValue.Length - 1);
+
+                // Patch for MacOS removing the ':' from the realm parameter protocol
+                appParameters[REALM_PARAM] = Regex.Replace(realmParamValue, @"(https?)//(.*?)$", @"$1://$2");
+            }
         }
     }
 }

--- a/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
@@ -99,7 +99,7 @@ namespace Global.AppArgs
                     appParameters[REALM_PARAM] = realmParamValue.Remove(realmParamValue.Length - 1);
 
                 // Patch for MacOS removing the ':' from the realm parameter protocol
-                appParameters[REALM_PARAM] = Regex.Replace(realmParamValue, @"(https?)//(.*?)$", @"$1://$2");
+                appParameters[REALM_PARAM] = Regex.Replace(appParameters[REALM_PARAM], @"(https?)//(.*?)$", @"$1://$2");
             }
         }
     }

--- a/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
@@ -96,10 +96,12 @@ namespace Global.AppArgs
             {
                 // Patch for WinOS sometimes affecting the 'realm' parameter in deep links putting a '/' at the end
                 if (realmParamValue.EndsWith('/'))
-                    appParameters[REALM_PARAM] = realmParamValue.Remove(realmParamValue.Length - 1);
+                    realmParamValue = realmParamValue.Remove(realmParamValue.Length - 1);
 
                 // Patch for MacOS removing the ':' from the realm parameter protocol
-                appParameters[REALM_PARAM] = Regex.Replace(appParameters[REALM_PARAM], @"(https?)//(.*?)$", @"$1://$2");
+                realmParamValue = Regex.Replace(realmParamValue, @"(https?)//(.*?)$", @"$1://$2");
+
+                appParameters[REALM_PARAM] = realmParamValue;
             }
         }
     }

--- a/Explorer/Assets/Scripts/Global/Tests/EditMode/RealmLaunchSettingsShould.cs
+++ b/Explorer/Assets/Scripts/Global/Tests/EditMode/RealmLaunchSettingsShould.cs
@@ -109,5 +109,21 @@ namespace Global.Tests.EditMode
 
             Assert.AreEqual(world, realmLaunchSettings.targetWorld);
         }
+
+        [Test]
+        [TestCase("127.0.0.1:8000")]
+        [TestCase("localhost:8000")]
+        public void IgnoreMacOSRealmInvalidation(string realm)
+        {
+            RealmLaunchSettings realmLaunchSettings = new RealmLaunchSettings();
+            ApplicationParametersParser applicationParametersParser = new (new[]
+            {
+                $"decentraland://realm=http//{realm}", // MacOS removes the ':' from the realm url param
+            });
+
+            realmLaunchSettings.ApplyConfig(applicationParametersParser);
+
+            Assert.AreEqual($"http://{realm}", realmLaunchSettings.customRealm);
+        }
     }
 }


### PR DESCRIPTION
Re-added missing MacOS deep link parsing patch (mistakenly removed at https://github.com/decentraland/unity-explorer/pull/1726).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `realm` parameter for deep links on both Windows and MacOS, addressing trailing slashes and colons for better protocol formatting.
	- Enhanced test coverage for `RealmLaunchSettings` to ensure correct processing of realm URLs on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->