### PR TITLE
Fix: road teleporting behaviour

### DIFF
--- a/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
@@ -5,7 +5,6 @@ using DCL.MapRenderer.MapLayers.Pins;
 using DCL.PlacesAPIService;
 using DCL.UI;
 using DCL.WebRequests;
-using ECS.SceneLifeCycle.Realm;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -201,7 +200,8 @@ namespace DCL.Navmap
         {
             OnJumpIn?.Invoke(parcel);
 
-            if (destination == parcel) { mapPathEventBus.ArrivedToDestination(); }
+            if (destination == parcel)
+                mapPathEventBus.ArrivedToDestination();
 
             chatMessagesBus.Send($"/{ChatCommandsUtils.COMMAND_GOTO} {parcel.x},{parcel.y}", ORIGIN);
         }

--- a/Explorer/Assets/DCL/ParcelsService/TeleportController.cs
+++ b/Explorer/Assets/DCL/ParcelsService/TeleportController.cs
@@ -23,6 +23,7 @@ namespace DCL.ParcelsService
 {
     public class TeleportController : ITeleportController
     {
+        private const string TRAM_LINE_TITLE = "Tram Line";
         private static readonly Random RANDOM = new ();
 
         private readonly ISceneReadinessReportQueue sceneReadinessReportQueue;
@@ -59,6 +60,7 @@ namespace DCL.ParcelsService
             retrieveScene = null;
         }
 
+
         public async UniTask<WaitForSceneReadiness?> TeleportToSceneSpawnPointAsync(Vector2Int parcel, AsyncLoadProcessReport loadReport, CancellationToken ct)
         {
             // if current scene is still loading it will block the teleport until its assets are resolved or timed out
@@ -76,7 +78,7 @@ namespace DCL.ParcelsService
             Vector3 targetWorldPosition;
             Vector3? cameraTarget = null;
 
-            if (sceneDef != null)
+            if (sceneDef != null && !IsTramLine(sceneDef.metadata.OriginalJson.AsSpan()))
             {
                 // Override parcel as it's a new target
                 parcel = sceneDef.metadata.scene.DecodedBase;
@@ -118,6 +120,30 @@ namespace DCL.ParcelsService
             }
 
             return new WaitForSceneReadiness(parcel, loadReport, sceneReadinessReportQueue);
+        }
+
+        private static bool IsTramLine(ReadOnlySpan<char> originalJson) =>
+            ExtractTitleValue(originalJson).SequenceEqual(TRAM_LINE_TITLE.AsSpan());
+
+        private static ReadOnlySpan<char> ExtractTitleValue(ReadOnlySpan<char> json)
+        {
+            int titleIndex = json.IndexOf(@"""title"":");
+            if (titleIndex == -1)
+                return ReadOnlySpan<char>.Empty;
+
+            // Move to the start of the title value (after "title": ")
+            int valueStartIndex = json[titleIndex..].IndexOf(':') + 1;
+            ReadOnlySpan<char> valueSpan = json.Slice(titleIndex + valueStartIndex);
+
+            int openQuoteIndex = valueSpan.IndexOf('"');
+            if (openQuoteIndex == -1)
+                return ReadOnlySpan<char>.Empty;
+
+            int closeQuoteIndex = valueSpan[(openQuoteIndex + 1)..].IndexOf('"');
+            if (closeQuoteIndex == -1)
+                return ReadOnlySpan<char>.Empty;
+
+            return valueSpan.Slice(openQuoteIndex + 1, closeQuoteIndex);
         }
 
         /// <summary>


### PR DESCRIPTION
## What does this PR change?
Fix #1184
Add check for Tram Line scenes so teleportation doesn't use it's spawn point

## How to test the changes?

1. Launch the explorer
2. Teleport to roads in the Genesis City via Map.
3. Use different roads with different coordinates. Try to cover big variety of possible road types.
4. Verify you teleportation point is equal to one you have chosen (and one printed in the chat by "System")

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

