### PR TITLE
chore: Remove rig builder for remote entities

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/AvatarBase.prefab
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/AvatarBase.prefab
@@ -937,7 +937,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2561918839770535189}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fff0960ef4ea6e04eac66b4a7fd2189d, type: 3}
   m_Name: 
@@ -1048,7 +1048,7 @@ MonoBehaviour:
   AvatarAnimator: {fileID: 6654053651110562472}
   MovementBlendThreshold: 0.1
   walkIntervalSeconds: 0.37
-  jobIntervalSeconds: 0.31
+  jogIntervalSeconds: 0.31
   runIntervalSeconds: 0.25
   jumpIntervalSeconds: 0.25
   landIntervalSeconds: 0.25
@@ -3520,7 +3520,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2645e75a453f6954f8aa7b950093750d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  RandomID: 0
   <AvatarAnimator>k__BackingField: {fileID: 6654053651110562472}
+  <RigBuilder>k__BackingField: {fileID: 2952854576378652397}
   <AvatarSkinnedMeshRenderer>k__BackingField: {fileID: 918335364077391645}
   <FeetIKRig>k__BackingField: {fileID: 8371887180010344672}
   <RightLegConstraint>k__BackingField: {fileID: 1621103848960102164}

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
@@ -133,7 +133,10 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             var avatarBase = InstantiateNewAvatar(entity, ref avatarShapeComponent, ref transformComponent);
 
             if (avatarBase != null)
+            {
+                avatarBase.RigBuilder.enabled = true;
                 mainPlayerAvatarBaseProxy.SetObject(avatarBase);
+            }
         }
 
         [Query]

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
@@ -16,6 +16,8 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         private AnimatorOverrideController overrideController;
 
         [field: SerializeField] public Animator AvatarAnimator { get; private set; }
+        [field: SerializeField] public RigBuilder RigBuilder { get; private set; }
+
 
         [field: SerializeField] public SkinnedMeshRenderer AvatarSkinnedMeshRenderer { get; private set; }
 


### PR DESCRIPTION
## What does this PR change?

There was an overhead added by the `RigBuilder` on remote entities. I just disabled the component, since remote entities do not use IK, so they dont need it

It brings a slight improvement of about `1.41ms` in Median. Illsutrated here, this are 30 avatars in `olavra`. Left is with RigBuilder, Right is without

![image](https://github.com/user-attachments/assets/8b114b70-1b7c-42f4-9b91-701b56034e69)


## How to test the changes?

1. Launch the explorer
2. Get some friends. Do all the basic avatar related stuff (emotes, run, jump). They should look the same as in `main`
3. Check in the backpack that your avatar is fine

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

