### PR TITLE
Fix: Rapid Scene loading and unloading issues

### DIFF
--- a/Explorer/Assets/DCL/LOD/Settings/ILODSettingsAsset.cs
+++ b/Explorer/Assets/DCL/LOD/Settings/ILODSettingsAsset.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using DCL.AssetsProvision;
-using DCL.AvatarRendering.AvatarShape.Rendering.TextureArray;
+﻿using DCL.AvatarRendering.AvatarShape.Rendering.TextureArray;
 using UnityEngine;
 
 namespace DCL.LOD

--- a/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
@@ -602,9 +602,13 @@ MonoBehaviour:
           m_SubObjectName: 
           m_SubObjectType: 
           m_EditorAssetChanged: 0
+        <LODSettings>k__BackingField:
+          m_AssetGUID: 0703f7736b8c9b244953ae7c6ff9a037
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_EditorAssetChanged: 0
         frameTimeCap: 33
         frameTimeCapDeepProfiler: 300
-        memoryCap: 16
         <ScenesLoadingBudget>k__BackingField: 100
         <AssetsLoadingBudget>k__BackingField: 50
         <WebRequestsBudget>k__BackingField: 20

--- a/Explorer/Assets/DCL/PluginSystem/Global/StaticSettings.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/StaticSettings.cs
@@ -21,6 +21,9 @@ namespace DCL.PluginSystem.Global
         [field: SerializeField]
         public RealmPartitionSettingsRef RealmPartitionSettings { get; private set; }
 
+        [field: SerializeField]
+        public LODSettingsRef LODSettings { get; private set; }
+
         // Performance budgeting
         [field: Header("Performance Budgeting")] [field: Space]
         [field: SerializeField]

--- a/Explorer/Assets/Scripts/ECS/Prioritization/ScenesPartitioningUtils.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/ScenesPartitioningUtils.cs
@@ -137,17 +137,23 @@ namespace ECS.Prioritization
                 //We only change bucket from a lower bucket up to LODBucket after an UnloadingTime has passed.
                 //This allows for some leniency so scenes are not unloaded immediately as soon as they are in the right bucket.
                 //But ONLY when going from a lower bucket to the LODBucket. In any other case the scenes will be re-bucketed immediately.
+                //Keep in mind that the time will only change if the player is moving the camera, otherwise we don't recalculate bucketing
                 if (partition.Bucket == newBucketIndex)
+                {
                     partition.TimeOutOfBucket = 0;
-                else if (newBucketIndex == LODBucket && newBucketIndex > partition.Bucket && partition.TimeOutOfBucket < UnloadingTime)
+                }
+                else if (newBucketIndex == (byte) LODBucket && newBucketIndex > partition.Bucket && partition.TimeOutOfBucket < UnloadingTime)
                 {
                     partition.TimeOutOfBucket += DeltaTime;
                     //With this we make sure the partition is re-bucketed to the highest possible bucket before it becomes a LOD
                     //i.e. if it was 0 and needs to go to 2, we switch it to 1 until the time out of bucket passes.
-                    partition.Bucket = newBucketIndex--;
+                    partition.Bucket = (byte) (newBucketIndex - 1);
                 }
                 else
+                {
                     partition.Bucket = newBucketIndex;
+                    partition.TimeOutOfBucket = 0;
+                }
 
 
                 // Is behind is a dot product

--- a/Explorer/Assets/Scripts/ECS/Prioritization/ScenesPartitioningUtils.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/ScenesPartitioningUtils.cs
@@ -140,7 +140,12 @@ namespace ECS.Prioritization
                 if (partition.Bucket == newBucketIndex)
                     partition.TimeOutOfBucket = 0;
                 else if (newBucketIndex == LODBucket && newBucketIndex > partition.Bucket && partition.TimeOutOfBucket < UnloadingTime)
+                {
                     partition.TimeOutOfBucket += DeltaTime;
+                    //With this we make sure the partition is re-bucketed to the highest possible bucket before it becomes a LOD
+                    //i.e. if it was 0 and needs to go to 2, we switch it to 1 until the time out of bucket passes.
+                    partition.Bucket = newBucketIndex--;
+                }
                 else
                     partition.Bucket = newBucketIndex;
 

