### PR TITLE
feat: added parcel view and map type selector logic

### DIFF
--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrl.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrl.cs
@@ -13,6 +13,8 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
         PrivacyPolicy,
         TermsOfUse,
 
+        ApiChunks,
+
         ApiPlaces,
         POI,
         PlacesByCategory,

--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
@@ -73,6 +73,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.ApiEvents => $"https://events.decentraland.{ENV}/api/events",
                 DecentralandUrl.OpenSea => $"https://opensea.decentraland.{ENV}",
                 DecentralandUrl.Host => $"https://decentraland.{ENV}",
+                DecentralandUrl.ApiChunks => $"https://api.decentraland.{ENV}/v1/map.png",
                 DecentralandUrl.PeerAbout => $"https://peer.decentraland.{ENV}/about",
                 DecentralandUrl.DAO => $"https://decentraland.{ENV}/dao/",
                 DecentralandUrl.Notification => $"https://notifications.decentraland.{ENV}/notifications",

--- a/Explorer/Assets/DCL/MapRenderer/Addressables/MapRendererConfiguration.prefab
+++ b/Explorer/Assets/DCL/MapRenderer/Addressables/MapRendererConfiguration.prefab
@@ -218,7 +218,7 @@ Transform:
   m_Children:
   - {fileID: 2512951518552392734}
   - {fileID: 6230479589610019337}
-  - {fileID: 7964758222206947239}
+  - {fileID: 1705380967094917977}
   - {fileID: 1137272574085786475}
   - {fileID: 5609044988966314515}
   - {fileID: 3920442518738607191}
@@ -244,6 +244,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c1518fa59fec409ea8f6ff340ffff185, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  <AtlasRoot>k__BackingField: {fileID: 1705380967094917977}
   <SatelliteAtlasRoot>k__BackingField: {fileID: 1137272574085786475}
   <ColdUserMarkersRoot>k__BackingField: {fileID: 5609044988966314515}
   <HotUserMarkersRoot>k__BackingField: {fileID: 3920442518738607191}
@@ -319,6 +320,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 5694240695484966351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5523592907632312957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1705380967094917977}
+  m_Layer: 27
+  m_Name: ParcelAtlas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1705380967094917977
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5523592907632312957}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5694240695484966351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5638601633516325390
 GameObject:
   m_ObjectHideFlags: 0
