### PR TITLE
fix: Hide BUY button for base equipped items in the Passport

### DIFF
--- a/Explorer/Assets/DCL/Passport/Fields/EquippedItem_PassportFieldView.cs
+++ b/Explorer/Assets/DCL/Passport/Fields/EquippedItem_PassportFieldView.cs
@@ -101,10 +101,11 @@ namespace DCL.Passport.Fields
         {
             cts?.SafeCancelAndDispose();
             cts = new CancellationTokenSource();
-            HoverBackgroundTransform.localScale = Vector3.one;
+            var hoverBackgroundScale = new Vector3(1, BuyButton.gameObject.activeSelf ? 1 : 0.85f, 1);
+            HoverBackgroundTransform.localScale = hoverBackgroundScale;
             HoverBackgroundTransform.gameObject.SetActive(true);
             ContainerTransform.DOScale(hoveredScale, ANIMATION_TIME).SetEase(Ease.Flash).ToUniTask(cancellationToken: cts.Token);
-            HoverBackgroundTransform.DOScale(Vector3.one, ANIMATION_TIME).SetEase(Ease.Flash).ToUniTask(cancellationToken: cts.Token);
+            HoverBackgroundTransform.DOScale(hoverBackgroundScale, ANIMATION_TIME).SetEase(Ease.Flash).ToUniTask(cancellationToken: cts.Token);
         }
 
         private void AnimateExit()

--- a/Explorer/Assets/DCL/Passport/Modules/EquippedItems_PassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/EquippedItems_PassportModuleController.cs
@@ -196,7 +196,7 @@ namespace DCL.Passport.Modules
                 equippedWearableItem.FlapBackground.color = rarityColor;
                 equippedWearableItem.CategoryImage.sprite = categoryIcons.GetTypeImage(wearable.GetCategory());
                 string marketPlaceLink = GetMarketplaceLink(wearable.GetUrn());
-                equippedWearableItem.BuyButton.interactable = wearable.IsOnChain() && marketPlaceLink != string.Empty;
+                equippedWearableItem.BuyButton.gameObject.SetActive(wearable.IsOnChain() && marketPlaceLink != string.Empty);
                 equippedWearableItem.BuyButton.onClick.AddListener(() => webBrowser.OpenUrl(marketPlaceLink));
                 WaitForThumbnailAsync(wearable, equippedWearableItem, getEquippedItemsCts.Token).Forget();
                 instantiatedEquippedItems.Add(equippedWearableItem);
@@ -219,7 +219,7 @@ namespace DCL.Passport.Modules
                 equippedWearableItem.FlapBackground.color = rarityColor;
                 equippedWearableItem.CategoryImage.sprite = categoryIcons.GetTypeImage("emote");
                 string marketPlaceLink = GetMarketplaceLink(emote.GetUrn());
-                equippedWearableItem.BuyButton.interactable = emote.IsOnChain() && rarityName != "base" && marketPlaceLink != string.Empty;
+                equippedWearableItem.BuyButton.gameObject.SetActive(emote.IsOnChain() && rarityName != "base" && marketPlaceLink != string.Empty);
                 equippedWearableItem.BuyButton.onClick.AddListener(() => webBrowser.OpenUrl(marketPlaceLink));
                 WaitForThumbnailAsync(emote, equippedWearableItem, getEquippedItemsCts.Token).Forget();
                 instantiatedEquippedItems.Add(equippedWearableItem);


### PR DESCRIPTION
## What does this PR change?
Fix #2239 

Hide BUY button for base equipped items in the Passport.

## How to test the changes?
Follow STR described in the issue associated.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md