--- a/Explorer/Assets/Scripts/ECS/Prioritization/ScenesPartitioningUtils.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/ScenesPartitioningUtils.cs
@@ -20,7 +20,7 @@ namespace ECS.Prioritization
             public bool IsBehind;
             public bool OutOfRange;
             public float RawSqrDistance;
-            public float TimeOutOfRange;
+            public float TimeOutOfBucket;
         }
 
         public static bool TryUpdateCameraTransformOnChanged(PartitionDiscreteDataBase partitionDiscreteData, in CameraComponent cameraComponent,
@@ -138,9 +138,9 @@ namespace ECS.Prioritization
                 //This allows for some leniency so scenes are not unloaded immediately as soon as they are in the right bucket.
                 //But ONLY when going from a lower bucket to the LODBucket. In any other case the scenes will be re-bucketed immediately.
                 if (partition.Bucket == newBucketIndex)
-                    partition.TimeOutOfRange = 0;
-                else if (newBucketIndex == LODBucket && newBucketIndex > partition.Bucket && partition.TimeOutOfRange < UnloadingTime)
-                    partition.TimeOutOfRange += DeltaTime;
+                    partition.TimeOutOfBucket = 0;
+                else if (newBucketIndex == LODBucket && newBucketIndex > partition.Bucket && partition.TimeOutOfBucket < UnloadingTime)
+                    partition.TimeOutOfBucket += DeltaTime;
                 else
                     partition.Bucket = newBucketIndex;
 

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/IRealmPartitionSettings.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/IRealmPartitionSettings.cs
@@ -38,6 +38,12 @@ namespace ECS.Prioritization
         int UnloadingDistanceToleranceInParcels { get; }
 
         /// <summary>
+        /// Time tolerance added before unloading an out of range scene. This adds a little of time rubber-band so moving the camera won't cause scenes to load/unload suddenly.
+        /// Scenes will be considered out of range only after this Time has passed after it started to be out of range.
+        /// </summary>
+        float TimeUntilUnloadingInMilliseconds { get; }
+
+        /// <summary>
         ///     The number of closest scenes that can be requested at a time
         /// </summary>
         int ScenesRequestBatchSize { get; }

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/IRealmPartitionSettings.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/IRealmPartitionSettings.cs
@@ -41,7 +41,7 @@ namespace ECS.Prioritization
         /// Time tolerance added before unloading an out of range scene. This adds a little of time rubber-band so moving the camera won't cause scenes to load/unload suddenly.
         /// Scenes will be considered out of range only after this Time has passed after it started to be out of range.
         /// </summary>
-        float TimeUntilUnloadingInMilliseconds { get; }
+        float TimeUntilUnloadingInSeconds { get; }
 
         /// <summary>
         ///     The number of closest scenes that can be requested at a time

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettings.asset
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettings.asset
@@ -18,6 +18,7 @@ MonoBehaviour:
   maxLoadingDistanceInParcels: 20
   <MinLoadingDistanceInParcels>k__BackingField: 20
   <AggregateAngleTolerance>k__BackingField: 10
-  <UnloadingDistanceToleranceInParcels>k__BackingField: 1
+  <UnloadingDistanceToleranceInParcels>k__BackingField: 10
+  <TimeUntilUnloadingInMilliseconds>k__BackingField: 5000
   <ScenesRequestBatchSize>k__BackingField: 6
   <ScenesDefinitionsRequestBatchSize>k__BackingField: 30

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettings.asset
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettings.asset
@@ -19,6 +19,6 @@ MonoBehaviour:
   <MinLoadingDistanceInParcels>k__BackingField: 20
   <AggregateAngleTolerance>k__BackingField: 10
   <UnloadingDistanceToleranceInParcels>k__BackingField: 10
-  <TimeUntilUnloadingInSeconds>k__BackingField: 5
+  <TimeUntilUnloadingInSeconds>k__BackingField: 3
   <ScenesRequestBatchSize>k__BackingField: 6
   <ScenesDefinitionsRequestBatchSize>k__BackingField: 30

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettings.asset
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettings.asset
@@ -19,6 +19,6 @@ MonoBehaviour:
   <MinLoadingDistanceInParcels>k__BackingField: 20
   <AggregateAngleTolerance>k__BackingField: 10
   <UnloadingDistanceToleranceInParcels>k__BackingField: 10
-  <TimeUntilUnloadingInMilliseconds>k__BackingField: 5
+  <TimeUntilUnloadingInSeconds>k__BackingField: 5
   <ScenesRequestBatchSize>k__BackingField: 6
   <ScenesDefinitionsRequestBatchSize>k__BackingField: 30

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettings.asset
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettings.asset
@@ -19,6 +19,6 @@ MonoBehaviour:
   <MinLoadingDistanceInParcels>k__BackingField: 20
   <AggregateAngleTolerance>k__BackingField: 10
   <UnloadingDistanceToleranceInParcels>k__BackingField: 10
-  <TimeUntilUnloadingInMilliseconds>k__BackingField: 5000
+  <TimeUntilUnloadingInMilliseconds>k__BackingField: 5
   <ScenesRequestBatchSize>k__BackingField: 6
   <ScenesDefinitionsRequestBatchSize>k__BackingField: 30

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettingsAsset.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettingsAsset.cs
@@ -20,7 +20,7 @@ namespace ECS.Prioritization
         public float AggregateAngleTolerance { get; private set; }
 
         public Action<int>? OnMaxLoadingDistanceInParcelsChanged { get; set; }
-        
+
         public int MaxLoadingDistanceInParcels
         {
             get => Math.Min(MinLoadingDistanceInParcels,
@@ -41,6 +41,9 @@ namespace ECS.Prioritization
 
         [field: SerializeField] [field: Min(1)]
         public int UnloadingDistanceToleranceInParcels { get; private set; } = 1;
+
+        [field: SerializeField]
+        public float TimeUntilUnloadingInMilliseconds { get; private set; } = 5000;
 
         [field: SerializeField]
         public int ScenesRequestBatchSize { get; private set; }

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettingsAsset.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettingsAsset.cs
@@ -43,7 +43,7 @@ namespace ECS.Prioritization
         public int UnloadingDistanceToleranceInParcels { get; private set; } = 1;
 
         [field: SerializeField]
-        public float TimeUntilUnloadingInMilliseconds { get; private set; } = 5000;
+        public float TimeUntilUnloadingInSeconds { get; private set; } = 5;
 
         [field: SerializeField]
         public int ScenesRequestBatchSize { get; private set; }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/PartitionDataContainer.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/PartitionDataContainer.cs
@@ -70,7 +70,7 @@ namespace ECS.SceneLifeCycle.Components
             };
         }
 
-        public JobHandle ScheduleJob(IReadOnlyCameraSamplingData readOnlyCameraSamplingData, float unloadSqrDistance, float deltaTime, float unloadTime)
+        public JobHandle ScheduleJob(IReadOnlyCameraSamplingData readOnlyCameraSamplingData, float unloadSqrDistance, float deltaTime, float unloadTime, int LODBucket)
         {
             partitionJob.CameraForward = readOnlyCameraSamplingData.Forward;
             partitionJob.CameraPosition = readOnlyCameraSamplingData.Position;
@@ -78,6 +78,7 @@ namespace ECS.SceneLifeCycle.Components
             partitionJob.UnloadingSqrDistance = unloadSqrDistance;
             partitionJob.UnloadingTime = unloadTime;
             partitionJob.DeltaTime = deltaTime;
+            partitionJob.LODBucket = LODBucket;
             return partitionJob.Schedule(CurrentPartitionIndex, 8);
         }
 

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/PartitionDataContainer.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/PartitionDataContainer.cs
@@ -5,6 +5,7 @@ using ECS.Prioritization.Components;
 using Unity.Jobs;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
+using UnityEngine;
 
 namespace ECS.SceneLifeCycle.Components
 {
@@ -56,7 +57,7 @@ namespace ECS.SceneLifeCycle.Components
         {
             partitions.Dispose();
             parcelCorners.Dispose();
-            
+
             CurrentPartitionIndex = 0;
 
             // Hard limit of the real scenes that can exist
@@ -69,12 +70,14 @@ namespace ECS.SceneLifeCycle.Components
             };
         }
 
-        public JobHandle ScheduleJob(IReadOnlyCameraSamplingData readOnlyCameraSamplingData, float unloadSqrDistance)
+        public JobHandle ScheduleJob(IReadOnlyCameraSamplingData readOnlyCameraSamplingData, float unloadSqrDistance, float deltaTime, float unloadTime)
         {
             partitionJob.CameraForward = readOnlyCameraSamplingData.Forward;
             partitionJob.CameraPosition = readOnlyCameraSamplingData.Position;
             partitionJob.ParcelCorners = parcelCorners;
             partitionJob.UnloadingSqrDistance = unloadSqrDistance;
+            partitionJob.UnloadingTime = unloadTime;
+            partitionJob.DeltaTime = deltaTime;
             return partitionJob.Schedule(CurrentPartitionIndex, 8);
         }
 

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/PartitionSceneEntitiesSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/PartitionSceneEntitiesSystem.cs
@@ -97,7 +97,7 @@ namespace ECS.SceneLifeCycle.Systems
                 float unloadingDistance = (Mathf.Max(1, realmPartitionSettings.UnloadingDistanceToleranceInParcels) + realmPartitionSettings.MaxLoadingDistanceInParcels)
                                           * PARCEL_SIZE;
                 float unloadingSqrDistance = unloadingDistance * unloadingDistance;
-                partitionJobHandle = partitionDataContainer.ScheduleJob(readOnlyCameraSamplingData, unloadingSqrDistance, t, realmPartitionSettings.TimeUntilUnloadingInMilliseconds, lodSettingsAsset.SDK7LodThreshold);
+                partitionJobHandle = partitionDataContainer.ScheduleJob(readOnlyCameraSamplingData, unloadingSqrDistance, t, realmPartitionSettings.TimeUntilUnloadingInSeconds, lodSettingsAsset.SDK7LodThreshold);
                 isRunningJob = true;
             }
         }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/PartitionSceneEntitiesSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/PartitionSceneEntitiesSystem.cs
