### PR TITLE
Fix: can teleport outside city

### DIFF
--- a/Explorer/Assets/DCL/Landscape/IContainParcel.cs
+++ b/Explorer/Assets/DCL/Landscape/IContainParcel.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace DCL.Landscape
+{
+    public interface IContainParcel
+    {
+        bool Contains(Vector2Int parcel);
+    }
+}

--- a/Explorer/Assets/DCL/Landscape/IContainParcel.cs.meta
+++ b/Explorer/Assets/DCL/Landscape/IContainParcel.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 02d6455156214c41b7dc575e46aa6ffa
+timeCreated: 1727946197

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -22,7 +22,7 @@ using JobHandle = Unity.Jobs.JobHandle;
 
 namespace DCL.Landscape
 {
-    public class TerrainGenerator : IDisposable
+    public class TerrainGenerator : IDisposable, IContainParcel
     {
         private const string TERRAIN_OBJECT_NAME = "Generated Terrain";
         private const float ROOT_VERTICAL_SHIFT = -0.01f; // fix for not clipping with scene (potential) floor
@@ -106,8 +106,13 @@ namespace DCL.Landscape
             isInitialized = true;
         }
 
-        public bool Contains(Vector2Int parcel) =>
-            terrainModel.IsInsideBounds(parcel);
+        public bool Contains(Vector2Int parcel)
+        {
+            if (IsTerrainGenerated)
+                return terrainModel.IsInsideBounds(parcel);
+
+            return true;
+        }
 
         public void Dispose()
         {

--- a/Explorer/Assets/DCL/Landscape/Worlds/TerrainModel.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/TerrainModel.cs
@@ -72,6 +72,9 @@ namespace DCL.Landscape
             }
         }
 
+        public bool IsInsideBounds(Vector2Int parcel) =>
+            parcel.x >= MinInUnits.x && parcel.x <= MaxInUnits.x && parcel.y >= MinInUnits.y && parcel.y <= MaxInUnits.y;
+
         private void CalculateChunkSizeAndCount()
         {
             int maxSideLengthInUnits = Mathf.Max(SizeInUnits.x, SizeInUnits.y);

--- a/Explorer/Assets/DCL/Landscape/Worlds/TerrainModel.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/TerrainModel.cs
@@ -73,7 +73,7 @@ namespace DCL.Landscape
         }
 
         public bool IsInsideBounds(Vector2Int parcel) =>
