### PR TITLE
feat: sdk pointer event toggle highlight

### DIFF
--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessPointerEventsSystem.cs
@@ -72,9 +72,8 @@ namespace DCL.Interaction.Systems
                 if (candidateForHoverLeaveIsValid && newEntityWasHovered == false)
                     candidateForHoverLeaveIsValid = false;
 
-                SetupPointerEvents(raycastResultForSceneEntities, ref hoverFeedbackComponent, pbPointerEvents!, newEntityWasHovered, out bool isAtDistance);
+                SetupPointerEvents(entityInfo, raycastResultForSceneEntities, ref hoverFeedbackComponent, pbPointerEvents!, newEntityWasHovered, out bool isAtDistance);
                 hoverStateComponent.AssignCollider(raycastResultForSceneEntities.Collider, isAtDistance);
-                HighlightNewEntity(entityInfo, isAtDistance);
             }
 
             if (candidateForHoverLeaveIsValid)
@@ -129,6 +128,7 @@ namespace DCL.Interaction.Systems
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SetupPointerEvents(
+            GlobalColliderSceneEntityInfo entityInfo,
             in PlayerOriginRaycastResultForSceneEntities raycastResultForSceneEntities,
             ref HoverFeedbackComponent hoverFeedbackComponent,
             PBPointerEvents pbPointerEvents,
@@ -137,6 +137,7 @@ namespace DCL.Interaction.Systems
         )
         {
             isAtDistance = false;
+            bool highlightEnabled = true;
             var anyInputInfo = sdkInputActionsMap.Values.GatherAnyInputInfo();
             pbPointerEvents.AppendPointerEventResultsIntent.Initialize(raycastResultForSceneEntities.RaycastHit, raycastResultForSceneEntities.OriginRay);
 
@@ -144,6 +145,10 @@ namespace DCL.Interaction.Systems
             {
                 PBPointerEvents.Types.Entry pointerEvent = pbPointerEvents.PointerEvents[i]!;
                 PBPointerEvents.Types.Info info = pointerEvent.EventInfo!;
+
+                if (info is { HasShowFeedback: true, ShowFeedback: false }
+                    or { HasShowHighlight: true, ShowHighlight: false })
+                    highlightEnabled = false;
 
                 info.PrepareDefaultValues();
 
@@ -155,9 +160,13 @@ namespace DCL.Interaction.Systems
                     pbPointerEvents.AppendPointerEventResultsIntent.TryAppendHoverInput(PointerEventType.PetHoverEnter, pointerEvent, i);
 
                 // Try Append Hover Feedback
-                HoverFeedbackUtils.TryAppendHoverFeedback(sdkInputActionsMap, pointerEvent,
-                    ref hoverFeedbackComponent, anyInputInfo.AnyButtonIsPressed);
+                if (!info.HasHoverText || !string.IsNullOrEmpty(info.HoverText))
+                    HoverFeedbackUtils.TryAppendHoverFeedback(sdkInputActionsMap, pointerEvent,
+                        ref hoverFeedbackComponent, anyInputInfo.AnyButtonIsPressed);
             }
+
+            if (highlightEnabled)
+                HighlightNewEntity(entityInfo, isAtDistance);
 
             if (isAtDistance)
 

--- a/Explorer/Assets/Protocol/DecentralandProtocol/PointerEvents.gen.cs
+++ b/Explorer/Assets/Protocol/DecentralandProtocol/PointerEvents.gen.cs
@@ -387,7 +387,7 @@ namespace DCL.ECSComponents {
         public const int ShowFeedbackFieldNumber = 4;
         private bool showFeedback_;
         /// <summary>
-        /// enable or disable hover text (default true)
+        /// enable or disable hover text and highlight (default true)
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]

--- a/Explorer/Assets/Protocol/DecentralandProtocol/PointerEvents.gen.cs
+++ b/Explorer/Assets/Protocol/DecentralandProtocol/PointerEvents.gen.cs
@@ -27,22 +27,23 @@ namespace DCL.ECSComponents {
             "CjBkZWNlbnRyYWxhbmQvc2RrL2NvbXBvbmVudHMvcG9pbnRlcl9ldmVudHMu",
             "cHJvdG8SG2RlY2VudHJhbGFuZC5zZGsuY29tcG9uZW50cxo1ZGVjZW50cmFs",
             "YW5kL3Nkay9jb21wb25lbnRzL2NvbW1vbi9pbnB1dF9hY3Rpb24ucHJvdG8i",
-            "1AMKD1BCUG9pbnRlckV2ZW50cxJKCg5wb2ludGVyX2V2ZW50cxgBIAMoCzIy",
+            "hAQKD1BCUG9pbnRlckV2ZW50cxJKCg5wb2ludGVyX2V2ZW50cxgBIAMoCzIy",
             "LmRlY2VudHJhbGFuZC5zZGsuY29tcG9uZW50cy5QQlBvaW50ZXJFdmVudHMu",
-            "RW50cnka2QEKBEluZm8SRAoGYnV0dG9uGAEgASgOMi8uZGVjZW50cmFsYW5k",
+            "RW50cnkaiQIKBEluZm8SRAoGYnV0dG9uGAEgASgOMi8uZGVjZW50cmFsYW5k",
             "LnNkay5jb21wb25lbnRzLmNvbW1vbi5JbnB1dEFjdGlvbkgAiAEBEhcKCmhv",
             "dmVyX3RleHQYAiABKAlIAYgBARIZCgxtYXhfZGlzdGFuY2UYAyABKAJIAogB",
-            "ARIaCg1zaG93X2ZlZWRiYWNrGAQgASgISAOIAQFCCQoHX2J1dHRvbkINCgtf",
-            "aG92ZXJfdGV4dEIPCg1fbWF4X2Rpc3RhbmNlQhAKDl9zaG93X2ZlZWRiYWNr",
-            "GpgBCgVFbnRyeRJICgpldmVudF90eXBlGAEgASgOMjQuZGVjZW50cmFsYW5k",
-            "LnNkay5jb21wb25lbnRzLmNvbW1vbi5Qb2ludGVyRXZlbnRUeXBlEkUKCmV2",
-            "ZW50X2luZm8YAiABKAsyMS5kZWNlbnRyYWxhbmQuc2RrLmNvbXBvbmVudHMu",
-            "UEJQb2ludGVyRXZlbnRzLkluZm9CFKoCEURDTC5FQ1NDb21wb25lbnRzYgZw",
-            "cm90bzM="));
+            "ARIaCg1zaG93X2ZlZWRiYWNrGAQgASgISAOIAQESGwoOc2hvd19oaWdobGln",
+            "aHQYBSABKAhIBIgBAUIJCgdfYnV0dG9uQg0KC19ob3Zlcl90ZXh0Qg8KDV9t",
+            "YXhfZGlzdGFuY2VCEAoOX3Nob3dfZmVlZGJhY2tCEQoPX3Nob3dfaGlnaGxp",
+            "Z2h0GpgBCgVFbnRyeRJICgpldmVudF90eXBlGAEgASgOMjQuZGVjZW50cmFs",
+            "YW5kLnNkay5jb21wb25lbnRzLmNvbW1vbi5Qb2ludGVyRXZlbnRUeXBlEkUK",
+            "CmV2ZW50X2luZm8YAiABKAsyMS5kZWNlbnRyYWxhbmQuc2RrLmNvbXBvbmVu",
+            "dHMuUEJQb2ludGVyRXZlbnRzLkluZm9CFKoCEURDTC5FQ1NDb21wb25lbnRz",
+            "YgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::DCL.ECSComponents.InputActionReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::DCL.ECSComponents.PBPointerEvents), global::DCL.ECSComponents.PBPointerEvents.Parser, new[]{ "PointerEvents" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::DCL.ECSComponents.PBPointerEvents.Types.Info), global::DCL.ECSComponents.PBPointerEvents.Types.Info.Parser, new[]{ "Button", "HoverText", "MaxDistance", "ShowFeedback" }, new[]{ "Button", "HoverText", "MaxDistance", "ShowFeedback" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::DCL.ECSComponents.PBPointerEvents), global::DCL.ECSComponents.PBPointerEvents.Parser, new[]{ "PointerEvents" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::DCL.ECSComponents.PBPointerEvents.Types.Info), global::DCL.ECSComponents.PBPointerEvents.Types.Info.Parser, new[]{ "Button", "HoverText", "MaxDistance", "ShowFeedback", "ShowHighlight" }, new[]{ "Button", "HoverText", "MaxDistance", "ShowFeedback", "ShowHighlight" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::DCL.ECSComponents.PBPointerEvents.Types.Entry), global::DCL.ECSComponents.PBPointerEvents.Types.Entry.Parser, new[]{ "EventType", "EventInfo" }, null, null, null, null)})
           }));
     }
