### PR TITLE
fix: emotes spam stuck

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/ApplicationParamsEmoteProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/ApplicationParamsEmoteProvider.cs
@@ -1,0 +1,45 @@
+using CommunicationData.URLHelpers;
+using Cysharp.Threading.Tasks;
+using DCL.AvatarRendering.Loading.Components;
+using DCL.Web3;
+using Global.AppArgs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace DCL.AvatarRendering.Emotes
+{
+    public class ApplicationParamsEmoteProvider : IEmoteProvider
+    {
+        private readonly IAppArgs appArgs;
+        private readonly IEmoteProvider source;
+
+        public ApplicationParamsEmoteProvider(IAppArgs appArgs,
+            IEmoteProvider source)
+        {
+            this.appArgs = appArgs;
+            this.source = source;
+        }
+
+        public async UniTask<int> GetOwnedEmotesAsync(Web3Address userId, CancellationToken ct,
+            IEmoteProvider.OwnedEmotesRequestOptions requestOptions,
+            List<IEmote> output)
+        {
+            if (!appArgs.TryGetValue("self-preview-emotes", out string? emotesCsv))
+                return await source.GetOwnedEmotesAsync(userId, ct, requestOptions, output);
+
+            URN[] pointers = emotesCsv!.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                                       .Select(s => new URN(s))
+                                       .ToArray();
+
+            await UniTask.WhenAll(GetEmotesAsync(pointers, BodyShape.MALE, ct, output),
+                GetEmotesAsync(pointers, BodyShape.FEMALE, ct, output));
+
+            return output.Count;
+        }
+
+        public UniTask GetEmotesAsync(IReadOnlyCollection<URN> emoteIds, BodyShape bodyShape, CancellationToken ct, List<IEmote> output) =>
+            source.GetEmotesAsync(emoteIds, bodyShape, ct, output);
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/ApplicationParamsEmoteProvider.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/ApplicationParamsEmoteProvider.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9ac8d76a492e445abdcceb68bd16ef84
+timeCreated: 1729690669

--- a/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
@@ -131,6 +131,7 @@ namespace DCL.Backpack.CharacterPreview
                     previewAvatarModel.SkinColor = newColor;
                     break;
             }
+
             OnModelUpdated();
         }
 
