### PR TITLE
fix: prevent map zoom when floating panel is opened

### DIFF
--- a/Explorer/Assets/DCL/Backpack/Assets/ItemInfoPanel.prefab
+++ b/Explorer/Assets/DCL/Backpack/Assets/ItemInfoPanel.prefab
@@ -2392,7 +2392,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 180.2434, y: -25.525}
+  m_AnchoredPosition: {x: 180.2434, y: -25.525024}
   m_SizeDelta: {x: 316.4868, y: 31.05}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9084722218786637228

--- a/Explorer/Assets/DCL/Navmap/Assets/FloatingPanel.prefab
+++ b/Explorer/Assets/DCL/Navmap/Assets/FloatingPanel.prefab
@@ -2837,6 +2837,7 @@ GameObject:
   - component: {fileID: 4114018274006828034}
   - component: {fileID: 6487922241336898360}
   - component: {fileID: 5086411524165218327}
+  - component: {fileID: 5047332679652971454}
   m_Layer: 5
   m_Name: FloatingPanel
   m_TagString: Untagged
@@ -3015,6 +3016,51 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 0
+--- !u!114 &5047332679652971454
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2842296464104635411}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 0
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4920695936791869430}
+          m_TargetAssemblyTypeName: DCL.Navmap.FloatingPanelView, Navmap
+          m_MethodName: OnPointerEnter
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 1
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4920695936791869430}
+          m_TargetAssemblyTypeName: DCL.Navmap.FloatingPanelView, Navmap
+          m_MethodName: OnPointerExit
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1 &2945859757405099506
 GameObject:
   m_ObjectHideFlags: 0
@@ -3299,10 +3345,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 703224478356600950}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 20}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 85.770004, y: -15}
+  m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2776545587846399643
 CanvasRenderer:
@@ -5531,10 +5577,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 703224478356600950}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 24}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -15}
+  m_SizeDelta: {x: 24, y: 24}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &7440721715820606642
 CanvasRenderer:
@@ -5626,10 +5672,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 703224478356600950}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 29}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 26, y: -15}
+  m_SizeDelta: {x: 35.77, y: 29}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &47943878561337394
 CanvasRenderer:
@@ -8694,10 +8740,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 703224478356600950}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 100}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 68.770004, y: -15}
+  m_SizeDelta: {x: 10, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8026308591178416971
 CanvasRenderer:
@@ -9344,10 +9390,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 703224478356600950}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 29}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 113.825005, y: -15}
+  m_SizeDelta: {x: 32.11, y: 29}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5989007666601268136
 CanvasRenderer:

--- a/Explorer/Assets/DCL/Navmap/Assets/Navmap.prefab
+++ b/Explorer/Assets/DCL/Navmap/Assets/Navmap.prefab
@@ -1002,7 +1002,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &8235211841819826033
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
@@ -44,7 +44,8 @@ namespace DCL.Navmap
             FloatingPanelView view,
             IPlacesAPIService placesAPIService,
             IWebRequestController webRequestController,
-            IMapPathEventBus mapPathEventBus, IChatMessagesBus chatMessagesBus)
+            IMapPathEventBus mapPathEventBus, IChatMessagesBus chatMessagesBus,
+            NavmapZoomController zoomController)
         {
             this.view = view;
             this.placesAPIService = placesAPIService;
@@ -65,6 +66,9 @@ namespace DCL.Navmap
             ResetCategories();
             InitButtons();
             this.mapPathEventBus.OnRemovedDestination += RemoveDestination;
+
+            view.onPointerEnterAction += () => zoomController.SetBlockZoom(true);
+            view.onPointerExitAction += () => zoomController.SetBlockZoom(false);
         }
 
         public void Dispose()

--- a/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/FloatingPanelController.cs
@@ -35,6 +35,8 @@ namespace DCL.Navmap
         private Vector2Int destination = DEFAULT_DESTINATION_PARCEL;
         private PlacesData.PlaceInfo currentParcelPlaceInfo;
 
+        private NavmapZoomController zoomController;
+
         public event Action<Vector2Int> OnJumpIn;
         public event Action<PlacesData.PlaceInfo?> OnSetAsDestination;
         private readonly IChatMessagesBus chatMessagesBus;
@@ -51,6 +53,7 @@ namespace DCL.Navmap
             this.placesAPIService = placesAPIService;
             this.mapPathEventBus = mapPathEventBus;
             this.chatMessagesBus = chatMessagesBus;
+            this.zoomController = zoomController;
 
             view.closeButton.onClick.AddListener(HidePanel);
             view.mapPinCloseButton.onClick.AddListener(HidePanel);
@@ -67,15 +70,24 @@ namespace DCL.Navmap
             InitButtons();
             this.mapPathEventBus.OnRemovedDestination += RemoveDestination;
 
