### PR TITLE
chore: hide main avatar only on first person camera

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -13,7 +13,6 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
     [UpdateInGroup(typeof(CameraGroup))]
     public partial class AvatarShapeVisibilitySystem : BaseUnityLoopSystem
     {
-        private const float AVATAR_MINIMUM_CAMERA_DISTANCE_SQR = 3.5f * 3.5f;
         private SingleInstanceEntity camera;
 
         public AvatarShapeVisibilitySystem(World world) : base(world) { }
@@ -28,7 +27,7 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             AddPlayerCachedVisibilityComponentQuery(World, camera.GetCameraComponent(World));
             AddOthersCachedVisibilityComponentQuery(World);
 
-            UpdateVisibilityOnCameraDistanceQuery(World, camera.GetCameraComponent(World));
+            UpdateMainPlayerAvatarVisibilityOnFirstPersonQuery(World, camera.GetCameraComponent(World));
             UpdateAvatarsVisibilityStateQuery(World);
         }
 
@@ -53,10 +52,10 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         }
 
         [Query]
-        private void UpdateVisibilityOnCameraDistance([Data] in CameraComponent cameraComponent, ref AvatarShapeComponent avatarShape, ref AvatarCachedVisibilityComponent avatarCachedVisibility, in PlayerComponent playerComponent)
+        [All(typeof(PlayerComponent))]
+        private void UpdateMainPlayerAvatarVisibilityOnFirstPerson([Data] in CameraComponent camera, ref AvatarShapeComponent avatarShape, ref AvatarCachedVisibilityComponent avatarCachedVisibility)
         {
-            Vector3 cameraToPlayer = playerComponent.CameraFocus.position - cameraComponent.Camera.transform.position;
-            bool shouldBeHidden = avatarShape.HiddenByModifierArea || cameraToPlayer.sqrMagnitude < AVATAR_MINIMUM_CAMERA_DISTANCE_SQR;
+            bool shouldBeHidden = avatarShape.HiddenByModifierArea || camera.Mode == CameraMode.FirstPerson;
             UpdateVisibilityState(ref avatarShape, ref avatarCachedVisibility, shouldBeHidden);
         }
 


### PR DESCRIPTION
Updated main avatar visibility toggle logic to run on first person cam instead of camera distance.

### QA INSTRUCTIONS

* Confirm that the main avatar is hidden when entering first person mode
* Confirm that the main avatar is NOT hidden when the THIRD PERSON camera gets close ot it (for example in genesis plaza if you make the camera slide through the floor when moving the mouse up, you make it get close to the main player)
* Confirm the problem shown in [the video from this other PR](https://github.com/decentraland/unity-explorer/pull/2468) is also not happening