### PR TITLE
fix: OrdinalIgnoreCase is excessively slow in unity, so introduce a s…

### DIFF
--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Utility;
 
 namespace SceneRunner.Scene
 {
@@ -15,7 +16,7 @@ namespace SceneRunner.Scene
         private readonly string sceneID;
         private readonly string buildDate;
         private readonly bool ignoreConvertedFiles;
-        
+
         //From v25 onwards, the asset bundle path contains the sceneID in the hash
         //This was done to solve cache issues
         public const int ASSET_BUNDLE_VERSION_REQUIRES_HASH = 25;
@@ -27,7 +28,7 @@ namespace SceneRunner.Scene
             this.assetBundlesBaseUrl = assetBundlesBaseUrl;
             this.version = version;
             hasSceneIDInPath = int.Parse(version.AsSpan().Slice(1)) >= 25;
-            convertedFiles = new HashSet<string>(files, StringComparer.OrdinalIgnoreCase);
+            convertedFiles = new HashSet<string>(files, new UrlHashComparer());
             this.sceneID = sceneID;
             this.buildDate = buildDate;
             ignoreConvertedFiles = false;
@@ -70,7 +71,7 @@ namespace SceneRunner.Scene
         {
             if (hasSceneIDInPath)
                 return assetBundlesBaseUrl.Append(new URLPath($"{version}/{sceneID}/{hash}"));
-            
+
             return assetBundlesBaseUrl.Append(new URLPath($"{version}/{hash}"));
         }
 

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/Tests/SceneAssetBundleManifestShould.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/Tests/SceneAssetBundleManifestShould.cs
@@ -7,6 +7,33 @@ namespace SceneRunner.Scene.Tests
 {
     public class SceneAssetBundleManifestShould
     {
+        private const string CONTENT_URL = "https://content-assets-as-bundle.decentraland.org/";
+        private const string VERSION = "v15";
+        private const string SCENE_ID = "bafkreiaquafn3vdokqaf4ite7szje6255nyrudg7a4ucpdwgu543gup4fu";
+        private const string BUILD_DATE = "2024-03-15T23:44:16.092Z";
+        private readonly string[] originalHashes = {
+            "bafkreiaryit63vshyvyddoo3dfjdapvlfcyf2jfbd6enktal3kbv2pcdru_windows",
+            "bafkreicjhpml7xdib2knhbl2qn7sgqq7cudwys75xwgejdd47cxp3dkbc4_windows",
+            "bafkreicljlsrh7upl5guvinmtjjqn7eagyu7e6wsef4a5nyerjuyw7t5fu_windows",
+            "bafkreidgli7y7lyskioyjcgkub3ja2af7b2cj7hsjjjqvgifjk7eusixoe_windows",
+            "bafkreigohcob7ium7ynqeya6ceavkkuvdndx6kjprgqah4lgpvmze6jzji_windows",
+            "bafkreihm3s5xcauc6i256xnywwssnodcvtrs6z3454itsf2ph63e3tx7iq_windows"
+        };
+
+        private readonly string[] randomCaseHashes;
+
+        private readonly SceneAssetBundleManifest sharedManifest;
+        public SceneAssetBundleManifestShould()
+        {
+            randomCaseHashes = new string[originalHashes.Length];
+            for (var i = 0; i < originalHashes.Length; i++)
+            {
+                randomCaseHashes[i] = originalHashes[i].ToUpper();
+            }
+
+            sharedManifest = new SceneAssetBundleManifest(URLDomain.FromString(CONTENT_URL), VERSION, originalHashes, SCENE_ID, BUILD_DATE);
+        }
+
         [Test]
         public void ComputeDatedHash()
         {
@@ -34,6 +61,44 @@ namespace SceneRunner.Scene.Tests
                 var manifest = new SceneAssetBundleManifest(URLDomain.FromString(CONTENT_URL));
 
                 fixed (char* p = EXPECTED) { Assert.AreEqual(Hash128.Compute(p, (ulong)(EXPECTED.Length * sizeof(char))), manifest.ComputeHash(HASH)); }
+            }
+        }
+
+        [Test]
+        public void HandlesIncorrectCasing_TryGet()
+        {
+            foreach (string hash in randomCaseHashes)
+            {
+                Assert.IsTrue(sharedManifest.TryGet(hash, out string _));
+            }
+        }
+
+        [Test]
+        public void HandlesIncorrectCasing_TryGet_OutString()
+        {
+            for(int i = 0; i < originalHashes.Length; i++)
+            {
+                Assert.IsTrue(sharedManifest.TryGet(randomCaseHashes[i], out string originalHash));
+                Assert.AreEqual(originalHashes[i], originalHash);
+            }
+        }
+
+        [Test]
+        public void HandlesCorrectCasing_Contains()
+        {
+
+            foreach (string hash in originalHashes)
+            {
+                Assert.IsTrue(sharedManifest.Contains(hash));
+            }
+        }
+
+        [Test]
+        public void HandlesIncorrectCasing_Contains()
+        {
+            foreach (string hash in randomCaseHashes)
+            {
+                Assert.IsTrue(sharedManifest.Contains(hash));
             }
         }
     }

--- a/Explorer/Assets/Scripts/Utility/UrlHashComparer.cs
+++ b/Explorer/Assets/Scripts/Utility/UrlHashComparer.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+
+namespace Utility
+{
+    public class UrlHashComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string? x, string? y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x == null || y == null) return false;
+            if (x.Length != y.Length) return false;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                char xChar = x[i];
+                char yChar = y[i];
+
+                if (xChar == yChar) continue;
+
+                // Only do case comparison for ASCII letters
+                if (xChar >= 'A' && xChar <= 'Z') xChar += (char)32;
+                if (yChar >= 'A' && yChar <= 'Z') yChar += (char)32;
+
+                if (xChar != yChar) return false;
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(string? obj)
+        {
+            if (obj == null) return 0;
+
+            int hash = 17;
+            for (int i = 0; i < obj.Length; i++)
+            {
+                char c = obj[i];
+                if (c >= 'A' && c <= 'Z') c += (char)32;
+                hash = hash * 31 + c;
+            }
+            return hash;
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR change?

For some reason benchmarking OrdinalIgnoreCase in .NET (8...12) it is much, much faster than within Unity so although this implementation is simpler it was still slower. However within unity the differences when using this custom comparer are far greater. 

Using deep profiler:
![before-change](https://github.com/user-attachments/assets/f851df9f-1f6b-4023-8a8d-238e09405bd5)
![after-change](https://github.com/user-attachments/assets/8d367a26-3f7f-46d0-beeb-49655494ff82)

In a real build:
**0.41ms -> 0.13ms**
![image](https://github.com/user-attachments/assets/83ff1a64-fe3f-48da-91ed-4b130b3b359d)


## How to test the changes?

1. Launch the explorer
2. Verify happy paths work

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

