### PR TITLE
chore: global px will always be loaded

### DIFF
--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadGlobalPortableExperiencesStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadGlobalPortableExperiencesStartupOperation.cs
@@ -45,21 +45,10 @@ namespace DCL.UserInAppInitializationFlow.StartupOperations
         public async UniTask<Result> ExecuteAsync(AsyncLoadProcessReport report, CancellationToken ct)
         {
             float finalizationProgress = loadingStatus.SetCurrentStage(LoadingStatus.LoadingStage.GlobalPXsLoading);
-            await CheckGlobalPxLoadingConditionsAsync(ct);
-            report.SetProgress(finalizationProgress);
-            return Result.SuccessResult();
-        }
-
-        private async UniTask CheckGlobalPxLoadingConditionsAsync(CancellationToken ct)
-        {
-            var ownProfile = await selfProfile.ProfileAsync(ct);
-
-            //If we havent completed the tutorial, we won't load the GlobalPX as it will interfere with the onboarding.
-            if (ownProfile is not { TutorialStep: > 0 })
-                return;
-
             LoadDebugPortableExperiences(ct);
             LoadRemotePortableExperiences(ct);
+            report.SetProgress(finalizationProgress);
+            return Result.SuccessResult();
         }
 
         private void LoadRemotePortableExperiences(CancellationToken ct)


### PR DESCRIPTION
## What does this PR change?

At some point we had disabled the loading of the global pxs when users had to do the tutorial, but now the PX already implements hidding on worlds, so it isnt necessary + when users finish the tutorial they will get the quests from the px.
This addresses that.
...

## How to test the changes?

Log in with a new user, you should be taken into the tutorial world and NOT see the UI from the portable experience.
When you finish the tutorial (or at least one of the steps), and go back to Genesis Plaza, you should see the UI from the global PX with the quests and whatnot.
Also the minimap pins from the portable experience should also be visible on the navmap (both in world and in genesis).
