### PR TITLE
fix: remove deprecated hub usage in workflows

### DIFF
--- a/.github/workflows/auto-sync-main-to-dev.yml
+++ b/.github/workflows/auto-sync-main-to-dev.yml
@@ -5,24 +5,26 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  create-pr:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out the code
+        uses: actions/checkout@v3
+
       - name: Create or update branch
         run: |
           git checkout -B chore/sync
           git push --force --set-upstream origin chore/sync
-      - name: pull-request
-        uses: repo-sync/pull-request@v2
-        with:
-          source_branch: "chore/sync"                          # If blank, default: triggered branch
-          destination_branch: "dev"                            # If blank, default: master
-          pr_title: "chore: sync main to dev" # Title of pull request
-          pr_body: |                                           # Full markdown support, requires pr_title to be set
-            :crown: *An automated PR*
-          pr_label: "auto-pr"                                  # Comma-separated list (no spaces)
-          pr_draft: false                                      # Creates pull request as draft
-          pr_allow_empty: false                                # Creates pull request even if there are no changes
-          github_token: ${{ github.token }}                    # If blank, default: secrets.GITHUB_TOKEN
+
+      - name: Create pull request using GitHub CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base dev \
+            --head chore/sync \
+            --title "chore: sync main to dev" \
+            --body ":crown: *An automated PR*" \
+            --label auto-pr \
+            --draft false

--- a/.github/workflows/auto-sync-main-to-dev.yml
+++ b/.github/workflows/auto-sync-main-to-dev.yml
@@ -27,4 +27,3 @@ jobs:
             --title "chore: sync main to dev" \
             --body ":crown: *An automated PR*" \
             --label auto-pr \
-            --draft false

--- a/.github/workflows/auto-sync-main-to-dev.yml
+++ b/.github/workflows/auto-sync-main-to-dev.yml
@@ -3,6 +3,7 @@ name: Create PR for syncing main to dev
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   create-pr:

--- a/.github/workflows/auto-sync-main-to-dev.yml
+++ b/.github/workflows/auto-sync-main-to-dev.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create or update branch
         run: |

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -19,17 +19,17 @@ jobs:
 
       - name: Create or update branch
         run: |
-          git checkout -B release/release_${{ env.current_date }}
-          git push --force --set-upstream origin release/release_${{ env.current_date }}
+          git checkout -B release/release-${{ env.current_date }}
+          git push --force --set-upstream origin release/release-${{ env.current_date }}
 
-      - name: Create pull request
-        uses: repo-sync/pull-request@v2
-        with:
-          source_branch: "release/release_${{ env.current_date }}"
-          destination_branch: "main"
-          pr_title: "release: ${{ env.current_date }}"
-          pr_body: ":rocket: Automated release PR"
-          pr_label: "release, auto-pr"
-          pr_draft: false
-          pr_allow_empty: false
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create pull request using GitHub CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head release/release-${{ env.current_date }} \
+            --title "release: ${{ env.current_date }}" \
+            --body ":rocket: Automated release PR" \
+            --label release,auto-pr \
+            --draft false

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -32,4 +32,3 @@ jobs:
             --title "release: ${{ env.current_date }}" \
             --body ":rocket: Automated release PR" \
             --label release,auto-pr \
-            --draft false

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -9,7 +9,7 @@ jobs:
     
     steps:
       - name: Check out the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: dev
           


### PR DESCRIPTION
## What does this PR change?

The `repo-sync/pull-request` action is replaced with a direct call to gh pr create.
The GitHub CLI is actively supported, while `repo-sync/pull-request` has been already deprecated

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

