### PR TITLE
chore: adjust minimum camera distance for main avatar visibility

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -13,7 +13,7 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
     [UpdateInGroup(typeof(CameraGroup))]
     public partial class AvatarShapeVisibilitySystem : BaseUnityLoopSystem
     {
-        private const float AVATAR_MINIMUM_CAMERA_DISTANCE_SQR = 1;
+        private const float AVATAR_MINIMUM_CAMERA_DISTANCE_SQR = 3.5f * 3.5f;
         private SingleInstanceEntity camera;
 
         public AvatarShapeVisibilitySystem(World world) : base(world) { }


### PR DESCRIPTION
### WHY
Right now when performance degrades a lot and therea re hiccups in the main thread, the main camera following (in first person camera) can't keep up with the main player position, thus getting outside the minimum camera distance range that hides the main avatar in first person mode.

### WHAT
Adjusted minimum camera distance for hiding the avatar by testing in a specific place where the problem is always reproducible.

### TEST STEPS

Put the camera in first person mode, go to `51, 72` and move towards the center of the Art Week Plaza to reproduce the issue, as shown in the video:

https://github.com/user-attachments/assets/e4770549-3921-4d5c-b27a-3d5be82227d7

Do the same with the build from this PR and confirm that the problem doesn't happen anymore.

