### PR TITLE
fix: changed method to change realm when loading onboarding world

### DIFF
--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -28,7 +28,7 @@ namespace DCL.UserInAppInitializationFlow
     public class RealUserInAppInitializationFlow : IUserInAppInitializationFlow
     {
         private static readonly ILoadingScreen.EmptyLoadingScreen EMPTY_LOADING_SCREEN = new ();
-        
+
         private readonly ILoadingStatus loadingStatus;
         private readonly IMVCManager mvcManager;
         private readonly AudioClipConfig backgroundMusic;
@@ -39,7 +39,7 @@ namespace DCL.UserInAppInitializationFlow
         private readonly CheckOnboardingStartupOperation checkOnboardingStartupOperation;
         private readonly RestartRealmStartupOperation restartRealmStartupOperation;
         private readonly IStartupOperation startupOperation;
-        
+
         public RealUserInAppInitializationFlow(
             ILoadingStatus loadingStatus,
             IHealthCheck livekitHealthCheck,
@@ -74,7 +74,7 @@ namespace DCL.UserInAppInitializationFlow
             var switchRealmMiscVisibilityStartupOperation = new SwitchRealmMiscVisibilityStartupOperation(loadingStatus, realmNavigator);
             loadPlayerAvatarStartupOperation = new LoadPlayerAvatarStartupOperation(loadingStatus, selfProfile, mainPlayerAvatarBaseProxy);
             var loadLandscapeStartupOperation = new LoadLandscapeStartupOperation(loadingStatus, realmNavigator);
-            checkOnboardingStartupOperation = new CheckOnboardingStartupOperation(loadingStatus, realmController, selfProfile, featureFlagsCache, decentralandUrlsSource, appParameters);
+            checkOnboardingStartupOperation = new CheckOnboardingStartupOperation(loadingStatus, selfProfile, featureFlagsCache, decentralandUrlsSource, appParameters, realmNavigator);
             restartRealmStartupOperation = new RestartRealmStartupOperation(loadingStatus, realmController);
             var teleportStartupOperation = new TeleportStartupOperation(loadingStatus, realmNavigator, startParcel);
             var loadGlobalPxOperation = new LoadGlobalPortableExperiencesStartupOperation(loadingStatus, selfProfile, featureFlagsCache, debugSettings, portableExperiencesController);

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/CheckOnboardingStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/CheckOnboardingStartupOperation.cs
@@ -67,7 +67,7 @@ namespace DCL.UserInAppInitializationFlow.StartupOperations
 
             // If the user has already completed the tutorial, we don't need to check the onboarding realm
             if (ownProfile is { TutorialStep: > 0 } )
-                //return;
+                return;
 
             // If the onboarding feature flag is enabled, we set the realm to the onboarding realm
             if (featureFlagsCache.Configuration.IsEnabled(FeatureFlagsStrings.ONBOARDING, FeatureFlagsStrings.ONBOARDING_ENABLED_VARIANT))


### PR DESCRIPTION
## What does this PR change?

The issue users were experiencing was related to the Island that was not being reset when setting the new realm when loading into the onboarding world. This meant that new users that were redirected to that world, would be in the same island as genesis city users, seeing their chat and their avatars.

We were using just the `realmController.SetRealmAsync` but that only changed the realm data, but did not force a reset of the archipelago room. In the case of the onboarding world, it has no comms, so there should be no room connection, but we were keeping GC's one.

I changed this to use the TryChangeRealmAsync on the RealmNavigator, that properly goes through all the steps of stopping the current realm and switching it to a new one. Avoiding any other potential issue that could appear.
...

## How to test the changes?

Create a new user and start the game. When you are taken to the onboarding world you should not see any floating avatars as described in this ticket #2481 nor the chat from GC players.