### PR TITLE
feat: support for zone terrain

### DIFF
--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -89,7 +89,8 @@ namespace DCL.Landscape
             terrains = new List<Terrain>();
         }
 
-        public void Initialize(TerrainGenerationData terrainGenData, ref NativeList<int2> emptyParcels, ref NativeParallelHashSet<int2> ownedParcels, string parcelChecksum)
+        public void Initialize(TerrainGenerationData terrainGenData, ref NativeList<int2> emptyParcels,
+            ref NativeParallelHashSet<int2> ownedParcels, string parcelChecksum, bool isZone)
         {
             this.ownedParcels = ownedParcels;
             this.emptyParcels = emptyParcels;
@@ -97,7 +98,8 @@ namespace DCL.Landscape
 
             parcelSize = terrainGenData.parcelSize;
             factory = new TerrainFactory(terrainGenData);
-            localCache = new TerrainGeneratorLocalCache(terrainGenData.seed, this.terrainGenData.chunkSize, CACHE_VERSION, parcelChecksum);
+            localCache = new TerrainGeneratorLocalCache(terrainGenData.seed, this.terrainGenData.chunkSize,
+                CACHE_VERSION, parcelChecksum, isZone);
 
             chunkDataGenerator = new TerrainChunkDataGenerator(localCache, timeProfiler, terrainGenData, reportData);
             boundariesGenerator = new TerrainBoundariesGenerator(factory, parcelSize);

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -27,7 +27,7 @@ namespace DCL.Landscape
         private const float ROOT_VERTICAL_SHIFT = -0.01f; // fix for not clipping with scene (potential) floor
 
         // increment this number if we want to force the users to generate a new terrain cache
-        private const int CACHE_VERSION = 8;
+        private const int CACHE_VERSION = 9;
 
         private const float PROGRESS_COUNTER_EMPTY_PARCEL_DATA = 0.1f;
         private const float PROGRESS_COUNTER_TERRAIN_DATA = 0.3f;

--- a/Explorer/Assets/DCL/Landscape/TerrainGeneratorTest.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGeneratorTest.cs
@@ -76,7 +76,7 @@ namespace DCL.Landscape
             {
                 IMemoryProfiler memoryProfiler = new Profiler();
                 gen = new TerrainGenerator(memoryProfiler, true, clearCache);
-                gen.Initialize(genData, ref emptyParcels, ref ownedParcels, "");
+                gen.Initialize(genData, ref emptyParcels, ref ownedParcels, "", false);
                 await gen.GenerateTerrainAndShowAsync(worldSeed, digHoles, hideTrees, hideDetails);
             }
 

--- a/Explorer/Assets/DCL/Landscape/Utils/LandscapeParcelService.cs
+++ b/Explorer/Assets/DCL/Landscape/Utils/LandscapeParcelService.cs
@@ -80,11 +80,15 @@ namespace DCL.Landscape.Utils
 
     public class LandscapeParcelService
     {
-        private const string MANIFEST_URL = "https://places-dcf8abb.s3.amazonaws.com/WorldManifest.json";
-        private readonly IWebRequestController webRequestController;
+        private const string ORG_MANIFEST_URL = "https://places-dcf8abb.s3.amazonaws.com/WorldManifest.json";
+        private const string ZONE_MANIFEST_URL = "https://places-e22845c.s3.us-east-1.amazonaws.com/WorldManifest.json";
 
-        public LandscapeParcelService(IWebRequestController webRequestController)
+        private readonly IWebRequestController webRequestController;
+        private readonly string currentManifestURL;
+
+        public LandscapeParcelService(IWebRequestController webRequestController, bool isZone)
         {
+            currentManifestURL = isZone ? ZONE_MANIFEST_URL : ORG_MANIFEST_URL;
             this.webRequestController = webRequestController;
         }
 
@@ -92,7 +96,9 @@ namespace DCL.Landscape.Utils
         {
             try
             {
-                string? result = await webRequestController.GetAsync(new CommonArguments(URLAddress.FromString(MANIFEST_URL)), ct, ReportCategory.LANDSCAPE)
+                var result = await webRequestController
+                    .GetAsync(new CommonArguments(URLAddress.FromString(currentManifestURL)), ct,
+                        ReportCategory.LANDSCAPE)
                                                            .StoreTextAsync();
 
                 if (result != null)

--- a/Explorer/Assets/DCL/PluginSystem/Global/LandscapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/LandscapePlugin.cs
@@ -27,6 +27,7 @@ namespace DCL.PluginSystem.Global
         private readonly IDebugContainerBuilder debugContainerBuilder;
         private readonly MapRendererTextureContainer textureContainer;
         private readonly bool enableLandscape;
+        private readonly bool isZone;
         private ProvidedAsset<RealmPartitionSettingsAsset> realmPartitionSettings;
         private ProvidedAsset<LandscapeData> landscapeData;
         private ProvidedAsset<ParcelData> parcelData;
@@ -41,18 +42,19 @@ namespace DCL.PluginSystem.Global
             IDebugContainerBuilder debugContainerBuilder,
             MapRendererTextureContainer textureContainer,
             IWebRequestController webRequestController,
-            bool enableLandscape)
+            bool enableLandscape,
+            bool isZone)
         {
             this.floor = floor;
             this.assetsProvisioner = assetsProvisioner;
             this.debugContainerBuilder = debugContainerBuilder;
             this.textureContainer = textureContainer;
             this.enableLandscape = enableLandscape;
-
+            this.isZone = isZone;
             this.terrainGenerator = terrainGenerator;
             this.worldTerrainGenerator = worldTerrainGenerator;
 
-            parcelService = new LandscapeParcelService(webRequestController);
+            parcelService = new LandscapeParcelService(webRequestController, isZone);
         }
 
         public void Dispose()
@@ -90,7 +92,8 @@ namespace DCL.PluginSystem.Global
                 parcelChecksum = fetchParcelResult.Checksum;
             }
 
-            terrainGenerator.Initialize(landscapeData.Value.terrainData, ref emptyParcels, ref ownedParcels, parcelChecksum);
+            terrainGenerator.Initialize(landscapeData.Value.terrainData, ref emptyParcels, ref ownedParcels,
+                parcelChecksum, isZone);
             worldTerrainGenerator.Initialize(landscapeData.Value.worldsTerrainData);
         }
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
@@ -50,6 +50,8 @@ namespace Global.Dynamic
         public bool LocalSceneDevelopment { get; private set; }
         public bool UseRemoteAssetBundles { get; private set; }
 
