### PR TITLE
feat: testing realms

### DIFF
--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandEnvironment.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandEnvironment.cs
@@ -4,5 +4,6 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
     {
         Org,
         Zone,
+        Today
     }
 }

--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
@@ -7,9 +7,12 @@ namespace DCL.Browser.DecentralandUrls
     //TODO test urls
     public class DecentralandUrlsSource : IDecentralandUrlsSource
     {
-        private static string GENERAL_ENV = "{ENV}";
-        private static string ASSET_BUNDLE_ENV = "{ASSET_BUNDLE_ENV}";
-        private static string GENESIS_URL; 
+        private const string ENV = "{ENV}";
+        private static string ASSET_BUNDLE_URL;
+        private static string GENESIS_URL;
+
+        private const string ASSET_BUNDLE_URL_TEMPLATE = "https://ab-cdn.decentraland.{0}";
+        private const string GENESIS_URL_TEMPLATE = "https://realm-provider-ea.decentraland.{0}/main";
 
 
         private readonly Dictionary<DecentralandUrl, string> cache = new ();
@@ -24,22 +27,19 @@ namespace DCL.Browser.DecentralandUrls
             switch (environment)
             {
                 case DecentralandEnvironment.Org:
-                    GENERAL_ENV = environment.ToString()!.ToLower();
-                    ASSET_BUNDLE_ENV = environment.ToString()!.ToLower();
-                    GENESIS_URL = "https://realm-provider-ea.decentraland.org/main";
-                    break;
                 case DecentralandEnvironment.Zone:
-                    GENERAL_ENV = environment.ToString()!.ToLower();
-                    ASSET_BUNDLE_ENV = environment.ToString()!.ToLower();
-                    GENESIS_URL = "https://realm-provider-ea.decentraland.zone/main";
+                    ASSET_BUNDLE_URL = string.Format(ASSET_BUNDLE_URL_TEMPLATE, environmentDomainLowerCase);
+                    GENESIS_URL = string.Format(GENESIS_URL_TEMPLATE, environmentDomainLowerCase);
                     break;
                 case DecentralandEnvironment.Today:
+                    
                     //The today environemnt is a mixture of the org and today enviroments. 
                     //We want to fetch pointers from org, but asset bundles from today
                     //Thats because how peer-testing.decentraland.org works. 
                     //Its a catalyst that replicates the org environment and eth network, but doesnt propagate back to the production catalysts
-                    GENERAL_ENV = DecentralandEnvironment.Org.ToString()!.ToLower();
-                    ASSET_BUNDLE_ENV = environment.ToString()!.ToLower();
+                    environmentDomainLowerCase = DecentralandEnvironment.Org.ToString()!.ToLower();
+                    ASSET_BUNDLE_URL = "https://ab-cdn.decentraland.today";
+                    
                     //On staging, we hardcode the catalyst because its the only valid one with a valid comms configuration
                     GENESIS_URL = "https://peer-testing.decentraland.org";
                     break;
@@ -50,7 +50,7 @@ namespace DCL.Browser.DecentralandUrls
         {
             if (cache.TryGetValue(decentralandUrl, out string? url) == false)
             {
-                url = RawUrl(decentralandUrl).Replace(GENERAL_ENV, environmentDomainLowerCase);
+                url = RawUrl(decentralandUrl).Replace(ENV, environmentDomainLowerCase);
                 cache[decentralandUrl] = url;
             }
 
@@ -60,34 +60,34 @@ namespace DCL.Browser.DecentralandUrls
         private static string RawUrl(DecentralandUrl decentralandUrl) =>
             decentralandUrl switch
             {
-                DecentralandUrl.DiscordLink => $"https://decentraland.{GENERAL_ENV}/discord/",
-                DecentralandUrl.PrivacyPolicy => $"https://decentraland.{GENERAL_ENV}/privacy",
-                DecentralandUrl.TermsOfUse => $"https://decentraland.{GENERAL_ENV}/terms",
-                DecentralandUrl.ApiPlaces => $"https://places.decentraland.{GENERAL_ENV}/api/places",
-                DecentralandUrl.ApiAuth => $"https://auth-api.decentraland.{GENERAL_ENV}",
-                DecentralandUrl.AuthSignature => $"https://decentraland.{GENERAL_ENV}/auth/requests",
-                DecentralandUrl.POI => $"https://dcl-lists.decentraland.{GENERAL_ENV}/pois",
-                DecentralandUrl.ContentModerationReport => $"https://places.decentraland.{GENERAL_ENV}/api/report",
+                DecentralandUrl.DiscordLink => $"https://decentraland.{ENV}/discord/",
+                DecentralandUrl.PrivacyPolicy => $"https://decentraland.{ENV}/privacy",
+                DecentralandUrl.TermsOfUse => $"https://decentraland.{ENV}/terms",
+                DecentralandUrl.ApiPlaces => $"https://places.decentraland.{ENV}/api/places",
+                DecentralandUrl.ApiAuth => $"https://auth-api.decentraland.{ENV}",
+                DecentralandUrl.AuthSignature => $"https://decentraland.{ENV}/auth/requests",
+                DecentralandUrl.POI => $"https://dcl-lists.decentraland.{ENV}/pois",
+                DecentralandUrl.ContentModerationReport => $"https://places.decentraland.{ENV}/api/report",
                 DecentralandUrl.GateKeeperSceneAdapter =>
-                    $"https://comms-gatekeeper.decentraland.{GENERAL_ENV}/get-scene-adapter",
-                DecentralandUrl.OpenSea => $"https://opensea.decentraland.{GENERAL_ENV}",
-                DecentralandUrl.Host => $"https://decentraland.{GENERAL_ENV}",
-                DecentralandUrl.PeerAbout => $"https://peer.decentraland.{GENERAL_ENV}/about",
-                DecentralandUrl.DAO => $"https://decentraland.{GENERAL_ENV}/dao/",
-                DecentralandUrl.Notification => $"https://notifications.decentraland.{GENERAL_ENV}/notifications",
+                    $"https://comms-gatekeeper.decentraland.{ENV}/get-scene-adapter",
+                DecentralandUrl.OpenSea => $"https://opensea.decentraland.{ENV}",
+                DecentralandUrl.Host => $"https://decentraland.{ENV}",
+                DecentralandUrl.PeerAbout => $"https://peer.decentraland.{ENV}/about",
+                DecentralandUrl.DAO => $"https://decentraland.{ENV}/dao/",
+                DecentralandUrl.Notification => $"https://notifications.decentraland.{ENV}/notifications",
                 DecentralandUrl.NotificationRead =>
-                    $"https://notifications.decentraland.{GENERAL_ENV}/notifications/read",
-                DecentralandUrl.FeatureFlags => $"https://feature-flags.decentraland.{GENERAL_ENV}",
-                DecentralandUrl.Help => $"https://decentraland.{GENERAL_ENV}/help/",
-                DecentralandUrl.Market => $"https://market.decentraland.{GENERAL_ENV}",
-                DecentralandUrl.AssetBundlesCDN => $"https://ab-cdn.decentraland.{ASSET_BUNDLE_ENV}",
-                DecentralandUrl.ArchipelagoStatus => $"https://archipelago-ea-stats.decentraland.{GENERAL_ENV}/status",
-                DecentralandUrl.GatekeeperStatus => $"https://comms-gatekeeper.decentraland.{GENERAL_ENV}/status",
+                    $"https://notifications.decentraland.{ENV}/notifications/read",
+                DecentralandUrl.FeatureFlags => $"https://feature-flags.decentraland.{ENV}",
+                DecentralandUrl.Help => $"https://decentraland.{ENV}/help/",
+                DecentralandUrl.Market => $"https://market.decentraland.{ENV}",
+                DecentralandUrl.AssetBundlesCDN => ASSET_BUNDLE_URL,
+                DecentralandUrl.ArchipelagoStatus => $"https://archipelago-ea-stats.decentraland.{ENV}/status",
+                DecentralandUrl.GatekeeperStatus => $"https://comms-gatekeeper.decentraland.{ENV}/status",
                 DecentralandUrl.Genesis => GENESIS_URL,
-                DecentralandUrl.Badges => $"https://badges.decentraland.{GENERAL_ENV}",
-                DecentralandUrl.CameraReelUsers => $"https://camera-reel-service.decentraland.{GENERAL_ENV}/api/users",
+                DecentralandUrl.Badges => $"https://badges.decentraland.{ENV}",
+                DecentralandUrl.CameraReelUsers => $"https://camera-reel-service.decentraland.{ENV}/api/users",
                 DecentralandUrl.CameraReelImages =>
-                    $"https://camera-reel-service.decentraland.{GENERAL_ENV}/api/images",
+                    $"https://camera-reel-service.decentraland.{ENV}/api/images",
                 _ => throw new ArgumentOutOfRangeException(nameof(decentralandUrl), decentralandUrl, null!)
             };
     }

--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
@@ -85,8 +85,9 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.GatekeeperStatus => $"https://comms-gatekeeper.decentraland.{GENERAL_ENV}/status",
                 DecentralandUrl.Genesis => GENESIS_URL,
                 DecentralandUrl.Badges => $"https://badges.decentraland.{GENERAL_ENV}",
-                DecentralandUrl.CameraReelUsers =>  $"https://camera-reel-service.decentraland.{ENV}/api/users",
-                DecentralandUrl.CameraReelImages => $"https://camera-reel-service.decentraland.{ENV}/api/images",
+                DecentralandUrl.CameraReelUsers => $"https://camera-reel-service.decentraland.{GENERAL_ENV}/api/users",
+                DecentralandUrl.CameraReelImages =>
+                    $"https://camera-reel-service.decentraland.{GENERAL_ENV}/api/images",
                 _ => throw new ArgumentOutOfRangeException(nameof(decentralandUrl), decentralandUrl, null!)
             };
     }

