### PR TITLE
fix: Videos were freezing if paused more than 10 secs and played again

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/VideoEventsSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/VideoEventsSystem.cs
@@ -99,8 +99,11 @@ namespace DCL.SDKComponents.MediaStream
                     state = mediaPlayerControl.IsSeeking() ? VideoState.VsSeeking : VideoState.VsBuffering;
 
                     // If the seeking/buffering never ends, update state with error so the scene can react
-                    if ((Time.realtimeSinceStartup - mediaPlayer.LastStateChangeTime) > MAX_VIDEO_FROZEN_SECONDS_BEFORE_ERROR)
+                    if ((Time.realtimeSinceStartup - mediaPlayer.LastStateChangeTime) > MAX_VIDEO_FROZEN_SECONDS_BEFORE_ERROR &&
+                        mediaPlayer.LastPropagatedState != VideoState.VsPaused)
+                    {
                         state = VideoState.VsError;
+                    }
                 }
             }
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/VideoEventsSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/VideoEventsSystem.cs
@@ -100,7 +100,9 @@ namespace DCL.SDKComponents.MediaStream
 
                     // If the seeking/buffering never ends, update state with error so the scene can react
                     if ((Time.realtimeSinceStartup - mediaPlayer.LastStateChangeTime) > MAX_VIDEO_FROZEN_SECONDS_BEFORE_ERROR &&
-                        mediaPlayer.LastPropagatedState != VideoState.VsPaused)
+                        mediaPlayer.LastPropagatedState != VideoState.VsPaused &&
+                        mediaPlayer.LastPropagatedState != VideoState.VsBuffering &&
+                        mediaPlayer.LastPropagatedState != VideoState.VsSeeking)
                     {
                         state = VideoState.VsError;
                     }


### PR DESCRIPTION
## What does this PR change?

The problem was related to a mechanism to detect erroneous streams after no change in current time for more than 10 seconds. Now it checks that it was not manually paused previously and, if it was, then it plays normally.
There PR where the mechansim was originally implemented: https://github.com/decentraland/unity-explorer/pull/2563

## How to test the changes?

1. Download this scene: https://github.com/decentraland-scenes/media-gallery-test and uncompress it somewhere
2. Enter the scene root folder and run `npm i` and then `npm run start -- --explorer-alpha`
4. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
5. Download the build from this PR and connect it to the running scene using [the console command](https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene) according to your OS.
6. There is a big cube and a small cube beneath every rectangle. Choose one rectangle and press the big cube below. The video will play.
7. Pause it when you want by pressing the same cube.
8. Wait for 15 seconds.
9. Press the cube again. The video should resume.
