### PR TITLE
fix: nametags cancellation token

### DIFF
--- a/Explorer/Assets/DCL/NameTags/NametagView.cs
+++ b/Explorer/Assets/DCL/NameTags/NametagView.cs
@@ -48,13 +48,10 @@ namespace DCL.Nametags
         [field: SerializeField]
         public float MaxWidth { get; private set; }
 
-        private readonly Color finishColor = new (1,1,1,0);
+        private readonly Color finishColor = new (1, 1, 1, 0);
         private Vector2 messageContentAnchoredPosition;
-
         private bool isAnimatingIn;
         private bool isWaiting;
-        private bool isAnimatingOut;
-
         private Vector2 usernameFinalPosition;
         private Vector2 verifiedIconFinalPosition;
         private Vector2 verifiedIconInitialPosition;
@@ -62,74 +59,68 @@ namespace DCL.Nametags
         private Vector2 backgroundFinalSize;
         private Vector2 textContentInitialPosition;
         private Vector2 usernamePos;
-
         private float alpha;
         private float previousDistance;
-
-        private readonly Color startingTextColor = new (1,1,1,0);
-        private Color textColor = new (1,1,1,1);
-        private Color usernameTextColor = new (1,1,1,1);
+        private float additionalHeight;
+        private readonly Color startingTextColor = new (1, 1, 1, 0);
+        private Color textColor = new (1, 1, 1, 1);
+        private Color usernameTextColor = new (1, 1, 1, 1);
         private Color backgroundColor = new (1, 1, 1, 1);
-        private ChatBubbleConfigurationSO chatBubbleConfiguration;
+        private ChatBubbleConfigurationSO? chatBubbleConfiguration;
         private bool isClaimedName;
