### PR TITLE
fix: Gigantic feat

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetUtility.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetUtility.cs
@@ -1,8 +1,6 @@
 ﻿using DCL.Optimization.Pools;
 using System.Collections.Generic;
-using ECS.Unity.Materials;
 using UnityEngine;
-using UnityEngine.Animations;
 using Utility;
 
 namespace DCL.AvatarRendering.Loading.Assets

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetUtility.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetUtility.cs
@@ -1,6 +1,8 @@
 ﻿using DCL.Optimization.Pools;
 using System.Collections.Generic;
+using ECS.Unity.Materials;
 using UnityEngine;
+using UnityEngine.Animations;
 using Utility;
 
 namespace DCL.AvatarRendering.Loading.Assets
@@ -35,8 +37,11 @@ namespace DCL.AvatarRendering.Loading.Assets
             {
                 Transform child = children.Value[index];
                 child.gameObject.layer = parent.gameObject.layer;
-            }
 
+                Object.Destroy(child.GetComponent<Animator>());
+                Object.Destroy(child.GetComponent<Animation>());
+            }
+            
             cachedWearable.Instance.gameObject.SetActive(true);
             return cachedWearable;
         }

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetUtility.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetUtility.cs
@@ -36,6 +36,7 @@ namespace DCL.AvatarRendering.Loading.Assets
                 Transform child = children.Value[index];
                 child.gameObject.layer = parent.gameObject.layer;
 
+                //Wearables shouldnt have animators or animations since it will break the skinning
                 Object.Destroy(child.GetComponent<Animator>());
                 Object.Destroy(child.GetComponent<Animation>());
             }


### PR DESCRIPTION
## What does this PR change?

Fixes #2789 

A wearable cannot contains animators or animation because that breaks the skinning. This PR cleans up the wearable to avoid the situation

## How to test the changes?

Testing with https://decentraland.org/marketplace/contracts/0xd2bd1cadfe12ee9d37ff95912af7f8a97ae71ba0/tokens/128



1. Launch the explorer
2. Instantiate an avatar with urn `urn:decentraland:matic:collections-v2:0xd2bd1cadfe12ee9d37ff95912af7f8a97ae71ba0:0` (using the avatar creator debug)
3. Check that there are no giant feet, and the avatar has the slippers
4. Do several emotes and check that everything is okay


## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

