### PR TITLE
fix: handle same notification id in thumbnail resolver

### DIFF
--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuController.cs
@@ -236,7 +236,7 @@ namespace DCL.Notifications.NotificationsMenu
                 ReportCategory.UI);
             Sprite? thumbnailSprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height),
                 VectorUtilities.OneHalf, PIXELS_PER_UNIT, 0, SpriteMeshType.FullRect, Vector4.one, false);
-            notificationThumbnailCache.Add(notificationData.Id, thumbnailSprite);
+            notificationThumbnailCache.TryAdd(notificationData.Id, thumbnailSprite);
             notificationView.NotificationImage.SetImage(thumbnailSprite);
         }
 


### PR DESCRIPTION
## What does this PR change?

Fix #2431 
Fixes a corner case where backend returns multiple notifications with the same id (that shouldn't happen) to avoid the thumbnail resolver to fail

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Check that the notifications thumbnails are loaded correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