-            view.onPointerEnterAction += () => zoomController.SetBlockZoom(true);
-            view.onPointerExitAction += () => zoomController.SetBlockZoom(false);
+            view.onPointerEnterAction += NavmapBlockZoom;
+            view.onPointerExitAction += NavmapUnblockZoom;
         }
+
+        private void NavmapBlockZoom() =>
+            zoomController.SetBlockZoom(true);
+
+        private void NavmapUnblockZoom() =>
+            zoomController.SetBlockZoom(false);
 
         public void Dispose()
         {
             likeButtonController.OnButtonClicked -= OnLike;
             dislikeButtonController.OnButtonClicked -= OnDislike;
             favoriteButtonController.OnButtonClicked -= OnFavorite;
+
+            view.onPointerEnterAction -= NavmapBlockZoom;
+            view.onPointerExitAction -= NavmapUnblockZoom;
         }
 
         private void InitButtons()

--- a/Explorer/Assets/DCL/Navmap/FloatingPanelView.cs
+++ b/Explorer/Assets/DCL/Navmap/FloatingPanelView.cs
@@ -2,6 +2,7 @@ using DCL.Audio;
 using DCL.UI;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.UI;
 
 namespace DCL.Navmap
@@ -99,5 +100,14 @@ namespace DCL.Navmap
         [field: Header("Audio")]
         [field: SerializeField]
         public AudioClipConfig OnShowAudio { get; private set; }
+
+        internal UnityAction? onPointerEnterAction;
+        internal UnityAction? onPointerExitAction;
+
+        public void OnPointerEnter() =>
+            onPointerEnterAction?.Invoke();
+
+        public void OnPointerExit() =>
+            onPointerExitAction?.Invoke();
     }
 }

--- a/Explorer/Assets/DCL/Navmap/FloatingPanelView.cs
+++ b/Explorer/Assets/DCL/Navmap/FloatingPanelView.cs
@@ -1,8 +1,8 @@
 using DCL.Audio;
 using DCL.UI;
+using System;
 using TMPro;
 using UnityEngine;
-using UnityEngine.Events;
 using UnityEngine.UI;
 
 namespace DCL.Navmap
@@ -101,8 +101,8 @@ namespace DCL.Navmap
         [field: SerializeField]
         public AudioClipConfig OnShowAudio { get; private set; }
 
-        internal UnityAction? onPointerEnterAction;
-        internal UnityAction? onPointerExitAction;
+        internal event Action? onPointerEnterAction;
+        internal event Action? onPointerExitAction;
 
         public void OnPointerEnter() =>
             onPointerEnterAction?.Invoke();

--- a/Explorer/Assets/DCL/Navmap/NavmapController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapController.cs
@@ -88,7 +88,7 @@ namespace DCL.Navmap
             filterController = new NavmapFilterController(this.navmapView.filterView, mapRenderer, webBrowser);
             searchBarController = new NavmapSearchBarController(navmapView.SearchBarView, navmapView.SearchBarResultPanel, navmapView.HistoryRecordPanelView, placesAPIService, navmapView.floatingPanelView, webRequestController, inputBlock);
             FloatingPanelController = new FloatingPanelController(navmapView.floatingPanelView, placesAPIService,
-                webRequestController, mapPathEventBus, chatMessagesBus);
+                webRequestController, mapPathEventBus, chatMessagesBus, zoomController);
             FloatingPanelController.OnJumpIn += _ => searchBarController.ResetSearch();
             FloatingPanelController.OnSetAsDestination += SetDestination;
             this.navmapView.DestinationInfoElement.QuitButton.onClick.AddListener(OnRemoveDestinationButtonClicked);

--- a/Explorer/Assets/DCL/Navmap/NavmapZoomController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapZoomController.cs
@@ -29,6 +29,7 @@ namespace DCL.Navmap
         private int currentZoomLevel;
 
         private IMapCameraController cameraController;
+        private bool blockZoom;
 
         public NavmapZoomController(NavmapZoomView view, DCLInput dclInput)
         {
@@ -54,6 +55,9 @@ namespace DCL.Navmap
         {
             cts.SafeCancelAndDispose();
         }
+
+        public void SetBlockZoom(bool value) =>
+            blockZoom = value;
 
         private void CurveClamp01()
         {
@@ -145,7 +149,7 @@ namespace DCL.Navmap
 
         private void Zoom(bool zoomIn)
         {
-            if (!active || isScaling)
+            if (!active || isScaling || blockZoom)
                 return;
 
             EventSystem.current.SetSelectedGameObject(null);


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
Fix #2284 

Prevent the execution of the map zoom if the cursor is on top of the floating panel for the Jump In destination

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open the map
3. Scroll and check that map zooms in/out
4. Click on any point of the map
5. Hover with the mouse on the panel to Jump In
6. Scroll the mouse wheel and check that the map doesn't zooms in/out and only the modal does
7. Hover with the mouse in the map
8. Scroll the mouse wheel and check that the map zooms in/out

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