+        public DecentralandEnvironment Environment { get; private set; }
+
         public override void Dispose()
         {
             base.Dispose();
@@ -85,6 +87,7 @@ namespace Global.Dynamic
                 ApplicationParametersParser = applicationParametersParser,
                 DebugSettings = debugSettings,
                 WorldVolumeMacBus = new WorldVolumeMacBus(),
+                Environment = sceneLoaderSettings.DecentralandEnvironment
             };
 
             await bootstrapContainer.InitializeContainerAsync<BootstrapContainer, BootstrapSettings>(settingsContainer, ct, async container =>

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -234,7 +234,10 @@ namespace Global.Dynamic
             var genesisTerrain = new TerrainGenerator(staticContainer.Profiler);
             var worldsTerrain = new WorldTerrainGenerator();
             var satelliteView = new SatelliteFloor();
-            var landscapePlugin = new LandscapePlugin(satelliteView, genesisTerrain, worldsTerrain, assetsProvisioner, debugBuilder, container.MapRendererContainer.TextureContainer, staticContainer.WebRequestsContainer.WebRequestController, dynamicWorldParams.EnableLandscape);
+            var landscapePlugin = new LandscapePlugin(satelliteView, genesisTerrain, worldsTerrain, assetsProvisioner,
+                debugBuilder, container.MapRendererContainer.TextureContainer,
+                staticContainer.WebRequestsContainer.WebRequestController, dynamicWorldParams.EnableLandscape,
+                bootstrapContainer.Environment.Equals(DecentralandEnvironment.Zone));
 
             IMultiPool MultiPoolFactory() =>
                 new DCLMultiPool();


### PR DESCRIPTION
## What does this PR change?

Adds support for zone terrain

## How to test the changes?

1. Delete the terrain cache so you have a fresh start (Its in https://docs.unity3d.com/ScriptReference/Application-persistentDataPath.html)
2. Start the app normally and check that the terrain is fine (look around, check that no grass is in parcels, go to the sea and check its fine)
3. Start the app again but with the param `--dclenv zone`
4. Do the same terrain check. Go to `-68,-90` and check that its a valid scene and terrain does not invade it
5. Restart app again and check the terrain in regular world. Everything should be fine 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

