### PR TITLE
chore: Upload builds to S3 bucket

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -257,6 +257,11 @@ jobs:
             !build/**/*_BurstDebugInformation_DoNotShip
           if-no-files-found: error
 
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: Decentraland_${{ matrix.target }}
+
       - name: Upload artifact to S3
         uses: shallwefootball/s3-upload-action@master
         id: upload-artifact-s3
@@ -264,8 +269,8 @@ jobs:
           aws_key_id: ${{ secrets.EXPLORER_TEAM_AWS_ID }}
           aws_secret_access_key: ${{ secrets.EXPLORER_TEAM_AWS_SECRET }}
           aws_bucket: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          source_dir: 'Decentraland_${{ matrix.target }}.zip'
-          destination_dir: ${{ inputs.tag_version != '' && format('@dcl/unity-explorer/releases/{0}', inputs.tag_version) || format('@dcl/unity-explorer/branch/{0}', github.head_ref || github.ref_name) }}
+          source_dir: Decentraland_${{ matrix.target }}
+          destination_dir: ${{ inputs.tag_version != '' && format('@dcl/unity-explorer/releases/{0}/Decentraland_{1}.zip', inputs.tag_version, matrix.target) || format('@dcl/unity-explorer/branch/{0}/Decentraland_{1}.zip', github.head_ref || github.ref_name, matrix.target) }}
 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -259,22 +259,24 @@ jobs:
 
       - name: Compress the build folder to upload it to S3
         run: |
+          mkdir upload_to_s3/ && \
           if [ "${{ matrix.target }}" == "macos" ]; then
-            zip -r Decentraland_${{ matrix.target }}.zip build.tar
+            zip -r upload_to_s3/Decentraland_${{ matrix.target }}.zip build.tar
           elif [ "${{ matrix.target }}" == "windows64" ]; then
-            zip -r Decentraland_${{ matrix.target }}.zip build -x build/**/*_BackUpThisFolder_ButDontShipItWithYourGame -x build/**/*_BurstDebugInformation_DoNotShip
+            zip -r upload_to_s3/Decentraland_${{ matrix.target }}.zip build -x "build/*_BackUpThisFolder_ButDontShipItWithYourGame**" -x "build/*_BurstDebugInformation_DoNotShip**"
           fi
 
       - name: Upload artifact to S3
-        id: upload-artifact-s3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
-          AWS_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          SOURCE_PATH: Decentraland_${{ matrix.target }}.zip
-          DESTINATION_PATH: ${{ inputs.tag_version != '' && format('@dcl/{0}/releases/{1}/Decentraland_{2}.zip', github.event.repository.name, inputs.tag_version, matrix.target) || format('@dcl/{0}/branch/{1}/Decentraland_{2}.zip', github.event.repository.name, github.head_ref || github.ref_name, matrix.target) }}
+          EXPLORER_TEAM_S3_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
+          DESTINATION_PATH: ${{ inputs.tag_version && format('@dcl/{0}/releases/{1}/test_{2}.zip', 'npx-repo-name', inputs.tag_version, matrix.target) || format('@dcl/{0}/branch/{1}/test_{2}.zip', 'npx-repo-name', github.head_ref || github.ref_name, matrix.target) }}
         run: |
-          aws s3 cp $SOURCE_PATH s3://$AWS_BUCKET/$DESTINATION_PATH
+          npx @dcl/cdn-uploader@next \
+            --bucket $EXPLORER_TEAM_S3_BUCKET \
+            --local-folder upload_to_s3 \
+            --bucket-folder $DESTINATION_PATH
 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -271,7 +271,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
           EXPLORER_TEAM_S3_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          DESTINATION_PATH: ${{ inputs.tag_version && format('@dcl/{0}/releases/{1}/test_{2}.zip', 'npx-repo-name', inputs.tag_version, matrix.target) || format('@dcl/{0}/branch/{1}/test_{2}.zip', 'npx-repo-name', github.head_ref || github.ref_name, matrix.target) }}
