### PR TITLE
fix: removed origin header from get requests

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
@@ -18,9 +18,6 @@ namespace DCL.WebRequests
     /// </summary>
     public static class GenericDownloadHandlerUtils
     {
-        private const string ORIGIN_HEADER_KEY = "Origin";
-        private const string ORIGIN_HEADER_VALUE = "explorer";
-
         public delegate Exception CreateExceptionOnParseFail(Exception exception, string text);
 
         public static Adapter<GenericPostRequest, GenericPostArguments> SignedFetchPostAsync(
@@ -45,20 +42,9 @@ namespace DCL.WebRequests
             );
         }
 
-        public static Adapter<GenericGetRequest, GenericGetArguments> GetAsync(
-            this IWebRequestController controller,
-            CommonArguments commonArguments,
-            CancellationToken ct,
-            ReportData reportData,
-            WebRequestHeadersInfo? headersInfo = null,
-            WebRequestSignInfo? signInfo = null,
-            ISet<long>? ignoreErrorCodes = null
-        )
-        {
-            headersInfo ??= new WebRequestHeadersInfo();
-            headersInfo.Value.Add(ORIGIN_HEADER_KEY, ORIGIN_HEADER_VALUE); // Probably in the future we will add this origin header also in the rest of requests
-            return new Adapter<GenericGetRequest, GenericGetArguments>(controller, commonArguments, default(GenericGetArguments), ct, reportData, headersInfo, signInfo, ignoreErrorCodes, GET_GENERIC);
-        }
+        public static Adapter<GenericGetRequest, GenericGetArguments> GetAsync(this IWebRequestController controller, CommonArguments commonArguments, CancellationToken ct, ReportData reportData, WebRequestHeadersInfo? headersInfo = null,
+            WebRequestSignInfo? signInfo = null, ISet<long>? ignoreErrorCodes = null) =>
+            new (controller, commonArguments, default(GenericGetArguments), ct, reportData, headersInfo, signInfo, ignoreErrorCodes, GET_GENERIC);
 
         public static Adapter<GenericPostRequest, GenericPostArguments> PostAsync(
             this IWebRequestController controller,


### PR DESCRIPTION
## What does this PR change?

Fix #2271 
This PR removes the origin header that was wrongly introduced.
This has been removed to avoid the
`The header Origin is managed automatically, setting it may have no effect or result in unexpected behavior.`
Warning that was spammed for every get request.
This Warning was being sent because the header Origin is a Forbidden header name and cannot be manually changed
...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Do a smoke test of inventory, map, walking around and scene loading

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

