### PR TITLE
fix: SceneShader variant merging and branching in TexArray

### DIFF
--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/Editor/CompileSceneShader.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/Editor/CompileSceneShader.cs
@@ -16,7 +16,7 @@ namespace DCL.Rendering.Menus
 
         private static readonly string[] ASSET_NAMES =
         {
-            "Scene.shader", "SceneVariants.shadervariants", "SceneVariantsManuallyAdded.shadervariants",
+            "Scene.shader", "SceneVariants.shadervariants",
         };
 
         [MenuItem("Decentraland/Shaders/Compile \"Scene\" Shader Variants")]

--- a/Explorer/ProjectSettings/GraphicsSettings.asset
+++ b/Explorer/ProjectSettings/GraphicsSettings.asset
@@ -44,7 +44,6 @@ GraphicsSettings:
   - {fileID: 20000000, guid: 29ff2a68595df104ab86d7589e04b702, type: 2}
   - {fileID: 20000000, guid: 5108e1fd8995a4642b1032eb189390ae, type: 2}
   - {fileID: 20000000, guid: 208c657bf63862c449775069ddb6a9d4, type: 2}
-  - {fileID: 20000000, guid: bced61a4141f5844f8f72cb24280f892, type: 2}
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_CustomRenderPipeline: {fileID: 11400000, guid: 362b7d6d8bc7d8a4caba9aa7515a5f6d, type: 2}

--- a/Explorer/ProjectSettings/GraphicsSettings.asset
+++ b/Explorer/ProjectSettings/GraphicsSettings.asset
@@ -42,6 +42,9 @@ GraphicsSettings:
   - {fileID: 4800000, guid: 6e9f244bbe8f40e38644cb9c55cf1a67, type: 3}
   m_PreloadedShaders:
   - {fileID: 20000000, guid: 29ff2a68595df104ab86d7589e04b702, type: 2}
+  - {fileID: 20000000, guid: 5108e1fd8995a4642b1032eb189390ae, type: 2}
+  - {fileID: 20000000, guid: 208c657bf63862c449775069ddb6a9d4, type: 2}
+  - {fileID: 20000000, guid: bced61a4141f5844f8f72cb24280f892, type: 2}
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_CustomRenderPipeline: {fileID: 11400000, guid: 362b7d6d8bc7d8a4caba9aa7515a5f6d, type: 2}


### PR DESCRIPTION
Fix: #2043 #2009

Might not fix the #2009, because it's believed the back end server is down. But we can presume if it fixes the Bubble Shooter then it'll fix the other, because the time line of the bug lines up.

Merges 2 variant lists, adds them back into pre-loaded shaders, adds dynamic branching to texarray and makes other variant changes
