### PR TITLE
feat: use entity hash for ABs

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Utils/LoadThumbnailsUtils.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Utils/LoadThumbnailsUtils.cs
@@ -48,7 +48,7 @@ namespace DCL.AvatarRendering.Thumbnails.Utils
             var sceneAbDto = await webRequestController.GetAsync(new CommonArguments(urlBuilder.Build(), attemptsCount: 1), ct, reportCategory)
                                                        .CreateFromJson<SceneAbDto>(WRJsonParser.Unity, WRThreadFlags.SwitchBackToMainThread);
 
-            return new SceneAssetBundleManifest(assetBundleURL, sceneAbDto.Version, sceneAbDto.Files, hash);
+            return new SceneAssetBundleManifest(assetBundleURL, sceneAbDto.Version, sceneAbDto.Files, hash, sceneAbDto.Date);
         }
 
         private static async UniTask<bool> TryResolveAssetBundleManifestAsync(IWebRequestController requestController, URLDomain assetBundleURL, IAvatarAttachment attachment, CancellationTokenSource? cancellationTokenSource)

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Utils/LoadThumbnailsUtils.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Utils/LoadThumbnailsUtils.cs
@@ -48,7 +48,7 @@ namespace DCL.AvatarRendering.Thumbnails.Utils
             var sceneAbDto = await webRequestController.GetAsync(new CommonArguments(urlBuilder.Build(), attemptsCount: 1), ct, reportCategory)
                                                        .CreateFromJson<SceneAbDto>(WRJsonParser.Unity, WRThreadFlags.SwitchBackToMainThread);
 
