### PR TITLE
fix: livekit ConnectionString error handling

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/SignFlow/LiveConnectionArchipelagoSignFlow.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/SignFlow/LiveConnectionArchipelagoSignFlow.cs
@@ -149,7 +149,9 @@ namespace DCL.Multiplayer.Connections.Archipelago.SignFlow
 
                     if (result.Success == false)
                     {
-                        ReportHub.LogError(ReportCategory.LIVEKIT, $"Cannot listen for connection string: {result.Error?.Message}");
+                        if (token.IsCancellationRequested == false)
+                            ReportHub.LogError(ReportCategory.LIVEKIT, $"Cannot listen for connection string: {result.Error?.Message}");
+
                         continue;
                     }
 


### PR DESCRIPTION
## What does this PR change?

Throws only if the operation is not cancelled

## How to test the changes?

1. Launch the explorer
2. Play happy path

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for connection string logging to reduce unnecessary log entries when operations are canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->