### PR TITLE
fix: removed player marker when user disconnects

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/UsersMarker/UsersMarkersHotAreaController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/UsersMarker/UsersMarkersHotAreaController.cs
@@ -3,6 +3,7 @@ using Arch.System;
 using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using Cysharp.Threading.Tasks;
+using DCL.AvatarRendering.AvatarShape;
 using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.Character.Components;
 using DCL.CharacterPreview.Components;
@@ -111,12 +112,14 @@ namespace DCL.MapRenderer.MapLayers.Users
         }
     }
 
+    [UpdateAfter(typeof(AvatarGroup))]
     [UpdateInGroup(typeof(PresentationSystemGroup))]
     public partial class TrackPlayersPositionSystem : ControllerECSBridgeSystem
     {
         internal TrackPlayersPositionSystem(World world) : base(world) { }
     }
 
+    [UpdateAfter(typeof(AvatarGroup))]
     [UpdateAfter(typeof(TrackPlayersPositionSystem))]
     [UpdateInGroup(typeof(PresentationSystemGroup))]
     public partial class RemovedTrackedPlayersPositionSystem : ControllerECSBridgeSystem


### PR DESCRIPTION
## What does this PR change?

Fix #2310
Removes correctly the player markers of players that leave the game
...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Have some people around you
3. Check their red marker in the map works fine
4. Check that if they disconnect the red marker in the map/minimap disappears correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

