### PR TITLE
fix: Emote wheel closure

### DIFF
--- a/Explorer/Assets/DCL/EmotesWheel/EmotesWheelController.cs
+++ b/Explorer/Assets/DCL/EmotesWheel/EmotesWheelController.cs
@@ -70,8 +70,6 @@ namespace DCL.EmotesWheel
             emoteWheelInput.Customize.performed += OpenBackpack;
             emoteWheelInput.Close.performed += Close;
             dclInput.UI.Close.performed += Close;
-
-            ListenToSlotsInput(this.dclInput.EmoteWheel);
         }
 
         public override void Dispose()
@@ -122,14 +120,17 @@ namespace DCL.EmotesWheel
             }
         }
 
+        protected override void OnViewShow() =>
+            ListenToSlotsInput(this.dclInput.EmoteWheel);
+
         protected override void OnViewClose()
         {
-            base.OnViewClose();
-
             BlockUnwantedInputs();
 
             fetchProfileCts.SafeCancelAndDispose();
             slotSetUpCts.SafeCancelAndDispose();
+
+            UnregisterSlotsInput(emoteWheelInput);
         }
 
         protected override async UniTask WaitForCloseIntentAsync(CancellationToken ct)


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
Fix #2047 
Changes the emote wheel input registration such that the keys are listened only after the menu opening and unregisters the inputs after closing preventing the possibility to fire an emote before the actual menu is properly shown.


## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open the emote wheel and trigger an emote
3. Try to trigger an emote while the wheel is opening
4. Verify that B+num shortcut still works
5. Spamming B doesn't break the lifecycle of the wheel menu

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

