### PR TITLE
chore: add open support tracking event

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
@@ -30,6 +30,7 @@
         {
             public const string MESSAGE_SENT = "chat_message_sent";
             public const string BUBBLE_SWITCHED = "chat_bubble_switched";
+            public const string OPEN_SUPPORT = "open_support";
         }
 
         public static class Profile

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DCL.Analytics.asmdef
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DCL.Analytics.asmdef
@@ -27,7 +27,8 @@
         "GUID:543b8f091a5947a3880b7f2bca2358bd",
         "GUID:e11871a9242c44ec98ed3459ff7781d9",
         "GUID:8baf705856414dad9a73b3f382f1bc8b",
-        "GUID:254c118155004a75a699a9410d44311f"
+        "GUID:254c118155004a75a699a9410d44311f",
+        "GUID:ca926b7b13255b84199c21c5e2d9dfa4"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/MVCManagerAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/MVCManagerAnalyticsDecorator.cs
@@ -3,6 +3,7 @@ using DCL.AuthenticationScreenFlow;
 using DCL.Chat;
 using DCL.ExplorePanel;
 using DCL.Passport;
+using DCL.UI.Sidebar;
 using MVC;
 using System;
 using System.Collections.Generic;
@@ -32,6 +33,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
                 { typeof(ExplorePanelController), CreateAnalytics<ExplorePanelController>(c => new MapEventsAnalytics(analytics, c.NavmapController)) },
                 { typeof(PassportController), CreateAnalytics<PassportController>(c => new PassportAnalytics(analytics, c)) },
                 { typeof(AuthenticationScreenController), CreateAnalytics<AuthenticationScreenController>(c => new AuthenticationScreenAnalytics(analytics, c)) },
+                { typeof(SidebarController), CreateAnalytics<SidebarController>(c => new SupportAnalytics(analytics, c)) },
             };
 
             Func<IController, IDisposable> CreateAnalytics<T>(Func<T, IDisposable> factory) where T: IController =>

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/SupportAnalytics.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/SupportAnalytics.cs
@@ -1,0 +1,29 @@
+﻿using DCL.UI.Sidebar;
+using System;
+
+namespace DCL.PerformanceAndDiagnostics.Analytics
+{
+    public class SupportAnalytics : IDisposable
+    {
+        private readonly IAnalyticsController analytics;
+        private readonly SidebarController sidebarController;
+
+        public SupportAnalytics(IAnalyticsController analytics, SidebarController sidebarController)
+        {
+            this.analytics = analytics;
+            this.sidebarController = sidebarController;
+
+            this.sidebarController.HelpOpened += OnHelpOpened;
+        }
+
+        public void Dispose()
+        {
+            sidebarController.HelpOpened -= OnHelpOpened;
+        }
+
+        private void OnHelpOpened()
+        {
+            analytics.Track(AnalyticsEvents.UI.OPEN_SUPPORT);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/SupportAnalytics.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/SupportAnalytics.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 405796d6462446fa9329bd4e371b8bea
+timeCreated: 1730991363

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
@@ -11,6 +11,7 @@ using DCL.SidebarBus;
 using DCL.UI.ProfileElements;
 using DCL.Web3.Identities;
 using MVC;
+using System;
 using System.Threading;
 using Utility;
 
@@ -31,6 +32,8 @@ namespace DCL.UI.Sidebar
 
         private CancellationTokenSource profileWidgetCts = new ();
         private CancellationTokenSource systemMenuCts = new ();
+
+        public event Action? HelpOpened;
 
         public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Persistent;
 
@@ -88,8 +91,11 @@ namespace DCL.UI.Sidebar
             viewInstance.sidebarSettingsWidget.OnViewHidden += OnSidebarSettingsClosed;
         }
 
-        private void OnHelpButtonClicked() =>
+        private void OnHelpButtonClicked()
+        {
             webBrowser.OpenUrl(DecentralandUrl.Help);
+            HelpOpened?.Invoke();
+        }
 
         private void OnAutoHideToggleChanged(bool value)
         {


### PR DESCRIPTION
## What does this PR change?

This PR add tracking event when users clicks on the help button. 
Closing #2728 
## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Click help button
3. The user should get redirected to the help page

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

