### PR TITLE
fix: tweens update with scene cycle

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/TweenPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/TweenPlugin.cs
@@ -8,6 +8,7 @@ using ECS.LifeCycle.Systems;
 using System.Collections.Generic;
 using System.Threading;
 using DCL.SDKComponents.Tween.Components;
+using SceneRunner.Scene;
 using UnityEngine.Pool;
 
 namespace DCL.PluginSystem.World
@@ -28,7 +29,7 @@ namespace DCL.PluginSystem.World
         {
             ResetDirtyFlagSystem<PBTween>.InjectToWorld(ref builder);
             TweenLoaderSystem.InjectToWorld(ref builder);
-            var tweenUpdaterSystem = TweenUpdaterSystem.InjectToWorld(ref builder, sharedDependencies.EcsToCRDTWriter, tweenerPool, sharedDependencies.EcsSystemsGate);
+            var tweenUpdaterSystem = TweenUpdaterSystem.InjectToWorld(ref builder, sharedDependencies.EcsToCRDTWriter, tweenerPool, sharedDependencies.EcsSystemsGate, sharedDependencies.SceneStateProvider);
             finalizeWorldSystems.Add(tweenUpdaterSystem);
         }
     }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweener.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweener.cs
@@ -21,7 +21,7 @@ namespace DCL.SDKComponents.Tween.Components
 
         protected abstract TweenerCore<T, T, TU> CreateTweener(T start, T end, float duration);
         protected abstract (T, T) GetTweenValues(PBTween pbTween, SDKTransform startTransform);
-        public abstract void SetResult(ref SDKTransform sdkTransform);
+        public abstract void SetResult(ref SDKTransform sdkTransform, Transform transform);
 
         public void Play() =>
             core.Play();

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweener.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweener.cs
@@ -15,13 +15,10 @@ namespace DCL.SDKComponents.Tween.Components
         protected T currentValue;
         private TweenerCore<T, T, TU> core;
 
-        protected Vector3 startPosition;
-        protected Quaternion startRotation;
-        protected Vector3 startScale;
-
         protected abstract TweenerCore<T, T, TU> CreateTweener(T start, T end, float duration);
-        protected abstract (T, T) GetTweenValues(PBTween pbTween, SDKTransform startTransform);
-        public abstract void SetResult(ref SDKTransform sdkTransform, Transform transform);
+        protected abstract (T, T) GetTweenValues(PBTween pbTween);
+        public abstract void UpdateSDKTransform(ref SDKTransform sdkTransform);
+        public abstract void UpdateTransform(Transform transform);
 
         public void Play() =>
             core.Play();
@@ -46,16 +43,12 @@ namespace DCL.SDKComponents.Tween.Components
             core.SetEase(ease).SetAutoKill(false).OnComplete(() => { finished = true; }).Goto(tweenModelCurrentTime, isPlaying);
         }
 
-        public void Initialize(PBTween pbTween, SDKTransform sdkTransform, float durationInSeconds)
+        public void Initialize(PBTween pbTween, float durationInSeconds)
         {
             core?.Kill();
             finished = false;
 
-            startPosition = sdkTransform.Position;
-            startRotation = sdkTransform.Rotation;
-            startScale = sdkTransform.Scale;
-
-            var tweenValues = GetTweenValues(pbTween, sdkTransform);
+            var tweenValues = GetTweenValues(pbTween);
             core = CreateTweener(tweenValues.Item1, tweenValues.Item2, durationInSeconds);
         }
     }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweenerImpl.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweenerImpl.cs
@@ -16,24 +16,22 @@ namespace DCL.SDKComponents.Tween.Components
             return DOTween.To(() => currentValue, x => currentValue = x, end, duration);
         }
 
-        protected override (Vector3, Vector3) GetTweenValues(PBTween pbTween, SDKTransform startTransform)
+        protected override (Vector3, Vector3) GetTweenValues(PBTween pbTween)
         {
             Vector3 start = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Move.Start);
             Vector3 end = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Move.End);
-            startTransform.Position.Value = start;
             currentValue = start;
             return (start, end);
         }
 
