### PR TITLE
fix: Incorrect birthdate in the Profile when it is saved from the Passport

### DIFF
--- a/Explorer/Assets/DCL/Passport/Modules/UserAdditionalFields_PassportSubModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/UserAdditionalFields_PassportSubModuleController.cs
@@ -24,6 +24,8 @@ namespace DCL.Passport.Modules
         private readonly IObjectPool<AdditionalField_PassportFieldView> additionalFieldsPoolForEdition;
         private readonly List<AdditionalField_PassportFieldView> instantiatedAdditionalFieldsForEdition = new ();
 
+        private readonly string[] validInputFormatsForDate = { "dd/MM/yyyy", "ddMMyyyy" };
+
         public int CurrentAdditionalFieldsCount => instantiatedAdditionalFields.Count;
 
         public UserAdditionalFields_PassportSubModuleController(UserDetailedInfo_PassportModuleView view)
@@ -231,7 +233,7 @@ namespace DCL.Passport.Modules
         {
             foreach (var additionalFieldForEdition in instantiatedAdditionalFieldsForEdition)
             {
-                string valueToSave = !string.IsNullOrEmpty(additionalFieldForEdition.EditionTextInput.text) ? additionalFieldForEdition.EditionTextInput.text : null;
+                string? valueToSave = !string.IsNullOrEmpty(additionalFieldForEdition.EditionTextInput.text) ? additionalFieldForEdition.EditionTextInput.text : null;
                 switch (additionalFieldForEdition.Type)
                 {
                     case AdditionalFieldType.GENDER:
@@ -242,7 +244,7 @@ namespace DCL.Passport.Modules
                         break;
                     case AdditionalFieldType.BIRTH_DATE:
                         if (valueToSave != null)
-                            currentProfile.Birthdate = DateTime.ParseExact(valueToSave, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+                            currentProfile.Birthdate = DateTime.ParseExact(valueToSave, validInputFormatsForDate, CultureInfo.InvariantCulture, DateTimeStyles.None);
                         else
                             currentProfile.Birthdate = null;
                         break;

--- a/Explorer/Assets/DCL/Passport/Modules/UserDetailedInfo_PassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/UserDetailedInfo_PassportModuleController.cs
@@ -122,14 +122,24 @@ namespace DCL.Passport.Modules
         {
             saveInfoCts = saveInfoCts.SafeRestart();
             SaveInfoAsync(saveInfoCts.Token).Forget();
-            return;
+        }
 
-            async UniTaskVoid SaveInfoAsync(CancellationToken ct)
+        private async UniTaskVoid SaveInfoAsync(CancellationToken ct)
+        {
+            try
             {
                 SetInfoSectionAsSavingStatus(true);
                 descriptionController.SaveDataIntoProfile();
                 additionalFieldsController.SaveDataIntoProfile();
                 await passportProfileInfoController.UpdateProfileAsync(ct);
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception e)
+            {
+                const string ERROR_MESSAGE = "There was an error while trying to save your profile. Please try again!";
+                passportErrorsController.Show(ERROR_MESSAGE);
+                ReportHub.LogError(ReportCategory.PROFILE, $"{ERROR_MESSAGE} ERROR: {e.Message}");
+                SetInfoSectionAsEditionMode(false);
             }
         }
 


### PR DESCRIPTION
## What does this PR change?
Fix #2153 

## How to test the changes?
1. Go to the Passport.
2. Change the date on Birth Date using the format `ddMMyyyy`.
3. Check that the date is saved correctly.
4. Change the date on Birth Date using the format `dd/MM/yyyy`.
5. Check that the date is saved correctly.
6. Change the date on Birth Date using an invalid date format, for example writting a normal text.
7. Chack that the Passport show you an error saying that the profile's saving has failed.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md