### PR TITLE
fix: emote lazy loading

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarShapeComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarShapeComponent.cs
@@ -3,7 +3,6 @@ using DCL.AvatarRendering.Loading.Components;
 using System.Collections.Generic;
 using UnityEngine;
 using WearablePromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Wearables.Components.WearablesResolution, DCL.AvatarRendering.Wearables.Components.Intentions.GetWearablesByPointersIntention>;
-using EmotePromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution, DCL.AvatarRendering.Emotes.GetEmotesByPointersIntention>;
 
 namespace DCL.AvatarRendering.AvatarShape.Components
 {
@@ -19,7 +18,6 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         public BodyShape BodyShape;
 
         public WearablePromise WearablePromise;
-        public EmotePromise? EmotePromise;
 
         public string ID;
         public string Name;
@@ -40,7 +38,6 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             EyesColor = eyesColor;
             IsVisible = true;
             HiddenByModifierArea = false;
-            EmotePromise = null;
         }
 
         public AvatarShapeComponent(string name, string id) : this()

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarShapeComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarShapeComponent.cs
@@ -19,14 +19,14 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         public BodyShape BodyShape;
 
         public WearablePromise WearablePromise;
-        public EmotePromise EmotePromise;
+        public EmotePromise? EmotePromise;
 
         public string ID;
         public string Name;
 
         public readonly List<CachedAttachment> InstantiatedWearables;
 
