### PR TITLE
fix: Avatar moving on its own when pressin CAPS (#1743)

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Components/MovementInputComponent.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Components/MovementInputComponent.cs
@@ -5,7 +5,6 @@ namespace DCL.CharacterMotion.Components
 {
     public struct MovementInputComponent : IInputComponent
     {
-        public bool AutoWalk;
         public MovementKind Kind;
 
         /// <summary>

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/UpdateInputMovementSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/UpdateInputMovementSystem.cs
@@ -17,14 +17,12 @@ namespace DCL.CharacterMotion.Systems
         private readonly InputAction movementAxis;
         private readonly InputAction sprintAction;
         private readonly InputAction walkAction;
-        private readonly InputAction autoWalkAction;
 
         public UpdateInputMovementSystem(World world, DCLInput dclInput) : base(world)
         {
             movementAxis = dclInput.Player.Movement;
             sprintAction = dclInput.Player.Sprint;
             walkAction = dclInput.Player.Walk;
-            autoWalkAction = dclInput.Player.AutoWalk;
         }
 
         protected override void Update(float t)
@@ -43,12 +41,6 @@ namespace DCL.CharacterMotion.Systems
 
             inputToUpdate.Axes = movementAxis.ReadValue<Vector2>();
 
-            if (!inputModifierComponent.DisableWalk && autoWalkAction.WasPerformedThisFrame())
-                inputToUpdate.AutoWalk = !inputToUpdate.AutoWalk;
-
-            if (inputToUpdate is { AutoWalk: true, Axes: { sqrMagnitude: > 0.1f } })
-                inputToUpdate.AutoWalk = false;
-
             if (inputToUpdate.Axes == Vector2.zero)
                 inputToUpdate.Kind = MovementKind.IDLE;
             else
@@ -57,12 +49,6 @@ namespace DCL.CharacterMotion.Systems
                 bool walkPressed = walkAction.IsPressed();
 
                 inputToUpdate.Kind = ProcessInputMovementKind(inputModifierComponent, runPressed, walkPressed);
-            }
-
-            if (inputToUpdate.AutoWalk)
-            {
-                inputToUpdate.Axes = new Vector2(0, 1);
-                inputToUpdate.Kind = MovementKind.WALK;
             }
         }
 

--- a/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.cs
+++ b/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.cs
@@ -161,15 +161,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
-                },
-                {
-                    ""name"": ""AutoWalk"",
-                    ""type"": ""Button"",
-                    ""id"": ""b4656ae5-6783-44e3-aab6-f47c82bbb0b5"",
-                    ""expectedControlType"": ""Button"",
-                    ""processors"": """",
-                    ""interactions"": """",
-                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -599,17 +590,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""groups"": """",
                     ""action"": ""Walk"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
-                    ""id"": ""ce03bf46-b4a6-4780-b639-6cf34b8a35cc"",
-                    ""path"": ""<Keyboard>/capsLock"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": """",
-                    ""action"": ""AutoWalk"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 }
@@ -2919,7 +2899,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
         m_Player_ActionBackward = m_Player.FindAction("ActionBackward", throwIfNotFound: true);
         m_Player_ActionRight = m_Player.FindAction("ActionRight", throwIfNotFound: true);
         m_Player_ActionLeft = m_Player.FindAction("ActionLeft", throwIfNotFound: true);
-        m_Player_AutoWalk = m_Player.FindAction("AutoWalk", throwIfNotFound: true);
         // Camera
         m_Camera = asset.FindActionMap("Camera", throwIfNotFound: true);
         m_Camera_ZoomOut = m_Camera.FindAction("ZoomOut", throwIfNotFound: true);
@@ -3070,7 +3049,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_Player_ActionBackward;
     private readonly InputAction m_Player_ActionRight;
     private readonly InputAction m_Player_ActionLeft;
-    private readonly InputAction m_Player_AutoWalk;
     public struct PlayerActions
     {
         private @DCLInput m_Wrapper;
@@ -3090,7 +3068,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
         public InputAction @ActionBackward => m_Wrapper.m_Player_ActionBackward;
         public InputAction @ActionRight => m_Wrapper.m_Player_ActionRight;
         public InputAction @ActionLeft => m_Wrapper.m_Player_ActionLeft;
-        public InputAction @AutoWalk => m_Wrapper.m_Player_AutoWalk;
         public InputActionMap Get() { return m_Wrapper.m_Player; }
         public void Enable() { Get().Enable(); }
         public void Disable() { Get().Disable(); }
@@ -3145,9 +3122,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
             @ActionLeft.started += instance.OnActionLeft;
             @ActionLeft.performed += instance.OnActionLeft;
             @ActionLeft.canceled += instance.OnActionLeft;
-            @AutoWalk.started += instance.OnAutoWalk;
-            @AutoWalk.performed += instance.OnAutoWalk;
-            @AutoWalk.canceled += instance.OnAutoWalk;
         }
 
         private void UnregisterCallbacks(IPlayerActions instance)
@@ -3197,9 +3171,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
             @ActionLeft.started -= instance.OnActionLeft;
             @ActionLeft.performed -= instance.OnActionLeft;
             @ActionLeft.canceled -= instance.OnActionLeft;
-            @AutoWalk.started -= instance.OnAutoWalk;
-            @AutoWalk.performed -= instance.OnAutoWalk;
-            @AutoWalk.canceled -= instance.OnAutoWalk;
         }
 
         public void RemoveCallbacks(IPlayerActions instance)
@@ -3967,7 +3938,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
         void OnActionBackward(InputAction.CallbackContext context);
         void OnActionRight(InputAction.CallbackContext context);
         void OnActionLeft(InputAction.CallbackContext context);
-        void OnAutoWalk(InputAction.CallbackContext context);
     }
     public interface ICameraActions
     {

--- a/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.inputactions
+++ b/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.inputactions
@@ -139,15 +139,6 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
-                },
-                {
-                    "name": "AutoWalk",
-                    "type": "Button",
-                    "id": "b4656ae5-6783-44e3-aab6-f47c82bbb0b5",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -577,17 +568,6 @@
                     "processors": "",
                     "groups": "",
                     "action": "Walk",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "ce03bf46-b4a6-4780-b639-6cf34b8a35cc",
-                    "path": "<Keyboard>/capsLock",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "AutoWalk",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }


### PR DESCRIPTION
The feature has been removed from code and from the input system config.

## What does this PR change?

Now the Caps lock key does not make the avatar walk.

## How to test the changes?

1. Launch the explorer
2. Press Caps lock key.

The avatar does nothing.