### PR TITLE
style: badges minor fixes

### DIFF
--- a/Explorer/Assets/DCL/Passport/Prefabs/Badges/BadgeInfo_PassportSubView.prefab
+++ b/Explorer/Assets/DCL/Passport/Prefabs/Badges/BadgeInfo_PassportSubView.prefab
@@ -442,8 +442,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 367, y: 0}
-  m_SizeDelta: {x: 70, y: 22}
+  m_AnchoredPosition: {x: 348.14984, y: 0}
+  m_SizeDelta: {x: 120, y: 22}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &5172796849477954305
 CanvasRenderer:
@@ -935,7 +935,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 360, y: 10}
+  m_SizeDelta: {x: 340, y: 10}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &2515089727087958638
 CanvasRenderer:
@@ -1259,7 +1259,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 360, y: 10}
+  m_SizeDelta: {x: 340, y: 10}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &378815463696260501
 CanvasRenderer:
@@ -2003,8 +2003,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 367, y: 0}
-  m_SizeDelta: {x: 70, y: 22}
+  m_AnchoredPosition: {x: 348.14984, y: 0}
+  m_SizeDelta: {x: 120, y: 22}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &5906000884932099535
 CanvasRenderer:
@@ -2145,7 +2145,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -583}
-  m_SizeDelta: {x: -92, y: 0}
+  m_SizeDelta: {x: -80, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &8055502815389580269
 MonoBehaviour:

--- a/Explorer/Assets/DCL/Passport/Prefabs/Badges/BadgeOverviewItem_PassportField.prefab
+++ b/Explorer/Assets/DCL/Passport/Prefabs/Badges/BadgeOverviewItem_PassportField.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
+  m_Maskable: 0
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Explorer/Assets/DCL/Passport/Prefabs/Badges/BadgeOverviewItem_PassportField.prefab
+++ b/Explorer/Assets/DCL/Passport/Prefabs/Badges/BadgeOverviewItem_PassportField.prefab
@@ -201,7 +201,7 @@ MonoBehaviour:
   m_Color: {r: 0.08627451, g: 0.08235294, b: 0.09411765, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
+  m_Maskable: 0
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []


### PR DESCRIPTION
## What does this PR change?
This PR was created to fix this issue #2450 and fix the line break from the counter when there is a badge that supports a ridiculous large number, as happens in the example attached bellow.

<img width="363" alt="Screenshot 2024-10-31 at 15 13 07" src="https://github.com/user-attachments/assets/d9baef67-677e-4dd2-8528-2533f82638d7">

## How to test the changes?
1. Launch the explorer
2. Open your profile card or others profile card to check that the tooltip, when hovering a badge with a large name, is not being masked anymore.
3. Then try to find someone who has unlocked the 'Walkabout Wanderer Bronze' badge. Validate that the counter next to the progress bar is not making a line break.
