### PR TITLE
fix: added fake room for scenes with offline:offline adapter

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ForkGlobalRealmRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ForkGlobalRealmRoom.cs
@@ -34,6 +34,8 @@ namespace DCL.Multiplayer.Connections.Archipelago.Rooms
                 current = wssRoomFactory();
             else if (adapterUrl.Contains("https://"))
                 current = httpsRoomFactory();
+            else if (adapterUrl.Contains("offline:offline"))
+                current = new IConnectiveRoom.Fake();
             else
                 throw new InvalidOperationException($"Cannot determine the protocol from the about url: {adapterUrl}");
 


### PR DESCRIPTION
## What does this PR change?

This PR uses a fake room for the scenes that have specified in the scene.json an adapter called 
`
"fixedAdapter": "offline:offline"
`
In this way we won't have an error in the connection that forces a connection retry

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. /goto onboardingdcl
3. verify that everything works fine
4. Go back to genesis

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