--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
@@ -7,7 +7,10 @@ namespace DCL.Browser.DecentralandUrls
     //TODO test urls
     public class DecentralandUrlsSource : IDecentralandUrlsSource
     {
-        private const string ENV = "{ENV}";
+        private static string GENERAL_ENV = "{ENV}";
+        private static string ASSET_BUNDLE_ENV = "{ASSET_BUNDLE_ENV}";
+        private static string GENESIS_URL; 
+
 
         private readonly Dictionary<DecentralandUrl, string> cache = new ();
         private readonly string environmentDomainLowerCase;
@@ -17,13 +20,37 @@ namespace DCL.Browser.DecentralandUrls
         public DecentralandUrlsSource(DecentralandEnvironment environment)
         {
             environmentDomainLowerCase = environment.ToString()!.ToLower();
+
+            switch (environment)
+            {
+                case DecentralandEnvironment.Org:
+                    GENERAL_ENV = environment.ToString()!.ToLower();
+                    ASSET_BUNDLE_ENV = environment.ToString()!.ToLower();
+                    GENESIS_URL = "https://realm-provider-ea.decentraland.org/main";
+                    break;
+                case DecentralandEnvironment.Zone:
+                    GENERAL_ENV = environment.ToString()!.ToLower();
+                    ASSET_BUNDLE_ENV = environment.ToString()!.ToLower();
+                    GENESIS_URL = "https://realm-provider-ea.decentraland.zone/main";
+                    break;
+                case DecentralandEnvironment.Today:
+                    //The today environemnt is a mixture of the org and today enviroments. 
+                    //We want to fetch pointers from org, but asset bundles from today
+                    //Thats because how peer-testing.decentraland.org works. 
+                    //Its a catalyst that replicates the org environment and eth network, but doesnt propagate back to the production catalysts
+                    GENERAL_ENV = DecentralandEnvironment.Org.ToString()!.ToLower();
+                    ASSET_BUNDLE_ENV = environment.ToString()!.ToLower();
+                    //On staging, we hardcode the catalyst because its the only valid one with a valid comms configuration
+                    GENESIS_URL = "https://peer-testing.decentraland.org";
+                    break;
+            }
         }
 
         public string Url(DecentralandUrl decentralandUrl)
         {
             if (cache.TryGetValue(decentralandUrl, out string? url) == false)
             {
-                url = RawUrl(decentralandUrl).Replace(ENV, environmentDomainLowerCase);
+                url = RawUrl(decentralandUrl).Replace(GENERAL_ENV, environmentDomainLowerCase);
                 cache[decentralandUrl] = url;
             }
 
@@ -33,30 +60,31 @@ namespace DCL.Browser.DecentralandUrls
         private static string RawUrl(DecentralandUrl decentralandUrl) =>
             decentralandUrl switch
             {
-                DecentralandUrl.DiscordLink => $"https://decentraland.{ENV}/discord/",
-                DecentralandUrl.PrivacyPolicy => $"https://decentraland.{ENV}/privacy",
-                DecentralandUrl.TermsOfUse => $"https://decentraland.{ENV}/terms",
-                DecentralandUrl.ApiPlaces => $"https://places.decentraland.{ENV}/api/places",
-                DecentralandUrl.ApiAuth => $"https://auth-api.decentraland.{ENV}",
-                DecentralandUrl.AuthSignature => $"https://decentraland.{ENV}/auth/requests",
-                DecentralandUrl.POI => $"https://dcl-lists.decentraland.{ENV}/pois",
-                DecentralandUrl.ContentModerationReport => $"https://places.decentraland.{ENV}/api/report",
-                DecentralandUrl.GateKeeperSceneAdapter => $"https://comms-gatekeeper.decentraland.{ENV}/get-scene-adapter",
-                DecentralandUrl.OpenSea => $"https://opensea.decentraland.{ENV}",
-                DecentralandUrl.Host => $"https://decentraland.{ENV}",
-                DecentralandUrl.PeerAbout => $"https://peer.decentraland.{ENV}/about",
-                DecentralandUrl.DAO => $"https://decentraland.{ENV}/dao/",
-                DecentralandUrl.Notification => $"https://notifications.decentraland.{ENV}/notifications",
-                DecentralandUrl.NotificationRead => $"https://notifications.decentraland.{ENV}/notifications/read",
-                DecentralandUrl.FeatureFlags => $"https://feature-flags.decentraland.{ENV}",
-                DecentralandUrl.Help => $"https://decentraland.{ENV}/help/",
-                DecentralandUrl.Market => $"https://market.decentraland.{ENV}",
-                // All ABs are in org
-                DecentralandUrl.AssetBundlesCDN => $"https://ab-cdn.decentraland.{ENV}",
-                DecentralandUrl.ArchipelagoStatus => $"https://archipelago-ea-stats.decentraland.{ENV}/status",
-                DecentralandUrl.GatekeeperStatus => $"https://comms-gatekeeper.decentraland.{ENV}/status",
-                DecentralandUrl.Genesis => $"https://realm-provider-ea.decentraland.{ENV}/main",
-                DecentralandUrl.Badges => $"https://badges.decentraland.{ENV}",
+                DecentralandUrl.DiscordLink => $"https://decentraland.{GENERAL_ENV}/discord/",
+                DecentralandUrl.PrivacyPolicy => $"https://decentraland.{GENERAL_ENV}/privacy",
+                DecentralandUrl.TermsOfUse => $"https://decentraland.{GENERAL_ENV}/terms",
+                DecentralandUrl.ApiPlaces => $"https://places.decentraland.{GENERAL_ENV}/api/places",
+                DecentralandUrl.ApiAuth => $"https://auth-api.decentraland.{GENERAL_ENV}",
+                DecentralandUrl.AuthSignature => $"https://decentraland.{GENERAL_ENV}/auth/requests",
+                DecentralandUrl.POI => $"https://dcl-lists.decentraland.{GENERAL_ENV}/pois",
+                DecentralandUrl.ContentModerationReport => $"https://places.decentraland.{GENERAL_ENV}/api/report",
+                DecentralandUrl.GateKeeperSceneAdapter =>
+                    $"https://comms-gatekeeper.decentraland.{GENERAL_ENV}/get-scene-adapter",
+                DecentralandUrl.OpenSea => $"https://opensea.decentraland.{GENERAL_ENV}",
+                DecentralandUrl.Host => $"https://decentraland.{GENERAL_ENV}",
+                DecentralandUrl.PeerAbout => $"https://peer.decentraland.{GENERAL_ENV}/about",
+                DecentralandUrl.DAO => $"https://decentraland.{GENERAL_ENV}/dao/",
+                DecentralandUrl.Notification => $"https://notifications.decentraland.{GENERAL_ENV}/notifications",
+                DecentralandUrl.NotificationRead =>
+                    $"https://notifications.decentraland.{GENERAL_ENV}/notifications/read",
+                DecentralandUrl.FeatureFlags => $"https://feature-flags.decentraland.{GENERAL_ENV}",
+                DecentralandUrl.Help => $"https://decentraland.{GENERAL_ENV}/help/",
+                DecentralandUrl.Market => $"https://market.decentraland.{GENERAL_ENV}",
+                DecentralandUrl.AssetBundlesCDN => $"https://ab-cdn.decentraland.{ASSET_BUNDLE_ENV}",
+                DecentralandUrl.ArchipelagoStatus => $"https://archipelago-ea-stats.decentraland.{GENERAL_ENV}/status",
+                DecentralandUrl.GatekeeperStatus => $"https://comms-gatekeeper.decentraland.{GENERAL_ENV}/status",
+                DecentralandUrl.Genesis => GENESIS_URL,
+                DecentralandUrl.Badges => $"https://badges.decentraland.{GENERAL_ENV}",
                 _ => throw new ArgumentOutOfRangeException(nameof(decentralandUrl), decentralandUrl, null!)
             };
     }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Builders/BuilderExtensions.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Builders/BuilderExtensions.cs
@@ -94,5 +94,14 @@ namespace DCL.DebugUtilities
 
             return builder.AddControl(label, marker);
         }
