### PR TITLE
fix: missing animator component on emotes

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
@@ -42,7 +42,12 @@ namespace DCL.AvatarRendering.Emotes.Play
                 Stop(emoteInUse);
 
             if (!pools.ContainsKey(mainAsset))
-                pools.Add(mainAsset, new GameObjectPool<EmoteReferences>(poolRoot, () => CreateNewEmoteReference(mainAsset), onRelease: releaseEmoteReferences));
+            {
+                if (IsValid(mainAsset))
+                    pools.Add(mainAsset, new GameObjectPool<EmoteReferences>(poolRoot, () => CreateNewEmoteReference(mainAsset), onRelease: releaseEmoteReferences));
+                else
+                    return false;
+            }
 
             EmoteReferences? emoteReferences = pools[mainAsset]!.Get();
             if (!emoteReferences) return false;
@@ -94,6 +99,9 @@ namespace DCL.AvatarRendering.Emotes.Play
             emoteComponent.CurrentEmoteReference = emoteReferences;
             return true;
         }
+
+        private static bool IsValid(GameObject mainAsset) =>
+            mainAsset.GetComponent<Animator>();
 
         private static EmoteReferences CreateNewEmoteReference(GameObject mainAsset)
         {


### PR DESCRIPTION
## What does this PR change?

Fixes #2274 

Fixes cases on which the emotes are not correctly converted and contains no `Animator`. This was provoking a flood in the object hierarchy degrading the performance significantly.

## How to test the changes?

1. Launch the explorer with `--self-force-emotes urn:decentraland:matic:collections-v2:0x7bdc37ff3e8dca2d69f01a3dc34f3ad82e2e1870:0`
2. Try playing that emote
3. The emote will not be played, but the client should not degrade its performance
4. Play any other emote. It should work as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

