### PR TITLE
fix: issues with quick transition between LOD - Scene - LOD - Scene

### DIFF
--- a/Explorer/Assets/DCL/LOD/Settings/ILODSettingsAsset.cs
+++ b/Explorer/Assets/DCL/LOD/Settings/ILODSettingsAsset.cs
@@ -10,6 +10,7 @@ namespace DCL.LOD
         //Threshold for bucket partition (inclusive)
         int[] LodPartitionBucketThresholds { get;  }
         int SDK7LodThreshold { get; set;  }
+        float TimeToChangeToLod { get; set; }
 
 
         //Texture array settings. Default resolutions and their default sizes

--- a/Explorer/Assets/DCL/LOD/Settings/ILODSettingsAsset.cs
+++ b/Explorer/Assets/DCL/LOD/Settings/ILODSettingsAsset.cs
@@ -10,9 +10,8 @@ namespace DCL.LOD
         //Threshold for bucket partition (inclusive)
         int[] LodPartitionBucketThresholds { get;  }
         int SDK7LodThreshold { get; set;  }
+        /// <summary>  The time in seconds before changing from a scene/scene promise to LOD. </summary>
         float TimeToChangeToLod { get; set; }
-
-
         //Texture array settings. Default resolutions and their default sizes
         TextureArrayResolutionDescriptor[] DefaultTextureArrayResolutionDescriptors { get;  }
         int ArraySizeForMissingResolutions { get; }

--- a/Explorer/Assets/DCL/LOD/Settings/LODSettingsAsset.cs
+++ b/Explorer/Assets/DCL/LOD/Settings/LODSettingsAsset.cs
@@ -13,8 +13,9 @@ namespace DCL.LOD
         {
             5
         };
-
         [field: SerializeField] public int SDK7LodThreshold { get; set; } = 2;
+
+        [Tooltip("The time in seconds before changing from a scene/scene promise to LOD")]
         [field: SerializeField] public float TimeToChangeToLod { get; set; } = 5;
 
         [field: SerializeField] public TextureArrayResolutionDescriptor[] DefaultTextureArrayResolutionDescriptors { get; set; } =

--- a/Explorer/Assets/DCL/LOD/Settings/LODSettingsAsset.cs
+++ b/Explorer/Assets/DCL/LOD/Settings/LODSettingsAsset.cs
@@ -15,6 +15,7 @@ namespace DCL.LOD
         };
 
         [field: SerializeField] public int SDK7LodThreshold { get; set; } = 2;
+        [field: SerializeField] public float TimeToChangeToLod { get; set; } = 5;
 
         [field: SerializeField] public TextureArrayResolutionDescriptor[] DefaultTextureArrayResolutionDescriptors { get; set; } =
         {

--- a/Explorer/Assets/DCL/LOD/Systems/UpdateVisualSceneStateSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/UpdateVisualSceneStateSystem.cs
@@ -22,9 +22,6 @@ namespace ECS.SceneLifeCycle.Systems
     [LogCategory(ReportCategory.LOD)]
     public partial class UpdateVisualSceneStateSystem : BaseUnityLoopSystem
     {
-        private const float TIME_TO_CHANGE_FROM_SCENE = 5;
-        private const float TIME_TO_CHANGE_FROM_LOD = 2;
-
         /// <summary>
         ///     Represents one of the methods in UpdateVisualSceneStateSystem, they should be converted to static ones to avoid closures
         /// </summary>
@@ -124,7 +121,7 @@ namespace ECS.SceneLifeCycle.Systems
         {
             if (visualSceneState.TimeToChange == 0 && visualSceneState.CurrentVisualSceneState != VisualSceneStateEnum.SHOWING_LOD) return;
 
-            if (visualSceneState.TimeToChange < TIME_TO_CHANGE_FROM_SCENE)
+            if (visualSceneState.TimeToChange < lodSettingsAsset.TimeToChangeToLod)
             {
                 visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_SCENE;
                 visualSceneState.TimeToChange += deltaTime;
@@ -164,12 +161,13 @@ namespace ECS.SceneLifeCycle.Systems
         {
             if (visualSceneState.TimeToChange == 0 && visualSceneState.CurrentVisualSceneState != VisualSceneStateEnum.SHOWING_LOD) return;
 
-            if (visualSceneState.TimeToChange < TIME_TO_CHANGE_FROM_SCENE)
+            if (visualSceneState.TimeToChange < lodSettingsAsset.TimeToChangeToLod)
             {
                 visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_SCENE;
                 visualSceneState.TimeToChange += deltaTime;
                 return;
             }
+            
             visualSceneState.TimeToChange = 0;
             visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_LOD;
 

--- a/Explorer/Assets/DCL/LOD/Systems/UpdateVisualSceneStateSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/UpdateVisualSceneStateSystem.cs
@@ -112,8 +112,6 @@ namespace ECS.SceneLifeCycle.Systems
                     // we call it directly so we avoid an extra query
                     if (visualSceneStateComponent.IsDirty)
                         continuationMethod(entity, deltaTime, ref visualSceneStateComponent, ref sceneDefinitionComponent, ref partitionComponent, ref customComponent);
-                    else
-                        visualSceneStateComponent.TimeToChange = 0;
                 }
             }
         }

--- a/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
@@ -20,23 +20,22 @@ namespace DCL.LOD
             SceneDefinitionComponent sceneDefinitionComponent, ILODSettingsAsset lodSettingsAsset, IRealmData realmData)
         {
             //If we are in a world, dont show lods
-            if (realmData.ScenesAreFixed) visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_SCENE;
+            if (realmData.ScenesAreFixed) visualSceneState.CandidateVisualSceneState = visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_SCENE;
 
             //If the scene is empty, no lods are possible
-            else if (sceneDefinitionComponent.IsEmpty) visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_SCENE;
-            else if (roadCoordinates.Contains(sceneDefinitionComponent.Definition.metadata.scene.DecodedBase)) visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.ROAD;
+            else if (sceneDefinitionComponent.IsEmpty) visualSceneState.CandidateVisualSceneState = visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_SCENE;
+            else if (roadCoordinates.Contains(sceneDefinitionComponent.Definition.metadata.scene.DecodedBase)) visualSceneState.CandidateVisualSceneState = visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.ROAD;
 
             //For SDK6 scenes, we just show lod0
-            else if (!sceneDefinitionComponent.IsSDK7) visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_LOD;
+            else if (!sceneDefinitionComponent.IsSDK7) visualSceneState.CandidateVisualSceneState = visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_LOD;
             else
             {
-                var candidateState = partition.Bucket < lodSettingsAsset.SDK7LodThreshold
+                visualSceneState.CandidateVisualSceneState = partition.Bucket < lodSettingsAsset.SDK7LodThreshold
                     ? VisualSceneStateEnum.SHOWING_SCENE
                     : VisualSceneStateEnum.SHOWING_LOD;
 
-                if (candidateState != visualSceneState.CurrentVisualSceneState)
+                if (visualSceneState.CandidateVisualSceneState != visualSceneState.CurrentVisualSceneState)
                 {
-                    visualSceneState.CurrentVisualSceneState = candidateState;
                     visualSceneState.IsDirty = true;
                 }
             }

--- a/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
@@ -37,6 +37,7 @@ namespace DCL.LOD
                 if (visualSceneState.CandidateVisualSceneState != visualSceneState.CurrentVisualSceneState)
                 {
                     visualSceneState.IsDirty = true;
+                    visualSceneState.TimeToChange = 0;
                 }
             }
         }