@@ -92,7 +92,7 @@ namespace ECS.SceneLifeCycle.Systems
                 float unloadingDistance = (Mathf.Max(1, realmPartitionSettings.UnloadingDistanceToleranceInParcels) + realmPartitionSettings.MaxLoadingDistanceInParcels)
                                           * PARCEL_SIZE;
                 float unloadingSqrDistance = unloadingDistance * unloadingDistance;
-                partitionJobHandle = partitionDataContainer.ScheduleJob(readOnlyCameraSamplingData, unloadingSqrDistance);
+                partitionJobHandle = partitionDataContainer.ScheduleJob(readOnlyCameraSamplingData, unloadingSqrDistance, t, realmPartitionSettings.TimeUntilUnloadingInMilliseconds);
                 isRunningJob = true;
             }
         }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/PartitionSceneEntitiesSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/PartitionSceneEntitiesSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Arch.Core;
 using Arch.System;
 using Arch.SystemGroups;
+using DCL.LOD;
 using DCL.Optimization.Pools;
 using ECS.Abstract;
 using ECS.Prioritization;
@@ -33,6 +34,8 @@ namespace ECS.SceneLifeCycle.Systems
         private readonly IComponentPool<PartitionComponent> partitionComponentPool;
         private readonly IReadOnlyCameraSamplingData readOnlyCameraSamplingData;
         private readonly IRealmPartitionSettings realmPartitionSettings;
