### PR TITLE
Fix: HideUI shortcut must hide Scene UI

### DIFF
--- a/Explorer/Assets/Scripts/Global/StaticContainer.cs
+++ b/Explorer/Assets/Scripts/Global/StaticContainer.cs
@@ -202,7 +202,7 @@ namespace Global
                     diagnosticsContainer.Sentry!.AddCurrentSceneToScope(scope, container.ScenesCache.CurrentScene.Info);
             });
 
-            container.LoadingStatus = enableAnalytics ? 
+            container.LoadingStatus = enableAnalytics ?
                 new LoadingStatusAnalyticsDecorator(new LoadingStatus(), analyticsController) : new LoadingStatus();
 
             container.ECSWorldPlugins = new IDCLWorldPlugin[]
@@ -219,10 +219,10 @@ namespace Global
                 new PrimitivesRenderingPlugin(sharedDependencies),
                 new VisibilityPlugin(),
                 new AudioSourcesPlugin(sharedDependencies, container.WebRequestsContainer.WebRequestController, container.CacheCleaner, container.assetsProvisioner),
-                assetBundlePlugin, 
+                assetBundlePlugin,
                 new GltfContainerPlugin(sharedDependencies, container.CacheCleaner, container.SceneReadinessReportQueue, container.SingletonSharedDependencies.SceneAssetLock, componentsContainer.ComponentPoolsRegistry, localSceneDevelopment, useRemoteAssetBundles, container.LoadingStatus),
                 new InteractionPlugin(sharedDependencies, profilingProvider, exposedGlobalDataContainer.GlobalInputEvents, componentsContainer.ComponentPoolsRegistry, container.assetsProvisioner),
-                new SceneUIPlugin(sharedDependencies, container.assetsProvisioner, container.InputBlock),
+                new SceneUIPlugin(sharedDependencies, container.assetsProvisioner, container.InputBlock, container.InputProxy),
                 container.CharacterContainer.CreateWorldPlugin(componentsContainer.ComponentPoolsRegistry),
                 new AnimatorPlugin(),
                 new TweenPlugin(),


### PR DESCRIPTION
## What does this PR change?

The system that hides UI when the shortcut is pressed did not have the proper reference to the scene UI root. Which it cannot have easily as the sceneUI plugin is init'ed in the StaticContainer.
The easy and clean solution is to just have a callback when the hideUI button is pressed to hide it.
...

## How to test the changes?

Open the game, wait until the portable experience UI is shown and press the "U" key to hide the UI.
It should hide the PX UI as well.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