-        private CancellationTokenSource cts;
+        private CancellationTokenSource? cts;
 
         public void InjectConfiguration(ChatBubbleConfigurationSO chatBubbleConfigurationSo)
         {
             chatBubbleConfiguration = chatBubbleConfigurationSo;
-            messageContentAnchoredPosition = new (0,chatBubbleConfiguration.bubbleMarginOffsetHeight / 3);
-        }
-
-        public void ResetElement()
-        {
-            preferredSize = Vector2.zero;
-            backgroundFinalSize = Vector2.zero;
-            textContentInitialPosition = Vector2.zero;
-            usernamePos = Vector2.zero;
-            Username.text = string.Empty;
-            Username.rectTransform.anchoredPosition = Vector2.zero;
-            MessageContent.text = string.Empty;
-            Background.size = Vector2.zero;
-            previousDistance = 0;
-            cts.SafeCancelAndDispose();
+            messageContentAnchoredPosition = new (0, chatBubbleConfiguration.bubbleMarginOffsetHeight / 3);
         }
 
         public void SetUsername(string username, string walletId, bool hasClaimedName)
         {
             ResetElement();
+
+            cts.SafeCancelAndDispose();
+            cts = new CancellationTokenSource();
+
             isClaimedName = hasClaimedName;
             VerifiedIcon.gameObject.SetActive(hasClaimedName);
             Username.text = hasClaimedName ? username : $"{username}<color=#FFFFFF66><font=\"LiberationSans SDF\">#{walletId}</font></color>";
             Username.rectTransform.sizeDelta = new Vector2(Username.preferredWidth, DEFAULT_HEIGHT);
             MessageContent.color = startingTextColor;
 
+            float nametagMarginOffsetHeight = chatBubbleConfiguration?.nametagMarginOffsetHeight ?? 0.15f;
+            float nametagMarginOffsetWidth = chatBubbleConfiguration?.nametagMarginOffsetWidth ?? 0.2f;
+
             if (hasClaimedName)
             {
-                verifiedIconInitialPosition = new Vector2(Username.rectTransform.anchoredPosition.x + (Username.preferredWidth / 2) + (VerifiedIcon.sizeDelta.x / 2) - (chatBubbleConfiguration.nametagMarginOffsetHeight / 2), 0);
+                verifiedIconInitialPosition = new Vector2(Username.rectTransform.anchoredPosition.x + (Username.preferredWidth / 2) + (VerifiedIcon.sizeDelta.x / 2) - (nametagMarginOffsetHeight / 2), 0);
                 VerifiedIcon.anchoredPosition = verifiedIconInitialPosition;
                 usernamePos.x = Username.rectTransform.anchoredPosition.x;
                 usernamePos.x -= VerifiedIcon.sizeDelta.x / 2;
                 Username.rectTransform.anchoredPosition = usernamePos;
-                Background.size = new Vector2(Username.preferredWidth + chatBubbleConfiguration.nametagMarginOffsetWidth + VerifiedIcon.sizeDelta.x, Username.preferredHeight + chatBubbleConfiguration.nametagMarginOffsetHeight);
+                Background.size = new Vector2(Username.preferredWidth + nametagMarginOffsetWidth + VerifiedIcon.sizeDelta.x, Username.preferredHeight + nametagMarginOffsetHeight);
             }
             else
             {
                 Username.rectTransform.anchoredPosition = Vector2.zero;
-                Background.size = new Vector2(Username.preferredWidth + chatBubbleConfiguration.nametagMarginOffsetWidth, Username.preferredHeight + chatBubbleConfiguration.nametagMarginOffsetHeight);
+                Background.size = new Vector2(Username.preferredWidth + nametagMarginOffsetWidth, Username.preferredHeight + nametagMarginOffsetHeight);
             }
         }
 
         public void SetTransparency(float distance, float maxDistance)
         {
-            if(Math.Abs(distance - previousDistance) < DISTANCE_THRESHOLD)
+            if (Math.Abs(distance - previousDistance) < DISTANCE_THRESHOLD)
                 return;
+
+            float fullOpacityMaxDistance = chatBubbleConfiguration?.fullOpacityMaxDistance ?? 20;
 
             previousDistance = distance;
             usernameTextColor = Username.color;
-            alpha = alphaOverDistanceCurve.Evaluate((distance - chatBubbleConfiguration.fullOpacityMaxDistance) / (maxDistance - chatBubbleConfiguration.fullOpacityMaxDistance) );
-            textColor.a = distance > chatBubbleConfiguration.fullOpacityMaxDistance ? alpha : 1;
-            usernameTextColor.a = distance > chatBubbleConfiguration.fullOpacityMaxDistance ? alpha : 1;
-            backgroundColor.a = distance > chatBubbleConfiguration.fullOpacityMaxDistance ? alpha : 1;
+            alpha = alphaOverDistanceCurve.Evaluate((distance - fullOpacityMaxDistance) / (maxDistance - fullOpacityMaxDistance));
+            textColor.a = distance > fullOpacityMaxDistance ? alpha : 1;
+            usernameTextColor.a = distance > fullOpacityMaxDistance ? alpha : 1;
+            backgroundColor.a = distance > fullOpacityMaxDistance ? alpha : 1;
             BubblePeak.color = backgroundColor;
             Background.color = backgroundColor;
             Username.color = usernameTextColor;
@@ -141,29 +132,52 @@ namespace DCL.Nametags
             cts.SafeCancelAndDispose();
             cts = new CancellationTokenSource();
 
-            StartChatBubbleFlowAsync(chatMessage).Forget();
+            StartChatBubbleFlowAsync(chatMessage, cts.Token).Forget();
         }
 
-        private async UniTaskVoid StartChatBubbleFlowAsync(string chatMessage)
+        private void ResetElement()
         {
-            if (isAnimatingIn || isWaiting)
-                await AnimateOutAsync();
+            preferredSize = Vector2.zero;
+            backgroundFinalSize = Vector2.zero;
+            textContentInitialPosition = Vector2.zero;
+            usernamePos = Vector2.zero;
+            Username.text = string.Empty;
+            Username.rectTransform.anchoredPosition = Vector2.zero;
+            MessageContent.text = string.Empty;
+            Background.size = Vector2.zero;
+            previousDistance = 0;
+        }
 
