### PR TITLE
fix: Terrain local cache still open when trying to delete

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Utils/TerrainGeneratorLocalCache.cs
+++ b/Explorer/Assets/DCL/Landscape/Utils/TerrainGeneratorLocalCache.cs
@@ -156,7 +156,7 @@ namespace DCL.Landscape.Utils
             }
 
             TerrainLocalCache? localCache;
-            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+            await using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
             {
                 localCache = await UniTask.RunOnThreadPool(() => (TerrainLocalCache)FORMATTER.Deserialize(fileStream));
             }

--- a/Explorer/Assets/DCL/Landscape/Utils/TerrainGeneratorLocalCache.cs
+++ b/Explorer/Assets/DCL/Landscape/Utils/TerrainGeneratorLocalCache.cs
@@ -155,9 +155,11 @@ namespace DCL.Landscape.Utils
                 return emptyCache;
             }
 
-            await using var fileStream = new FileStream(filePath, FileMode.Open);
-
-            TerrainLocalCache? localCache = await UniTask.RunOnThreadPool(() => (TerrainLocalCache)FORMATTER.Deserialize(fileStream));
+            TerrainLocalCache? localCache;
+            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+            {
+                localCache = await UniTask.RunOnThreadPool(() => (TerrainLocalCache)FORMATTER.Deserialize(fileStream));
+            }
 
             if (localCache.checksum != parcelChecksum)
             {


### PR DESCRIPTION
## What does this PR change?

The file stream was not correctly disposed when trying to delete the file. This PR resorts the code as needed

## How to test the changes?

1. Launch the explorer
2. Do the steps in this [PR](https://github.com/decentraland/unity-explorer/pull/2206)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