-        public override void SetResult(ref SDKTransform sdkTransform, Transform transform)
+        public override void UpdateSDKTransform(ref SDKTransform sdkTransform)
         {
             sdkTransform.Position.Value = currentValue;
-            sdkTransform.Rotation.Value = startRotation;
-            sdkTransform.Scale = startScale;
+        }
 
-            transform.localRotation = startRotation;
+        public override void UpdateTransform(Transform transform)
+        {
             transform.localPosition = currentValue;
-            transform.localScale = startScale;
         }
     }
 
@@ -44,34 +42,32 @@ namespace DCL.SDKComponents.Tween.Components
             return DOTween.To(() => currentValue, x => currentValue = x, end, duration);
         }
 
-        protected override (Vector3, Vector3) GetTweenValues(PBTween pbTween, SDKTransform startTransform)
+        protected override (Vector3, Vector3) GetTweenValues(PBTween pbTween)
         {
             Vector3 start = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Scale.Start);
             Vector3 end = PrimitivesConversionExtensions.PBVectorToUnityVector(pbTween.Scale.End);
-            startTransform.Scale = start;
             currentValue = start;
             return (start, end);
         }
 
-        public override void SetResult(ref SDKTransform sdkTransform, Transform transform)
+        public override void UpdateSDKTransform(ref SDKTransform sdkTransform)
         {
             sdkTransform.Scale = currentValue;
-            sdkTransform.Position.Value = startPosition;
-            sdkTransform.Rotation.Value = startRotation;
-
-            transform.localScale = currentValue;
-            transform.localPosition = startPosition;
-            transform.localRotation = startRotation;
         }
+
+        public override void UpdateTransform(Transform transform)
+        {
+            transform.localScale = currentValue;
+        }
+
     }
 
     public class RotationTweener : CustomTweener<Quaternion, NoOptions>
     {
-        protected override (Quaternion, Quaternion) GetTweenValues(PBTween pbTween, SDKTransform startTransform)
+        protected override (Quaternion, Quaternion) GetTweenValues(PBTween pbTween)
         {
             Quaternion start = PrimitivesConversionExtensions.PBQuaternionToUnityQuaternion(pbTween.Rotate.Start);
             Quaternion end = PrimitivesConversionExtensions.PBQuaternionToUnityQuaternion(pbTween.Rotate.End);
-            startTransform.Rotation.Value = start;
             currentValue = start;
             return (start, end);
         }
@@ -83,15 +79,15 @@ namespace DCL.SDKComponents.Tween.Components
                 end, duration);
         }
 
-        public override void SetResult(ref SDKTransform sdkTransform, Transform transform)
+        public override void UpdateSDKTransform(ref SDKTransform sdkTransform)
         {
             sdkTransform.Rotation.Value = currentValue;
-            sdkTransform.Position.Value = startPosition;
-            sdkTransform.Scale = startScale;
-
-            transform.localRotation = currentValue;
-            transform.localPosition = startPosition;
-            transform.localScale = startScale;
         }
+
+        public override void UpdateTransform(Transform transform)
+        {
+            transform.localRotation = currentValue;
+        }
+
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweenerImpl.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweenerImpl.cs
@@ -31,8 +31,8 @@ namespace DCL.SDKComponents.Tween.Components
             sdkTransform.Rotation.Value = startRotation;
             sdkTransform.Scale = startScale;
 
-            transform.rotation = startRotation;
-            transform.position = currentValue;
+            transform.localRotation = startRotation;
+            transform.localPosition = currentValue;
             transform.localScale = startScale;
         }
     }
@@ -60,8 +60,8 @@ namespace DCL.SDKComponents.Tween.Components
             sdkTransform.Rotation.Value = startRotation;
 
             transform.localScale = currentValue;
-            transform.position = startPosition;
-            transform.rotation = startRotation;
+            transform.localPosition = startPosition;
+            transform.localRotation = startRotation;
         }
     }
 
