### PR TITLE
fix: infinite loading screens

### DIFF
--- a/Explorer/Assets/DCL/Chat/Commands/IChatCommand.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/IChatCommand.cs
@@ -6,9 +6,14 @@ namespace DCL.Chat.Commands
 {
     public interface IChatCommand
     {
-        // Constants that shared between several ChatCommands
-        const string COMMAND_GOTO = "goto";
+
 
         UniTask<string> ExecuteAsync(Match match, CancellationToken ct);
+    }
+
+    public static class ChatCommandsUtils
+    {
+        // Constants that shared between several ChatCommands
+        public static string COMMAND_GOTO = "goto";
     }
 }

--- a/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
+using DCL.Chat.MessageBus;
 using UnityEngine;
 
 namespace DCL.Navmap
@@ -36,18 +37,21 @@ namespace DCL.Navmap
 
         public event Action<Vector2Int> OnJumpIn;
         public event Action<PlacesData.PlaceInfo?> OnSetAsDestination;
+        private readonly IChatMessagesBus chatMessagesBus;
+
 
         public FloatingPanelController(
             FloatingPanelView view,
             IPlacesAPIService placesAPIService,
             IWebRequestController webRequestController,
             IRealmNavigator realmNavigator,
-            IMapPathEventBus mapPathEventBus)
+            IMapPathEventBus mapPathEventBus, IChatMessagesBus chatMessagesBus)
         {
             this.view = view;
             this.placesAPIService = placesAPIService;
             this.realmNavigator = realmNavigator;
             this.mapPathEventBus = mapPathEventBus;
+            this.chatMessagesBus = chatMessagesBus;
 
             view.closeButton.onClick.AddListener(HidePanel);
             view.mapPinCloseButton.onClick.AddListener(HidePanel);
@@ -200,7 +204,7 @@ namespace DCL.Navmap
 
             if (destination == parcel) { mapPathEventBus.ArrivedToDestination(); }
 
-            realmNavigator.TryInitializeTeleportToParcelAsync(parcel, cts.Token).Forget();
+            chatMessagesBus.Send($"/goto {parcel.x},{parcel.y}");
         }
 
         private void SetEmptyParcelInfo(Vector2Int parcel)

--- a/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
+using DCL.Chat.Commands;
 using DCL.Chat.MessageBus;
 using UnityEngine;
 
@@ -204,7 +205,7 @@ namespace DCL.Navmap
 
             if (destination == parcel) { mapPathEventBus.ArrivedToDestination(); }
 
-            chatMessagesBus.Send($"/goto {parcel.x},{parcel.y}");
+            chatMessagesBus.Send($"/{ChatCommandsUtils.COMMAND_GOTO} {parcel.x},{parcel.y}");
         }
 
         private void SetEmptyParcelInfo(Vector2Int parcel)

--- a/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
@@ -193,7 +193,7 @@ namespace DCL.Navmap
             view.removeMapPinDestinationButton.gameObject.SetActive(parcelIsDestination);
             view.removeDestinationButton.gameObject.SetActive(parcelIsDestination);
         }
-
+        
         private void JumpIn(Vector2Int parcel)
         {
             OnJumpIn?.Invoke(parcel);

--- a/Explorer/Assets/DCL/Navmap/Navmap.asmdef
+++ b/Explorer/Assets/DCL/Navmap/Navmap.asmdef
@@ -27,7 +27,8 @@
         "GUID:91cf8206af184dac8e30eb46747e9939",
         "GUID:e0eedfa2deb9406daf86fd8368728e39",
         "GUID:e7751264a6735a942a64770d71eb49e0",
-        "GUID:d832748739a186646b8656bdbd447ad0"
+        "GUID:d832748739a186646b8656bdbd447ad0",
+        "GUID:766b242fb43af451aaa331f39872177d"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Navmap/NavmapController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapController.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using DCL.Chat.MessageBus;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using Utility;
@@ -74,7 +75,8 @@ namespace DCL.Navmap
             IMapPathEventBus mapPathEventBus,
             World world,
             Entity playerEntity,
-            IInputBlock inputBlock)
+            IInputBlock inputBlock,
+            IChatMessagesBus chatMessagesBus)
         {
             this.navmapView = navmapView;
             this.mapRenderer = mapRenderer;
@@ -86,7 +88,8 @@ namespace DCL.Navmap
             zoomController = new NavmapZoomController(navmapView.zoomView, dclInput);
             filterController = new NavmapFilterController(this.navmapView.filterView, mapRenderer, webBrowser);
             searchBarController = new NavmapSearchBarController(navmapView.SearchBarView, navmapView.SearchBarResultPanel, navmapView.HistoryRecordPanelView, placesAPIService, navmapView.floatingPanelView, webRequestController, inputBlock);
-            FloatingPanelController = new FloatingPanelController(navmapView.floatingPanelView, placesAPIService, webRequestController, realmNavigator, mapPathEventBus);
+            FloatingPanelController = new FloatingPanelController(navmapView.floatingPanelView, placesAPIService,
+                webRequestController, realmNavigator, mapPathEventBus, chatMessagesBus);
             FloatingPanelController.OnJumpIn += _ => searchBarController.ResetSearch();
             FloatingPanelController.OnSetAsDestination += SetDestination;
             this.navmapView.DestinationInfoElement.QuitButton.onClick.AddListener(OnRemoveDestinationButtonClicked);

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -39,6 +39,7 @@ using MVC;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using DCL.Chat.MessageBus;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.Audio;
@@ -84,10 +85,13 @@ namespace DCL.PluginSystem.Global
         private readonly INotificationsBusController notificationsBusController;
         private readonly ChatEntryConfigurationSO chatEntryConfiguration;
         private readonly IInputBlock inputBlock;
-
+        private readonly IChatMessagesBus chatMessagesBus;
+        
         private NavmapController? navmapController;
         private SettingsController? settingsController;
         private BackpackSubPlugin? backpackSubPlugin;
+        
+        
 
         public ExplorePanelPlugin(IAssetsProvisioner assetsProvisioner,
             IMVCManager mvcManager,
@@ -122,7 +126,8 @@ namespace DCL.PluginSystem.Global
             IInputBlock inputBlock,
             IEmoteProvider emoteProvider,
             Arch.Core.World world,
-            Entity playerEntity)
+            Entity playerEntity,
+            IChatMessagesBus chatMessagesBus)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.mvcManager = mvcManager;
@@ -158,6 +163,7 @@ namespace DCL.PluginSystem.Global
             this.emoteProvider = emoteProvider;
             this.world = world;
             this.playerEntity = playerEntity;
+            this.chatMessagesBus = chatMessagesBus;
         }
 
         public void Dispose()
@@ -208,7 +214,9 @@ namespace DCL.PluginSystem.Global
             ProvidedAsset<QualitySettingsAsset> qualitySettingsAsset = await assetsProvisioner.ProvideMainAssetAsync(settings.QualitySettingsAsset, ct);
             settingsController = new SettingsController(explorePanelView.GetComponentInChildren<SettingsView>(), settingsMenuConfiguration.Value, generalAudioMixer.Value, realmPartitionSettings.Value, landscapeData.Value, qualitySettingsAsset.Value);
 