@@ -289,6 +290,7 @@ namespace DCL.ECSComponents {
           hoverText_ = other.hoverText_;
           maxDistance_ = other.maxDistance_;
           showFeedback_ = other.showFeedback_;
+          showHighlight_ = other.showHighlight_;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
 
@@ -409,6 +411,34 @@ namespace DCL.ECSComponents {
           _hasBits0 &= ~4;
         }
 
+        /// <summary>Field number for the "show_highlight" field.</summary>
+        public const int ShowHighlightFieldNumber = 5;
+        private bool showHighlight_;
+        /// <summary>
+        /// enable or disable hover highlight (default true)
+        /// </summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool ShowHighlight {
+          get { if ((_hasBits0 & 8) != 0) { return showHighlight_; } else { return false; } }
+          set {
+            _hasBits0 |= 8;
+            showHighlight_ = value;
+          }
+        }
+        /// <summary>Gets whether the "show_highlight" field is set</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public bool HasShowHighlight {
+          get { return (_hasBits0 & 8) != 0; }
+        }
+        /// <summary>Clears the value of the "show_highlight" field</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+        [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+        public void ClearShowHighlight() {
+          _hasBits0 &= ~8;
+        }
+
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
         public override bool Equals(object other) {
@@ -428,6 +458,7 @@ namespace DCL.ECSComponents {
           if (HoverText != other.HoverText) return false;
           if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(MaxDistance, other.MaxDistance)) return false;
           if (ShowFeedback != other.ShowFeedback) return false;
+          if (ShowHighlight != other.ShowHighlight) return false;
           return Equals(_unknownFields, other._unknownFields);
         }
 
