### PR TITLE
fix: removed ifdefs on gameObject pool

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Pools/GameObjectPool.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Pools/GameObjectPool.cs
@@ -24,9 +24,8 @@ namespace DCL.Optimization.Pools
         public GameObjectPool(Transform rootContainer, Func<T>? creationHandler = null, Action<T>? onRelease = null, int maxSize = 2048, Action<T>? onGet = null)
         {
             parentContainer = new GameObject($"POOL_CONTAINER_{typeof(T).Name}").transform;
-#if UNITY_EDITOR
             parentContainer.SetParent(rootContainer);
-#endif
+
             if (onRelease != null) this.onRelease += onRelease;
             if (onGet != null) this.onGet += onGet;
             gameObjectPool = new ExtendedObjectPool<T>(creationHandler ?? HandleCreation, actionOnGet: HandleGet, actionOnRelease: HandleRelease, actionOnDestroy: UnityObjectUtils.SafeDestroyGameObject, defaultCapacity: maxSize / 4, maxSize: maxSize);
@@ -91,9 +90,7 @@ namespace DCL.Optimization.Pools
             (gameObject = component.gameObject).SetActive(false);
             gameObject.name = DEFAULT_COMPONENT_NAME;
 
-#if UNITY_EDITOR
             component.gameObject.transform.SetParent(parentContainer, false);
-#endif
         }
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
@@ -192,11 +192,9 @@ namespace DCL.PluginSystem.Global
         {
             NametagView nametagPrefab = (await assetsProvisioner.ProvideMainAssetAsync(settings.NametagView, ct: ct)).Value.GetComponent<NametagView>();
 
-#if UNITY_EDITOR
             var poolRoot = componentPoolsRegistry.RootContainerTransform();
             poolParent = new GameObject("POOL_CONTAINER_NameTags").transform;
             poolParent.parent = poolRoot;
-#endif
 
             nametagViewPool = new ObjectPool<NametagView>(
                 () =>

--- a/Explorer/Assets/DCL/SDKComponents/NFTShape/Frames/Pool/FramesPool.cs
+++ b/Explorer/Assets/DCL/SDKComponents/NFTShape/Frames/Pool/FramesPool.cs
@@ -18,11 +18,9 @@ namespace DCL.SDKComponents.NFTShape.Frames.Pool
         public FramesPool(IReadOnlyFramePrefabs framePrefabs, IComponentPoolsRegistry? componentPoolsRegistry = null)
         {
             this.framePrefabs = framePrefabs;
-#if UNITY_EDITOR
             var poolRoot = componentPoolsRegistry?.RootContainerTransform();
             framePoolParent = new GameObject("POOL_CONTAINER_NFT_FRAMES").transform;
             framePoolParent.parent = poolRoot;
-#endif
         }
 
         public bool IsInitialized => framePrefabs.IsInitialized;
@@ -51,9 +49,7 @@ namespace DCL.SDKComponents.NFTShape.Frames.Pool
                     g => g.gameObject.SetActive(true),
                     g =>
                     {
-#if UNITY_EDITOR
                         g.transform.SetParent(framePoolParent);
-#endif
                         g.gameObject.SetActive(false);
                     },
                     g => UnityObjectUtils.SafeDestroyGameObject(g.transform)


### PR DESCRIPTION
## What does this PR change?

Some Ifdefs used on the GameObject pool were breaking the reuse of some pooled objects.
So for now Im removing them and creating a ticket to potentially improve it in the future.
...

## How to test the changes?

Go to any scene with more than 1 other avatar and hover over them. You should be able to see a tooltip and click on them to open the passport.