+        private readonly ILODSettingsAsset lodSettingsAsset;
+
 
         private readonly byte emptyScenePartition;
 
@@ -46,12 +49,14 @@ namespace ECS.SceneLifeCycle.Systems
             IPartitionSettings partitionSettings,
             IReadOnlyCameraSamplingData readOnlyCameraSamplingData,
             PartitionDataContainer partitionDataContainer,
-            IRealmPartitionSettings realmPartitionSettings) : base(world)
+            IRealmPartitionSettings realmPartitionSettings,
+            ILODSettingsAsset lodSettingsAsset) : base(world)
         {
             this.partitionComponentPool = partitionComponentPool;
             this.readOnlyCameraSamplingData = readOnlyCameraSamplingData;
             this.partitionDataContainer = partitionDataContainer;
             this.realmPartitionSettings = realmPartitionSettings;
+            this.lodSettingsAsset = lodSettingsAsset;
 
 
             partitionDataContainer.Initialize(DEPLOYED_SCENES_LIMIT, partitionSettings.SqrDistanceBuckets, partitionSettings);
@@ -92,7 +97,7 @@ namespace ECS.SceneLifeCycle.Systems
                 float unloadingDistance = (Mathf.Max(1, realmPartitionSettings.UnloadingDistanceToleranceInParcels) + realmPartitionSettings.MaxLoadingDistanceInParcels)
                                           * PARCEL_SIZE;
                 float unloadingSqrDistance = unloadingDistance * unloadingDistance;
-                partitionJobHandle = partitionDataContainer.ScheduleJob(readOnlyCameraSamplingData, unloadingSqrDistance, t, realmPartitionSettings.TimeUntilUnloadingInMilliseconds);
+                partitionJobHandle = partitionDataContainer.ScheduleJob(readOnlyCameraSamplingData, unloadingSqrDistance, t, realmPartitionSettings.TimeUntilUnloadingInMilliseconds, lodSettingsAsset.SDK7LodThreshold);
                 isRunningJob = true;
             }
         }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Tests/PartitionSceneEntitiesSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Tests/PartitionSceneEntitiesSystemShould.cs
