### PR TITLE
fix: Hide UI images until its texture is loaded

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Classes/DCLImage.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Classes/DCLImage.cs
@@ -47,6 +47,12 @@ namespace DCL.SDKComponents.SceneUI.Classes
             set => SetUVs(value);
         }
 
+        public bool IsHidden
+        {
+            get => canvas.style.opacity == 0f;
+            set => canvas.style.opacity = value ? 0f : 1f;
+        }
+
         private IStyle style => canvas.style;
 
         public void Initialize(VisualElement canvasToApply)
@@ -57,6 +63,7 @@ namespace DCL.SDKComponents.SceneUI.Classes
             this.color = new Color(1, 1, 1, 0);
             this.uvs = default(DCLUVs);
             this.canvas = canvasToApply;
+            IsHidden = false;
 
             canvasToApply.generateVisualContent += OnGenerateVisualContent;
         }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIBackground/UIBackgroundInstantiationSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIBackground/UIBackgroundInstantiationSystem.cs
@@ -110,6 +110,8 @@ namespace DCL.SDKComponents.SceneUI.Systems.UIBackground
 
             var texturePromise = uiBackgroundComponent.TexturePromise.Value;
 
+            // We hide the image until the texture is loaded in order to avoid to show a white image in the meanwhile
+            uiBackgroundComponent.Image.IsHidden = true;
             if (texturePromise.TryConsume(World, out StreamableLoadingResult<Texture2D> promiseResult))
             {
                 // Backgrounds with texture
@@ -119,6 +121,7 @@ namespace DCL.SDKComponents.SceneUI.Systems.UIBackground
                     ReportHub.LogError(ReportCategory.SCENE_UI, "Error consuming texture promise");
 
                 uiBackgroundComponent.Status = LifeCycle.LoadingFinished;
+                uiBackgroundComponent.Image.IsHidden = false;
 
                 // Write value back as it's nullable (and can't be accessed by ref)
                 uiBackgroundComponent.TexturePromise = texturePromise;


### PR DESCRIPTION
## What does this PR change?
Fix #2141 

When we initiated a dialogue with any NPC, a white square briefly appeared in the dialogue box before the NPC's image loads correctly. This caused a visual glitch that appeared for a moment before the proper asset is displayed.

![image](https://github.com/user-attachments/assets/3364a65c-eda0-42bc-9175-0d13ad6e1264)

This was happening because the loading life-cycle of an image UI component consists on 2 steps: Firstly the component with an empty texture (white) is instantiated and, after this, we request the texture loading. This second step can take a bit of time, so during this time we would see a white box in the screen.

In order to solve this we simply hide the component's canvas at the beginning and, when the texture has been loaded, we show it back.

## How to test the changes?
1. Launch the explorer.
2. Initiate a dialogue with any NPC.
3. Check that the white box doesn't appear anymore.
4. Do a general sanity check for any UI with images in different scenes and check that everything work as before.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md