@@ -439,6 +470,7 @@ namespace DCL.ECSComponents {
           if (HasHoverText) hash ^= HoverText.GetHashCode();
           if (HasMaxDistance) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(MaxDistance);
           if (HasShowFeedback) hash ^= ShowFeedback.GetHashCode();
+          if (HasShowHighlight) hash ^= ShowHighlight.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
           }
@@ -473,6 +505,10 @@ namespace DCL.ECSComponents {
             output.WriteRawTag(32);
             output.WriteBool(ShowFeedback);
           }
+          if (HasShowHighlight) {
+            output.WriteRawTag(40);
+            output.WriteBool(ShowHighlight);
+          }
           if (_unknownFields != null) {
             _unknownFields.WriteTo(output);
           }
@@ -499,6 +535,10 @@ namespace DCL.ECSComponents {
             output.WriteRawTag(32);
             output.WriteBool(ShowFeedback);
           }
+          if (HasShowHighlight) {
+            output.WriteRawTag(40);
+            output.WriteBool(ShowHighlight);
+          }
           if (_unknownFields != null) {
             _unknownFields.WriteTo(ref output);
           }
@@ -519,6 +559,9 @@ namespace DCL.ECSComponents {
             size += 1 + 4;
           }
           if (HasShowFeedback) {
+            size += 1 + 1;
+          }
+          if (HasShowHighlight) {
             size += 1 + 1;
           }
           if (_unknownFields != null) {
@@ -544,6 +587,9 @@ namespace DCL.ECSComponents {
           }
           if (other.HasShowFeedback) {
             ShowFeedback = other.ShowFeedback;
+          }
+          if (other.HasShowHighlight) {
+            ShowHighlight = other.ShowHighlight;
           }
           _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
         }
@@ -576,6 +622,10 @@ namespace DCL.ECSComponents {
                 ShowFeedback = input.ReadBool();
                 break;
               }
+              case 40: {
+                ShowHighlight = input.ReadBool();
+                break;
+              }
             }
           }
         #endif
@@ -605,6 +655,10 @@ namespace DCL.ECSComponents {
               }
               case 32: {
                 ShowFeedback = input.ReadBool();
+                break;
+              }
+              case 40: {
+                ShowHighlight = input.ReadBool();
                 break;
               }
             }

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/protocol": "^1.0.0-11406954347.commit-ba19c4f",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
         "@protobuf-ts/protoc": "^2.8.2",
         "@types/fs-extra": "^11.0.1",
         "@types/glob": "^8.0.1",
@@ -36,9 +36,10 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-11406954347.commit-ba19c4f",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11406954347.commit-ba19c4f.tgz",
-      "integrity": "sha512-oMoq5IKAe1gout5SbP2w3Jq3Im+tbUiREW70BC+aVwwOly0YDtTWTZG9FyjeF36RDhyCg7z6jwtHL/rbWp0skw==",
+      "version": "1.0.0-11593429245.commit-6dd6863",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
+      "integrity": "sha512-2MEa2+Q9Qd5l0TYlPjIUVBspnEyFvkTOqfHyJGwejxiiE0kIfdo29b5fUtKkMpcBS1VRfkJmsEiD1kOVzDSSlg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -569,9 +570,8 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-11406954347.commit-ba19c4f",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11406954347.commit-ba19c4f.tgz",
-      "integrity": "sha512-oMoq5IKAe1gout5SbP2w3Jq3Im+tbUiREW70BC+aVwwOly0YDtTWTZG9FyjeF36RDhyCg7z6jwtHL/rbWp0skw==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
+      "integrity": "sha512-2MEa2+Q9Qd5l0TYlPjIUVBspnEyFvkTOqfHyJGwejxiiE0kIfdo29b5fUtKkMpcBS1VRfkJmsEiD1kOVzDSSlg==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       }

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
+        "@dcl/protocol": "^1.0.0-11599848164.commit-ef74edc",
         "@protobuf-ts/protoc": "^2.8.2",
         "@types/fs-extra": "^11.0.1",
         "@types/glob": "^8.0.1",