-            await AnimateInAsync(chatMessage);
-            isAnimatingIn = false;
-            isWaiting = true;
-            await UniTask.Delay(chatBubbleConfiguration.bubbleIdleTime + AdditionalMessageVisibilityTimeMs(chatMessage), cancellationToken: cts.Token);
-            isWaiting = false;
-            await AnimateOutAsync();
-            isAnimatingOut = false;
+        private async UniTaskVoid StartChatBubbleFlowAsync(string chatMessage, CancellationToken ct)
+        {
+            try
+            {
+                if (isAnimatingIn || isWaiting)
+                    await AnimateOutAsync(ct);
+
+                await AnimateInAsync(chatMessage, ct);
+
+                isAnimatingIn = false;
+                isWaiting = true;
+
+                await UniTask.Delay((chatBubbleConfiguration?.bubbleIdleTime ?? 5000) + AdditionalMessageVisibilityTimeMs(chatMessage), cancellationToken: ct);
+
+                isWaiting = false;
+
+                await AnimateOutAsync(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                isAnimatingIn = false;
+                isWaiting = false;
+            }
         }
 
         private int AdditionalMessageVisibilityTimeMs(string chatMessage) =>
-            chatMessage.Length * chatBubbleConfiguration.additionalMsPerCharacter;
+            chatMessage.Length * (chatBubbleConfiguration?.additionalMsPerCharacter ?? 20);
 
-        private float additionalHeight;
         //TODO: jobify this to improve the performance
-        private async UniTask AnimateInAsync(string messageContent)
+        private async UniTask AnimateInAsync(string messageContent, CancellationToken ct)
         {
             SetHeightAndTextStyle(messageContent);
             isAnimatingIn = true;
@@ -172,13 +186,14 @@ namespace DCL.Nametags
 
             //Set message content and calculate the preferred size of the background with the addition of a margin
             MessageContent.text = messageContent;
+
             //Force mesh is needed otherwise entryText.GetParsedText() in CalculatePreferredWidth will return the original text
             //of the previous frame
             MessageContent.ForceMeshUpdate();
 
             //Calculate message content preferred size with fixed width
             preferredSize = MessageContent.GetPreferredValues(messageContent, MaxWidth, 0);
-            preferredSize.x =  CalculatePreferredWidth(messageContent);
+            preferredSize.x = CalculatePreferredWidth(messageContent);
             preferredSize.y += additionalHeight;
             MessageContentRectTransform.sizeDelta = preferredSize;
 
@@ -187,35 +202,39 @@ namespace DCL.Nametags
             textContentInitialPosition.y = -preferredSize.y;
             MessageContentRectTransform.anchoredPosition = textContentInitialPosition;
 
-            preferredSize.x = MessageContentRectTransform.sizeDelta.x + chatBubbleConfiguration.bubbleMarginOffsetWidth;
-            preferredSize.y += chatBubbleConfiguration.bubbleMarginOffsetHeight;
+            float bubbleMarginOffsetWidth = chatBubbleConfiguration?.bubbleMarginOffsetWidth ?? 0.4f;
+            float bubbleMarginOffsetHeight = chatBubbleConfiguration?.bubbleMarginOffsetHeight ?? 0.6f;
+            float animationInDuration = chatBubbleConfiguration?.animationInDuration ?? 0.5f;
+
+            preferredSize.x = MessageContentRectTransform.sizeDelta.x + bubbleMarginOffsetWidth;
+            preferredSize.y += bubbleMarginOffsetHeight;
 
             //set the username final position based on previous calculations
-            usernameFinalPosition.x = (-preferredSize.x / 2) + (Username.preferredWidth / 2) + (chatBubbleConfiguration.bubbleMarginOffsetWidth / 2);
-            usernameFinalPosition.y = MessageContentRectTransform.sizeDelta.y + (chatBubbleConfiguration.bubbleMarginOffsetHeight / 3);
+            usernameFinalPosition.x = (-preferredSize.x / 2) + (Username.preferredWidth / 2) + (bubbleMarginOffsetWidth / 2);
+            usernameFinalPosition.y = MessageContentRectTransform.sizeDelta.y + (bubbleMarginOffsetHeight / 3);
 
             if (isClaimedName)
             {
                 verifiedIconFinalPosition.x = usernameFinalPosition.x + (Username.preferredWidth / 2) + (VerifiedIcon.sizeDelta.x / 2);
                 verifiedIconFinalPosition.y = usernameFinalPosition.y;
-                VerifiedIcon.DOAnchorPos(verifiedIconFinalPosition, chatBubbleConfiguration.animationInDuration).SetEase(backgroundEaseAnimationCurve).ToUniTask(cancellationToken: cts.Token);
+                VerifiedIcon.DOAnchorPos(verifiedIconFinalPosition, animationInDuration).SetEase(backgroundEaseAnimationCurve).ToUniTask(cancellationToken: ct);
             }
 
             //Start all animations
             await UniTask.WhenAll(
-                DOTween.Sequence().AppendInterval(chatBubbleConfiguration.animationInDuration / 3).Append(MessageContent.DOColor(textColor, chatBubbleConfiguration.animationInDuration / 4)).Play().ToUniTask(cancellationToken: cts.Token),
-                Username.rectTransform.DOAnchorPos(usernameFinalPosition, chatBubbleConfiguration.animationInDuration).SetEase(backgroundEaseAnimationCurve).ToUniTask(cancellationToken: cts.Token),
-                MessageContent.rectTransform.DOAnchorPos(messageContentAnchoredPosition, chatBubbleConfiguration.animationInDuration).SetEase(backgroundEaseAnimationCurve).ToUniTask(cancellationToken: cts.Token),
-                DOTween.To(() => Background.size, x=> Background.size = x, preferredSize, chatBubbleConfiguration.animationInDuration).SetEase(backgroundEaseAnimationCurve).ToUniTask(cancellationToken: cts.Token)
-                );
+                DOTween.Sequence().AppendInterval(animationInDuration / 3).Append(MessageContent.DOColor(textColor, animationInDuration / 4)).Play().ToUniTask(cancellationToken: ct),
+                Username.rectTransform.DOAnchorPos(usernameFinalPosition, animationInDuration).SetEase(backgroundEaseAnimationCurve).ToUniTask(cancellationToken: ct),
+                MessageContent.rectTransform.DOAnchorPos(messageContentAnchoredPosition, animationInDuration).SetEase(backgroundEaseAnimationCurve).ToUniTask(cancellationToken: ct),
+                DOTween.To(() => Background.size, x => Background.size = x, preferredSize, animationInDuration).SetEase(backgroundEaseAnimationCurve).ToUniTask(cancellationToken: ct)
+            );
         }
 
         private void SetHeightAndTextStyle(string messageContent)
         {
             if (messageContent.Contains("\\U") && messageContent.Length == EMOJI_LENGTH)
             {
-                additionalHeight = chatBubbleConfiguration.singleEmojiExtraHeight;
-                MessageContent.fontSize = chatBubbleConfiguration.singleEmojiSize;
+                additionalHeight = chatBubbleConfiguration?.singleEmojiExtraHeight ?? 0.1f;
+                MessageContent.fontSize = chatBubbleConfiguration?.singleEmojiSize ?? 3.5f;
                 MessageContent.alignment = TextAlignmentOptions.Center;
             }
             else
@@ -226,41 +245,44 @@ namespace DCL.Nametags
             }
         }
 
