### PR TITLE
fix: count command chat messages

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatCommandsHandler.cs
+++ b/Explorer/Assets/DCL/Chat/ChatCommandsHandler.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace DCL.Chat
 {
-    internal class ChatCommandsHandler
+    public class ChatCommandsHandler
     {
         private const string CHAT_COMMAND_CHAR = "/";
 
@@ -36,7 +36,7 @@ namespace DCL.Chat
             return false;
         }
 
-        public bool StartsLikeCommand(string message) =>
+        public static bool StartsLikeCommand(string message) =>
             message
                .AsSpan()
                .Trim()

--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -32,6 +32,7 @@ namespace DCL.Chat
         private const string EMOJI_SUGGESTION_PATTERN = @":\w+";
         private const string EMOJI_TAG = "[emoji]";
         private const string HASH_CHARACTER = "#";
+        private const string ORIGIN = "chat";
         private static readonly Regex EMOJI_PATTERN_REGEX = new (EMOJI_SUGGESTION_PATTERN, RegexOptions.Compiled);
 
         private readonly IReadOnlyEntityParticipantTable entityParticipantTable;
@@ -306,7 +307,7 @@ namespace DCL.Chat
             viewInstance.InputField.text = string.Empty;
             viewInstance.InputField.ActivateInputField();
 
-            chatMessagesBus.Send(messageToSend);
+            chatMessagesBus.Send(messageToSend, ORIGIN);
         }
 
         private LoopListViewItem2? OnGetItemByIndex(LoopListView2 listView, int index)