@@ -373,37 +405,6 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6366793694737368896}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5694240695484966351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6670063525065793327
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7964758222206947239}
-  m_Layer: 27
-  m_Name: Atlas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7964758222206947239
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6670063525065793327}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererConfiguration.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererConfiguration.cs
@@ -8,6 +8,9 @@ namespace DCL.MapRenderer.ComponentsFactory
     public class MapRendererConfiguration : MonoBehaviour
     {
         [field: SerializeField]
+        public Transform AtlasRoot { get; private set; }
+
+        [field: SerializeField]
         public Transform SatelliteAtlasRoot { get; private set; }
 
         [field: SerializeField]

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas.meta
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2ad177b75f2443528c781a97ae773fa6
+timeCreated: 1731337630

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkAtlasController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkAtlasController.cs
@@ -1,0 +1,97 @@
+using Cysharp.Threading.Tasks;
+using DCL.MapRenderer.CoordsUtils;
+using DCL.MapRenderer.Culling;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+
+namespace DCL.MapRenderer.MapLayers.Atlas
+{
+    internal class ParcelChunkAtlasController : MapLayerControllerBase, IAtlasController
+    {
+        public delegate UniTask<IChunkController> ChunkBuilder(Vector3 chunkLocalPosition, Vector2Int coordsCenter, Transform parent, CancellationToken ct);
+
+        public const int CHUNKS_CREATED_PER_BATCH = 5;
+
+        private readonly int chunkSize;
+        private readonly int parcelsInsideChunk;
+        private readonly ChunkBuilder chunkBuilder;
+        private readonly List<IChunkController> chunks;
+
+        private int parcelSize => coordsUtils.ParcelSize;
+
+        public ParcelChunkAtlasController(Transform parent, int chunkSize,
+            ICoordsUtils coordsUtils, IMapCullingController cullingController, ChunkBuilder chunkBuilder)
+            : base(parent, coordsUtils, cullingController)
+        {
+            this.chunkSize = chunkSize;
+            this.chunkBuilder = chunkBuilder;
+
+            var worldSize = ((Vector2)coordsUtils.WorldMaxCoords - coordsUtils.WorldMinCoords) * parcelSize;
+            var chunkAmounts = new Vector2Int(Mathf.CeilToInt(worldSize.x / this.chunkSize), Mathf.CeilToInt(worldSize.y / this.chunkSize));
+            chunks = new List<IChunkController>(chunkAmounts.x * chunkAmounts.y);
+            parcelsInsideChunk = Mathf.Max(1, chunkSize / parcelSize);
+        }
+
+        public async UniTask InitializeAsync(CancellationToken ct)
+        {
+            var linkedCt = CancellationTokenSource.CreateLinkedTokenSource(ctsDisposing.Token, ct).Token;
+
+            ClearCurrentChunks();
+            float halfParcelSize = parcelSize * 0.5f;
+
+            List<UniTask<IChunkController>> chunksCreating = new List<UniTask<IChunkController>>(CHUNKS_CREATED_PER_BATCH);
+
+            for (int i = coordsUtils.WorldMinCoords.x; i <= coordsUtils.WorldMaxCoords.x; i += parcelsInsideChunk)
+            {
+                for (int j = coordsUtils.WorldMinCoords.y; j <= coordsUtils.WorldMaxCoords.y; j += parcelsInsideChunk)
+                {
+                    if (chunksCreating.Count >= CHUNKS_CREATED_PER_BATCH)
+                    {
+                        chunks.AddRange(await UniTask.WhenAll(chunksCreating));
+                        chunksCreating.Clear();
+                    }
+
+                    Vector2Int coordsCenter = new Vector2Int(i, j);
+
+                    // Subtract half parcel size to displace the pivot, this allow easier PositionToCoords calculations.
+                    Vector3 localPosition = new Vector3((parcelSize * i) - halfParcelSize, (parcelSize * j) - halfParcelSize, 0);
+
+                    var instance = chunkBuilder.Invoke(chunkLocalPosition: localPosition, coordsCenter, instantiationParent, linkedCt);
+                    chunksCreating.Add(instance);
+                }
+            }
+
+            if (chunksCreating.Count >= 0)
+            {
+                chunks.AddRange(await UniTask.WhenAll(chunksCreating));
+                chunksCreating.Clear();
+            }
+        }
+
+        private void ClearCurrentChunks()
+        {
+            foreach (IChunkController chunk in chunks)
+                chunk.Dispose();
+
+            chunks.Clear();
+        }
+
+        protected override void DisposeImpl()
+        {
+            ClearCurrentChunks();
+        }
+
+        UniTask IMapLayerController.Enable(CancellationToken cancellationToken)
+        {
+            instantiationParent.gameObject.SetActive(true);
+            return UniTask.CompletedTask;
+        }
+
+        UniTask IMapLayerController.Disable(CancellationToken cancellationToken)
+        {
+            instantiationParent.gameObject.SetActive(false);
+            return UniTask.CompletedTask;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkAtlasController.cs.meta
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkAtlasController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d781855523e045e49544661a25dc8ad1
+timeCreated: 1731337647

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkController.cs
@@ -1,0 +1,70 @@
+using CommunicationData.URLHelpers;
+using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.WebRequests;
+using System.Threading;
+using UnityEngine;
+using Utility;
+
+namespace DCL.MapRenderer.MapLayers.Atlas
+{
+    public class ParcelChunkController : IChunkController
+    {
+        private const int PIXELS_PER_UNIT = 50;
+
+        private readonly SpriteRenderer spriteRenderer;
+
+        private readonly IWebRequestController webRequestController;
+        private readonly IDecentralandUrlsSource decentralandUrlsSource;
+
+        private string CHUNKS_API => decentralandUrlsSource.Url(DecentralandUrl.ApiChunks);
+
+        public ParcelChunkController(
+            IWebRequestController webRequestController,
+            IDecentralandUrlsSource decentralandUrlsSource,
+            SpriteRenderer prefab,
+            Vector3 chunkLocalPosition,
+            Vector2Int coordsCenter,
+            Transform parent
+        )
+        {
+            this.webRequestController = webRequestController;
+            this.decentralandUrlsSource = decentralandUrlsSource;
+
+            spriteRenderer = Object.Instantiate(prefab, parent);
+#if UNITY_EDITOR
+            spriteRenderer.gameObject.name = $"Chunk {coordsCenter.x},{coordsCenter.y}";
+#endif
+            Transform transform = spriteRenderer.transform;
+
+            transform.localScale = Vector3.one * PIXELS_PER_UNIT;
+            transform.localPosition = chunkLocalPosition;
+        }
+
+        public void Dispose()
+        {
+            if (spriteRenderer)
+                UnityObjectUtils.SafeDestroy(spriteRenderer.gameObject);
+        }
+
+        public async UniTask LoadImageAsync(int chunkSize, int parcelSize, Vector2Int mapPosition, CancellationToken ct)
+        {
+            var url = $"{CHUNKS_API}?center={mapPosition.x},{mapPosition.y}&width={chunkSize}&height={chunkSize}&size={parcelSize}";
+
+            Texture2D texture =
+                await webRequestController.GetTextureAsync(new CommonArguments(URLAddress.FromString(url)),
+                    new GetTextureArguments(false),
+                    GetTextureWebRequest.CreateTexture(TextureWrapMode.Clamp)
+                                        .SuppressExceptionsWithFallback(Texture2D.whiteTexture, reportContext: ReportCategory.UI), ct, ReportCategory.UI);
+
+            spriteRenderer.sprite =
+                Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), VectorUtilities.OneHalf, PIXELS_PER_UNIT, 0, SpriteMeshType.FullRect, Vector4.one, false);
+        }
+
+        public void SetDrawOrder(int order)
+        {
+            spriteRenderer.sortingOrder = order;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkController.cs.meta
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e839da7df09f450290c60f4efeb8af18
+timeCreated: 1731337670

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/MapLayer.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/MapLayer.cs
@@ -7,6 +7,7 @@ namespace DCL.MapRenderer.MapLayers
     public enum MapLayer
     {
         None,
+        ParcelsAtlas = 1,
         SatelliteAtlas = 1 << 1,
         ScenesOfInterest = 1 << 3,
         HotUsersMarkers = 1 << 4,

--- a/Explorer/Assets/DCL/Navmap/Assets/FiltersContainer.prefab
+++ b/Explorer/Assets/DCL/Navmap/Assets/FiltersContainer.prefab
@@ -1027,7 +1027,7 @@ GameObject:
   - component: {fileID: 6828311989852796747}
   - component: {fileID: 1759737050753820564}
   - component: {fileID: 8543187336464388907}
-  - component: {fileID: 2378586389848250059}
+  - component: {fileID: 8453302727989527501}
   m_Layer: 5
   m_Name: Parcel
   m_TagString: Untagged
@@ -1048,6 +1048,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6971537159535640398}
+  - {fileID: 5917304412092776076}
   m_Father: {fileID: 2160334673304586875}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1093,7 +1094,7 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &2378586389848250059
+--- !u!114 &8453302727989527501
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1102,7 +1103,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1492058447442673321}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -1134,9 +1135,13 @@ MonoBehaviour:
     m_DisabledTrigger: Disabled
   m_Interactable: 1
   m_TargetGraphic: {fileID: 8543187336464388907}
-  m_OnClick:
+  toggleTransition: 1
+  graphic: {fileID: 0}
+  m_Group: {fileID: 8192593615125694294}
+  onValueChanged:
     m_PersistentCalls:
       m_Calls: []
+  m_IsOn: 0
 --- !u!1 &1668229819691209829
 GameObject:
   m_ObjectHideFlags: 0
@@ -2147,8 +2152,10 @@ MonoBehaviour:
   favoritesToggle: {fileID: 1386078261693798373}
   poisToggle: {fileID: 6014701182686629457}
   peopleToggle: {fileID: 5474851314465079333}
-  satelliteButton: {fileID: 8679033338586892109}
-  parcelButton: {fileID: 2378586389848250059}
+  satelliteButton: {fileID: 5117286241236820275}
+  satelliteButtonHighlight: {fileID: 4588498124397608187}
+  parcelButton: {fileID: 8453302727989527501}
+  parcelButtonHighlight: {fileID: 9181117658965186628}
   <OpenAudio>k__BackingField: {fileID: 11400000, guid: ed99255f331fdd34c92d271fbbaddfb2, type: 2}
   <CloseAudio>k__BackingField: {fileID: 11400000, guid: 4cd70dff1a2f8374faad51b696201090, type: 2}
   <ToggleOnAudio>k__BackingField: {fileID: 11400000, guid: bbf6fdc100a3def44853fe48acbf4fd5, type: 2}
@@ -2161,7 +2168,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2873273918354832599}
   m_Enabled: 1
-  m_Alpha: 0.91
+  m_Alpha: 1
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
@@ -2280,7 +2287,7 @@ GameObject:
   - component: {fileID: 2360532852920986821}
   - component: {fileID: 8167201991114731043}
   - component: {fileID: 4886887869861241499}
-  - component: {fileID: 8679033338586892109}
+  - component: {fileID: 5117286241236820275}
   m_Layer: 5
   m_Name: Satellite
   m_TagString: Untagged
@@ -2301,6 +2308,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7175122030162333864}
+  - {fileID: 3810256798117893030}
   m_Father: {fileID: 2160334673304586875}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2346,7 +2354,7 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &8679033338586892109
+--- !u!114 &5117286241236820275
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2355,7 +2363,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 3187400880335987957}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -2387,9 +2395,13 @@ MonoBehaviour:
     m_DisabledTrigger: Disabled
   m_Interactable: 1
   m_TargetGraphic: {fileID: 4886887869861241499}
-  m_OnClick:
+  toggleTransition: 1
+  graphic: {fileID: 0}
+  m_Group: {fileID: 8192593615125694294}
+  onValueChanged:
     m_PersistentCalls:
       m_Calls: []
+  m_IsOn: 1
 --- !u!1 &3282114068418518688
 GameObject:
   m_ObjectHideFlags: 0
@@ -2629,7 +2641,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -32.6}
+  m_AnchoredPosition: {x: 0, y: -37.3}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1943668055227394628
@@ -3470,6 +3482,81 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4588498124397608187
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3810256798117893030}
+  - component: {fileID: 1864090028663113701}
+  - component: {fileID: 72290627809589460}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3810256798117893030
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4588498124397608187}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2360532852920986821}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1864090028663113701
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4588498124397608187}
+  m_CullTransparentMesh: 1
+--- !u!114 &72290627809589460
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4588498124397608187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.08627451, g: 0.08235294, b: 0.09411765, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4848194f7bc4d4e509d067d3160eadac, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 2
 --- !u!1 &4631552107189048511
 GameObject:
   m_ObjectHideFlags: 0
