### PR TITLE
feature: add feature flag to control skybox settings

### DIFF
--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -15,5 +15,7 @@
         public const string WALLETS_VARIANT = "wallet";
         public const string ONBOARDING = "onboarding";
         public const string ONBOARDING_ENABLED_VARIANT = "enabled";
+        public const string SKYBOX_SETTINGS = "alfa-skybox-settings";
+        public const string SKYBOX_SETTINGS_VARIANT = "settings";
     }
 }

--- a/Explorer/Assets/DCL/SkyBox/Plugin/TimeOfDaySystem.cs
+++ b/Explorer/Assets/DCL/SkyBox/Plugin/TimeOfDaySystem.cs
@@ -92,9 +92,9 @@ namespace DCL.SkyBox
 
             light.transform.localRotation = output.LightRotation;
             //light.intensity = output.LightIntensity;
-            Color ambientSkyColor = new Color((float)125 / 255, (float)136 / 255, (float)159 / 255);
-            Color ambientEquatorColor = new Color((float)170 / 255, (float)197 / 255, (float)178 / 255);
-            Color ambientGroundColor = new Color((float)12 / 255, (float)9 / 255, (float)3 / 255);
+            //Color ambientSkyColor = new Color((float)125 / 255, (float)136 / 255, (float)159 / 255);
+            //Color ambientEquatorColor = new Color((float)170 / 255, (float)197 / 255, (float)178 / 255);
+            //Color ambientGroundColor = new Color((float)12 / 255, (float)9 / 255, (float)3 / 255);
             // RenderSettings.ambientSkyColor = ambientSkyColor * output.LightIntensity;
             // RenderSettings.ambientEquatorColor = ambientEquatorColor * output.LightIntensity;
             // RenderSettings.ambientGroundColor = ambientGroundColor * output.LightIntensity;

--- a/Explorer/Assets/DCL/StylizedSkybox/Scripts/Plugin/StylizedSkyboxPlugin.cs
+++ b/Explorer/Assets/DCL/StylizedSkybox/Scripts/Plugin/StylizedSkyboxPlugin.cs
@@ -4,6 +4,7 @@ using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
 using DCL.DebugUtilities;
 using DCL.DebugUtilities.UIBindings;
+using DCL.FeatureFlags;
 using DCL.PluginSystem;
 using DCL.PluginSystem.Global;
 using System;
@@ -21,17 +22,20 @@ namespace DCL.StylizedSkybox.Scripts.Plugin
         private readonly IDebugContainerBuilder debugContainerBuilder;
         private SkyboxController? skyboxController;
         private readonly ElementBinding<int> timeOfDay;
+        private readonly FeatureFlagsCache featureFlagsCache;
 
         public StylizedSkyboxPlugin(
             IAssetsProvisioner assetsProvisioner,
             Light directionalLight,
-            IDebugContainerBuilder debugContainerBuilder
+            IDebugContainerBuilder debugContainerBuilder,
+            FeatureFlagsCache featureFlagsCache
         )
         {
             timeOfDay = new ElementBinding<int>(0);
             this.assetsProvisioner = assetsProvisioner;
             this.directionalLight = directionalLight;
             this.debugContainerBuilder = debugContainerBuilder;
+            this.featureFlagsCache = featureFlagsCache;
         }
 
         public void Dispose() { }
@@ -43,7 +47,7 @@ namespace DCL.StylizedSkybox.Scripts.Plugin
             skyboxController = Object.Instantiate((await assetsProvisioner.ProvideMainAssetAsync(settings.StylizedSkyboxPrefab, ct: ct)).Value.GetComponent<SkyboxController>());
             AnimationClip skyboxAnimation = (await assetsProvisioner.ProvideMainAssetAsync(settings.SkyboxAnimationCycle, ct: ct)).Value;
 
-            skyboxController.Initialize(settings.SkyboxMaterial, directionalLight, skyboxAnimation);
+            skyboxController.Initialize(settings.SkyboxMaterial, directionalLight, skyboxAnimation, featureFlagsCache);
 
             debugContainerBuilder.TryAddWidget("Skybox")
                                  ?.AddSingleButton("Play", () => skyboxController.Play())

--- a/Explorer/Assets/DCL/StylizedSkybox/Scripts/SkyboxController.cs
+++ b/Explorer/Assets/DCL/StylizedSkybox/Scripts/SkyboxController.cs
@@ -61,10 +61,6 @@ public class SkyboxController : MonoBehaviour
     private bool pause;
     private float sinceLastRefresh = 5;
 
