### PR TITLE
fix: Connect to fake room

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ForkGlobalRealmRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ForkGlobalRealmRoom.cs
@@ -35,7 +35,7 @@ namespace DCL.Multiplayer.Connections.Archipelago.Rooms
             else if (adapterUrl.Contains("https://"))
                 current = httpsRoomFactory();
             else if (adapterUrl.Contains("offline:offline"))
-                current = new IConnectiveRoom.Fake();
+                current = new IConnectiveRoom.Null();
             else
                 throw new InvalidOperationException($"Cannot determine the protocol from the about url: {adapterUrl}");
 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Connective/IConnectiveRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Connective/IConnectiveRoom.cs
@@ -21,7 +21,7 @@ namespace DCL.Multiplayer.Connections.Rooms.Connective
 
         IRoom Room();
 
-        class Fake : IConnectiveRoom
+        class Null : IConnectiveRoom
         {
             public UniTask<bool> StartAsync() =>
                 UniTask.FromResult(true);

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Connective/IConnectiveRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Connective/IConnectiveRoom.cs
@@ -24,13 +24,13 @@ namespace DCL.Multiplayer.Connections.Rooms.Connective
         class Fake : IConnectiveRoom
         {
             public UniTask<bool> StartAsync() =>
-                UniTask.FromResult(false);
+                UniTask.FromResult(true);
 
             public UniTask StopAsync() =>
                 UniTask.CompletedTask;
 
             public State CurrentState() =>
-                State.Stopped;
+                State.Running;
 
             public IRoom Room() =>
                 NullRoom.INSTANCE;


### PR DESCRIPTION
## What does this PR change?

Changes how we consider the fake room. It returns as connected, so it can be used in the :offline:offline adapter


## How to test the changes?


1. Open through  decentraland://?realm=onboardingdcl.dcl.eth as new user
2. Check that you get to the onboarding world

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