@@ -3675,7 +3762,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -32.6}
+  m_AnchoredPosition: {x: 0, y: -37.3}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8914274772688972496
@@ -4264,6 +4351,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2160334673304586875}
   - component: {fileID: 8775299550377685445}
+  - component: {fileID: 8192593615125694294}
   m_Layer: 5
   m_Name: GameObject
   m_TagString: Untagged
@@ -4318,6 +4406,19 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &8192593615125694294
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7884413949355032175}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2fafe2cfe61f6974895a912c3755e8f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AllowSwitchOff: 0
 --- !u!1 &7948082654767285871
 GameObject:
   m_ObjectHideFlags: 0
@@ -5091,6 +5192,81 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &9181117658965186628
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5917304412092776076}
+  - component: {fileID: 5112516366357595054}
+  - component: {fileID: 7262635365189358121}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5917304412092776076
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9181117658965186628}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6828311989852796747}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5112516366357595054
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9181117658965186628}
+  m_CullTransparentMesh: 1
+--- !u!114 &7262635365189358121
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9181117658965186628}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.08627451, g: 0.08235294, b: 0.09411765, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4848194f7bc4d4e509d067d3160eadac, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 2
 --- !u!1001 &220476741165683242
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Navmap/Assets/Navmap.prefab
+++ b/Explorer/Assets/DCL/Navmap/Assets/Navmap.prefab
@@ -860,7 +860,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &8235211841819826033
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Navmap/FilterPanel/NavmapFilterPanelView.cs
+++ b/Explorer/Assets/DCL/Navmap/FilterPanel/NavmapFilterPanelView.cs
@@ -58,14 +58,13 @@ namespace DCL.Navmap.FilterPanel
             peopleToggle.onValueChanged.AddListener((isOn) => OnToggleClicked(MapLayer.HotUsersMarkers, isOn));
             favoritesToggle.onValueChanged.AddListener((isOn) => OnToggleClicked(MapLayer.Favorites, isOn));
 
