### PR TITLE
style: update reward screen title

### DIFF
--- a/Explorer/Assets/DCL/RewardPanel/Assets/RewardPanel.prefab
+++ b/Explorer/Assets/DCL/RewardPanel/Assets/RewardPanel.prefab
@@ -390,7 +390,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: mission reward
+  m_text: quest reward
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}


### PR DESCRIPTION
## What does this PR change?
This PR was created to replace the word `mission` by `quest` in the reward screen.

## How to test the changes?
1. Launch the explorer
2. Complete all the tasks of the `daily quest` (the push with the update of the portable experience quest modal is pending) to get the reward.
3. Once the reward screen is displayed, check the title has been updated.

<img width="961" alt="Screenshot 2024-10-15 at 18 15 44" src="https://github.com/user-attachments/assets/5d43db7f-dea8-474a-8a63-ec239b320bdf">