@@ -1,5 +1,6 @@
 ﻿using Arch.Core;
 using DCL.Ipfs;
+using DCL.LOD;
 using DCL.Optimization.Pools;
 using ECS.Prioritization;
 using ECS.Prioritization.Components;
@@ -17,12 +18,15 @@ namespace ECS.SceneLifeCycle.Tests
     public class PartitionSceneEntitiesSystemShould : UnitySystemTestBase<PartitionSceneEntitiesSystem>
     {
         private IPartitionSettings partitionSettings;
+        private ILODSettingsAsset lodSettings;
         private IReadOnlyCameraSamplingData samplingData;
         private IComponentPool<PartitionComponent> componentPool;
 
         [SetUp]
         public void SetUp()
         {
+            lodSettings = Substitute.For<ILODSettingsAsset>();
+            lodSettings.SDK7LodThreshold.Returns(2);
             partitionSettings = Substitute.For<IPartitionSettings>();
             partitionSettings.AngleTolerance.Returns(0);
             partitionSettings.PositionSqrTolerance.Returns(0);
@@ -34,7 +38,7 @@ namespace ECS.SceneLifeCycle.Tests
             componentPool.Get().Returns(_ => new PartitionComponent());
             IRealmPartitionSettings realmPartitionSettings = Substitute.For<IRealmPartitionSettings>();
 
-            system = new PartitionSceneEntitiesSystem(world, componentPool, partitionSettings, samplingData, new PartitionDataContainer(), realmPartitionSettings);
+            system = new PartitionSceneEntitiesSystem(world, componentPool, partitionSettings, samplingData, new PartitionDataContainer(), realmPartitionSettings, lodSettings);
             system.partitionDataContainer.Restart();
         }
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/GlobalWorldFactory.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/GlobalWorldFactory.cs
@@ -155,7 +155,7 @@ namespace Global.Dynamic
             ControlSceneUpdateLoopSystem.InjectToWorld(ref builder, realmPartitionSettings, destroyCancellationSource.Token, scenesCache);
 
             IComponentPool<PartitionComponent> partitionComponentPool = componentPoolsRegistry.GetReferenceTypePool<PartitionComponent>();
-            PartitionSceneEntitiesSystem.InjectToWorld(ref builder, partitionComponentPool, partitionSettings, cameraSamplingData, staticContainer.PartitionDataContainer, staticContainer.RealmPartitionSettings);
+            PartitionSceneEntitiesSystem.InjectToWorld(ref builder, partitionComponentPool, partitionSettings, cameraSamplingData, staticContainer.PartitionDataContainer, staticContainer.RealmPartitionSettings, staticContainer.LODSettings);
             PartitionGlobalAssetEntitiesSystem.InjectToWorld(ref builder, partitionComponentPool, partitionSettings, cameraSamplingData);
 
             CheckCameraQualifiedForRepartitioningSystem.InjectToWorld(ref builder, partitionSettings, realmData, cameraSamplingData);

--- a/Explorer/Assets/Scripts/Global/StaticContainer.cs
+++ b/Explorer/Assets/Scripts/Global/StaticContainer.cs
@@ -113,7 +113,7 @@ namespace Global
                 await UniTask.WhenAll(
                     assetsProvisioner.ProvideMainAssetAsync(settings.PartitionSettings, ct, nameof(PartitionSettings)),
                     assetsProvisioner.ProvideMainAssetAsync(settings.RealmPartitionSettings, ct, nameof(RealmPartitionSettings)),
-                    assetsProvisioner.ProvideMainAssetAsync(settings.LODSettings, ct, nameof(RealmPartitionSettings))
+                    assetsProvisioner.ProvideMainAssetAsync(settings.LODSettings, ct, nameof(LODSettings))
                 );
         }
 

