### PR TITLE
fix: Force back-face culling for avatars

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/AvatarMaterialConfiguration.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/AvatarMaterialConfiguration.cs
@@ -146,7 +146,8 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
             else if (name.Contains(ComputeShaderConstants.HAIR_MATERIAL_NAME, StringComparison.OrdinalIgnoreCase))
                 avatarMaterial.SetColor(BASE_COLOR, avatarShapeComponent.HairColor);
 
-            avatarMaterial.SetInt(CULL_MODE, (int)originalMaterial.GetFloat(CULL));
+            //Force back-face culling for all avatar materials
+            avatarMaterial.SetInt(CULL_MODE, 2);
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

From original wearables, the face-culling option was not consistent. This breaked SRP batching capability.

As confirmed with the art team, we can enforce it, therefore recovering the missed capability and gaining extra frames.

BEFORE 

<img width="1288" alt="Screen Shot 2024-09-16 at 09 29 00" src="https://github.com/user-attachments/assets/a2e1d176-ace2-4e42-8889-72062d02cadd">

<img width="1317" alt="Screen Shot 2024-09-16 at 09 30 09" src="https://github.com/user-attachments/assets/0bb5d08f-30ea-4db4-8813-3e57c17bc858">

AFTER

<img width="1289" alt="Screen Shot 2024-09-16 at 09 38 48" src="https://github.com/user-attachments/assets/f5c250ff-25d7-49fc-bac3-4e1f9949aee2">

<img width="1310" alt="Screen Shot 2024-09-16 at 09 37 55" src="https://github.com/user-attachments/assets/e8bb72d0-8c9f-4a5d-8613-244c5e7c6d1d">




## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Instantiate 3 times the 30 avatars. See that they are isntantiated

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved rendering consistency for avatar materials by enforcing a fixed back-face culling mode.
  
- **Bug Fixes**
	- Addressed potential rendering issues by standardizing the culling mode across all avatar materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->