+          DESTINATION_PATH: ${{ inputs.tag_version && format('@dcl/{0}/releases/{1}/Decentraland_{2}.zip', github.event.repository.name, inputs.tag_version, matrix.target) || format('@dcl/{0}/branch/{1}/Decentraland_{2}.zip', github.event.repository.name, github.head_ref || github.ref_name, matrix.target) }}
         run: |
           npx @dcl/cdn-uploader@next \
             --bucket $EXPLORER_TEAM_S3_BUCKET \

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -266,11 +266,11 @@ jobs:
         uses: shallwefootball/s3-upload-action@master
         id: upload-artifact-s3
         with:
-          aws_key_id: ${{ secrets.EXPLORER_TEAM_AWS_ID }}
-          aws_secret_access_key: ${{ secrets.EXPLORER_TEAM_AWS_SECRET }}
+          aws_key_id: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
           aws_bucket: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
           source_dir: Decentraland_${{ matrix.target }}
-          destination_dir: ${{ inputs.tag_version != '' && format('@dcl/unity-explorer/releases/{0}/Decentraland_{1}.zip', inputs.tag_version, matrix.target) || format('@dcl/unity-explorer/branch/{0}/Decentraland_{1}.zip', github.head_ref || github.ref_name, matrix.target) }}
+          destination_dir: ${{ inputs.tag_version != '' && format('@dcl/{0}/releases/{1}/Decentraland_{2}.zip', github.event.repository.name, inputs.tag_version, matrix.target) || format('@dcl/{0}/branch/{1}/Decentraland_{2}.zip', github.event.repository.name, github.head_ref || github.ref_name, matrix.target) }}
 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -254,7 +254,17 @@ jobs:
             !build/**/*_BackUpThisFolder_ButDontShipItWithYourGame
             !build/**/*_BurstDebugInformation_DoNotShip
           if-no-files-found: error
-          
+
+      - name: Upload artifact to S3
+        uses: shallwefootball/s3-upload-action@master
+        id: upload-artifact-s3
+        with:
+          aws_key_id: ${{ secrets.SDK_TEAM_AWS_ID }}
+          aws_secret_access_key: ${{ secrets.SDK_TEAM_AWS_SECRET }}
+          aws_bucket: ${{ secrets.SDK_TEAM_S3_BUCKET }}
+          source_dir: 'Decentraland_${{ matrix.target }}.zip'
+          destination_dir: ${{ inputs.tag_version != '' && format('releases/{0}', inputs.tag_version) || format('branch/{0}', github.head_ref || github.ref_name) }}
+
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -271,7 +271,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
           EXPLORER_TEAM_S3_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          DESTINATION_PATH: ${{ inputs.tag_version && format('@dcl/{0}/releases/{1}/Decentraland_{2}.zip', github.event.repository.name, inputs.tag_version, matrix.target) || format('@dcl/{0}/branch/{1}/Decentraland_{2}.zip', github.event.repository.name, github.head_ref || github.ref_name, matrix.target) }}
+          DESTINATION_PATH: ${{ inputs.tag_version && format('@dcl/{0}/releases/{1}/', github.event.repository.name, inputs.tag_version) || format('@dcl/{0}/branch/{1}/', github.event.repository.name, github.head_ref || github.ref_name) }}
         run: |
           npx @dcl/cdn-uploader@next \
             --bucket $EXPLORER_TEAM_S3_BUCKET \

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -257,20 +257,24 @@ jobs:
             !build/**/*_BurstDebugInformation_DoNotShip
           if-no-files-found: error
 
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: Decentraland_${{ matrix.target }}
+      - name: Compress the build folder to upload it to S3
+        run: |
+          if [ "${{ matrix.target }}" == "macos" ]; then
+            zip -r Decentraland_${{ matrix.target }}.zip build.tar
+          elif [ "${{ matrix.target }}" == "windows64" ]; then
+            zip -r Decentraland_${{ matrix.target }}.zip build -x build/**/*_BackUpThisFolder_ButDontShipItWithYourGame -x build/**/*_BurstDebugInformation_DoNotShip
+          fi
 
       - name: Upload artifact to S3
-        uses: shallwefootball/s3-upload-action@master
         id: upload-artifact-s3
