### PR TITLE
fix: remove delegate and introduce explicit calls to ReportHub

### DIFF
--- a/Explorer/Assets/DCL/Ipfs/LogIpfsRealm.cs
+++ b/Explorer/Assets/DCL/Ipfs/LogIpfsRealm.cs
@@ -11,14 +11,10 @@ namespace DCL.Ipfs
     public class LogIpfsRealm : IIpfsRealm
     {
         private readonly IIpfsRealm origin;
-        private readonly Action<string> log;
 
-        public LogIpfsRealm(IIpfsRealm origin) : this(origin, ReportHub.WithReport(ReportCategory.REALM).Log) { }
-
-        public LogIpfsRealm(IIpfsRealm origin, Action<string> log)
+        public LogIpfsRealm(IIpfsRealm origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public URLDomain CatalystBaseUrl
@@ -26,7 +22,9 @@ namespace DCL.Ipfs
             get
             {
                 var result = origin.CatalystBaseUrl;
-                log($"IpfsRealm CatalystBaseUrl requested, result: {result}");
+                ReportHub
+                    .WithReport(ReportCategory.REALM)
+                    .Log($"IpfsRealm CatalystBaseUrl requested, result: {result}");
                 return result;
             }
         }
@@ -36,7 +34,9 @@ namespace DCL.Ipfs
             get
             {
                 var result = origin.ContentBaseUrl;
-                log($"IpfsRealm ContentBaseUrl requested, result: {result}");
+                ReportHub
+                    .WithReport(ReportCategory.REALM)
+                    .Log($"IpfsRealm ContentBaseUrl requested, result: {result}");
                 return result;
             }
         }
@@ -46,7 +46,9 @@ namespace DCL.Ipfs
             get
             {
                 var result = origin.LambdasBaseUrl;
-                log($"IpfsRealm LambdasBaseUrl requested, result: {result}");
+                ReportHub
+                    .WithReport(ReportCategory.REALM)
+                    .Log($"IpfsRealm LambdasBaseUrl requested, result: {result}");
                 return result;
             }
         }
@@ -56,7 +58,9 @@ namespace DCL.Ipfs
             get
             {
                 var result = origin.SceneUrns;
-                log($"IpfsRealm SceneUrns requested, result: {string.Join(", ", result)}");
+                ReportHub
+                    .WithReport(ReportCategory.REALM)
+                    .Log($"IpfsRealm SceneUrns requested, result: {string.Join(", ", result)}");
                 return result;
             }
         }
@@ -66,7 +70,9 @@ namespace DCL.Ipfs
             get
             {
                 var result = origin.EntitiesActiveEndpoint;
-                log($"IpfsRealm EntitiesActiveEndpoint requested, result: {result}");
+                ReportHub
+                    .WithReport(ReportCategory.REALM)
+                    .Log($"IpfsRealm EntitiesActiveEndpoint requested, result: {result}");
                 return result;
             }
         }
@@ -77,14 +83,18 @@ namespace DCL.Ipfs
             sb.AppendLine("IpfsRealm PublishAsync requested");
             sb.AppendLine($"Entity: {entity.FullInfo()}");
             sb.AppendLine($"Content files: {string.Join(", ", contentFiles?.Keys ?? Array.Empty<string>())}");
-            log(sb.ToString());
+            ReportHub
+                .WithReport(ReportCategory.REALM)
+                .Log(sb.ToString());
             await origin.PublishAsync(entity, ct, contentFiles);
         }
 
         public string GetFileHash(byte[] file)
         {
             string result = origin.GetFileHash(file);
-            log($"IpfsRealm GetFileHash requested, result: {result}");
+            ReportHub
+                .WithReport(ReportCategory.REALM)
+                .Log($"IpfsRealm GetFileHash requested, result: {result}");
             return result;
         }
     }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/AdapterAddress/IAdapterAddresses.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/AdapterAddress/IAdapterAddresses.cs
@@ -12,9 +12,8 @@ namespace DCL.Multiplayer.Connections.Archipelago.AdapterAddress
         public static IAdapterAddresses NewDefault()
         {
             return new LogAdapterAddresses(
-                new RefinedAdapterAddresses(),
-                ReportHub.WithReport(ReportCategory.ARCHIPELAGO_REQUEST).Log
-            );
+                new RefinedAdapterAddresses()
+                );
         }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/AdapterAddress/LogAdapterAddresses.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/AdapterAddress/LogAdapterAddresses.cs
@@ -1,25 +1,28 @@
 using Cysharp.Threading.Tasks;
 using System;
 using System.Threading;
+using DCL.Diagnostics;
 
 namespace DCL.Multiplayer.Connections.Archipelago.AdapterAddress
 {
     public class LogAdapterAddresses : IAdapterAddresses
     {
         private readonly IAdapterAddresses origin;
-        private readonly Action<string> log;
 
-        public LogAdapterAddresses(IAdapterAddresses origin, Action<string> log)
+        public LogAdapterAddresses(IAdapterAddresses origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public string AdapterUrlAsync(string unrefinedComms)
         {
-            log($"Original comms adapter is: {unrefinedComms}");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"Original comms adapter is: {unrefinedComms}");
             unrefinedComms = origin.AdapterUrlAsync(unrefinedComms);
-            log($"Modified comms adapter is: {unrefinedComms}");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"Modified comms adapter is: {unrefinedComms}");
             return unrefinedComms;
         }
     }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/LogArchipelagoLiveConnection.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/LogArchipelagoLiveConnection.cs
