### PR TITLE
fix: emote timeouts no longer prevent avatars from loading

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetEmotesByPointersIntention.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetEmotesByPointersIntention.cs
@@ -17,7 +17,7 @@ namespace DCL.AvatarRendering.Emotes
         public IReadOnlyCollection<URN> Pointers => pointers;
 
         // TODO why so many allocations?
-        public HashSet<URN> ProcessedPointers { get; }
+        public HashSet<URN> RequestedPointers { get; }
         public HashSet<URN> SuccessfulPointers { get; }
         public AssetSource PermittedSources { get; }
         public BodyShape BodyShape { get; }
@@ -33,7 +33,7 @@ namespace DCL.AvatarRendering.Emotes
         {
             this.pointers = pointers;
             CancellationTokenSource = new CancellationTokenSource();
-            ProcessedPointers = POINTERS_HASHSET_POOL.Get();
+            RequestedPointers = POINTERS_HASHSET_POOL.Get();
             SuccessfulPointers = POINTERS_HASHSET_POOL.Get();
             PermittedSources = permittedSources;
             BodyShape = bodyShape;
@@ -52,7 +52,7 @@ namespace DCL.AvatarRendering.Emotes
         public void Dispose()
         {
             POINTERS_POOL.Release(pointers);
-            POINTERS_HASHSET_POOL.Release(ProcessedPointers);
+            POINTERS_HASHSET_POOL.Release(RequestedPointers);
             POINTERS_HASHSET_POOL.Release(SuccessfulPointers);
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
@@ -206,7 +206,7 @@ namespace DCL.AvatarRendering.Emotes.Load
             // Keep only successful emotes in the result list
             resolvedEmotesTmp.List.RemoveAll(emote => !successfulPointers.Contains(emote.GetUrn()));
 
-            World.Add(entity, new StreamableResult(new EmotesResolution(resolvedEmotesTmp, successfulPointers.Count)));
+            World.Add(entity, new StreamableResult(new EmotesResolution(resolvedEmotesTmp, resolvedEmotesTmp.List.Count)));
         }
 
         private static StreamableResult NewEmotesResult(RepoolableList<IEmote> resolvedEmotesTmp, int pointersCount) =>

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
@@ -175,30 +175,52 @@ namespace DCL.AvatarRendering.Emotes.Load
                     static _ => "Pointer request cancelled"))
                 return;
 
-            if (TryCancelByTimeout(entity, ref intention, dt)) return;
-
-            using var _ = ListPool<URN>.Get(out var missingPointersTmp)!;
+            using var _ = ListPool<URN>.Get(out var pointersToRequest)!;
             var resolvedEmotesTmp = RepoolableList<IEmote>.NewList();
 
-            HandlePointers(in intention, missingPointersTmp!, resolvedEmotesTmp);
-            if (TryCancelByMissingPointers(missingPointersTmp!, partitionComponent, intention.BodyShape)) return;
-            HandleResolvedEmotes(in intention, partitionComponent, resolvedEmotesTmp.List, out bool success);
-            if (success) World!.Add(entity, NewEmotesResult(resolvedEmotesTmp, intention.Pointers.Count));
+            ExtractMissingPointersAndResolvedEmotes(in intention, pointersToRequest!, resolvedEmotesTmp);
+
+            if (intention.Timeout.IsTimeout(dt))
+            {
+                var pointersStrLog = string.Join(",", intention.Pointers);
+                ReportHub.LogWarning(GetReportCategory(), $"Loading emotes timed out, {pointersStrLog}");
+
+                ResolveIntentionWithSuccessfulEmotes(entity, intention, resolvedEmotesTmp);
+
+                return;
+            }
+
+            if (RequestMissingPointers(pointersToRequest!, partitionComponent, intention.BodyShape)) return;
+
+            bool success = GetAssetBundlesUntilAllAreResolved(in intention, partitionComponent, resolvedEmotesTmp.List);
+
+            if (success)
+                World!.Add(entity, NewEmotesResult(resolvedEmotesTmp, intention.Pointers.Count));
+        }
+
+        private void ResolveIntentionWithSuccessfulEmotes(Entity entity,
+            GetEmotesByPointersIntention intention,
+            RepoolableList<IEmote> resolvedEmotesTmp)
+        {
+            HashSet<URN> successfulPointers = intention.SuccessfulPointers;
+            // Keep only successful emotes in the result list
+            resolvedEmotesTmp.List.RemoveAll(emote => !successfulPointers.Contains(emote.GetUrn()));
+
+            World.Add(entity, new StreamableResult(new EmotesResolution(resolvedEmotesTmp, successfulPointers.Count)));
         }
 
         private static StreamableResult NewEmotesResult(RepoolableList<IEmote> resolvedEmotesTmp, int pointersCount) =>
             new (new EmotesResolution(resolvedEmotesTmp, pointersCount));
 
