### PR TITLE
Fix/GP Colliders issue

### DIFF
--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Systems/ConfigureGltfContainerColliders.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Systems/ConfigureGltfContainerColliders.cs
@@ -19,6 +19,8 @@ namespace ECS.Unity.GLTFContainer.Systems
 
         internal static void SetupInvisibleColliders(ref GltfContainerComponent component, GltfContainerAsset asset)
         {
+            if (asset.InvisibleColliders.Count == 0) return;
+
             // Invisible colliders are contained in the asset by default (not instantiation on demand needed)
             if (component.InvisibleMeshesCollisionMask != ColliderLayer.ClNone)
                 EnableColliders(asset.InvisibleColliders, component.InvisibleMeshesCollisionMask);

--- a/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
@@ -2,7 +2,8 @@
 using Arch.System;
 using Arch.SystemGroups;
 using DCL.ECSComponents;
-using DCL.Time;
+using DCL.TimeR;
+using DCL.TimeR;
 using ECS.Abstract;
 using ECS.Groups;
 using ECS.Prioritization.Components;
@@ -123,7 +124,7 @@ namespace ECS.Unity.SceneBoundsChecker
                     // While the collider remains inactive, the bounds will continue to be zero, causing incorrect calculations.
                     // Therefore, it is necessary to force the collider to be activated at least once
                     sdkCollider.ForceActiveBySceneBounds(auxiliaryBounds.extents == Vector3.zero
-                                                         || (auxiliaryBounds.max.y <= sceneGeometry.Height && sceneGeometry.CircumscribedPlanes.Contains(auxiliaryBounds)));
+                                                         || (auxiliaryBounds.max.y <= sceneGeometry.Height && sceneGeometry.CircumscribedPlanes.Contains(sdkCollider.Collider.bounds)));
 
                     // write the structure back
                     colliders[i] = sdkCollider;


### PR DESCRIPTION
## What does this PR change?

The issue was that the colliders on GP were not being re-enabled after returning to it after a transition from LODS->Scene. This was a silly issue caused by the reuse of the `auxiliaryBounds` Bounds, where we were only setting the extents, but not the bounds themselves, so when this check came `sceneGeometry.CircumscribedPlanes.Contains(auxiliaryBounds)` it would return false sometimes because the bounds there were calculated according to the extents, not the real bounds... So the fix is to just use the real bounds of the collider for this check like -> `sceneGeometry.CircumscribedPlanes.Contains(sdkCollider.Collider.bounds)`
Also I made a small optimization on the `SetupInvisibleColliders` method in the `ConfigureGltfContainerColliders` class to avoid doing some calculations when there are no colliders to Enable.

## How to test the changes?

Follow the steps on this pretty ticket here -> #2265 
Just go outside GP, wait until the LOD replaces it and go back. Now everything it should have colliders instead of being passthrough 😁 