@@ -11,7 +11,6 @@ namespace DCL.Multiplayer.Connections.Archipelago.LiveConnections
     public class LogArchipelagoLiveConnection : IArchipelagoLiveConnection
     {
         private readonly IArchipelagoLiveConnection origin;
-        private readonly Action<string> log;
 
         private bool? previousConnected;
 
@@ -23,7 +22,9 @@ namespace DCL.Multiplayer.Connections.Archipelago.LiveConnections
 
                 if (previousConnected != result)
                 {
-                    log($"ArchipelagoLiveConnection connected: {result}");
+                    ReportHub
+                        .WithReport(ReportCategory.ARCHIPELAGO_REQUEST)
+                        .Log($"ArchipelagoLiveConnection connected: {result}");
                     previousConnected = result;
                 }
 
@@ -31,42 +32,55 @@ namespace DCL.Multiplayer.Connections.Archipelago.LiveConnections
             }
         }
 
-        public LogArchipelagoLiveConnection(IArchipelagoLiveConnection origin) : this(origin, ReportHub.WithReport(ReportCategory.ARCHIPELAGO_REQUEST).Log) { }
-
-        public LogArchipelagoLiveConnection(IArchipelagoLiveConnection origin, Action<string> log)
+        public LogArchipelagoLiveConnection(IArchipelagoLiveConnection origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public async UniTask<Result> ConnectAsync(string adapterUrl, CancellationToken token)
         {
-            log($"ArchipelagoLiveConnection ConnectAsync start to: {adapterUrl}");
+            ReportHub
+                .WithReport(ReportCategory.ARCHIPELAGO_REQUEST)
+                .Log($"ArchipelagoLiveConnection ConnectAsync start to: {adapterUrl}");
             var result = await origin.ConnectAsync(adapterUrl, token);
-            log($"ArchipelagoLiveConnection ConnectAsync finished to: {adapterUrl} with result: {result.Success}");
+            ReportHub
+                .WithReport(ReportCategory.ARCHIPELAGO_REQUEST)
+                .Log($"ArchipelagoLiveConnection ConnectAsync finished to: {adapterUrl} with result: {result.Success}");
             return result;
         }
 
         public async UniTask DisconnectAsync(CancellationToken token)
         {
-            log("ArchipelagoLiveConnection DisconnectAsync start");
+            ReportHub
+                .WithReport(ReportCategory.ARCHIPELAGO_REQUEST)
+                .Log("ArchipelagoLiveConnection DisconnectAsync start");
             await origin.DisconnectAsync(token);
-            log("ArchipelagoLiveConnection DisconnectAsync finished");
+            ReportHub
+                .WithReport(ReportCategory.ARCHIPELAGO_REQUEST)
+                .Log("ArchipelagoLiveConnection DisconnectAsync finished");
         }
 
         public async UniTask<EnumResult<IArchipelagoLiveConnection.ResponseError>> SendAsync(MemoryWrap data, CancellationToken token)
         {
-            log($"ArchipelagoLiveConnection SendAsync start with size: {data.Length} and content: {data.HexReadableString()}");
+            ReportHub
+                .WithReport(ReportCategory.ARCHIPELAGO_REQUEST)
+                .Log($"ArchipelagoLiveConnection SendAsync start with size: {data.Length} and content: {data.HexReadableString()}");
             var result = await origin.SendAsync(data, token);
-            log($"ArchipelagoLiveConnection SendAsync finished with size: {data.Length} and content: {data.HexReadableString()}");
+            ReportHub
+                .WithReport(ReportCategory.ARCHIPELAGO_REQUEST)
+                .Log($"ArchipelagoLiveConnection SendAsync finished with size: {data.Length} and content: {data.HexReadableString()}");
             return result;
         }
 
         public async UniTask<EnumResult<MemoryWrap, IArchipelagoLiveConnection.ResponseError>> ReceiveAsync(CancellationToken token)
         {
-            log("ArchipelagoLiveConnection ReceiveAsync start");
+            ReportHub
+                .WithReport(ReportCategory.ARCHIPELAGO_REQUEST)
+                .Log("ArchipelagoLiveConnection ReceiveAsync start");
             var result = await origin.ReceiveAsync(token);
-            log($"ArchipelagoLiveConnection ReceiveAsync finished with error: {result.Error?.Message ?? "no error"}, size: {(result.Success ? result.Value.Length : 0)}");
+            ReportHub
+                .WithReport(ReportCategory.ARCHIPELAGO_REQUEST)
+                .Log($"ArchipelagoLiveConnection ReceiveAsync finished with error: {result.Error?.Message ?? "no error"}, size: {(result.Success ? result.Value.Length : 0)}");
             return result;
         }
     }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/LogMetaDataSource.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/LogMetaDataSource.cs
@@ -11,21 +11,21 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
         private const string PREFIX = "MetaDataSource:";
 
         private readonly IMetaDataSource origin;
-        private readonly Action<string> log;
 
