### PR TITLE
style: increase reward background opacity

### DIFF
--- a/Explorer/Assets/DCL/RewardPanel/Assets/RewardPanel.prefab
+++ b/Explorer/Assets/DCL/RewardPanel/Assets/RewardPanel.prefab
@@ -1314,7 +1314,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.69803923}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.9019608}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Explorer/Assets/DCL/RewardPanel/Assets/RewardPanel.prefab
+++ b/Explorer/Assets/DCL/RewardPanel/Assets/RewardPanel.prefab
@@ -1314,7 +1314,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.9019608}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.98039216}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Explorer/Assets/DCL/RewardPanel/Assets/RewardPanel.prefab
+++ b/Explorer/Assets/DCL/RewardPanel/Assets/RewardPanel.prefab
@@ -706,8 +706,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 4, y: -3}
-  m_SizeDelta: {x: 36, y: 36}
+  m_AnchoredPosition: {x: 6, y: -3}
+  m_SizeDelta: {x: 34, y: 34}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &3684894549492617500
 CanvasRenderer:

--- a/Explorer/Assets/Textures/BackpackPanel/NFTDefaultIcon.png
+++ b/Explorer/Assets/Textures/BackpackPanel/NFTDefaultIcon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a408a104d180fdde87a041db8c666f8b5d662a79600a054947431059a754a583
-size 444
+oid sha256:3fff5e86d7a4cf9deaf45f5fe8d400d757811e1514b733a99b08723457e0ad3f
+size 396


### PR DESCRIPTION
## What does this PR change?
The opacity of the background was not enough to enhance legibility. As you can see in the screenshot it was a bit chaotic.
<img width="1034" alt="Screenshot 2024-10-08 at 18 50 48" src="https://github.com/user-attachments/assets/22daff12-7288-47e2-acbb-8a23f9265eb2">

This is the new version, with 98% opacity while the previous was 70%
<img width="1093" alt="Screenshot 2024-10-09 at 10 59 53" src="https://github.com/user-attachments/assets/8d515fbe-32fe-43d7-840f-4125c623d20b">

## How to test the changes?
1. Launch the explorer.
2. Launch the quest writing in the chat `/loadpx globalpx`.
3. Complete all the task to win the reward and validate the new background transparency is there.
