### PR TITLE
fix: NRE on chat message

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -102,15 +102,18 @@ namespace DCL.Chat
             this.eventSystem = eventSystem;
             this.inputBlock = inputBlock;
 
-            chatMessagesBus.MessageAdded += OnMessageAdded;
-            chatHistory.OnMessageAdded += CreateChatEntry;
-            chatHistory.OnCleared += ChatHistoryOnOnCleared;
             device = InputSystem.GetDevice<Mouse>();
         }
 
         protected override void OnViewInstantiated()
         {
             cameraEntity = world.CacheCamera();
+            
+            //We start processing messages once the view is ready
+            chatMessagesBus.MessageAdded += OnMessageAdded;
+            chatHistory.OnMessageAdded += CreateChatEntry;
+            chatHistory.OnCleared += ChatHistoryOnOnCleared;
+            
             viewInstance!.OnChatViewPointerEnter += OnChatViewPointerEnter;
             viewInstance.OnChatViewPointerExit += OnChatViewPointerExit;
             viewInstance.CharacterCounter.SetMaximumLength(viewInstance.InputField.characterLimit);


### PR DESCRIPTION
## What does this PR change?

If we received a chat message while the view wasnt ready (IE: the loading screen) we would get the follwoing NRE

```
NullReferenceException: Object reference not set to an instance of an object
DCL.Chat.ChatController.CreateChatEntry (DCL.Chat.ChatMessage chatMessage) (at Assets/DCL/Chat/ChatController.cs:473)
DCL.Chat.History.ChatHistory.AddMessage (DCL.Chat.ChatMessage message) (at Assets/DCL/Chat/History/ChatHistory.cs:31)
DCL.Chat.ChatController.OnMessageAdded (DCL.Chat.ChatMessage chatMessage) (at Assets/DCL/Chat/ChatController.cs:452)
DCL.PerformanceAndDiagnostics.Analytics.ChatMessagesBusAnalyticsDecorator.ReEmit (DCL.Chat.ChatMessage obj) (at Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs:29)
DCL.Chat.MessageBus.CommandsHandleChatMessageBus.OriginOnOnMessageAdded (DCL.Chat.ChatMessage obj) (at Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs:70)
DCL.Chat.MessageBus.IgnoreWithSymbolsChatMessageBus.OriginOnOnMessageAdded (DCL.Chat.ChatMessage obj) (at Assets/DCL/Chat/MessageBus/IgnoreWithSymbolsChatMessageBus.cs:32)
```

This PR fixes that, we will start processing chat messages once the view is ready


## How to test the changes?

1. Get a friend, ask her to load the client.
2. Start loading your client, and ask your friend to spam chat messages
3. You should not see the NRE in the logs. You will miss messages while you are in loading screen, but once you are out, everything should be as expected

(You can reproduce the behaviour in old builds and following the same steps. If you check the logs, the NRE should be there)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

