### PR TITLE
Fix: emotes delay after jump

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller
@@ -234,7 +234,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 4335159024260668230}
-  m_Tag: 
+  m_Tag: Jumping
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
@@ -261,7 +261,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 2713069973875984472}
-  m_Tag: 
+  m_Tag: Jumping
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
@@ -364,7 +364,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: af0fff55c4269da409d05b868baba30c, type: 2}
-  m_Tag: 
+  m_Tag: Jumping
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
@@ -2002,7 +2002,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 6289439487926101618}
-  m_Tag: 
+  m_Tag: Jumping
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
@@ -2089,7 +2089,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: -421941194223418433}
-  m_Tag: 
+  m_Tag: Jumping
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
@@ -2117,7 +2117,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 6027077386426129523}
-  m_Tag: 
+  m_Tag: Jumping
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
@@ -2224,7 +2224,7 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 94556097429062471}
-  m_Tag: 
+  m_Tag: Jumping
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -158,14 +158,11 @@ namespace DCL.AvatarRendering.Emotes.Play
             {
                 // we wait until the avatar finishes moving to trigger the emote,
                 // avoid the case where: you stop moving, trigger the emote, the emote gets triggered and next frame it gets cancelled because inertia keeps moving the avatar
-
-                if (avatarView.IsAnimatorInTag(AnimationHashes.JUMP_STATE))
-                    return;
-
-                if (avatarView.GetAnimatorFloat(AnimationHashes.MOVEMENT_BLEND) > 0.05f)
-                    return;
-
-                if (!animationComponent.States.IsGrounded || animationComponent.States.MovementBlendValue > 0.05f)
+                //We also avoid triggering the emote while the character is jumping or landing, as the landing animation breaks the emote flow if they have props
+                if (!animationComponent.States.IsGrounded ||
+                    animationComponent.States.MovementBlendValue > 0.05f ||
+                    avatarView.IsAnimatorInTag(AnimationHashes.JUMPING_TAG) ||
+                    avatarView.GetAnimatorFloat(AnimationHashes.MOVEMENT_BLEND) > 0.05f)
                     return;
 
                 if (emoteStorage.TryGetElement(emoteId.Shorten(), out IEmote emote))

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -149,7 +149,7 @@ namespace DCL.AvatarRendering.Emotes.Play
         [Query]
         [None(typeof(DeleteEntityIntention))]
         private void ConsumeEmoteIntent(Entity entity, ref CharacterEmoteComponent emoteComponent, in CharacterEmoteIntent emoteIntent,
-            in IAvatarView avatarView, in AvatarShapeComponent avatarShapeComponent, in CharacterAnimationComponent animationComponent)
+            in IAvatarView avatarView, in AvatarShapeComponent avatarShapeComponent)
         {
             URN emoteId = emoteIntent.EmoteId;
 
@@ -159,10 +159,8 @@ namespace DCL.AvatarRendering.Emotes.Play
                 // we wait until the avatar finishes moving to trigger the emote,
                 // avoid the case where: you stop moving, trigger the emote, the emote gets triggered and next frame it gets cancelled because inertia keeps moving the avatar
                 //We also avoid triggering the emote while the character is jumping or landing, as the landing animation breaks the emote flow if they have props
-                if (!animationComponent.States.IsGrounded ||
-                    animationComponent.States.MovementBlendValue > 0.05f ||
-                    avatarView.IsAnimatorInTag(AnimationHashes.JUMPING_TAG) ||
-                    avatarView.GetAnimatorFloat(AnimationHashes.MOVEMENT_BLEND) > 0.05f)
+                if (avatarView.IsAnimatorInTag(AnimationHashes.JUMPING_TAG) ||
+                    avatarView.GetAnimatorFloat(AnimationHashes.MOVEMENT_BLEND) > 0.1f)
                     return;
 
                 if (emoteStorage.TryGetElement(emoteId.Shorten(), out IEmote emote))

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
@@ -141,6 +141,9 @@ namespace DCL.AvatarRendering.Emotes.Play
 
             ListPool<AnimationClip>.Release(uniqueClips);
 
+            // some of our legacy emotes have unity events that we are not handling, so we disable that system to avoid further errors
+            animator.fireEvents = false;
+
             return references;
         }
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
@@ -141,8 +141,6 @@ namespace DCL.AvatarRendering.Emotes.Play
 
             ListPool<AnimationClip>.Release(uniqueClips);
 
