### PR TITLE
chore: add custom world to chat command

### DIFF
--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
@@ -59,7 +59,11 @@ namespace Global.Dynamic.ChatCommands
         {
             worldName = match.Groups[2].Value;
 
-            if (!paramUrls.TryGetValue(worldName, out realmUrl))
+            if (worldName.StartsWith("https"))
+            {
+                realmUrl = worldName;
+            }
+            else if (!paramUrls.TryGetValue(worldName, out realmUrl))
             {
                 if (!worldName.EndsWith(WORLD_SUFFIX))
                     worldName += WORLD_SUFFIX;


### PR DESCRIPTION
## What does this PR change?

Adds the possibility to go to a custom world from chat commands

## How to test the changes?

1. Launch the explorer
2. .try `/world https://sdk-team-cdn.decentraland.org/ipfs/goerli-plaza-main-latest`. It should take you to `goerli`

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