-        private async UniTask AnimateOutAsync()
+        private async UniTask AnimateOutAsync(CancellationToken ct)
         {
-            isAnimatingOut = true;
             BubblePeak.gameObject.SetActive(false);
-            backgroundFinalSize.y = Username.preferredHeight + chatBubbleConfiguration.nametagMarginOffsetHeight;
+            backgroundFinalSize.y = Username.preferredHeight + (chatBubbleConfiguration?.nametagMarginOffsetHeight ?? 0.15f);
+
+            float nametagMarginOffsetWidth = chatBubbleConfiguration?.nametagMarginOffsetWidth ?? 0.2f;
+            float animationOutDuration = chatBubbleConfiguration?.animationOutDuration ?? 0.35f;
 
             if (isClaimedName)
             {
-                backgroundFinalSize.x = Username.preferredWidth + chatBubbleConfiguration.nametagMarginOffsetWidth + VerifiedIcon.sizeDelta.x;
-                Username.rectTransform.DOAnchorPos(new Vector2(-VerifiedIcon.sizeDelta.x / 2, 0), chatBubbleConfiguration.animationOutDuration / 2).SetEase(Ease.Linear).ToUniTask(cancellationToken: cts.Token);
-                VerifiedIcon.DOAnchorPos(verifiedIconInitialPosition, chatBubbleConfiguration.animationOutDuration / 2).SetEase(Ease.Linear).ToUniTask(cancellationToken: cts.Token);
+                backgroundFinalSize.x = Username.preferredWidth + nametagMarginOffsetWidth + VerifiedIcon.sizeDelta.x;
+                Username.rectTransform.DOAnchorPos(new Vector2(-VerifiedIcon.sizeDelta.x / 2, 0), animationOutDuration / 2).SetEase(Ease.Linear).ToUniTask(cancellationToken: ct);
+                VerifiedIcon.DOAnchorPos(verifiedIconInitialPosition, animationOutDuration / 2).SetEase(Ease.Linear).ToUniTask(cancellationToken: ct);
             }
             else
             {
-                backgroundFinalSize.x = Username.preferredWidth + chatBubbleConfiguration.nametagMarginOffsetWidth;
-                Username.rectTransform.DOAnchorPos(Vector2.zero, chatBubbleConfiguration.animationOutDuration / 2).SetEase(Ease.Linear).ToUniTask(cancellationToken: cts.Token);
+                backgroundFinalSize.x = Username.preferredWidth + nametagMarginOffsetWidth;
+                Username.rectTransform.DOAnchorPos(Vector2.zero, animationOutDuration / 2).SetEase(Ease.Linear).ToUniTask(cancellationToken: ct);
             }
 
             await UniTask.WhenAll(
-                MessageContent.rectTransform.DOAnchorPos(textContentInitialPosition, chatBubbleConfiguration.animationOutDuration / 2).SetEase(Ease.Linear).ToUniTask(cancellationToken: cts.Token),
-                MessageContent.DOColor(finishColor, chatBubbleConfiguration.animationOutDuration / 10).ToUniTask(cancellationToken: cts.Token),
-                DOTween.To(() => Background.size, x => Background.size = x, backgroundFinalSize, chatBubbleConfiguration.animationOutDuration / 2).SetEase(Ease.Linear).ToUniTask(cancellationToken: cts.Token)
-                );
+                MessageContent.rectTransform.DOAnchorPos(textContentInitialPosition, animationOutDuration / 2).SetEase(Ease.Linear).ToUniTask(cancellationToken: ct),
+                MessageContent.DOColor(finishColor, animationOutDuration / 10).ToUniTask(cancellationToken: ct),
+                DOTween.To(() => Background.size, x => Background.size = x, backgroundFinalSize, animationOutDuration / 2).SetEase(Ease.Linear).ToUniTask(cancellationToken: ct)
+            );
         }
 
         private float CalculatePreferredWidth(string messageContent)
         {
-            if(Username.preferredWidth + chatBubbleConfiguration.nametagMarginOffsetWidth + (isClaimedName ? VerifiedIcon.sizeDelta.x : 0) > MessageContent.preferredWidth)
-                return Username.preferredWidth + chatBubbleConfiguration.nametagMarginOffsetWidth + (isClaimedName ? VerifiedIcon.sizeDelta.x : 0);
+            float nametagMarginOffsetWidth = chatBubbleConfiguration?.nametagMarginOffsetWidth ?? 0.2f;
 
-            if(MessageContent.GetPreferredValues(messageContent, MaxWidth, 0).x < MaxWidth)
+            if (Username.preferredWidth + nametagMarginOffsetWidth + (isClaimedName ? VerifiedIcon.sizeDelta.x : 0) > MessageContent.preferredWidth)
+                return Username.preferredWidth + nametagMarginOffsetWidth + (isClaimedName ? VerifiedIcon.sizeDelta.x : 0);
+
+            if (MessageContent.GetPreferredValues(messageContent, MaxWidth, 0).x < MaxWidth)
                 return MessageContent.GetPreferredValues(messageContent, MaxWidth, 0).x;
 
             return MaxWidth;
         }
