### PR TITLE
fix: removed rich text from chat

### DIFF
--- a/Explorer/Assets/DCL/Chat/Assets/Chat.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/Chat.prefab
@@ -213,7 +213,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2680055985081135439}
   m_HandleRect: {fileID: 7426884741399343867}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -505,7 +505,7 @@ MonoBehaviour:
   m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 1
   checkPaddingRequired: 0
-  m_isRichText: 1
+  m_isRichText: 0
   m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
@@ -1379,7 +1379,7 @@ MonoBehaviour:
   m_CaretBlinkRate: 0.85
   m_CaretWidth: 2
   m_ReadOnly: 0
-  m_RichText: 1
+  m_RichText: 0
   m_GlobalFontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_OnFocusSelectAll: 0
   m_ResetOnDeActivation: 1

--- a/Explorer/Assets/DCL/Chat/Assets/ChatEntry.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/ChatEntry.prefab
@@ -801,7 +801,7 @@ MonoBehaviour:
   m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
-  m_isRichText: 1
+  m_isRichText: 0
   m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1

--- a/Explorer/Assets/DCL/Chat/Assets/ChatEntryOwn.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/ChatEntryOwn.prefab
@@ -207,7 +207,7 @@ MonoBehaviour:
   m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
-  m_isRichText: 1
+  m_isRichText: 0
   m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1

--- a/Explorer/Assets/DCL/NameTags/Assets/NametagObject.prefab
+++ b/Explorer/Assets/DCL/NameTags/Assets/NametagObject.prefab
@@ -396,7 +396,7 @@ MonoBehaviour:
   m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
-  m_isRichText: 1
+  m_isRichText: 0
   m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 0
@@ -539,7 +539,7 @@ SpriteRenderer:
   m_Size: {x: 0.6, y: 0.6}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!1 &8873411207359884927


### PR DESCRIPTION
## What does this PR change?

This PR removes the possibility of using rich text in chat, chat bubble and chat entries

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Chat with emojis
3. Try to chat with stuff like "We are <color = green>green</color> with envy"
4. Verify no strange text appears and all work fine

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