-            navmapController = new NavmapController(navmapView: explorePanelView.GetComponentInChildren<NavmapView>(), mapRendererContainer.MapRenderer, placesAPIService, webRequestController, webBrowser, dclInput, realmNavigator, realmData, mapPathEventBus, world, playerEntity, inputBlock);
+            navmapController = new NavmapController(navmapView: explorePanelView.GetComponentInChildren<NavmapView>(),
+                mapRendererContainer.MapRenderer, placesAPIService, webRequestController, webBrowser, dclInput,
+                realmNavigator, realmData, mapPathEventBus, world, playerEntity, inputBlock, chatMessagesBus);
 
             await navmapController.InitializeAssetsAsync(assetsProvisioner, ct);
             await backpackSubPlugin.InitializeAsync(settings.BackpackSettings, explorePanelView.GetComponentInChildren<BackpackView>(), ct);

--- a/Explorer/Assets/DCL/PluginSystem/Global/TeleportPromptPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/TeleportPromptPlugin.cs
@@ -8,6 +8,7 @@ using DCL.TeleportPrompt;
 using DCL.WebRequests;
 using MVC;
 using System.Threading;
+using DCL.Chat.MessageBus;
 using ECS.SceneLifeCycle.Realm;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -17,27 +18,26 @@ namespace DCL.PluginSystem.Global
     public class TeleportPromptPlugin : IDCLGlobalPlugin<TeleportPromptPlugin.TeleportPromptSettings>
     {
         private readonly IAssetsProvisioner assetsProvisioner;
-        private readonly IRealmNavigator realmNavigator;
         private readonly IMVCManager mvcManager;
         private readonly IWebRequestController webRequestController;
         private readonly IPlacesAPIService placesAPIService;
         private readonly ICursor cursor;
         private TeleportPromptController teleportPromptController;
+        private readonly IChatMessagesBus chatMessagesBus;
 
         public TeleportPromptPlugin(
             IAssetsProvisioner assetsProvisioner,
-            IRealmNavigator realmNavigator,
             IMVCManager mvcManager,
             IWebRequestController webRequestController,
             IPlacesAPIService placesAPIService,
-            ICursor cursor)
+            ICursor cursor, IChatMessagesBus chatMessagesBus)
         {
             this.assetsProvisioner = assetsProvisioner;
-            this.realmNavigator = realmNavigator;
             this.mvcManager = mvcManager;
             this.webRequestController = webRequestController;
             this.placesAPIService = placesAPIService;
             this.cursor = cursor;
+            this.chatMessagesBus = chatMessagesBus;
         }
 
         public async UniTask InitializeAsync(TeleportPromptSettings promptSettings, CancellationToken ct)
@@ -46,10 +46,9 @@ namespace DCL.PluginSystem.Global
                 TeleportPromptController.CreateLazily(
                     (await assetsProvisioner.ProvideMainAssetAsync(promptSettings.TeleportPromptPrefab, ct: ct)).Value.GetComponent<TeleportPromptView>(), null),
                 cursor,
-                realmNavigator,
-                mvcManager,
                 webRequestController,
-                placesAPIService);
+                placesAPIService,
+                chatMessagesBus);
 
             mvcManager.RegisterController(teleportPromptController);
         }

--- a/Explorer/Assets/DCL/PluginSystem/World/GltfContainerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/GltfContainerPlugin.cs
@@ -74,7 +74,8 @@ namespace DCL.PluginSystem.World
             WriteGltfContainerLoadingStateSystem.InjectToWorld(ref builder, sharedDependencies.EcsToCRDTWriter, buffer);
             GltfContainerVisibilitySystem.InjectToWorld(ref builder, buffer);
 
-            GatherGltfAssetsSystem.InjectToWorld(ref builder, sceneReadinessReportQueue, sharedDependencies.SceneData, buffer, sharedDependencies.SceneStateProvider);
+            GatherGltfAssetsSystem.InjectToWorld(ref builder, sceneReadinessReportQueue, sharedDependencies.SceneData,
+                buffer, sharedDependencies.SceneStateProvider, globalDeps.MemoryBudget);
 
             ResetDirtyFlagSystem<PBGltfContainer>.InjectToWorld(ref builder);
 