-
     }
 }

--- a/Explorer/Assets/DCL/NameTags/NametagView.cs
+++ b/Explorer/Assets/DCL/NameTags/NametagView.cs
@@ -179,6 +179,8 @@ namespace DCL.Nametags
         //TODO: jobify this to improve the performance
         private async UniTask AnimateInAsync(string messageContent, CancellationToken ct)
         {
+            ct.ThrowIfCancellationRequested();
+
             SetHeightAndTextStyle(messageContent);
             isAnimatingIn = true;
             MessageContent.gameObject.SetActive(true);
@@ -247,6 +249,8 @@ namespace DCL.Nametags
 
         private async UniTask AnimateOutAsync(CancellationToken ct)
         {
+            ct.ThrowIfCancellationRequested();
+
             BubblePeak.gameObject.SetActive(false);
             backgroundFinalSize.y = Username.preferredHeight + (chatBubbleConfiguration?.nametagMarginOffsetHeight ?? 0.15f);
 

--- a/Explorer/Assets/DCL/NameTags/NametagView.cs
+++ b/Explorer/Assets/DCL/NameTags/NametagView.cs
@@ -15,6 +15,17 @@ namespace DCL.Nametags
         private const float DISTANCE_THRESHOLD = 0.1f;
         private const float DEFAULT_HEIGHT = 0.3f;
         private const float MESSAGE_CONTENT_FONT_SIZE = 1.3f;
+        private const float DEFAULT_MARGIN_OFFSET_HEIGHT = 0.15f;
+        private const float DEFAULT_MARGIN_OFFSET_WIDTH = 0.2f;
+        private const int DEFAULT_OPACITY_MAX_DISTANCE = 20;
+        private const int DEFAULT_ADDITIONAL_MS_PER_CHARACTER = 20;
+        private const float DEFAULT_BUBBLE_MARGIN_OFFSET_WIDTH = 0.4f;
+        private const float DEFAULT_BUBBLE_MARGIN_OFFSET_HEIGHT = 0.6f;
+        private const float DEFAULT_BUBBLE_ANIMATION_IN_DURATION = 0.5f;
+        private const float DEFAULT_BUBBLE_ANIMATION_OUT_DURATION = 0.35f;
+        private const int DEFAULT_BUBBLE_IDLE_TIME_MS = 5000;
+        private const float DEFAULT_SINGLE_EMOJI_EXTRA_HEIGHT = 0.1f;
+        private const float DEFAULT_SINGLE_EMOJI_SIZE = 3.5f;
 
         [field: SerializeField]
         public TMP_Text Username { get; private set; }
@@ -89,8 +100,8 @@ namespace DCL.Nametags
             Username.rectTransform.sizeDelta = new Vector2(Username.preferredWidth, DEFAULT_HEIGHT);
             MessageContent.color = startingTextColor;
 
-            float nametagMarginOffsetHeight = chatBubbleConfiguration?.nametagMarginOffsetHeight ?? 0.15f;
-            float nametagMarginOffsetWidth = chatBubbleConfiguration?.nametagMarginOffsetWidth ?? 0.2f;
+            float nametagMarginOffsetHeight = chatBubbleConfiguration?.nametagMarginOffsetHeight ?? DEFAULT_MARGIN_OFFSET_HEIGHT;
+            float nametagMarginOffsetWidth = chatBubbleConfiguration?.nametagMarginOffsetWidth ?? DEFAULT_MARGIN_OFFSET_WIDTH;
 
             if (hasClaimedName)
             {
@@ -113,7 +124,7 @@ namespace DCL.Nametags
             if (Math.Abs(distance - previousDistance) < DISTANCE_THRESHOLD)
                 return;
 
-            float fullOpacityMaxDistance = chatBubbleConfiguration?.fullOpacityMaxDistance ?? 20;
+            float fullOpacityMaxDistance = chatBubbleConfiguration?.fullOpacityMaxDistance ?? DEFAULT_OPACITY_MAX_DISTANCE;
 
             previousDistance = distance;
             usernameTextColor = Username.color;
@@ -160,7 +171,7 @@ namespace DCL.Nametags
                 isAnimatingIn = false;
                 isWaiting = true;
 
-                await UniTask.Delay((chatBubbleConfiguration?.bubbleIdleTime ?? 5000) + AdditionalMessageVisibilityTimeMs(chatMessage), cancellationToken: ct);
+                await UniTask.Delay((chatBubbleConfiguration?.bubbleIdleTime ?? DEFAULT_BUBBLE_IDLE_TIME_MS) + AdditionalMessageVisibilityTimeMs(chatMessage), cancellationToken: ct);
 
                 isWaiting = false;
 
@@ -174,7 +185,7 @@ namespace DCL.Nametags
         }
 
         private int AdditionalMessageVisibilityTimeMs(string chatMessage) =>
-            chatMessage.Length * (chatBubbleConfiguration?.additionalMsPerCharacter ?? 20);
+            chatMessage.Length * (chatBubbleConfiguration?.additionalMsPerCharacter ?? DEFAULT_ADDITIONAL_MS_PER_CHARACTER);
 
         //TODO: jobify this to improve the performance
         private async UniTask AnimateInAsync(string messageContent, CancellationToken ct)
@@ -204,9 +215,9 @@ namespace DCL.Nametags
             textContentInitialPosition.y = -preferredSize.y;
             MessageContentRectTransform.anchoredPosition = textContentInitialPosition;
 
-            float bubbleMarginOffsetWidth = chatBubbleConfiguration?.bubbleMarginOffsetWidth ?? 0.4f;
-            float bubbleMarginOffsetHeight = chatBubbleConfiguration?.bubbleMarginOffsetHeight ?? 0.6f;
-            float animationInDuration = chatBubbleConfiguration?.animationInDuration ?? 0.5f;
+            float bubbleMarginOffsetWidth = chatBubbleConfiguration?.bubbleMarginOffsetWidth ?? DEFAULT_BUBBLE_MARGIN_OFFSET_WIDTH;
+            float bubbleMarginOffsetHeight = chatBubbleConfiguration?.bubbleMarginOffsetHeight ?? DEFAULT_BUBBLE_MARGIN_OFFSET_HEIGHT;
+            float animationInDuration = chatBubbleConfiguration?.animationInDuration ?? DEFAULT_BUBBLE_ANIMATION_IN_DURATION;
 
             preferredSize.x = MessageContentRectTransform.sizeDelta.x + bubbleMarginOffsetWidth;
             preferredSize.y += bubbleMarginOffsetHeight;
@@ -235,8 +246,8 @@ namespace DCL.Nametags
         {
             if (messageContent.Contains("\\U") && messageContent.Length == EMOJI_LENGTH)
             {
-                additionalHeight = chatBubbleConfiguration?.singleEmojiExtraHeight ?? 0.1f;
-                MessageContent.fontSize = chatBubbleConfiguration?.singleEmojiSize ?? 3.5f;
+                additionalHeight = chatBubbleConfiguration?.singleEmojiExtraHeight ?? DEFAULT_SINGLE_EMOJI_EXTRA_HEIGHT;
+                MessageContent.fontSize = chatBubbleConfiguration?.singleEmojiSize ?? DEFAULT_SINGLE_EMOJI_SIZE;
                 MessageContent.alignment = TextAlignmentOptions.Center;
             }
             else
@@ -252,10 +263,10 @@ namespace DCL.Nametags
             ct.ThrowIfCancellationRequested();
 
             BubblePeak.gameObject.SetActive(false);
-            backgroundFinalSize.y = Username.preferredHeight + (chatBubbleConfiguration?.nametagMarginOffsetHeight ?? 0.15f);
+            backgroundFinalSize.y = Username.preferredHeight + (chatBubbleConfiguration?.nametagMarginOffsetHeight ?? DEFAULT_MARGIN_OFFSET_HEIGHT);
 
-            float nametagMarginOffsetWidth = chatBubbleConfiguration?.nametagMarginOffsetWidth ?? 0.2f;
-            float animationOutDuration = chatBubbleConfiguration?.animationOutDuration ?? 0.35f;
+            float nametagMarginOffsetWidth = chatBubbleConfiguration?.nametagMarginOffsetWidth ?? DEFAULT_MARGIN_OFFSET_WIDTH;
+            float animationOutDuration = chatBubbleConfiguration?.animationOutDuration ?? DEFAULT_BUBBLE_ANIMATION_OUT_DURATION;
 
             if (isClaimedName)
             {
@@ -278,7 +289,7 @@ namespace DCL.Nametags
 
         private float CalculatePreferredWidth(string messageContent)
         {
-            float nametagMarginOffsetWidth = chatBubbleConfiguration?.nametagMarginOffsetWidth ?? 0.2f;
+            float nametagMarginOffsetWidth = chatBubbleConfiguration?.nametagMarginOffsetWidth ?? DEFAULT_MARGIN_OFFSET_WIDTH;
 
             if (Username.preferredWidth + nametagMarginOffsetWidth + (isClaimedName ? VerifiedIcon.sizeDelta.x : 0) > MessageContent.preferredWidth)
                 return Username.preferredWidth + nametagMarginOffsetWidth + (isClaimedName ? VerifiedIcon.sizeDelta.x : 0);


### PR DESCRIPTION
## What does this PR change?

Fixes #2270 

There was a miss-management of the cancellation token in the name tags animation process. The original `CancellationTokenSource.Token` was referenced on each case, instead of passing a `CancellationToken` through parameter. When the original source was disposed it provoked the described exception.
The solution consists on only referencing the `CancellationTokenSource` once, at the start of the process and pass the `CancellationToken` only to the pipeline. Additionally, when the `cts` is disposed a new instance is required, since it becomes unusable. A proper `OperationCancelledException` handling was implementer to reset the internal animation state.

## How to test the changes?

1. Launch the explorer
2. Group up with another peer in the same place
3. Write in the chat
4. The chat bubbles over the nametags should be working as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