-            // some of our legacy emotes have unity events that we are not handling, so we disable that system to avoid further errors
-            animator.fireEvents = false;
             return references;
         }
 

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Components/AnimationHashes.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Components/AnimationHashes.cs
@@ -20,5 +20,7 @@ namespace DCL.Character.CharacterMotion.Components
         public static readonly int LONG_FALL = Animator.StringToHash("IsLongFall");
         public static readonly int STUNNED = Animator.StringToHash("IsStunned");
         public static readonly int SLIDE_BLEND = Animator.StringToHash("SlideBlend");
+        public static readonly int JUMP_STATE = Animator.StringToHash("JumpState");
+
     }
 }

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Components/AnimationHashes.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Components/AnimationHashes.cs
@@ -20,7 +20,7 @@ namespace DCL.Character.CharacterMotion.Components
         public static readonly int LONG_FALL = Animator.StringToHash("IsLongFall");
         public static readonly int STUNNED = Animator.StringToHash("IsStunned");
         public static readonly int SLIDE_BLEND = Animator.StringToHash("SlideBlend");
-        public static readonly int JUMP_STATE = Animator.StringToHash("JumpState");
+        public static readonly int JUMPING_TAG = Animator.StringToHash("Jumping");
 
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/AvatarEmoteCommandPropagationSystem.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/AvatarEmoteCommandPropagationSystem.cs
@@ -33,6 +33,8 @@ namespace DCL.Multiplayer.SDK.Systems.GlobalWorld
         [None(typeof(DeleteEntityIntention))]
         private void UpdateEmoteCommandDataComponent(PlayerCRDTEntity playerCRDTEntity, CharacterEmoteIntent emoteIntent)
         {
+            if (!emoteStorage.TryGetElement(emoteIntent.EmoteId.Shorten(), out IEmote emote)) return;
+
             SceneEcsExecutor sceneEcsExecutor = playerCRDTEntity.SceneFacade.EcsExecutor;
             World sceneWorld = sceneEcsExecutor.World;
 
@@ -41,17 +43,14 @@ namespace DCL.Multiplayer.SDK.Systems.GlobalWorld
             if (!componentFound)
                 emoteCommandComponent = new AvatarEmoteCommandComponent();
 
-            if (emoteStorage.TryGetElement(emoteIntent.EmoteId.Shorten(), out IEmote emote))
-            {
-                emoteCommandComponent.IsDirty = true;
-                emoteCommandComponent.PlayingEmote = emoteIntent.EmoteId;
-                emoteCommandComponent.LoopingEmote = emote.IsLooping();
+            emoteCommandComponent.IsDirty = true;
+            emoteCommandComponent.PlayingEmote = emoteIntent.EmoteId;
+            emoteCommandComponent.LoopingEmote = emote.IsLooping();
 
-                if (componentFound)
-                    sceneWorld.Set(playerCRDTEntity.SceneWorldEntity, emoteCommandComponent);
-                else
-                    sceneWorld.Add(playerCRDTEntity.SceneWorldEntity, emoteCommandComponent);
-            }
+            if (componentFound)
+                sceneWorld.Set(playerCRDTEntity.SceneWorldEntity, emoteCommandComponent);
+            else
+                sceneWorld.Add(playerCRDTEntity.SceneWorldEntity, emoteCommandComponent);
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fixes this issue -> #1960 
Basically we were checking only for movement, but when landing (even when jumping in place) the emote got desynchronized with the assets if it had them because it had to play the landing animation first and then it would play the emote itself.
This fixes it by adding a tag to all animator States that are related with Jumping. So we check for that tag and wait until landing has finished to start emoting.
...

## How to test the changes?

Play any emote that has associated assets (including the Confetti thrower one) while jumping. Now the emote should start after playing the landing animation and there should be no wrong synchronization with the assets.