-        public AvatarShapeComponent(string name, string id, BodyShape bodyShape, WearablePromise wearablePromise, EmotePromise emotePromise,
+        public AvatarShapeComponent(string name, string id, BodyShape bodyShape, WearablePromise wearablePromise,
             Color skinColor, Color hairColor, Color eyesColor)
         {
             ID = id;
@@ -34,13 +34,13 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             BodyShape = bodyShape;
             IsDirty = true;
             WearablePromise = wearablePromise;
-            EmotePromise = emotePromise;
             InstantiatedWearables = new List<CachedAttachment>();
             SkinColor = skinColor;
             HairColor = hairColor;
             EyesColor = eyesColor;
             IsVisible = true;
             HiddenByModifierArea = false;
+            EmotePromise = null;
         }
 
         public AvatarShapeComponent(string name, string id) : this()

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
@@ -129,7 +129,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         [None(typeof(AvatarBase), typeof(AvatarTransformMatrixComponent), typeof(AvatarCustomSkinningComponent))]
         private void InstantiateMainPlayerAvatar(in Entity entity, ref AvatarShapeComponent avatarShapeComponent, ref CharacterTransform transformComponent)
         {
-            // TODO: require emotes for main player (??)
             var avatarBase = InstantiateNewAvatar(entity, ref avatarShapeComponent, ref transformComponent);
 
             if (avatarBase != null)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
@@ -210,6 +210,7 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             avatarBase.gameObject.SetActive(true);
 
             wearableIntention.Dispose();
+            avatarShapeComponent.EmotePromise?.LoadingIntention.Dispose();
 
             if (wearablesResult.Succeeded)
                 wearablesResult.Asset.Dispose();

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
@@ -93,7 +93,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             if (!ReadyToInstantiateNewAvatar(ref avatarShapeComponent)) return null;
 
             if (!avatarShapeComponent.WearablePromise.SafeTryConsume(World, GetReportCategory(), out WearablesLoadResult wearablesResult)) return null;
-            if (!avatarShapeComponent.EmotePromise.SafeTryConsume(World, GetReportCategory(), out EmotesLoadResult emotesResult)) return null;
 
             AvatarBase avatarBase = avatarPoolRegistry.Get();
             avatarBase.gameObject.name = $"Avatar {avatarShapeComponent.ID}";
@@ -130,6 +129,7 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         [None(typeof(AvatarBase), typeof(AvatarTransformMatrixComponent), typeof(AvatarCustomSkinningComponent))]
         private void InstantiateMainPlayerAvatar(in Entity entity, ref AvatarShapeComponent avatarShapeComponent, ref CharacterTransform transformComponent)
         {
+            // TODO: require emotes for main player (??)
             var avatarBase = InstantiateNewAvatar(entity, ref avatarShapeComponent, ref transformComponent);
 
             if (avatarBase != null)
@@ -149,7 +149,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             if (!ReadyToInstantiateNewAvatar(ref avatarShapeComponent)) return;
 
             if (!avatarShapeComponent.WearablePromise.SafeTryConsume(World, GetReportCategory(), out WearablesLoadResult wearablesResult)) return;
-            if (!avatarShapeComponent.EmotePromise.SafeTryConsume(World, GetReportCategory(), out EmotesLoadResult emotesResult)) return;
 
             ReleaseAvatar.Execute(vertOutBuffer, wearableAssetsCache, avatarMaterialPoolHandler,
                 computeShaderSkinningPool, avatarShapeComponent, ref skinningComponent,
@@ -164,7 +163,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             AvatarBase avatarBase)
         {
             GetWearablesByPointersIntention wearableIntention = avatarShapeComponent.WearablePromise.LoadingIntention;
-            GetEmotesByPointersIntention emoteIntention = avatarShapeComponent.EmotePromise.LoadingIntention;
 
             HashSet<string> wearablesToHide = wearablesResult.Succeeded ? wearablesResult.Asset.HiddenCategories : EMPTY_STRING_HASH_SET;
             HashSet<string> usedCategories = HashSetPool<string>.Get();
@@ -212,7 +210,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             avatarBase.gameObject.SetActive(true);
 
             wearableIntention.Dispose();
-            emoteIntention.Dispose();
 
             if (wearablesResult.Succeeded)
                 wearablesResult.Asset.Dispose();

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
@@ -209,7 +209,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             avatarBase.gameObject.SetActive(true);
 
             wearableIntention.Dispose();
-            avatarShapeComponent.EmotePromise?.LoadingIntention.Dispose();
 
             if (wearablesResult.Succeeded)
                 wearablesResult.Asset.Dispose();

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarLoaderSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarLoaderSystem.cs
@@ -34,7 +34,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
 
         protected override void Update(float t)
         {
-            CreateMainPlayerAvatarShapeFromSDKComponentQuery(World);
             CreateAvatarShapeFromSDKComponentQuery(World);
             UpdateMainPlayerAvatarFromSDKComponentQuery(World);
             UpdateAvatarFromSDKComponentQuery(World);
@@ -56,26 +55,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
                 pbAvatarShape.GetSkinColor().ToUnityColor(),
                 pbAvatarShape.GetHairColor().ToUnityColor(),
                 pbAvatarShape.GetEyeColor().ToUnityColor()));
-        }
-
-        [Query]
-        [All(typeof(PlayerComponent))]
-        [None(typeof(AvatarShapeComponent), typeof(Profile))]
-        private void CreateMainPlayerAvatarShapeFromSDKComponent(in Entity entity, ref PBAvatarShape pbAvatarShape, ref PartitionComponent partition)
-        {
-            pbAvatarShape.IsDirty = false;
-
-            WearablePromise wearablePromise = CreateWearablePromise(pbAvatarShape, partition);
-
-            var avatarShapeComponent = new AvatarShapeComponent(pbAvatarShape.Name, pbAvatarShape.Id, pbAvatarShape, wearablePromise,
-                pbAvatarShape.GetSkinColor().ToUnityColor(),
-                pbAvatarShape.GetHairColor().ToUnityColor(),
-                pbAvatarShape.GetEyeColor().ToUnityColor());
-
-            // No lazy load for main player. Get all emotes, so it can play them accordingly without undesired delays
-            avatarShapeComponent.EmotePromise = CreateEmotePromise(pbAvatarShape, partition);
-
-            World.Add(entity, avatarShapeComponent);
         }
 
         [Query]

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarLoaderSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarLoaderSystem.cs
@@ -35,7 +35,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         protected override void Update(float t)
         {
             CreateAvatarShapeFromSDKComponentQuery(World);
-            UpdateMainPlayerAvatarFromSDKComponentQuery(World);
             UpdateAvatarFromSDKComponentQuery(World);
             CreateMainPlayerAvatarShapeFromProfileQuery(World);
             CreateAvatarShapeFromProfileQuery(World);
@@ -44,7 +43,7 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         }
 
         [Query]
-        [None(typeof(PlayerComponent), typeof(AvatarShapeComponent), typeof(Profile))]
+        [None(typeof(AvatarShapeComponent), typeof(Profile))]
         private void CreateAvatarShapeFromSDKComponent(in Entity entity, ref PBAvatarShape pbAvatarShape, ref PartitionComponent partition)
         {
             pbAvatarShape.IsDirty = false;
@@ -101,23 +100,7 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         }
 
         [Query]
-        [All(typeof(PlayerComponent))]
-        [None(typeof(Profile), typeof(DeleteEntityIntention))]
-        private void UpdateMainPlayerAvatarFromSDKComponent(ref PBAvatarShape pbAvatarShape, ref AvatarShapeComponent avatarShapeComponent, ref PartitionComponent partition)
-        {
-            if (!pbAvatarShape.IsDirty) return;
-
-            UpdateAvatarFromSDKComponent(ref pbAvatarShape, ref avatarShapeComponent, ref partition);
-
-            if (avatarShapeComponent.EmotePromise is { IsConsumed: false })
-                avatarShapeComponent.EmotePromise.Value.ForgetLoading(World);
-
-            // No lazy load for main player. Get all emotes, so it can play them accordingly without undesired delays
-            avatarShapeComponent.EmotePromise = CreateEmotePromise(pbAvatarShape, partition);
-        }
-
-        [Query]
-        [None(typeof(PBAvatarShape), typeof(DeleteEntityIntention))]
+        [None(typeof(PlayerComponent), typeof(PBAvatarShape), typeof(DeleteEntityIntention))]
         private void UpdateAvatarFromProfile(ref Profile profile, ref AvatarShapeComponent avatarShapeComponent, ref PartitionComponent partition)
         {
             if (!profile.IsDirty)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarLoaderSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarLoaderSystem.cs
@@ -5,6 +5,7 @@ using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.AvatarRendering.AvatarShape.Helpers;
 using DCL.AvatarRendering.Emotes;
 using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Character.Components;
 using DCL.Diagnostics;
 using DCL.ECSComponents;
 using DCL.Profiles;
@@ -33,34 +34,70 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
 
         protected override void Update(float t)
         {
+            CreateMainPlayerAvatarShapeFromSDKComponentQuery(World);
             CreateAvatarShapeFromSDKComponentQuery(World);
+            UpdateMainPlayerAvatarFromSDKComponentQuery(World);
             UpdateAvatarFromSDKComponentQuery(World);
-
+            CreateMainPlayerAvatarShapeFromProfileQuery(World);
             CreateAvatarShapeFromProfileQuery(World);
+            UpdateMainPlayerAvatarFromProfileQuery(World);
             UpdateAvatarFromProfileQuery(World);
         }
 
         [Query]
-        [None(typeof(AvatarShapeComponent), typeof(Profile))]
+        [None(typeof(PlayerComponent), typeof(AvatarShapeComponent), typeof(Profile))]
         private void CreateAvatarShapeFromSDKComponent(in Entity entity, ref PBAvatarShape pbAvatarShape, ref PartitionComponent partition)
         {
-            WearablePromise wearablePromise = CreateWearablePromise(pbAvatarShape, partition);
-            EmotePromise emotePromise = CreateEmotePromise(pbAvatarShape, partition);
             pbAvatarShape.IsDirty = false;
 
-            World.Add(entity, new AvatarShapeComponent(pbAvatarShape.Name, pbAvatarShape.Id, pbAvatarShape, wearablePromise, emotePromise,
+            WearablePromise wearablePromise = CreateWearablePromise(pbAvatarShape, partition);
+
+            World.Add(entity, new AvatarShapeComponent(pbAvatarShape.Name, pbAvatarShape.Id, pbAvatarShape, wearablePromise,
                 pbAvatarShape.GetSkinColor().ToUnityColor(),
                 pbAvatarShape.GetHairColor().ToUnityColor(),
                 pbAvatarShape.GetEyeColor().ToUnityColor()));
         }
 
         [Query]
-        [None(typeof(AvatarShapeComponent), typeof(PBAvatarShape))]
+        [All(typeof(PlayerComponent))]
+        [None(typeof(AvatarShapeComponent), typeof(Profile))]
+        private void CreateMainPlayerAvatarShapeFromSDKComponent(in Entity entity, ref PBAvatarShape pbAvatarShape, ref PartitionComponent partition)
+        {
+            pbAvatarShape.IsDirty = false;
+
+            WearablePromise wearablePromise = CreateWearablePromise(pbAvatarShape, partition);
+
+            var avatarShapeComponent = new AvatarShapeComponent(pbAvatarShape.Name, pbAvatarShape.Id, pbAvatarShape, wearablePromise,
+                pbAvatarShape.GetSkinColor().ToUnityColor(),
+                pbAvatarShape.GetHairColor().ToUnityColor(),
+                pbAvatarShape.GetEyeColor().ToUnityColor());
+
+            // No lazy load for main player. Get all emotes, so it can play them accordingly without undesired delays
+            avatarShapeComponent.EmotePromise = CreateEmotePromise(pbAvatarShape, partition);
+
+            World.Add(entity, avatarShapeComponent);
+        }
+
+        [Query]
+        [None(typeof(AvatarShapeComponent), typeof(PBAvatarShape), typeof(PlayerComponent))]
         private void CreateAvatarShapeFromProfile(in Entity entity, in Profile profile, ref PartitionComponent partition)
         {
             WearablePromise wearablePromise = CreateWearablePromise(profile, partition);
-            EmotePromise emotePromise = CreateEmotePromise(profile, partition);
-            World.Add(entity, new AvatarShapeComponent(profile.Name, profile.UserId, profile.Avatar.BodyShape, wearablePromise, emotePromise, profile.Avatar.SkinColor, profile.Avatar.HairColor, profile.Avatar.EyesColor));
+            World.Add(entity, new AvatarShapeComponent(profile.Name, profile.UserId, profile.Avatar.BodyShape, wearablePromise, profile.Avatar.SkinColor, profile.Avatar.HairColor, profile.Avatar.EyesColor));
+        }
+
+        [Query]
+        [All(typeof(PlayerComponent))]
+        [None(typeof(AvatarShapeComponent), typeof(PBAvatarShape))]
+        private void CreateMainPlayerAvatarShapeFromProfile(in Entity entity, in Profile profile, ref PartitionComponent partition)
+        {
+            WearablePromise wearablePromise = CreateWearablePromise(profile, partition);
+
+            var avatarShapeComponent = new AvatarShapeComponent(profile.Name, profile.UserId, profile.Avatar.BodyShape, wearablePromise, profile.Avatar.SkinColor, profile.Avatar.HairColor, profile.Avatar.EyesColor);
+            // No lazy load for main player. Get all emotes, so it can play them accordingly without undesired delays
+            avatarShapeComponent.EmotePromise = CreateEmotePromise(profile, partition);
+
+            World.Add(entity, avatarShapeComponent);
         }
 
         [Query]
@@ -73,18 +110,31 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             if (!avatarShapeComponent.WearablePromise.IsConsumed)
                 avatarShapeComponent.WearablePromise.ForgetLoading(World);
 
-            if (!avatarShapeComponent.EmotePromise.IsConsumed)
-                avatarShapeComponent.EmotePromise.ForgetLoading(World);
-
             WearablePromise newPromise = CreateWearablePromise(pbAvatarShape, partition);
             avatarShapeComponent.WearablePromise = newPromise;
-            avatarShapeComponent.EmotePromise = CreateEmotePromise(pbAvatarShape, partition);
+
             avatarShapeComponent.BodyShape = pbAvatarShape;
             avatarShapeComponent.HairColor = pbAvatarShape.GetHairColor().ToUnityColor();
             avatarShapeComponent.SkinColor = pbAvatarShape.GetSkinColor().ToUnityColor();
             avatarShapeComponent.EyesColor = pbAvatarShape.GetEyeColor().ToUnityColor();
             avatarShapeComponent.IsDirty = true;
             pbAvatarShape.IsDirty = false;
+        }
+
+        [Query]
+        [All(typeof(PlayerComponent))]
+        [None(typeof(Profile), typeof(DeleteEntityIntention))]
+        private void UpdateMainPlayerAvatarFromSDKComponent(ref PBAvatarShape pbAvatarShape, ref AvatarShapeComponent avatarShapeComponent, ref PartitionComponent partition)
+        {
+            if (!pbAvatarShape.IsDirty) return;
+
+            UpdateAvatarFromSDKComponent(ref pbAvatarShape, ref avatarShapeComponent, ref partition);
+
+            if (avatarShapeComponent.EmotePromise is { IsConsumed: false })
+                avatarShapeComponent.EmotePromise.Value.ForgetLoading(World);
+
+            // No lazy load for main player. Get all emotes, so it can play them accordingly without undesired delays
+            avatarShapeComponent.EmotePromise = CreateEmotePromise(pbAvatarShape, partition);
         }
 
         [Query]
@@ -97,19 +147,31 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             if (!avatarShapeComponent.WearablePromise.IsConsumed)
                 avatarShapeComponent.WearablePromise.ForgetLoading(World);
 
-            if (!avatarShapeComponent.EmotePromise.IsConsumed)
-                avatarShapeComponent.EmotePromise.ForgetLoading(World);
-
             WearablePromise newPromise = CreateWearablePromise(profile, partition);
             avatarShapeComponent.ID = profile.UserId;
             avatarShapeComponent.Name = profile.Name;
             avatarShapeComponent.WearablePromise = newPromise;
-            avatarShapeComponent.EmotePromise = CreateEmotePromise(profile, partition);
             avatarShapeComponent.BodyShape = profile.Avatar.BodyShape;
             avatarShapeComponent.HairColor = profile.Avatar.HairColor;
             avatarShapeComponent.SkinColor = profile.Avatar.SkinColor;
             avatarShapeComponent.EyesColor = profile.Avatar.EyesColor;
             avatarShapeComponent.IsDirty = true;
+        }
+
+        [Query]
+        [All(typeof(PlayerComponent))]
+        [None(typeof(PBAvatarShape), typeof(DeleteEntityIntention))]
+        private void UpdateMainPlayerAvatarFromProfile(ref Profile profile, ref AvatarShapeComponent avatarShapeComponent, ref PartitionComponent partition)
+        {
+            UpdateAvatarFromProfile(ref profile, ref avatarShapeComponent, ref partition);
+
+            if (!profile.IsDirty) return;
+
+            if (avatarShapeComponent.EmotePromise is { IsConsumed: false })
+                avatarShapeComponent.EmotePromise.Value.ForgetLoading(World);
+
+            // No lazy load for main player. Get all emotes, so it can play them accordingly without undesired delays
+            avatarShapeComponent.EmotePromise = CreateEmotePromise(profile, partition);
         }
 
         private WearablePromise CreateWearablePromise(PBAvatarShape pbAvatarShape, PartitionComponent partition) =>

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/Instantiate/AvatarInstantiatorSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/Instantiate/AvatarInstantiatorSystemShould.cs
@@ -4,12 +4,8 @@ using Cysharp.Threading.Tasks;
 using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.AvatarRendering.AvatarShape.ComputeShader;
 using DCL.AvatarRendering.AvatarShape.Helpers;
-using DCL.AvatarRendering.AvatarShape.Rendering.TextureArray;
-using DCL.AvatarRendering.AvatarShape.Helpers;
 using DCL.AvatarRendering.AvatarShape.Systems;
 using DCL.AvatarRendering.AvatarShape.UnityInterface;
-using DCL.AvatarRendering.Emotes;
-using DCL.AvatarRendering.Wearables;
 using DCL.AvatarRendering.Emotes;
 using DCL.AvatarRendering.Loading.Assets;
 using DCL.AvatarRendering.Loading.Components;
@@ -84,19 +80,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests.Instantiate
                 GetMockWearable("hair", WearablesConstants.Categories.HAIR),
             })));
 
