### PR TITLE
fix: Keep de-activated other avatar previews while the Passport is open (probably avoid crashes/freezes)

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
@@ -161,7 +161,11 @@ namespace DCL.CharacterPreview
             }
         }
 
-        public void OnShow()
+        /// <summary>
+        /// Shows the character preview.
+        /// </summary>
+        /// <param name="triggerOnShowBusEvent">True for keeping the rest of preview controllers informed about this showing.</param>
+        public void OnShow(bool triggerOnShowBusEvent = true)
         {
             if (initialized)
             {
@@ -171,10 +175,16 @@ namespace DCL.CharacterPreview
             else if (previewAvatarModel.Initialized) { Initialize(); }
 
             previewController?.SetPreviewPlatformActive(isPreviewPlatformActive);
-            characterPreviewEventBus.OnAnyCharacterPreviewShow(this);
+
+            if (triggerOnShowBusEvent)
+                characterPreviewEventBus.OnAnyCharacterPreviewShow(this);
         }
 
-        public void OnHide()
+        /// <summary>
+        /// Hides the character preview.
+        /// </summary>
+        /// <param name="triggerOnHideBusEvent">True for keeping the rest of preview controllers informed about this hiding.</param>
+        public void OnHide(bool triggerOnHideBusEvent = true)
         {
             if (initialized)
             {
@@ -184,7 +194,8 @@ namespace DCL.CharacterPreview
                 initialized = false;
             }
 
-            characterPreviewEventBus.OnAnyCharacterPreviewHide(this);
+            if (triggerOnHideBusEvent)
+                characterPreviewEventBus.OnAnyCharacterPreviewHide(this);
         }
 
         // If another character preview is shown, we deactivate the current one in order to avoid rendering issues.

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -278,6 +278,7 @@ namespace DCL.Passport
             LoadPassportSectionAsync(currentUserId, PassportSection.OVERVIEW, characterPreviewLoadingCts.Token).Forget();
             currentSection = PassportSection.OVERVIEW;
             viewInstance.BadgeInfoModuleView.gameObject.SetActive(false);
+            characterPreviewController?.OnShow();
         }
 
         private void OpenBadgesSection(string? badgeIdSelected = null)
@@ -297,6 +298,7 @@ namespace DCL.Passport
             LoadPassportSectionAsync(currentUserId, PassportSection.BADGES, characterPreviewLoadingCts.Token, badgeIdSelected).Forget();
             currentSection = PassportSection.BADGES;
             viewInstance.BadgeInfoModuleView.gameObject.SetActive(true);
+            characterPreviewController?.OnHide(triggerOnHideBusEvent: false);
         }
 
         private void OnBadgeNotificationReceived(INotification notification) =>

--- a/Explorer/Assets/DCL/Passport/Prefabs/Badges/Badge3DPreviewCamera.prefab
+++ b/Explorer/Assets/DCL/Passport/Prefabs/Badges/Badge3DPreviewCamera.prefab
@@ -67,7 +67,7 @@ Camera:
     width: 1
     height: 1
   near clip plane: 0.3
-  far clip plane: 20
+  far clip plane: 40
   field of view: 37
   orthographic: 0
   orthographic size: 3


### PR DESCRIPTION
## What does this PR change?
Fix #2312 
Fix #2365 

This PR avoid, when the Badges section in the Passport is open, to have other preview cameras (like the avatar one) activated at the same time.

This was happening when we did open the Passport and open the Badges tab... both cameras, avatar and badge previews, were activated and this was provoking an important downgrade in terms of performance, especially for high resolutions like in Macs.

Another scenario where it was happening was when we did open the Backpack and then open the Passport from the top-right side of the Explorer Menu and then open the Badges section... 3 cameras were activated here: the Backpack's avatar preview, the Passport avatar preview and the Badges preview. This was also provoking important performance's donwgrades.

I was not personally able to reproduce the 2 linked issues (#2312 and #2365) but it is very likely that it could be due to this, so let's confirm it with @decentraland/qa team!

## How to test the changes?
- Try to reproduce the 2 linked issues.
- Also, check that all the previews are working as expected: The Backpack one, the Passport one and the Badges one.

**NOTE**: Even if this PR wouldn't fix any of the 2 linked issues, let's push it for it merging because it's gonna improve the performance while we have the Passport open.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md