### PR TITLE
chore: Unload cache after teleport amount

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/IAttachmentsAssetsCache.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/IAttachmentsAssetsCache.cs
@@ -11,5 +11,7 @@ namespace DCL.AvatarRendering.Loading.Assets
         void Release(CachedAttachment cachedAttachment);
 
         void Unload(IPerformanceBudget frameTimeBudget, int maxUnloadAmount);
+
+        void UnloadImmediate();
     }
 }

--- a/Explorer/Assets/DCL/Profiles/Cache/DefaultProfileCache.cs
+++ b/Explorer/Assets/DCL/Profiles/Cache/DefaultProfileCache.cs
@@ -25,6 +25,7 @@ namespace DCL.Profiles
         public void Unload(IPerformanceBudget concurrentBudgetProvider, int maxAmount)
         {
             // TODO: clear unused profiles
+            //When done, remember to add the `UnloadImmediate` call in CacheCleaner
 
             UpdateProfilingCounter();
         }

--- a/Explorer/Assets/DCL/ResourcesUnloading/CacheCleaner.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/CacheCleaner.cs
@@ -65,11 +65,29 @@ namespace DCL.ResourcesUnloading
             wearableStorage!.Unload(fpsCapBudget);
             emoteCache!.Unload(fpsCapBudget);
             gltfContainerAssetsCache!.Unload(fpsCapBudget, GLTF_UNLOAD_CHUNK);
+            lodCache!.Unload(fpsCapBudget, GLTF_UNLOAD_CHUNK);
             assetBundleCache!.Unload(fpsCapBudget, AB_UNLOAD_CHUNK);
             profileCache!.Unload(fpsCapBudget, PROFILE_UNLOAD_CHUNK);
             profileIntentionCache!.Unload(fpsCapBudget, PROFILE_UNLOAD_CHUNK);
-            lodCache!.Unload(fpsCapBudget, GLTF_UNLOAD_CHUNK);
             roadCache!.Unload(fpsCapBudget, GLTF_UNLOAD_CHUNK);
+
+            ClearExtendedObjectPools();
+        }
+
+        public void UnloadCacheImmediate()
+        {
+            nftShapeCache!.UnloadImmediate();
+            texturesCache!.UnloadImmediate();
+            audioClipsCache!.UnloadImmediate();
+            wearableAssetsCache!.UnloadImmediate();
+            wearableStorage!.Unload(fpsCapBudget);
+            emoteCache!.Unload(fpsCapBudget);
+            gltfContainerAssetsCache!.UnloadImmediate();
+            lodCache!.UnloadImmediate();
+            assetBundleCache!.UnloadImmediate();
+            //TODO - Commented out since profile cache is not unloading anything. Uncomment when solved
+            //profileCache!.Unload(fpsCapBudget, PROFILE_UNLOAD_CHUNK);
+            profileIntentionCache!.UnloadImmediate();
 
             ClearExtendedObjectPools();
         }

