### PR TITLE
Fix: arrived at destination notification bugfixes

### DIFF
--- a/Explorer/Assets/DCL/Notifications/Assets/NotificationIcons.asset
+++ b/Explorer/Assets/DCL/Notifications/Assets/NotificationIcons.asset
@@ -21,4 +21,6 @@ MonoBehaviour:
     value: {fileID: 21300000, guid: 479c1fa50834d4504a321e03a5ccee10, type: 3}
   - key: 24
     value: {fileID: 21300000, guid: de68e65bf4fba44b7a66667b1e4e3c6e, type: 3}
-  defaultIcon: {fileID: 21300000, guid: 51d0609124e474b04a9b42ec3746f089, type: 3}
+  - key: 17
+    value: {fileID: 21300000, guid: de68e65bf4fba44b7a66667b1e4e3c6e, type: 3}
+  defaultIcon: {fileID: 21300000, guid: 93b9e2f69bc2e4cada2159afb0632935, type: 3}

--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuController.cs
@@ -20,6 +20,10 @@ namespace DCL.Notifications.NotificationsMenu
     public class NotificationsMenuController : IDisposable
     {
         private const int PIXELS_PER_UNIT = 50;
+        private static readonly List<NotificationType> NOTIFICATION_TYPES_TO_IGNORE = new()
+            {
+                NotificationType.INTERNAL_ARRIVED_TO_DESTINATION
+            };
 
         private readonly NotificationsMenuView view;
         private readonly NotificationsRequestController notificationsRequestController;
@@ -164,6 +168,9 @@ namespace DCL.Notifications.NotificationsMenu
 
         private void OnNotificationReceived(INotification notification)
         {
+            if(NOTIFICATION_TYPES_TO_IGNORE.Contains(notification.Type))
+                return;
+
             notifications.Insert(0, notification);
             view.LoopList.SetListItemCount(notifications.Count, false);
             view.LoopList.RefreshAllShownItem();


### PR DESCRIPTION
## What does this PR change?

Fix #2123 
Fixes the errors listed in the issue related to the arrived at destination location by ignoring internal notification in the notification panel (as per design)

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

* Launch the explorer.
* Set a destination on the map.
* Travel to the set destination --> this should trigger the arrival notification.
* Observe if the push notification for destination arrival appears.
* Check the notifications panel in the sidebar and see if previous notifications are cleared and if new ones are obscured behind the arrival notification.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