--- a/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/ILoadingScreen.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/ILoadingScreen.cs
@@ -9,12 +9,13 @@ namespace DCL.SceneLoadingScreens.LoadingScreen
 {
     public interface ILoadingScreen
     {
-        UniTask<Result> ShowWhileExecuteTaskAsync(Func<AsyncLoadProcessReport, UniTask> operation,
+        UniTask<Result> ShowWhileExecuteTaskAsync(Func<AsyncLoadProcessReport, UniTask<Result>> operation,
             CancellationToken ct);
 
         class EmptyLoadingScreen : ILoadingScreen
         {
-            public async UniTask<Result> ShowWhileExecuteTaskAsync(Func<AsyncLoadProcessReport, UniTask> operation,
+            public async UniTask<Result> ShowWhileExecuteTaskAsync(
+                Func<AsyncLoadProcessReport, UniTask<Result>> operation,
                 CancellationToken ct)
             {
                 var loadReport = AsyncLoadProcessReport.Create();

--- a/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
@@ -19,7 +19,7 @@ namespace DCL.SceneLoadingScreens.LoadingScreen
         }
 
         public async UniTask<Result> ShowWhileExecuteTaskAsync(
-            Func<AsyncLoadProcessReport, UniTask> operation, CancellationToken ct)
+            Func<AsyncLoadProcessReport, UniTask<Result>> operation, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
 
@@ -33,18 +33,10 @@ namespace DCL.SceneLoadingScreens.LoadingScreen
 
             var result = Result.ErrorResult("Load Timeout!");
 
-            async UniTask ExecuteOperationAsync()
+            async UniTask<Result> ExecuteOperationAsync()
             {
-                try
-                {
-                    await operation(loadReport);
-                    result = Result.SuccessResult();
-                }
-                catch (Exception e)
-                {
-                    loadReport.SetProgress(1f);
-                    result = Result.ErrorResult(e.Message);
-                }
+                result = await operation(loadReport);
+                return result;
             }
 
             await UniTask.WhenAny(showLoadingScreenTask, ExecuteOperationAsync());

--- a/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
@@ -4,6 +4,7 @@ using MVC;
 using System;
 using System.Threading;
 using UnityEngine;
+using Utility.Types;
 
 namespace DCL.SceneLoadingScreens.LoadingScreen
 {
@@ -17,7 +18,7 @@ namespace DCL.SceneLoadingScreens.LoadingScreen
             this.mvcManager = mvcManager;
         }
 
-        public async UniTask<ILoadingScreen.LoadResult> ShowWhileExecuteTaskAsync(
+        public async UniTask<Result> ShowWhileExecuteTaskAsync(
             Func<AsyncLoadProcessReport, UniTask> operation, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
@@ -30,18 +31,19 @@ namespace DCL.SceneLoadingScreens.LoadingScreen
                                                                new SceneLoadingScreenController.Params(loadReport, timeout)), ct)
                                                       .AttachExternalCancellation(ct);
 
-            var result = ILoadingScreen.LoadResult.TimeoutResult;
+            var result = Result.ErrorResult("Load Timeout!");
 
             async UniTask ExecuteOperationAsync()
             {
                 try
                 {
                     await operation(loadReport);
-                    result = ILoadingScreen.LoadResult.SuccessResult;
+                    result = Result.SuccessResult();
                 }
                 catch (Exception e)
                 {
-                    result = ILoadingScreen.LoadResult.ExceptionResult(e.Message);
+                    loadReport.SetProgress(1f);
+                    result = Result.ErrorResult(e.Message);
                 }
             }
 

--- a/Explorer/Assets/DCL/ScenesDebug/ScenesConsistency/ChatTeleports/ChatTeleport.cs
+++ b/Explorer/Assets/DCL/ScenesDebug/ScenesConsistency/ChatTeleports/ChatTeleport.cs
@@ -1,5 +1,6 @@
 using Cysharp.Threading.Tasks;
 using DCL.Chat;
+using DCL.Chat.Commands;
 using DCL.ScenesDebug.ScenesConsistency.DelayedResources;
 using DCL.Utilities.Extensions;
 using UnityEngine;
@@ -22,7 +23,7 @@ namespace DCL.ScenesDebug.ScenesConsistency.ChatTeleports
         public void GoTo(Vector2Int coordinate)
         {
             var field = chatViewResource.DangerousResource().EnsureNotNull().InputField;
-            field.text = $"/goto {coordinate.x},{coordinate.y}";
+            field.text = $"/{ChatCommandsUtils.COMMAND_GOTO} {coordinate.x},{coordinate.y}";
             field.OnSubmit(new BaseEventData(null!));
         }
     }

--- a/Explorer/Assets/DCL/TeleportPrompt/TeleportPrompt.asmdef
+++ b/Explorer/Assets/DCL/TeleportPrompt/TeleportPrompt.asmdef
@@ -16,7 +16,8 @@
         "GUID:1d2c76eb8b48e0b40940e8b31a679ce1",
         "GUID:e0eedfa2deb9406daf86fd8368728e39",
         "GUID:101b8b6ebaf64668909b49c4b7a1420d",
-        "GUID:3640f3c0b42946b0b8794a1ed8e06ca5"
+        "GUID:3640f3c0b42946b0b8794a1ed8e06ca5",
+        "GUID:766b242fb43af451aaa331f39872177d"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -120,7 +120,7 @@ namespace DCL.UserInAppInitializationFlow
             while (result.Success == false && showAuthentication);
         }
 
-        private static void ApplyErrorIfLoadingScreenError(ref Result result, ILoadingScreen.LoadResult showResult)
+        private static void ApplyErrorIfLoadingScreenError(ref Result result, Result showResult)
         {
             if (!showResult.Success)
                 result = Result.ErrorResult(showResult.ErrorMessage);

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
@@ -4,6 +4,7 @@ using DCL.AsyncLoadReporting;
 using System;
 using System.Threading;
 using UnityEngine;
+using Utility.Types;
 
 namespace ECS.SceneLifeCycle.Realm
 {
@@ -21,9 +22,11 @@ namespace ECS.SceneLifeCycle.Realm
 
         URLDomain? CurrentRealm { get; }
 
-        UniTask<bool> TryChangeRealmAsync(URLDomain realm, CancellationToken ct, Vector2Int parcelToTeleport = default);
+        UniTask<Result> TryChangeRealmAsync(URLDomain realm, CancellationToken ct,
+            Vector2Int parcelToTeleport = default);
 
-        UniTask<bool> TryInitializeTeleportToParcelAsync(Vector2Int parcel, CancellationToken ct, bool isLocal = false);
+        UniTask<Result> TryInitializeTeleportToParcelAsync(Vector2Int parcel, CancellationToken ct,
+            bool isLocal = false);
 
         UniTask InitializeTeleportToSpawnPointAsync(AsyncLoadProcessReport teleportLoadReport, CancellationToken ct, Vector2Int parcelToTeleport = default);
 
@@ -31,7 +34,14 @@ namespace ECS.SceneLifeCycle.Realm
 
         UniTask SwitchMiscVisibilityAsync();
 
+        UniTask ChangeRealmAsync(URLDomain realm, CancellationToken ct);
+
+        UniTask<UniTask> TeleportToParcelAsync(Vector2Int parcel, AsyncLoadProcessReport processReport,
+            CancellationToken ct);
+        
         // True if changed to GenesisCity, False - when changed to any other realm
         event Action<bool> RealmChanged;
+        
+        
     }
 }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
@@ -25,7 +25,7 @@ namespace ECS.SceneLifeCycle.Realm
 
         bool CheckIsNewRealm(URLDomain realm);
 
-        UniTask<bool> CheckRealmIsReacheable(URLDomain realm, CancellationToken ct);
+        UniTask<bool> CheckRealmIsReacheableAsync(URLDomain realm, CancellationToken ct);
 
         UniTask<Result> TryInitializeTeleportToParcelAsync(Vector2Int parcel, CancellationToken ct,
             bool isLocal = false);

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
@@ -20,10 +20,12 @@ namespace ECS.SceneLifeCycle.Realm
         public const string SDK_TEST_SCENES_URL = "https://sdk-team-cdn.decentraland.org/ipfs/sdk7-test-scenes-main-latest";
         public const string TEST_SCENES_URL = "https://sdk-test-scenes.decentraland.zone";
 
-        URLDomain? CurrentRealm { get; }
-
         UniTask<Result> TryChangeRealmAsync(URLDomain realm, CancellationToken ct,
             Vector2Int parcelToTeleport = default);
+
+        bool CheckIsNewRealm(URLDomain realm);
+
+        UniTask<bool> CheckRealmIsReacheable(URLDomain realm, CancellationToken ct);
 
         UniTask<Result> TryInitializeTeleportToParcelAsync(Vector2Int parcel, CancellationToken ct,
             bool isLocal = false);

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/Realm.asmdef
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/Realm.asmdef
@@ -7,7 +7,8 @@
         "GUID:e25ef972de004615a22937e739de2def",
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:04c3e7e2f3374472f84666dc489d6cd2",
-        "GUID:1b8e1e1bd01505f478f0369c04a4fb2f"
+        "GUID:1b8e1e1bd01505f478f0369c04a4fb2f",
+        "GUID:fa7b3fdbb04d67549916da7bd2af58ab"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/GatherGltfAssetsSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/GatherGltfAssetsSystem.cs
@@ -9,6 +9,7 @@ using ECS.SceneLifeCycle.Reporting;
 using ECS.Unity.GLTFContainer.Components;
 using SceneRunner.Scene;
 using System.Collections.Generic;
+using DCL.Optimization.PerformanceBudgeting;
 using UnityEngine;
 using UnityEngine.Pool;
 
@@ -34,13 +35,17 @@ namespace ECS.SceneLifeCycle.Systems
         private readonly EntityEventBuffer<GltfContainerComponent> eventsBuffer;
         private readonly EntityEventBuffer<GltfContainerComponent>.ForEachDelegate forEachEvent;
         private readonly ISceneStateProvider sceneStateProvider;
+        private readonly MemoryBudget memoryBudget;
 
-        internal GatherGltfAssetsSystem(World world, ISceneReadinessReportQueue readinessReportQueue, ISceneData sceneData, EntityEventBuffer<GltfContainerComponent> eventsBuffer, ISceneStateProvider sceneStateProvider) : base(world)
+        internal GatherGltfAssetsSystem(World world, ISceneReadinessReportQueue readinessReportQueue,
+            ISceneData sceneData, EntityEventBuffer<GltfContainerComponent> eventsBuffer,
+            ISceneStateProvider sceneStateProvider, MemoryBudget memoryBudget) : base(world)
         {
             this.readinessReportQueue = readinessReportQueue;
             this.sceneData = sceneData;
             this.eventsBuffer = eventsBuffer;
             this.sceneStateProvider = sceneStateProvider;
+            this.memoryBudget = memoryBudget;
 
             forEachEvent = GatherEntities;
         }
@@ -119,6 +124,18 @@ namespace ECS.SceneLifeCycle.Systems
                 // If is still not concluded apply certain timeout to be in sync with `WaitForSceneReadiness`
                 if (Time.time - startTime > WaitForSceneReadiness.TIMEOUT.TotalSeconds)
                     concluded = true;
+
+                // Memory is full. Assets may be on deadlock. Show broken state of scene
+                if (memoryBudget.GetMemoryUsageStatus() != MemoryUsageStatus.FULL)
+                {
+                    for (var i = 0; i < reports!.Value.Count; i++)
+                    {
+                        var report = reports.Value[i];
+                        report.SetProgress(1);
+                    }
+
+                    concluded = true;
+                }
 
                 if (concluded)
                 {

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/GatherGltfAssetsSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/GatherGltfAssetsSystem.cs
@@ -126,7 +126,7 @@ namespace ECS.SceneLifeCycle.Systems
                     concluded = true;
 
                 // Memory is full. Assets may be on deadlock. Show broken state of scene
-                if (memoryBudget.GetMemoryUsageStatus() != MemoryUsageStatus.FULL)
+                if (memoryBudget.GetMemoryUsageStatus() == MemoryUsageStatus.FULL)
                 {
                     for (var i = 0; i < reports!.Value.Count; i++)
                     {

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEngine;
+using Utility.Types;
 using static DCL.Chat.Commands.IChatCommand;
 
 namespace Global.Dynamic.ChatCommands
@@ -70,13 +71,13 @@ namespace Global.Dynamic.ChatCommands
             if (match.Groups[3].Success && match.Groups[4].Success)
                 parcel = new Vector2Int(int.Parse(match.Groups[3].Value), int.Parse(match.Groups[4].Value));
 
-            bool isSuccess = await realmNavigator.TryChangeRealmAsync(realm, ct, parcel);
+            var result = await realmNavigator.TryChangeRealmAsync(realm, ct, parcel);
 
             if (ct.IsCancellationRequested)
                 return "🔴 Error. The operation was canceled!";
 
-            return isSuccess ? $"🟢 Welcome to the {worldName} world!" :
-                realm == realmNavigator.CurrentRealm ? $"🟡 You are already in {worldName}!" : $"🔴 Error. The world {worldName} doesn't exist or not reachable!";
+
+            return (result.Success ? $"🟢 Welcome to the {worldName} world!" : result!.ErrorMessage)!;
         }
 
         private string GetWorldAddress(string worldPath)

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
@@ -28,7 +28,10 @@ namespace Global.Dynamic.ChatCommands
         // Parameters to URL mapping
         private readonly Dictionary<string, string> paramUrls;
 
-        public static readonly Regex REGEX = new ($@"^/({COMMAND_WORLD}|{COMMAND_GOTO})\s+((?!-?\d+\s*,\s*-?\d+$).+?)(?:\s+(-?\d+)\s*,\s*(-?\d+))?$", RegexOptions.Compiled);
+        public static readonly Regex REGEX =
+            new(
+                $@"^/({COMMAND_WORLD}|{ChatCommandsUtils.COMMAND_GOTO})\s+((?!-?\d+\s*,\s*-?\d+$).+?)(?:\s+(-?\d+)\s*,\s*(-?\d+))?$",
+                RegexOptions.Compiled);
         private readonly URLDomain worldDomain = URLDomain.FromString(IRealmNavigator.WORLDS_DOMAIN);
 
         private readonly Dictionary<string, URLAddress> worldAddressesCaches = new ();

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
@@ -74,7 +74,7 @@ namespace Global.Dynamic.ChatCommands
             if (!realmNavigator.CheckIsNewRealm(realm))
                 return $"🟡 You are already in {worldName}!";
 
-            if (!await realmNavigator.CheckRealmIsReacheable(realm, ct))
+            if (!await realmNavigator.CheckRealmIsReacheableAsync(realm, ct))
                 return $"🔴 Error. The world {worldName} doesn't exist or not reachable!";
             
             var result = await realmNavigator.TryChangeRealmAsync(realm, ct, parcel);

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
@@ -71,6 +71,12 @@ namespace Global.Dynamic.ChatCommands
             if (match.Groups[3].Success && match.Groups[4].Success)
                 parcel = new Vector2Int(int.Parse(match.Groups[3].Value), int.Parse(match.Groups[4].Value));
 
+            if (!realmNavigator.CheckIsNewRealm(realm))
+                return $"🟡 You are already in {realm}!";
+
+            if (!await realmNavigator.CheckRealmIsReacheable(realm, ct))
+                return $"🔴 Error. The world {realm} doesn't exist or not reachable!";
+            
             var result = await realmNavigator.TryChangeRealmAsync(realm, ct, parcel);
 
             if (ct.IsCancellationRequested)

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
@@ -76,8 +76,9 @@ namespace Global.Dynamic.ChatCommands
             if (ct.IsCancellationRequested)
                 return "🔴 Error. The operation was canceled!";
 
-
-            return (result.Success ? $"🟢 Welcome to the {worldName} world!" : result!.ErrorMessage)!;
+            return result.Success
+                ? $"🟢 Welcome to the {worldName} world!"
+                : $"🔴 Teleport was not fully successfull to {worldName} world"!;
         }
 
         private string GetWorldAddress(string worldPath)

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
@@ -72,10 +72,10 @@ namespace Global.Dynamic.ChatCommands
                 parcel = new Vector2Int(int.Parse(match.Groups[3].Value), int.Parse(match.Groups[4].Value));
 
             if (!realmNavigator.CheckIsNewRealm(realm))
-                return $"🟡 You are already in {realm}!";
+                return $"🟡 You are already in {worldName}!";
 
             if (!await realmNavigator.CheckRealmIsReacheable(realm, ct))
-                return $"🔴 Error. The world {realm} doesn't exist or not reachable!";
+                return $"🔴 Error. The world {worldName} doesn't exist or not reachable!";
             
             var result = await realmNavigator.TryChangeRealmAsync(realm, ct, parcel);
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/GoToChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/GoToChatCommand.cs
@@ -1,11 +1,11 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCL.Chat.Commands;
 using ECS.SceneLifeCycle.Realm;
-using System;
 using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEngine;
 using Utility;
+using Utility.Types;
 using Random = UnityEngine.Random;
 using static DCL.Chat.Commands.IChatCommand;
 
@@ -42,14 +42,14 @@ namespace Global.Dynamic.ChatCommands
                 y = Random.Range(GenesisCityData.MIN_PARCEL.y, GenesisCityData.MAX_SQUARE_CITY_PARCEL.y);
             }
 
-            var success = await realmNavigator.TryInitializeTeleportToParcelAsync(new Vector2Int(x, y), ct, isLocal);
+            var teleportResult =
+                await realmNavigator.TryInitializeTeleportToParcelAsync(new Vector2Int(x, y), ct, isLocal);
 
             if (ct.IsCancellationRequested)
-            {
                 return "🔴 Error. The operation was canceled!";
-            }
 
-            return success
+
+            return teleportResult.Success
                 ? $"🟢 You teleported to {x},{y} in Genesis City"
                 : "\ud83d\udd34 Teleport failed, please try again later!";
         }

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/GoToChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/GoToChatCommand.cs
@@ -16,7 +16,10 @@ namespace Global.Dynamic.ChatCommands
         private const string COMMAND_GOTO_LOCAL = "goto-local";
         private const string PARAMETER_RANDOM = "random";
 
-        public static readonly Regex REGEX = new ($@"^/({COMMAND_GOTO}|{COMMAND_GOTO_LOCAL})\s+(?:(-?\d+)\s*,\s*(-?\d+)|{PARAMETER_RANDOM})$", RegexOptions.Compiled);
+        public static readonly Regex REGEX =
+            new(
+                $@"^/({ChatCommandsUtils.COMMAND_GOTO}|{COMMAND_GOTO_LOCAL})\s+(?:(-?\d+)\s*,\s*(-?\d+)|{PARAMETER_RANDOM})$",
+                RegexOptions.Compiled);
         private readonly IRealmNavigator realmNavigator;
 
         private int x;

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/GoToChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/GoToChatCommand.cs
@@ -48,10 +48,9 @@ namespace Global.Dynamic.ChatCommands
             if (ct.IsCancellationRequested)
                 return "🔴 Error. The operation was canceled!";
 
-
             return teleportResult.Success
                 ? $"🟢 You teleported to {x},{y} in Genesis City"
-                : "\ud83d\udd34 Teleport failed, please try again later!";
+                : "🔴 Teleport failed. Try again later!";
         }
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -144,20 +144,6 @@ namespace Global.Dynamic
             localSceneDevelopmentController?.Dispose();
         }
 
