### PR TITLE
fix: NRE in MovementBadgesSystem

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/MovementBadgesSystem.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/MovementBadgesSystem.cs
@@ -76,7 +76,7 @@ namespace DCL.Analytics.Systems
 
         private void HandleIdentityChange()
         {
-            if (!currentIdentity!.Address.Equals(identityCache.Identity.Address))
+            if (currentIdentity == null || !currentIdentity.Address.Equals(identityCache.Identity.Address))
             {
                 currentIdentity = identityCache.Identity;
                 badgeHeightReached = false;


### PR DESCRIPTION
## What does this PR change?
Fix a NRE in happened in `MovementBadgesSystem`.

![image](https://github.com/user-attachments/assets/c2195a92-01df-4988-a5ec-48a1c21ac5e1)

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md