### PR TITLE
fix: The outline of text shapes is wrong when created

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/TextShape/TMPProSdkExtensions.cs
+++ b/Explorer/Assets/DCL/SDKComponents/TextShape/TMPProSdkExtensions.cs
@@ -64,8 +64,12 @@ namespace DCL.SDKComponents.TextShape
                 materialPropertyBlock.SetColor(ID_OUTLINE_COLOR, textShape.OutlineColor?.ToUnityColor() ?? Color.white);
                 materialPropertyBlock.SetFloat(ID_OUTLINE_WIDTH, textShape.OutlineWidth);
             }
-            else if (tmpText.fontMaterial.IsKeywordEnabled(OUTLINE_ON_KEYWORD))
+            else
+            {
                 tmpText.fontMaterial.DisableKeyword(OUTLINE_ON_KEYWORD);
+                materialPropertyBlock.SetColor(ID_OUTLINE_COLOR, Color.clear);
+                materialPropertyBlock.SetFloat(ID_OUTLINE_WIDTH, 0.0f);
+            }
 
             if (textShape.ShadowOffsetX != 0 || textShape.ShadowOffsetY != 0)
             {
@@ -75,8 +79,15 @@ namespace DCL.SDKComponents.TextShape
                 materialPropertyBlock.SetFloat(ID_UNDERLAY_OFFSET_X, textShape.ShadowOffsetX);
                 materialPropertyBlock.SetFloat(ID_UNDERLAY_OFFSET_Y, textShape.ShadowOffsetY);
             }
-            else if (tmpText.fontMaterial.IsKeywordEnabled(UNDERLAY_ON_KEYWORD))
+            else
+            {
                 tmpText.fontMaterial.DisableKeyword(UNDERLAY_ON_KEYWORD);
+                materialPropertyBlock.SetColor(ID_UNDERLAY_COLOR, Color.clear);
+                materialPropertyBlock.SetFloat(ID_UNDERLAY_SOFTNESS, 0.0f);
+                materialPropertyBlock.SetFloat(ID_UNDERLAY_OFFSET_X, 0.0f);
+                materialPropertyBlock.SetFloat(ID_UNDERLAY_OFFSET_Y, 0.0f);
+            }
+
 
             tmpText.renderer.SetPropertyBlock(materialPropertyBlock);
         }


### PR DESCRIPTION
When the cached TextMeshPro instances were reused and the new outline width equaled zero, it tried to disable the outline shader keyword which does not exist in the shader (so the previous values related to outline stayed the same and were still used). Now it also resets the values of the related properties.

## What does this PR change?

It resets the default values of the outline and shadow effects when they are not used.

## How to test the changes?

1. Launch the explorer (Genesis)
2. Go to NicoE world.

Texts atop the buttons should be white without outline.