### PR TITLE
fix: support resolutions for vertical monitor orientation

### DIFF
--- a/Explorer/Assets/DCL/Settings/ModuleControllers/ResolutionSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/ResolutionSettingsController.cs
@@ -51,11 +51,14 @@ namespace DCL.Settings.ModuleControllers
 
                 // Exclude all resolutions that are not 16:9 or 16:10
                 if (!ResolutionUtils.IsResolutionCompatibleWithAspectRatio(resolution.width, resolution.height, 16, 9) &&
-                    !ResolutionUtils.IsResolutionCompatibleWithAspectRatio(resolution.width, resolution.height, 16, 10))
+                    !ResolutionUtils.IsResolutionCompatibleWithAspectRatio(resolution.width, resolution.height, 16, 10) &&
+                    //Check for vertical monitors as well
+                    !ResolutionUtils.IsResolutionCompatibleWithAspectRatio(resolution.width, resolution.height, 9, 16) &&
+                    !ResolutionUtils.IsResolutionCompatibleWithAspectRatio(resolution.width, resolution.height, 10, 16))
                     continue;
 
-                // Exclude all resolutions width less than 1024
-                if (resolution.width <= 1024)
+                // Exclude all resolutions width less than 1024 (same for height in case of vertical monitors)
+                if (Mathf.Min(resolution.width, resolution.height) <= 1024)
                     continue;
 
                 // Exclude possible duplicates


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Fix #2411 

Prevent the filtering of valid resolutions when the monitor is in vertical orientation (which flips the aspect ratio e.g: 16:9 -> 9:16)

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

You can check that the current live build suffers from the same problem as the one described in the linked issue on any monitor when it is in vertical orientation.

1. Make sure your monitor is in vertical orientation
2. Launch the explorer
3. Check that in the settings menu all the standard resolutions are there but with flipped aspect ratios

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

