### PR TITLE
Fix: zero lookAt rotation in multiplayer

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Movement/Interpolation.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Interpolation.cs
@@ -42,7 +42,7 @@ namespace DCL.Multiplayer.Movement
         {
             Quaternion lookRotation;
 
-            if (lookDirection != Vector3.zero)
+            if (lookDirection != Vector3.zero && new Vector3(lookDirection.x, 0, lookDirection.z) != Vector3.zero)
             {
                 lookDirection.y = 0; // Flattened to have ground plane direction only (XZ)
                 lookRotation = Quaternion.LookRotation(lookDirection, Vector3.up);

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Interpolation.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Interpolation.cs
@@ -40,15 +40,11 @@ namespace DCL.Multiplayer.Movement
         private static void LookAt(float dt, ref CharacterTransform transComp, Vector3 lookDirection, float rotationSpeed, float yRotation,
             bool instant, bool useMessageRotation)
         {
-            Quaternion lookRotation;
+            lookDirection.y = 0; // Flattened to have ground plane direction only (XZ)
 
-            if (lookDirection.x != 0 && lookDirection.z != 0)
-            {
-                lookDirection.y = 0; // Flattened to have ground plane direction only (XZ)
-                lookRotation = Quaternion.LookRotation(lookDirection, Vector3.up);
-            }
-            else
-                lookRotation = transComp.Transform.rotation;
+            Quaternion lookRotation = lookDirection != Vector3.zero
+                ? Quaternion.LookRotation(lookDirection, Vector3.up)
+                : transComp.Transform.rotation;
 
             if (useMessageRotation)
                 lookRotation.eulerAngles = new Vector3(lookRotation.eulerAngles.x, yRotation, lookRotation.eulerAngles.z);

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Interpolation.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Interpolation.cs
@@ -42,7 +42,7 @@ namespace DCL.Multiplayer.Movement
         {
             Quaternion lookRotation;
 
-            if (lookDirection != Vector3.zero && new Vector3(lookDirection.x, 0, lookDirection.z) != Vector3.zero)
+            if (lookDirection.x != 0 && lookDirection.z != 0)
             {
                 lookDirection.y = 0; // Flattened to have ground plane direction only (XZ)
                 lookRotation = Quaternion.LookRotation(lookDirection, Vector3.up);


### PR DESCRIPTION
## What does this PR change?
additional check for zero vector

doesn't produces spikes anymore
![image](https://github.com/user-attachments/assets/c75188ca-4eec-492c-943c-c12fc25eed45)

## How to test the changes?
just fast smoke test

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