-        public LogMetaDataSource(IMetaDataSource origin) : this(origin, ReportHub.WithReport(ReportCategory.LIVEKIT).Log) { }
-
-        public LogMetaDataSource(IMetaDataSource origin, Action<string> log)
+        public LogMetaDataSource(IMetaDataSource origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public async UniTask<MetaData> MetaDataAsync(CancellationToken token)
         {
-            log($"{PREFIX} MetaDataAsync start");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"{PREFIX} MetaDataAsync start");
             MetaData result = await origin.MetaDataAsync(token);
-            log($"{PREFIX} MetaDataAsync finish {result.realmName} {result.sceneId}");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"{PREFIX} MetaDataAsync finish {result.realmName} {result.sceneId}");
             return result;
         }
     }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/LogRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/LogRoom.cs
@@ -20,7 +20,6 @@ namespace DCL.Multiplayer.Connections.Rooms
         private const string PREFIX = "LogRoom:";
 
         private readonly IRoom origin;
-        private readonly Action<string> log;
 
         public IActiveSpeakers ActiveSpeakers { get; }
         public IParticipantsHub Participants { get; }
@@ -43,17 +42,14 @@ namespace DCL.Multiplayer.Connections.Rooms
 
         public LogRoom() : this(new Room()) { }
 
