### PR TITLE
fix: prevent badges progress bar size overflow

### DIFF
--- a/Explorer/Assets/DCL/Passport/Fields/Badges/BadgeDetailCard_PassportFieldView.cs
+++ b/Explorer/Assets/DCL/Passport/Fields/Badges/BadgeDetailCard_PassportFieldView.cs
@@ -141,12 +141,12 @@ namespace DCL.Passport.Fields.Badges
             if (badgeInfo.data.isTier)
             {
                 int progressPercentage = badgeInfo.GetProgressPercentage();
-                ProgressBarFill.sizeDelta = new Vector2(progressPercentage * (ProgressBar.sizeDelta.x / 100), ProgressBarFill.sizeDelta.y);
+                ProgressBarFill.sizeDelta = new Vector2(Mathf.Clamp(progressPercentage, 0, 100) * (ProgressBar.sizeDelta.x / 100), ProgressBarFill.sizeDelta.y);
             }
             else
             {
                 int simpleBadgeProgressPercentage = badgeInfo.data.progress.stepsDone * 100 / badgeInfo.data.progress.totalStepsTarget;
-                ProgressBarFill.sizeDelta = new Vector2(simpleBadgeProgressPercentage * (ProgressBar.sizeDelta.x / 100), ProgressBarFill.sizeDelta.y);
+                ProgressBarFill.sizeDelta = new Vector2(Mathf.Clamp(simpleBadgeProgressPercentage, 0, 100) * (ProgressBar.sizeDelta.x / 100), ProgressBarFill.sizeDelta.y);
             }
         }
 

--- a/Explorer/Assets/DCL/Passport/Modules/Badges/BadgeInfo_PassportModuleSubController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/Badges/BadgeInfo_PassportModuleSubController.cs
@@ -241,7 +241,7 @@ namespace DCL.Passport.Modules.Badges
                 badgeInfoModuleView.NextTierValueText.text = nextTierToComplete.tierName;
                 badgeInfoModuleView.NextTierDescriptionText.text = nextTierToComplete.description;
                 int nextTierProgressPercentage = badgeInfo.GetProgressPercentage();
-                badgeInfoModuleView.NextTierProgressBarFill.sizeDelta = new Vector2(nextTierProgressPercentage * (badgeInfoModuleView.NextTierProgressBar.sizeDelta.x / 100), badgeInfoModuleView.NextTierProgressBarFill.sizeDelta.y);
+                badgeInfoModuleView.NextTierProgressBarFill.sizeDelta = new Vector2(Mathf.Clamp(nextTierProgressPercentage, 0, 100) * (badgeInfoModuleView.NextTierProgressBar.sizeDelta.x / 100), badgeInfoModuleView.NextTierProgressBarFill.sizeDelta.y);
                 badgeInfoModuleView.NextTierProgressValueText.text = $"{badgeInfo.data.progress.stepsDone}/{badgeInfo.data.progress.nextStepsTarget ?? badgeInfo.data.progress.totalStepsTarget}";
             }
         }
@@ -252,7 +252,7 @@ namespace DCL.Passport.Modules.Badges
             badgeInfoModuleView.BadgeDateText.text = !badgeInfo.isLocked ? $"Unlocked: {BadgesUtils.FormatTimestampDate(badgeInfo.data.completedAt)}" : "Locked";
             badgeInfoModuleView.BadgeDescriptionText.text = badgeInfo.data.description;
             int simpleBadgeProgressPercentage = badgeInfo.data.progress.stepsDone * 100 / badgeInfo.data.progress.totalStepsTarget;
-            badgeInfoModuleView.SimpleBadgeProgressBarFill.sizeDelta = new Vector2(simpleBadgeProgressPercentage * (badgeInfoModuleView.SimpleBadgeProgressBar.sizeDelta.x / 100), badgeInfoModuleView.SimpleBadgeProgressBarFill.sizeDelta.y);
+            badgeInfoModuleView.SimpleBadgeProgressBarFill.sizeDelta = new Vector2(Mathf.Clamp(simpleBadgeProgressPercentage, 0, 100) * (badgeInfoModuleView.SimpleBadgeProgressBar.sizeDelta.x / 100), badgeInfoModuleView.SimpleBadgeProgressBarFill.sizeDelta.y);
             badgeInfoModuleView.SimpleBadgeProgressValueText.text = $"{badgeInfo.data.progress.stepsDone}/{badgeInfo.data.progress.totalStepsTarget}";
         }
 


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Fix #2414 

Clamps the calculated badge progress to 0-100 in order to prevent the visual overflow that can happen due to backend errors

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open your profile
3. Browse the badges
4. Check that every progress bar doesn't overflow (even if the progress is above 100%, e.g. 9 steps of 2 total)

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

