### PR TITLE
fix: remove doppler from audiosources

### DIFF
--- a/Explorer/Assets/DCL/Audio/Avatar/AvatarAudioController.prefab
+++ b/Explorer/Assets/DCL/Audio/Avatar/AvatarAudioController.prefab
@@ -68,7 +68,7 @@ AudioSource:
   Spatialize: 0
   SpatializePostEffects: 0
   Priority: 128
-  DopplerLevel: 1
+  DopplerLevel: 0
   MinDistance: 1
   MaxDistance: 50
   Pan2D: 0
@@ -209,7 +209,7 @@ AudioSource:
   Spatialize: 0
   SpatializePostEffects: 0
   Priority: 128
-  DopplerLevel: 1
+  DopplerLevel: 0
   MinDistance: 1
   MaxDistance: 50
   Pan2D: 0

--- a/Explorer/Assets/DCL/Audio/Prefabs/LandscapeAudioSource.prefab
+++ b/Explorer/Assets/DCL/Audio/Prefabs/LandscapeAudioSource.prefab
@@ -51,7 +51,7 @@ AudioSource:
   Spatialize: 0
   SpatializePostEffects: 0
   Priority: 160
-  DopplerLevel: 1
+  DopplerLevel: 0
   MinDistance: 1
   MaxDistance: 150
   Pan2D: 0

--- a/Explorer/Assets/DCL/Audio/Prefabs/MediaPlayer.prefab
+++ b/Explorer/Assets/DCL/Audio/Prefabs/MediaPlayer.prefab
@@ -246,7 +246,7 @@ AudioSource:
   Spatialize: 0
   SpatializePostEffects: 0
   Priority: 127
-  DopplerLevel: 1
+  DopplerLevel: 0
   MinDistance: 40
   MaxDistance: 60
   Pan2D: 0

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/EmoteAudioSource.prefab
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/EmoteAudioSource.prefab
@@ -51,7 +51,7 @@ AudioSource:
   Spatialize: 0
   SpatializePostEffects: 0
   Priority: 129
-  DopplerLevel: 1
+  DopplerLevel: 0
   MinDistance: 0
   MaxDistance: 15
   Pan2D: 0


### PR DESCRIPTION
## What does this PR change?

I removed the doppler effect from all AudioSources.
...

## How to test the changes?

Do sounds! try moving the camera close and far at the same time, there should be no audio distortion caused by the doppler effect.