--- a/Explorer/Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs
@@ -35,7 +35,7 @@ namespace DCL.Chat.MessageBus
         public void Send(string message)
         {
             //If the message doesn't start as a command (with "/"), we just forward it to the chat
-            if (!chatCommandsHandler.StartsLikeCommand(message))
+            if (!ChatCommandsHandler.StartsLikeCommand(message))
             {
                 origin.Send(message);
                 return;

--- a/Explorer/Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs
@@ -32,12 +32,12 @@ namespace DCL.Chat.MessageBus
             commandCts.SafeCancelAndDispose();
         }
 
-        public void Send(string message)
+        public void Send(string message, string origin)
         {
             //If the message doesn't start as a command (with "/"), we just forward it to the chat
             if (!ChatCommandsHandler.StartsLikeCommand(message))
             {
-                origin.Send(message);
+                this.origin.Send(message, origin);
                 return;
             }
 

--- a/Explorer/Assets/DCL/Chat/MessageBus/IChatMessagesBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/IChatMessagesBus.cs
@@ -12,7 +12,7 @@ namespace DCL.Chat.MessageBus
     public interface IChatMessagesBus : IDisposable
     {
         public event Action<ChatMessage> MessageAdded;
-        public void Send(string message);
+        public void Send(string message, string origin);
     }
 
     public static class ChatMessageBusExtensions
@@ -24,7 +24,7 @@ namespace DCL.Chat.MessageBus
         {
             void CreateTestChatEntry()
             {
-                messagesBus.Send(StringUtils.GenerateRandomString(UnityEngine.Random.Range(1, 250)));
+                messagesBus.Send(StringUtils.GenerateRandomString(UnityEngine.Random.Range(1, 250)), "debug panel");
             }
 
             debugContainerBuilder.TryAddWidget("Chat")?.AddControl(new DebugButtonDef("Create chat message", CreateTestChatEntry), null!);

--- a/Explorer/Assets/DCL/Chat/MessageBus/IgnoreWithSymbolsChatMessageBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/IgnoreWithSymbolsChatMessageBus.cs
@@ -34,10 +34,10 @@ namespace DCL.Chat.MessageBus
 
         public event Action<ChatMessage>? MessageAdded;
 
-        public void Send(string message)
+        public void Send(string message, string origin)
         {
             if (Valid(message))
-                origin.Send(message);
+                this.origin.Send(message, origin);
             else
                 MessageAdded?.Invoke(
                     ChatMessage.NewFromSystem("Message with the special character is forbidden")

--- a/Explorer/Assets/DCL/Chat/MessageBus/MultiplayerChatMessagesBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/MultiplayerChatMessagesBus.cs
@@ -56,7 +56,7 @@ namespace DCL.Chat.MessageBus
 
         public event Action<ChatMessage>? MessageAdded;
 
-        public void Send(string message)
+        public void Send(string message, string origin)
         {
             if (cancellationTokenSource.IsCancellationRequested)
                 throw new Exception("ChatMessagesBus is disposed");

--- a/Explorer/Assets/DCL/Chat/MessageBus/SelfResendChatMessageBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/SelfResendChatMessageBus.cs
@@ -38,9 +38,9 @@ namespace DCL.Chat.MessageBus
             MessageAdded?.Invoke(obj);
         }
 
-        public void Send(string message)
+        public void Send(string message, string origin)
         {
-            origin.Send(message);
+            this.origin.Send(message, origin);
             SendSelfAsync(message).Forget();
         }
 

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -34,6 +34,7 @@ namespace DCL.Minimap
     {
         private const MapLayer RENDER_LAYERS = MapLayer.SatelliteAtlas | MapLayer.PlayerMarker | MapLayer.ScenesOfInterest | MapLayer.Favorites | MapLayer.HotUsersMarkers | MapLayer.Pins | MapLayer.Path;
         private const float ANIMATION_TIME = 0.2f;
+        private const string ORIGIN = "minimap";
 
         private readonly IMapRenderer mapRenderer;
         private readonly IMVCManager mvcManager;
@@ -91,7 +92,7 @@ namespace DCL.Minimap
             viewInstance.collapseMinimapButton.onClick.AddListener(CollapseMinimap);
             viewInstance.minimapRendererButton.Button.onClick.AddListener(() => mvcManager.ShowAsync(ExplorePanelController.IssueCommand(new ExplorePanelParameter(ExploreSections.Navmap))).Forget());
             viewInstance.sideMenuButton.onClick.AddListener(OpenSideMenu);
-            viewInstance.goToGenesisCityButton.onClick.AddListener(() => chatMessagesBus.Send($"/{ChatCommandsUtils.COMMAND_GOTO} 0,0"));
+            viewInstance.goToGenesisCityButton.onClick.AddListener(() => chatMessagesBus.Send($"/{ChatCommandsUtils.COMMAND_GOTO} 0,0", ORIGIN));
             viewInstance.SideMenuCanvasGroup.alpha = 0;
             viewInstance.SideMenuCanvasGroup.gameObject.SetActive(false);
             new SideMenuController(viewInstance.sideMenuView);

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -4,6 +4,7 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.Character.Components;
+using DCL.Chat.Commands;
 using DCL.Chat.MessageBus;
 using DCL.Diagnostics;
 using DCL.ExplorePanel;
@@ -90,7 +91,7 @@ namespace DCL.Minimap
             viewInstance.collapseMinimapButton.onClick.AddListener(CollapseMinimap);
             viewInstance.minimapRendererButton.Button.onClick.AddListener(() => mvcManager.ShowAsync(ExplorePanelController.IssueCommand(new ExplorePanelParameter(ExploreSections.Navmap))).Forget());
             viewInstance.sideMenuButton.onClick.AddListener(OpenSideMenu);
-            viewInstance.goToGenesisCityButton.onClick.AddListener(() => chatMessagesBus.Send("/goto 0,0"));
+            viewInstance.goToGenesisCityButton.onClick.AddListener(() => chatMessagesBus.Send($"/{ChatCommandsUtils.COMMAND_GOTO} 0,0"));
             viewInstance.SideMenuCanvasGroup.alpha = 0;
             viewInstance.SideMenuCanvasGroup.gameObject.SetActive(false);
             new SideMenuController(viewInstance.sideMenuView);

--- a/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
@@ -18,6 +18,7 @@ namespace DCL.Navmap
 {
     public class FloatingPanelController : IDisposable
     {
+        private const string ORIGIN = "jump in";
         private static readonly Vector2Int DEFAULT_DESTINATION_PARCEL = new (-9999, 9999);
 
         private readonly FloatingPanelView view;
@@ -198,14 +199,14 @@ namespace DCL.Navmap
             view.removeMapPinDestinationButton.gameObject.SetActive(parcelIsDestination);
             view.removeDestinationButton.gameObject.SetActive(parcelIsDestination);
         }
-        
+
         private void JumpIn(Vector2Int parcel)
         {
             OnJumpIn?.Invoke(parcel);
 
             if (destination == parcel) { mapPathEventBus.ArrivedToDestination(); }
 
-            chatMessagesBus.Send($"/{ChatCommandsUtils.COMMAND_GOTO} {parcel.x},{parcel.y}");
+            chatMessagesBus.Send($"/{ChatCommandsUtils.COMMAND_GOTO} {parcel.x},{parcel.y}", ORIGIN);
         }
 
         private void SetEmptyParcelInfo(Vector2Int parcel)

--- a/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
@@ -23,7 +23,6 @@ namespace DCL.Navmap
 
         private readonly FloatingPanelView view;
         private readonly IPlacesAPIService placesAPIService;
-        private readonly IRealmNavigator realmNavigator;
         private readonly Dictionary<string, GameObject> categoriesDictionary;
 
         private readonly ImageController placeImageController;
@@ -46,12 +45,10 @@ namespace DCL.Navmap
             FloatingPanelView view,
             IPlacesAPIService placesAPIService,
             IWebRequestController webRequestController,
-            IRealmNavigator realmNavigator,
             IMapPathEventBus mapPathEventBus, IChatMessagesBus chatMessagesBus)
         {
             this.view = view;
             this.placesAPIService = placesAPIService;
-            this.realmNavigator = realmNavigator;
             this.mapPathEventBus = mapPathEventBus;
             this.chatMessagesBus = chatMessagesBus;
 

--- a/Explorer/Assets/DCL/Navmap/NavmapController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapController.cs
@@ -88,7 +88,7 @@ namespace DCL.Navmap
             filterController = new NavmapFilterController(this.navmapView.filterView, mapRenderer, webBrowser);
             searchBarController = new NavmapSearchBarController(navmapView.SearchBarView, navmapView.SearchBarResultPanel, navmapView.HistoryRecordPanelView, placesAPIService, navmapView.floatingPanelView, webRequestController, inputBlock);
             FloatingPanelController = new FloatingPanelController(navmapView.floatingPanelView, placesAPIService,
-                webRequestController, realmNavigator, mapPathEventBus, chatMessagesBus);
+                webRequestController, mapPathEventBus, chatMessagesBus);
             FloatingPanelController.OnJumpIn += _ => searchBarController.ResetSearch();
             FloatingPanelController.OnSetAsDestination += SetDestination;
             this.navmapView.DestinationInfoElement.QuitButton.onClick.AddListener(OnRemoveDestinationButtonClicked);

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
@@ -28,13 +28,15 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
         private void ReEmit(ChatMessage obj) =>
             MessageAdded?.Invoke(obj);
 
-        public void Send(string message)
+        public void Send(string message, string origin)
         {
-            core.Send(message);
+            core.Send(message, origin);
 
             analytics.Track(AnalyticsEvents.UI.MESSAGE_SENT, new JsonObject
             {
                 { "is_command", ChatCommandsHandler.StartsLikeCommand(message) },
+                { "origin", origin },
+
                 // { "emoji_count", emoji_count },
                 // { "message", message },
                 // { "channel_mame", "nearby"}, // temporally hardcoded

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
@@ -34,8 +34,8 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
             analytics.Track(AnalyticsEvents.UI.MESSAGE_SENT, new JsonObject
             {
+                { "is_command", ChatCommandsHandler.StartsLikeCommand(message) },
                 // { "emoji_count", emoji_count },
-                // { "is_command", command_name },
                 // { "message", message },
                 // { "channel_mame", "nearby"}, // temporally hardcoded
                 // { "receiver_id", string.Empty} // temporal mock

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/IdentityAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/IdentityAnalyticsDecorator.cs
@@ -2,7 +2,6 @@
 using DCL.Web3.Authenticators;
 using DCL.Web3.Identities;
 using System.Threading;
-using UnityEngine;
 
 namespace DCL.PerformanceAndDiagnostics.Analytics
 {

--- a/Explorer/Assets/DCL/TeleportPrompt/TeleportPromptController.cs
+++ b/Explorer/Assets/DCL/TeleportPrompt/TeleportPromptController.cs
@@ -1,4 +1,5 @@
 ﻿using Cysharp.Threading.Tasks;
+using DCL.Chat.Commands;
 using DCL.Diagnostics;
 using DCL.Input;
 using DCL.PlacesAPIService;
@@ -53,7 +54,8 @@ namespace DCL.TeleportPrompt
             {
                 if (result != TeleportPromptResultType.Approved)
                     return;
-                chatMessagesBus.Send($"/goto {inputData.Coords.x},{inputData.Coords.y}");
+
+                chatMessagesBus.Send($"/{ChatCommandsUtils.COMMAND_GOTO} {inputData.Coords.x},{inputData.Coords.y}");
             });
         }
 

--- a/Explorer/Assets/DCL/TeleportPrompt/TeleportPromptController.cs
+++ b/Explorer/Assets/DCL/TeleportPrompt/TeleportPromptController.cs
@@ -16,7 +16,7 @@ namespace DCL.TeleportPrompt
 {
     public partial class TeleportPromptController : ControllerBase<TeleportPromptView, TeleportPromptController.Params>
     {
-        private const string ORIGIN = "teleport promt";
+        private const string ORIGIN = "teleport prompt";
         public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Popup;
 
         private readonly ICursor cursor;

--- a/Explorer/Assets/DCL/TeleportPrompt/TeleportPromptController.cs
+++ b/Explorer/Assets/DCL/TeleportPrompt/TeleportPromptController.cs
@@ -16,6 +16,7 @@ namespace DCL.TeleportPrompt
 {
     public partial class TeleportPromptController : ControllerBase<TeleportPromptView, TeleportPromptController.Params>
     {
+        private const string ORIGIN = "teleport promt";
         public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Popup;
 
         private readonly ICursor cursor;
@@ -55,7 +56,7 @@ namespace DCL.TeleportPrompt
                 if (result != TeleportPromptResultType.Approved)
                     return;
 
-                chatMessagesBus.Send($"/{ChatCommandsUtils.COMMAND_GOTO} {inputData.Coords.x},{inputData.Coords.y}");
+                chatMessagesBus.Send($"/{ChatCommandsUtils.COMMAND_GOTO} {inputData.Coords.x},{inputData.Coords.y}", ORIGIN);
             });
         }
 


### PR DESCRIPTION
## What does this PR change?

All sent chat messages considered to be same on Analytics, so I added property to have possibility to filter chat commands on the backend

## How to test the changes?

You cannot verify adjustment to analytics, but it would be good to check that these variations of /goto are working fine:
1. from JumpIn button on Navmap
2. from Back-to-Genesis on Minimap
3. from chat `/goto`

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