-        private void HandleResolvedEmotes(
+        private bool GetAssetBundlesUntilAllAreResolved(
             in GetEmotesByPointersIntention intention,
             IPartitionComponent partitionComponent,
-            IEnumerable<IEmote> resolvedEmotes,
-            out bool success
+            IEnumerable<IEmote> emotes
         )
         {
             var emotesWithResponse = 0;
 
-            foreach (IEmote emote in resolvedEmotes)
+            foreach (IEmote emote in emotes)
             {
                 if (emote.ManifestResult is { Exception: not null })
                     emotesWithResponse++;
@@ -224,32 +246,30 @@ namespace DCL.AvatarRendering.Emotes.Load
                     }
             }
 
-            success = emotesWithResponse == intention.Pointers.Count;
+            return emotesWithResponse == intention.Pointers.Count;
         }
 
-        private bool TryCancelByMissingPointers(ICollection<URN> missingPointersTmp, IPartitionComponent partitionComponent, BodyShape forBodyShape)
+        private bool RequestMissingPointers(ICollection<URN> missingPointers, IPartitionComponent partitionComponent, BodyShape forBodyShape)
         {
-            if (missingPointersTmp.Count > 0)
-            {
-                var promise = EmotesFromRealmPromise.Create(
-                    World!,
-                    new GetEmotesByPointersFromRealmIntention(missingPointersTmp.ToList(),
-                        new CommonLoadingArguments(realmData.Ipfs.EntitiesActiveEndpoint)
-                    ),
-                    partitionComponent
-                );
+            if (missingPointers.Count <= 0) return false;
 
-                World!.Create(promise, forBodyShape, partitionComponent);
-                return true;
-            }
+            var promise = EmotesFromRealmPromise.Create(
+                World!,
+                new GetEmotesByPointersFromRealmIntention(missingPointers.ToList(),
+                    new CommonLoadingArguments(realmData.Ipfs.EntitiesActiveEndpoint)
+                ),
+                partitionComponent
+            );
 
-            return false;
+            World!.Create(promise, forBodyShape, partitionComponent);
+
+            return true;
         }
 
-        private void HandlePointers(
+        private void ExtractMissingPointersAndResolvedEmotes(
             in GetEmotesByPointersIntention intention,
-            ICollection<URN> mutMissingPointersTmp,
-            RepoolableList<IEmote> mutResolvedEmotesTmp
+            ICollection<URN> missingPointers,
+            RepoolableList<IEmote> resolvedEmotes
         )
         {
             foreach (URN loadingIntentionPointer in intention.Pointers)
@@ -268,35 +288,18 @@ namespace DCL.AvatarRendering.Emotes.Load
 
                 if (!emoteStorage.TryGetElement(shortenedPointer, out IEmote emote))
                 {
-                    if (!intention.ProcessedPointers.Contains(loadingIntentionPointer))
+                    if (!intention.RequestedPointers.Contains(loadingIntentionPointer))
                     {
-                        mutMissingPointersTmp.Add(shortenedPointer);
-                        intention.ProcessedPointers.Add(loadingIntentionPointer);
+                        missingPointers.Add(shortenedPointer);
+                        intention.RequestedPointers.Add(loadingIntentionPointer);
                     }
 
                     continue;
                 }
 
                 if (emote.Model.Succeeded)
-                    mutResolvedEmotesTmp.List.Add(emote);
+                    resolvedEmotes.List.Add(emote);
             }
-        }
-
-        private bool TryCancelByTimeout(Entity entity, ref GetEmotesByPointersIntention intention, float dt)
-        {
-            if (intention.Timeout.IsTimeout(dt))
-            {
-                if (World!.Has<StreamableResult>(entity) == false)
-                {
-                    var pointersStrLog = string.Join(",", intention.Pointers);
-                    ReportHub.LogWarning(GetReportCategory(), $"Loading emotes timed out, {pointersStrLog}");
-                    World.Add(entity, new StreamableResult(GetReportCategory(), new TimeoutException($"Emote intention timeout {pointersStrLog}")));
-                }
-
-                return true;
-            }
-
-            return false;
         }
 
         private bool CreateAssetBundlePromiseIfRequired(IEmote component, in GetEmotesByPointersIntention intention, IPartitionComponent partitionComponent)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
