### PR TITLE
fix: [QA] LOD Loads Only When Very Close to Scenes (#1728)

### DIFF
--- a/Explorer/Assets/DCL/LOD/Systems/InstantiateSceneLODInfoSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/InstantiateSceneLODInfoSystem.cs
@@ -77,7 +77,7 @@ namespace DCL.LOD.Systems
                     var newLod = new LODAsset(instantiatedLOD, result.Asset,
                         GetTextureSlot(sceneLODInfo.CurrentLODLevelPromise, sceneDefinitionComponent.Definition, instantiatedLOD));
 
-                    sceneLODInfo.AddSuccessLOD(instantiatedLOD, newLod, defaultFOV, defaultLodBias, realmPartitionSettings.MaxLoadingDistanceInParcels);
+                    sceneLODInfo.AddSuccessLOD(instantiatedLOD, newLod, defaultFOV, defaultLodBias, realmPartitionSettings.MaxLoadingDistanceInParcels, sceneDefinitionComponent.Parcels.Count);
                 }
                 else
                 {

--- a/Explorer/Assets/DCL/LOD/Systems/RecalculateLODDistanceSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/RecalculateLODDistanceSystem.cs
@@ -7,6 +7,7 @@ using DCL.LOD.Components;
 using ECS.Abstract;
 using ECS.Prioritization;
 using ECS.SceneLifeCycle;
+using ECS.SceneLifeCycle.SceneDefinition;
 using UnityEngine;
 
 namespace DCL.LOD.Systems
@@ -42,14 +43,14 @@ namespace DCL.LOD.Systems
         }
 
         [Query]
-        public void RecalculateSceneLODDistance(ref SceneLODInfo sceneLODInfo)
+        public void RecalculateSceneLODDistance(ref SceneLODInfo sceneLODInfo, in SceneDefinitionComponent sceneDefinition)
         {
             // Not yet initialized
             if (string.IsNullOrEmpty(sceneLODInfo.id))
                 return;
 
             if (SceneLODInfoUtils.LODCount(sceneLODInfo.metadata.SuccessfullLODs) > 0)
-                sceneLODInfo.RecalculateLODDistances(defaultFOV, defaultLodBias, realmPartitionSettingsAsset.MaxLoadingDistanceInParcels);
+                sceneLODInfo.RecalculateLODDistances(defaultFOV, defaultLodBias, realmPartitionSettingsAsset.MaxLoadingDistanceInParcels, sceneDefinition.Parcels.Count);
         }
 
 


### PR DESCRIPTION
## What does this PR change?

It makes LOD0 of "small" scenes to appear when the camera is farther than before. Scenes with 10 parcels or less are considered "small" (arbitrary value, depending on performance). The smaller the scene is (under 11 parcels), the larger the distance from which the LOD0 is visible with respect to its original value.

## How to test the changes?

1. Launch the explorer
2. Go to -94,-96.
3. Walk around and see how LOD0 of the small scenes appear at farther distances.

Demo video:
https://github.com/user-attachments/assets/603f325d-990d-4c8c-9e9f-8d097ea6be20

The LOD ranges of the scene of the purple ground and the pink floating stone, at the end of the video, have changed like this:
FROM
![Screenshot 2024-09-24 191854](https://github.com/user-attachments/assets/525d02ff-62c4-4a1b-8360-c08629e87654)
TO
![Screenshot 2024-09-24 191236](https://github.com/user-attachments/assets/92fb95ef-b780-401c-9f1d-b9952aea79df)

And performance has been affected this way (measured with PIX, in a build without the changes and another with them, walking like in the video):
FROM
![Screenshot 2024-09-24 161945](https://github.com/user-attachments/assets/bd572efa-13f6-41af-a63a-3cb06d0cd2b5)
TO
![Screenshot 2024-09-24 161203](https://github.com/user-attachments/assets/cfc40c3a-ac90-416e-8b39-ca05360a7725)

The impact on the FPS mean is very small.
We will tweak the constant values to get the best result in the future.