+
+        public static DebugWidgetBuilder AddCustomMarker(this DebugWidgetBuilder builder,
+            ElementBinding<string> binding)
+        {
+            var marker = new DebugSetOnlyLabelDef(binding);
+            return builder.AddControl(marker, null);
+        }
+        
+        
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/ChangeRealmChatCommand.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEngine;
+using Utility.Types;
 
 namespace Global.Dynamic.ChatCommands
 {
@@ -34,13 +35,16 @@ namespace Global.Dynamic.ChatCommands
 
         private readonly Dictionary<string, URLAddress> worldAddressesCaches = new ();
         private readonly IRealmNavigator realmNavigator;
+        private readonly EnvironmentValidator environmentValidator;
 
         private string? worldName;
         private string? realmUrl;
 
-        public ChangeRealmChatCommand(IRealmNavigator realmNavigator, IDecentralandUrlsSource decentralandUrlsSource)
+        public ChangeRealmChatCommand(IRealmNavigator realmNavigator, IDecentralandUrlsSource decentralandUrlsSource,
+            EnvironmentValidator environmentValidator)
         {
             this.realmNavigator = realmNavigator;
+            this.environmentValidator = environmentValidator;
 
             paramUrls = new Dictionary<string, string>
             {
@@ -71,6 +75,11 @@ namespace Global.Dynamic.ChatCommands
 
             var realm = URLDomain.FromString(realmUrl!);
 
+            var environmentValidationResult = environmentValidator.ValidateTeleport(realm.ToString());
+
+            if (!environmentValidationResult.Success)
+                return environmentValidationResult.ErrorMessage!;
+                
             Vector2Int parcel = default;
 
             if (match.Groups[3].Success && match.Groups[4].Success)

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/EnvironmentValidator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/EnvironmentValidator.cs
@@ -1,0 +1,44 @@
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using Utility.Types;
+
+namespace Global.Dynamic.ChatCommands
+{
+    public class EnvironmentValidator
+    {
+        private readonly DecentralandEnvironment dclEnvironment;
+
+        private readonly string zoneDescription;
+        private readonly string orgDescription;
+
+
+        public EnvironmentValidator(DecentralandEnvironment dclEnvironment)
+        {
+            this.dclEnvironment = dclEnvironment;
+            zoneDescription = DecentralandEnvironment.Zone.ToString().ToLower();
+            orgDescription = DecentralandEnvironment.Org.ToString().ToLower();
+        }
+
+        public Result ValidateTeleport(string realmToTeleportTo)
+        {
+            switch (dclEnvironment)
+            {
+                case DecentralandEnvironment.Today:
+                    return Result.ErrorResult(
+                        "🔴 Error. You cannot change realms in the Today environment. Please restart DCL with the desired environment");
+                case DecentralandEnvironment.Zone:
+                    if (realmToTeleportTo.Contains(zoneDescription))
+                        return Result.SuccessResult();
+                    return Result.ErrorResult(
+                        "🔴 Error. You cannot teleport to other realms that are not Zone in Zone environment. Please restart DCL with the desired environment");
+                case DecentralandEnvironment.Org:
+                    if (realmToTeleportTo.Contains(orgDescription))
+                        return Result.SuccessResult();
+
+                    return Result.ErrorResult(
+                        "🔴 Error. You cannot teleport to other realms that are not Org or World in Org environment. Please restart DCL with the desired environment");
+            }
+
+            return Result.SuccessResult();
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/EnvironmentValidator.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/ChatCommands/EnvironmentValidator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7f2c242be74a4331ab38e635ffaf44ec
+timeCreated: 1730478237

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -292,7 +292,8 @@ namespace Global.Dynamic
                 staticContainer.RealmData,
                 staticContainer.ScenesCache,
                 staticContainer.PartitionDataContainer,
-                staticContainer.SingletonSharedDependencies.SceneAssetLock);
+                staticContainer.SingletonSharedDependencies.SceneAssetLock,
+                debugBuilder);
 
             bool localSceneDevelopment = !string.IsNullOrEmpty(dynamicWorldParams.LocalSceneDevelopmentRealm);
             container.reloadSceneController = new ECSReloadScene(staticContainer.ScenesCache, globalWorld, playerEntity, localSceneDevelopment);

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -404,7 +404,11 @@ namespace Global.Dynamic
             var chatCommandsFactory = new Dictionary<Regex, Func<IChatCommand>>
             {
                 { GoToChatCommand.REGEX, () => new GoToChatCommand(realmNavigator) },
-                { ChangeRealmChatCommand.REGEX, () => new ChangeRealmChatCommand(realmNavigator, bootstrapContainer.DecentralandUrlsSource) },
+                {
+                    ChangeRealmChatCommand.REGEX,
+                    () => new ChangeRealmChatCommand(realmNavigator, bootstrapContainer.DecentralandUrlsSource,
+                        new EnvironmentValidator(bootstrapContainer.Environment))
+                },
                 { DebugPanelChatCommand.REGEX, () => new DebugPanelChatCommand(debugBuilder, connectionStatusPanelPlugin) },
                 { ShowEntityInfoChatCommand.REGEX, () => new ShowEntityInfoChatCommand(worldInfoHub) },
                 { ClearChatCommand.REGEX, () => new ClearChatCommand(chatHistory) },

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmController.cs
@@ -22,6 +22,7 @@ using SceneRunner.Scene;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using DCL.DebugUtilities;
 using Unity.Mathematics;
 
 namespace Global.Dynamic
@@ -52,6 +53,8 @@ namespace Global.Dynamic
 
         public IRealmData RealmData => realmData;
 
+        private readonly RealmNavigatorDebugView realmNavigatorDebugView;
+
         public GlobalWorld GlobalWorld
         {
             get => globalWorld.EnsureNotNull("GlobalWorld in RealmController is null");
@@ -73,7 +76,8 @@ namespace Global.Dynamic
             RealmData realmData,
             IScenesCache scenesCache,
             PartitionDataContainer partitionDataContainer,
-            SceneAssetLock sceneAssetLock)
+            SceneAssetLock sceneAssetLock,
+            IDebugContainerBuilder debugContainerBuilder)
         {
             this.web3IdentityCache = web3IdentityCache;
             this.webRequestController = webRequestController;
@@ -85,6 +89,8 @@ namespace Global.Dynamic
             this.scenesCache = scenesCache;
             this.partitionDataContainer = partitionDataContainer;
             this.sceneAssetLock = sceneAssetLock;
+
+            realmNavigatorDebugView = new RealmNavigatorDebugView(debugContainerBuilder);
         }
 
         public async UniTask SetRealmAsync(URLDomain realm, CancellationToken ct)
@@ -127,6 +133,8 @@ namespace Global.Dynamic
             partitionDataContainer.Restart();
 
             currentDomain = realm;
+            realmNavigatorDebugView.UpdateRealmName(currentDomain.Value.ToString(), result.lambdas.publicUrl,
+                result.content.publicUrl);
         }
 
         public async UniTask RestartRealmAsync(CancellationToken ct)

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigatorDebugView.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigatorDebugView.cs
@@ -1,0 +1,36 @@
+using DCL.DebugUtilities;
+using DCL.DebugUtilities.UIBindings;
+
+namespace Global.Dynamic
+{
+    public class RealmNavigatorDebugView
+    {
+        private readonly ElementBinding<string> currentRealmName;
+        private readonly ElementBinding<string> currentCatalystLambdas;
+        private readonly ElementBinding<string> currentCatalystContent;
+
+
+        public RealmNavigatorDebugView(IDebugContainerBuilder debugContainerBuilder)
+        {
+            currentRealmName = new ElementBinding<string>("");
+            currentCatalystLambdas = new ElementBinding<string>("");
+            currentCatalystContent = new ElementBinding<string>("");
+
+            debugContainerBuilder
+                .TryAddWidget("Realm")?
+                .AddCustomMarker(new ElementBinding<string>("Current Realm"))
+                .AddCustomMarker(currentRealmName)
+                .AddCustomMarker(new ElementBinding<string>("Current Lambdas Catalyst"))
+                .AddCustomMarker(currentCatalystLambdas)
+                .AddCustomMarker(new ElementBinding<string>("Current Content Catalyst"))
+                .AddCustomMarker(currentCatalystContent);
+        }
+
+        public void UpdateRealmName(string newRealm, string catalystLambdas, string catalystContent)
+        {
+            currentRealmName.Value = newRealm;
+            currentCatalystLambdas.Value = catalystLambdas;
+            currentCatalystContent.Value = catalystContent;
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigatorDebugView.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigatorDebugView.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 56afb9b0b7eb461cb22fa60a6b63b641
+timeCreated: 1730481850


### PR DESCRIPTION
## What does this PR change?

`peer-testing.decentraland.org` is a new testing environment. 

- This environment allows creators who own land in the Ethereum blockchain to deploy content without deploying to the production (`org`) environment, therefore overriding the production content only on those parcels.
- The `un-overriden` parcels still show the production content

So, what this PR does

1. Adds support for `.today` environment. 
- It will connect to [peer-testing.decentraland.org/](http://peer-testing.decentraland.org/about) only since its the only valid test environment with comms configuration
- It will grab asset bundles from the `.today` environment
- All other URLs remains pointing to `.org`, since they should replicate the behaviour there

2. Introduces some rigidness for environments based on the `dclenv` argument. 
- If you start with `today`, you wont be able to teleport to other realms. `today` can only be tested in `peer-testing.decentraland.org/` since its the only one with a valid comms configuration
- If you start with `zone`, you wont be able to teleport to worlds or other realms that are not `.zone`. This avoids possible conflicts after the initials configuration with `DecentralandURLSources`
- If you start with `org`, you wont be able to teleport to other realms that are not `.org`. This avoids possible conflicts after the initials configuration with `DecentralandURLSources`

We could remove this rigidness on another PR, but until we do, this is a more clear approach

3. Brings back the current realm to the debug panel; and add catalyst information for better debugging

<img width="264" alt="image" src="https://github.com/user-attachments/assets/c8f5bcbe-93a9-4908-aa7b-788e0b66e65e">


## How to test the changes?

Start with the environment you want to test by using the arg `--dclenv environment`; where environment is `org`, `zone` or `today`.

1. Ask the content team to see where they deployed a scene in the `today`. Check that the content is visible; and check that you see other users. Try to teleport to another realm or world. Everything should be blocked
2. Start in `zone`. Walk around zone, you shouldn't see production content. Terrain should be okay and not overlapping scenes (as scene on [2468](https://github.com/decentraland/unity-explorer/pull/2648)). Try to teleport to another realm that is not `.zone` or world. Everything should be blocked.
3. Start in `org`. Do the same checks as in `zone`. Try to teleport to another realm that is not `.org`. Everything should be blocked. You should be able to teleport to worlds just fine
4. Start without environment variables. You should be in the same state as starting in `org`

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

