### PR TITLE
fix: Avatar Emissions brought back and roughness on scene fixed

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/AvatarMaterialConfiguration.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/AvatarMaterialConfiguration.cs
@@ -71,15 +71,9 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
             avatarMaterial.SetColor(BASE_COLOR, baseColor);
             avatarMaterial.renderQueue = (int)RenderQueue.Geometry;
 
-            if (originalMaterial.IsKeywordEnabled("_EMISSION"))
-            {
-                var emissionColor = originalMaterial.GetColor("_EmissionColor");
-                avatarMaterial.SetColor("_Emissive_Color", emissionColor);
-            }
-            else
-            {
-                avatarMaterial.SetColor("_Emissive_Color", Color.black);
-            }
+            // this should really check for keyword _EMISSION, however for some reason it's rather inconsistent.
+            var emissionColor = originalMaterial.GetColor("_EmissionColor");
+            avatarMaterial.SetColor("_Emissive_Color", emissionColor);
 
             if (originalMaterial.IsKeywordEnabled("_ALPHATEST_ON") || originalMaterial.GetFloat(ALPHA_CLIP) > 0)
                 ConfigureAlphaTest(originalMaterial, avatarMaterial, baseColor);


### PR DESCRIPTION
Avatar emissions are brought back, but shouldn't cause areas to glow when they shouldn't and smoothness fix on scene shader, as recognised in the play test, where some things were super shiney and sparkly when they shouldn't be.