--- a/Explorer/Assets/DCL/LOD/Tests/EditMode/ResolveVisualSceneStateSystemShould.cs
+++ b/Explorer/Assets/DCL/LOD/Tests/EditMode/ResolveVisualSceneStateSystemShould.cs
@@ -126,12 +126,12 @@ namespace DCL.LOD.Tests
             SceneDefinitionComponent sceneDefinitionComponent = SceneDefinitionComponentFactory.CreateFromDefinition(sceneEntityDefinition, new IpfsPath());
             Entity entity = world.Create(partitionComponent, sceneDefinitionComponent);
 
-            system.Update(0);
+            system.Update(10);
 
             VisualSceneState visualSceneState = world.Get<VisualSceneState>(entity);
 
             Assert.IsFalse(visualSceneState.IsDirty);
-            Assert.IsTrue(visualSceneState.CurrentVisualSceneState == expectedVisualSceneState);
+            Assert.IsTrue(visualSceneState.CandidateVisualSceneState == expectedVisualSceneState);
         }
     }
 }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/VisualSceneState.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/VisualSceneState.cs
@@ -8,6 +8,7 @@ namespace ECS.SceneLifeCycle.Components
     {
         public VisualSceneStateEnum CurrentVisualSceneState;
         public bool IsDirty;
+        public float TimeToChange;
     }
 
     public enum VisualSceneStateEnum
@@ -17,5 +18,5 @@ namespace ECS.SceneLifeCycle.Components
         SHOWING_LOD,
         ROAD
     }
-    
+
 }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/VisualSceneState.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/VisualSceneState.cs
@@ -6,9 +6,12 @@ namespace ECS.SceneLifeCycle.Components
 {
     public struct VisualSceneState
     {
+        /// <summary>  The current VisualSceneState that the scene is, could be different from the CandidateVisualSceneState if we are delaying the switch from Scene -> LODs </summary>
         public VisualSceneStateEnum CurrentVisualSceneState;
+        /// <summary>  The VisualSceneState to which these scene is going to change to</summary>
         public VisualSceneStateEnum CandidateVisualSceneState;
         public bool IsDirty;
+        /// <summary>  The time in Seconds that has passed since this scene started trying to change from one VisualSceneState to another</summary>
         public float TimeToChange;
     }
 

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/VisualSceneState.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/VisualSceneState.cs
@@ -7,6 +7,7 @@ namespace ECS.SceneLifeCycle.Components
     public struct VisualSceneState
     {
         public VisualSceneStateEnum CurrentVisualSceneState;
+        public VisualSceneStateEnum CandidateVisualSceneState;
         public bool IsDirty;
         public float TimeToChange;
     }


### PR DESCRIPTION
## What does this PR change?

Added a small time before we switch from a scene/scene promise to a LOD, reducing the visual glitches and reducing the edge cases caused by quickly panning around the camera.


## How to test the changes?

Go to -150,0, zoom into 1st person view, then approach the lonely house at -150,-3 until it changes from LOD to Scene. Then zoom out. It should take about 5seconds until it turns into LOD again. If you zoom in, it will turn into a scene again.
This delay should work for all scenes allowing to pan the camera around and leave a scene and come back without it changing too quickly to LODs.
Please let me know if the time set is OK or if we need more time for the change to happen.

https://github.com/user-attachments/assets/a8cb663d-37d6-49f0-ac6d-8b21bdd174cc