-            satelliteButton.onValueChanged.AddListener((isOn) => ToggleMapType(MapLayer.SatelliteAtlas, isOn));
-            parcelButton.onValueChanged.AddListener((isOn) => ToggleMapType(MapLayer.ParcelsAtlas, isOn));
+            satelliteButton.onValueChanged.AddListener(ToggleSatelliteMap);
+            parcelButton.onValueChanged.AddListener(ToggleParcelMap);
         }
 
         private void OnEnable()
         {
-            ToggleMapType(MapLayer.ParcelsAtlas, false);
-            ToggleMapType(MapLayer.SatelliteAtlas, true);
+            ToggleSatelliteMap(true);
         }
 
         public void ToggleFilterPanel(bool isOn)
@@ -76,12 +75,28 @@ namespace DCL.Navmap.FilterPanel
             UIAudioEventsBus.Instance.SendPlayAudioEvent(isOn ? OpenAudio : CloseAudio);
         }
 
-        private void ToggleMapType(MapLayer mapLayer, bool isOn)
+        private void ToggleSatelliteMap(bool isOn)
         {
-            satelliteButtonHighlight.SetActive(mapLayer == MapLayer.SatelliteAtlas && isOn);
-            parcelButtonHighlight.SetActive(mapLayer == MapLayer.ParcelsAtlas && isOn);
-            UIAudioEventsBus.Instance.SendPlayAudioEvent(isOn ? ToggleOnAudio : ToggleOffAudio);
-            OnFilterChanged?.Invoke(mapLayer, isOn);
+            if (!isOn)
+                return;
+
+            satelliteButtonHighlight.SetActive(true);
+            parcelButtonHighlight.SetActive(false);
+            UIAudioEventsBus.Instance.SendPlayAudioEvent(ToggleOnAudio);
+            OnFilterChanged?.Invoke(MapLayer.ParcelsAtlas, false);
+            OnFilterChanged?.Invoke(MapLayer.SatelliteAtlas, true);
+        }
+
+        private void ToggleParcelMap(bool isOn)
+        {
+            if (!isOn)
+                return;
+
+            satelliteButtonHighlight.SetActive(false);
+            parcelButtonHighlight.SetActive(true);
+            UIAudioEventsBus.Instance.SendPlayAudioEvent(ToggleOnAudio);
+            OnFilterChanged?.Invoke(MapLayer.SatelliteAtlas, false);
+            OnFilterChanged?.Invoke(MapLayer.ParcelsAtlas, true);
         }
 
         private void OnToggleClicked(MapLayer mapLayer, bool isOn)

