### PR TITLE
Fix: Jumping/Landing in place makes no sound

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Animation/AvatarAnimationEventsHandler.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Animation/AvatarAnimationEventsHandler.cs
@@ -82,6 +82,8 @@ namespace DCL.CharacterMotion.Animation
         {
             if (!AvatarAnimator.GetBool(AnimationHashes.GROUNDED)) return;
 
+            if (!CheckMovementBlendThreshold()) return;
+
             if (!TryGetAudioClipType(AvatarAnimationEventType.Step, out var audioClipType)) return;
 
             float interval = GetIntervalFor(audioClipType);
@@ -121,21 +123,17 @@ namespace DCL.CharacterMotion.Animation
             AudioPlaybackController.PlayAudioForType(clipType);
         }
 
-        private bool TryGetAudioClipType(AvatarAnimationEventType eventType, out AvatarAudioClipType audioClipType)
+        private bool CheckMovementBlendThreshold()
         {
             float movementBlend = AvatarAnimator.GetFloat(AnimationHashes.MOVEMENT_BLEND);
-            if (movementBlend > MovementBlendThreshold)
-            {
-                int movementType = AvatarAnimator.GetInteger(AnimationHashes.MOVEMENT_TYPE);
-                var key = ((MovementKind)movementType, eventType);
-                if (AUDIO_CLIP_LOOKUP.TryGetValue(key, out audioClipType))
-                {
-                    return true;
-                }
-            }
+            return movementBlend > MovementBlendThreshold;
+        }
 
-            audioClipType = AvatarAudioClipType.None;
-            return false;
+        private bool TryGetAudioClipType(AvatarAnimationEventType eventType, out AvatarAudioClipType audioClipType)
+        {
+            int movementType = AvatarAnimator.GetInteger(AnimationHashes.MOVEMENT_TYPE);
+            var key = ((MovementKind)movementType, eventType);
+            return AUDIO_CLIP_LOOKUP.TryGetValue(key, out audioClipType);
         }
 
         [PublicAPI("Used by Animation Events")]


### PR DESCRIPTION
## What does this PR change?

This was caused by checking the movement blend value, but when we jump/land in place, we have no blend value, so check's always false. So I removed the check when jumping or landing which makes sense.


## How to test the changes?

Jump in place. You should hear the sounds both when you take off and when you land.
