### PR TITLE
fix: UI sibling sorting error

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Components/UITransformComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Components/UITransformComponent.cs
@@ -15,19 +15,19 @@ namespace DCL.SDKComponents.SceneUI.Components
 
         public VisualElement Transform
         {
-            get => isRoot ? rootTransform : reusableTransform;
-            internal set { if (isRoot) rootTransform = value; else reusableTransform = value;}
+            get => IsRoot ? rootTransform : reusableTransform;
+            internal set { if (IsRoot) rootTransform = value; else reusableTransform = value;}
         }
 
         public bool IsHidden;
         public PointerEventType? PointerEventTriggered;
+        public bool IsRoot { get; private set; }
 
         public UITransformRelationLinkedData RelationData;
 
         internal EventCallback<PointerDownEvent> currentOnPointerDownCallback;
         internal EventCallback<PointerUpEvent> currentOnPointerUpCallback;
 
-        private bool isRoot;
 
         private VisualElement rootTransform;
         private VisualElement reusableTransform;
@@ -40,7 +40,7 @@ namespace DCL.SDKComponents.SceneUI.Components
 
             RelationData.parent = EntityReference.Null;
             RelationData.rightOf = 0;
-            isRoot = true;
+            IsRoot = true;
         }
 
         public void InitializeAsChild(string componentName, CRDTEntity entity, CRDTEntity rightOf)
@@ -48,7 +48,7 @@ namespace DCL.SDKComponents.SceneUI.Components
             reusableTransform ??= new VisualElement();
             Transform.name = UiElementUtils.BuildElementName(componentName, entity);
             IsHidden = false;
-            isRoot = false;
+            IsRoot = false;
             PointerEventTriggered = null;
 
             RelationData.parent = EntityReference.Null;
@@ -92,7 +92,7 @@ namespace DCL.SDKComponents.SceneUI.Components
             RelationData.Dispose();
 
             // If it's not a root its transform can be reused
-            if (isRoot) return;
+            if (IsRoot) return;
 
             this.UnregisterPointerCallbacks();
             reusableTransform.tabIndex = 0;

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UITransform/UITransformSortingSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UITransform/UITransformSortingSystem.cs
@@ -64,11 +64,10 @@ namespace DCL.SDKComponents.SceneUI.Systems.UITransform
                         if (newRightOfComponent.RelationData.parent != EntityReference.Null)
                         {
                             Assert.AreEqual(uiTransformComponent.RelationData.parent, newRightOfComponent.RelationData.parent);
-
-                            parent.RelationData.ChangeChildRightOf(uiTransformComponent.RelationData.rightOf,
-                                newRightOf,
-                                ref newRightOfComponent.RelationData);
+                            parent.RelationData.ChangeChildRightOf(uiTransformComponent.RelationData.rightOf, newRightOf, ref newRightOfComponent.RelationData);
                         }
+                        else if (!newRightOfComponent.IsRoot)
+                            ReportHub.LogError(ReportCategory.SCENE_UI, $"Can't Resolve sibling order for entity: {uiTransformComponent.RelationData.parent.Entity.ToString()} - as its new RightOfEntity: {newRightOfEntity.ToString()} - has no parent, but it is NOT a ROOT either");
                     }
                     else
                     {

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UITransform/UITransformSortingSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UITransform/UITransformSortingSystem.cs
@@ -61,11 +61,14 @@ namespace DCL.SDKComponents.SceneUI.Systems.UITransform
                     {
                         ref var newRightOfComponent = ref World.Get<UITransformComponent>(newRightOfEntity);
 
-                        Assert.AreEqual(uiTransformComponent.RelationData.parent, newRightOfComponent.RelationData.parent);
+                        if (newRightOfComponent.RelationData.parent != EntityReference.Null)
+                        {
+                            Assert.AreEqual(uiTransformComponent.RelationData.parent, newRightOfComponent.RelationData.parent);
 
-                        parent.RelationData.ChangeChildRightOf(uiTransformComponent.RelationData.rightOf,
-                            newRightOf,
-                            ref newRightOfComponent.RelationData);
+                            parent.RelationData.ChangeChildRightOf(uiTransformComponent.RelationData.rightOf,
+                                newRightOf,
+                                ref newRightOfComponent.RelationData);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
## What does this PR change?

This fixes a null ref that was happening on the onboardingdcl scene sometimes, its basically just a null check before doing a sorting. Otherwise the user gets stuck with a white square in the middle of the screen.

