### PR TITLE
fix: Terrain cache local handling

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Utils/TerrainGeneratorLocalCache.cs
+++ b/Explorer/Assets/DCL/Landscape/Utils/TerrainGeneratorLocalCache.cs
@@ -141,39 +141,47 @@ namespace DCL.Landscape.Utils
                 checksum = parcelChecksum,
             };
 
-            var path = GetFilePath(seed, chunkSize, version);
+            string? filePath = GetFilePath(seed, chunkSize, version);
             var dictionaryPath = GetDictionaryDirectory();
 
-            if (force && File.Exists(path))
-                File.Delete(path);
+            CheckCorruptStates();
 
-            if (!File.Exists(path))
+            if (force && File.Exists(filePath))
+                ClearCache();
+
+            if (!File.Exists(filePath))
             {
-                //If the file does not exist, but the dictionary path does, theres a possible corrupt state. 
-                //We gotta clear it
-                ClearDictionaryPath();
+                Directory.CreateDirectory(dictionaryPath);
                 return emptyCache;
             }
 
-            await using var fileStream = new FileStream(path, FileMode.Open);
+            await using var fileStream = new FileStream(filePath, FileMode.Open);
 
             TerrainLocalCache? localCache = await UniTask.RunOnThreadPool(() => (TerrainLocalCache)FORMATTER.Deserialize(fileStream));
 
             if (localCache.checksum != parcelChecksum)
             {
-                File.Delete(path);
-                ClearDictionaryPath();
+                ClearCache();
+                Directory.CreateDirectory(dictionaryPath);
                 return emptyCache;
             }
 
             localCache.isValid = true;
             return localCache;
 
-            void ClearDictionaryPath()
+            void CheckCorruptStates()
             {
-                if (Directory.Exists(dictionaryPath))
-                    Directory.Delete(GetDictionaryDirectory(), true);
-                Directory.CreateDirectory(dictionaryPath);
+                if (File.Exists(filePath) && !Directory.Exists(dictionaryPath))
+                    File.Delete(filePath);
+
+                if (!File.Exists(filePath) && Directory.Exists(dictionaryPath))
+                    Directory.Delete(dictionaryPath, true);
+            }
+
+            void ClearCache()
+            {
+                File.Delete(filePath);
+                Directory.Delete(dictionaryPath, true);
             }
         }
 


### PR DESCRIPTION
## What does this PR change?

Corrected the way we store and delete the local cache, since the new version was prone to failure when the `checksum` was not the one that was stored

## How to test the changes?

1. Delete all local terrain files
2. Enter the client and see the terrain. Explore the borders as well
3. Reset the client and repeat step 2. You are looking to the cached terrain now, everything should be the same.
4. Get out and delete only the `terrain_cache_dictionaries` folder
5. Repeat step 2
6. Get out and delete the terrain cache file
7. Repeat step 2
8. Repeat one last time step 2 to see once again the cached terrain

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