-        public LogRoom(IRoom origin) : this(origin, ReportHub.WithReport(ReportCategory.LIVEKIT).Log) { }
-
-        public LogRoom(IRoom origin, Action<string> log)
+        public LogRoom(IRoom origin)
         {
             this.origin = origin;
-            this.log = log;
 
-            ActiveSpeakers = new LogActiveSpeakers(origin.ActiveSpeakers, log);
-            Participants = new LogParticipantsHub(origin.Participants, log);
-            DataPipe = new LogDataPipe(origin.DataPipe, log);
-            Info = new LogRoomInfo(origin.Info, log);
+            ActiveSpeakers = new LogActiveSpeakers(origin.ActiveSpeakers);
+            Participants = new LogParticipantsHub(origin.Participants);
+            DataPipe = new LogDataPipe(origin.DataPipe);
+            Info = new LogRoomInfo(origin.Info);
 
             this.origin.LocalTrackPublished += OriginOnLocalTrackPublished;
             this.origin.LocalTrackUnpublished += OriginOnLocalTrackUnpublished;
@@ -71,110 +67,137 @@ namespace DCL.Multiplayer.Connections.Rooms
 
         private void OriginOnRoomMetadataChanged(string metadata)
         {
-            log($"{PREFIX} room metadata changed {metadata}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} room metadata changed {metadata}");
             RoomMetadataChanged?.Invoke(metadata);
         }
 
         private void OriginOnConnectionUpdated(IRoom room, ConnectionUpdate connectionupdate)
         {
-            log($"{PREFIX} connection updated {connectionupdate}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} connection updated {connectionupdate}");
             ConnectionUpdated?.Invoke(room, connectionupdate);
         }
 
         private void OriginOnConnectionStateChanged(ConnectionState connectionstate)
         {
-            log($"{PREFIX} connection state changed {connectionstate}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} connection state changed {connectionstate}");
             ConnectionStateChanged?.Invoke(connectionstate);
         }
 
         private void OriginOnConnectionQualityChanged(ConnectionQuality quality, Participant participant)
         {
-            log($"{PREFIX} connection quality changed {quality} by {participant.Sid} {participant.Name}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} connection quality changed {quality} by {participant.Sid} {participant.Name}");
             ConnectionQualityChanged?.Invoke(quality, participant);
         }
 
         private void OriginOnTrackUnmuted(TrackPublication publication, Participant participant)
         {
-            log($"{PREFIX} track unmuted {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} track unmuted {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
             TrackUnmuted?.Invoke(publication, participant);
         }
 
         private void OriginOnTrackMuted(TrackPublication publication, Participant participant)
         {
-            log($"{PREFIX} track muted {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} track muted {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
             TrackMuted?.Invoke(publication, participant);
         }
 
         private void OriginOnTrackUnsubscribed(ITrack track, TrackPublication publication, Participant participant)
         {
-            log($"{PREFIX} track unsubscribed {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} track unsubscribed {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
             TrackUnsubscribed?.Invoke(track, publication, participant);
         }
 
         private void OriginOnTrackSubscribed(ITrack track, TrackPublication publication, Participant participant)
         {
-            log($"{PREFIX} track subscribed {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} track subscribed {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
             TrackSubscribed?.Invoke(track, publication, participant);
         }
 
         private void OriginOnLocalTrackPublished(TrackPublication publication, Participant participant)
         {
-            log($"{PREFIX} local track published {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} local track published {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
             LocalTrackPublished?.Invoke(publication, participant);
         }
 
         private void OriginOnTrackUnpublished(TrackPublication publication, Participant participant)
         {
-            log($"{PREFIX} track unpublished {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} track unpublished {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
             TrackUnpublished?.Invoke(publication, participant);
         }
 
         private void OriginOnLocalTrackUnpublished(TrackPublication publication, Participant participant)
         {
-            log($"{PREFIX} local track unpublished {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} local track unpublished {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
             LocalTrackUnpublished?.Invoke(publication, participant);
         }
 
         private void OriginOnTrackPublished(TrackPublication publication, Participant participant)
         {
-            log($"{PREFIX} track published {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} track published {publication.Sid} {publication.Kind} by {participant.Sid} {participant.Name}");
             TrackPublished?.Invoke(publication, participant);
         }
 
         public void UpdateLocalMetadata(string metadata)
         {
-            log($"{PREFIX} update local metadata: '{metadata}'");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} update local metadata: '{metadata}'");
             origin.UpdateLocalMetadata(metadata);
         }
 
         public void SetLocalName(string name)
         {
-            log($"{PREFIX} set local name: '{name}'");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} set local name: '{name}'");
             origin.SetLocalName(name);
         }
 
         public async Task<bool> ConnectAsync(string url, string authToken, CancellationToken cancelToken, bool autoSubscribe)
         {
-            log($"{PREFIX} connect start {url} with token {authToken}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} connect start {url} with token {authToken}");
             bool result = await origin.ConnectAsync(url, authToken, cancelToken, autoSubscribe);
-            log($"{PREFIX} connect start {url} with token {authToken} with result {result}");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} connect start {url} with token {authToken} with result {result}");
             return result;
         }
 
         public async Task DisconnectAsync(CancellationToken token)
         {
-            log($"{PREFIX} disconnect start");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} disconnect start");
             await origin.DisconnectAsync(token);
-            log($"{PREFIX} disconnect end");
+            ReportHub
+                .WithReport(ReportCategory.LIVEKIT)
+                .Log($"{PREFIX} disconnect end");
         }
-    }
-
-    public static class LogRoomExtensions
-    {
-        public static IRoom WithLog(this IRoom room) =>
-            new LogRoom(room);
-
-        public static IRoom WithLog(this IRoom room, Action<string> log) =>
-            new LogRoom(room, log);
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogActiveSpeakers.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogActiveSpeakers.cs
@@ -11,32 +11,32 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
         private const string PREFIX = "LogActiveSpeakers:";
 
         private readonly IActiveSpeakers origin;
-        private readonly Action<string> log;
 
         public int Count
         {
             get
             {
                 int count = origin.Count;
-                log($"{PREFIX} count {count}");
+                ReportHub
+                   .WithReport(ReportCategory.LIVEKIT)
+                   .Log($"{PREFIX} count {count}");
                 return count;
             }
         }
 
         public event Action? Updated;
 
-        public LogActiveSpeakers(IActiveSpeakers origin) : this(origin, ReportHub.WithReport(ReportCategory.LIVEKIT).Log) { }
-
-        public LogActiveSpeakers(IActiveSpeakers origin, Action<string> log)
+        public LogActiveSpeakers(IActiveSpeakers origin)
         {
             this.origin = origin;
-            this.log = log;
             origin.Updated += OriginOnUpdated;
         }
 
         private void OriginOnUpdated()
         {
-            log($"{PREFIX} updated");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"{PREFIX} updated");
             Updated?.Invoke();
         }
 
@@ -46,7 +46,9 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
 
             foreach (string? speaker in origin)
             {
-                log($"{PREFIX} speaker:{count++} - {speaker}");
+                ReportHub
+                   .WithReport(ReportCategory.LIVEKIT)
+                   .Log($"{PREFIX} speaker:{count++} - {speaker}");
                 yield return speaker;
             }
         }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogDataPipe.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogDataPipe.cs
@@ -12,28 +12,28 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
         private const string PREFIX = "LogDataPipe:";
 
         private readonly IDataPipe origin;
-        private readonly Action<string> log;
 
         public event ReceivedDataDelegate? DataReceived;
 
-        public LogDataPipe(IDataPipe origin) : this(origin, ReportHub.WithReport(ReportCategory.LIVEKIT).Log) { }
-
-        public LogDataPipe(IDataPipe origin, Action<string> log)
+        public LogDataPipe(IDataPipe origin)
         {
             this.origin = origin;
-            this.log = log;
             origin.DataReceived += OriginOnDataReceived;
         }
 
         private void OriginOnDataReceived(ReadOnlySpan<byte> data, Participant participant, DataPacketKind kind)
         {
-            log($"{PREFIX} data received {data.Length} bytes from {participant.ReadableString()} - {kind}");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"{PREFIX} data received {data.Length} bytes from {participant.ReadableString()} - {kind}");
             DataReceived?.Invoke(data, participant, kind);
         }
 
         public void PublishData(Span<byte> data, string topic, IReadOnlyCollection<string> destinationSids, DataPacketKind kind = DataPacketKind.KindLossy)
         {
-            log($"{PREFIX} publish data {data.Length} bytes to {topic} - {string.Join(", ", destinationSids)} - {kind}");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"{PREFIX} publish data {data.Length} bytes to {topic} - {string.Join(", ", destinationSids)} - {kind}");
             origin.PublishData(data, topic, destinationSids, kind);
         }
     }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogParticipantsHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogParticipantsHub.cs
