### PR TITLE
chore: Replace data types in GlobalDeferredSystems

### DIFF
--- a/Explorer/Assets/DCL/ECS/GlobalPartitioning/GlobalDeferredLoadingSystem.cs
+++ b/Explorer/Assets/DCL/ECS/GlobalPartitioning/GlobalDeferredLoadingSystem.cs
@@ -56,12 +56,12 @@ namespace DCL.GlobalPartitioning
                 CreateQuery<GetWearableAssetBundleManifestIntention, SceneAssetBundleManifest>(),
                 CreateQuery<GetAssetBundleIntention, AssetBundleData>(),
                 CreateQuery<GetGLTFIntention, GLTFData>(),
-                CreateQuery<GetProfileIntention, Profile>(),
-                CreateQuery<GetTextureIntention, Texture2D>(),
-                CreateQuery<GetNFTShapeIntention, Texture2D>(),
+                CreateQuery<GetProfileIntention, ProfileData>(),
+                CreateQuery<GetTextureIntention, Texture2DData>(),
+                CreateQuery<GetNFTShapeIntention, Texture2DData>(),
                 CreateQuery<GetEmotesByPointersFromRealmIntention, EmotesDTOList>(),
                 CreateQuery<GetOwnedEmotesFromRealmIntention, EmotesResolution>(),
-                CreateQuery<GetAudioClipIntention, AudioClip>(),
+                CreateQuery<GetAudioClipIntention, AudioClipData>(),
             };
         }
 

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/DeferredLoading/AssetsDeferredLoadingSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/DeferredLoading/AssetsDeferredLoadingSystem.cs
@@ -29,9 +29,9 @@ namespace ECS.StreamableLoading.DeferredLoading
             {
                 CreateQuery<GetAssetBundleIntention, AssetBundleData>(),
                 CreateQuery<GetGLTFIntention, GLTFData>(),
-                CreateQuery<GetTextureIntention, Texture2D>(),
-                CreateQuery<GetNFTShapeIntention, Texture2D>(),
-                CreateQuery<GetAudioClipIntention, AudioClip>(),
+                CreateQuery<GetTextureIntention, Texture2DData>(),
+                CreateQuery<GetNFTShapeIntention, Texture2DData>(),
+                CreateQuery<GetAudioClipIntention, AudioClipData>(),
             };
         }
 


### PR DESCRIPTION
## What does this PR change?

Data types were using the old return type instead of the new `..Data`. This was harmless because the promise entity gets deleted after consumed. But, for whatever reason, it took longer to consume, they were unnecessarily queried.

Also, this is the consists way to do it.

## How to test the changes?



1. Launch the explorer
2. Play happy path

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

