### PR TITLE
fix: Reset "force renderer" when unequip a wearable slot

### DIFF
--- a/Explorer/Assets/DCL/Backpack/BackpackSlotsController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackSlotsController.cs
@@ -51,7 +51,11 @@ namespace DCL.Backpack
                 avatarSlotView.OnSlotButtonPressed += OnSlotButtonPressed;
                 avatarSlotView.OverrideHide.onClick.AddListener(() => RemoveForceRender(avatarSlotView.Category));
                 avatarSlotView.NoOverride.onClick.AddListener(() => AddForceRender(avatarSlotView.Category));
-                avatarSlotView.UnequipButton.onClick.AddListener(() => backpackCommandBus.SendCommand(new BackpackUnEquipWearableCommand(avatarSlotView.SlotWearableUrn)));
+                avatarSlotView.UnequipButton.onClick.AddListener(() =>
+                {
+                    RemoveForceRender(avatarSlotView.Category);
+                    backpackCommandBus.SendCommand(new BackpackUnEquipWearableCommand(avatarSlotView.SlotWearableUrn));
+                });
             }
         }
 


### PR DESCRIPTION
## What does this PR change?
Fix #2180 
Fix #1836 

When we did set a wearable (for example the skeleton legs) that hides another wearable (the shoes), if we did configure the hidden slot as "force render" and, after that, we unequipped it, the final status of the avatar kept with the 2 wearables visible: the wearable that hides another wearables (the skeleton legs) + the avatar's feet naked above the first wearable.

### How we reproduced the issue?
#### STEP 1: _Select a wearable (skeleton legs) that hides another wearable (shoes)._
![image](https://github.com/user-attachments/assets/d8af72ef-4047-4c2b-a8f6-38ca668b3fef)

#### STEP 2: _Set the shoes slot as "FORCE RENDER"._
![image](https://github.com/user-attachments/assets/aa3f1613-27e9-48ba-a506-d7a89fafaee5)

#### STEP 3: _Unequipp shoes being the slot configured as "FORCE RENDER"._
![image](https://github.com/user-attachments/assets/9c2a1993-0db6-405e-a866-9f3da9b79cbc)

#### RESULT BEFORE THE FIX
![image](https://github.com/user-attachments/assets/8efc5661-51d7-4d26-b9fc-21575cfb8173)

#### RESULT AFTER THE FIX
![image](https://github.com/user-attachments/assets/68d10d1e-544b-493d-9986-0db358f28b87)

## How to test the changes?
1. Launch the explorer.
2. Open your backpack.
3. Choose a wearable that hides some other wearable (for example the skeleton legs).
4. Go to the hidden slot (in this case the "shoes" slot) and select any wearable.
5. Set the hidden slot as "force render" (clicking the red eye in the right-bottom side of the slot).
6. Check that the hidden wearable is now visible in the avatar preview.
7. Unequipp the hidden slot (that is currently configure as "force render").
8. Check that the hidden wearable is effectively hidden in the avatar preview.
9. Close the backpack and check that your avatar wears the correct wearables.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md