-            parcel.x >= MinInUnits.x && parcel.x <= MaxInUnits.x && parcel.y >= MinInUnits.y && parcel.y <= MaxInUnits.y;
+            parcel.x >= MinParcel.x && parcel.x <= MaxParcel.x && parcel.y >= MinParcel.y && parcel.y <= MaxParcel.y;
 
         private void CalculateChunkSizeAndCount()
         {

--- a/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
@@ -17,7 +17,7 @@ using Utility;
 
 namespace DCL.Landscape
 {
-    public class WorldTerrainGenerator : IDisposable
+    public class WorldTerrainGenerator : IDisposable, IContainParcel
     {
         private const string TERRAIN_OBJECT_NAME = "World Generated Terrain";
         private const float ROOT_VERTICAL_SHIFT = -0.001f; // fix for not clipping with scene (potential) floor
@@ -57,8 +57,13 @@ namespace DCL.Landscape
                 UnityObjectUtils.SafeDestroy(rootGo);
         }
 
-        public bool Contains(Vector2Int parcel) =>
-            terrainModel.IsInsideBounds(parcel);
+        public bool Contains(Vector2Int parcel)
+        {
+            if (IsInitialized)
+                return terrainModel.IsInsideBounds(parcel);
+
+            return false;
+        }
 
         public void Initialize(TerrainGenerationData terrainGenData)
         {

--- a/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
@@ -42,6 +42,8 @@ namespace DCL.Landscape
         private NoiseGeneratorCache noiseGenCache;
         public bool IsInitialized { get; private set; }
 
+        private TerrainModel terrainModel;
+
         public WorldTerrainGenerator(bool measureTime = false)
         {
             timeProfiler = new TimeProfiler(measureTime);
@@ -54,6 +56,9 @@ namespace DCL.Landscape
             if (rootGo != null)
                 UnityObjectUtils.SafeDestroy(rootGo);
         }
+
+        public bool Contains(Vector2Int parcel) =>
+            terrainModel.IsInsideBounds(parcel);
 
         public void Initialize(TerrainGenerationData terrainGenData)
         {
@@ -82,7 +87,7 @@ namespace DCL.Landscape
 
             this.ownedParcels = ownedParcels;
             var worldModel = new WorldModel(ownedParcels);
-            var terrainModel = new TerrainModel(parcelSize, worldModel, terrainGenData.borderPadding + Mathf.RoundToInt(0.1f * (worldModel.SizeInParcels.x + worldModel.SizeInParcels.y) / 2f));
+            terrainModel = new TerrainModel(parcelSize, worldModel, terrainGenData.borderPadding + Mathf.RoundToInt(0.1f * (worldModel.SizeInParcels.x + worldModel.SizeInParcels.y) / 2f));
 
             rootGo = factory.InstantiateSingletonTerrainRoot(TERRAIN_OBJECT_NAME);
             rootGo.position = new Vector3(0, ROOT_VERTICAL_SHIFT, 0);

--- a/Explorer/Assets/DCL/PluginSystem/Global/LandscapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/LandscapePlugin.cs
@@ -1,7 +1,6 @@
 ﻿using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
-using DCL.AsyncLoadReporting;
 using DCL.DebugUtilities;
 using DCL.Landscape;
 using DCL.Landscape.Config;

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
@@ -40,10 +40,8 @@ namespace ECS.SceneLifeCycle.Realm
 
         UniTask<UniTask> TeleportToParcelAsync(Vector2Int parcel, AsyncLoadProcessReport processReport,
             CancellationToken ct);
-        
+
         // True if changed to GenesisCity, False - when changed to any other realm
         event Action<bool> RealmChanged;
-        
-        
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
@@ -89,7 +89,7 @@ namespace Global.Dynamic.ChatCommands
 
             return result.Success
                 ? $"🟢 Welcome to the {worldName} world!"
-                : $"🔴 Teleport was not fully successfull to {worldName} world"!;
+                : $"🔴 Teleport was not fully successful to {worldName} world"!;
         }
 
         private string GetWorldAddress(string worldPath)

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/GoToChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/GoToChatCommand.cs
@@ -7,7 +7,6 @@ using UnityEngine;
 using Utility;
 using Utility.Types;
 using Random = UnityEngine.Random;
-using static DCL.Chat.Commands.IChatCommand;
 
 namespace Global.Dynamic.ChatCommands
 {
@@ -17,7 +16,7 @@ namespace Global.Dynamic.ChatCommands
         private const string PARAMETER_RANDOM = "random";
 
         public static readonly Regex REGEX =
-            new(
+            new (
                 $@"^/({ChatCommandsUtils.COMMAND_GOTO}|{COMMAND_GOTO_LOCAL})\s+(?:(-?\d+)\s*,\s*(-?\d+)|{PARAMETER_RANDOM})$",
                 RegexOptions.Compiled);
         private readonly IRealmNavigator realmNavigator;
@@ -45,7 +44,7 @@ namespace Global.Dynamic.ChatCommands
                 y = Random.Range(GenesisCityData.MIN_PARCEL.y, GenesisCityData.MAX_SQUARE_CITY_PARCEL.y);
             }
 
-            var teleportResult =
+            Result teleportResult =
                 await realmNavigator.TryInitializeTeleportToParcelAsync(new Vector2Int(x, y), ct, isLocal);
 
             if (ct.IsCancellationRequested)
@@ -53,7 +52,7 @@ namespace Global.Dynamic.ChatCommands
 
             return teleportResult.Success
                 ? $"🟢 You teleported to {x},{y} in Genesis City"
-                : "🔴 Teleport failed. Try again later!";
+                : $"🔴 Teleport failed: {teleportResult.ErrorMessage}";
         }
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -209,26 +209,28 @@ namespace Global.Dynamic
 
             if (!isLocal && !isGenesis)
             {
+                if(genesisTerrain.IsTerrainGenerated && !genesisTerrain.Contains(parcel))
+                    return Result.ErrorResult($"Parcel {parcel} is outside of the bounds.");
+
                 var url = URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.Genesis));
                 return await TryChangeRealmAsync(url, ct, parcel);
             }
 
-            // if(worldsTerrain.IsInitialized && genesisTerrain.IsTerrainGenerated)
-            // {
-            //     if (isLocal)
-            //         switch (isGenesis)
-            //         {
-            //             case false when !worldsTerrain.Contains(parcel):
-            //                 return Result.ErrorResult($"Parcel {parcel} is outside of the bounds.");
-            //             case true when !genesisTerrain.Contains(parcel):
-            //                 return Result.ErrorResult($"Parcel {parcel} is outside of the bounds.");
-            //         }
-            //     else
-            //     {
-            //         if (!genesisTerrain.Contains(parcel))
-            //             return Result.ErrorResult($"Parcel {parcel} is outside of the bounds.");
-            //     }
-            // }
+            {
+                if (isLocal)
+                    switch (isGenesis)
+                    {
+                        case false when worldsTerrain.IsInitialized && !worldsTerrain.Contains(parcel):
+                            return Result.ErrorResult($"Parcel {parcel} is outside of the bounds.");
+                        case true when genesisTerrain.IsTerrainGenerated && !genesisTerrain.Contains(parcel):
+                            return Result.ErrorResult($"Parcel {parcel} is outside of the bounds.");
+                    }
+                else
+                {
+                    if (genesisTerrain.IsTerrainGenerated && !genesisTerrain.Contains(parcel))
+                        return Result.ErrorResult($"Parcel {parcel} is outside of the bounds.");
+                }
+            }
 
             Result loadResult = await loadingScreen.ShowWhileExecuteTaskAsync(TryTeleportAsync(parcel, ct), ct);
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -20,7 +20,9 @@ using System;
 using System.Linq;
 using System.Threading;
 using DCL.Diagnostics;
-using DCL.Roads.Components;
+using DCL.Ipfs;
+using ECS.SceneLifeCycle.SceneDefinition;
+using ECS.StreamableLoading.Common;
 using Global.Dynamic.TeleportOperations;
 using Unity.Collections;
 using Unity.Mathematics;
@@ -49,12 +51,12 @@ namespace Global.Dynamic
         private readonly ObjectProxy<Entity> cameraEntity;
         private readonly CameraSamplingData cameraSamplingData;
 
+        private readonly ITeleportOperation[] realmChangeOperations;
+        private readonly ITeleportOperation teleportInSameRealmOperation;
+
         private URLDomain? CurrentRealm;
 
         public event Action<bool>? RealmChanged;
-
-        private readonly ITeleportOperation[] realmChangeOperations;
-        private readonly ITeleportOperation teleportInSameRealmOperation;
 
         public RealmNavigator(
             ILoadingScreen loadingScreen,
@@ -99,7 +101,7 @@ namespace Global.Dynamic
                 new LoadLandscapeTeleportOperation(this),
                 new PrewarmRoadAssetPoolsTeleportOperation(realmController, roadsPlugin),
                 new MoveToParcelInNewRealmTeleportOperation(this),
-                new RestartRoomAsyncTeleportOperation(roomHub, livekitTimeout)
+                new RestartRoomAsyncTeleportOperation(roomHub, livekitTimeout),
             };
 
             teleportInSameRealmOperation = new MoveToParcelInSameRealmTeleportOperation(this);
@@ -116,6 +118,7 @@ namespace Global.Dynamic
         public async UniTask<bool> CheckRealmIsReacheableAsync(URLDomain realm, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
+
             if (!await realmController.IsReachableAsync(realm, ct))
                 return false;
 
@@ -126,13 +129,15 @@ namespace Global.Dynamic
             Vector2Int parcelToTeleport = default)
         {
             ct.ThrowIfCancellationRequested();
-            var loadResult
+
+            Result loadResult
                 = await loadingScreen.ShowWhileExecuteTaskAsync(DoChangeRealmAsync(realm, parcelToTeleport, ct), ct);
 
             if (!loadResult.Success)
             {
                 if (!globalWorld.Has<CameraSamplingData>(cameraEntity.Object))
                     globalWorld.Add(cameraEntity.Object, cameraSamplingData);
+
                 ReportHub.LogError(ReportCategory.REALM,
                     $"Error trying to teleport to a realm {realm}: {loadResult.ErrorMessage}");
             }
@@ -152,13 +157,15 @@ namespace Global.Dynamic
                 {
                     CurrentDestinationParcel = parcelToTeleport,
                     CurrentDestinationRealm = realm,
-                    ParentReport = parentLoadReport
+                    ParentReport = parentLoadReport,
                 };
-                foreach (var realmChangeOperation in realmChangeOperations)
+
+                foreach (ITeleportOperation realmChangeOperation in realmChangeOperations)
                 {
                     try
                     {
-                        var currentOperationResult = await realmChangeOperation.ExecuteAsync(teleportParams, ct);
+                        Result currentOperationResult = await realmChangeOperation.ExecuteAsync(teleportParams, ct);
+
                         if (!currentOperationResult.Success)
                         {
                             parentLoadReport.SetProgress(1);
@@ -179,7 +186,7 @@ namespace Global.Dynamic
         public async UniTask InitializeTeleportToSpawnPointAsync(AsyncLoadProcessReport teleportLoadReport,
             CancellationToken ct, Vector2Int parcelToTeleport)
         {
-            var isGenesis = !realmController.RealmData.ScenesAreFixed;
+            bool isGenesis = !realmController.RealmData.ScenesAreFixed;
             UniTask waitForSceneReadiness;
 
             if (isGenesis)
@@ -198,7 +205,7 @@ namespace Global.Dynamic
         {
             ct.ThrowIfCancellationRequested();
 
-            var isGenesis = !realmController.RealmData.ScenesAreFixed;
+            bool isGenesis = !realmController.RealmData.ScenesAreFixed;
 
             if (!isLocal && !isGenesis)
             {
@@ -206,12 +213,31 @@ namespace Global.Dynamic
                 return await TryChangeRealmAsync(url, ct, parcel);
             }
 
-            var loadResult = await loadingScreen.ShowWhileExecuteTaskAsync(TryTeleportAsync(parcel, ct), ct);
+            // if(worldsTerrain.IsInitialized && genesisTerrain.IsTerrainGenerated)
+            // {
+            //     if (isLocal)
+            //         switch (isGenesis)
+            //         {
+            //             case false when !worldsTerrain.Contains(parcel):
+            //                 return Result.ErrorResult($"Parcel {parcel} is outside of the bounds.");
+            //             case true when !genesisTerrain.Contains(parcel):
+            //                 return Result.ErrorResult($"Parcel {parcel} is outside of the bounds.");
+            //         }
+            //     else
+            //     {
+            //         if (!genesisTerrain.Contains(parcel))
+            //             return Result.ErrorResult($"Parcel {parcel} is outside of the bounds.");
+            //     }
+            // }
+
+            Result loadResult = await loadingScreen.ShowWhileExecuteTaskAsync(TryTeleportAsync(parcel, ct), ct);
+
             if (!loadResult.Success)
             {
                 ReportHub.LogError(ReportCategory.SCENE_LOADING,
                     $"Error trying to teleport to a parcel {parcel}: {loadResult.ErrorMessage}");
             }
+
             return loadResult;
         }
 
@@ -221,14 +247,17 @@ namespace Global.Dynamic
             {
                 ct.ThrowIfCancellationRequested();
                 parentLoadReport.SetProgress(RealFlowLoadingStatus.PROGRESS[LandscapeLoaded]);
+
                 var teleportParams = new TeleportParams
                 {
                     ParentReport = parentLoadReport,
-                    CurrentDestinationParcel = parcel
+                    CurrentDestinationParcel = parcel,
                 };
+
                 try
                 {
-                    var currentOperationResult = await teleportInSameRealmOperation.ExecuteAsync(teleportParams, ct);
+                    Result currentOperationResult = await teleportInSameRealmOperation.ExecuteAsync(teleportParams, ct);
+
                     if (!currentOperationResult.Success)
                     {
                         parentLoadReport.SetProgress(1);
@@ -249,7 +278,7 @@ namespace Global.Dynamic
         {
             if (landscapeEnabled)
             {
-                var isGenesis = !realmController.RealmData.ScenesAreFixed;
+                bool isGenesis = !realmController.RealmData.ScenesAreFixed;
 
                 if (isGenesis)
                 {
@@ -265,6 +294,7 @@ namespace Global.Dynamic
                 else
                 {
                     genesisTerrain.Hide();
+
                     await GenerateWorldTerrainAsync((uint)realmController.RealmData.GetHashCode(), landscapeLoadReport,
                         ct);
                 }
@@ -273,7 +303,7 @@ namespace Global.Dynamic
 
         public async UniTask SwitchMiscVisibilityAsync()
         {
-            var isGenesis = !realmController.RealmData.ScenesAreFixed;
+            bool isGenesis = !realmController.RealmData.ScenesAreFixed;
 
             RealmChanged?.Invoke(isGenesis);
             mapRenderer.SetSharedLayer(MapLayer.PlayerMarker, isGenesis);
@@ -284,15 +314,16 @@ namespace Global.Dynamic
         public async UniTask<UniTask> TeleportToParcelAsync(Vector2Int parcel, AsyncLoadProcessReport processReport,
             CancellationToken ct)
         {
-            var waitForSceneReadiness =
+            WaitForSceneReadiness? waitForSceneReadiness =
                 await teleportController.TeleportToSceneSpawnPointAsync(parcel, processReport, ct);
+
             return waitForSceneReadiness.ToUniTask(ct);
         }
 
         private async UniTask<UniTask> TeleportToWorldSpawnPointAsync(Vector2Int parcelToTeleport,
             AsyncLoadProcessReport processReport, CancellationToken ct)
         {
-            var promises = await realmController.WaitForFixedScenePromisesAsync(ct);
+            AssetPromise<SceneEntityDefinition, GetSceneDefinition>[]? promises = await realmController.WaitForFixedScenePromisesAsync(ct);
 
             if (!promises.Any(p =>
                     p.Result.HasValue
@@ -300,8 +331,9 @@ namespace Global.Dynamic
                 ))
                 parcelToTeleport = promises[0].Result!.Value.Asset!.metadata.scene.DecodedBase;
 
-            var waitForSceneReadiness =
+            WaitForSceneReadiness? waitForSceneReadiness =
                 await teleportController.TeleportToSceneSpawnPointAsync(parcelToTeleport, processReport, ct);
+
             return waitForSceneReadiness.ToUniTask(ct);
         }
 
@@ -318,19 +350,19 @@ namespace Global.Dynamic
             if (!worldsTerrain.IsInitialized)
                 return;
 
-            var promises = await realmController.WaitForFixedScenePromisesAsync(ct);
+            AssetPromise<SceneEntityDefinition, GetSceneDefinition>[]? promises = await realmController.WaitForFixedScenePromisesAsync(ct);
 
             var decodedParcelsAmount = 0;
 
-            foreach (var promise in promises)
+            foreach (AssetPromise<SceneEntityDefinition, GetSceneDefinition> promise in promises)
                 decodedParcelsAmount += promise.Result!.Value.Asset!.metadata.scene.DecodedParcels.Count;
 
             using (var ownedParcels =
                    new NativeParallelHashSet<int2>(decodedParcelsAmount, AllocatorManager.Persistent))
             {
-                foreach (var promise in promises)
+                foreach (AssetPromise<SceneEntityDefinition, GetSceneDefinition> promise in promises)
                 {
-                    foreach (var parcel in promise.Result!.Value.Asset!.metadata.scene.DecodedParcels)
+                    foreach (Vector2Int parcel in promise.Result!.Value.Asset!.metadata.scene.DecodedParcels)
                         ownedParcels.Add(parcel.ToInt2());
                 }
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/MoveToParcelInSameRealmTeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/MoveToParcelInSameRealmTeleportOperation.cs
@@ -18,7 +18,6 @@ namespace Global.Dynamic.TeleportOperations
             this.realmNavigator = realmNavigator;
         }
 
-
         public async UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
         {
             try

--- a/Explorer/Assets/Scripts/Utility/GenesisCityData.cs
+++ b/Explorer/Assets/Scripts/Utility/GenesisCityData.cs
@@ -16,5 +16,16 @@ namespace Utility
             Rect.MinMaxRect(62, 151, 162, MAX_PARCEL.y),
             Rect.MinMaxRect(151, 59, MAX_PARCEL.x, 150),
         };
+
+        public static bool IsInsideBounds(float x, float y)
+        {
+            Vector2 pos = new Vector2(x, y);
+
+            foreach (Rect rect in INTERACTABLE_WORLD_BOUNDS)
+                if (rect.Contains(pos))
+                    return true;
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?
fix #2254

Prevent user to teleport outside of bounds of Genesis or World, by checking if parcel is inside generated terrain parcels. Works only when Landscape is enabled.

## How to test the changes?

1. Launch the explorer
2. `/goto 1000,1000` -> error message from the system in the chat
3. `/goto 50,50` -> you teleported
4. `/goto olavra`
5. `/goto-local 50,50` -> validate error message in chat
6. `/goto-local 5,5 `-> you teleported normally
7. `/goto 1,1000` -> error message
8. `/goto 100,1` -> you teleported back in Genesis

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