@@ -9,48 +9,48 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
     {
         private const string PREFIX = "LogParticipantsHub:";
         private readonly IParticipantsHub origin;
-        private readonly Action<string> log;
+        private readonly string logPrefix;
 
         public event ParticipantDelegate? UpdatesFromParticipant;
 
-        public LogParticipantsHub(IParticipantsHub origin) : this(
-            origin,
-            ReportHub
-               .WithReport(ReportCategory.LIVEKIT)
-               .Log
-        ) { }
-
-        public LogParticipantsHub(IParticipantsHub origin, Action<string> log)
+        public LogParticipantsHub(IParticipantsHub origin)
         {
             this.origin = origin;
-            this.log = log;
             origin.UpdatesFromParticipant += OriginOnUpdatesFromParticipant;
         }
 
         private void OriginOnUpdatesFromParticipant(Participant participant, UpdateFromParticipant update)
         {
-            log($"{PREFIX} updates from participant {participant} - {update}");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"{logPrefix} - {PREFIX} updates from participant {participant} - {update}");
             UpdatesFromParticipant?.Invoke(participant, update);
         }
 
         public Participant LocalParticipant()
         {
             Participant participant = origin.LocalParticipant();
-            log($"{PREFIX} local {participant.ReadableString()}");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"{PREFIX} local {participant.ReadableString()}");
             return participant;
         }
 
         public Participant? RemoteParticipant(string identity)
         {
             Participant? participant = origin.RemoteParticipant(identity);
-            log($"{PREFIX} with sid {identity} remote {participant?.ReadableString() ?? "NONE"}");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"{PREFIX} with sid {identity} remote {participant?.ReadableString() ?? "NONE"}");
             return participant;
         }
 
         public IReadOnlyCollection<string> RemoteParticipantIdentities()
         {
             IReadOnlyCollection<string> sids = origin.RemoteParticipantIdentities();
-            log($"{PREFIX} remote sids {(sids.Count > 0 ? string.Join(", ", sids) : "empty")} ");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"{PREFIX} remote sids {(sids.Count > 0 ? string.Join(", ", sids) : "empty")} ");
             return sids;
         }
     }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogRoomInfo.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogRoomInfo.cs
@@ -8,14 +8,15 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
     public class LogRoomInfo : IRoomInfo
     {
         private readonly IRoomInfo origin;
-        private readonly Action<string> log;
 
         public ConnectionState ConnectionState
         {
             get
             {
                 ConnectionState connectionState = origin.ConnectionState;
-                log($"LogRoomInfo: ConnectionState: {connectionState}");
+                ReportHub
+                   .WithReport(ReportCategory.LIVEKIT)
+                   .Log($"LogRoomInfo: ConnectionState: {connectionState}");
                 return connectionState;
             }
         }
@@ -25,7 +26,9 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
             get
             {
                 string sid = origin.Sid;
-                log($"LogRoomInfo: Sid: {sid}");
+                ReportHub
+                   .WithReport(ReportCategory.LIVEKIT)
+                   .Log($"LogRoomInfo: Sid: {sid}");
                 return sid;
             }
         }
@@ -35,7 +38,9 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
             get
             {
                 string name = origin.Name;
-                log($"LogRoomInfo: Name: {name}");
+                ReportHub
+                   .WithReport(ReportCategory.LIVEKIT)
+                   .Log($"LogRoomInfo: Name: {name}");
                 return name;
             }
         }
@@ -45,17 +50,16 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
             get
             {
                 string metadata = origin.Metadata;
-                log($"LogRoomInfo: Metadata: {metadata}");
+                ReportHub
+                   .WithReport(ReportCategory.LIVEKIT)
+                   .Log($"LogRoomInfo: Metadata: {metadata}");
                 return metadata;
             }
         }
 
-        public LogRoomInfo(IRoomInfo origin) : this(origin, ReportHub.WithReport(ReportCategory.LIVEKIT).Log) { }
-
-        public LogRoomInfo(IRoomInfo origin, Action<string> log)
+        public LogRoomInfo(IRoomInfo origin)
         {
             this.origin = origin;
-            this.log = log;
         }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/Poses/RemotePoses.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/Poses/RemotePoses.cs
@@ -14,18 +14,12 @@ namespace DCL.Multiplayer.Profiles.Poses
     {
         private readonly IRoomHub roomHub;
         private readonly ConcurrentDictionary<string, Vector2Int> poses = new ();
-        private readonly Action<string> log;
 
         public int Count => poses.Count;
 
-        public RemotePoses(IRoomHub roomHub) : this(roomHub, ReportHub.WithReport(ReportCategory.MULTIPLAYER_MOVEMENT).Log)
-        {
-        }
-
-        public RemotePoses(IRoomHub roomHub, Action<string> log)
+        public RemotePoses(IRoomHub roomHub)
         {
             this.roomHub = roomHub;
-            this.log = log;
 
             roomHub.IslandRoom().Participants.UpdatesFromParticipant += ParticipantsOnUpdatesFromParticipant;
         }
@@ -47,7 +41,9 @@ namespace DCL.Multiplayer.Profiles.Poses
             {
                 var message = JsonUtility.FromJson<Message>(participant.Metadata);
                 var pose = poses[participant.Identity] = new Vector2Int(message.x, message.y);
-                log($"RemotePoses: pose of {participant.Identity} is {pose}");
+                ReportHub
+                    .WithReport(ReportCategory.MULTIPLAYER_MOVEMENT)
+                    .Log($"RemotePoses: pose of {participant.Identity} is {pose}");
             }
         }
 
