### PR TITLE
fix: Avoid null material copy on dispose

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Helpers/AvatarMaterialPoolHandler.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Helpers/AvatarMaterialPoolHandler.cs
@@ -35,8 +35,9 @@ namespace DCL.AvatarRendering.AvatarShape
                     },
                     actionOnRelease: mat =>
                     {
-                        // reset material so it does not contain any old properties
-                        mat.CopyPropertiesFromMaterial(material);
+                        if (material != null)
+                            // reset material so it does not contain any old properties
+                            mat.CopyPropertiesFromMaterial(material);
                     },
                     actionOnDestroy: UnityObjectUtils.SafeDestroy,
                     defaultCapacity: defaultMaterialCapacity);


### PR DESCRIPTION
## What does this PR change?

On program exit, the disposal was throwing a NRE. This just stops that from occuring

This was the error before this PR

```
Trying to copy properties from null material.
 #0 GetStacktrace(int)
 #1 DebugStringToFile(DebugStringToFileData const&)
 #2 MaterialScripting::CopyPropertiesFrom(Material*, Material*)
 #3 Material_CUSTOM_CopyPropertiesFromMaterial(ScriptingBackendNativeObjectPtrOpaque*, ScriptingBackendNativeObjectPtrOpaque*)
 #4 Action_1_Invoke_m5A038831CEB84A7E374FE59D43444412629F833F_ClosedInstInvoker(Action_1_t923A20D1D4F6B55B2ED5AE21B90F1A0CE0450D99*, void*, MethodInfo const*)
 #5 ObjectPool_1_Release_m71F1CADB7AD9CC20BD824583A3675A4260965DB5_gshared
 #6 AvatarMaterialPoolHandler_Release_mC6B2F1508B89DA6B310DDD7CC98E6F9DDD6E3978
 #7 AvatarCustomSkinningComponent_Dispose_mB80D6A7FADE8689A209776D09EBE4F7B37321B45
 #8 ReleaseAvatar_Execute_m08D17EE6333CF3E2B9B1F1F02C0B3A0BCEA613B0
 #9 AvatarCleanUpSystem_InternalDestroyAvatar_m020C950FF1DC917CDD73BAE22FF15EAF8F2A01CE
 #10 
```

## How to test the changes?


1. Launch the explorer
2. Play happy path

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