-    private void Start()
-    {
-    }
-
     private void Update()
     {
         if (!isInitialized)
@@ -136,24 +132,18 @@ public class SkyboxController : MonoBehaviour
             RenderSettings.fog = true;
         }
 
-        bool useRemoteSkyboxSettings = featureFlagsCache != null && featureFlagsCache.Configuration.IsEnabled("alfa-skybox-settings");
+        bool useRemoteSkyboxSettings = featureFlagsCache != null && featureFlagsCache.Configuration.IsEnabled(FeatureFlagsStrings.SKYBOX_SETTINGS);
+
+        if (useRemoteSkyboxSettings &&
+            featureFlagsCache.Configuration.TryGetJsonPayload(FeatureFlagsStrings.SKYBOX_SETTINGS, FeatureFlagsStrings.SKYBOX_SETTINGS_VARIANT, out SkyboxSettings skyboxSettings))
+        {
+            Speed = skyboxSettings.speed;
+            ApplySkyboxState(skyboxSettings.time);
+            return;
+        }
 
         int defaultTime = SecondsInDay / 2;
-
-        if (!useRemoteSkyboxSettings)
-        {
-            ApplySkyboxState(defaultTime);
-            return;
-        }
-
-        if (!featureFlagsCache.Configuration.TryGetJsonPayload("alfa-skybox-settings", "settings", out SkyboxSettings skyboxSettings))
-        {
-            ApplySkyboxState(defaultTime);
-            return;
-        }
-
-        Speed = skyboxSettings.speed;
-        ApplySkyboxState(skyboxSettings.time);
+        ApplySkyboxState(defaultTime);
     }
 
     private void ApplySkyboxState(float time)

--- a/Explorer/Assets/DCL/StylizedSkybox/StylizedSkybox.asmdef
+++ b/Explorer/Assets/DCL/StylizedSkybox/StylizedSkybox.asmdef
@@ -6,7 +6,8 @@
         "GUID:101b8b6ebaf64668909b49c4b7a1420d",
         "GUID:15fc0a57446b3144c949da3e2b9737a9",
         "GUID:df380645f10b7bc4b97d4f5eb6303d95",
-        "GUID:3640f3c0b42946b0b8794a1ed8e06ca5"
+        "GUID:3640f3c0b42946b0b8794a1ed8e06ca5",
+        "GUID:ace653ac543d483ba8abee112a3ba2a6"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -572,7 +572,7 @@ namespace Global.Dynamic
                 new CharacterPreviewPlugin(staticContainer.ComponentsContainer.ComponentPoolsRegistry, assetsProvisioner, staticContainer.CacheCleaner),
                 new WebRequestsPlugin(staticContainer.WebRequestsContainer.AnalyticsContainer, debugBuilder),
                 new Web3AuthenticationPlugin(assetsProvisioner, dynamicWorldDependencies.Web3Authenticator, debugBuilder, container.MvcManager, selfProfile, webBrowser, staticContainer.RealmData, identityCache, characterPreviewFactory, dynamicWorldDependencies.SplashScreen, audioMixerVolumesController, staticContainer.FeatureFlagsCache, characterPreviewEventBus, globalWorld),
-                new StylizedSkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, debugBuilder),
+                new StylizedSkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, debugBuilder, staticContainer.FeatureFlagsCache),
                 new LoadingScreenPlugin(assetsProvisioner, container.MvcManager, audioMixerVolumesController,
                     staticContainer.InputBlock, debugBuilder, staticContainer.LoadingStatus),
                 new ExternalUrlPromptPlugin(assetsProvisioner, webBrowser, container.MvcManager, dclCursor),


### PR DESCRIPTION
## What does this PR change?

Added a couple of settings that we read from the FF to handle the skybox.
For now its only the initial time and the speed, but in the future we can easily expand it to handle other settings we would wanna tweak remotely.

...

## How to test the changes?

You can set the settings through here  (as long as you have the proper permissions xD) ->
https://features.decentraland.systems/#/features/variants/explorer-alfa-skybox-settings

Otherwise, the value I set right now is time of day 0 (midnight) and speed 300 (10 times faster than normal).

In the new settings <time> represents in seconds the hour of the day, 0 being 0:00:00 hs and 86400 being 23:59:59hs. 
<speed> represents how much we accelerate the clock, the default value is 30 (so one minute = 2 seconds), higher value means shorter days and viceversa. 1 represents real time.

Keep in mind that the changes to the feature flags ONLY apply during game start (so changing them wont change the time of a user already logged in)

This implements this -> #2725 