### PR TITLE
fix: Correct max loading distance

### DIFF
--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettingsAsset.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettingsAsset.cs
@@ -23,8 +23,7 @@ namespace ECS.Prioritization
         
         public int MaxLoadingDistanceInParcels
         {
-            get => Math.Min(MinLoadingDistanceInParcels,
-                Math.Min(maxLoadingDistanceInParcels, ParcelMathJobifiedHelper.RADIUS_HARD_LIMIT));
+            get => maxLoadingDistanceInParcels;
 
             set
             {


### PR DESCRIPTION
## What does this PR change?

There was a wrong min value calculation for max loading distance. It was incorrectly "hardcoded" to the min value

No need to do `Min` or `Clamp` on Get. Those are already done in Set

## How to test the changes?


1. Launch the explorer
2. Set loading distance to 100
3. Check that you can see further than at least 20 parcels (you can fly around to get the idea)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

