### PR TITLE
style: update loading screen tips

### DIFF
--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages Shared Data.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages Shared Data.asset
@@ -23,24 +23,20 @@ MonoBehaviour:
     m_Key: IMAGE-1
     m_Metadata:
       m_Items: []
-  - m_Id: 85537579008
+  - m_Id: 94622441472
     m_Key: IMAGE-2
     m_Metadata:
       m_Items: []
-  - m_Id: 94622441472
+  - m_Id: 104160288768
     m_Key: IMAGE-3
     m_Metadata:
       m_Items: []
-  - m_Id: 104160288768
+  - m_Id: 114549579776
     m_Key: IMAGE-4
     m_Metadata:
       m_Items: []
-  - m_Id: 114549579776
-    m_Key: IMAGE-5
-    m_Metadata:
-      m_Items: []
   - m_Id: 125765148672
-    m_Key: IMAGE-6
+    m_Key: IMAGE-5
     m_Metadata:
       m_Items: []
   m_Metadata:
@@ -71,7 +67,6 @@ MonoBehaviour:
           - es
         - m_KeyId: 85537579008
           m_TableCodes:
-          - en
           - it
           - es
         - m_KeyId: 94622441472

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages_en.asset
@@ -26,10 +26,6 @@ MonoBehaviour:
     m_Localized: f75abfa64274a47fd9b3b14143dd8fa0
     m_Metadata:
       m_Items: []
-  - m_Id: 85537579008
-    m_Localized: e4f1395814ee0473e86cb6c06009fc6e
-    m_Metadata:
-      m_Items: []
   - m_Id: 94622441472
     m_Localized: beceeda1295384ef4921493b30d5cf45
     m_Metadata:

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips Shared Data.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips Shared Data.asset
@@ -31,44 +31,36 @@ MonoBehaviour:
     m_Key: BODY-1
     m_Metadata:
       m_Items: []
-  - m_Id: 1078349173612544
+  - m_Id: 1078455436304384
     m_Key: TITLE-2
     m_Metadata:
       m_Items: []
-  - m_Id: 1078419382067200
+  - m_Id: 1078488571305984
     m_Key: BODY-2
     m_Metadata:
       m_Items: []
-  - m_Id: 1078455436304384
+  - m_Id: 1078537170706432
     m_Key: TITLE-3
     m_Metadata:
       m_Items: []
-  - m_Id: 1078488571305984
+  - m_Id: 1078590144765952
     m_Key: BODY-3
     m_Metadata:
       m_Items: []
-  - m_Id: 1078537170706432
+  - m_Id: 1078626870091776
     m_Key: TITLE-4
     m_Metadata:
       m_Items: []
-  - m_Id: 1078590144765952
+  - m_Id: 1078683115708416
     m_Key: BODY-4
     m_Metadata:
       m_Items: []
-  - m_Id: 1078626870091776
+  - m_Id: 1078715894194176
     m_Key: TITLE-5
     m_Metadata:
       m_Items: []
-  - m_Id: 1078683115708416
-    m_Key: BODY-5
-    m_Metadata:
-      m_Items: []
-  - m_Id: 1078715894194176
-    m_Key: TITLE-6
-    m_Metadata:
-      m_Items: []
   - m_Id: 1078768453017600
-    m_Key: BODY-6
+    m_Key: BODY-5
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
@@ -39,18 +39,8 @@ MonoBehaviour:
       and pay platform fees."
     m_Metadata:
       m_Items: []
-  - m_Id: 1078349173612544
-    m_Localized: Creator Hub
-    m_Metadata:
-      m_Items: []
-  - m_Id: 1078419382067200
-    m_Localized: 'Create scenes, artworks, challenges and more, using the simple
-      Builder: an easy drag and drop tool. For more experienced creators, the SDK
-      provides the tools to fill the world with social games and applications.'
-    m_Metadata:
-      m_Items: []
   - m_Id: 1078455436304384
-    m_Localized: Decentraland Editor
+    m_Localized: Creator Hub
     m_Metadata:
       m_Items: []
   - m_Id: 1078488571305984


### PR DESCRIPTION
## What does this PR change?

This PR was created to remove the builder tip and to update the `Decentraland editor` tip title for `Creator Hud` instead.
<img width="708" alt="Screenshot 2024-10-03 at 14 09 19" src="https://github.com/user-attachments/assets/866c5dfe-91f5-46f3-bdb0-3e1c872fa1e6">
<img width="951" alt="Screenshot 2024-10-03 at 14 06 49" src="https://github.com/user-attachments/assets/bd35fdff-a6cf-4573-a87b-40b1a92c6f4a">


## How to test the changes?

1. Launch the explorer.
2. While in the loading screen, check the Builder tip has been successfully removed.
3. Check that the tip which contains the SDK image has the new `Creator Hud` title implemented.
