### PR TITLE
Chore: add logic to load global PX as part of startup operations

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/DCL.Plugins.asmdef
+++ b/Explorer/Assets/DCL/PluginSystem/DCL.Plugins.asmdef
@@ -130,7 +130,8 @@
         "GUID:543b8f091a5947a3880b7f2bca2358bd",
         "GUID:e5a23cdae0ef4d86aafc237a73280975",
         "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b",
-        "GUID:1c5f9b69f95e40d18f11049c155eeaf8"
+        "GUID:1c5f9b69f95e40d18f11049c155eeaf8",
+        "GUID:8c4c611b27046bc4a848721d1fdd4a9f"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/DCL.UserInAppInitializationFlow.asmdef
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/DCL.UserInAppInitializationFlow.asmdef
@@ -30,7 +30,9 @@
         "GUID:8baf705856414dad9a73b3f382f1bc8b",
         "GUID:7175400a68914a45acecc9fb068de3b8",
         "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b",
-        "GUID:3640f3c0b42946b0b8794a1ed8e06ca5"
+        "GUID:3640f3c0b42946b0b8794a1ed8e06ca5",
+        "GUID:f1eaef1b40a68e74cb90cbedebf57bbf",
+        "GUID:8c4c611b27046bc4a848721d1fdd4a9f"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealFlowLoadingStatus.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealFlowLoadingStatus.cs
@@ -23,7 +23,8 @@ namespace DCL.UserInAppInitializationFlow
             ///     Player has teleported to the spawn point of the starting scene
             /// </summary>
             PlayerTeleported = 10,
-            Completed = 11,
+            LoadGlobalPXs = 11,
+            Completed = 12,
         }
 
         public static readonly Dictionary<Stage, float> PROGRESS = new (EnumUtils.GetEqualityComparer<Stage>())
@@ -39,6 +40,7 @@ namespace DCL.UserInAppInitializationFlow
             [Stage.OnboardingChecked] = 0.80f,
             [Stage.RealmRestarted] = 0.85f,
             [Stage.PlayerTeleported] = 0.95f,
+            [Stage.LoadGlobalPXs] = 0.99f,
             [Stage.Completed] = 1f,
         };
 

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -17,6 +17,8 @@ using DCL.UserInAppInitializationFlow.StartupOperations.Struct;
 using DCL.Web3.Identities;
 using ECS.SceneLifeCycle.Realm;
 using Global.AppArgs;
+using Global.Dynamic.DebugSettings;
+using PortableExperiences.Controller;
 using UnityEngine;
 using Utility.Types;
 
@@ -53,7 +55,9 @@ namespace DCL.UserInAppInitializationFlow
             FeatureFlagsCache featureFlagsCache,
             IWeb3IdentityCache web3IdentityCache,
             IRealmController realmController,
