### PR TITLE
fix: fixed suppress error in satellite map chunk download

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkController.cs
@@ -2,6 +2,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.MapRenderer.ComponentsFactory;
+using DCL.Utilities.Extensions;
 using DCL.WebRequests;
 using DG.Tweening;
 using System.Threading;
@@ -64,10 +65,10 @@ namespace DCL.MapRenderer.MapLayers.Atlas.SatelliteAtlas
             atlasChunk.MainSpriteRenderer.color = INITIAL_COLOR;
             var url = $"{CHUNKS_API}{chunkId.x}%2C{chunkId.y}.jpg";
 
-            Texture2D texture = (await webRequestController.GetTextureAsync(new CommonArguments(URLAddress.FromString(url)),
-                new GetTextureArguments(false), GetTextureWebRequest.CreateTexture(TextureWrapMode.Clamp, FilterMode.Trilinear)
-                                                                    .SuppressExceptionsWithFallback(Texture2D.whiteTexture, reportContext: ReportCategory.UI),
-                linkedCts.Token, ReportCategory.UI))!;
+            var textureTask = webRequestController.GetTextureAsync(new CommonArguments(URLAddress.FromString(url)),
+                new GetTextureArguments(false), GetTextureWebRequest.CreateTexture(TextureWrapMode.Clamp, FilterMode.Trilinear),
+                linkedCts.Token, ReportCategory.UI);
+            var texture = await textureTask!.SuppressExceptionWithFallbackAsync(Texture2D.whiteTexture, SuppressExceptionWithFallback.Behaviour.SuppressAnyException, reportData: ReportCategory.UI)!;
 
             textureContainer.AddChunk(chunkId, texture);
 


### PR DESCRIPTION
## What does this PR change?

This PR fixed a bug in the suppress error for the satellite map chunks download, so that the client keeps working even if the map is not succesfully downloaded

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Verify that it works correctly
3. If map is not visible the explorer should work anyway

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

