### PR TITLE
fix: Empty Emote Wheel for new users 

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/IEmoteStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/IEmoteStorage.cs
@@ -1,6 +1,12 @@
+using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading;
+using System.Collections.Generic;
 
 namespace DCL.AvatarRendering.Emotes
 {
-    public interface IEmoteStorage : IAvatarElementStorage<IEmote, EmoteDTO> { }
+    public interface IEmoteStorage : IAvatarElementStorage<IEmote, EmoteDTO>
+    {
+        List<URN> EmbededURNs { get; }
+        void AddEmbeded(URN urn, IEmote emote);
+    }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
@@ -1,7 +1,6 @@
 using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Assets;
 using DCL.AvatarRendering.Wearables.Components;
-using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.StreamableLoading.Common.Components;
 using System.Collections.Generic;
@@ -20,6 +19,8 @@ namespace DCL.AvatarRendering.Emotes
 
         private readonly object lockObject = new ();
 
+        public List<URN> EmbededURNs { get; } = new ();
+
         public bool TryGetElement(URN urn, out IEmote element)
         {
             lock (lockObject)
@@ -36,6 +37,16 @@ namespace DCL.AvatarRendering.Emotes
         public void Set(URN urn, IEmote element)
         {
             lock (lockObject) { emotes[urn] = element; }
+        }
+
+
+        public void AddEmbeded(URN urn, IEmote emote)
+        {
+            lock (lockObject)
+            {
+                EmbededURNs.Add(urn);
+                emotes[urn] = emote;
+            }
         }
 
         public IEmote GetOrAddByDTO(EmoteDTO emoteDto, bool qualifiedForUnloading = true)

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Tests/AvatarEmoteCommandPropagationSystemShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Tests/AvatarEmoteCommandPropagationSystemShould.cs
@@ -122,6 +122,7 @@ namespace DCL.Multiplayer.SDK.Tests
         private class FakeEmoteStorage : IEmoteStorage
         {
             internal readonly Dictionary<URN, IEmote> emotes = new ();
+            public List<URN> EmbededURNs { get; }
 
             public bool TryGetElement(URN urn, out IEmote element)
             {
@@ -149,6 +150,11 @@ namespace DCL.Multiplayer.SDK.Tests
 
             public bool TryGetOwnedNftRegistry(URN nftUrn, out IReadOnlyDictionary<URN, NftBlockchainOperationEntry> registry) =>
                 throw new NotImplementedException();
+
+            public void AddEmbeded(URN urn, IEmote emote)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
@@ -135,7 +135,7 @@ namespace DCL.PluginSystem.Global
             audioSourceReference = (await assetsProvisioner.ProvideMainAssetAsync(settings.EmoteAudioSource, ct)).Value.GetComponent<AudioSource>();
 
             foreach (IEmote embeddedEmote in embeddedEmotes)
-                emoteStorage.Set(embeddedEmote.GetUrn(), embeddedEmote);
+                emoteStorage.AddEmbeded(embeddedEmote.GetUrn(), embeddedEmote);
 
             var persistentEmoteWheelOpenerController = new PersistentEmoteWheelOpenerController(() => mainUIView.SidebarView.PersistentEmoteWheelOpener, mvcManager);
 

--- a/Explorer/Assets/DCL/Profiles/DataModels/Avatar.cs
+++ b/Explorer/Assets/DCL/Profiles/DataModels/Avatar.cs
@@ -47,6 +47,15 @@ namespace DCL.Profiles
             BodySnapshotUrl = URLAddress.EMPTY;
         }
 
+        public bool IsEmotesWheelEmpty()
+        {
+            foreach (URN urn in Emotes)
+                if (!urn.IsNullOrEmpty())
+                    return false;
+
+            return true;
+        }
+
         public bool IsSameAvatar(Avatar? other)
         {
             if (other == null)
@@ -63,19 +72,19 @@ namespace DCL.Profiles
 
         public void Clear()
         {
-            this.wearables.Clear();
-            this.forceRender.Clear();
+            wearables.Clear();
+            forceRender.Clear();
 
-            for (var i = 0; i < this.emotes.Length; i++)
-                this.emotes[i] = "";
+            for (var i = 0; i < emotes.Length; i++)
+                emotes[i] = "";
 
-            this.BodyShape = default(BodyShape);
-            this.EyesColor = default(Color);
-            this.HairColor = default(Color);
-            this.SkinColor = default(Color);
-            this.SkinColor = default(Color);
-            this.BodySnapshotUrl = default(URLAddress);
-            this.FaceSnapshotUrl = default(URLAddress);
+            BodyShape = default(BodyShape);
+            EyesColor = default(Color);
+            HairColor = default(Color);
+            SkinColor = default(Color);
+            SkinColor = default(Color);
+            BodySnapshotUrl = default(URLAddress);
+            FaceSnapshotUrl = default(URLAddress);
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?
Fix #2124

- filled up emote wheel with default emotes

## How to test the changes?

- See related ticket.
- Check that emote wheel for not new users didn't brake

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

