### PR TITLE
fix: removed specified visibility in uitoolkit components to allow in…

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/Assets/DebugLongMarker.uxml
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/Assets/DebugLongMarker.uxml
@@ -1,6 +1,6 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements">
     <DCL.DebugUtilities.Views.DebugLongMarkerElement>
         <ui:Label tabindex="-1" text="1500 MB" display-tooltip-when-elided="true" class="debug-text--normal"
-                  style="text-overflow: ellipsis; white-space: nowrap; visibility: visible; overflow: hidden;"/>
+                  style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden;"/>
     </DCL.DebugUtilities.Views.DebugLongMarkerElement>
 </ui:UXML>

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/Assets/DebugSetOnlyLabel.uxml
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/Assets/DebugSetOnlyLabel.uxml
@@ -1,6 +1,6 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements">
     <DCL.DebugUtilities.Views.DebugSetOnlyLabelElement>
         <ui:Label tabindex="-1" text="1500 MB" display-tooltip-when-elided="true" class="debug-text--normal"
-                  style="text-overflow: ellipsis; white-space: nowrap; visibility: visible; overflow: hidden;"/>
+                  style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden;"/>
     </DCL.DebugUtilities.Views.DebugSetOnlyLabelElement>
 </ui:UXML>


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
Fix: #2098 

Removed the specified visibility in DebugSetOnlyLabelElement and DebugLongMarkerElement in order to allow its value to be inherited from parent, preventing the rendering of the element even if the parent is hidden


## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer (works both in build and editor with ApplicationParametersParser DEBUG_FLAG removed)
2. Open the debug panel
3. Expand a section (e.g. PERFORMANCE)
4. Close the explorer
5. Launch the explorer
6. Check whether the text is shown even if the debug panel is hidden

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