@@ -66,7 +62,9 @@ namespace DCL.Multiplayer.Profiles.Poses
         {
             await UniTask.SwitchToThreadPool();
             roomHub.IslandRoom().UpdateLocalMetadata(new Message(pose).ToJson());
-            log($"RemotePoses: pose of self {pose} is sent");
+            ReportHub
+                .WithReport(ReportCategory.MULTIPLAYER_MOVEMENT)
+                .Log($"RemotePoses: pose of self {pose} is sent");
         }
 
         //TODO later transfer to Proto

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/RemoveIntentions/LogRemoveIntentions.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/RemoveIntentions/LogRemoveIntentions.cs
@@ -7,22 +7,18 @@ namespace DCL.Multiplayer.Profiles.RemoveIntentions
     public class LogRemoveIntentions : IRemoveIntentions
     {
         private readonly IRemoveIntentions origin;
-        private readonly Action<string> log;
 
-        public LogRemoveIntentions(IRemoveIntentions origin) : this(origin, ReportHub.WithReport(ReportCategory.LIVEKIT).Log)
-        {
-        }
-
-        public LogRemoveIntentions(IRemoveIntentions origin, Action<string> log)
+        public LogRemoveIntentions(IRemoveIntentions origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public OwnedBunch<RemoveIntention> Bunch()
         {
             OwnedBunch<RemoveIntention> bunch = origin.Bunch();
-            log($"LogRemoveIntentions: bunch with count {bunch.Collection().Count}");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"LogRemoveIntentions: bunch with count {bunch.Collection().Count}");
             return bunch;
         }
     }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportHub.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportHub.cs
@@ -150,13 +150,15 @@ namespace DCL.Diagnostics
             }
 
             [HideInCallstack]
+            [Conditional("UNITY_EDITOR")] [Conditional("VERBOSE_LOGS")] // don't remove conditionals, otherwise strings will be allocated in production builds
             public void Log(object message, ReportHandler reportToHandlers = ReportHandler.All)
             {
                 ReportHub.Log(reportData, message, reportToHandlers);
             }
 
             [HideInCallstack]
-            public void Log(string message)
+            [Conditional("UNITY_EDITOR")] [Conditional("VERBOSE_LOGS")] // don't remove conditionals, otherwise strings will be allocated in production builds
+            public void Log(object message)
             {
                 ReportHub.Log(reportData, message);
             }

