### PR TITLE
fix: creator hub title in loading screen

### DIFF
--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
@@ -40,7 +40,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 1078349173612544
-    m_Localized: Builder
+    m_Localized: Creator Hub
     m_Metadata:
       m_Items: []
   - m_Id: 1078419382067200


### PR DESCRIPTION
## What does this PR change?

Changed builder title to `Creator Hub` in the loading screen.

<img width="865" alt="Screenshot 2024-09-27 at 11 13 22" src="https://github.com/user-attachments/assets/953b0608-90b9-4383-9478-732251f2f6d0">


## How to test the changes?

1. Launch the explorer
2. Hit until the loading screen
3. Change the pages until you see the Creator Hub title

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