@@ -57,6 +57,7 @@ namespace DCL.AvatarRendering.Emotes.Load
             GetEmotesByPointersQuery(World, t);
         }
 
+        // TODO: this query should not be in this system. This system should only process scene emotes, but this query is processing emotes of avatars
         [Query]
         [None(typeof(StreamableResult))]
         private void GetEmotesFromRealm([Data] float dt, in Entity entity,


### PR DESCRIPTION
## What does this PR change?

Fixes #2296
Fixes #2276 

Fixes this exception which produces to not be able to see other avatars in-world:
```
TimeoutException: Emote intention timeout urn:decentraland:matic:collections-v2:0x0b472c2c04325a545a43370b54e93c87f3d5badf:2:210624583337114373395836055367340864637790190801098222508621955124,urn:decentraland:matic:collections-v2:0xef832a5183bf2e4099efed4c6ec981b7b41aa545:0:135,urn:decentraland:matic:collections-v2:0xa6c722476bdd17bf2adb65e96388345d83259f3b:0:537,urn:decentraland:matic:collections-v2:0xe2fa84a384fa86c29855dd3909874b3dbddc74bc:0:541,clap,money,kiss,headexplode,urn:decentraland:matic:collections-v2:0x0ae365f8acc27f2c95fc7d60cf49a74f3af21573:3:315936875005671560093754083051011296956685286201647333762932932770
UnityEngine.DebugLogHandler:LogException(Exception, Object)
DCL.Diagnostics.DebugLogReportHandler:LogExceptionInternal(Exception, ReportData, Object) (at Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Handlers/DebugLogReportHandler.cs:109)
DCL.Diagnostics.ReportHandlerBase:LogException(Exception, ReportData, Object) (at Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Handlers/ReportHandlerBase.cs:49)
DCL.Diagnostics.ReportHubLogger:LogException(Exception, ReportData, ReportHandler) (at Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportHubLogger.cs:126)
DCL.Diagnostics.ReportHub:LogException(Exception, ReportData, ReportHandler) (at Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportHub.cs:137)
ECS.StreamableLoading.Common.Components.StreamableLoadingResult`1:.ctor(ReportData, Exception) (at Assets/Scripts/ECS/StreamableLoading/Common/Components/StreamableLoadingResult.cs:27)
DCL.AvatarRendering.Emotes.Load.LoadSceneEmotesSystem:TryCancelByTimeout(Entity, GetEmotesByPointersIntention&, Single) (at Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs:293)
DCL.AvatarRendering.Emotes.Load.LoadSceneEmotesSystem:GetEmotesByPointers(Single, Entity&, GetEmotesByPointersIntention&, IPartitionComponent&) (at Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs:178)
DCL.AvatarRendering.Emotes.Load.LoadSceneEmotesSystem:GetEmotesByPointersQuery(World, Single) (at Arch.System.SourceGenerator/Arch.System.SourceGenerator.QueryGenerator/LoadSceneEmotesSystem.GetEmotesByPointers(float, in Entity, ref GetEmotesByPointersIntention, ref IPartitionComponent).g.cs:37)
DCL.AvatarRendering.Emotes.Load.LoadSceneEmotesSystem:Update(Single) (at Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs:57)
ECS.Abstract.BaseUnityLoopSystem:Update(Single&) (at Assets/Scripts/ECS/Abstract/BaseUnityLoopSystem.cs:55)
Arch.SystemGroups.ExecutionNode`1:Update(Single&, Boolean) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/ExecutionNode.cs:78)
Arch.SystemGroups.SystemGroup:Update(Info&) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/SystemGroup.cs:107)
Arch.SystemGroups.DefaultSystemGroups.PresentationSystemGroup:Update() (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/DefaultSystemGroups/PresentationSystemGroup.cs:23)
Arch.SystemGroups.SystemGroupAggregate:TriggerUpdate() (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/PlayerLoopHelper/Aggregation/SystemGroupAggregate.cs:36)
```

The solution involves in considering the timeout, so the intent is resolved with the successful emotes available at that moment, rather than failing all of them. This approach allows the avatar to be created later within the `AvatarInstantiatorSystem`.

## How to test the changes?

1. Launch the explorer
2. Group together in a single scene
3. Check that all avatars load as expected
4. Check that you can play your emotes

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