--- a/Explorer/Assets/DCL/Navmap/FilterPanel/NavmapFilterPanelView.cs
+++ b/Explorer/Assets/DCL/Navmap/FilterPanel/NavmapFilterPanelView.cs
@@ -29,10 +29,16 @@ namespace DCL.Navmap.FilterPanel
         private Toggle peopleToggle;
 
         [field: SerializeField]
-        private Button satelliteButton;
+        private Toggle satelliteButton;
 
         [field: SerializeField]
-        private Button parcelButton;
+        private GameObject satelliteButtonHighlight;
+
+        [field: SerializeField]
+        private Toggle parcelButton;
+
+        [field: SerializeField]
+        private GameObject parcelButtonHighlight;
 
 
         [field: Header("Audio")]
@@ -51,6 +57,15 @@ namespace DCL.Navmap.FilterPanel
             poisToggle.onValueChanged.AddListener((isOn) => OnToggleClicked(MapLayer.ScenesOfInterest, isOn));
             peopleToggle.onValueChanged.AddListener((isOn) => OnToggleClicked(MapLayer.HotUsersMarkers, isOn));
             favoritesToggle.onValueChanged.AddListener((isOn) => OnToggleClicked(MapLayer.Favorites, isOn));
+
+            satelliteButton.onValueChanged.AddListener((isOn) => ToggleMapType(MapLayer.SatelliteAtlas, isOn));
+            parcelButton.onValueChanged.AddListener((isOn) => ToggleMapType(MapLayer.ParcelsAtlas, isOn));
+        }
+
+        private void OnEnable()
+        {
+            ToggleMapType(MapLayer.ParcelsAtlas, false);
+            ToggleMapType(MapLayer.SatelliteAtlas, true);
         }
 
         public void ToggleFilterPanel(bool isOn)