--- a/Explorer/Assets/Scripts/Global/StaticContainer.cs
+++ b/Explorer/Assets/Scripts/Global/StaticContainer.cs
@@ -11,6 +11,7 @@ using DCL.FeatureFlags;
 using DCL.Gizmos.Plugin;
 using DCL.Input;
 using DCL.Interaction.Utility;
+using DCL.LOD;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Optimization.PerformanceBudgeting;
@@ -61,6 +62,7 @@ namespace Global
         private ProvidedInstance<CharacterObject> characterObject;
         private ProvidedAsset<PartitionSettingsAsset> partitionSettings;
         private ProvidedAsset<RealmPartitionSettingsAsset> realmPartitionSettings;
+        private ProvidedAsset<LODSettingsAsset> lodSettings;
 
         private IAssetsProvisioner assetsProvisioner;
 
@@ -83,6 +85,7 @@ namespace Global
         public IEntityCollidersGlobalCache EntityCollidersGlobalCache { get; private set; }
         public IPartitionSettings PartitionSettings => partitionSettings.Value;
         public IRealmPartitionSettings RealmPartitionSettings => realmPartitionSettings.Value;
+        public ILODSettingsAsset LODSettings => lodSettings.Value;
         public StaticSettings StaticSettings { get; private set; }
         public CacheCleaner CacheCleaner { get; private set; }
         public IEthereumApi EthereumApi { get; private set; }
@@ -106,10 +109,11 @@ namespace Global
         {
             StaticSettings = settings;
 
-            (partitionSettings, realmPartitionSettings) =
+            (partitionSettings, realmPartitionSettings, lodSettings) =
                 await UniTask.WhenAll(
                     assetsProvisioner.ProvideMainAssetAsync(settings.PartitionSettings, ct, nameof(PartitionSettings)),
-                    assetsProvisioner.ProvideMainAssetAsync(settings.RealmPartitionSettings, ct, nameof(RealmPartitionSettings))
+                    assetsProvisioner.ProvideMainAssetAsync(settings.RealmPartitionSettings, ct, nameof(RealmPartitionSettings)),
+                    assetsProvisioner.ProvideMainAssetAsync(settings.LODSettings, ct, nameof(RealmPartitionSettings))
                 );
         }
 

