### PR TITLE
fix: Add default resolution

### DIFF
--- a/Explorer/Assets/DCL/Settings/ModuleControllers/ResolutionSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/ResolutionSettingsController.cs
@@ -60,9 +60,7 @@ namespace DCL.Settings.ModuleControllers
                 if (possibleResolutions.Contains(resolution))
                     continue;
 
-                possibleResolutions.Add(resolution);
-                view.DropdownView.Dropdown.options.Add(new TMP_Dropdown.OptionData
-                    { text = ResolutionUtils.FormatResolutionDropdownOption(resolution) });
+                AddResolution(resolution);
             }
 
             //Adds a fallback resolution if no other resolution is available
@@ -73,8 +71,14 @@ namespace DCL.Settings.ModuleControllers
                     width = 1920,
                     height = 1080
                 };
+                AddResolution(resolution);
+            }
+
+            void AddResolution(Resolution resolution)
+            {
                 possibleResolutions.Add(resolution);
-                view.DropdownView.Dropdown.options.Add(new TMP_Dropdown.OptionData { text = ResolutionUtils.FormatResolutionDropdownOption(resolution) });
+                view.DropdownView.Dropdown.options.Add(new TMP_Dropdown.OptionData
+                    { text = ResolutionUtils.FormatResolutionDropdownOption(resolution) });
             }
         }
 

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/ResolutionSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/ResolutionSettingsController.cs
@@ -61,6 +61,19 @@ namespace DCL.Settings.ModuleControllers
                     continue;
 
                 possibleResolutions.Add(resolution);
+                view.DropdownView.Dropdown.options.Add(new TMP_Dropdown.OptionData
+                    { text = ResolutionUtils.FormatResolutionDropdownOption(resolution) });
+            }
+
+            //Adds a fallback resolution if no other resolution is available
+            if (possibleResolutions.Count == 0)
+            {
+                var resolution = new Resolution
+                {
+                    width = 1920,
+                    height = 1080
+                };
+                possibleResolutions.Add(resolution);
                 view.DropdownView.Dropdown.options.Add(new TMP_Dropdown.OptionData { text = ResolutionUtils.FormatResolutionDropdownOption(resolution) });
             }
         }


### PR DESCRIPTION
## What does this PR change?

On my Mac, if I have a second monitor connected, I dont get any resolutions added because `Screen.resolutions` doesnt return 16:9 resolutions. Therefore, I get an `OutOfBounds` exception in `SetResolutionSettings()`.

This PR adds a default resolution for this scenario

## How to test the changes?



1. Launch the explorer
2. Do happy path

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