--- a/Explorer/Assets/DCL/ResourcesUnloading/ICacheCleaner.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/ICacheCleaner.cs
@@ -4,6 +4,7 @@
     {
         void UnloadCache();
 
+        void UnloadCacheImmediate();
         void UpdateProfilingCounters();
     }
 }

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/LoadingStatus.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/LoadingStatus.cs
@@ -14,7 +14,8 @@ namespace DCL.UserInAppInitializationFlow
         private static readonly Dictionary<LoadingStage, float> PROGRESS = new (EnumUtils.GetEqualityComparer<LoadingStage>())
         {
             [LoadingStage.Init] = 0f, 
-            [LoadingStage.AuthenticationScreenShowing] = 0.05f, 
+            [LoadingStage.AuthenticationScreenShowing] = 0.05f,
+            [LoadingStage.UnloadCacheChecking] = 0.05f, 
             [LoadingStage.LiveKitConnectionEnsuring] = 0.1f, //Used in initialization Flow
             [LoadingStage.LivekitStopping] = 0.1f, //Used in Teleport Flow
             [LoadingStage.FeatureFlagInitializing] = 0.15f,
@@ -38,6 +39,7 @@ namespace DCL.UserInAppInitializationFlow
             AuthenticationScreenShowing,
             LiveKitConnectionEnsuring,
             FeatureFlagInitializing,
+            UnloadCacheChecking,
             ProfileLoading,
             EnvironmentMiscSetting,
             PlayerAvatarLoading,

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/IRealmPartitionSettings.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/IRealmPartitionSettings.cs
@@ -48,6 +48,11 @@ namespace ECS.Prioritization
         int ScenesDefinitionsRequestBatchSize { get; }
 
         /// <summary>
+        ///     How many teleports to do before forcing an unload cache
+        /// </summary>
+        int UnloadCacheAfterTeleportCount { get; }
+
+        /// <summary>
         ///     Get the desired update frequency for a scene in a given partition.
         ///     It should take both bucket index and isBehind into account.
         /// </summary>

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettings.asset
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettings.asset
@@ -21,3 +21,4 @@ MonoBehaviour:
   <UnloadingDistanceToleranceInParcels>k__BackingField: 1
   <ScenesRequestBatchSize>k__BackingField: 6
   <ScenesDefinitionsRequestBatchSize>k__BackingField: 30
+  <UnloadCacheAfterTeleportCount>k__BackingField: 4

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettingsAsset.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Settings/RealmPartitionSettingsAsset.cs
@@ -13,7 +13,7 @@ namespace ECS.Prioritization
         [SerializeField] private int behindFps = 1;
         [SerializeField] private float aggregatePositionTolerance = 0.5f;
         [SerializeField] private int maxLoadingDistanceInParcels;
-
+        
         [field: SerializeField] public int MinLoadingDistanceInParcels { get; private set; }
 
         [field: SerializeField]
@@ -48,6 +48,8 @@ namespace ECS.Prioritization
         public int ScenesDefinitionsRequestBatchSize { get; private set; }
 
         public float AggregatePositionSqrTolerance { get; private set; }
+
+        [field: SerializeField] public int UnloadCacheAfterTeleportCount { get; private set; }
 
         private void OnEnable()
         {

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Cache/IStreamableCache.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Cache/IStreamableCache.cs
@@ -38,6 +38,12 @@ namespace ECS.StreamableLoading.Cache
         /// </summary>
         void Unload(IPerformanceBudget frameTimeBudget, int maxUnloadAmount);
 
+        /// <summary>
+        ///     Unload assets without taking into consideration budgeting.
+        ///     Use it with caution
+        /// </summary>
+        void UnloadImmediate();
+
 #region Referencing
         /// <summary>
         ///     Base implementation is empty as not every asset requires reference counting

--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Cache/NoCache.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Cache/NoCache.cs
@@ -63,6 +63,10 @@ namespace ECS.StreamableLoading.Cache
 
         public void Unload(IPerformanceBudget frameTimeBudget, int maxUnloadAmount) { }
 
+        public void UnloadImmediate()
+        {
+        }
+
         bool IEqualityComparer<TLoadingIntention>.Equals(TLoadingIntention x, TLoadingIntention y) =>
             EqualityComparer<TLoadingIntention>.Default.Equals(x, y);
 

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
@@ -91,6 +91,30 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
             asset.Root.transform.SetParent(parentContainer, false);
         }
 
+        public void UnloadImmediate()
+        {
+            var unloadedAmount = 0;
+
+            while (unloadQueue.Count > 0 && unloadQueue.TryDequeue(out var key) &&
+                   cache.TryGetValue(key, out var assets))
+            {
+                unloadedAmount += UnloadGLTF(assets, key);
+            }
+
+            ProfilingCounters.GltfInCacheAmount.Value -= unloadedAmount;
+        }
+
+        private int UnloadGLTF(List<GltfContainerAsset> assets, string key)
+        {
+            var assetsToUnload = assets.Count;
+            foreach (var asset in assets)
+                asset.Dispose();
+
+            assets.Clear();
+            cache.Remove(key);
+            return assetsToUnload;
+        }
+
         public void Unload(IPerformanceBudget frameTimeBudget, int maxUnloadAmount)
         {
             var unloadedAmount = 0;
@@ -99,13 +123,7 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
                    && unloadedAmount < maxUnloadAmount && unloadQueue.Count > 0
                    && unloadQueue.TryDequeue(out string key) && cache.TryGetValue(key, out List<GltfContainerAsset> assets))
             {
-                unloadedAmount += assets.Count;
-
-                foreach (GltfContainerAsset asset in assets)
-                    asset.Dispose();
-
-                assets.Clear();
-                cache.Remove(key);
+                unloadedAmount += UnloadGLTF(assets, key);
             }
 
             ProfilingCounters.GltfInCacheAmount.Value -= unloadedAmount;

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Cache/IGltfContainerAssetsCache.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Cache/IGltfContainerAssetsCache.cs
@@ -14,5 +14,7 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
         void Unload(IPerformanceBudget frameTimeBudget, int maxUnloadAmount);
 
         void Dereference(in string key, GltfContainerAsset asset);
+
+        void UnloadImmediate();
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/Bootstraper.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/Bootstraper.cs
@@ -130,7 +130,6 @@ namespace Global.Dynamic
                 world,
                 playerEntity,
                 appArgs,
-                staticContainer.LoadingStatus,
                 ct);
         }
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -157,7 +157,6 @@ namespace Global.Dynamic
             World globalWorld,
             Entity playerEntity,
             IAppArgs appArgs,