-            return new SceneAssetBundleManifest(assetBundleURL, sceneAbDto.Version, sceneAbDto.Files);
+            return new SceneAssetBundleManifest(assetBundleURL, sceneAbDto.Version, sceneAbDto.Files, hash);
         }
 
         private static async UniTask<bool> TryResolveAssetBundleManifestAsync(IWebRequestController requestController, URLDomain assetBundleURL, IAvatarAttachment attachment, CancellationTokenSource? cancellationTokenSource)

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ResolveWearableByPointerSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ResolveWearableByPointerSystemShould.cs
@@ -33,7 +33,7 @@ namespace DCL.AvatarRendering.Wearables.Tests
         [SetUp]
         public void Setup()
         {
-            mockedABManifest = new StreamableLoadingResult<SceneAssetBundleManifest>(new SceneAssetBundleManifest(URLDomain.EMPTY, "0", Array.Empty<string>()));
+            mockedABManifest = new StreamableLoadingResult<SceneAssetBundleManifest>(new SceneAssetBundleManifest(URLDomain.EMPTY, "v0", Array.Empty<string>(), "hash"));
 
             wearableStorage = new WearableStorage();
 

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ResolveWearableByPointerSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ResolveWearableByPointerSystemShould.cs
@@ -33,7 +33,7 @@ namespace DCL.AvatarRendering.Wearables.Tests
         [SetUp]
         public void Setup()
         {
-            mockedABManifest = new StreamableLoadingResult<SceneAssetBundleManifest>(new SceneAssetBundleManifest(URLDomain.EMPTY, "v0", Array.Empty<string>(), "hash"));
+            mockedABManifest = new StreamableLoadingResult<SceneAssetBundleManifest>(new SceneAssetBundleManifest(URLDomain.EMPTY, "v0", Array.Empty<string>(), "hash", "04_10_2024"));
 
             wearableStorage = new WearableStorage();
 

--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
@@ -52,7 +52,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.Help => $"https://decentraland.{ENV}/help/",
                 DecentralandUrl.Market => $"https://market.decentraland.{ENV}",
                 // All ABs are in org
-                DecentralandUrl.AssetBundlesCDN => "https://ab-cdn.decentraland.org",
+                DecentralandUrl.AssetBundlesCDN => $"https://ab-cdn.decentraland.{ENV}",
                 DecentralandUrl.ArchipelagoStatus => $"https://archipelago-stats.decentraland.{ENV}/status",
                 DecentralandUrl.GatekeeperStatus => $"https://comms-gatekeeper.decentraland.{ENV}/status",
                 DecentralandUrl.Genesis => $"https://realm-provider-ea.decentraland.{ENV}/main",

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneFacade/Systems/LoadSceneSystemLogicBase.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneFacade/Systems/LoadSceneSystemLogicBase.cs
@@ -87,7 +87,7 @@ namespace ECS.SceneLifeCycle.Systems
                     .CreateFromJson<SceneAbDto>(WRJsonParser.Unity, WRThreadFlags.SwitchToThreadPool);
 
                 if (sceneAbDto.ValidateVersion())
-                    return new SceneAssetBundleManifest(assetBundleURL, sceneAbDto.Version, sceneAbDto.files, sceneId);
+                    return new SceneAssetBundleManifest(assetBundleURL, sceneAbDto.Version, sceneAbDto.files, sceneId, sceneAbDto.Date);
 
                 ReportHub.LogError(reportCategory.WithSessionStatic(), $"Asset Bundle Version Mismatch for {sceneId}");
                 return SceneAssetBundleManifest.NULL;

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneFacade/Systems/LoadSceneSystemLogicBase.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneFacade/Systems/LoadSceneSystemLogicBase.cs
@@ -87,7 +87,7 @@ namespace ECS.SceneLifeCycle.Systems
                     .CreateFromJson<SceneAbDto>(WRJsonParser.Unity, WRThreadFlags.SwitchToThreadPool);
 
                 if (sceneAbDto.ValidateVersion())
-                    return new SceneAssetBundleManifest(assetBundleURL, sceneAbDto.Version, sceneAbDto.files);
+                    return new SceneAssetBundleManifest(assetBundleURL, sceneAbDto.Version, sceneAbDto.files, sceneId);
 
                 ReportHub.LogError(reportCategory.WithSessionStatic(), $"Asset Bundle Version Mismatch for {sceneId}");
                 return SceneAssetBundleManifest.NULL;

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/Tests/PrepareAssetBundleLoadingParametersSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/Tests/PrepareAssetBundleLoadingParametersSystemShould.cs
@@ -50,8 +50,9 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
         public void LoadFromWebWithOldPath()
         {
             LogAssert.ignoreFailingMessages = true;
+            string version = "v" + (SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH - 1);
 
-            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v25", new[] { "abcd" }, "hash"));
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, version, new[] { "abcd" }, "hash"));
 
             var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
             Entity e = world.Create(intent, new StreamableLoadingState());
@@ -61,7 +62,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
 
             Assert.That(intent.CommonArguments.Attempts, Is.EqualTo(StreamableLoadingDefaults.ATTEMPTS_COUNT));
             Assert.That(intent.CommonArguments.CurrentSource, Is.EqualTo(AssetSource.WEB));
-            Assert.That(intent.CommonArguments.URL, Is.EqualTo("http://www.fakepath.com/v25/abcd"));
+            Assert.That(intent.CommonArguments.URL, Is.EqualTo($"http://www.fakepath.com/{version}/abcd"));
             Assert.That(intent.cacheHash, Is.Not.Null);
         }
         
@@ -69,8 +70,8 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
         public void LoadFromWebWithNewPath()
         {
             LogAssert.ignoreFailingMessages = true;
-
-            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v26", new[] { "abcd" }, "hash"));
+            string version = "v" + SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH;
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, version, new[] { "abcd" }, "hash"));
 
             var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
             Entity e = world.Create(intent, new StreamableLoadingState());
@@ -80,7 +81,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
 
             Assert.That(intent.CommonArguments.Attempts, Is.EqualTo(StreamableLoadingDefaults.ATTEMPTS_COUNT));
             Assert.That(intent.CommonArguments.CurrentSource, Is.EqualTo(AssetSource.WEB));
-            Assert.That(intent.CommonArguments.URL, Is.EqualTo("http://www.fakepath.com/v26/hash/abcd"));
+            Assert.That(intent.CommonArguments.URL, Is.EqualTo($"http://www.fakepath.com/{version}/hash/abcd"));
             Assert.That(intent.cacheHash, Is.Not.Null);
         }
 
