### PR TITLE
fix: Added a GET request as fallback when HEAD request fails

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/OpenMediaPromise.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/OpenMediaPromise.cs
@@ -27,7 +27,10 @@ namespace DCL.SDKComponents.MediaStream
             isReachable = false;
             this.url = url;
 
-            isReachable = await webRequestController.IsReachableAsync(reportData, URLAddress.FromString(this.url), ct);
+            isReachable = await webRequestController.IsHeadReachableAsync(reportData, URLAddress.FromString(this.url), ct);
+            if (!isReachable)
+                isReachable = await webRequestController.IsGetReachableAsync(reportData, URLAddress.FromString(this.url), ct);
+
             ReportHub.Log(ReportCategory.MEDIA_STREAM, $"Resource <{url}> isReachable = <{isReachable}>");
 
             status = Status.Resolved;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/OpenMediaPromise.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/OpenMediaPromise.cs
@@ -28,6 +28,7 @@ namespace DCL.SDKComponents.MediaStream
             this.url = url;
 
             isReachable = await webRequestController.IsHeadReachableAsync(reportData, URLAddress.FromString(this.url), ct);
+            //This is needed because some servers might not handle HEAD requests correctly and return 404 errors, even thou they are perfectly
             if (!isReachable)
                 isReachable = await webRequestController.IsGetReachableAsync(reportData, URLAddress.FromString(this.url), ct);
 

--- a/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
@@ -165,21 +165,8 @@ namespace DCL.WebRequests
                 {
                     // It means there is no such end-point at all
                     case WebRequestUtils.BAD_REQUEST:
-                        return false;
                     case WebRequestUtils.NOT_FOUND:
-                    {
-                        try
-                        {
-                            await GetAsync<WebRequestUtils.NoOp<GenericGetRequest>, WebRequestUtils.NoResult>(controller, new CommonArguments(url), new WebRequestUtils.NoOp<GenericGetRequest>(),
-                                ct, reportData);
-                        }
-                        catch (Exception)
-                        {
-                            return false;
-                        }
-
-                        return true;
-                    }
+                        return false;
                 }
                 // Assume everything else means that there is such an endpoint for Non-HEAD ops
                 return true;

--- a/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
@@ -149,7 +149,7 @@ namespace DCL.WebRequests
             WebRequestSignInfo? signInfo = null) where TOp: struct, IWebRequestOp<GenericHeadRequest, TResult> =>
             controller.SendAsync<GenericHeadRequest, GenericHeadArguments, TOp, TResult>(HEAD_GENERIC, commonArguments, arguments, webRequestOp, ct, reportCategory, headersInfo, signInfo);
 
-        public static async UniTask<bool> IsReachableAsync(this IWebRequestController controller, ReportData reportData, URLAddress url, CancellationToken ct)
+        public static async UniTask<bool> IsHeadReachableAsync(this IWebRequestController controller, ReportData reportData, URLAddress url, CancellationToken ct)
         {
             await UniTask.SwitchToMainThread();
 
@@ -188,6 +188,20 @@ namespace DCL.WebRequests
 
             return true;
         }
+
+        public static async UniTask<bool> IsGetReachableAsync(this IWebRequestController controller, ReportData reportData, URLAddress url, CancellationToken ct)
+        {
+            await UniTask.SwitchToMainThread();
+
+            try { await GetAsync<WebRequestUtils.NoOp<GenericGetRequest>, WebRequestUtils.NoResult>(controller, new CommonArguments(url), new WebRequestUtils.NoOp<GenericGetRequest>(), ct, reportData); }
+            catch (UnityWebRequestException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
 
         /// <summary>
         ///     Make a request that is optimized for texture creation

--- a/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
@@ -165,10 +165,22 @@ namespace DCL.WebRequests
                 {
                     // It means there is no such end-point at all
                     case WebRequestUtils.BAD_REQUEST:
-                    case WebRequestUtils.NOT_FOUND:
                         return false;
-                }
+                    case WebRequestUtils.NOT_FOUND:
+                    {
+                        try
+                        {
+                            await GetAsync<WebRequestUtils.NoOp<GenericGetRequest>, WebRequestUtils.NoResult>(controller, new CommonArguments(url), new WebRequestUtils.NoOp<GenericGetRequest>(),
+                                ct, reportData);
+                        }
+                        catch (Exception)
+                        {
+                            return false;
+                        }
 
+                        return true;
+                    }
+                }
                 // Assume everything else means that there is such an endpoint for Non-HEAD ops
                 return true;
             }

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmController.cs
@@ -138,7 +138,7 @@ namespace Global.Dynamic
         }
 
         public async UniTask<bool> IsReachableAsync(URLDomain realm, CancellationToken ct) =>
-            await webRequestController.IsReachableAsync(ReportCategory.REALM, realm.Append(new URLPath("/about")), ct);
+            await webRequestController.IsHeadReachableAsync(ReportCategory.REALM, realm.Append(new URLPath("/about")), ct);
 
         public async UniTask<AssetPromise<SceneEntityDefinition, GetSceneDefinition>[]> WaitForFixedScenePromisesAsync(CancellationToken ct)
         {


### PR DESCRIPTION
## What does this PR change?

This fixes this issue #2333 .
What happens here is that our Media Player logic does a HEAD request to check if the resource is available. But in this case, the HEAD returns 404 even thou a GET request goes through perfectly.
So I added a check in case of receiving a 404 after a HEAD to make a GET. If the GET Fails, then we assume the resource IS in fact unavailable.
...

## How to test the changes?

Just go to the Inn while there is a stream in process (otherwise you will just see the default image)
It should work normally and you should be able to see the stream.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