-            ILoadingStatus loadingStatus,
             CancellationToken ct)
         {
             var container = new DynamicWorldContainer();
@@ -343,7 +342,9 @@ namespace Global.Dynamic
                 staticContainer.ExposedGlobalDataContainer.ExposedCameraData.CameraEntityProxy,
                 exposedGlobalDataContainer.CameraSamplingData,
                 localSceneDevelopment,
-                loadingStatus);
+                staticContainer.LoadingStatus,
+                staticContainer.CacheCleaner,
+                staticContainer.RealmPartitionSettings.UnloadCacheAfterTeleportCount);
 
             IHealthCheck livekitHealthCheck = bootstrapContainer.DebugSettings.EnableEmulateNoLivekitConnection
                 ? new IHealthCheck.AlwaysFails("Livekit connection is in debug, always fail mode")
@@ -362,7 +363,7 @@ namespace Global.Dynamic
             livekitHealthCheck.WithRetries();
 
             container.UserInAppInAppInitializationFlow = new RealUserInAppInitializationFlow(
-                loadingStatus,
+                staticContainer.LoadingStatus,
                 livekitHealthCheck,
                 bootstrapContainer.DecentralandUrlsSource,
                 container.MvcManager,
@@ -459,7 +460,7 @@ namespace Global.Dynamic
                     container.ProfileRepository,
                     container.ProfileBroadcast,
                     debugBuilder,
-                    loadingStatus,
+                    staticContainer.LoadingStatus,
                     entityParticipantTable,
                     container.MessagePipesHub,
                     container.RemoteMetadata,
@@ -559,7 +560,9 @@ namespace Global.Dynamic
                 new CharacterPreviewPlugin(staticContainer.ComponentsContainer.ComponentPoolsRegistry, assetsProvisioner, staticContainer.CacheCleaner),
                 new WebRequestsPlugin(staticContainer.WebRequestsContainer.AnalyticsContainer, debugBuilder),
                 new Web3AuthenticationPlugin(assetsProvisioner, dynamicWorldDependencies.Web3Authenticator, debugBuilder, container.MvcManager, selfProfile, webBrowser, staticContainer.RealmData, identityCache, characterPreviewFactory, dynamicWorldDependencies.SplashScreen, audioMixerVolumesController, staticContainer.FeatureFlagsCache, characterPreviewEventBus, globalWorld),
-                new StylizedSkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, debugBuilder), new LoadingScreenPlugin(assetsProvisioner, container.MvcManager, audioMixerVolumesController, staticContainer.InputBlock, debugBuilder, loadingStatus),
+                new StylizedSkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, debugBuilder),
+                new LoadingScreenPlugin(assetsProvisioner, container.MvcManager, audioMixerVolumesController,
+                    staticContainer.InputBlock, debugBuilder, staticContainer.LoadingStatus),
                 new ExternalUrlPromptPlugin(assetsProvisioner, webBrowser, container.MvcManager, dclCursor),
                 new TeleportPromptPlugin(assetsProvisioner, container.MvcManager,
                     staticContainer.WebRequestsContainer.WebRequestController, placesAPIService, dclCursor,

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/CompleteLoadingStatus.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/CompleteLoadingStatus.cs
@@ -7,9 +7,17 @@ namespace Global.Dynamic.TeleportOperations
 {
     public class CompleteLoadingStatus : ITeleportOperation
     {
+        private readonly TeleportCounter teleportCounter;
+
+        public CompleteLoadingStatus(TeleportCounter teleportCounter)
+        {
+            this.teleportCounter = teleportCounter;
+        }
+        
         public UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
         {
             teleportParams.ParentReport.SetProgress(teleportParams.LoadingStatus.SetCurrentStage(LoadingStatus.LoadingStage.Completed));
+            teleportCounter.teleportsDone++;
             return UniTask.FromResult(Result.SuccessResult());
         }
     }

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/TeleportCounter.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/TeleportCounter.cs
@@ -1,0 +1,7 @@
+namespace Global.Dynamic.TeleportOperations
+{
+    public class TeleportCounter
+    {
+        public int teleportsDone;
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/TeleportCounter.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/TeleportCounter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6dfd3b53d9f8466eb5434b5b31cfb966
+timeCreated: 1729769381

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/UnloadCacheImmediateTeleportOperation.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/UnloadCacheImmediateTeleportOperation.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using DCL.ResourcesUnloading;
+using DCL.UserInAppInitializationFlow;
+using UnityEngine;
+using UnityEngine.InputSystem.LowLevel;
+using Utility.Types;
+
+namespace Global.Dynamic.TeleportOperations
+{
+    public class UnloadCacheImmediateTeleportOperation : ITeleportOperation
+    {
+        private readonly TeleportCounter teleportCounter;
+        private readonly ICacheCleaner cacheCleaner;
+        private readonly int teleportsBeforeUnload;
+
+        public UnloadCacheImmediateTeleportOperation(TeleportCounter teleportCounter, ICacheCleaner cacheCleaner,
+            int teleportsBeforeUnload)
+        {
+            this.teleportCounter = teleportCounter;
+            this.cacheCleaner = cacheCleaner;
+            this.teleportsBeforeUnload = teleportsBeforeUnload;
+        }
+
+        public UniTask<Result> ExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
+        {
+            teleportParams.LoadingStatus.SetCurrentStage(LoadingStatus.LoadingStage.UnloadCacheChecking);
+            if (teleportCounter.teleportsDone >= teleportsBeforeUnload)
+            {
+                cacheCleaner.UnloadCacheImmediate();
+                Resources.UnloadUnusedAssets();
+                teleportCounter.teleportsDone = 0;
+            }
+
+            return UniTask.FromResult(Result.SuccessResult());
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/UnloadCacheImmediateTeleportOperation.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/TeleportOperations/UnloadCacheImmediateTeleportOperation.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 433c427ee7f54d1eb1878e0bf34c0a53
+timeCreated: 1729769435


### PR DESCRIPTION
## What does this PR change?

After a certain amount of teleports (in this scenario, numbered at 4) the cache will unload immediately. That should help with situation were the users are hopping between scenes and therefore filling up the cache quickly.

## How to test the changes?

1. Launch the explorer
2. Teleport at least 4 times to new places (coordinates or realm). Check that memory goes down after the fourth teleport

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