-        private static void BuildTeleportWidget(IRealmNavigator realmNavigator, IDebugContainerBuilder debugContainerBuilder, List<string> realms)
-        {
-            debugContainerBuilder.TryAddWidget("Realm")
-                                ?.AddControl(new DebugDropdownDef(realms, new ElementBinding<string>(string.Empty,
-                                      evt => { realmNavigator.TryChangeRealmAsync(URLDomain.FromString(evt.newValue), CancellationToken.None).Forget(); }), string.Empty), null)
-                                 .AddStringFieldWithConfirmation("https://peer.decentraland.org", "Change", realm => { realmNavigator.TryChangeRealmAsync(URLDomain.FromString(realm), CancellationToken.None).Forget(); });
-        }
-
-        private static void BuildReloadSceneWidget(IDebugContainerBuilder debugBuilder, IChatMessagesBus chatMessagesBus)
-        {
-            debugBuilder.TryAddWidget("Scene Reload")
-                       ?.AddSingleButton("Reload Scene", () => chatMessagesBus.Send("/reload"));
-        }
-
         public static async UniTask<(DynamicWorldContainer? container, bool success)> CreateAsync(
             BootstrapContainer bootstrapContainer,
             DynamicWorldDependencies dynamicWorldDependencies,
@@ -543,14 +529,18 @@ namespace Global.Dynamic
                     staticContainer.InputBlock,
                     emoteProvider,
                     globalWorld,
-                    playerEntity
+                    playerEntity,
+                    container.ChatMessagesBus
                 ),
                 new CharacterPreviewPlugin(staticContainer.ComponentsContainer.ComponentPoolsRegistry, assetsProvisioner, staticContainer.CacheCleaner),
                 new WebRequestsPlugin(staticContainer.WebRequestsContainer.AnalyticsContainer, debugBuilder),
                 new Web3AuthenticationPlugin(assetsProvisioner, dynamicWorldDependencies.Web3Authenticator, debugBuilder, container.MvcManager, selfProfile, webBrowser, staticContainer.RealmData, identityCache, characterPreviewFactory, dynamicWorldDependencies.SplashScreen, audioMixerVolumesController, staticContainer.FeatureFlagsCache, characterPreviewEventBus, globalWorld),
                 new StylizedSkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, debugBuilder),
                 new LoadingScreenPlugin(assetsProvisioner, container.MvcManager, audioMixerVolumesController, staticContainer.InputBlock),
