### PR TITLE
fix: update audio for streams with no volume set

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerExtensions.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerExtensions.cs
@@ -22,7 +22,16 @@ namespace DCL.SDKComponents.MediaStream
             else
             {
                 if (!hasVolume)
+                    //This following part is a workaround applied for the MacOS platform, the reason
+                    //is related to the video and audio streams, the MacOS environment does not support
+                    //the volume control for the video and audio streams, as it doesn’t allow to route audio
+                    //from HLS through to Unity. This is a limitation of Apple’s AVFoundation framework
+                    //Similar issue reported here https://github.com/RenderHeads/UnityPlugin-AVProVideo/issues/1086
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+                    mediaPlayer.AudioVolume = MediaPlayerComponent.DEFAULT_VOLUME * volume;
+#else
                     mediaPlayer.AudioVolume = MediaPlayerComponent.DEFAULT_VOLUME;
+#endif
                 else if (!Mathf.Approximately(mediaPlayer.AudioVolume, volume))
                     mediaPlayer.AudioVolume = volume;
             }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -86,7 +86,7 @@ namespace DCL.SDKComponents.MediaStream
 
             if (component.State != VideoState.VsError)
             {
-                float actualVolume = sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME * worldVolumePercentage * masterVolumePercentage;
+                float actualVolume = (sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME) * worldVolumePercentage * masterVolumePercentage;
                 component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
             }
 
@@ -101,7 +101,7 @@ namespace DCL.SDKComponents.MediaStream
 
             if (component.State != VideoState.VsError)
             {
-                float actualVolume = sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME * worldVolumePercentage * masterVolumePercentage;
+                float actualVolume = (sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME) * worldVolumePercentage * masterVolumePercentage;
                 component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
             }
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -86,7 +86,7 @@ namespace DCL.SDKComponents.MediaStream
 
             if (component.State != VideoState.VsError)
             {
-                float actualVolume = sdkComponent.Volume * worldVolumePercentage * masterVolumePercentage;
+                float actualVolume = sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME * worldVolumePercentage * masterVolumePercentage;
                 component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
             }
 
@@ -101,7 +101,7 @@ namespace DCL.SDKComponents.MediaStream
 
             if (component.State != VideoState.VsError)
             {
-                float actualVolume = sdkComponent.Volume * worldVolumePercentage * masterVolumePercentage;
+                float actualVolume = sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME * worldVolumePercentage * masterVolumePercentage;
                 component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
             }
 


### PR DESCRIPTION
## What does this PR change?

Fix #2588
This is an integration of the fix of https://github.com/decentraland/unity-explorer/issues/2294 to tackle a specific case 

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Go to 0,83
3. Verify that master volume and world volume correctly modify the stream audio volume

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

