### PR TITLE
fix: weekly release page

### DIFF
--- a/.github/workflows/build-release-main-page.yml
+++ b/.github/workflows/build-release-main-page.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: 'main'
 
       - name: Get version
         id: get_version


### PR DESCRIPTION
## What does this PR change?

The weekly release page was building the page using `dev` which is default and not `main`



## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

