### PR TITLE
fix: 50 plus gltf entities scene not loading locally

### DIFF
--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/GLTF/GltFastDownloadProvider.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/GLTF/GltFastDownloadProvider.cs
@@ -58,17 +58,10 @@ namespace ECS.StreamableLoading.GLTF
             {
                 webRequest.downloadHandler = new DownloadHandlerBuffer();
 
-                try
-                {
-                    await webRequest.SendWebRequest().WithCancellation(new CancellationToken());
-                }
-                catch
-                {
-                    if (isBaseGltfFetch) acquiredBudget.Release();
-                    throw new Exception($"Error on GLTF download ({targetGltfOriginalPath} - {uri}): {webRequest.downloadHandler.error} - {webRequest.downloadHandler.text}");
-                }
+                try { await webRequest.SendWebRequest().WithCancellation(new CancellationToken()); }
+                catch { throw new Exception($"Error on GLTF download ({targetGltfOriginalPath} - {uri}): {webRequest.downloadHandler.error} - {webRequest.downloadHandler.text}"); }
+                finally { if (isBaseGltfFetch) acquiredBudget.Release(); }
 
-                if (isBaseGltfFetch) acquiredBudget.Release();
                 return new GltfDownloadResult
                 {
                     Data = webRequest.downloadHandler.data,

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/GLTF/LoadGLTFSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/GLTF/LoadGLTFSystem.cs
@@ -62,15 +62,13 @@ namespace ECS.StreamableLoading.GLTF
 
         protected override async UniTask<StreamableLoadingResult<GLTFData>> FlowInternalAsync(GetGLTFIntention intention, IAcquiredBudget acquiredBudget, IPartitionComponent partition, CancellationToken ct)
         {
-            // Release budget now to not hold it until dependencies are resolved to prevent a deadlock
-            acquiredBudget.Release();
-
             if (!sceneData.SceneContent.TryGetContentUrl(intention.Name!, out var finalDownloadUrl))
                 return new StreamableLoadingResult<GLTFData>(
                     new ReportData(GetReportCategory()),
                     new Exception("The content to download couldn't be found"));
 
-            GltFastDownloadProvider gltfDownloadProvider = new GltFastDownloadProvider(World, sceneData, partition, intention.Name!);
+            // Acquired budget is released inside GLTFastDownloadedProvider once the GLTF has been fetched
+            GltFastDownloadProvider gltfDownloadProvider = new GltFastDownloadProvider(World, sceneData, partition, intention.Name!, acquiredBudget);
             var gltfImport = new GltfImport(
                 downloadProvider: gltfDownloadProvider,
                 logger: gltfConsoleLogger,


### PR DESCRIPTION
### WHY

An Assets Loading Budget "Token" (max 50, defined in SO: GlobalPluginsSettings->StaticSettings->AssetsLoadingBudget) is assigned to every GLTF that wants to be loaded.

Since we didn't release that budget until the GLTF finished loading, when a scene with 50 or more GLTFs (that use external textures, thus needing an extra budget token for those) is loaded, the loading flow gets deadlocked, and all those asset promises are never finished (the loading screen goes away after timeout).

### WHAT

Moved the `AcquiredBudget` release to the correct place, **as soon as the GLTF file itself has been fetched, regardless of its dependencies**, just as we already do [for Asset Bundles as well](https://github.com/decentraland/unity-explorer/blob/7f466c89500a8499eede466d4b435026a618a260/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs#L67~L68).

Fixes https://github.com/decentraland/creator-hub/issues/211

------------------------------------

### TEST STEPS

1. Download [this test scene](https://github.com/user-attachments/files/17367943/big-scene.zip)
2. Uncompress it somewhere and enter its root folder with a console/terminal
3. run `npm i`
4. run `npm run start -- --explorer-alpha`
5. Confirm that with the latest published E@ the scene doesn't load its assets, after the loading screen timeout runs out the loading screen will be toggled off and you will see an empty scene with no instantiated assets:
<img width="1484" alt="Screenshot 2024-10-14 at 8 19 40 PM" src="https://github.com/user-attachments/assets/4b52f348-c78e-46ef-b744-4b0db2eda164">

6. Close the Explorer but leave the scene running in the terminal
7. Download the build from this PR
8. Connect the PR build to the locally runnign scene, following [the steps in the Wiki](https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene) (remember to put the correct scene position parameter, in this case: `--position 0,0`)
9. Confirm that now you actually see the instantiated assets in the scene:
<img width="1156" alt="Screenshot 2024-10-14 at 8 25 20 PM" src="https://github.com/user-attachments/assets/6e56c0f9-a321-4ac2-96ad-ad0998831d10">