--- a/Explorer/Assets/Scripts/Global/Tests/PlayMode/Integration Tests Global Container.asset
+++ b/Explorer/Assets/Scripts/Global/Tests/PlayMode/Integration Tests Global Container.asset
@@ -64,16 +64,6 @@ MonoBehaviour:
     - rid: 6784895265395441664
       type: {class: StaticSettings, ns: DCL.PluginSystem.Global, asm: DCL.Plugins}
       data:
-        <ReportHandlingSettingsDevelopment>k__BackingField:
-          m_AssetGUID: 0dd75559898ca8d4db9fc8ab99ac2269
-          m_SubObjectName: 
-          m_SubObjectType: 
-          m_EditorAssetChanged: 0
-        <ReportHandlingSettingsProduction>k__BackingField:
-          m_AssetGUID: 6c1c35a66af59874a8373ebcd51572a4
-          m_SubObjectName: 
-          m_SubObjectType: 
-          m_EditorAssetChanged: 0
         <PartitionSettings>k__BackingField:
           m_AssetGUID: 8d266ff458e71f2439f9c30bd7e68d4a
           m_SubObjectName: 
@@ -84,9 +74,16 @@ MonoBehaviour:
           m_SubObjectName: 
           m_SubObjectType: 
           m_EditorAssetChanged: 0
-        <FrameTimeCap>k__BackingField: 33
+        <LODSettings>k__BackingField:
+          m_AssetGUID: 0703f7736b8c9b244953ae7c6ff9a037
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_EditorAssetChanged: 0
+        frameTimeCap: 33
+        frameTimeCapDeepProfiler: 300
         <ScenesLoadingBudget>k__BackingField: 100
         <AssetsLoadingBudget>k__BackingField: 50
+        <WebRequestsBudget>k__BackingField: 20
     - rid: 6784895265412481024
       type: {class: CharacterCameraSettings, ns: DCL.PluginSystem.Global, asm: DCL.Plugins}
       data:
@@ -96,6 +93,11 @@ MonoBehaviour:
           m_SubObjectType: 
           m_EditorAssetChanged: 0
         <cinemachineCameraAudioSettingsReference>k__BackingField:
+          m_AssetGUID: 
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_EditorAssetChanged: 0
+        <controlsSettingsAsset>k__BackingField:
           m_AssetGUID: 
           m_SubObjectName: 
           m_SubObjectType: 


### PR DESCRIPTION
## What does this PR change?

I added a small tweak to how scenes are re-bucketed, this will help with the issue I was tackling as well as with the jarring visual issues caused by moving the camera and seeing scenes load/unload in rapid succession depending on the distance and whatnot.

The first and simpler change was to put a higher value into the `Realm Partition Settings` field called `Unloading Distance Tolerance.` This value helps with scenes turning into LODs when we zoom out for example. The value was set to 1 and now is set to 10 which is the zoom out distance basically.

The other, more fun, change is having a small time buffer in between a budget change should happen and when it does happen. BUT only for the transition between a low budgeted partition and the budget used for LODs. This means that with current values, if we are in a partition budget index of 0 or 1 and it wants to go to 2 (which is the one used to switch to LODs), it will start counting and only after this new `TimeUntilUnloadingInSeconds `value is reached, the budget index wont change.
This will allow for smoother transitions and less load when moving near a scene that is being loaded/unloaded constantly because of budget changes...

This also solves this issue #2318 that happened when panning quickly near a scene, it would load the scene, unload, load, unload, load, unload, but as the processes are async, sometimes 2 loadings happened before the unload finished and this would break the scene systems.

## How to test the changes?

We need a fire test to make sure all is working well.
Also, the easiest way to test is to get away from a scene until it unloads, then get close until it loads, then get away again. It should unload further away than it loaded + it should take some seconds until it unloads.
Another test that can be done is by being in 1st person, get close enough to a scene until it changes from LOD to scene, then stay still and zoom out. The scene should not convert to a LOD.
Also, now if you pan around with the camera while standing in between multiple scenes, they should not load/unload as soon as you move the camera, but take a little while until the Scene->LOD transition happen.