### PR TITLE
fix: Reset material properties when returning to pool

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/MaterialWorldPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MaterialWorldPlugin.cs
@@ -44,7 +44,19 @@ namespace DCL.PluginSystem.World
             basicMatPool = new ObjectPool<Material>(() => new Material(settings.basicMaterial), actionOnDestroy: UnityObjectUtils.SafeDestroy, defaultCapacity: settings.PoolInitialCapacity, maxSize: settings.PoolMaxSize);
             pbrMatPool = new ObjectPool<Material>(() => new Material(settings.pbrMaterial), actionOnDestroy: UnityObjectUtils.SafeDestroy, defaultCapacity: settings.PoolInitialCapacity, maxSize: settings.PoolMaxSize);
 
-            destroyMaterial = (in MaterialData data, Material material) => { (data.IsPbrMaterial ? pbrMatPool : basicMatPool).Release(material); };
+            destroyMaterial = (in MaterialData data, Material material) =>
+            {
+                if (data.IsPbrMaterial)
+                {
+                    material.CopyPropertiesFromMaterial(settings.pbrMaterial);
+                    pbrMatPool.Release(material);
+                }
+                else
+                {
+                    material.CopyPropertiesFromMaterial(settings.basicMaterial);
+                    basicMatPool.Release(material);
+                }
+            };
 
             loadingAttemptsCount = settings.LoadingAttemptsCount;
             return UniTask.CompletedTask;


### PR DESCRIPTION
## What does this PR change?

Fixes the issue of seeing released textures on new materials. Like these:

![image](https://github.com/user-attachments/assets/aadc3d90-7dbc-4931-aefe-b5f8367c0dc4)

![image](https://github.com/user-attachments/assets/bf36d09a-8743-4529-893f-40186e8b966d)



## How to test the changes?

1. Launch the explorer
2. Go to 43,100
3. Go to -139,-28
4. Check that images don't have unrelated textures

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