-        with:
-          aws_key_id: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
-          aws_bucket: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          source_dir: Decentraland_${{ matrix.target }}.zip
-          destination_dir: ${{ inputs.tag_version != '' && format('@dcl/{0}/releases/{1}/Decentraland_{2}.zip', github.event.repository.name, inputs.tag_version, matrix.target) || format('@dcl/{0}/branch/{1}/Decentraland_{2}.zip', github.event.repository.name, github.head_ref || github.ref_name, matrix.target) }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
+          AWS_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
+          SOURCE_PATH: Decentraland_${{ matrix.target }}.zip
+          DESTINATION_PATH: ${{ inputs.tag_version != '' && format('@dcl/{0}/releases/{1}/Decentraland_{2}.zip', github.event.repository.name, inputs.tag_version, matrix.target) || format('@dcl/{0}/branch/{1}/Decentraland_{2}.zip', github.event.repository.name, github.head_ref || github.ref_name, matrix.target) }}
+        run: |
+          aws s3 cp $SOURCE_PATH s3://$AWS_BUCKET/$DESTINATION_PATH
 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -237,6 +237,7 @@ jobs:
         run: tar --exclude='build/Decentraland_BackUpThisFolder_ButDontShipItWithYourGame' -cvf build.tar build
           
       - name: Upload artifact for macOS
+        id: upload-artifact
         if: matrix.target == 'macos'
         uses: actions/upload-artifact@v4
         with:
@@ -245,6 +246,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload artifact for Windows
+        id: upload-artifact
         if: matrix.target == 'windows64'
         uses: actions/upload-artifact@v4
         with:
@@ -258,12 +260,13 @@ jobs:
       - name: Upload artifact to S3
         uses: shallwefootball/s3-upload-action@master
         id: upload-artifact-s3
+        needs: upload-artifact
         with:
-          aws_key_id: ${{ secrets.SDK_TEAM_AWS_ID }}
-          aws_secret_access_key: ${{ secrets.SDK_TEAM_AWS_SECRET }}
-          aws_bucket: ${{ secrets.SDK_TEAM_S3_BUCKET }}
+          aws_key_id: ${{ secrets.EXPLORER_TEAM_AWS_ID }}
+          aws_secret_access_key: ${{ secrets.EXPLORER_TEAM_AWS_SECRET }}
+          aws_bucket: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
           source_dir: 'Decentraland_${{ matrix.target }}.zip'
-          destination_dir: ${{ inputs.tag_version != '' && format('releases/{0}', inputs.tag_version) || format('branch/{0}', github.head_ref || github.ref_name) }}
+          destination_dir: ${{ inputs.tag_version != '' && format('@dcl/unity-explorer/releases/{0}', inputs.tag_version) || format('@dcl/unity-explorer/branch/{0}', github.head_ref || github.ref_name) }}
 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -271,7 +271,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
           EXPLORER_TEAM_S3_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          DESTINATION_PATH: ${{ inputs.tag_version && format('@dcl/{0}/releases/{1}/', github.event.repository.name, inputs.tag_version) || format('@dcl/{0}/branch/{1}/', github.event.repository.name, github.head_ref || github.ref_name) }}
+          DESTINATION_PATH: ${{ inputs.tag_version && format('@dcl/{0}/releases/{1}', github.event.repository.name, inputs.tag_version) || format('@dcl/{0}/branch/{1}', github.event.repository.name, github.head_ref || github.ref_name) }}
         run: |
           npx @dcl/cdn-uploader@next \
             --bucket $EXPLORER_TEAM_S3_BUCKET \

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -269,7 +269,7 @@ jobs:
           aws_key_id: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
           aws_bucket: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          source_dir: Decentraland_${{ matrix.target }}
+          source_dir: Decentraland_${{ matrix.target }}.zip
           destination_dir: ${{ inputs.tag_version != '' && format('@dcl/{0}/releases/{1}/Decentraland_{2}.zip', github.event.repository.name, inputs.tag_version, matrix.target) || format('@dcl/{0}/branch/{1}/Decentraland_{2}.zip', github.event.repository.name, github.head_ref || github.ref_name, matrix.target) }}
 
       - name: Upload debug symbols

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -237,7 +237,7 @@ jobs:
         run: tar --exclude='build/Decentraland_BackUpThisFolder_ButDontShipItWithYourGame' -cvf build.tar build
           
       - name: Upload artifact for macOS
-        id: upload-artifact
+        id: upload-macos-artifact
         if: matrix.target == 'macos'
         uses: actions/upload-artifact@v4
         with:
@@ -246,7 +246,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload artifact for Windows
-        id: upload-artifact
+        id: upload-windows-artifact
         if: matrix.target == 'windows64'
         uses: actions/upload-artifact@v4
         with:
@@ -260,7 +260,6 @@ jobs:
       - name: Upload artifact to S3
         uses: shallwefootball/s3-upload-action@master
         id: upload-artifact-s3
-        needs: upload-artifact
         with:
           aws_key_id: ${{ secrets.EXPLORER_TEAM_AWS_ID }}
           aws_secret_access_key: ${{ secrets.EXPLORER_TEAM_AWS_SECRET }}

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -53,8 +53,17 @@ jobs:
             .id")
           
           echo "Mac Artifact ID: $MAC_ARTIFACT_ID"
-          echo "MAC_ARTIFACT_ID=$MAC_ARTIFACT_ID" >> "$GITHUB_ENV"          
-          
+          echo "MAC_ARTIFACT_ID=$MAC_ARTIFACT_ID" >> "$GITHUB_ENV"
+
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            ARTIFACT_S3_DESTINATION_PATH="@dcl/$REPO/releases/$GITHUB_REF_NAME"
+          else
+            ARTIFACT_S3_DESTINATION_PATH="@dcl/$REPO/branch/${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          fi
+
+          echo "Artifact S3 Destination Path: $ARTIFACT_S3_DESTINATION_PATH"
+          echo "ARTIFACT_S3_DESTINATION_PATH=$ARTIFACT_S3_DESTINATION_PATH" >> "$GITHUB_ENV"
+
           PR_NUMBER=$(jq -r '.pull_requests[0].number' \
             <<< "$WORKFLOW_RUN_EVENT_OBJ")
           
@@ -81,7 +90,9 @@ jobs:
         env:
           JOB_PATH: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ env.PREVIOUS_JOB_ID }}"
           WINDOWS_ARTIFACT_URL: "${{ github.server_url }}/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.WINDOWS_ARTIFACT_ID }}"