-            var emotePromise = EmotePromise.Create(world, new GetEmotesByPointersIntention(new List<URN> { "clap" }, BodyShape.MALE), partitionComponent);
-
-            world.Add(emotePromise.Entity, new StreamableLoadingResult<EmotesResolution>(
-                    new EmotesResolution(
-                        RepoolableList<IEmote>.NewListWithContentOf(
-                            GetMockEmote("clap", "emote")
-                        ),
-                        1
-                    )
-                )
-            );
-
-            avatarShapeComponent = new AvatarShapeComponent("TEST_AVATAR", "TEST_ID", BodyShape.MALE, wearablePromise, emotePromise,
+            avatarShapeComponent = new AvatarShapeComponent("TEST_AVATAR", "TEST_ID", BodyShape.MALE, wearablePromise,
                 randomSkinColor, randomHairColor, randomEyesColor);
 
             Material? celShadingMaterial = await Addressables.LoadAssetAsync<Material>("Avatar_Toon_TestAsset");

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/Instantiate/AvatarInstantiatorSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/Instantiate/AvatarInstantiatorSystemShould.cs
@@ -198,16 +198,10 @@ namespace DCL.AvatarRendering.AvatarShape.Tests.Instantiate
                 WearableComponentsUtils.CreateGetWearablesByPointersIntention(BodyShape.MALE, new List<string>(), Array.Empty<string>()),
                 new PartitionComponent());
 
