### PR TITLE
fix: raw gltf external dependencies deeper path

### DIFF
--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/GLTF/GltFastDownloadProvider.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/GLTF/GltFastDownloadProvider.cs
@@ -1,4 +1,5 @@
 using Arch.Core;
+using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.Prioritization.Components;
@@ -21,12 +22,11 @@ namespace ECS.StreamableLoading.GLTF
     {
         private const int ATTEMPTS_COUNT = 6;
 
-        private string targetGltfOriginalPath;
-        private string targetGltfDirectoryPath;
-        private ISceneData sceneData;
-        private World world;
-        private IPartitionComponent partitionComponent;
         private readonly IAcquiredBudget acquiredBudget;
+        private readonly string targetGltfOriginalPath;
+        private readonly ISceneData sceneData;
+        private readonly World world;
+        private readonly IPartitionComponent partitionComponent;
 
         public GltFastDownloadProvider(World world, ISceneData sceneData, IPartitionComponent partitionComponent, string targetGltfOriginalPath, IAcquiredBudget acquiredBudget)
         {
@@ -35,7 +35,11 @@ namespace ECS.StreamableLoading.GLTF
             this.partitionComponent = partitionComponent;
             this.targetGltfOriginalPath = targetGltfOriginalPath;
             this.acquiredBudget = acquiredBudget;
-            targetGltfDirectoryPath = targetGltfOriginalPath.Remove(targetGltfOriginalPath.LastIndexOf('/') + 1);
+        }
+
+        public void Dispose()
+        {
+            acquiredBudget.Release();
         }
 
         // RequestAsync is used for fetching the GLTF file itself + some external textures. Whenever this
@@ -43,18 +47,18 @@ namespace ECS.StreamableLoading.GLTF
         public async Task<IDownload> RequestAsync(Uri uri)
         {
             bool isBaseGltfFetch = uri.OriginalString.Equals(targetGltfOriginalPath);
-            string originalFilePath = string.Concat(targetGltfDirectoryPath, GetFileNameFromUri(uri));
+            string originalFilePath = GetFileOriginalPathFromUri(uri);
 
-            if (!sceneData.SceneContent.TryGetContentUrl(originalFilePath, out var tryGetContentUrlResult))
+            if (!sceneData.SceneContent.TryGetContentUrl(originalFilePath, out URLAddress tryGetContentUrlResult))
             {
                 if (isBaseGltfFetch) acquiredBudget.Release();
-                throw new Exception($"Error on GLTF download ({targetGltfOriginalPath} - {uri}): NOT FOUND");
+                throw new Exception($"Error on GLTF download ({targetGltfOriginalPath} - {originalFilePath}): NOT FOUND");
             }
 
             uri = new Uri(tryGetContentUrlResult);
 
             // TODO: Replace for WebRequestController (Planned in PR #1670)
-            using (UnityWebRequest webRequest = new UnityWebRequest(uri))
+            using (var webRequest = new UnityWebRequest(uri))
             {
                 webRequest.downloadHandler = new DownloadHandlerBuffer();
 
@@ -74,8 +78,8 @@ namespace ECS.StreamableLoading.GLTF
 
         public async Task<ITextureDownload> RequestTextureAsync(Uri uri, bool nonReadable, bool forceLinear)
         {
-            string textureOriginalPath = string.Concat(targetGltfDirectoryPath, GetFileNameFromUri(uri));
-            sceneData.SceneContent.TryGetContentUrl(textureOriginalPath, out var tryGetContentUrlResult);
+            string textureOriginalPath = GetFileOriginalPathFromUri(uri);
+            sceneData.SceneContent.TryGetContentUrl(textureOriginalPath, out URLAddress tryGetContentUrlResult);
 
             var texturePromise = Promise.Create(world, new GetTextureIntention
             {
@@ -83,7 +87,7 @@ namespace ECS.StreamableLoading.GLTF
             }, partitionComponent);
 
             // The textures fetching need to finish before the GLTF loading can continue its flow...
-            var promiseResult = await texturePromise.ToUniTaskAsync(world, cancellationToken: new CancellationToken());
+            Promise promiseResult = await texturePromise.ToUniTaskAsync(world, cancellationToken: new CancellationToken());
 
             if (promiseResult.Result is { Succeeded: false })
                 throw new Exception($"Error on GLTF Texture download: {promiseResult.Result.Value.Exception!.Message}");
@@ -95,16 +99,11 @@ namespace ECS.StreamableLoading.GLTF
             };
         }
 
-        public void Dispose()
-        {
-            acquiredBudget.Release();
-        }
-
-        private string GetFileNameFromUri(Uri uri)
+        private string GetFileOriginalPathFromUri(Uri uri)
         {
             // On windows the URI may come with some invalid '\' in parts of the path
             string patchedUri = uri.OriginalString.Replace('\\', '/');
-            return patchedUri.Substring(patchedUri.LastIndexOf('/') + 1);
+            return patchedUri.Replace(sceneData.SceneContent.ContentBaseUrl.Value, string.Empty);
         }
     }
 
@@ -116,9 +115,11 @@ namespace ECS.StreamableLoading.GLTF
         public string Error { get; set; }
         public byte[] Data { get; set; }
         public string Text { get; set; }
+
         public bool? IsBinary
         {
-            get {
+            get
+            {
                 if (Data == null) return false;
                 var gltfBinarySignature = BitConverter.ToUInt32(Data, 0);
                 return gltfBinarySignature == GLB_SIGNATURE;
@@ -142,13 +143,12 @@ namespace ECS.StreamableLoading.GLTF
 
         public TextureDownloadResult(Texture2D? texture)
         {
-            Texture = new DisposableTexture() { Texture = texture };
+            Texture = new DisposableTexture { Texture = texture };
             Error = null!;
             Success = false;
         }
 
-        public IDisposableTexture GetTexture(bool forceSampleLinear) =>
-            Texture;
+        public IDisposableTexture GetTexture(bool forceSampleLinear) => Texture;
 
         public void Dispose() => Texture.Dispose();
     }


### PR DESCRIPTION
### WHY

During local scene development, some GLTFs may have external dependencies on a deept path than just the same folder as the GLTF. The `GLTFastDownloadProvider` wasn't contemplating that.

### WHAT

Corrected how the `GLTFastDownloadProvider` forms its download urls

### QA INSTRUCTIONS

1. Download [this test scene](https://github.com/user-attachments/files/17481231/gltf-deeper-external-deps-test.zip) and uncompress it somewhere
2. Enter the scene root folder and run `npm i` and then `npm run start -- --explorer-alpha`
3. Confirm that the loading gets stuck at 88% or similar, and if the scene loads it's empty.
4. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
5. Download the build from this PR and connect it to the running scene using [the console command](https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene) according to your OS
6. After the scene loads confirm that you can see the robot in the scene:

<img width="1101" alt="Screenshot 2024-10-22 at 9 35 02 PM" src="https://github.com/user-attachments/assets/57064a29-b337-4439-bb46-41923d47faf4">

