### PR TITLE
Fix: Metadynelabs - First-Person Mode Not Enforced and Toggle Allowed

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/CameraModeArea/Systems/CameraModeAreaHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/CameraModeArea/Systems/CameraModeAreaHandlerSystem.cs
@@ -16,7 +16,7 @@ using System.Collections.Generic;
 
 namespace DCL.SDKComponents.CameraModeArea.Systems
 {
-    [UpdateInGroup(typeof(SyncedInitializationFixedUpdateThrottledGroup))]
+    [UpdateInGroup(typeof(SyncedInitializationSystemGroup))]
     [LogCategory(ReportCategory.CHARACTER_TRIGGER_AREA)]
     public partial class CameraModeAreaHandlerSystem : BaseUnityLoopSystem, IFinalizeWorldSystem
     {

--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Systems/MainCameraSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Systems/MainCameraSystem.cs
@@ -19,7 +19,6 @@ using UnityEngine;
 namespace DCL.SDKComponents.CameraControl.MainCamera.Systems
 {
     [UpdateInGroup(typeof(SyncedInitializationFixedUpdateThrottledGroup))]
-    [UpdateBefore(typeof(CameraModeAreaHandlerSystem))]
     [LogCategory(ReportCategory.SDK_CAMERA)]
     public partial class MainCameraSystem : BaseUnityLoopSystem, IFinalizeWorldSystem
     {


### PR DESCRIPTION
## What does this PR change?
fix #2046 

- removed Throttling from the system that handles CameraMode

## How to test the changes?

1. Check steps on the mentioned issue
2. It would be nice to re-check that nothing get broken with virtual cameras, so please run QA tests from [this PR](https://github.com/decentraland/unity-explorer/pull/1744)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

