### PR TITLE
feature: set forced Genesis default starting parcel from feature flags

### DIFF
--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -12,8 +12,10 @@
         public const string CUSTOM_MAP_PINS_ICONS = "alfa-map-pins-custom-icons";
         public const string USER_ALLOW_LIST = "user-allow-list";
         public const string CSV_VARIANT = "csv-variant";
+        public const string STRING_VARIANT = "string-variant";
         public const string WALLETS_VARIANT = "wallet";
         public const string ONBOARDING = "onboarding";
         public const string ONBOARDING_ENABLED_VARIANT = "enabled";
+        public const string GENESIS_STARTING_PARCEL = "alfa-genesis-spawn-parcel";
     }
 }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/Realm.asmdef
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/Realm.asmdef
@@ -8,7 +8,8 @@
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:04c3e7e2f3374472f84666dc489d6cd2",
         "GUID:1b8e1e1bd01505f478f0369c04a4fb2f",
-        "GUID:fa7b3fdbb04d67549916da7bd2af58ab"
+        "GUID:fa7b3fdbb04d67549916da7bd2af58ab",
+        "GUID:ace653ac543d483ba8abee112a3ba2a6"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -352,7 +352,8 @@ namespace Global.Dynamic
                 localSceneDevelopment,
                 staticContainer.LoadingStatus,
                 staticContainer.CacheCleaner,
-                staticContainer.SingletonSharedDependencies.MemoryBudget);
+                staticContainer.SingletonSharedDependencies.MemoryBudget,
+                staticContainer.FeatureFlagsCache);
 
             IHealthCheck livekitHealthCheck = bootstrapContainer.DebugSettings.EnableEmulateNoLivekitConnection
                 ? new IHealthCheck.AlwaysFails("Livekit connection is in debug, always fail mode")

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmHelper.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmHelper.cs
@@ -1,0 +1,27 @@
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace Global.Dynamic
+{
+    public static class RealmHelper
+    {
+        public static bool TryParseParcelFromString(string? positionString, out Vector2Int parcel)
+        {
+            parcel = Vector2Int.zero;
+
+            if (string.IsNullOrEmpty(positionString)) return false;
+
+            MatchCollection matches = new Regex(@"-*\d+").Matches(positionString);
+
+            if (matches.Count > 1)
+            {
+                parcel.x = int.Parse(matches[0].Value);
+                parcel.y = int.Parse(matches[1].Value);
+                return true;
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmHelper.cs.meta
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 12766af217cd4236a678abe112eb4d83
+timeCreated: 1731273263

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmLaunchSettings.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmLaunchSettings.cs
@@ -136,17 +136,7 @@ namespace Global.Dynamic
 
         private void ParsePositionAppParameter(string targetPositionParam)
         {
-            if (string.IsNullOrEmpty(targetPositionParam)) return;
-
-            Vector2Int targetPosition = Vector2Int.zero;
-
-            MatchCollection matches = new Regex(@"-*\d+").Matches(targetPositionParam);
-
-            if (matches.Count > 1)
-            {
-                targetPosition.x = int.Parse(matches[0].Value);
-                targetPosition.y = int.Parse(matches[1].Value);
-            }
+            if (!RealmHelper.TryParseParcelFromString(targetPositionParam, out var targetPosition)) return;
 
             targetScene = targetPosition;
         }


### PR DESCRIPTION
## What does this PR change?

This adds support for a FF that has new parcel coordinates for starting in Genesis City, instead of the default 0,0.
This re-direct should happen whenever a user teleports to Genesis without choosing a custom parcel.
...

## How to test the changes?

Using this feature flag -> https://features.decentraland.systems/#/features/strategies/explorer-alfa-genesis-spawn-parcel
You can switch the starting parcel, then the game will see what Scene it falls into and depending on that, spawn the player in the proper spawn point of that scene.