--- a/Explorer/Assets/DCL/Profiles/Repository/LogProfileRepository.cs
+++ b/Explorer/Assets/DCL/Profiles/Repository/LogProfileRepository.cs
@@ -8,28 +8,32 @@ namespace DCL.Profiles
     public class LogProfileRepository : IProfileRepository
     {
         private readonly IProfileRepository origin;
-        private readonly Action<string> log;
 
-        public LogProfileRepository(IProfileRepository origin) : this(origin, ReportHub.WithReport(ReportCategory.PROFILE).Log) { }
-
-        public LogProfileRepository(IProfileRepository origin, Action<string> log)
+        public LogProfileRepository(IProfileRepository origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public async UniTask SetAsync(Profile profile, CancellationToken ct)
         {
-            log($"ProfileRepository: set requested for profile: {profile}");
+            ReportHub
+               .WithReport(ReportCategory.PROFILE)
+               .Log($"ProfileRepository: set requested for profile: {profile}");
             await origin.SetAsync(profile, ct);
-            log($"ProfileRepository: set finished for profile: {profile}");
+            ReportHub
+               .WithReport(ReportCategory.PROFILE)
+               .Log($"ProfileRepository: set finished for profile: {profile}");
         }
 
         public async UniTask<Profile?> GetAsync(string id, int version, CancellationToken ct)
         {
-            log($"ProfileRepository: get requested for id: {id}, version: {version}");
+            ReportHub
+               .WithReport(ReportCategory.PROFILE)
+               .Log($"ProfileRepository: get requested for id: {id}, version: {version}");
             var result = await origin.GetAsync(id, version, ct);
-            log($"ProfileRepository: get finished for id: {id}, version: {version}, profile: {result}{(result == null ? "null" : string.Empty)}");
+            ReportHub
+               .WithReport(ReportCategory.PROFILE)
+               .Log($"ProfileRepository: get finished for id: {id}, version: {version}, profile: {result}{(result == null ? "null" : string.Empty)}");
             return result;
         }
     }

--- a/Explorer/Assets/DCL/Rendering/Highlight/HighlightRendererFeature.cs
+++ b/Explorer/Assets/DCL/Rendering/Highlight/HighlightRendererFeature.cs
@@ -39,8 +39,7 @@ namespace DCL.Rendering.Highlight
         private static readonly Dictionary<Renderer, HighlightSettings> m_HighLightRenderers = new ();
 
         public static readonly IHighlightedObjects HighlightedObjects = new LogHighlightedObjects(
-            new HighlightedObjects(m_HighLightRenderers),
-            ReportHub.WithReport(ReportCategory.HIGHLIGHTS).Log
+            new HighlightedObjects(m_HighLightRenderers)
         );
 
         // Input P;ass Data

--- a/Explorer/Assets/DCL/Rendering/Highlight/HighlightedObject/LogHighlightedObjects.cs
+++ b/Explorer/Assets/DCL/Rendering/Highlight/HighlightedObject/LogHighlightedObjects.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using DCL.Diagnostics;
 
 namespace DCL.Rendering.Highlight.HighlightedObject
 {
@@ -8,25 +9,27 @@ namespace DCL.Rendering.Highlight.HighlightedObject
     {
         private readonly HashSet<Renderer> highlighted = new ();
         private readonly IHighlightedObjects origin;
-        private readonly Action<string> log;
 
-        public LogHighlightedObjects(IHighlightedObjects origin, Action<string> log)
+        public LogHighlightedObjects(IHighlightedObjects origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public void Highlight(Renderer renderer, Color color, float thickness)
         {
             highlighted.Add(renderer);
-            log($"Highlighting {renderer.name}, currently {highlighted.Count} highlighted objects");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"Highlighting {renderer.name}, currently {highlighted.Count} highlighted objects");
             origin.Highlight(renderer, color, thickness);
         }
 
         public void Disparage(Renderer renderer)
         {
             highlighted.Remove(renderer);
-            log($"Disparage {renderer.name}, currently {highlighted.Count} highlighted objects");
+            ReportHub
+               .WithReport(ReportCategory.LIVEKIT)
+               .Log($"Disparage {renderer.name}, currently {highlighted.Count} highlighted objects");
             origin.Disparage(renderer);
         }
 

--- a/Explorer/Assets/DCL/Web3/Accounts/LogWeb3Account.cs
+++ b/Explorer/Assets/DCL/Web3/Accounts/LogWeb3Account.cs
@@ -9,21 +9,19 @@ namespace DCL.Web3.Accounts
     public class LogWeb3Account : IWeb3Account
     {
         private readonly IWeb3Account origin;
-        private readonly Action<string> log;
 
-        public LogWeb3Account(IWeb3Account origin) : this(origin, ReportHub.WithReport(ReportCategory.PROFILE).Log) { }
-
-        public LogWeb3Account(IWeb3Account origin, Action<string> log)
+        public LogWeb3Account(IWeb3Account origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public Web3Address Address
         {
             get
             {
-                log($"Web3Account Address requested: {origin.Address}");
+                ReportHub
+                   .WithReport(ReportCategory.PROFILE)
+                   .Log($"Web3Account Address requested: {origin.Address}");
                 return origin.Address;
             }
         }
@@ -32,24 +30,34 @@ namespace DCL.Web3.Accounts
         {
             get
             {
-                log($"Web3Account PrivateKey requested: {origin.PrivateKey}");
+                ReportHub
+                   .WithReport(ReportCategory.PROFILE)
+                   .Log($"Web3Account PrivateKey requested: {origin.PrivateKey}");
                 return origin.PrivateKey;
             }
         }
 
         public string Sign(string message)
         {
-            log($"Web3Account Sign requested: {message}");
+            ReportHub
+               .WithReport(ReportCategory.PROFILE)
+               .Log($"Web3Account Sign requested: {message}");
             string result = origin.Sign(message);
-            log($"Web3Account Sign result: {result} for {message}");
+            ReportHub
+               .WithReport(ReportCategory.PROFILE)
+               .Log($"Web3Account Sign result: {result} for {message}");
             return result;
         }
 
         public bool Verify(string message, string signature)
         {
-            log($"Web3Account Verify requested: {message} with {signature}");
+            ReportHub
+               .WithReport(ReportCategory.PROFILE)
+               .Log($"Web3Account Verify requested: {message} with {signature}");
             bool result = origin.Verify(message, signature);
-            log($"Web3Account Verify result: {result} for {message} with {signature}");
+            ReportHub
+               .WithReport(ReportCategory.PROFILE)
+               .Log($"Web3Account Verify result: {result} for {message} with {signature}");
             return result;
         }
     }

--- a/Explorer/Assets/DCL/Web3/Identities/LogWeb3Identity.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/LogWeb3Identity.cs
@@ -10,14 +10,10 @@ namespace DCL.Web3.Identities
     public class LogWeb3Identity : IWeb3Identity
     {
         private readonly IWeb3Identity origin;
-        private readonly Action<string> log;
 
-        public LogWeb3Identity(IWeb3Identity origin) : this(origin, ReportHub.WithReport(ReportCategory.PROFILE).Log) { }
-
-        public LogWeb3Identity(IWeb3Identity origin, Action<string> log)
+        public LogWeb3Identity(IWeb3Identity origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public void Dispose()
@@ -29,7 +25,9 @@ namespace DCL.Web3.Identities
         {
             get
             {
-                log($"Web3Identity Address requested: {origin.Address}");
+                ReportHub
+                    .WithReport(ReportCategory.PROFILE)
+                    .Log($"Web3Identity Address requested: {origin.Address}");
                 return origin.Address;
             }
         }
@@ -38,18 +36,22 @@ namespace DCL.Web3.Identities
         {
             get
             {
-                log($"Web3Identity Expiration requested: {origin.Expiration}");
+                ReportHub
+                    .WithReport(ReportCategory.PROFILE)
+                    .Log($"Web3Identity Expiration requested: {origin.Expiration}");
                 return origin.Expiration;
             }
         }
 
-        public IWeb3Account EphemeralAccount => new LogWeb3Account(origin.EphemeralAccount, log);
+        public IWeb3Account EphemeralAccount => new LogWeb3Account(origin.EphemeralAccount);
 
         public bool IsExpired
         {
             get
             {
-                log($"Web3Identity IsExpired requested: {origin.IsExpired}");
+                ReportHub
+                    .WithReport(ReportCategory.PROFILE)
+                    .Log($"Web3Identity IsExpired requested: {origin.IsExpired}");
                 return origin.IsExpired;
             }
         }
@@ -58,16 +60,22 @@ namespace DCL.Web3.Identities
         {
             get
             {
-                log($"Web3Identity AuthChain requested: {origin.AuthChain}");
+                ReportHub
+                    .WithReport(ReportCategory.PROFILE)
+                    .Log($"Web3Identity AuthChain requested: {origin.AuthChain}");
                 return origin.AuthChain;
             }
         }
 
         public AuthChain Sign(string entityId)
         {
-            log($"Web3Identity Sign requested: entity {entityId}");
+            ReportHub
+                .WithReport(ReportCategory.PROFILE)
+                .Log($"Web3Identity Sign requested: entity {entityId}");
             var result = origin.Sign(entityId);
-            log($"Web3Identity Sign result: {result} for entity {entityId}");
+            ReportHub
+                .WithReport(ReportCategory.PROFILE)
+                .Log($"Web3Identity Sign result: {result} for entity {entityId}");
             return result;
         }
     }

--- a/Explorer/Assets/DCL/Web3/Identities/LogWeb3IdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/LogWeb3IdentityCache.cs
@@ -6,21 +6,17 @@ namespace DCL.Web3.Identities
     public class LogWeb3IdentityCache : IWeb3IdentityCache
     {
         private readonly IWeb3IdentityCache origin;
-        private readonly Action<string> log;
 
-        public LogWeb3IdentityCache(IWeb3IdentityCache origin) : this(origin, ReportHub.WithReport(ReportCategory.PROFILE).Log)
-        {
-        }
-
-        public LogWeb3IdentityCache(IWeb3IdentityCache origin, Action<string> log)
+        public LogWeb3IdentityCache(IWeb3IdentityCache origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public void Dispose()
         {
-            log("Web3IdentityCache Dispose requested");
+            ReportHub
+               .WithReport(ReportCategory.PROFILE)
+               .Log("Web3IdentityCache Dispose requested");
             origin.Dispose();
         }
 
@@ -28,23 +24,29 @@ namespace DCL.Web3.Identities
         {
             get
             {
-                log("Web3IdentityCache Identity value get requested");
+                ReportHub
+                   .WithReport(ReportCategory.PROFILE)
+                   .Log("Web3IdentityCache Identity value get requested");
                 var value = origin.Identity;
                 return value == null
                     ? null
-                    : new LogWeb3Identity(value, log);
+                    : new LogWeb3Identity(value);
             }
 
             set
             {
-                log("Web3IdentityCache Identity value set requested");
+                ReportHub
+                   .WithReport(ReportCategory.PROFILE)
+                   .Log("Web3IdentityCache Identity value set requested");
                 origin.Identity = value;
             }
         }
 
         public void Clear()
         {
-            log("Web3IdentityCache Clear requested");
+            ReportHub
+               .WithReport(ReportCategory.PROFILE)
+               .Log("Web3IdentityCache Clear requested");
             origin.Clear();
         }
     }

--- a/Explorer/Assets/Scripts/SceneRuntime/Factory/JsSceneSourceCode/IJsSceneLocalSourceCode.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Factory/JsSceneSourceCode/IJsSceneLocalSourceCode.cs
@@ -21,8 +21,7 @@ namespace SceneRuntime.Factory.JsSceneSourceCode
             {
                 origin = Application.isEditor
                     ? new LogJsSceneLocalSourceCode(
-                        new StreamingAssetsJsSceneLocalSourceCode(),
-                        ReportHub.WithReport(ReportCategory.SCENE_FACTORY).Log
+                        new StreamingAssetsJsSceneLocalSourceCode()
                     )
                     : new Null();
             }

--- a/Explorer/Assets/Scripts/SceneRuntime/Factory/JsSceneSourceCode/LogJsSceneLocalSourceCode.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Factory/JsSceneSourceCode/LogJsSceneLocalSourceCode.cs
@@ -1,23 +1,24 @@
 using System;
 using UnityEngine;
+using DCL.Diagnostics;
 
 namespace SceneRuntime.Factory.JsSceneSourceCode
 {
     public class LogJsSceneLocalSourceCode : IJsSceneLocalSourceCode
     {
         private readonly IJsSceneLocalSourceCode origin;
-        private readonly Action<string> log;
 
-        public LogJsSceneLocalSourceCode(IJsSceneLocalSourceCode origin, Action<string> log)
+        public LogJsSceneLocalSourceCode(IJsSceneLocalSourceCode origin)
         {
             this.origin = origin;
-            this.log = log;
         }
 
         public string? CodeForScene(Vector2Int coordinates)
         {
             string? result = origin.CodeForScene(coordinates);
-            log($"Code for scene {coordinates} is {(result != null ? "found" : "not found")}");
+            ReportHub
+               .WithReport(ReportCategory.SCENE_LOADING)
+               .Log($"Code for scene {coordinates} is {(result != null ? "found" : "not found")}");
             return result;
         }
     }


### PR DESCRIPTION
## What does this PR change?

- Introduces correct conditionals to decorator ```[Conditional("UNITY_EDITOR")] [Conditional("VERBOSE_LOGS")] ```
- Removes delegates from each log to ensure they are removed as part of the compilation step when VERBOSE_LOGS is disabled

## How to test the changes?

- Ensure anything relating to multiplayer works as normal
- General smoke test

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