@@ -36,10 +36,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-11593429245.commit-6dd6863",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
-      "integrity": "sha512-2MEa2+Q9Qd5l0TYlPjIUVBspnEyFvkTOqfHyJGwejxiiE0kIfdo29b5fUtKkMpcBS1VRfkJmsEiD1kOVzDSSlg==",
-      "license": "Apache-2.0",
+      "version": "1.0.0-11599848164.commit-ef74edc",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11599848164.commit-ef74edc.tgz",
+      "integrity": "sha512-XSUOA0LbchlBUk5/BMJFBl0+qOm4UOIxwMGp38A1n4LQAatGO/RXjzReJRveqiFma+X7eq3e6+KCDqTLwepN0w==",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -570,8 +569,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
-      "integrity": "sha512-2MEa2+Q9Qd5l0TYlPjIUVBspnEyFvkTOqfHyJGwejxiiE0kIfdo29b5fUtKkMpcBS1VRfkJmsEiD1kOVzDSSlg==",
+      "version": "1.0.0-11599848164.commit-ef74edc",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11599848164.commit-ef74edc.tgz",
+      "integrity": "sha512-XSUOA0LbchlBUk5/BMJFBl0+qOm4UOIxwMGp38A1n4LQAatGO/RXjzReJRveqiFma+X7eq3e6+KCDqTLwepN0w==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
+    "@dcl/protocol": "^1.0.0-11599848164.commit-ef74edc",
     "@protobuf-ts/protoc": "^2.8.2",
     "@types/fs-extra": "^11.0.1",
     "@types/glob": "^8.0.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@dcl/protocol": "^1.0.0-11406954347.commit-ba19c4f",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
     "@protobuf-ts/protoc": "^2.8.2",
     "@types/fs-extra": "^11.0.1",
     "@types/glob": "^8.0.1",


### PR DESCRIPTION
### WHY

Currently scenes have no control over the automatic shader highlighting that happens on interractable objects (pointer event entities).

These are the possible pointer events feedback combinations that the scene can set today:

* Highlight ON + Hover Text ON
* Highlight ON + Hover Text OFF

These other states are not possible today:

* Highlight OFF + Hover Text OFF
* Highlight OFF + Hover Text ON

### WHAT

* Implemented support for new `showHighlight` property in the `PBPointerEvents` component, binding the highlight setup of entities to that property.
* Minor change on `showFeedback` usage to also avoid enabling the highlight if it's `false`, as the highlight is also **the feedback**
* Minor check to avoid enabling the `hoverText` if the component comes with that property with an empty string. Didn't touch the existent behaviour of not coming with that optional property that ends up using the default "Interact" hover text.

**Tackles**: https://github.com/decentraland/creator-hub/issues/160

**Related PRs**:
- https://github.com/decentraland/protocol/pull/224
- https://github.com/decentraland/js-sdk-toolchain/pull/1024

### QA TEST INSTRUCTIONS

1. Download [test scene](https://github.com/user-attachments/files/17576096/pointer-events-highlight.zip) and uncompress it somewhere
2. Enter the scene root folder and run `npm i` and then `npm run start -- --explorer-alpha`
3. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
4. Download the build from this PR and connect it to the running scene using [the console command](https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene) according to your OS
5. Once the scene loads, run the `/reload` chat command to reload the scene, to avoid [THIS OTHER BUG](https://github.com/decentraland/unity-explorer/issues).
6. Put your cursor on each one of the "pointer event cubes" and confirm that they have either the HIGHLIGHT/GLOW and the HOVER TEXT enabled/disabled according to the text shape on top of each cube. (The actual hover text value of each cube can be ignored, it's only important to see if the text appears or not)

<img width="1299" alt="Screenshot 2024-10-30 at 5 20 53 PM" src="https://github.com/user-attachments/assets/ac33fc10-ac3f-4ca9-bdfd-ba0a682180d9">

