### PR TITLE
fix-revert: Revert "Avoid downloading the same remote profile multiple times"

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Profiles/Announcements/RemoteAnnouncement.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/Announcements/RemoteAnnouncement.cs
@@ -1,8 +1,6 @@
-using System;
-
 namespace DCL.Multiplayer.Profiles.RemoteAnnouncements
 {
-    public readonly struct RemoteAnnouncement : IEquatable<RemoteAnnouncement>
+    public readonly struct RemoteAnnouncement
     {
         public readonly int Version;
         public readonly string WalletId;
@@ -15,14 +13,5 @@ namespace DCL.Multiplayer.Profiles.RemoteAnnouncements
 
         public override string ToString() =>
             $"(RemoteAnnouncement: {{ Version: {Version}, WalletId: {WalletId} }})";
-
-        public bool Equals(RemoteAnnouncement other) =>
-            Version == other.Version && WalletId == other.WalletId;
-
-        public override bool Equals(object? obj) =>
-            obj is RemoteAnnouncement other && Equals(other);
-
-        public override int GetHashCode() =>
-            HashCode.Combine(Version, WalletId);
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/RemoteProfiles/RemoteProfiles.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/RemoteProfiles/RemoteProfiles.cs
@@ -13,7 +13,6 @@ namespace DCL.Multiplayer.Profiles.RemoteProfiles
         private readonly IProfileRepository profileRepository;
         private readonly List<RemoteProfile> remoteProfiles = new ();
         private readonly HashSet<string> pendingProfiles = new ();
-        private readonly HashSet<RemoteAnnouncement> uniqueAnnouncements = new ();
 
         public RemoteProfiles(IProfileRepository profileRepository)
         {
@@ -24,15 +23,7 @@ namespace DCL.Multiplayer.Profiles.RemoteProfiles
         {
             //TODO consider which option for performance would be better, just everything, to download or by chuncks, question about concurrency for web requests
             foreach (RemoteAnnouncement remoteAnnouncement in list)
-            {
-                // Avoid downloading the same profile multiple times
-                if (!uniqueAnnouncements.Add(remoteAnnouncement))
-                    return;
-
                 TryDownloadAsync(remoteAnnouncement).Forget();
-            }
-
-            uniqueAnnouncements.Clear();
         }
 
         public bool NewBunchAvailable() =>


### PR DESCRIPTION
## What does this PR change?
It reverts the "Avoid downloading the same remote profile multiple times" fix -> #2165 

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md