### PR TITLE
fix: Progress bar for not achieved badges is always empty

### DIFF
--- a/Explorer/Assets/DCL/BadgesAPIService/BadgesUtils.cs
+++ b/Explorer/Assets/DCL/BadgesAPIService/BadgesUtils.cs
@@ -59,6 +59,6 @@ namespace DCL.BadgesAPIService
         }
 
         public static int GetProgressPercentage(this in BadgeInfo badgeInfo) =>
-            badgeInfo.isLocked ? 0 : badgeInfo.data.progress.stepsDone * 100 / (badgeInfo.data.progress.nextStepsTarget ?? badgeInfo.data.progress.totalStepsTarget);
+            badgeInfo.data.progress.stepsDone * 100 / (badgeInfo.data.progress.nextStepsTarget ?? badgeInfo.data.progress.totalStepsTarget);
     }
 }

--- a/Explorer/Assets/DCL/Passport/Fields/Badges/BadgeDetailCard_PassportFieldView.cs
+++ b/Explorer/Assets/DCL/Passport/Fields/Badges/BadgeDetailCard_PassportFieldView.cs
@@ -141,7 +141,7 @@ namespace DCL.Passport.Fields.Badges
             if (badgeInfo.data.isTier)
             {
                 int progressPercentage = badgeInfo.GetProgressPercentage();
-                ProgressBarFill.sizeDelta = new Vector2((!badgeInfo.isLocked ? progressPercentage : 0) * (ProgressBar.sizeDelta.x / 100), ProgressBarFill.sizeDelta.y);
+                ProgressBarFill.sizeDelta = new Vector2(progressPercentage * (ProgressBar.sizeDelta.x / 100), ProgressBarFill.sizeDelta.y);
             }
             else
             {

--- a/Explorer/Assets/DCL/Passport/Modules/Badges/BadgeInfo_PassportModuleSubController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/Badges/BadgeInfo_PassportModuleSubController.cs
@@ -241,7 +241,7 @@ namespace DCL.Passport.Modules.Badges
                 badgeInfoModuleView.NextTierValueText.text = nextTierToComplete.tierName;
                 badgeInfoModuleView.NextTierDescriptionText.text = nextTierToComplete.description;
                 int nextTierProgressPercentage = badgeInfo.GetProgressPercentage();
-                badgeInfoModuleView.NextTierProgressBarFill.sizeDelta = new Vector2((!badgeInfo.isLocked ? nextTierProgressPercentage : 0) * (badgeInfoModuleView.NextTierProgressBar.sizeDelta.x / 100), badgeInfoModuleView.NextTierProgressBarFill.sizeDelta.y);
+                badgeInfoModuleView.NextTierProgressBarFill.sizeDelta = new Vector2(nextTierProgressPercentage * (badgeInfoModuleView.NextTierProgressBar.sizeDelta.x / 100), badgeInfoModuleView.NextTierProgressBarFill.sizeDelta.y);
                 badgeInfoModuleView.NextTierProgressValueText.text = $"{badgeInfo.data.progress.stepsDone}/{badgeInfo.data.progress.nextStepsTarget ?? badgeInfo.data.progress.totalStepsTarget}";
             }
         }


### PR DESCRIPTION
## What does this PR change?
Fix #2309 

The progress bar of all "not achieved" badges doesn't show the progress although the number is increasing.

![image](https://github.com/user-attachments/assets/3b1c60f0-10a9-41c9-a23a-46974e1eddec)

## How to test the changes?
1. Launch the explorer.
2. Open your passport.
3. Observe that the progress bars of all yours "not achieved" badges is correctly updated: the steps number in the left side of the screen match with the length of the orange progress bar.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md