### PR TITLE
fix: Avoid NRE from BadgesHeightReachedSystem when re-login

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/BadgesHeightReachedSystem.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/BadgesHeightReachedSystem.cs
@@ -50,7 +50,7 @@ namespace DCL.Analytics.Systems
             this.playerEntity = playerEntity;
             this.identityCache = identityCache;
 
-            currentIdentity = identityCache.Identity;
+            currentIdentity = identityCache?.Identity;
 
             totalElevationGainBinding = new ElementBinding<string>(string.Empty);
             debugContainerBuilder
@@ -60,6 +60,8 @@ namespace DCL.Analytics.Systems
 
         protected override void Update(float t)
         {
+            if(identityCache?.Identity == null) return;
+
             HandleIdentityChange();
 
             if (badgeHeightReached || !realmData.Configured) return;


### PR DESCRIPTION
## What does this PR change?
Avoid NRE from BadgesHeightReachedSystem when re-login

## How to test the changes?
1. Launch the explorer
2. Enter the world
3. Logout the user
4. Login it again
5. Check the "Vertical Voyager" value in the Debug Panel works fine.
6. Check that everything else works as expected.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md