### PR TITLE
fix: scene was loading in distance

### DIFF
--- a/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/VisualSceneStateResolver.cs
@@ -34,7 +34,14 @@ namespace DCL.LOD
                     ? VisualSceneStateEnum.SHOWING_SCENE
                     : VisualSceneStateEnum.SHOWING_LOD;
 
-                if (visualSceneState.CandidateVisualSceneState != candidateVisualSceneState && candidateVisualSceneState != visualSceneState.CurrentVisualSceneState)
+                if (visualSceneState.CurrentVisualSceneState == VisualSceneStateEnum.UNINITIALIZED)
+                {
+                    visualSceneState.CandidateVisualSceneState = candidateVisualSceneState;
+                    visualSceneState.CurrentVisualSceneState = candidateVisualSceneState;
+                    visualSceneState.IsDirty = true;
+                }
+                else if (visualSceneState.CandidateVisualSceneState != candidateVisualSceneState &&
+                         candidateVisualSceneState != visualSceneState.CurrentVisualSceneState)
                 {
                     visualSceneState.CandidateVisualSceneState = candidateVisualSceneState;
                     visualSceneState.IsDirty = true;


### PR DESCRIPTION
## What does this PR change?

Scene were loading in distance, when the LOD should load. This happened when the scene was not initialized

## How to test the changes?

1. Launch the explorer
2. .Go to 70,0 and walk to Genesis Plaza. Wait till it appear. It should first load the LOD, and when you get approx 2 parcels away, it should load the scene

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

