### PR TITLE
chore: Add loading intention type on fail to get more info

### DIFF
--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/AssetPromiseExtensions.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Common/AssetPromiseExtensions.cs
@@ -19,7 +19,8 @@ namespace ECS.StreamableLoading.Common
                 result = promise.Result
                          ?? new StreamableLoadingResult<TAsset>(
                              reportData,
-                             new Exception("The promise generated no result")
+                             new Exception(
+                                 $"The promise of intention {promise.LoadingIntention.GetType()} generated no result")
                          );
 
                 return true;


### PR DESCRIPTION
## What does this PR change?

Adds the loading intention type that failed to get more information when this error appears:

```
Exception: The promise generated no result
DCL.Diagnostics.ReportHandlerBase:LogException(Exception, ReportData, Object)
DCL.Diagnostics.ReportHubLogger:LogException(Exception, ReportData, ReportHandler)
DCL.Diagnostics.ReportHub:LogException(Exception, ReportData, ReportHandler)
ECS.StreamableLoading.Common.Components.StreamableLoadingResult`1:.ctor(ReportData, Exception)
ECS.StreamableLoading.Common.AssetPromiseExtensions:SafeTryConsume(AssetPromise`2&, World, ReportData, StreamableLoadingResult`1&)
DCL.AvatarRendering.AvatarShape.Systems.AvatarInstantiatorSystem:InstantiateNewAvatar(Entity&, AvatarShapeComponent&, CharacterTransform&)
DCL.AvatarRendering.AvatarShape.Systems.AvatarInstantiatorSystem:Update(Single)
DCL.AvatarRendering.AvatarShape.Systems.AvatarInstantiatorSystem:Update(Single)
ECS.Abstract.BaseUnityLoopSystem:Update(Single&)
Arch.SystemGroups.DefaultGroup`1:Update(T&, Boolean)
Arch.SystemGroups.SystemGroup:Update(Info&)
Arch.SystemGroups.DefaultSystemGroups.PresentationSystemGroup:Update()
Arch.SystemGroups.SystemGroupAggregate:TriggerUpdate()
```

## How to test the changes?

No QA needed

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md



