### PR TITLE
fix: Missing icon on minigame map pins

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/Addressables/MapPinMarkerObject.prefab
+++ b/Explorer/Assets/DCL/MapRenderer/Addressables/MapPinMarkerObject.prefab
@@ -374,12 +374,12 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: a98b57eed8453f04c8b749ee44056726, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 165a169697a08114d9b11e44679f140b, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 0.56, y: 0.56}
+  m_Size: {x: 0.72, y: 0.72}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1

--- a/Explorer/Assets/DCL/Minimap/Assets/MinimapMapPinMarkerObject.prefab
+++ b/Explorer/Assets/DCL/Minimap/Assets/MinimapMapPinMarkerObject.prefab
@@ -216,7 +216,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: a98b57eed8453f04c8b749ee44056726, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 165a169697a08114d9b11e44679f140b, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1

--- a/Explorer/Assets/DCL/Navmap/Assets/DestinationInfoElement.prefab
+++ b/Explorer/Assets/DCL/Navmap/Assets/DestinationInfoElement.prefab
@@ -967,9 +967,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 113753565512829668}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -17, y: 0}
   m_SizeDelta: {x: 34, y: 34}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &7510354311571325674
@@ -1000,7 +1000,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: a98b57eed8453f04c8b749ee44056726, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 165a169697a08114d9b11e44679f140b, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Explorer/Assets/Textures/MapPins/MiniGamePin_DefaultIcon.png.meta
+++ b/Explorer/Assets/Textures/MapPins/MiniGamePin_DefaultIcon.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 13
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -37,13 +37,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -99,7 +99,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 


### PR DESCRIPTION
## What does this PR change?

The icon was wrongly imported for some reason, so I fixed it and re-added it to the prefabs.

...

## How to test the changes?

Just check the nav map after enabling the global px (/loadpx globalpx), the pin should show a joystick icon. The same icon should appear on the minimap when setting it as destination as well as in the bottom panel with the current destination in the navmap window.