-            var newEmotePromise = EmotePromise.Create(world,
-                EmoteComponentsUtils.CreateGetEmotesByPointersIntention(BodyShape.MALE, new List<URN>()),
-                new PartitionComponent());
-
             world.Add(newWearablePromise.Entity, new StreamableLoadingResult<WearablesResolution>(new WearablesResolution(new List<IWearable> { GetMockWearable("body_shape", WearablesConstants.Categories.BODY_SHAPE) })));
-            world.Add(newEmotePromise.Entity, new StreamableLoadingResult<EmotesResolution>(new EmotesResolution(RepoolableList<IEmote>.NewListWithContentOf(GetMockEmote("emote", WearablesConstants.Categories.EYES)), 1)));
 
             world.Get<AvatarShapeComponent>(avatarEntity).IsDirty = true;
             world.Get<AvatarShapeComponent>(avatarEntity).WearablePromise = newWearablePromise;
-            world.Get<AvatarShapeComponent>(avatarEntity).EmotePromise = newEmotePromise;
 
             system.Update(0);
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetEmotesByPointersIntention.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetEmotesByPointersIntention.cs
@@ -12,6 +12,9 @@ namespace DCL.AvatarRendering.Emotes
 {
     public struct GetEmotesByPointersIntention : IAssetIntention, IDisposable, IEquatable<GetEmotesByPointersIntention>
     {
+        private readonly List<URN> pointers;
+        private bool isDisposed;
+
         public CancellationTokenSource CancellationTokenSource { get; }
 
         public IReadOnlyCollection<URN> Pointers => pointers;
@@ -23,8 +26,6 @@ namespace DCL.AvatarRendering.Emotes
         public BodyShape BodyShape { get; }
 
         public LoadTimeout Timeout;
-
-        private readonly List<URN> pointers;
 
         public GetEmotesByPointersIntention(List<URN> pointers,
             BodyShape bodyShape,
@@ -51,9 +52,11 @@ namespace DCL.AvatarRendering.Emotes
 
         public void Dispose()
         {
+            if (isDisposed) return;
             POINTERS_POOL.Release(pointers);
             POINTERS_HASHSET_POOL.Release(RequestedPointers);
             POINTERS_HASHSET_POOL.Release(SuccessfulPointers);
+            isDisposed = true;
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/EcsEmoteProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/EcsEmoteProvider.cs
@@ -90,7 +90,7 @@ namespace DCL.AvatarRendering.Emotes
         {
             output.Clear();
 
-            using GetEmotesByPointersIntention intention = EmoteComponentsUtils.CreateGetEmotesByPointersIntention(bodyShape, emoteIds);
+            GetEmotesByPointersIntention intention = EmoteComponentsUtils.CreateGetEmotesByPointersIntention(bodyShape, emoteIds);
             var promise = PromiseByPointers.Create(world, intention, PartitionComponent.TOP_PRIORITY);
             promise = await promise.ToUniTaskAsync(world, cancellationToken: ct);
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/FinalizeEmoteLoadingSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/FinalizeEmoteLoadingSystem.cs
@@ -15,7 +15,6 @@ using ECS.StreamableLoading.AudioClips;
 using ECS.StreamableLoading.Common;
 using ECS.StreamableLoading.Common.Components;
 using SceneRunner.Scene;
-using UnityEngine;
 using AssetBundleManifestPromise = ECS.StreamableLoading.Common.AssetPromise<SceneRunner.Scene.SceneAssetBundleManifest, DCL.AvatarRendering.Wearables.Components.GetWearableAssetBundleManifestIntention>;
 using AssetBundlePromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.AssetBundles.AssetBundleData, ECS.StreamableLoading.AssetBundles.GetAssetBundleIntention>;
 using AudioPromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.AudioClips.AudioClipData, ECS.StreamableLoading.AudioClips.GetAudioClipIntention>;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -1,11 +1,32 @@
 using Arch.Core;
+using Arch.System;
 using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
+using AssetManagement;
+using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Components;
+using DCL.AvatarRendering.Loading.DTO;
 using DCL.AvatarRendering.Loading.Systems.Abstract;
+using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Diagnostics;
+using DCL.SDKComponents.AudioSources;
 using DCL.WebRequests;
+using ECS;
+using ECS.Prioritization.Components;
+using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.Cache;
+using ECS.StreamableLoading.Common.Components;
+using SceneRunner.Scene;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Pool;
+using Utility;
+using StreamableResult = ECS.StreamableLoading.Common.Components.StreamableLoadingResult<DCL.AvatarRendering.Emotes.EmotesResolution>;
+using AssetBundlePromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.AssetBundles.AssetBundleData, ECS.StreamableLoading.AssetBundles.GetAssetBundleIntention>;
+using EmotesFromRealmPromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesDTOList, DCL.AvatarRendering.Emotes.GetEmotesByPointersFromRealmIntention>;
+using AudioPromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.AudioClips.AudioClipData, ECS.StreamableLoading.AudioClips.GetAudioClipIntention>;
 
 namespace DCL.AvatarRendering.Emotes.Load
 {
@@ -13,14 +34,238 @@ namespace DCL.AvatarRendering.Emotes.Load
     [LogCategory(ReportCategory.EMOTE)]
     public partial class LoadEmotesByPointersSystem : LoadElementsByPointersSystem<EmotesDTOList, GetEmotesByPointersFromRealmIntention, EmoteDTO>
     {
+        private readonly IEmoteStorage emoteStorage;
+        private readonly IRealmData realmData;
+        private readonly URLSubdirectory customStreamingSubdirectory;
+        private readonly URLBuilder urlBuilder = new ();
+
         public LoadEmotesByPointersSystem(
             World world,
             IWebRequestController webRequestController,
-            IStreamableCache<EmotesDTOList, GetEmotesByPointersFromRealmIntention> cache
+            IStreamableCache<EmotesDTOList, GetEmotesByPointersFromRealmIntention> cache,
+            IEmoteStorage emoteStorage,
+            IRealmData realmData,
+            URLSubdirectory customStreamingSubdirectory
         )
-            : base(world, cache, webRequestController) { }
+            : base(world, cache, webRequestController)
+        {
+            this.emoteStorage = emoteStorage;
+            this.realmData = realmData;
+            this.customStreamingSubdirectory = customStreamingSubdirectory;
+        }
 
         protected override EmotesDTOList CreateAssetFromListOfDTOs(RepoolableList<EmoteDTO> list) =>
             new (list);
+
+        protected override void Update(float t)
+        {
+            base.Update(t);
+
+            GetEmotesByPointersQuery(World, t);
+        }
+
+        [Query]
+        [None(typeof(StreamableResult))]
+        private void GetEmotesByPointers([Data] float dt, in Entity entity,
+            ref GetEmotesByPointersIntention intention,
+            ref IPartitionComponent partitionComponent)
+        {
+            if (intention.TryCancelByRequest<GetEmotesByPointersIntention, EmotesResolution>(
+                    World!,
+                    GetReportCategory(),
+                    entity,
+                    static _ => "Pointer request cancelled"))
+                return;
+
+            using var _ = ListPool<URN>.Get(out var pointersToRequest)!;
+            var resolvedEmotesTmp = RepoolableList<IEmote>.NewList();
+
+            ExtractMissingPointersAndResolvedEmotes(in intention, pointersToRequest!, resolvedEmotesTmp);
+
+            if (intention.Timeout.IsTimeout(dt))
+            {
+                var pointersStrLog = string.Join(",", intention.Pointers);
+                ReportHub.LogWarning(GetReportCategory(), $"Loading emotes timed out, {pointersStrLog}");
+
+                ResolveIntentionWithSuccessfulEmotes(entity, intention, resolvedEmotesTmp);
+
+                return;
+            }
+
+            if (RequestMissingPointers(pointersToRequest!, partitionComponent, intention.BodyShape)) return;
+
+            bool success = GetAssetBundlesUntilAllAreResolved(in intention, partitionComponent, resolvedEmotesTmp.List);
+
+            if (success)
+                World!.Add(entity, NewEmotesResult(resolvedEmotesTmp, intention.Pointers.Count));
+        }
+
+        private void ResolveIntentionWithSuccessfulEmotes(Entity entity,
+            GetEmotesByPointersIntention intention,
+            RepoolableList<IEmote> resolvedEmotesTmp)
+        {
+            HashSet<URN> successfulPointers = intention.SuccessfulPointers;
+            // Keep only successful emotes in the result list
+            resolvedEmotesTmp.List.RemoveAll(emote => !successfulPointers.Contains(emote.GetUrn()));
+
+            World.Add(entity, new StreamableResult(new EmotesResolution(resolvedEmotesTmp, resolvedEmotesTmp.List.Count)));
+        }
+
+        private static StreamableResult NewEmotesResult(RepoolableList<IEmote> resolvedEmotesTmp, int pointersCount) =>
+            new (new EmotesResolution(resolvedEmotesTmp, pointersCount));
+
+        private bool GetAssetBundlesUntilAllAreResolved(
+            in GetEmotesByPointersIntention intention,
+            IPartitionComponent partitionComponent,
+            IEnumerable<IEmote> emotes
+        )
+        {
+            var emotesWithResponse = 0;
+
+            foreach (IEmote emote in emotes)
+            {
+                if (emote.ManifestResult is { Exception: not null })
+                    emotesWithResponse++;
+
+                if (emote.IsLoading) continue;
+                if (CreateAssetBundlePromiseIfRequired(emote, in intention, partitionComponent)) continue;
+
+                if (emote.AssetResults[intention.BodyShape] != null)
+
+                    // TODO: it may occur that the requested emote does not support the body shape
+                    // If that is the case, the promise will never be resolved
+                    emotesWithResponse++;
+
+                if (emote.AssetResults[intention.BodyShape] is { Succeeded: true })
+
+                    // Reference must be added only once when the wearable is resolved
+                    if (!intention.SuccessfulPointers.Contains(emote.GetUrn()))
+                    {
+                        intention.SuccessfulPointers.Add(emote.GetUrn());
+
+                        // We need to add a reference here, so it is not lost if the flow interrupts in between (i.e. before creating instances of CachedWearable)
+                        emote.AssetResults[intention.BodyShape]?.Asset?.AddReference();
+                    }
+            }
+
+            return emotesWithResponse == intention.Pointers.Count;
+        }
+
+        private bool RequestMissingPointers(ICollection<URN> missingPointers, IPartitionComponent partitionComponent, BodyShape forBodyShape)
+        {
+            if (missingPointers.Count <= 0) return false;
+
+            var promise = EmotesFromRealmPromise.Create(
+                World!,
+                new GetEmotesByPointersFromRealmIntention(missingPointers.ToList(),
+                    new CommonLoadingArguments(realmData.Ipfs.EntitiesActiveEndpoint)
+                ),
+                partitionComponent
+            );
+
+            World!.Create(promise, forBodyShape, partitionComponent);
+
+            return true;
+        }
+
+        private void ExtractMissingPointersAndResolvedEmotes(
+            in GetEmotesByPointersIntention intention,
+            ICollection<URN> missingPointers,
+            RepoolableList<IEmote> resolvedEmotes
+        )
+        {
+            foreach (URN loadingIntentionPointer in intention.Pointers)
+            {
+                if (loadingIntentionPointer.IsNullOrEmpty())
+                {
+                    ReportHub.LogError(
+                        GetReportCategory(),
+                        "ResolveWearableByPointerSystem: Null pointer found in the list of pointers"
+                    );
+
+                    continue;
+                }
+
+                URN shortenedPointer = loadingIntentionPointer.Shorten();
+
+                if (!emoteStorage.TryGetElement(shortenedPointer, out IEmote emote))
+                {
+                    if (!intention.RequestedPointers.Contains(loadingIntentionPointer))
+                    {
+                        missingPointers.Add(shortenedPointer);
+                        intention.RequestedPointers.Add(loadingIntentionPointer);
+                    }
+
+                    continue;
+                }
+
+                if (emote.Model.Succeeded)
+                    resolvedEmotes.List.Add(emote);
+            }
+        }
+
+        private bool CreateAssetBundlePromiseIfRequired(IEmote component, in GetEmotesByPointersIntention intention, IPartitionComponent partitionComponent)
+        {
+            // Manifest is required for Web loading only
+            if (component.ManifestResult == null
+                && EnumUtils.HasFlag(intention.PermittedSources, AssetSource.WEB)
+
+                // Skip processing manifest for embedded emotes which do not start with 'urn'
+                && component.GetUrn().IsValid())
+
+                // The resolution of the AB promise will be finalized by FinalizeEmoteAssetBundleSystem
+                return component.CreateAssetBundleManifestPromise(World!, intention.BodyShape, intention.CancellationTokenSource, partitionComponent);
+
+            if (!component.TryGetMainFileHash(intention.BodyShape, out string? hash))
+                return false;
+
+            if (component.AssetResults[intention.BodyShape] == null)
+            {
+                SceneAssetBundleManifest? manifest = !EnumUtils.HasFlag(intention.PermittedSources, AssetSource.WEB) ? null : component.ManifestResult?.Asset;
+
+                // The resolution of the AB promise will be finalized by FinalizeEmoteAssetBundleSystem
+                var promise = AssetBundlePromise.Create(
+                    World!,
+                    GetAssetBundleIntention.FromHash(
+                        typeof(GameObject),
+                        hash! + PlatformUtils.GetCurrentPlatform(),
+                        permittedSources: intention.PermittedSources,
+                        customEmbeddedSubDirectory: customStreamingSubdirectory,
+                        manifest: manifest,
+                        cancellationTokenSource: intention.CancellationTokenSource
+                    ),
+                    partitionComponent
+                );
+
+                TryCreateAudioClipPromises(component, intention.BodyShape, partitionComponent);
+
+                component.UpdateLoadingStatus(true);
+                World!.Create(promise, component, intention.BodyShape);
+                return true;
+            }
+
+            return false;
+        }
+
+        private void TryCreateAudioClipPromises(IEmote component, BodyShape bodyShape, IPartitionComponent partitionComponent)
+        {
+            AvatarAttachmentDTO.Content[]? content = component.Model.Asset!.content;
+
+            foreach (AvatarAttachmentDTO.Content item in content ?? Array.Empty<AvatarAttachmentDTO.Content>())
+            {
+                var audioType = item.file.ToAudioType();
+
+                if (audioType == AudioType.UNKNOWN)
+                    continue;
+
+                urlBuilder.Clear();
+                urlBuilder.AppendDomain(realmData.Ipfs.ContentBaseUrl).AppendPath(new URLPath(item.hash));
+                URLAddress url = urlBuilder.Build();
+
+                // The resolution of the audio promise will be finalized by FinalizeEmoteAssetBundleSystem
+                AudioPromise promise = AudioUtils.CreateAudioClipPromise(World!, url.Value, audioType, partitionComponent);
+                World!.Create(promise, component, bodyShape);
+            }
+        }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -62,6 +62,7 @@ namespace DCL.AvatarRendering.Emotes.Load
             base.Update(t);
 
             GetEmotesByPointersQuery(World, t);
+            DisposeFinishedIntentsQuery(World);
         }
 
         [Query]
@@ -98,6 +99,15 @@ namespace DCL.AvatarRendering.Emotes.Load
 
             if (success)
                 World!.Add(entity, NewEmotesResult(resolvedEmotesTmp, intention.Pointers.Count));
+        }
+
+        [Query]
+        [All(typeof(StreamableResult))]
+        private void DisposeFinishedIntents(in Entity entity, ref GetEmotesByPointersIntention intention)
+        {
+            intention.Dispose();
+            // Destroyal will only be possible if no other system requires this intention later
+            World.Destroy(entity);
         }
 
         private void ResolveIntentionWithSuccessfulEmotes(Entity entity,

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -62,7 +62,6 @@ namespace DCL.AvatarRendering.Emotes.Load
             base.Update(t);
 
             GetEmotesByPointersQuery(World, t);
-            DisposeFinishedIntentsQuery(World);
         }
 
         [Query]
@@ -99,15 +98,6 @@ namespace DCL.AvatarRendering.Emotes.Load
 
             if (success)
                 World!.Add(entity, NewEmotesResult(resolvedEmotesTmp, intention.Pointers.Count));
-        }
-
-        [Query]
-        [All(typeof(StreamableResult))]
-        private void DisposeFinishedIntents(in Entity entity, ref GetEmotesByPointersIntention intention)
-        {
-            intention.Dispose();
-            // Destroyal will only be possible if no other system requires this intention later
-            World.Destroy(entity);
         }
 
         private void ResolveIntentionWithSuccessfulEmotes(Entity entity,

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
@@ -2,29 +2,19 @@ using Arch.Core;
 using Arch.System;
 using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
-using AssetManagement;
 using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Components;
 using DCL.AvatarRendering.Loading.DTO;
-using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Diagnostics;
-using DCL.SDKComponents.AudioSources;
-using ECS;
 using ECS.Abstract;
 using ECS.Prioritization.Components;
 using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.Common.Components;
-using SceneRunner.Scene;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
-using UnityEngine.Pool;
 using Utility;
 using StreamableResult = ECS.StreamableLoading.Common.Components.StreamableLoadingResult<DCL.AvatarRendering.Emotes.EmotesResolution>;
 using AssetBundlePromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.AssetBundles.AssetBundleData, ECS.StreamableLoading.AssetBundles.GetAssetBundleIntention>;
-using EmotesFromRealmPromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesDTOList, DCL.AvatarRendering.Emotes.GetEmotesByPointersFromRealmIntention>;
-using AudioPromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.AudioClips.AudioClipData, ECS.StreamableLoading.AudioClips.GetAudioClipIntention>;
 
 namespace DCL.AvatarRendering.Emotes.Load
 {
@@ -34,30 +24,23 @@ namespace DCL.AvatarRendering.Emotes.Load
     {
         private readonly URLSubdirectory customStreamingSubdirectory;
         private readonly IEmoteStorage emoteStorage;
-        private readonly IRealmData realmData;
-        private readonly URLBuilder urlBuilder;
 
         public LoadSceneEmotesSystem(
             World world,
             IEmoteStorage emoteStorage,
-            IRealmData realmData,
             URLSubdirectory customStreamingSubdirectory
         )
             : base(world)
         {
             this.emoteStorage = emoteStorage;
             this.customStreamingSubdirectory = customStreamingSubdirectory;
-            this.realmData = realmData;
-            urlBuilder = new URLBuilder();
         }
 
         protected override void Update(float t)
         {
             GetEmotesFromRealmQuery(World, t);
-            GetEmotesByPointersQuery(World, t);
         }
 
-        // TODO: this query should not be in this system. This system should only process scene emotes, but this query is processing emotes of avatars
         [Query]
         [None(typeof(StreamableResult))]
         private void GetEmotesFromRealm([Data] float dt, in Entity entity,
@@ -161,210 +144,6 @@ namespace DCL.AvatarRendering.Emotes.Load
             World.Create(promise, emote, intention.BodyShape);
 
             return true;
-        }
-
-        [Query]
-        [None(typeof(StreamableResult))]
-        private void GetEmotesByPointers([Data] float dt, in Entity entity,
-            ref GetEmotesByPointersIntention intention,
-            ref IPartitionComponent partitionComponent)
-        {
-            if (intention.TryCancelByRequest<GetEmotesByPointersIntention, EmotesResolution>(
-                    World!,
-                    GetReportCategory(),
-                    entity,
-                    static _ => "Pointer request cancelled"))
-                return;
-
-            using var _ = ListPool<URN>.Get(out var pointersToRequest)!;
-            var resolvedEmotesTmp = RepoolableList<IEmote>.NewList();
-
-            ExtractMissingPointersAndResolvedEmotes(in intention, pointersToRequest!, resolvedEmotesTmp);
-
-            if (intention.Timeout.IsTimeout(dt))
-            {
-                var pointersStrLog = string.Join(",", intention.Pointers);
-                ReportHub.LogWarning(GetReportCategory(), $"Loading emotes timed out, {pointersStrLog}");
-
-                ResolveIntentionWithSuccessfulEmotes(entity, intention, resolvedEmotesTmp);
-
-                return;
-            }
-
-            if (RequestMissingPointers(pointersToRequest!, partitionComponent, intention.BodyShape)) return;
-
-            bool success = GetAssetBundlesUntilAllAreResolved(in intention, partitionComponent, resolvedEmotesTmp.List);
-
-            if (success)
-                World!.Add(entity, NewEmotesResult(resolvedEmotesTmp, intention.Pointers.Count));
-        }
-
-        private void ResolveIntentionWithSuccessfulEmotes(Entity entity,
-            GetEmotesByPointersIntention intention,
-            RepoolableList<IEmote> resolvedEmotesTmp)
-        {
-            HashSet<URN> successfulPointers = intention.SuccessfulPointers;
-            // Keep only successful emotes in the result list
-            resolvedEmotesTmp.List.RemoveAll(emote => !successfulPointers.Contains(emote.GetUrn()));
-
-            World.Add(entity, new StreamableResult(new EmotesResolution(resolvedEmotesTmp, resolvedEmotesTmp.List.Count)));
-        }
-
-        private static StreamableResult NewEmotesResult(RepoolableList<IEmote> resolvedEmotesTmp, int pointersCount) =>
-            new (new EmotesResolution(resolvedEmotesTmp, pointersCount));
-
-        private bool GetAssetBundlesUntilAllAreResolved(
-            in GetEmotesByPointersIntention intention,
-            IPartitionComponent partitionComponent,
-            IEnumerable<IEmote> emotes
-        )
-        {
-            var emotesWithResponse = 0;
-
-            foreach (IEmote emote in emotes)
-            {
-                if (emote.ManifestResult is { Exception: not null })
-                    emotesWithResponse++;
-
-                if (emote.IsLoading) continue;
-                if (CreateAssetBundlePromiseIfRequired(emote, in intention, partitionComponent)) continue;
-
-                if (emote.AssetResults[intention.BodyShape] != null)
-
-                    // TODO: it may occur that the requested emote does not support the body shape
-                    // If that is the case, the promise will never be resolved
-                    emotesWithResponse++;
-
-                if (emote.AssetResults[intention.BodyShape] is { Succeeded: true })
-
-                    // Reference must be added only once when the wearable is resolved
-                    if (!intention.SuccessfulPointers.Contains(emote.GetUrn()))
-                    {
-                        intention.SuccessfulPointers.Add(emote.GetUrn());
-
-                        // We need to add a reference here, so it is not lost if the flow interrupts in between (i.e. before creating instances of CachedWearable)
-                        emote.AssetResults[intention.BodyShape]?.Asset?.AddReference();
-                    }
-            }
-
-            return emotesWithResponse == intention.Pointers.Count;
-        }
-
-        private bool RequestMissingPointers(ICollection<URN> missingPointers, IPartitionComponent partitionComponent, BodyShape forBodyShape)
-        {
-            if (missingPointers.Count <= 0) return false;
-
-            var promise = EmotesFromRealmPromise.Create(
-                World!,
-                new GetEmotesByPointersFromRealmIntention(missingPointers.ToList(),
-                    new CommonLoadingArguments(realmData.Ipfs.EntitiesActiveEndpoint)
-                ),
-                partitionComponent
-            );
-
-            World!.Create(promise, forBodyShape, partitionComponent);
-
-            return true;
-        }
-
-        private void ExtractMissingPointersAndResolvedEmotes(
-            in GetEmotesByPointersIntention intention,
-            ICollection<URN> missingPointers,
-            RepoolableList<IEmote> resolvedEmotes
-        )
-        {
-            foreach (URN loadingIntentionPointer in intention.Pointers)
-            {
-                if (loadingIntentionPointer.IsNullOrEmpty())
-                {
-                    ReportHub.LogError(
-                        GetReportCategory(),
-                        "ResolveWearableByPointerSystem: Null pointer found in the list of pointers"
-                    );
-
-                    continue;
-                }
-
-                URN shortenedPointer = loadingIntentionPointer.Shorten();
-
-                if (!emoteStorage.TryGetElement(shortenedPointer, out IEmote emote))
-                {
-                    if (!intention.RequestedPointers.Contains(loadingIntentionPointer))
-                    {
-                        missingPointers.Add(shortenedPointer);
-                        intention.RequestedPointers.Add(loadingIntentionPointer);
-                    }
-
-                    continue;
-                }
-
-                if (emote.Model.Succeeded)
-                    resolvedEmotes.List.Add(emote);
-            }
-        }
-
-        private bool CreateAssetBundlePromiseIfRequired(IEmote component, in GetEmotesByPointersIntention intention, IPartitionComponent partitionComponent)
-        {
-            // Manifest is required for Web loading only
-            if (component.ManifestResult == null
-                && EnumUtils.HasFlag(intention.PermittedSources, AssetSource.WEB)
-
-                // Skip processing manifest for embedded emotes which do not start with 'urn'
-                && component.GetUrn().IsValid())
-
-                // The resolution of the AB promise will be finalized by FinalizeEmoteAssetBundleSystem
-                return component.CreateAssetBundleManifestPromise(World!, intention.BodyShape, intention.CancellationTokenSource, partitionComponent);
-
-            if (!component.TryGetMainFileHash(intention.BodyShape, out string? hash))
-                return false;
-
-            if (component.AssetResults[intention.BodyShape] == null)
-            {
-                SceneAssetBundleManifest? manifest = !EnumUtils.HasFlag(intention.PermittedSources, AssetSource.WEB) ? null : component.ManifestResult?.Asset;
-
-                // The resolution of the AB promise will be finalized by FinalizeEmoteAssetBundleSystem
-                var promise = AssetBundlePromise.Create(
-                    World!,
-                    GetAssetBundleIntention.FromHash(
-                        typeof(GameObject),
-                        hash! + PlatformUtils.GetCurrentPlatform(),
-                        permittedSources: intention.PermittedSources,
-                        customEmbeddedSubDirectory: customStreamingSubdirectory,
-                        manifest: manifest,
-                        cancellationTokenSource: intention.CancellationTokenSource
-                    ),
-                    partitionComponent
-                );
-
-                TryCreateAudioClipPromises(component, intention.BodyShape, partitionComponent);
-
-                component.UpdateLoadingStatus(true);
-                World!.Create(promise, component, intention.BodyShape);
-                return true;
-            }
-
-            return false;
-        }
-
-        private void TryCreateAudioClipPromises(IEmote component, BodyShape bodyShape, IPartitionComponent partitionComponent)
-        {
-            AvatarAttachmentDTO.Content[]? content = component.Model.Asset!.content;
-
-            foreach (AvatarAttachmentDTO.Content item in content ?? Array.Empty<AvatarAttachmentDTO.Content>())
-            {
-                var audioType = item.file.ToAudioType();
-
-                if (audioType == AudioType.UNKNOWN)
-                    continue;
-
-                urlBuilder.Clear();
-                urlBuilder.AppendDomain(realmData.Ipfs.ContentBaseUrl).AppendPath(new URLPath(item.hash));
-                URLAddress url = urlBuilder.Build();
-
-                // The resolution of the audio promise will be finalized by FinalizeEmoteAssetBundleSystem
-                AudioPromise promise = AudioUtils.CreateAudioClipPromise(World!, url.Value, audioType, partitionComponent);
-                World!.Create(promise, component, bodyShape);
-            }
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -205,8 +205,6 @@ namespace DCL.AvatarRendering.Emotes.Play
                     emoteComponent.EmoteUrn = emoteId;
                     World.Remove<CharacterEmoteIntent>(entity);
 
-                    // TODO: memory leak here. We create a new entity for the intention but it is never destroyed
-                    // We should make a major refactor on how these "attached" promises are finalized by making a standard on how promises and intents are handled across the project
                     if (avatarShapeComponent.EmotePromise is { IsConsumed: true })
                         avatarShapeComponent.EmotePromise?.LoadingIntention.Dispose();
                 }
@@ -220,6 +218,8 @@ namespace DCL.AvatarRendering.Emotes.Play
 
                     // avatarShapeComponent.EmotePromise?.ForgetLoading(World);
 
+                    // TODO: memory leak here. We create a new entity for the intention but it is never destroyed
+                    // We should make a major refactor on how these "attached" promises are finalized by making a standard on how promises and intents are handled across the project
                     emotePromise = CreateEmotePromise(emoteId, avatarShapeComponent.BodyShape);
                     avatarShapeComponent.EmotePromise = emotePromise;
                 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -205,7 +205,8 @@ namespace DCL.AvatarRendering.Emotes.Play
                     emoteComponent.EmoteUrn = emoteId;
                     World.Remove<CharacterEmoteIntent>(entity);
 
-                    // Clean any pending pools since
+                    // TODO: memory leak here. We create a new entity for the promise but it is never destroyed
+                    // We should make a major refactor on how these "attached" promises are finalized by making a standard on how promises and intents are handled across the project
                     if (avatarShapeComponent.EmotePromise is { IsConsumed: true })
                         avatarShapeComponent.EmotePromise?.LoadingIntention.Dispose();
                 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -205,7 +205,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                     emoteComponent.EmoteUrn = emoteId;
                     World.Remove<CharacterEmoteIntent>(entity);
 
-                    // TODO: memory leak here. We create a new entity for the promise but it is never destroyed
+                    // TODO: memory leak here. We create a new entity for the intention but it is never destroyed
                     // We should make a major refactor on how these "attached" promises are finalized by making a standard on how promises and intents are handled across the project
                     if (avatarShapeComponent.EmotePromise is { IsConsumed: true })
                         avatarShapeComponent.EmotePromise?.LoadingIntention.Dispose();

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -204,12 +204,17 @@ namespace DCL.AvatarRendering.Emotes.Play
 
                     emoteComponent.EmoteUrn = emoteId;
                     World.Remove<CharacterEmoteIntent>(entity);
+
+                    // Clean any pending pools since
+                    if (avatarShapeComponent.EmotePromise is { IsConsumed: true })
+                        avatarShapeComponent.EmotePromise?.LoadingIntention.Dispose();
                 }
                 else
                 {
                     EmotePromise? emotePromise = avatarShapeComponent.EmotePromise;
 
-                    bool isLoadingThisEmote = emotePromise?.LoadingIntention.Pointers.Contains(emoteId) ?? false;
+                    bool isLoadingThisEmote = emotePromise is { IsConsumed: false }
+                                              && (emotePromise?.LoadingIntention.Pointers.Contains(emoteId) ?? false);
                     if (isLoadingThisEmote) return;
 
                     // avatarShapeComponent.EmotePromise?.ForgetLoading(World);

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
@@ -87,10 +87,10 @@ namespace DCL.CharacterPreview
                 PartitionComponent.TOP_PRIORITY
             );
 
-            avatarShape.EmotePromise = EmotePromise.Create(globalWorld,
+            globalWorld.Create(EmotePromise.Create(globalWorld,
                 EmoteComponentsUtils.CreateGetEmotesByPointersIntention(avatarShape.BodyShape,
                     avatarModel.Emotes ?? (IReadOnlyCollection<URN>)Array.Empty<URN>()),
-                PartitionComponent.TOP_PRIORITY);
+                PartitionComponent.TOP_PRIORITY));
 
             avatarShape.IsDirty = true;
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
@@ -110,7 +110,8 @@ namespace DCL.PluginSystem.Global
             FinalizeEmoteLoadingSystem.InjectToWorld(ref builder, emoteStorage);
 
             LoadEmotesByPointersSystem.InjectToWorld(ref builder, webRequestController,
-                new NoCache<EmotesDTOList, GetEmotesByPointersFromRealmIntention>(false, false));
+                new NoCache<EmotesDTOList, GetEmotesByPointersFromRealmIntention>(false, false),
+                emoteStorage, realmData, customStreamingSubdirectory);
 
             LoadOwnedEmotesSystem.InjectToWorld(ref builder, realmData, webRequestController,
                 new NoCache<EmotesResolution, GetOwnedEmotesFromRealmIntention>(false, false),
@@ -122,7 +123,7 @@ namespace DCL.PluginSystem.Global
 
             RemoteEmotesSystem.InjectToWorld(ref builder, web3IdentityCache, entityParticipantTable, messageBus, arguments.PlayerEntity);
 
-            LoadSceneEmotesSystem.InjectToWorld(ref builder, emoteStorage, realmData, customStreamingSubdirectory);
+            LoadSceneEmotesSystem.InjectToWorld(ref builder, emoteStorage, customStreamingSubdirectory);
         }
 
         public async UniTask InitializeAsync(EmoteSettings settings, CancellationToken ct)


### PR DESCRIPTION
## What does this PR change?

Fixes #2298

We do not request all the emotes of all the remote avatars anymore. Instead we request the emotes whenever they need to be played. For the **main player only** we keep requesting all of which are described in the `profile.emotes`.
This change should greatly reduce the amount of requests we make to the content server / asset bundles, specially when we are in places on which there is a lot people around. It should reduce the memory consumption and unlock many processes that were stuck due to budgeting.

## How to test the changes?

1. Launch the explorer
2. Check that you can play all your emotes
3. Get in a group of people and start playing emotes
4. You should be able to see your emotes and the ones from the remote avatars too
5. Go to the backpack and change your emotes
6. Check that emotes play in the backpack
7. Check that all emotes are described as expected
8. Play the new equipped emotes in-world
9. Open the passport the passport of another player
10. The emotes and wearables should be listed accordingly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

