### PR TITLE
Fix: null reference exception in debug panel

### DIFF
--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/UpdateCurrentSceneSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/UpdateCurrentSceneSystem.cs
@@ -26,11 +26,11 @@ namespace ECS.SceneLifeCycle.Systems
 
         private readonly SceneAssetLock sceneAssetLock;
 
-        private IDebugContainerBuilder debugBuilder;
-        private ElementBinding<string> sceneNameBinding;
-        private ElementBinding<string> sceneParcelsBinding;
-        private ElementBinding<string> sceneHeightBinding;
-        private DebugWidgetVisibilityBinding debugInfoVisibilityBinding;
+        private readonly IDebugContainerBuilder debugBuilder;
+        private readonly ElementBinding<string> sceneNameBinding;
+        private readonly ElementBinding<string> sceneParcelsBinding;
+        private readonly ElementBinding<string> sceneHeightBinding;
+        private readonly DebugWidgetVisibilityBinding debugInfoVisibilityBinding;
         private bool showDebugCube;
         private GameObject sceneBoundsCube;
 
@@ -44,12 +44,17 @@ namespace ECS.SceneLifeCycle.Systems
             this.sceneAssetLock = sceneAssetLock;
             ResetProcessedParcel();
 
+            debugInfoVisibilityBinding = new DebugWidgetVisibilityBinding(true);
+            sceneNameBinding = new ElementBinding<string>(string.Empty);
+            sceneParcelsBinding = new ElementBinding<string>(string.Empty);
+            sceneHeightBinding = new ElementBinding<string>(string.Empty);
+
             debugBuilder.TryAddWidget(IDebugContainerBuilder.Categories.CURRENT_SCENE)?
-                         .SetVisibilityBinding(debugInfoVisibilityBinding = new DebugWidgetVisibilityBinding(true))
-                         .AddCustomMarker("Name:", sceneNameBinding = new ElementBinding<string>(string.Empty))
-                         .AddCustomMarker("Parcels:", sceneParcelsBinding = new ElementBinding<string>(string.Empty))
-                         .AddCustomMarker("Height (m):", sceneHeightBinding = new ElementBinding<string>(string .Empty))
-                         .AddToggleField("Show scene bounds:", (state) => { showDebugCube = state.newValue; }, false);
+                         .SetVisibilityBinding(debugInfoVisibilityBinding)
+                         .AddCustomMarker("Name:", sceneNameBinding)
+                         .AddCustomMarker("Parcels:", sceneParcelsBinding)
+                         .AddCustomMarker("Height (m):", sceneHeightBinding)
+                         .AddToggleField("Show scene bounds:", state => { showDebugCube = state.newValue; }, false);
             this.debugBuilder = debugBuilder;
         }
 
@@ -72,7 +77,7 @@ namespace ECS.SceneLifeCycle.Systems
             UpdateCurrentScene(parcel);
             UpdateCurrentSceneInfo(parcel);
 
-            if (debugBuilder.IsVisible && debugInfoVisibilityBinding.IsExpanded)
+            if (debugBuilder.IsVisible && debugInfoVisibilityBinding.IsConnectedAndExpanded)
                 RefreshSceneDebugInfo();
         }
 


### PR DESCRIPTION
## What does this PR change?

Ensures that the values are initialized despite the selected debugging mode

## How to test the changes?

1. Launch the explorer
2. Goto 100,100 type /debug to show debug panel and then /goto 0,0
3. Jumping to new location should not freeze the load screen.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved visibility checks for debug information, ensuring accurate display based on connection status.

- **Refactor**
	- Enhanced clarity and readability by consolidating initialization logic for debug bindings.
	- Changed variable declarations to readonly to prevent unintended reassignments, improving code robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->