-            IAppArgs appParameters
+            IAppArgs appParameters,
+            IDebugSettings debugSettings,
+            IPortableExperiencesController portableExperiencesController
         )
         {
             this.loadingStatus = loadingStatus;
@@ -71,6 +75,7 @@ namespace DCL.UserInAppInitializationFlow
             checkOnboardingStartupOperation = new CheckOnboardingStartupOperation(loadingStatus, realmController, selfProfile, featureFlagsCache, decentralandUrlsSource, appParameters);
             restartRealmStartupOperation = new RestartRealmStartupOperation(loadingStatus, realmController);
             var teleportStartupOperation = new TeleportStartupOperation(loadingStatus, realmNavigator, startParcel);
+            var loadGlobalPxOperation = new LoadGlobalPortableExperiencesStartupOperation(loadingStatus, selfProfile, featureFlagsCache, debugSettings, portableExperiencesController);
 
             startupOperation = new SequentialStartupOperation(
                 loadingStatus,
@@ -82,7 +87,8 @@ namespace DCL.UserInAppInitializationFlow
                 loadLandscapeStartupOperation,
                 checkOnboardingStartupOperation,
                 restartRealmStartupOperation,
-                teleportStartupOperation
+                teleportStartupOperation,
+                loadGlobalPxOperation
             ).WithHandleExceptions();
         }
 

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadGlobalPortableExperiencesStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadGlobalPortableExperiencesStartupOperation.cs
@@ -1,0 +1,94 @@
+using Arch.Core;
+using CommunicationData.URLHelpers;
+using Cysharp.Threading.Tasks;
+using DCL.AsyncLoadReporting;
+using DCL.Diagnostics;
+using DCL.FeatureFlags;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Profiles;
+using DCL.Profiles.Self;
+using DCL.Utilities.Extensions;
+using ECS.SceneLifeCycle.Realm;
+using Global.AppArgs;
+using Global.Dynamic;
+using Global.Dynamic.DebugSettings;
+using PortableExperiences.Controller;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Utility.Types;
+
+namespace DCL.UserInAppInitializationFlow.StartupOperations
+{
+    public class LoadGlobalPortableExperiencesStartupOperation : IStartupOperation
+    {
+        private readonly RealFlowLoadingStatus loadingStatus;
+        private readonly ISelfProfile selfProfile;
+        private readonly FeatureFlagsCache featureFlagsCache;
+        private readonly IDebugSettings debugSettings;
+        private readonly IPortableExperiencesController portableExperiencesController;
+
+        public LoadGlobalPortableExperiencesStartupOperation(
+            RealFlowLoadingStatus loadingStatus,
+            ISelfProfile selfProfile,
+            FeatureFlagsCache featureFlagsCache,
+            IDebugSettings debugSettings,
+            IPortableExperiencesController portableExperiencesController)
+        {
+            this.loadingStatus = loadingStatus;
+            this.selfProfile = selfProfile;
+            this.featureFlagsCache = featureFlagsCache;
+            this.debugSettings = debugSettings;
+            this.portableExperiencesController = portableExperiencesController;
+        }
+
+        public async UniTask<Result> ExecuteAsync(AsyncLoadProcessReport report, CancellationToken ct)
+        {
+            await CheckGlobalPxLoadingConditionsAsync(ct);
+
+            report.SetProgress(loadingStatus.SetStage(RealFlowLoadingStatus.Stage.LoadGlobalPXs));
+            return Result.SuccessResult();
+        }
+
+        private async UniTask CheckGlobalPxLoadingConditionsAsync(CancellationToken ct)
+        {
+            var ownProfile = await selfProfile.ProfileAsync(ct);
+
+            //If we havent completed the tutorial, we won't load the GlobalPX as it will interfere with the onboarding.
+            if (ownProfile is not { TutorialStep: > 0 })
+                return;
+
+            LoadDebugPortableExperiences(ct);
+            LoadRemotePortableExperiences(ct);
+        }
+
+        private void LoadRemotePortableExperiences(CancellationToken ct)
+        {
+            //This allows us to disable loading the global px on debug builds or when using the editor in case we wanted to load a cleaner experience.
+            if (!debugSettings.EnableRemotePortableExperiences) return;
+
+            if (featureFlagsCache.Configuration.IsEnabled(FeatureFlagsStrings.GLOBAL_PORTABLE_EXPERIENCE, FeatureFlagsStrings.CSV_VARIANT))
+            {
+                if (!featureFlagsCache.Configuration.TryGetCsvPayload(FeatureFlagsStrings.GLOBAL_PORTABLE_EXPERIENCE, FeatureFlagsStrings.CSV_VARIANT, out List<List<string>>? csv)) return;
+
+                if (csv?[0] == null) return;
+
+                foreach (string value in csv[0]) { portableExperiencesController.
+                    CreatePortableExperienceByEnsAsync(new ENS(value), ct, true, true).
+                    SuppressAnyExceptionWithFallback(new IPortableExperiencesController.SpawnResponse(), ReportCategory.PORTABLE_EXPERIENCE).Forget(); }
+            }
+        }
+
+        private void LoadDebugPortableExperiences(CancellationToken ct)
+        {
+            if (debugSettings.PortableExperiencesEnsToLoad == null) return;
+
+            foreach (string pxEns in debugSettings.PortableExperiencesEnsToLoad)
+            {
+                portableExperiencesController.
+                    CreatePortableExperienceByEnsAsync(new ENS(pxEns), ct, true, true).
+                    SuppressAnyExceptionWithFallback(new IPortableExperiencesController.SpawnResponse(), ReportCategory.PORTABLE_EXPERIENCE).Forget();
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadGlobalPortableExperiencesStartupOperation.cs.meta
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadGlobalPortableExperiencesStartupOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fcafd9ceaef9be4408e73cccb31edb57
+timeCreated: 1726657964

--- a/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
@@ -15,6 +15,7 @@ using DCL.Web3.Authenticators;
 using DCL.Web3.Identities;
 using ECS.SceneLifeCycle.Realm;
 using Global.AppArgs;
+using Global.Dynamic.DebugSettings;
 using Segment.Analytics;
 using Sentry;
 using System;
@@ -58,7 +59,7 @@ namespace Global.Dynamic
         }
 
         public static async UniTask<BootstrapContainer> CreateAsync(
-            DebugSettings debugSettings,
+            DebugSettings.DebugSettings debugSettings,
             DynamicSceneLoaderSettings sceneLoaderSettings,
             IPluginSettingsContainer settingsContainer,
             RealmLaunchSettings realmLaunchSettings,

--- a/Explorer/Assets/Scripts/Global/Dynamic/Bootstraper.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/Bootstraper.cs
@@ -16,6 +16,7 @@ using DCL.UI.MainUI;
 using DCL.Utilities.Extensions;
 using DCL.Web3.Identities;
 using Global.AppArgs;
+using Global.Dynamic.DebugSettings;
 using MVC;
 using PortableExperiences.Controller;
 using SceneRunner.Debugging;

--- a/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1623b861e1c692c49900c7012328e140
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/DebugSettings.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/DebugSettings.cs
@@ -1,0 +1,68 @@
+﻿using LiveKit.Proto;
+using System;
+using UnityEngine;
+
+namespace Global.Dynamic.DebugSettings
+{
+    [Serializable]
+    public class DebugSettings : IDebugSettings
+    {
+        private static readonly DebugSettings RELEASE_SETTINGS = Release();
+
+        [SerializeField]
+        private bool showSplash;
+        [SerializeField]
+        private bool showAuthentication;
+        [SerializeField]
+        private bool showLoading;
+        [SerializeField]
+        private bool enableLandscape;
+        [SerializeField]
+        private bool enableLOD;
+        [SerializeField] private bool enableVersionUpdateGuard;
+        [SerializeField]
+        private bool enableEmulateNoLivekitConnection;
+        [SerializeField] [Tooltip("Enable Portable Experiences obtained from Feature Flags from loading at the start of the game")]
+        private bool enableRemotePortableExperiences;
+        [SerializeField] [Tooltip("Make sure the ENS put here will be loaded as a GlobalPX (format must be something.dcl.eth)")]
+        internal string[]? portableExperiencesEnsToLoad;
+        [SerializeField]
+        internal string[]? emotesToAddToUserProfile;
+        [Space]
+        [SerializeField]
+        private bool overrideConnectionQuality;
+        [SerializeField]
+        private ConnectionQuality connectionQuality;
+
+        public static DebugSettings Release() =>
+            new ()
+            {
+                showSplash = true,
+                showAuthentication = true,
+                showLoading = true,
+                enableLandscape = true,
+                enableLOD = true,
+                enableVersionUpdateGuard = true,
+                portableExperiencesEnsToLoad = null,
+                enableEmulateNoLivekitConnection = false,
+                overrideConnectionQuality = false,
+                connectionQuality = ConnectionQuality.QualityExcellent,
+                enableRemotePortableExperiences = true,
+                emotesToAddToUserProfile = null,
+            };
+
+        // To avoid configuration issues, force full flow on build (Application.isEditor is always true in Editor, but in profile builds (i.e. when set to Development) we will have the expected release flow too.
+        public string[]? EmotesToAddToUserProfile => Application.isEditor ? this.emotesToAddToUserProfile : RELEASE_SETTINGS.emotesToAddToUserProfile;
+        public string[]? PortableExperiencesEnsToLoad => Application.isEditor ? this.portableExperiencesEnsToLoad : RELEASE_SETTINGS.portableExperiencesEnsToLoad;
+        public bool EnableRemotePortableExperiences => Application.isEditor ? this.enableRemotePortableExperiences : RELEASE_SETTINGS.enableRemotePortableExperiences;
+        public bool ShowSplash => Application.isEditor ? this.showSplash : RELEASE_SETTINGS.showSplash;
+        public bool ShowAuthentication => Application.isEditor ? this.showAuthentication : RELEASE_SETTINGS.showAuthentication;
+        public bool ShowLoading => Application.isEditor ? this.showLoading : RELEASE_SETTINGS.showLoading;
+        public bool EnableLandscape => Application.isEditor ? this.enableLandscape : RELEASE_SETTINGS.enableLandscape;
+        public bool EnableLOD => Application.isEditor ? this.enableLOD : RELEASE_SETTINGS.enableLOD;
+        public bool EnableVersionUpdateGuard => Application.isEditor ? this.enableVersionUpdateGuard : RELEASE_SETTINGS.enableVersionUpdateGuard;
+        public bool EnableEmulateNoLivekitConnection => Application.isEditor? this.enableEmulateNoLivekitConnection : RELEASE_SETTINGS.enableEmulateNoLivekitConnection;
+        public bool OverrideConnectionQuality => Application.isEditor ? this.overrideConnectionQuality : RELEASE_SETTINGS.overrideConnectionQuality;
+        public ConnectionQuality ConnectionQuality => Application.isEditor ? this.connectionQuality : RELEASE_SETTINGS.connectionQuality;
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/DebugSettings.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/DebugSettings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d3d1a2c50c174dc6a45dfbf1a855c514
+timeCreated: 1727384382

--- a/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/Global.Dynamic.DebugSettings.asmdef
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/Global.Dynamic.DebugSettings.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Global.Dynamic.DebugSettings",
+    "rootNamespace": "",
+    "references": [
+        "GUID:702f733b4deb246808c6ce84d93b5c9c"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/Global.Dynamic.DebugSettings.asmdef.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/Global.Dynamic.DebugSettings.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8c4c611b27046bc4a848721d1fdd4a9f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/IDebugSettings.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/IDebugSettings.cs
@@ -1,0 +1,20 @@
+﻿using LiveKit.Proto;
+
+namespace Global.Dynamic.DebugSettings
+{
+    public interface IDebugSettings
+    {
+        string[]? PortableExperiencesEnsToLoad { get; }
+        string[]? EmotesToAddToUserProfile { get; }
+        bool ShowSplash { get; }
+        bool ShowAuthentication { get; }
+        bool ShowLoading { get; }
+        bool EnableLandscape { get; }
+        bool EnableLOD { get; }
+        bool EnableVersionUpdateGuard { get; }
+        bool EnableEmulateNoLivekitConnection { get; }
+        bool OverrideConnectionQuality { get; }
+        ConnectionQuality ConnectionQuality { get; }
+        bool EnableRemotePortableExperiences { get; }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/IDebugSettings.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DebugSettings/IDebugSettings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dbca69cfa7cd418ab46f7ebd2abd2cc9
+timeCreated: 1727384377

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -371,7 +371,9 @@ namespace Global.Dynamic
                 staticContainer.FeatureFlagsCache,
                 identityCache,
                 container.RealmController,
-                dynamicWorldParams.AppParameters
+                dynamicWorldParams.AppParameters,
+                bootstrapContainer.DebugSettings,
+                staticContainer.PortableExperiencesController
             );
 
             var worldInfoHub = new LocationBasedWorldInfoHub(

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -1,5 +1,4 @@
 using Arch.Core;
-using CommunicationData.URLHelpers;
 using CRDT;
 using CrdtEcsBridge.Components;
 using Cysharp.Threading.Tasks;
@@ -8,21 +7,16 @@ using DCL.Audio;
 using DCL.AuthenticationScreenFlow;
 using DCL.DebugUtilities;
 using DCL.Diagnostics;
-using DCL.FeatureFlags;
 using DCL.Input.Component;
-using DCL.Multiplayer.Movement.Systems;
 using DCL.PluginSystem;
 using DCL.PluginSystem.Global;
 using DCL.SceneLoadingScreens.SplashScreen;
 using DCL.Utilities;
 using DCL.Utilities.Extensions;
 using Global.AppArgs;
-using LiveKit.Proto;
-using PortableExperiences.Controller;
 using MVC;
 using SceneRunner.Debugging;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using UnityEngine;
@@ -30,84 +24,6 @@ using UnityEngine.UIElements;
 
 namespace Global.Dynamic
 {
-    public interface IDebugSettings
-    {
-        string[]? PortableExperiencesEnsToLoad { get; }
-        string[]? EmotesToAddToUserProfile { get; }
-        bool ShowSplash { get; }
-        bool ShowAuthentication { get; }
-        bool ShowLoading { get; }
-        bool EnableLandscape { get; }
-        bool EnableLOD { get; }
-        bool EnableVersionUpdateGuard { get; }
-        bool EnableEmulateNoLivekitConnection { get; }
-        bool OverrideConnectionQuality { get; }
-        ConnectionQuality ConnectionQuality { get; }
-        bool EnableRemotePortableExperiences { get; }
-    }
-
-    [Serializable]
-    public class DebugSettings : IDebugSettings
-    {
-        private static readonly DebugSettings RELEASE_SETTINGS = Release();
-
-        [SerializeField]
-        private bool showSplash;
-        [SerializeField]
-        private bool showAuthentication;
-        [SerializeField]
-        private bool showLoading;
-        [SerializeField]
-        private bool enableLandscape;
-        [SerializeField]
-        private bool enableLOD;
-        [SerializeField] private bool enableVersionUpdateGuard;
-        [SerializeField]
-        private bool enableEmulateNoLivekitConnection;
-        [SerializeField] [Tooltip("Enable Portable Experiences obtained from Feature Flags from loading at the start of the game")]
-        private bool enableRemotePortableExperiences;
-        [SerializeField] [Tooltip("Make sure the ENS put here will be loaded as a GlobalPX (format must be something.dcl.eth)")]
-        internal string[]? portableExperiencesEnsToLoad;
-        [SerializeField]
-        internal string[]? emotesToAddToUserProfile;
-        [Space]
-        [SerializeField]
-        private bool overrideConnectionQuality;
-        [SerializeField]
-        private ConnectionQuality connectionQuality;
-
-        public static DebugSettings Release() =>
-            new ()
-            {
-                showSplash = true,
-                showAuthentication = true,
-                showLoading = true,
-                enableLandscape = true,
-                enableLOD = true,
-                enableVersionUpdateGuard = true,
-                portableExperiencesEnsToLoad = null,
-                enableEmulateNoLivekitConnection = false,
-                overrideConnectionQuality = false,
-                connectionQuality = ConnectionQuality.QualityExcellent,
-                enableRemotePortableExperiences = true,
-                emotesToAddToUserProfile = null,
-            };
-
-        // To avoid configuration issues, force full flow on build (Application.isEditor is always true in Editor, but in profile builds (i.e. when set to Development) we will have the expected relesae flow too.
-        public string[]? EmotesToAddToUserProfile => Application.isEditor ? this.emotesToAddToUserProfile : RELEASE_SETTINGS.emotesToAddToUserProfile;
-        public string[]? PortableExperiencesEnsToLoad => Application.isEditor ? this.portableExperiencesEnsToLoad : RELEASE_SETTINGS.portableExperiencesEnsToLoad;
-        public bool EnableRemotePortableExperiences => Application.isEditor ? this.enableRemotePortableExperiences : RELEASE_SETTINGS.enableRemotePortableExperiences;
-        public bool ShowSplash => Application.isEditor ? this.showSplash : RELEASE_SETTINGS.showSplash;
-        public bool ShowAuthentication => Application.isEditor ? this.showAuthentication : RELEASE_SETTINGS.showAuthentication;
-        public bool ShowLoading => Application.isEditor ? this.showLoading : RELEASE_SETTINGS.showLoading;
-        public bool EnableLandscape => Application.isEditor ? this.enableLandscape : RELEASE_SETTINGS.enableLandscape;
-        public bool EnableLOD => Application.isEditor ? this.enableLOD : RELEASE_SETTINGS.enableLOD;
-        public bool EnableVersionUpdateGuard => Application.isEditor ? this.enableVersionUpdateGuard : RELEASE_SETTINGS.enableVersionUpdateGuard;
-        public bool EnableEmulateNoLivekitConnection => Application.isEditor? this.enableEmulateNoLivekitConnection : RELEASE_SETTINGS.enableEmulateNoLivekitConnection;
-        public bool OverrideConnectionQuality => Application.isEditor ? this.overrideConnectionQuality : RELEASE_SETTINGS.overrideConnectionQuality;
-        public ConnectionQuality ConnectionQuality => Application.isEditor ? this.connectionQuality : RELEASE_SETTINGS.connectionQuality;
-    }
-
     public class MainSceneLoader : MonoBehaviour
     {
         [Header("Startup Config")] [SerializeField]
@@ -117,7 +33,7 @@ namespace Global.Dynamic
         [SerializeField] private DebugViewsCatalog debugViewsCatalog = new ();
 
         [Space]
-        [SerializeField] private DebugSettings debugSettings = new ();
+        [SerializeField] private DebugSettings.DebugSettings debugSettings = new ();
 
         [Header("References")]
         [SerializeField] private PluginSettingsContainer globalPluginSettingsContainer = null!;
@@ -238,11 +154,6 @@ namespace Global.Dynamic
                 //The logo is used only at first launch, so we can safely release it after the game is loaded
                 logoAnimation.StopPlayback();
                 logoAnimation.runtimeAnimatorController = null;
-
-                LoadDebugPortableExperiences(ct);
-
-                LoadRemotePortableExperiences(ct);
-
                 RestoreInputs();
             }
             catch (OperationCanceledException)
@@ -254,34 +165,6 @@ namespace Global.Dynamic
                 // unhandled exception
                 GameReports.PrintIsDead();
                 throw;
-            }
-        }
-
-        private void LoadRemotePortableExperiences(CancellationToken ct)
-        {
-            if (!debugSettings.EnableRemotePortableExperiences) return;
-
-            if (staticContainer!.FeatureFlagsCache.Configuration.IsEnabled(FeatureFlagsStrings.GLOBAL_PORTABLE_EXPERIENCE, FeatureFlagsStrings.CSV_VARIANT))
-            {
-                if (!staticContainer.FeatureFlagsCache.Configuration.TryGetCsvPayload(FeatureFlagsStrings.GLOBAL_PORTABLE_EXPERIENCE, "csv-variant", out List<List<string>>? csv)) return;
-
-                if (csv?[0] == null) return;
-
-                foreach (string value in csv[0]) { staticContainer.PortableExperiencesController!.
-                                                                   CreatePortableExperienceByEnsAsync(new ENS(value), ct, true, true).
-                                                                   SuppressAnyExceptionWithFallback(new IPortableExperiencesController.SpawnResponse(), ReportCategory.PORTABLE_EXPERIENCE).Forget(); }
-            }
-        }
-
-        private void LoadDebugPortableExperiences(CancellationToken ct)
-        {
-            if (debugSettings.portableExperiencesEnsToLoad == null) return;
-
-            foreach (string pxEns in debugSettings.portableExperiencesEnsToLoad)
-            {
-                staticContainer!.PortableExperiencesController.
-                                 CreatePortableExperienceByEnsAsync(new ENS(pxEns), ct, true, true).
-                                 SuppressAnyExceptionWithFallback(new IPortableExperiencesController.SpawnResponse(), ReportCategory.PORTABLE_EXPERIENCE).Forget();
             }
         }
 


### PR DESCRIPTION
## What does this PR change?

After we added the onboarding experience to the game, the global PX should not load at the start regardless anymore, but only in those cases where we are not taking the user to the onboarding experience.
So we are checking the profile values for that and acting accordingly.
Also, converted the whole loading of these PX as part of the proper loading operations.
...
To test, start the game with a new user, you should be taken to the onboardingdcl world and not see the global px.
The following game starts should take you to Genesis and the global px should load after a short while. (if it is enabled in the feature flags - which it is right now)

Resolves #2163 