### PR TITLE
fix: remote avatar click interaction

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Profiles/Entities/Prefabs/RemoteAvatarCollider.prefab
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/Entities/Prefabs/RemoteAvatarCollider.prefab
@@ -52,10 +52,10 @@ CapsuleCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
+  m_Radius: 0.3
+  m_Height: 1.9
   m_Direction: 1
-  m_Center: {x: 0, y: 1, z: 0}
+  m_Center: {x: 0, y: 0.95, z: 0}
 --- !u!114 &933901144610452890
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## What does this PR change?

Fixes #2204

The remote avatar colliders were way bigger than the current's player avatar. The collider has been reduced so the click area is accordingly set to the avatar's area.

## How to test the changes?

1. Follow issue steps and check that the click area is correct
2. Check that you can always interact with the avatars as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