+          WINDOWS_ARTIFACT_S3_URL: format('https://{0}.s3.amazonaws.com/@dcl/{1}/Decentraland_windows64.zip', secrets.EXPLORER_TEAM_S3_BUCKET, env.ARTIFACT_S3_DESTINATION_PATH)
           MAC_ARTIFACT_URL: "${{ github.server_url }}/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.MAC_ARTIFACT_ID }}"
+          MAC_ARTIFACT_S3_URL: format('https://{0}.s3.amazonaws.com/@dcl/{1}/Decentraland_macos.zip', secrets.EXPLORER_TEAM_S3_BUCKET, env.ARTIFACT_S3_DESTINATION_PATH)
           HEAD_SHA: "${{ env.HEAD_SHA }}"
         uses: peter-evans/create-or-update-comment@v3
         with:
@@ -93,13 +104,15 @@ jobs:
             
             Windows and Mac build successfull in Unity Cloud! You can find a link to the downloadable artifact below.
             
-            | Name             | Link                    |
-            | --------         | ----------------------- |
-            | Commit           | ${{ env.HEAD_SHA }}     |
-            | Logs             | ${{ env.JOB_PATH }}     |
-            | Download Windows | ${{ env.WINDOWS_ARTIFACT_URL }} |
-            | Download Mac     | ${{ env.MAC_ARTIFACT_URL }} |
-            | Built on         | ${{ env.BUILD_DATE }} |
+            | Name                | Link                    |
+            | --------            | ----------------------- |
+            | Commit              | ${{ env.HEAD_SHA }}     |
+            | Logs                | ${{ env.JOB_PATH }}     |
+            | Download Windows    | ${{ env.WINDOWS_ARTIFACT_URL }} |
+            | Download Windows S3 | ${{ env.WINDOWS_ARTIFACT_S3_URL }} |
+            | Download Mac        | ${{ env.MAC_ARTIFACT_URL }} |
+            | Download Mac S3     | ${{ env.MAC_ARTIFACT_S3_URL }} |
+            | Built on            | ${{ env.BUILD_DATE }} |
 
             [badge]: https://img.shields.io/badge/Build-Success!-3fb950?logo=github&style=for-the-badge
 


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

This PR adds a CI step to upload the builds to a S3 bucket, relying on S3 capabilities because github often rate-limited our downloads.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