@@ -89,8 +89,8 @@ namespace DCL.SDKComponents.Tween.Components
             sdkTransform.Position.Value = startPosition;
             sdkTransform.Scale = startScale;
 
-            transform.rotation = currentValue;
-            transform.position = startPosition;
+            transform.localRotation = currentValue;
+            transform.localPosition = startPosition;
             transform.localScale = startScale;
         }
     }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweenerImpl.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/CustomTweenerImpl.cs
@@ -25,12 +25,15 @@ namespace DCL.SDKComponents.Tween.Components
             return (start, end);
         }
 
-        public override void SetResult(ref SDKTransform sdkTransform)
+        public override void SetResult(ref SDKTransform sdkTransform, Transform transform)
         {
             sdkTransform.Position.Value = currentValue;
-
             sdkTransform.Rotation.Value = startRotation;
             sdkTransform.Scale = startScale;
+
+            transform.rotation = startRotation;
+            transform.position = currentValue;
+            transform.localScale = startScale;
         }
     }
 
@@ -50,12 +53,15 @@ namespace DCL.SDKComponents.Tween.Components
             return (start, end);
         }
 
-        public override void SetResult(ref SDKTransform sdkTransform)
+        public override void SetResult(ref SDKTransform sdkTransform, Transform transform)
         {
             sdkTransform.Scale = currentValue;
-
             sdkTransform.Position.Value = startPosition;
             sdkTransform.Rotation.Value = startRotation;
+
+            transform.localScale = currentValue;
+            transform.position = startPosition;
+            transform.rotation = startRotation;
         }
     }
 
@@ -77,11 +83,15 @@ namespace DCL.SDKComponents.Tween.Components
                 end, duration);
         }
 
-        public override void SetResult(ref SDKTransform sdkTransform)
+        public override void SetResult(ref SDKTransform sdkTransform, Transform transform)
         {
             sdkTransform.Rotation.Value = currentValue;
             sdkTransform.Position.Value = startPosition;
             sdkTransform.Scale = startScale;
+
+            transform.rotation = currentValue;
+            transform.position = startPosition;
+            transform.localScale = startScale;
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/ICustomTweener.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/ICustomTweener.cs
@@ -15,7 +15,8 @@ namespace DCL.SDKComponents.Tween.Components
         bool IsFinished();
         bool IsActive();
 
-        void Initialize(PBTween pbTween, SDKTransform sdkTransform, float durationInSeconds);
-        void SetResult(ref SDKTransform sdkTransform, Transform transform);
+        void Initialize(PBTween pbTween, float durationInSeconds);
+        void UpdateSDKTransform(ref SDKTransform sdkTransform);
+        void UpdateTransform(Transform transform);
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/ICustomTweener.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/ICustomTweener.cs
@@ -16,6 +16,6 @@ namespace DCL.SDKComponents.Tween.Components
         bool IsActive();
 
         void Initialize(PBTween pbTween, SDKTransform sdkTransform, float durationInSeconds);
-        void SetResult(ref SDKTransform sdkTransform);
+        void SetResult(ref SDKTransform sdkTransform, Transform transform);
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/TweenerPool.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Components/CustomTweener/TweenerPool.cs
@@ -18,7 +18,7 @@ namespace DCL.SDKComponents.Tween.Components
             scaleTweenersPool = new ObjectPool<ScaleTweener>(() => new ScaleTweener());
         }
 
-        public ICustomTweener GetTweener(PBTween pbTween, SDKTransform sdkTransform, float durationInSeconds)
+        public ICustomTweener GetTweener(PBTween pbTween, float durationInSeconds)
         {
             ICustomTweener tweener = null;
             switch (pbTween.ModeCase)
@@ -34,7 +34,7 @@ namespace DCL.SDKComponents.Tween.Components
                     break;
             }
 
