### PR TITLE
fix: disable scene restriction toast while invisible in order to unbl…

### DIFF
--- a/Explorer/Assets/DCL/Minimap/SceneRestrictionsController.cs
+++ b/Explorer/Assets/DCL/Minimap/SceneRestrictionsController.cs
@@ -52,6 +52,7 @@ namespace DCL.Minimap
 
         private void OnMouseEnter()
         {
+            restrictionsView.ToastCanvasGroup.gameObject.SetActive(true);
             Vector3 toastPosition = restrictionsView.ToastRectTransform.anchoredPosition;
             toastPosition.x = restrictionsView.SceneRestrictionsIcon.transform.localPosition.x - (restrictionsView.SceneRestrictionsIcon.rect.width * TOAST_X_POSITION_OFFSET_ICON_WIDTH_SCALER);
             restrictionsView.ToastRectTransform.anchoredPosition = toastPosition;
@@ -59,7 +60,7 @@ namespace DCL.Minimap
         }
 
         private void OnMouseExit() =>
-            restrictionsView.ToastCanvasGroup.DOFade(0f, restrictionsView.FadeTime);
+            restrictionsView.ToastCanvasGroup.DOFade(0f, restrictionsView.FadeTime).OnComplete(() => restrictionsView.ToastCanvasGroup.gameObject.SetActive(false));
 
         private void ManageSceneRestrictions(SceneRestriction sceneRestriction)
         {

--- a/Explorer/Assets/DCL/Minimap/SceneRestrictionsView.cs
+++ b/Explorer/Assets/DCL/Minimap/SceneRestrictionsView.cs
@@ -44,6 +44,7 @@ namespace DCL.Minimap
         private void Awake()
         {
             ToastCanvasGroup.alpha = 0;
+            ToastCanvasGroup.gameObject.SetActive(false);
             SceneRestrictionsIcon.gameObject.SetActive(false);
             ToastRectTransform = ToastCanvasGroup.GetComponent<RectTransform>();
         }


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->
Fix #2683 

Deactivate the scene restriction toast object while it is transparent in order to allow the user to click on the quest tracker button

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Go to a mini game that put some restriction (avatar movements, camera locked, etc...)
3. Check that the quest tracker button is completely clickable 
4. Check that the scene restriction toast works correctly

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

