### PR TITLE
fix: Use correct promise type in GLTFastDownloadProvider

### DIFF
--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/GLTF/GltFastDownloadProvider.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/GLTF/GltFastDownloadProvider.cs
@@ -12,7 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;
-using Promise = ECS.StreamableLoading.Common.AssetPromise<UnityEngine.Texture2D, ECS.StreamableLoading.Textures.GetTextureIntention>;
+using Promise = ECS.StreamableLoading.Common.AssetPromiseUnityEngine.Texture2DData, ECS.StreamableLoading.Textures.GetTextureIntention;
 
 namespace ECS.StreamableLoading.GLTF
 {


### PR DESCRIPTION
## What does this PR change?

Correct the promise type in the GLTFastDownloadProvider

## How to test the changes?

1. Launch a local verison of tower-of-hanoi (let me know if you need help with this)
2. Scene should load normally

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

