### PR TITLE
fix: Nametags are displayed while the avatar is loading (#2304)

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -95,10 +95,10 @@ namespace DCL.Nametags
         }
 
         [Query]
-        [All(typeof(AvatarBase), typeof(NametagView))]
-        private void EnableTag(in NametagView nametagView)
+        [All(typeof(AvatarBase), typeof(NametagView), typeof(AvatarCustomSkinningComponent))]
+        private void EnableTag(NametagView nametagView, AvatarBase avatar)
         {
-            if (nametagView.isActiveAndEnabled)
+            if (nametagView.isActiveAndEnabled || avatar.AvatarSkinnedMeshRenderer == null)
                 return;
 
             nametagView.gameObject.SetActive(true);


### PR DESCRIPTION
## What does this PR change?

Now it checks if the renderer of the avatar is present before enabling the nametag.

## How to test the changes?

1. Launch the explorer
2. Create random avatars, ask some people to enter the scene or enter a scene that contains avatars.

You should not see any nametag without an avatar.