### PR TITLE
fix: sdk video event time propagation

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/MediaPlayerComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/MediaPlayerComponent.cs
@@ -17,6 +17,7 @@ namespace DCL.SDKComponents.MediaStream
         public bool IsFromContentServer;
         public VideoState State { get; private set; }
         public VideoState LastPropagatedState;
+        public float LastPropagatedVideoTime;
         public double PreviousCurrentTimeChecked;
         public float LastStateChangeTime { get; private set; }
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs
@@ -95,6 +95,7 @@ namespace DCL.SDKComponents.MediaStream
                 IsFromContentServer = url.Contains(CONTENT_SERVER_PREFIX),
                 PreviousCurrentTimeChecked = -1,
                 LastPropagatedState = VideoState.VsPaused,
+                LastPropagatedVideoTime = 0,
                 Cts = new CancellationTokenSource(),
                 OpenMediaPromise = new OpenMediaPromise(),
             };

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/VideoEventsSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/VideoEventsSystem.cs
@@ -59,9 +59,10 @@ namespace DCL.SDKComponents.MediaStream
 
         private void PropagateStateInVideoEvent(in CRDTEntity sdkEntity, ref MediaPlayerComponent mediaPlayer)
         {
-            if (mediaPlayer.LastPropagatedState == mediaPlayer.State) return;
+            if (mediaPlayer.LastPropagatedState == mediaPlayer.State && mediaPlayer.LastPropagatedVideoTime.Equals(mediaPlayer.CurrentTime)) return;
 
             mediaPlayer.LastPropagatedState = mediaPlayer.State;
+            mediaPlayer.LastPropagatedVideoTime = mediaPlayer.CurrentTime;
             ecsToCRDTWriter.AppendMessage<PBVideoEvent, (MediaPlayerComponent mediaPlayer, uint timestamp)>
             (
                 prepareMessage: static (pbVideoEvent, data) =>


### PR DESCRIPTION
### WHY
Currently we are avoiding propagating a new state of the `VideoEvent` component to the scene when the `VideoState`doesn't change, but that is wrong because the `CurrentTime` property should still be propagated for the scene to use it (example: the video state keeps being "Playing" and we never update the video time again because the state doesn't change...).

### WHAT
Added tracking for last propagated video time and added that to the check in which we avoid propagating unnecessary video events to the scene.

### QA TEST STEPS

1. Download [test scene](https://github.com/user-attachments/files/17660671/video-time-test.zip) and uncompress it somewhere
2. Enter the scene root folder and run `npm i` and then `npm run start -- --explorer-alpha`
3. When the Explorer opens and finishes loading the scene, get in front of the video screen and click the cube to start the video, confirm that the video time is not being propagated into the scene UI as shown in the video:

https://github.com/user-attachments/assets/0edf9ceb-7fff-476a-a881-324483c8fec1

4. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
5. Download the build from this PR and connect it to the running scene using [the console command](https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene) according to your OS
7. Once the scene loads, get in front of the video screen and click the cube to start the video.
8. Align the UI (best done in first person view) with the video timer and confirm that now the video time gets propagated into the scene. **Please look at it for more than 60 seconds, to make sure the time doesn't get de-synched**.

Video demo:

https://github.com/user-attachments/assets/1a4bd3fc-e1fd-4096-8559-aab049436116

