### PR TITLE
fix: scenes not switching to LOD properly.

### DIFF
--- a/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
@@ -30,12 +30,13 @@ namespace DCL.LOD
             else if (!sceneDefinitionComponent.IsSDK7) visualSceneState.CandidateVisualSceneState = visualSceneState.CurrentVisualSceneState = VisualSceneStateEnum.SHOWING_LOD;
             else
             {
-                visualSceneState.CandidateVisualSceneState = partition.Bucket < lodSettingsAsset.SDK7LodThreshold
+                var candidateVisualSceneState =  partition.Bucket < lodSettingsAsset.SDK7LodThreshold
                     ? VisualSceneStateEnum.SHOWING_SCENE
                     : VisualSceneStateEnum.SHOWING_LOD;
 
-                if (visualSceneState.CandidateVisualSceneState != visualSceneState.CurrentVisualSceneState)
+                if (visualSceneState.CandidateVisualSceneState != candidateVisualSceneState)
                 {
+                    visualSceneState.CandidateVisualSceneState = candidateVisualSceneState;
                     visualSceneState.IsDirty = true;
                     visualSceneState.TimeToChange = 0;
                 }

--- a/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
@@ -34,7 +34,7 @@ namespace DCL.LOD
                     ? VisualSceneStateEnum.SHOWING_SCENE
                     : VisualSceneStateEnum.SHOWING_LOD;
 
-                if (visualSceneState.CandidateVisualSceneState != candidateVisualSceneState)
+                if (visualSceneState.CandidateVisualSceneState != candidateVisualSceneState && candidateVisualSceneState != visualSceneState.CurrentVisualSceneState)
                 {
                     visualSceneState.CandidateVisualSceneState = candidateVisualSceneState;
                     visualSceneState.IsDirty = true;


### PR DESCRIPTION
## What does this PR change?

When I added the new LOD change delay, I did a last minute change and missed a check that should have been done before dirtying the scene state. Which meant that if we moved and changed buckets, the scene would get re-dirtied and the timer would be reset, so unless we stood still or at a distance that didnt change buckets, the LOD would not be loaded again.
This is fixed now :)
...

## How to test the changes?

https://github.com/user-attachments/assets/6107c9d0-131a-45e3-af06-327e0a3ba45c

RUN FOREST! RUN!
Spawn in Genesis Plaza and run away from it, after some seconds running it should switch from scene to LOD (its obvious because the scene has animations in the clouds and whatnot).
Same with any other scene (the smaller the scene, the closer the 5 seconds until they disappear will start counting)
It should work like in this video :)