-                new ExternalUrlPromptPlugin(assetsProvisioner, webBrowser, container.MvcManager, dclCursor), new TeleportPromptPlugin(assetsProvisioner, realmNavigator, container.MvcManager, staticContainer.WebRequestsContainer.WebRequestController, placesAPIService, dclCursor),
+                new ExternalUrlPromptPlugin(assetsProvisioner, webBrowser, container.MvcManager, dclCursor),
+                new TeleportPromptPlugin(assetsProvisioner, container.MvcManager,
+                    staticContainer.WebRequestsContainer.WebRequestController, placesAPIService, dclCursor,
+                    container.ChatMessagesBus),
                 new ChangeRealmPromptPlugin(
                     assetsProvisioner,
                     container.MvcManager,
@@ -626,10 +616,6 @@ namespace Global.Dynamic
             container.GlobalPlugins = globalPlugins;
 
             staticContainer.RoomHubProxy.SetObject(container.RoomHub);
-
-            BuildTeleportWidget(realmNavigator, debugBuilder, dynamicWorldParams.Realms);
-            BuildReloadSceneWidget(debugBuilder, container.ChatMessagesBus);
-
             return (container, true);
         }
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -2,7 +2,6 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.AsyncLoadReporting;
-using DCL.Ipfs;
 using DCL.Landscape;
 using DCL.MapRenderer;
 using DCL.MapRenderer.MapLayers;
@@ -14,17 +13,13 @@ using DCL.Roads.Systems;
 using DCL.SceneLoadingScreens.LoadingScreen;
 using DCL.UserInAppInitializationFlow;
 using DCL.Utilities;
-using DCL.Utilities.Extensions;
 using ECS.Prioritization.Components;
 using ECS.SceneLifeCycle.Realm;
 using ECS.SceneLifeCycle.Reporting;
-using ECS.SceneLifeCycle.SceneDefinition;
-using ECS.StreamableLoading.Common;
 using System;
 using System.Linq;
 using System.Threading;
 using DCL.Diagnostics;
-using DCL.UserInAppInitializationFlow.StartupOperations;
 using Global.Dynamic.TeleportOperations;
 using Unity.Collections;
 using Unity.Mathematics;
@@ -91,7 +86,7 @@ namespace Global.Dynamic
             this.decentralandUrlsSource = decentralandUrlsSource;
             this.globalWorld = globalWorld;
 
