### PR TITLE
fix: Authentication screen wont close

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -230,8 +230,12 @@ namespace DCL.AuthenticationScreenFlow
 #endif
         }
 
-        protected override UniTask WaitForCloseIntentAsync(CancellationToken ct) =>
-            (lifeCycleTask ??= new UniTaskCompletionSource()).Task.AttachExternalCancellation(ct);
+        protected override async UniTask WaitForCloseIntentAsync(CancellationToken ct)
+        {
+            lifeCycleTask?.TrySetCanceled(ct);
+            lifeCycleTask = new UniTaskCompletionSource();
+            await lifeCycleTask.Task;
+        }
 
         private void StartLoginFlowUntilEnd()
         {


### PR DESCRIPTION
## What does this PR change?

This fixes the issue when logging out and then back in. IN short, the auth screen wouldnt close.
This really small tweak fixes it. Looks like we were not awaiting properly for the event.

## How to test the changes?

Log into the game, then go to profile -> log out, then try to login again. Now the whole flow should work OK.
Fixes:
#1969 
#2006 
(they are the same issue reported twice 😁 )