@@ -59,6 +74,14 @@ namespace DCL.Navmap.FilterPanel
             canvasGroup.blocksRaycasts = isOn;
             canvasGroup.interactable = isOn;
             UIAudioEventsBus.Instance.SendPlayAudioEvent(isOn ? OpenAudio : CloseAudio);
+        }
+
+        private void ToggleMapType(MapLayer mapLayer, bool isOn)
+        {
+            satelliteButtonHighlight.SetActive(mapLayer == MapLayer.SatelliteAtlas && isOn);
+            parcelButtonHighlight.SetActive(mapLayer == MapLayer.ParcelsAtlas && isOn);
+            UIAudioEventsBus.Instance.SendPlayAudioEvent(isOn ? ToggleOnAudio : ToggleOffAudio);
+            OnFilterChanged?.Invoke(mapLayer, isOn);
         }
 
         private void OnToggleClicked(MapLayer mapLayer, bool isOn)

--- a/Explorer/Assets/DCL/Navmap/NavmapController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapController.cs
@@ -15,7 +15,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using DCL.Chat.MessageBus;
 using DCL.Navmap.FilterPanel;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -28,7 +27,7 @@ namespace DCL.Navmap
         private const string EMPTY_PARCEL_NAME = "Empty parcel";
         private const string WORLDS_WARNING_MESSAGE = "This is the Genesis City map. If you jump into any of this places you will leave the world you are currently visiting.";
         private const MapLayer ACTIVE_MAP_LAYERS =
-            MapLayer.SatelliteAtlas | MapLayer.PlayerMarker | MapLayer.ParcelHoverHighlight | MapLayer.ScenesOfInterest | MapLayer.Favorites | MapLayer.HotUsersMarkers | MapLayer.Pins |
+            MapLayer.SatelliteAtlas | MapLayer.ParcelsAtlas | MapLayer.PlayerMarker | MapLayer.ParcelHoverHighlight | MapLayer.ScenesOfInterest | MapLayer.Favorites | MapLayer.HotUsersMarkers | MapLayer.Pins |
             MapLayer.Art | MapLayer.Business | MapLayer.Casino | MapLayer.Crypto | MapLayer.Education | MapLayer.Fashion | MapLayer.Game | MapLayer.Music | MapLayer.Shop | MapLayer.Social | MapLayer.Sports;
 
         private readonly NavmapView navmapView;

--- a/Explorer/Assets/DCL/Navmap/SatelliteController.cs
+++ b/Explorer/Assets/DCL/Navmap/SatelliteController.cs
@@ -49,6 +49,7 @@ namespace DCL.Navmap
         public void Activate()
         {
             mapRenderer.SetSharedLayer(MapLayer.SatelliteAtlas, true);
+            mapRenderer.SetSharedLayer(MapLayer.ParcelsAtlas, false);
             view.SatelliteRenderImage.texture = cameraController.GetRenderTexture();
             view.SatellitePixelPerfectMapRendererTextureProvider.Activate(cameraController);
             view.SatelliteRenderImage.Activate(null, cameraController.GetRenderTexture(), cameraController);


### PR DESCRIPTION
## What does this PR change?

This PR adds back the support for parcel view and map type switching in the navmap

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open the map
3. Open the filter view in bottom left
4. Switch between parcel view and satellite view 

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

