### PR TITLE
fix: NRE for entities under observation

### DIFF
--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/GatherGltfAssetsSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/GatherGltfAssetsSystem.cs
@@ -62,8 +62,11 @@ namespace ECS.SceneLifeCycle.Systems
 
         public override void Dispose()
         {
-            HashSetPool<EntityReference>.Release(entitiesUnderObservation);
-            entitiesUnderObservation = null;
+            if (entitiesUnderObservation != null)
+            {
+                HashSetPool<EntityReference>.Release(entitiesUnderObservation);
+                entitiesUnderObservation = null;
+            }
             sceneData.SceneLoadingConcluded = true;
         }
 


### PR DESCRIPTION
## What does this PR change?

Fixes this:

```
NullReferenceException: Object reference not set to an instance of an object.
  at UnityEngine.Pool.CollectionPool`2+<>c[TCollection,TItem].<.cctor>b__5_1 (TCollection l) [0x00000] in <00000000000000000000000000000000>:0 
  at UnityEngine.Pool.ObjectPool`1[T].Release (T element) [0x00000] in <00000000000000000000000000000000>:0 
  at ECS.SceneLifeCycle.Systems.GatherGltfAssetsSystem.Dispose () [0x00000] in <00000000000000000000000000000000>:0 
  at Arch.SystemGroups.CustomGroupBase`1[T].DisposeInternal () [0x00000] in <00000000000000000000000000000000>:0 
  at Arch.SystemGroups.SystemGroup.Dispose () [0x00000] in <00000000000000000000000000000000>:0 
```

A scene may be disposed before initialized. This handles that situation

## How to test the changes?

1. Launch the explorer
2. Do some health checks

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

