### PR TITLE
added time check to change condition

### DIFF
--- a/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
@@ -34,8 +34,10 @@ namespace DCL.LOD
                     ? VisualSceneStateEnum.SHOWING_SCENE
                     : VisualSceneStateEnum.SHOWING_LOD;
 
-                if (visualSceneState.CandidateVisualSceneState != visualSceneState.CurrentVisualSceneState)
+                if (visualSceneState.CandidateVisualSceneState != visualSceneState.CurrentVisualSceneState && visualSceneState.TimeToChange < 0.01f)
                 {
+                    if (visualSceneState.CurrentVisualSceneState.Equals(VisualSceneStateEnum.UNINITIALIZED))
+                        visualSceneState.CurrentVisualSceneState = visualSceneState.CandidateVisualSceneState;
                     visualSceneState.IsDirty = true;
                     visualSceneState.TimeToChange = 0;
                 }


### PR DESCRIPTION
## What does this PR change?

If I run away from a scene, it does not swap to LOD unless I stop running

This LOOKS to be because, if I keep running, the visual scene state is reevaluated. And since it hasn't pass the 5 second threshold, it will never swap visual scene state

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

