### PR TITLE
fix: TextShapes are visible when they should not

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/TextShape/System/VisibilityTextShapeSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/TextShape/System/VisibilityTextShapeSystem.cs
@@ -38,7 +38,6 @@ namespace DCL.SDKComponents.TextShape.System
         /// <param name="textShape">The text shape whose TextMeshPro will be modified.</param>
         /// <param name="visibilityComponent">The component that stores whether the text should be visible or not.</param>
         [Query]
-        [All(typeof(TextShapeComponent), typeof(PBVisibilityComponent))]
         private void UpdateVisibilityDependingOnSceneBoundariesAndVisibilityComponent(ref TextShapeComponent textShape, PBVisibilityComponent visibilityComponent)
         {
             textShape.TextMeshPro.enabled = visibilityComponent.GetVisible() && textShape.IsContainedInScene;
@@ -49,7 +48,6 @@ namespace DCL.SDKComponents.TextShape.System
         /// </summary>
         /// <param name="textShape">The text shape whose TextMeshPro will be modified.</param>
         [Query]
-        [All(typeof(TextShapeComponent))]
         [None(typeof(PBVisibilityComponent))]
         private void UpdateVisibilityDependingOnSceneBoundariesOnly(ref TextShapeComponent textShape)
         {


### PR DESCRIPTION
## What does this PR change?

Now the visibility is set to its original value when the TextShape leaves and enters the scene again, instead of setting it as visible. Now both things are always considered, the original visibility and the position with respect to the scene.

## How to test the changes?

1. Launch the explorer
2. Jump to different worlds.

Check that only texts that should be visible really are, in Genesis plaza or other worlds.