### PR TITLE
Fix: avoid movement blocking to affect when closing emoji search

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -109,12 +109,12 @@ namespace DCL.Chat
         protected override void OnViewInstantiated()
         {
             cameraEntity = world.CacheCamera();
-            
+
             //We start processing messages once the view is ready
             chatMessagesBus.MessageAdded += OnMessageAdded;
             chatHistory.OnMessageAdded += CreateChatEntry;
             chatHistory.OnCleared += ChatHistoryOnOnCleared;
-            
+
             viewInstance!.OnChatViewPointerEnter += OnChatViewPointerEnter;
             viewInstance.OnChatViewPointerExit += OnChatViewPointerExit;
             viewInstance.CharacterCounter.SetMaximumLength(viewInstance.InputField.characterLimit);
@@ -124,7 +124,7 @@ namespace DCL.Chat
             viewInstance.InputField.onDeselect.AddListener(OnInputDeselected);
             viewInstance.CloseChatButton.onClick.AddListener(CloseChat);
             viewInstance.LoopList.InitListView(0, OnGetItemByIndex);
-            emojiPanelController = new EmojiPanelController(viewInstance.EmojiPanel, emojiPanelConfiguration, emojiMappingJson, emojiSectionViewPrefab, emojiButtonPrefab, inputBlock);
+            emojiPanelController = new EmojiPanelController(viewInstance.EmojiPanel, emojiPanelConfiguration, emojiMappingJson, emojiSectionViewPrefab, emojiButtonPrefab);
             emojiPanelController.OnEmojiSelected += AddEmojiToInput;
 
             emojiSuggestionPanelController = new EmojiSuggestionPanel(viewInstance.EmojiSuggestionPanel, emojiSuggestionViewPrefab, dclInput);

--- a/Explorer/Assets/DCL/EmojiPanel/EmojiPanelController.cs
+++ b/Explorer/Assets/DCL/EmojiPanel/EmojiPanelController.cs
@@ -38,14 +38,13 @@ namespace DCL.Emoji
             EmojiPanelConfigurationSO emojiPanelConfiguration,
             TextAsset emojiMappingJson,
             EmojiSectionView emojiSectionPrefab,
-            EmojiButton emojiButtonPrefab,
-            IInputBlock inputBlock)
+            EmojiButton emojiButtonPrefab)
         {
             this.view = view;
             this.emojiPanelConfiguration = emojiPanelConfiguration;
             this.emojiSectionPrefab = emojiSectionPrefab;
             this.emojiButtonPrefab = emojiButtonPrefab;
-            emojiSearchController = new EmojiSearchController(view.SearchPanelView, view.EmojiSearchedContent, emojiButtonPrefab, inputBlock);
+            emojiSearchController = new EmojiSearchController(view.SearchPanelView, view.EmojiSearchedContent, emojiButtonPrefab);
             emojiSearchController.OnSearchTextChanged += OnSearchTextChanged;
             emojiSearchController.OnEmojiSelected += emoji => OnEmojiSelected?.Invoke(emoji);
             foreach (var emojiData in JsonConvert.DeserializeObject<Dictionary<string, string>>(emojiMappingJson.text))

--- a/Explorer/Assets/DCL/EmojiPanel/EmojiSearchController.cs
+++ b/Explorer/Assets/DCL/EmojiPanel/EmojiSearchController.cs
@@ -19,16 +19,12 @@ namespace DCL.Emoji
         private CancellationTokenSource cts;
         private readonly IObjectPool<EmojiButton> searchItemsPool;
         private readonly List<EmojiButton> usedPoolItems = new ();
-        private readonly IInputBlock inputBlock;
 
-        public EmojiSearchController(SearchBarView view, Transform parent, EmojiButton emojiButton, IInputBlock inputBlock)
+        public EmojiSearchController(SearchBarView view, Transform parent, EmojiButton emojiButton)
         {
             this.view = view;
-            this.inputBlock = inputBlock;
 
             view.inputField.onValueChanged.AddListener(OnValueChanged);
-            view.inputField.onSelect.AddListener(BlockUnwantedInputs);
-            view.inputField.onDeselect.AddListener(UnblockUnwantedInputs);
             view.clearSearchButton.onClick.AddListener(ClearSearch);
             view.clearSearchButton.gameObject.SetActive(false);
 
@@ -44,22 +40,7 @@ namespace DCL.Emoji
         {
             ReleaseAllSearchResults();
             view.inputField.onValueChanged.RemoveListener(OnValueChanged);
-            view.inputField.onSelect.RemoveListener(BlockUnwantedInputs);
-            view.inputField.onDeselect.RemoveListener(UnblockUnwantedInputs);
             view.clearSearchButton.onClick.RemoveListener(ClearSearch);
-        }
-
-        private void BlockUnwantedInputs(string _)
-        {
-            inputBlock.Disable(InputMapComponent.Kind.SHORTCUTS , InputMapComponent.Kind.PLAYER);
-        }
-
-        private void UnblockUnwantedInputs(string _) =>
-            UnblockUnwantedInputs();
-
-        private void UnblockUnwantedInputs()
-        {
-            inputBlock.Enable(InputMapComponent.Kind.SHORTCUTS , InputMapComponent.Kind.PLAYER);
         }
 
         private EmojiButton CreatePoolElements(Transform parent, EmojiButton emojiButton)


### PR DESCRIPTION
## What does this PR change?

Fix #2527 (maybe also fixed #2477 )
Removes the input blocker management from the emoji panel as it's handled by the chat controller already

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Search for an emoji in the chat.
3. Exit the emoji search using 'Esc', then the 'X' button, or by clicking outside the chat.
4. Try to move the avatar or use hotkeys like U, B, N, M, I.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

