### PR TITLE
Fix: remove chat bubbles for late at party

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -133,7 +133,8 @@ namespace DCL.Nametags
 
         [Query]
         [All(typeof(ChatBubbleComponent))]
-        private void RemoveUnusedChatBubbleComponents(Entity e, in ChatBubbleComponent chatBubbleComponent)
+        //This query is used to remove the ChatBubbleComponent from the entity if the chat bubble has not been displayed
+        private void RemoveUnusedChatBubbleComponents(Entity e)
         {
             World.Remove<ChatBubbleComponent>(e);
         }

--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -73,6 +73,7 @@ namespace DCL.Nametags
             AddTagQuery(World, camera);
             ProcessChatBubbleComponentsQuery(World);
             UpdateOwnTagQuery(World, camera);
+            RemoveUnusedChatBubbleComponentsQuery(World);
         }
 
         [Query]
@@ -126,6 +127,14 @@ namespace DCL.Nametags
             if (nametagsData.showChatBubbles)
                 nametagView.SetChatMessage(chatBubbleComponent.ChatMessage);
 
+            World.Remove<ChatBubbleComponent>(e);
+        }
+
+
+        [Query]
+        [All(typeof(ChatBubbleComponent))]
+        private void RemoveUnusedChatBubbleComponents(Entity e, in ChatBubbleComponent chatBubbleComponent)
+        {
             World.Remove<ChatBubbleComponent>(e);
         }
 


### PR DESCRIPTION
## What does this PR change?

Fix #2321
With this PR if you arrive next to people that were chatting you won't see their previous messages in the chat bubble

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. With 1 client go far away from the second client
3. send a message
4. With the second client get close so that the nametag is visible
5. Verify that no old chat bubble is displayed

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