-            var livekitTimeout = TimeSpan.FromSeconds(0.01f);
+            var livekitTimeout = TimeSpan.FromSeconds(10f);
 
             realmChangeOperations = new ITeleportOperation[]
             {
@@ -130,7 +125,8 @@ namespace Global.Dynamic
             ct.ThrowIfCancellationRequested();
             var loadResult
                 = await loadingScreen.ShowWhileExecuteTaskAsync(DoChangeRealmAsync(realm, parcelToTeleport, ct), ct);
-            
+
+            if (!loadResult.Success)
             {
                 if (!globalWorld.Has<CameraSamplingData>(cameraEntity.Object))
                     globalWorld.Add(cameraEntity.Object, cameraSamplingData);

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -110,7 +110,7 @@ namespace Global.Dynamic
             return true;
         }
 
-        public async UniTask<bool> CheckRealmIsReacheable(URLDomain realm, CancellationToken ct)
+        public async UniTask<bool> CheckRealmIsReacheableAsync(URLDomain realm, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
             if (!await realmController.IsReachableAsync(realm, ct))

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -24,11 +24,14 @@ using System;
 using System.Linq;
 using System.Threading;
 using DCL.Diagnostics;
+using DCL.UserInAppInitializationFlow.StartupOperations;
+using Global.Dynamic.TeleportOperations;
 using Unity.Collections;
 using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.Assertions;
 using Utility;
+using Utility.Types;
 using static DCL.UserInAppInitializationFlow.RealFlowLoadingStatus.Stage;
 
 namespace Global.Dynamic
@@ -39,8 +42,6 @@ namespace Global.Dynamic
         private readonly IMapRenderer mapRenderer;
         private readonly IGlobalRealmController realmController;
         private readonly ITeleportController teleportController;
-        private readonly IRoomHub roomHub;
-        private readonly IRemoteEntities remoteEntities;
         private readonly IDecentralandUrlsSource decentralandUrlsSource;
         private readonly World globalWorld;
         private readonly RoadPlugin roadsPlugin;
@@ -51,10 +52,13 @@ namespace Global.Dynamic
 
         private readonly ObjectProxy<Entity> cameraEntity;
         private readonly CameraSamplingData cameraSamplingData;
-
+        
         public URLDomain? CurrentRealm { get; private set; }
 
         public event Action<bool>? RealmChanged;
+
+        private readonly ITeleportOperation[] realmChangeOperations;
+        private readonly ITeleportOperation teleportInSameRealmOperation;
 
         public RealmNavigator(
             ILoadingScreen loadingScreen,
@@ -84,68 +88,80 @@ namespace Global.Dynamic
             this.landscapeEnabled = landscapeEnabled;
             this.cameraEntity = cameraEntity;
             this.cameraSamplingData = cameraSamplingData;
-            this.roomHub = roomHub;
-            this.remoteEntities = remoteEntities;
             this.decentralandUrlsSource = decentralandUrlsSource;
             this.globalWorld = globalWorld;
+
+            var livekitTimeout = TimeSpan.FromSeconds(10);
+
+            realmChangeOperations = new ITeleportOperation[]
+            {
+                new RemoveRemoteEntitiesTeleportOperation(remoteEntities, globalWorld),
+                new StopRoomAsyncTeleportOperation(roomHub, livekitTimeout),
+                new RemoveCameraSamplingDataTeleportOperation(globalWorld, cameraEntity),
+                new ChangeRealmTeleportOperation(this),
+                new LoadLandscapeTeleportOperation(this),
+                new MoveToParcelInNewRealmTeleportOperation(this),
+                new RestartRoomAsyncTeleportOperation(roomHub, livekitTimeout)
+            };
+
+            teleportInSameRealmOperation = new MoveToParcelInSameRealmTeleportOperation(this);
         }
 
-        public async UniTask<bool> TryChangeRealmAsync(URLDomain realm, CancellationToken ct,
+        public async UniTask<Result> TryChangeRealmAsync(URLDomain realm, CancellationToken ct,
             Vector2Int parcelToTeleport = default)
         {
             if (realm == CurrentRealm || realm == realmController.RealmData.Ipfs.CatalystBaseUrl)
-                return false;
+                return Result.ErrorResult($"🟡 You are already in {realm}!");
 
             ct.ThrowIfCancellationRequested();
 
             if (!await realmController.IsReachableAsync(realm, ct))
-                return false;
+                return Result.ErrorResult($"🔴 Error. The world {realm} doesn't exist or not reachable!"); 
 
             ct.ThrowIfCancellationRequested();
 
-            var loadResult = await loadingScreen.ShowWhileExecuteTaskAsync(async parentLoadReport =>
-                {
-                    ct.ThrowIfCancellationRequested();
-
-                    remoteEntities.ForceRemoveAll(globalWorld);
-                    await roomHub.StopIfNotAsync();
-
-                    // By removing the CameraSamplingData, we stop the ring calculation
-                    globalWorld.Remove<CameraSamplingData>(cameraEntity.Object);
-
-                    await ChangeRealmAsync(realm, ct);
-                    parentLoadReport.SetProgress(RealFlowLoadingStatus.PROGRESS[ProfileLoaded]);
-
-                    var landscapeLoadReport
-                        = parentLoadReport.CreateChildReport(RealFlowLoadingStatus.PROGRESS[LandscapeLoaded]);
-
-                    await LoadTerrainAsync(landscapeLoadReport, ct);
-                    parentLoadReport.SetProgress(RealFlowLoadingStatus.PROGRESS[LandscapeLoaded]);
-
-                    var teleportLoadReport
-                        = parentLoadReport.CreateChildReport(RealFlowLoadingStatus.PROGRESS[PlayerTeleported]);
-
-                    await InitializeTeleportToSpawnPointAsync(teleportLoadReport, ct, parcelToTeleport);
-                    parentLoadReport.SetProgress(RealFlowLoadingStatus.PROGRESS[PlayerTeleported]);
-
-                    await roomHub.StartAsync();
-                    parentLoadReport.SetProgress(RealFlowLoadingStatus.PROGRESS[Completed]);
-                },
-                ct
-            );
+            var loadResult
+                = await loadingScreen.ShowWhileExecuteTaskAsync(DoChangeRealmAsync(realm, parcelToTeleport, ct), ct);
+            
             if (!loadResult.Success)
             {
                 if (!globalWorld.Has<CameraSamplingData>(cameraEntity.Object))
                     globalWorld.Add(cameraEntity.Object, cameraSamplingData);
-
                 ReportHub.LogError(ReportCategory.REALM,
                     $"Error trying to teleport to a realm {realm}: {loadResult.ErrorMessage}");
-
-                return false;
             }
 
+            return loadResult;
+        }
 
-            return true;
+
+        private Func<AsyncLoadProcessReport, UniTask> DoChangeRealmAsync(URLDomain realm, Vector2Int parcelToTeleport,
+            CancellationToken ct)
+        {
+            return async parentLoadReport =>
+            {
+                ct.ThrowIfCancellationRequested();
+                var teleportParams = new TeleportParams
+                {
+                    CurrentDestinationParcel = parcelToTeleport,
+                    CurrentDestinationRealm = realm,
+                    ParentReport = parentLoadReport
+                };
+                foreach (var realmChangeOperation in realmChangeOperations)
+                {
+                    var currentOperationResult = Result.SuccessResult();
+                    try
+                    {
+                        currentOperationResult = await realmChangeOperation.ExecuteAsync(teleportParams, ct);
+                        if (!currentOperationResult.Success)
+                            throw new Exception(currentOperationResult.ErrorMessage);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new Exception($"Unhandled exception while changing realm {e}");
+                    }
+                }
+            };
         }
 
         public async UniTask InitializeTeleportToSpawnPointAsync(AsyncLoadProcessReport teleportLoadReport,
@@ -165,42 +181,48 @@ namespace Global.Dynamic
             await waitForSceneReadiness;
         }
 
-        public async UniTask<bool> TryInitializeTeleportToParcelAsync(Vector2Int parcel, CancellationToken ct,
+        public async UniTask<Result> TryInitializeTeleportToParcelAsync(Vector2Int parcel, CancellationToken ct,
             bool isLocal = false)
         {
             ct.ThrowIfCancellationRequested();
 
             var isGenesis = !realmController.RealmData.ScenesAreFixed;
 
-                if (!isLocal && !isGenesis)
+            if (!isLocal && !isGenesis)
+            {
+                var url = URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.Genesis));
+                return await TryChangeRealmAsync(url, ct, parcel);
+            }
+
+            var loadResult = await loadingScreen.ShowWhileExecuteTaskAsync(async parentLoadReport =>
+            {
+                ct.ThrowIfCancellationRequested();
+                parentLoadReport.SetProgress(RealFlowLoadingStatus.PROGRESS[LandscapeLoaded]);
+                var teleportParams = new TeleportParams
                 {
-                    var url = URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.Genesis));
-                    await TryChangeRealmAsync(url, ct, parcel);
-                }
-                else
+                    ParentReport = parentLoadReport,
+                    CurrentDestinationParcel = parcel
+                };
+                try
                 {
-                    var loadResult = await loadingScreen.ShowWhileExecuteTaskAsync(async parentLoadReport =>
-                    {
-                        ct.ThrowIfCancellationRequested();
-                        parentLoadReport.SetProgress(RealFlowLoadingStatus.PROGRESS[LandscapeLoaded]);
-
-                        var teleportLoadReport
-                            = parentLoadReport.CreateChildReport(RealFlowLoadingStatus.PROGRESS[PlayerTeleported]);
-
-                        var waitForSceneReadiness = await TeleportToParcelAsync(parcel, teleportLoadReport, ct);
-                        await waitForSceneReadiness;
-
-                        parentLoadReport.SetProgress(RealFlowLoadingStatus.PROGRESS[Completed]);
-                    }, ct);
-                    if (!loadResult.Success)
-                    {
-                        ReportHub.LogError(ReportCategory.SCENE_LOADING,
-                            $"Error trying to teleport to a parcel {parcel}: {loadResult.ErrorMessage}");
-                        return false;
-                    }
+                    var currentOperationResult = await teleportInSameRealmOperation.ExecuteAsync(teleportParams, ct);
+                    if (!currentOperationResult.Success)
+                        throw new Exception(currentOperationResult.ErrorMessage);
                 }
+                catch (Exception e)
+                {
+                    throw new Exception($"Unhandled exception while teleporting in same realm {e}");
+                }
+            }, ct);
 
