### PR TITLE
fix: fixed color picker slider faded color

### DIFF
--- a/Explorer/Assets/DCL/UI/Assets/ColorPicker.prefab
+++ b/Explorer/Assets/DCL/UI/Assets/ColorPicker.prefab
@@ -1629,6 +1629,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 3be33b88cb4c01d4a804286c034bca21, type: 3}
     - target: {fileID: 4849719833439020044, guid: 6e9cc21c5ef05427c95cf3c15fd61b42, type: 3}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4849719833439020044, guid: 6e9cc21c5ef05427c95cf3c15fd61b42, type: 3}
       propertyPath: m_PixelsPerUnitMultiplier
       value: 2
       objectReference: {fileID: 0}
@@ -1840,6 +1844,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 7010f830f98b240438dcebe8c29d4c60, type: 3}
+    - target: {fileID: 4849719833439020044, guid: 6e9cc21c5ef05427c95cf3c15fd61b42, type: 3}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5215259471654060225, guid: 6e9cc21c5ef05427c95cf3c15fd61b42, type: 3}
       propertyPath: m_Colors.m_NormalColor.b
       value: 0.09411765
@@ -2112,6 +2120,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: e8bb632edb2c95644b51d7b45fcbd4f9, type: 3}
+    - target: {fileID: 4849719833439020044, guid: 6e9cc21c5ef05427c95cf3c15fd61b42, type: 3}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5215259471654060225, guid: 6e9cc21c5ef05427c95cf3c15fd61b42, type: 3}
       propertyPath: m_Colors.m_NormalColor.b
       value: 0.09411765


### PR DESCRIPTION
## What does this PR change?

Fix #2045 
Resets the colors of the slider to the original bright value

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open the backpack
3. Open the color picker
4. Verify that the slider colors appear correctly and not faded out

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