-            tweener!.Initialize(pbTween, sdkTransform, durationInSeconds);
+            tweener!.Initialize(pbTween, durationInSeconds);
             return tweener;
         }
 

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenSDKComponentHelper.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenSDKComponentHelper.cs
@@ -18,14 +18,17 @@ namespace DCL.SDKComponents.Tween.Helpers
 
         public static void UpdateTweenResult(ref SDKTransform sdkTransform, ref TransformComponent transformComponent, ICustomTweener tweener, bool shouldUpdateTransform)
         {
-            sdkTransform.IsDirty = true;
             tweener.UpdateSDKTransform(ref sdkTransform);
 
+            //we only set the SDK transform to dirty here if we didn't already update the transform, but if the sdkTransform was already dirty,
+            //we dont change it, as it might have pending updates to be done from the scene side.
             if (shouldUpdateTransform)
             {
                 tweener.UpdateTransform(transformComponent.Transform);
                 transformComponent.UpdateCache();
-            }
+            } else
+                sdkTransform.IsDirty = true;
+
         }
 
         public static void WriteSDKTransformUpdateInCRDT(SDKTransform sdkTransform, IECSToCRDTWriter ecsToCrdtWriter, CRDTEntity sdkEntity)

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenSDKComponentHelper.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenSDKComponentHelper.cs
@@ -3,6 +3,7 @@ using CrdtEcsBridge.Components.Transform;
 using CrdtEcsBridge.ECSToCRDTWriter;
 using DCL.ECSComponents;
 using DCL.SDKComponents.Tween.Components;
+using ECS.Unity.Transforms.Components;
 using UnityEngine;
 
 namespace DCL.SDKComponents.Tween.Helpers
@@ -15,19 +16,27 @@ namespace DCL.SDKComponents.Tween.Helpers
                 static (component, tweenStateStatus) => component.State = tweenStateStatus, sdkEntity, tweenStateStatus);
         }
 
-        public static void WriteTweenResult(ref SDKTransform sdkTransform, (ICustomTweener, CRDTEntity, Transform) tweenResult)
+        public static void UpdateTweenResult(ref SDKTransform sdkTransform, ref TransformComponent transformComponent, ICustomTweener tweener, bool shouldUpdateTransform)
         {
             sdkTransform.IsDirty = true;
-            sdkTransform.ParentId = tweenResult.Item2;
-            tweenResult.Item1.SetResult(ref sdkTransform, tweenResult.Item3);
+            tweener.UpdateSDKTransform(ref sdkTransform);
+
+            if (shouldUpdateTransform)
+            {
+                tweener.UpdateTransform(transformComponent.Transform);
+                transformComponent.UpdateCache();
+            }
         }
 
-        public static void WriteTweenResultInCRDT(IECSToCRDTWriter ecsToCrdtWriter, CRDTEntity sdkEntity, (ICustomTweener, CRDTEntity, Transform) result)
+        public static void WriteSDKTransformUpdateInCRDT(SDKTransform sdkTransform, IECSToCRDTWriter ecsToCrdtWriter, CRDTEntity sdkEntity)
         {
-            ecsToCrdtWriter.PutMessage<SDKTransform, (ICustomTweener, CRDTEntity, Transform)>(
-                static (component, result) => WriteTweenResult(ref component, result),
-                sdkEntity, result);
+            ecsToCrdtWriter.PutMessage<SDKTransform, SDKTransform>((component , transform) =>
+            {
+                component.Position.Value = transform.Position.Value;
+                component.ParentId = transform.ParentId;
+                component.Rotation.Value = transform.Rotation.Value;
+                component.Scale = transform.Scale;
+            }, sdkEntity, sdkTransform);
         }
-
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenSDKComponentHelper.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenSDKComponentHelper.cs
@@ -15,16 +15,16 @@ namespace DCL.SDKComponents.Tween.Helpers
                 static (component, tweenStateStatus) => component.State = tweenStateStatus, sdkEntity, tweenStateStatus);
         }
 
-        public static void WriteTweenResult(ref SDKTransform sdkTransform, (ICustomTweener, CRDTEntity) tweenResult)
+        public static void WriteTweenResult(ref SDKTransform sdkTransform, (ICustomTweener, CRDTEntity, Transform) tweenResult)
         {
             sdkTransform.IsDirty = true;
             sdkTransform.ParentId = tweenResult.Item2;
-            tweenResult.Item1.SetResult(ref sdkTransform);
+            tweenResult.Item1.SetResult(ref sdkTransform, tweenResult.Item3);
         }
 