-                return true;
+            if (!loadResult.Success)
+            {
+                ReportHub.LogError(ReportCategory.SCENE_LOADING,
+                    $"Error trying to teleport to a parcel {parcel}: {loadResult.ErrorMessage}");
+            }
+
+            return loadResult;
+
         }
 
         public async UniTask LoadTerrainAsync(AsyncLoadProcessReport landscapeLoadReport, CancellationToken ct)
@@ -239,7 +261,7 @@ namespace Global.Dynamic
             roadsPlugin.RoadAssetPool?.SwitchVisibility(isGenesis);
         }
 
-        private async UniTask<UniTask> TeleportToParcelAsync(Vector2Int parcel, AsyncLoadProcessReport processReport,
+        public async UniTask<UniTask> TeleportToParcelAsync(Vector2Int parcel, AsyncLoadProcessReport processReport,
             CancellationToken ct)
         {
             var waitForSceneReadiness =
@@ -263,11 +285,10 @@ namespace Global.Dynamic
             return waitForSceneReadiness.ToUniTask(ct);
         }
 
-        private async UniTask ChangeRealmAsync(URLDomain realm, CancellationToken ct)
+        public async UniTask ChangeRealmAsync(URLDomain realm, CancellationToken ct)
         {
             await realmController.SetRealmAsync(realm, ct);
             CurrentRealm = realm;
-
             await SwitchMiscVisibilityAsync();
         }
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9fac86bc9aa24c97b561e37796084956
+timeCreated: 1726677884

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/ChangeRealmTeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/ChangeRealmTeleportOperation.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using DCL.UserInAppInitializationFlow;
+using ECS.SceneLifeCycle.Realm;
+using Utility.Types;
+using static DCL.UserInAppInitializationFlow.RealFlowLoadingStatus.Stage;
+
+
+namespace Global.Dynamic.TeleportOperations
+{
+    public class ChangeRealmTeleportOperation : ITeleportOperation
+    {
+        private readonly IRealmNavigator realmNavigator;
+
+        public ChangeRealmTeleportOperation(IRealmNavigator realmNavigator)
+        {
+            this.realmNavigator = realmNavigator;
+        }
+
+        public async UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
+        {
+            try
+            {
+                await realmNavigator.ChangeRealmAsync(teleportParams.CurrentDestinationRealm, ct);
+                teleportParams.ParentReport.SetProgress(RealFlowLoadingStatus.PROGRESS[ProfileLoaded]);
+                return Result.SuccessResult();
+            }
+            catch (Exception e)
+            {
+                return Result.ErrorResult("Error while changing realm");
+            }
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/ChangeRealmTeleportOperation.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/ChangeRealmTeleportOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: af445acb84544bc388d397ff4028c124
+timeCreated: 1726679144

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/ITeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/ITeleportOperation.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using CommunicationData.URLHelpers;
+using Cysharp.Threading.Tasks;
+using DCL.AsyncLoadReporting;
+using UnityEngine;
+using Utility.Types;
+
+namespace Global.Dynamic.TeleportOperations
+{
+    public interface ITeleportOperation
+    {
+        UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct);
+    }
+
+    public struct TeleportParams
+    {
+        public URLDomain CurrentDestinationRealm;
+        public Vector2Int CurrentDestinationParcel;
+        public AsyncLoadProcessReport ParentReport;
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/ITeleportOperation.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/ITeleportOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e05cf72619cf4f358f6ba85d2e4b0a49
+timeCreated: 1726679878

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/LoadLandscapeTeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/LoadLandscapeTeleportOperation.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using DCL.UserInAppInitializationFlow;
+using ECS.SceneLifeCycle.Realm;
+using Utility.Types;
+using static DCL.UserInAppInitializationFlow.RealFlowLoadingStatus.Stage;
+
+
+namespace Global.Dynamic.TeleportOperations
+{
+    public class LoadLandscapeTeleportOperation : ITeleportOperation
+    {
+        private readonly IRealmNavigator realmNavigator;
+
+        public LoadLandscapeTeleportOperation(IRealmNavigator realmNavigator)
+        {
+            this.realmNavigator = realmNavigator;
+        }
+
+
+        public async UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
+        {
+            try
+            {
+                var landscapeLoadReport
+                    = teleportParams.ParentReport.CreateChildReport(RealFlowLoadingStatus.PROGRESS[LandscapeLoaded]);
+
+                await realmNavigator.LoadTerrainAsync(landscapeLoadReport, ct);
+                teleportParams.ParentReport.SetProgress(RealFlowLoadingStatus.PROGRESS[LandscapeLoaded]);
+                return Result.SuccessResult();
+            }
+            catch (Exception e)
+            {
+                return Result.ErrorResult("Error while loading landscape");
+            }
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/LoadLandscapeTeleportOperation.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/LoadLandscapeTeleportOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 68857ba192c446d795002c041d06a3fc
+timeCreated: 1726680100

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/MoveToParcelInNewRealmTeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/MoveToParcelInNewRealmTeleportOperation.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using DCL.UserInAppInitializationFlow;
+using ECS.SceneLifeCycle.Realm;
+using Utility.Types;
+using static DCL.UserInAppInitializationFlow.RealFlowLoadingStatus.Stage;
+
+
+namespace Global.Dynamic.TeleportOperations
+{
+    public class MoveToParcelInNewRealmTeleportOperation : ITeleportOperation
+    {
+        private readonly IRealmNavigator realmNavigator;
+
+        public MoveToParcelInNewRealmTeleportOperation(IRealmNavigator realmNavigator)
+        {
+            this.realmNavigator = realmNavigator;
+        }
+
+        public async UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
+        {
+            try
+            {
+                var teleportLoadReport
+                    = teleportParams.ParentReport.CreateChildReport(RealFlowLoadingStatus.PROGRESS[PlayerTeleported]);
+
+                await realmNavigator.InitializeTeleportToSpawnPointAsync(teleportLoadReport, ct,
+                    teleportParams.CurrentDestinationParcel);
+                teleportParams.ParentReport.SetProgress(RealFlowLoadingStatus.PROGRESS[PlayerTeleported]);
+                return Result.SuccessResult();
+            }
+            catch (Exception e)
+            {
+                return Result.ErrorResult("Error while moving to parcel");
+            }
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/MoveToParcelInNewRealmTeleportOperation.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/MoveToParcelInNewRealmTeleportOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6db7f3745c0d4865ae396af4a6b98c19
+timeCreated: 1726680313

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/MoveToParcelInSameRealmTeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/MoveToParcelInSameRealmTeleportOperation.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using DCL.UserInAppInitializationFlow;
+using ECS.SceneLifeCycle.Realm;
+using Utility.Types;
+using static DCL.UserInAppInitializationFlow.RealFlowLoadingStatus.Stage;
+
+
+namespace Global.Dynamic.TeleportOperations
+{
+    public class MoveToParcelInSameRealmTeleportOperation : ITeleportOperation
+    {
+        private readonly IRealmNavigator realmNavigator;
+
+        public MoveToParcelInSameRealmTeleportOperation(IRealmNavigator realmNavigator)
+        {
+            this.realmNavigator = realmNavigator;
+        }
+
+
+        public async UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
+        {
+            try
+            {
+                var teleportLoadReport
+                    = teleportParams.ParentReport.CreateChildReport(RealFlowLoadingStatus.PROGRESS[PlayerTeleported]);
+                var waitForSceneReadiness =
+                    await realmNavigator.TeleportToParcelAsync(teleportParams.CurrentDestinationParcel,
+                        teleportLoadReport, ct);
+                await waitForSceneReadiness;
+                teleportParams.ParentReport.SetProgress(RealFlowLoadingStatus.PROGRESS[Completed]);
+                return Result.SuccessResult();
+            }
+            catch (Exception e)
+            {
+                return Result.ErrorResult("Error while teleporting in same realm");
+            }
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/MoveToParcelInSameRealmTeleportOperation.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/MoveToParcelInSameRealmTeleportOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f1ee7a28f386416485bf9e24e4b6ec24
+timeCreated: 1726682690

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RemoveCameraSamplingDataTeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RemoveCameraSamplingDataTeleportOperation.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using Arch.Core;
+using Cysharp.Threading.Tasks;
+using DCL.Utilities;
+using ECS.Prioritization.Components;
+using Utility.Types;
+
+namespace Global.Dynamic.TeleportOperations
+{
+    public class RemoveCameraSamplingDataTeleportOperation : ITeleportOperation
+    {
+        private readonly World globalWorld;
+        private readonly ObjectProxy<Entity> cameraEntity;
+
+        public RemoveCameraSamplingDataTeleportOperation(World globalWorld, ObjectProxy<Entity> cameraEntity)
+        {
+            this.globalWorld = globalWorld;
+            this.cameraEntity = cameraEntity;
+        }
+
+        public UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
+        {
+            // By removing the CameraSamplingData, we stop the ring calculation
+            globalWorld.Remove<CameraSamplingData>(cameraEntity.Object);
+            return UniTask.FromResult(Result.SuccessResult());
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RemoveCameraSamplingDataTeleportOperation.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RemoveCameraSamplingDataTeleportOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d7e9822020004fd08147e7fd3618347b
+timeCreated: 1726678555

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RemoveRemoteEntitiesTeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RemoveRemoteEntitiesTeleportOperation.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using Arch.Core;
+using Cysharp.Threading.Tasks;
+using DCL.Multiplayer.Profiles.Entities;
+using Utility.Types;
+
+namespace Global.Dynamic.TeleportOperations
+{
+    public class RemoveRemoteEntitiesTeleportOperation : ITeleportOperation
+    {
+        private readonly IRemoteEntities remoteEntities;
+        private readonly World globalWorld;
+
+
+        public RemoveRemoteEntitiesTeleportOperation(IRemoteEntities remoteEntities, World globalWorld)
+        {
+            this.remoteEntities = remoteEntities;
+            this.globalWorld = globalWorld;
+        }
+
+        public UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
+        {
+            try
+            {
+                remoteEntities.ForceRemoveAll(globalWorld);
+                return UniTask.FromResult(Result.SuccessResult());
+            }
+            catch (Exception e)
+            {
+                return UniTask.FromResult(Result.ErrorResult("Failed to remove remote entities"));
+            }
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RemoveRemoteEntitiesTeleportOperation.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RemoveRemoteEntitiesTeleportOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a4424d5b45214ab69b5262c50c6c4104
+timeCreated: 1726681071

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RestartRoomAsyncTeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RestartRoomAsyncTeleportOperation.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using DCL.Multiplayer.Connections.RoomHubs;
+using DCL.UserInAppInitializationFlow;
+using static DCL.UserInAppInitializationFlow.RealFlowLoadingStatus.Stage;
+using Utility.Types;
+
+namespace Global.Dynamic.TeleportOperations
+{
+    public class RestartRoomAsyncTeleportOperation : ITeleportOperation
+    {
+        private readonly TimeSpan livekitTimeout;
+        private readonly IRoomHub roomHub;
+
+        public RestartRoomAsyncTeleportOperation(IRoomHub roomHub, TimeSpan livekitTimeout)
+        {
+            this.roomHub = roomHub;
+            this.livekitTimeout = livekitTimeout;
+        }
+
+        public async UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
+        {
+            try
+            {
+                await roomHub.StartAsync().Timeout(livekitTimeout);
+                teleportParams.ParentReport.SetProgress(RealFlowLoadingStatus.PROGRESS[Completed]);
+                return Result.SuccessResult();
+            }
+            catch (Exception e)
+            {
+                return Result.ErrorResult("Cannot restart room");
+            }
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RestartRoomAsyncTeleportOperation.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/RestartRoomAsyncTeleportOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b73834accd3948d38b01910b18792fd1
+timeCreated: 1726680444

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/StopRoomAsyncTeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/StopRoomAsyncTeleportOperation.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using DCL.Multiplayer.Connections.RoomHubs;
+using Utility.Types;
+
+namespace Global.Dynamic.TeleportOperations
+{
+    public class StopRoomAsyncTeleportOperation : ITeleportOperation
+    {
+        private readonly IRoomHub roomHub;
+        private readonly TimeSpan livekitTimeout;
+
+        public StopRoomAsyncTeleportOperation(IRoomHub roomHub, TimeSpan livekitTimeout)
+        {
+            this.roomHub = roomHub;
+            this.livekitTimeout = livekitTimeout;
+        }
+
+
+        public async UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
+        {
+            try
+            {
+                await roomHub.StopIfNotAsync().Timeout(livekitTimeout);
+                return Result.SuccessResult();
+            }
+            catch (Exception e)
+            {
+                return Result.ErrorResult("Cannot stop room");
+            }
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/StopRoomAsyncTeleportOperation.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/StopRoomAsyncTeleportOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3d49d6c1117d448489b388bcd574aeb8
+timeCreated: 1726678310


### PR DESCRIPTION
## What does this PR change?

1. Refactor the loading screen actions, so we can easily detect which step has failed
2. Adds a Timeout for Livekit actions since it seemed that they were holding the loading screen. The timeout can be adjusted further
3. Streamlines all `GoTo` commands through the chat
4. Makes the loading screen dissapear if you are on a memory full state. The scene wont be able to load, so we need to hide it

Still TODO

1. If something fails, we should rollback the realm change. Right now it take syou to an unstable state
2. If memory is full, we should warn the user that the scene may nto be complete
3. Still the livekit issues are there, we need to debug why it cannot stop/reconnect

## How to test the changes?


1. Launch the explorer
6. Teleport around and see if you fall into deadlock (eternal loading screen)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

