### PR TITLE
chore: Agressively reduce avatar texture pre-allocation

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayConstants.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayConstants.cs
@@ -19,10 +19,10 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
 
         // Some textures are less probably contained in the original material
         // so we can use a smaller starting array size for them
-        public const int MAIN_TEXTURE_ARRAY_SIZE = 500;
-        public const int NORMAL_TEXTURE_ARRAY_SIZE = 250;
-        public const int EMISSION_TEXTURE_ARRAY_SIZE = 150;
-        public const int FACIAL_FEATURES_TEXTURE_ARRAY_SIZE = 250;
+        public const int MAIN_TEXTURE_ARRAY_SIZE = 250;
+        public const int NORMAL_TEXTURE_ARRAY_SIZE = 125;
+        public const int EMISSION_TEXTURE_ARRAY_SIZE = 75;
+        public const int FACIAL_FEATURES_TEXTURE_ARRAY_SIZE = 75;
 
         public const int MAIN_TEXTURE_RESOLUTION = 512;
         public const int NORMAL_TEXTURE_RESOLUTION = 512;


### PR DESCRIPTION
## What does this PR change?

Reduce avatar allocation to be able to instantiate aprox 25 avatars (assuming 10 wearables per avatar)

BEFORE

<img width="1728" alt="Screen Shot 2024-09-16 at 12 25 33" src="https://github.com/user-attachments/assets/784e1047-a94c-46ee-8980-7a8908b324b2">

AFTER 

<img width="1728" alt="Screen Shot 2024-09-16 at 13 51 43" src="https://github.com/user-attachments/assets/a9762d44-90ef-4125-88bc-e2bb76cff93c">



## How to test the changes?



1. Launch the explorer
2. Instantiate avatars using the debug tool and check everything is okay

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md