@@ -89,7 +90,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
         {
             LogAssert.ignoreFailingMessages = true;
 
-            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v25", Array.Empty<string>(), "hash"));
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v" + (SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH - 1), Array.Empty<string>(), "hash"));
 
             var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
             Entity e = world.Create(intent, new StreamableLoadingState());
@@ -107,7 +108,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
         {
             LogAssert.ignoreFailingMessages = true;
 
-            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v26", Array.Empty<string>(), "hash"));
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v" + (SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH), Array.Empty<string>(), "hash"));
 
             var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
             Entity e = world.Create(intent, new StreamableLoadingState());

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/Tests/PrepareAssetBundleLoadingParametersSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/Tests/PrepareAssetBundleLoadingParametersSystemShould.cs
@@ -26,7 +26,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
         private ISceneData sceneData;
         private URLDomain path;
 
-        private static readonly URLDomain FAKE_AB_PATH = URLDomain.FromString("http://www.fakepath.com/v1/");
+        private static readonly URLDomain FAKE_AB_PATH = URLDomain.FromString("http://www.fakepath.com/");
 
         [Test]
         public void LoadFromEmbeddedFirst()
@@ -47,11 +47,11 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
         }
 
         [Test]
-        public void LoadFromWeb()
+        public void LoadFromWebWithOldPath()
         {
             LogAssert.ignoreFailingMessages = true;
 
-            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "200", new[] { "abcd" }));
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v25", new[] { "abcd" }, "hash"));
 
             var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
             Entity e = world.Create(intent, new StreamableLoadingState());
@@ -61,16 +61,53 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
 
             Assert.That(intent.CommonArguments.Attempts, Is.EqualTo(StreamableLoadingDefaults.ATTEMPTS_COUNT));
             Assert.That(intent.CommonArguments.CurrentSource, Is.EqualTo(AssetSource.WEB));
-            Assert.That(intent.CommonArguments.URL, Is.EqualTo("http://www.fakepath.com/v1/200/abcd"));
+            Assert.That(intent.CommonArguments.URL, Is.EqualTo("http://www.fakepath.com/v25/abcd"));
+            Assert.That(intent.cacheHash, Is.Not.Null);
+        }
+        
+        [Test]
+        public void LoadFromWebWithNewPath()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v26", new[] { "abcd" }, "hash"));
+
+            var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
+            Entity e = world.Create(intent, new StreamableLoadingState());
+            system.Update(0);
+
+            intent = world.Get<GetAssetBundleIntention>(e);
+
+            Assert.That(intent.CommonArguments.Attempts, Is.EqualTo(StreamableLoadingDefaults.ATTEMPTS_COUNT));
+            Assert.That(intent.CommonArguments.CurrentSource, Is.EqualTo(AssetSource.WEB));
+            Assert.That(intent.CommonArguments.URL, Is.EqualTo("http://www.fakepath.com/v26/hash/abcd"));
             Assert.That(intent.cacheHash, Is.Not.Null);
         }
 
         [Test]
-        public void FailIfAbsentInManifest()
+        public void FailIfAbsentInManifestOldHash()
         {
             LogAssert.ignoreFailingMessages = true;
 
-            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, null, Array.Empty<string>()));
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v25", Array.Empty<string>(), "hash"));
+
+            var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
+            Entity e = world.Create(intent, new StreamableLoadingState());
+
+            system.Update(0);
+
+            Assert.That(world.TryGet(e, out StreamableLoadingResult<AssetBundleData> result), Is.True);
+            Assert.That(result.Succeeded, Is.False);
+            Assert.That(result.Asset, Is.Null);
+            Assert.That(result.Exception, Is.TypeOf<ArgumentException>().Or.InnerException.TypeOf<ArgumentException>());
+        }
+        
+        [Test]
+        public void FailIfAbsentInManifestNewHash()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v26", Array.Empty<string>(), "hash"));
 
             var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
             Entity e = world.Create(intent, new StreamableLoadingState());

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/Tests/PrepareAssetBundleLoadingParametersSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/Tests/PrepareAssetBundleLoadingParametersSystemShould.cs
@@ -52,7 +52,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
             LogAssert.ignoreFailingMessages = true;
             string version = "v" + (SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH - 1);
 
-            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, version, new[] { "abcd" }, "hash"));
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, version, new[] { "abcd" }, "hash", "04_10_2024"));
 
             var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
             Entity e = world.Create(intent, new StreamableLoadingState());