@@ -180,14 +181,18 @@ namespace DCL.Backpack.CharacterPreview
             {
                 URN urn = emote.GetUrn().Shorten();
 
-                // In case you want to preview an emote, it might happen that the asset bundles are not loaded
-                // By adding the emote we force to fetch them if missing
+                // Ensure assets are loaded for the emote
                 if (!previewAvatarModel.Emotes?.Contains(urn) ?? true)
                 {
                     previewAvatarModel.Emotes!.Add(urn);
-                    await ShowLoadingSpinnerAndUpdateAvatarAsync(ct);
-                    // Remove the emote so it stays original
-                    previewAvatarModel.Emotes!.Remove(urn);
+
+                    try { await ShowLoadingSpinnerAndUpdateAvatarAsync(ct); }
+                    catch (OperationCanceledException) { }
+                    finally
+                    {
+                        // Remove the emote so it stays original
+                        previewAvatarModel.Emotes!.Remove(urn);
+                    }
                 }
 
                 PlayEmote(urn);

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
@@ -71,6 +71,8 @@ namespace DCL.CharacterPreview
 
         public UniTask UpdateAvatarAsync(CharacterPreviewAvatarModel avatarModel, CancellationToken ct)
         {
+            ct.ThrowIfCancellationRequested();
+
             ref AvatarShapeComponent avatarShape = ref globalWorld.Get<AvatarShapeComponent>(characterPreviewEntity);
 
             avatarShape.SkinColor = avatarModel.SkinColor;

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
@@ -127,7 +127,12 @@ namespace DCL.CharacterPreview
 
         public void PlayEmote(string emoteId)
         {
-            globalWorld.Add(characterPreviewEntity, new CharacterEmoteIntent { EmoteId = emoteId, TriggerSource = TriggerSource.PREVIEW });
+            var intent = new CharacterEmoteIntent { EmoteId = emoteId, TriggerSource = TriggerSource.PREVIEW };
+
+            if (globalWorld.Has<CharacterEmoteIntent>(characterPreviewEntity))
+                globalWorld.Set(characterPreviewEntity, intent);
+            else
+                globalWorld.Add(characterPreviewEntity, intent);
         }
 
         public void StopEmotes()

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
@@ -106,9 +106,10 @@ namespace DCL.CharacterPreview
             World world = globalWorld;
             Entity avatarEntity = characterPreviewEntity;
 
-            while (!ct.IsCancellationRequested
-                   && (!IsAvatarLoaded() || !IsEmoteLoaded()))
+            while (!IsAvatarLoaded() || !IsEmoteLoaded())
                 await UniTask.Yield(ct);
+
+            ct.ThrowIfCancellationRequested();
 
             return;
 

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
@@ -220,7 +220,18 @@ namespace DCL.CharacterPreview
         protected void OnModelUpdated()
         {
             updateModelCancellationToken = updateModelCancellationToken.SafeRestart();
-            ShowLoadingSpinnerAndUpdateAvatarAsync(updateModelCancellationToken.Token).Forget();
+
+            UpdateModelAsync(updateModelCancellationToken.Token).Forget();
+            return;
+
+            async UniTaskVoid UpdateModelAsync(CancellationToken ct)
+            {
+                try
+                {
+                    await ShowLoadingSpinnerAndUpdateAvatarAsync(ct);
+                }
+                catch (OperationCanceledException) { }
+            }
         }
 
         protected async UniTask ShowLoadingSpinnerAndUpdateAvatarAsync(CancellationToken ct)
@@ -231,7 +242,6 @@ namespace DCL.CharacterPreview
 
             DisableSpinner(spinner);
         }
-
 
         private void DisableSpinner(GameObject spinner)
         {
@@ -250,11 +260,8 @@ namespace DCL.CharacterPreview
             return spinner;
         }
 
-        private async UniTask UpdateAvatarAsync(CharacterPreviewAvatarModel model, CancellationToken ct)
-        {
-            try { await (previewController?.UpdateAvatarAsync(model, ct) ?? UniTask.CompletedTask); }
-            catch (OperationCanceledException) { }
-        }
+        private async UniTask UpdateAvatarAsync(CharacterPreviewAvatarModel model, CancellationToken ct) =>
+            await (previewController?.UpdateAvatarAsync(model, ct) ?? UniTask.CompletedTask);
 
         protected void StopEmotes() =>
             previewController?.StopEmotes();

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -256,7 +256,8 @@ namespace Global.Dynamic
             var selfProfile = new SelfProfile(container.ProfileRepository, identityCache, equippedWearables, wearableCatalog,
                 emotesCache, equippedEmotes, forceRender, selfEmotes);
 
-            IEmoteProvider emoteProvider = new EcsEmoteProvider(globalWorld, staticContainer.RealmData);
+            IEmoteProvider emoteProvider = new ApplicationParamsEmoteProvider(appArgs,
+                new EcsEmoteProvider(globalWorld, staticContainer.RealmData));
 
             container.wearablesProvider = new ApplicationParametersWearablesProvider(appArgs,
                 new ECSWearablesProvider(identityCache, globalWorld),


### PR DESCRIPTION
## What does this PR change?

Fixes #2536 

The root of the issue is that the avatar load process do not wait for the emotes to be loaded anymore since emotes lazy loading. This caused problems in the avatar preview.
The solution consists on waiting for the emote promise to be resolved before showing the avatar preview.
Additionally a new app param has been added to be able to preview emotes in the backpack:
```
--self-preview-emotes urn1,urn2
```

## How to test the changes?

If you dont have any emote 2.0 (with props) you can launch the explorer with this command:
```
--self-preview-emotes urn:decentraland:matic:collections-v2:0x0ae365f8acc27f2c95fc7d60cf49a74f3af21573:4
```

1. Launch the explorer
2. Check that the authentication screen shows the avatar preview as expected
3. Open the backpack and follow the issue steps
4. Open other user passports and check the avatar preview works as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

