### PR TITLE
chore: Aggresively reduce LOD texture pre-allocation

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArraySlotHandler.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArraySlotHandler.cs
@@ -18,7 +18,6 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             this.resolution = resolution;
             this.textureFormat = textureFormat;
 
-            //Initial capacity for (100 * minArraySize) textures
             arrays = new List<Texture2DArray>(initialCapacity);
             arrays.Add(CreateTexture2DArray());
             freeSlots = new Stack<TextureArraySlot>();

--- a/Explorer/Assets/DCL/LOD/Settings/LODSettings.asset
+++ b/Explorer/Assets/DCL/LOD/Settings/LODSettings.asset
@@ -13,22 +13,16 @@ MonoBehaviour:
   m_Name: LODSettings
   m_EditorClassIdentifier: 
   <LodPartitionBucketThresholds>k__BackingField: 05000000
+  <SDK7LodThreshold>k__BackingField: 2
   <DefaultTextureArrayResolutionDescriptors>k__BackingField:
-  - Resolution: 256
-    ArraySize: 500
-    InitialArrayCapacity: 100
   - Resolution: 512
     ArraySize: 100
-    InitialArrayCapacity: 10
+    InitialArrayCapacity: 5
   - Resolution: 1024
     ArraySize: 100
     InitialArrayCapacity: 10
-  - Resolution: 2048
-    ArraySize: 25
-    InitialArrayCapacity: 10
-  - Resolution: 4096
-    ArraySize: 25
-    InitialArrayCapacity: 10
+  <ArraySizeForMissingResolutions>k__BackingField: 10
+  <CapacityForMissingResolutions>k__BackingField: 1
   <LODDebugColors>k__BackingField:
   - {r: 0, g: 1, b: 0, a: 1}
   - {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
@@ -36,4 +30,3 @@ MonoBehaviour:
   - {r: 0, g: 0, b: 0, a: 1}
   <DebugCube>k__BackingField: {fileID: 8255452435763093729, guid: c9870b17ce36346458f07a63c096a16a, type: 3}
   <EnableLODStreaming>k__BackingField: 1
-  <AsyncIntegrationTimeMS>k__BackingField: 33

--- a/Explorer/Assets/DCL/LOD/Settings/LODSettingsAsset.cs
+++ b/Explorer/Assets/DCL/LOD/Settings/LODSettingsAsset.cs
@@ -18,17 +18,19 @@ namespace DCL.LOD
 
         [field: SerializeField] public TextureArrayResolutionDescriptor[] DefaultTextureArrayResolutionDescriptors { get; set; } =
         {
-            new (256, 500, 100), new (512, 100, 10), new (1024, 100, 10), new (2048, 25, 10), new (4096, 25, 10)
+            new(512, 100, 5), new(1024, 50, 1)
         };
 
-        public int ArraySizeForMissingResolutions => 50;
-        public int CapacityForMissingResolutions => 1;
+        [field: SerializeField] public int ArraySizeForMissingResolutions { get; set; } = 10;
+        [field: SerializeField] public int CapacityForMissingResolutions { get; set; } = 1;
 
         public bool IsColorDebugging { get; set; }
         [field: SerializeField] public Color[] LODDebugColors { get; set; } = { Color.green, Color.yellow, Color.red };
         [field: SerializeField] public DebugCube DebugCube { get; set; }
         [field: SerializeField] public bool EnableLODStreaming { get; set; }
-        [field: SerializeField] public float AsyncIntegrationTimeMS { get; set; } = 33;
+
+        //TODO (Juani): Commented until re-implemented
+        //public float AsyncIntegrationTimeMS { get; set; } = 33;
     }
 
 


### PR DESCRIPTION
## What does this PR change?

Aggresively reduces LOD texture allocation. We target to preallocate space for 100 LODs


We heavily allocated memory for LODs when its not necessary. A simple analysis shows that most LODs use a 512 texture, and some of them use 1024. We will just allocate this ones, remove the rest. 

<img width="1728" alt="Screen Shot 2024-09-16 at 12 32 58" src="https://github.com/user-attachments/assets/035129bd-6b69-4c22-9e40-7e9d00a2d0d3">

BEFORE

<img width="1728" alt="Screen Shot 2024-09-16 at 12 25 33" src="https://github.com/user-attachments/assets/d87870be-df79-4725-9d56-a601e64af626">

AFTER

<img width="1728" alt="Screen Shot 2024-09-16 at 13 26 48" src="https://github.com/user-attachments/assets/0442581e-04b1-46f8-9074-a287bcb2b5eb">



## How to test the changes?



1. Launch the explorer
2. Run around and see LODs. See if you detect anything unexpected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced refined Level of Detail (LOD) settings for improved performance and resource management.
	- Added new configuration fields for handling missing resolutions.

- **Bug Fixes**
	- Streamlined texture array resolution settings to optimize memory usage.

- **Documentation**
	- Updated comments and descriptions in LOD settings to reflect recent changes and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->