@@ -71,7 +71,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
         {
             LogAssert.ignoreFailingMessages = true;
             string version = "v" + SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH;
-            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, version, new[] { "abcd" }, "hash"));
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, version, new[] { "abcd" }, "hash", "04_10_2024"));
 
             var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
             Entity e = world.Create(intent, new StreamableLoadingState());
@@ -90,7 +90,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
         {
             LogAssert.ignoreFailingMessages = true;
 
-            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v" + (SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH - 1), Array.Empty<string>(), "hash"));
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v" + (SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH - 1), Array.Empty<string>(), "hash", "04_10_2024"));
 
             var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
             Entity e = world.Create(intent, new StreamableLoadingState());
@@ -108,7 +108,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
         {
             LogAssert.ignoreFailingMessages = true;
 
-            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v" + (SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH), Array.Empty<string>(), "hash"));
+            sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, "v" + (SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH), Array.Empty<string>(), "hash", "04_10_2024"));
 
             var intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
             Entity e = world.Create(intent, new StreamableLoadingState());

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/GLTF/GltFastDownloadProvider.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/GLTF/GltFastDownloadProvider.cs
@@ -12,7 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;
-using Promise = ECS.StreamableLoading.Common.AssetPromise<UnityEngine.Texture2D, ECS.StreamableLoading.Textures.GetTextureIntention>;
+using Promise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.Textures.Texture2DData, ECS.StreamableLoading.Textures.GetTextureIntention>;
 
 namespace ECS.StreamableLoading.GLTF
 {

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAbDto.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAbDto.cs
@@ -18,9 +18,13 @@ namespace SceneRunner.Scene
         internal string[] files;
         [SerializeField]
         private int exitCode;
+        [SerializeField]
+        private string date;
 
         public string Version => version;
         public IReadOnlyList<string> Files => files ?? Array.Empty<string>();
+        
+        public string Date => date;
 
         public bool ValidateVersion()
         {

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
@@ -7,9 +7,9 @@ namespace SceneRunner.Scene
 {
     public class SceneAssetBundleManifest
     {
-        //From v26 onwards, the asset bundle path contains the sceneID in the hash
+        //From v25 onwards, the asset bundle path contains the sceneID in the hash
         //This was done to solve cache issues
-        public const int ASSET_BUNDLE_VERSION_REQUIRES_HASH = 26;
+        public const int ASSET_BUNDLE_VERSION_REQUIRES_HASH = 25;
         
         public static readonly SceneAssetBundleManifest NULL = new ();
 

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
@@ -1,9 +1,7 @@
 ﻿using CommunicationData.URLHelpers;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using UnityEngine;
-using UnityEngine.Pool;
 
 namespace SceneRunner.Scene
 {
@@ -13,18 +11,21 @@ namespace SceneRunner.Scene
 
         private readonly URLDomain assetBundlesBaseUrl;
         private readonly string version;
+        private readonly int versionInt;
         private readonly HashSet<string> convertedFiles;
-
+        private readonly string sceneID;
 
         private readonly bool ignoreConvertedFiles;
 
         public IReadOnlyCollection<string> ConvertedFiles => convertedFiles;
 
-        public SceneAssetBundleManifest(URLDomain assetBundlesBaseUrl, string version, IReadOnlyList<string> files)
+        public SceneAssetBundleManifest(URLDomain assetBundlesBaseUrl, string version, IReadOnlyList<string> files, string sceneID)
         {
             this.assetBundlesBaseUrl = assetBundlesBaseUrl;
             this.version = version;
+            versionInt = int.Parse(version.AsSpan().Slice(1));
             convertedFiles = new HashSet<string>(files, StringComparer.OrdinalIgnoreCase);
+            this.sceneID = sceneID;
             ignoreConvertedFiles = false;
         }
 
@@ -61,8 +62,14 @@ namespace SceneRunner.Scene
 
         public bool TryGet(string hash, out string convertedFile) => convertedFiles.TryGetValue(hash, out convertedFile);
 
-        public URLAddress GetAssetBundleURL(string hash) =>
-            assetBundlesBaseUrl.Append(new URLPath($"{version}/{hash}"));
+        public URLAddress GetAssetBundleURL(string hash)
+        {
+            //From v26 onwards, the asset bundle path contains the sceneID in the hash
+            if (versionInt >= 26)
+                return assetBundlesBaseUrl.Append(new URLPath($"{version}/{sceneID}/{hash}"));
+            
+            return assetBundlesBaseUrl.Append(new URLPath($"{version}/{hash}"));
+        }
 
         public string GetVersion() =>
             version;

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
@@ -18,18 +18,20 @@ namespace SceneRunner.Scene
         private readonly int versionInt;
         private readonly HashSet<string> convertedFiles;
         private readonly string sceneID;
+        private readonly string date;
 
         private readonly bool ignoreConvertedFiles;
 
         public IReadOnlyCollection<string> ConvertedFiles => convertedFiles;
 
-        public SceneAssetBundleManifest(URLDomain assetBundlesBaseUrl, string version, IReadOnlyList<string> files, string sceneID)
+        public SceneAssetBundleManifest(URLDomain assetBundlesBaseUrl, string version, IReadOnlyList<string> files, string sceneID, string buildDate)
         {
             this.assetBundlesBaseUrl = assetBundlesBaseUrl;
             this.version = version;
             versionInt = int.Parse(version.AsSpan().Slice(1));
             convertedFiles = new HashSet<string>(files, StringComparer.OrdinalIgnoreCase);
             this.sceneID = sceneID;
+            this.date = buildDate;
             ignoreConvertedFiles = false;
         }
 
@@ -54,9 +56,9 @@ namespace SceneRunner.Scene
 
         public unsafe Hash128 ComputeHash(string hash)
         {
-            Span<char> hashBuilder = stackalloc char[version.Length + hash.Length];
-            version.AsSpan().CopyTo(hashBuilder);
-            hash.AsSpan().CopyTo(hashBuilder[version.Length..]);
+            Span<char> hashBuilder = stackalloc char[date.Length + hash.Length];
+            date.AsSpan().CopyTo(hashBuilder);
+            hash.AsSpan().CopyTo(hashBuilder[date.Length..]);
 
             fixed (char* ptr = hashBuilder) { return Hash128.Compute(ptr, (uint)(sizeof(char) * hashBuilder.Length)); }
         }

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
@@ -7,6 +7,10 @@ namespace SceneRunner.Scene
 {
     public class SceneAssetBundleManifest
     {
+        //From v26 onwards, the asset bundle path contains the sceneID in the hash
+        //This was done to solve cache issues
+        public const int ASSET_BUNDLE_VERSION_REQUIRES_HASH = 26;
+        
         public static readonly SceneAssetBundleManifest NULL = new ();
 
         private readonly URLDomain assetBundlesBaseUrl;
@@ -64,8 +68,7 @@ namespace SceneRunner.Scene
 
         public URLAddress GetAssetBundleURL(string hash)
         {
-            //From v26 onwards, the asset bundle path contains the sceneID in the hash
-            if (versionInt >= 26)
+            if (versionInt >= ASSET_BUNDLE_VERSION_REQUIRES_HASH)
                 return assetBundlesBaseUrl.Append(new URLPath($"{version}/{sceneID}/{hash}"));
             
             return assetBundlesBaseUrl.Append(new URLPath($"{version}/{hash}"));

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/Tests/SceneAssetBundleManifestShould.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/Tests/SceneAssetBundleManifestShould.cs
@@ -17,7 +17,7 @@ namespace SceneRunner.Scene.Tests
 
                 const string EXPECTED = "v125QmfNvE3nKmahA5emnBnXN2LzydpYncHVz4xy4piw84Er1D";
 
-                var manifest = new SceneAssetBundleManifest(URLDomain.FromString(CONTENT_URL), "v125", Array.Empty<string>(), "hash");
+                var manifest = new SceneAssetBundleManifest(URLDomain.FromString(CONTENT_URL), "v125", Array.Empty<string>(), "hash","04_10_2024");
 
                 fixed (char* p = EXPECTED) { Assert.AreEqual(Hash128.Compute(p, (ulong)(EXPECTED.Length * sizeof(char))), manifest.ComputeHash(HASH)); }
             }

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/Tests/SceneAssetBundleManifestShould.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/Tests/SceneAssetBundleManifestShould.cs
@@ -17,7 +17,7 @@ namespace SceneRunner.Scene.Tests
 
                 const string EXPECTED = "v125QmfNvE3nKmahA5emnBnXN2LzydpYncHVz4xy4piw84Er1D";
 
-                var manifest = new SceneAssetBundleManifest(URLDomain.FromString(CONTENT_URL), "v125", Array.Empty<string>());
+                var manifest = new SceneAssetBundleManifest(URLDomain.FromString(CONTENT_URL), "v125", Array.Empty<string>(), "hash");
 
                 fixed (char* p = EXPECTED) { Assert.AreEqual(Hash128.Compute(p, (ulong)(EXPECTED.Length * sizeof(char))), manifest.ComputeHash(HASH)); }
             }

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/Tests/SceneAssetBundleManifestShould.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/Tests/SceneAssetBundleManifestShould.cs
@@ -8,29 +8,27 @@ namespace SceneRunner.Scene.Tests
     public class SceneAssetBundleManifestShould
     {
         [Test]
-        public void ComputeVersionedHash()
+        public void ComputeDatedHash()
         {
             unsafe
             {
                 const string CONTENT_URL = "https://content-assets-as-bundle.decentraland.org/";
                 const string HASH = "QmfNvE3nKmahA5emnBnXN2LzydpYncHVz4xy4piw84Er1D";
+                const string DATE = "06_10_2024";
+                const string EXPECTED = "06_10_2024QmfNvE3nKmahA5emnBnXN2LzydpYncHVz4xy4piw84Er1D";
 
-                const string EXPECTED = "v125QmfNvE3nKmahA5emnBnXN2LzydpYncHVz4xy4piw84Er1D";
-
-                var manifest = new SceneAssetBundleManifest(URLDomain.FromString(CONTENT_URL), "v125", Array.Empty<string>(), "hash","04_10_2024");
-
+                var manifest = new SceneAssetBundleManifest(URLDomain.FromString(CONTENT_URL), "v125", Array.Empty<string>(), HASH,DATE);
                 fixed (char* p = EXPECTED) { Assert.AreEqual(Hash128.Compute(p, (ulong)(EXPECTED.Length * sizeof(char))), manifest.ComputeHash(HASH)); }
             }
         }
 
         [Test]
-        public void ComputeUnversionedHash()
+        public void ComputeUndatedHash()
         {
             unsafe
             {
                 const string CONTENT_URL = "https://content-assets-as-bundle.decentraland.org/";
                 const string HASH = "QmfNvE3nKmahA5emnBnXN2LzydpYncHVz4xy4piw84Er1D";
-
                 const string EXPECTED = "QmfNvE3nKmahA5emnBnXN2LzydpYncHVz4xy4piw84Er1D";
 
                 var manifest = new SceneAssetBundleManifest(URLDomain.FromString(CONTENT_URL));


### PR DESCRIPTION
## What does this PR change?

There's an issue with ABs and their dependencies. If I have an asset bundle which has external dependecies, and only the external dependecies change, leaving the origin asset bundle hash to remain the same, cache problems arouse. This tries to solve it by

- CDN Cache: Adds the entity hash to the ABs path if the version is greater than 25. 
- Unity Local Cache: Modifies how we use `Hash128`. We are now hashing the date as well, if we didn't, the local asset bundle cache will still return the old ones on a scene redeployment

As a result, each asset is going to be unique for every scene re-deploy

The downside is that assets will not persist during scene re-deployment. If a scene get redeployed, the local cache is invalid.

Requires this ABConverter [PR](https://github.com/decentraland/asset-bundle-converter/pull/156/files) to be merged.

NOTE:

This change affects only alpha. WebGL AB remains untouched, and nothing need to be done in `unity-renderer`

<img width="779" alt="image" src="https://github.com/user-attachments/assets/2db0fd1c-2f7b-4b3e-9ef1-f167f2eebad9">


## How to test the changes?

1. Launch the explorer
2. Try to go to this scene, which should now have the abs. Confirm that you see them
3. Run the explorer normally and check that ABs load on other scenes 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

