### PR TITLE
fix: Textures in the panels that surround the Genesis plaza main spaw…

### DIFF
--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Textures/GetTextureIntention.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Textures/GetTextureIntention.cs
@@ -22,6 +22,9 @@ namespace ECS.StreamableLoading.Textures
 
         public CancellationTokenSource CancellationTokenSource => CommonArguments.CancellationTokenSource;
 
+        // Note: Depending on the origin of the texture, it may not have a file hash, so the source URL is used in equality comparisons
+        private string cacheKey => string.IsNullOrEmpty(FileHash) ? CommonArguments.URL.Value : FileHash;
+
         public GetTextureIntention(string url, string fileHash, TextureWrapMode wrapMode, FilterMode filterMode, bool isReadable = false, int attemptsCount = StreamableLoadingDefaults.ATTEMPTS_COUNT)
         {
             CommonArguments = new CommonLoadingArguments(url, attempts: attemptsCount);
@@ -45,7 +48,7 @@ namespace ECS.StreamableLoading.Textures
         }
 
         public bool Equals(GetTextureIntention other) =>
-            FileHash == other.FileHash &&
+            cacheKey == other.cacheKey &&
             IsReadable == other.IsReadable &&
             WrapMode == other.WrapMode &&
             FilterMode == other.FilterMode &&
@@ -56,7 +59,7 @@ namespace ECS.StreamableLoading.Textures
             obj is GetTextureIntention other && Equals(other);
 
         public override int GetHashCode() =>
-            HashCode.Combine(IsReadable, (int)WrapMode, (int)FilterMode, FileHash, IsVideoTexture, VideoPlayerEntity);
+            HashCode.Combine(IsReadable, (int)WrapMode, (int)FilterMode, cacheKey, IsVideoTexture, VideoPlayerEntity);
 
         public override string ToString() =>
             $"Get Texture: {(IsVideoTexture ? $"Video {VideoPlayerEntity}" : CommonArguments.URL)}";

--- a/Explorer/Assets/Scripts/ECS/Unity/Textures/Components/TextureComponent.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Textures/Components/TextureComponent.cs
@@ -12,6 +12,8 @@ namespace ECS.Unity.Textures.Components
         public readonly int VideoPlayerEntity;
         public readonly string FileHash;
 
+        private string cacheKey => string.IsNullOrEmpty(FileHash) ? Src : FileHash;
+
         public TextureComponent(string src, string fileHash, TextureWrapMode wrapMode = TextureWrapMode.Clamp, FilterMode filterMode = FilterMode.Bilinear, bool isVideoTexture = false, int videoPlayerEntity = 0)
         {
             Src = src;
@@ -23,12 +25,12 @@ namespace ECS.Unity.Textures.Components
         }
 
         public bool Equals(TextureComponent other) =>
-            FileHash == other.FileHash && WrapMode == other.WrapMode && FilterMode == other.FilterMode && IsVideoTexture == other.IsVideoTexture && VideoPlayerEntity == other.VideoPlayerEntity;
+            cacheKey == other.cacheKey && WrapMode == other.WrapMode && FilterMode == other.FilterMode && IsVideoTexture == other.IsVideoTexture && VideoPlayerEntity == other.VideoPlayerEntity;
 
         public override bool Equals(object obj) =>
             obj is TextureComponent other && Equals(other);
 
         public override int GetHashCode() =>
-            HashCode.Combine(FileHash, (int)WrapMode, (int)FilterMode, IsVideoTexture, VideoPlayerEntity);
+            HashCode.Combine(cacheKey, (int)WrapMode, (int)FilterMode, IsVideoTexture, VideoPlayerEntity);
     }
 }


### PR DESCRIPTION
…n area are not appearing

Those panels use textures downloaded from arbitrary URLs and not from the content servers, which means they will not have a file hash available. File hashes were being used as "key" in the texture cache (GetTextureIntention are the actual key, but they compare using a hash partially formed by the file hash). Now either the hash or the source URL is used to form the key/hash, depending on whether the file hash is available.

This is related to this PR: https://github.com/decentraland/unity-explorer/pull/2484

## What does this PR change?

Now the textures of the panels in Genesis plaza are properly cached and displayed.

## How to test the changes?

1. Launch the explorer
2. Look at the panels surrounding the spawn area.

The texture of every panel should be correct.