-        public static void WriteTweenResultInCRDT(IECSToCRDTWriter ecsToCrdtWriter, CRDTEntity sdkEntity, (ICustomTweener, CRDTEntity) result)
+        public static void WriteTweenResultInCRDT(IECSToCRDTWriter ecsToCrdtWriter, CRDTEntity sdkEntity, (ICustomTweener, CRDTEntity, Transform) result)
         {
-            ecsToCrdtWriter.PutMessage<SDKTransform, (ICustomTweener, CRDTEntity)>(
+            ecsToCrdtWriter.PutMessage<SDKTransform, (ICustomTweener, CRDTEntity, Transform)>(
                 static (component, result) => WriteTweenResult(ref component, result),
                 sdkEntity, result);
         }

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenUpdaterSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenUpdaterSystem.cs
@@ -24,7 +24,7 @@ using static DG.Tweening.Ease;
 namespace DCL.SDKComponents.Tween.Systems
 {
     [UpdateInGroup(typeof(SyncedSimulationSystemGroup))]
-    [UpdateAfter(typeof(UpdateTransformSystem))]
+    [UpdateBefore(typeof(UpdateTransformSystem))]
     [UpdateAfter(typeof(TweenLoaderSystem))]
     [LogCategory(ReportCategory.TWEEN)]
     public partial class TweenUpdaterSystem : BaseUnityLoopSystem, IFinalizeWorldSystem

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Tests/TweenUpdaterSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Tests/TweenUpdaterSystemShould.cs
@@ -9,6 +9,7 @@ using NSubstitute;
 using NUnit.Framework;
 using Arch.Core;
 using Decentraland.Common;
+using SceneRunner.Scene;
 using Entity = Arch.Core.Entity;
 
 namespace DCL.SDKComponents.Tween.Tests
@@ -29,7 +30,7 @@ namespace DCL.SDKComponents.Tween.Tests
         public void SetUp()
         {
             tweneerPool = new TweenerPool();
-            system = new TweenUpdaterSystem(world, Substitute.For<IECSToCRDTWriter>(), tweneerPool, null);
+            system = new TweenUpdaterSystem(world, Substitute.For<IECSToCRDTWriter>(), tweneerPool, null, Substitute.For<SceneStateProvider>());
             var crdtEntity = new CRDTEntity(1);
 
             var startVector = new Vector3() { X = 0, Y = 0, Z = 0};


### PR DESCRIPTION
## What does this PR change?

**In the previous episode of Tweenage Ninja Turtles:**
We fixed how tweens were updating its values, making them update the SDK transform and letting the UpdateTransform system to take over and do the proper transform update.
BUT, this brought an unintended (or intended?) consequence, tween update frequency would depend on the update cycle of the scene. So if it either had low FPS because of throttling or because something heavy was going on in the scene, the tween would update slower than normal.
Apparently, this is not expected and tweens should be independent of the scene update cycle.

**In this episode:**
We fix that by updating the Transform along with the SDK transform... It is NOT the most elegant solution. I still believe the whole flow needs refactoring. And we need to discuss properly how or if to throttle tweens when they are in far away scenes (otherwise if a scene uses tweens and is loaded, it would still be running all those tweens even if its FPS should be 1).
But for the current needs this will fix the issue mentioned.
STILL, as the tween sequencer runs on the scene, changing from one tween to the next DO have delays because that's outside of the client's control... we should also discuss if to migrate the sequencer to the client instead of having it in the scene.

## How to test the changes?

Test all these tween scenes in Goerli (/goto goerli) : 
* (pos 84,-4) -> the rays use tweens to expand
*  this other scene has tweens when pushing or rotating the mirrors (pos 82,-5). 
* This scene has many moving platforms using tweens (pos 77,-5)
* The Droid scene uses tweens to move the robot and turn it around (81,-3)
* This ticket -> https://github.com/decentraland/unity-explorer/issues/2374
