### PR TITLE
fix: Nametag visibility

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -13,6 +13,7 @@ using ECS.Abstract;
 using ECS.LifeCycle.Components;
 using ECS.Prioritization.Components;
 using System.Runtime.CompilerServices;
+using DCL.AvatarRendering.AvatarShape.UnityInterface;
 using UnityEngine;
 using UnityEngine.Pool;
 #if UNITY_EDITOR
@@ -63,6 +64,7 @@ namespace DCL.Nametags
                 return;
             }
 
+            EnableTagQuery(World);
             RemoveTagQuery(World);
 
             CameraComponent camera = playerCamera.GetCameraComponent(World);
@@ -90,6 +92,16 @@ namespace DCL.Nametags
             UpdateTagPosition(nametagView, camera.Camera, characterTransform.Position);
 
             World.Add(e, nametagView);
+        }
+
+        [Query]
+        [All(typeof(AvatarBase), typeof(NametagView))]
+        private void EnableTag(in NametagView nametagView)
+        {
+            if (nametagView.isActiveAndEnabled)
+                return;
+
+            nametagView.gameObject.SetActive(true);
         }
 
         [Query]

--- a/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
@@ -183,8 +183,12 @@ namespace DCL.PluginSystem.Global
             NametagView nametagPrefab = (await assetsProvisioner.ProvideMainAssetAsync(settings.NametagView, ct: ct)).Value.GetComponent<NametagView>();
 
             nametagViewPool = new ObjectPool<NametagView>(
-                () => Object.Instantiate(nametagPrefab, Vector3.zero, Quaternion.identity, null),
-                actionOnGet: (nametagView) => nametagView.gameObject.SetActive(true),
+                () =>
+                {
+                    var nametagView = Object.Instantiate(nametagPrefab, Vector3.zero, Quaternion.identity, null);
+                    nametagView.gameObject.SetActive(false);
+                    return nametagView;
+                },
                 actionOnRelease: (nametagView) => nametagView.gameObject.SetActive(false),
                 actionOnDestroy: UnityObjectUtils.SafeDestroy);
         }


### PR DESCRIPTION
## What does this PR change?

Hides nametags until the avatar is ready
## How to test the changes?



1. Launch the explorer
2. Get some friends. Connect one by one. Nametags should appear with avatar
3. Same works with the avatar debug tool. If you isntantiate avatars, they should appear when the avatar appears

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

