### PR TITLE
Fix: add remediation when a broken wearable doesnt gets replaced by default wearable.

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Helpers/AvatarInstantiationPolymorphicBehaviour.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Helpers/AvatarInstantiationPolymorphicBehaviour.cs
@@ -4,6 +4,7 @@ using DCL.AvatarRendering.Loading.Assets;
 using DCL.AvatarRendering.Loading.Components;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Diagnostics;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -20,7 +21,14 @@ namespace DCL.AvatarRendering.AvatarShape.Helpers
             Transform parent)
         {
             var originalAssets = resultWearable.WearableAssetResults[avatarShapeComponent.BodyShape].Results;
-            var mainAsset = originalAssets[WearablePolymorphicBehaviour.MAIN_ASSET_INDEX]!.Value.Asset!;
+
+            if (originalAssets?[WearablePolymorphicBehaviour.MAIN_ASSET_INDEX]?.Asset == null)
+            {
+                ReportHub.LogError(ReportCategory.WEARABLE, $"Cannot find the asset for wearable with ID {resultWearable.DTO.id} name {resultWearable.DTO.Metadata.name} and body shape {avatarShapeComponent.BodyShape.Value}");
+                return null;
+            }
+
+            var mainAsset = originalAssets[WearablePolymorphicBehaviour.MAIN_ASSET_INDEX].Value.Asset!;
 
             string category = resultWearable.GetCategory();
 

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -51,7 +51,7 @@ namespace DCL.Minimap
         private MapRendererTrackPlayerPosition mapRendererTrackPlayerPosition;
         private IMapCameraController? mapCameraController;
         private Vector2Int previousParcelPosition;
-        private SceneRestrictionsController sceneRestrictionsController;
+        private SceneRestrictionsController? sceneRestrictionsController;
 
         public IReadOnlyDictionary<MapLayer, IMapLayerParameter> LayersParameters { get; } = new Dictionary<MapLayer, IMapLayerParameter>
             { { MapLayer.PlayerMarker, new PlayerMarkerParameter { BackgroundIsActive = false } } };
@@ -255,7 +255,8 @@ namespace DCL.Minimap
             realmNavigator.RealmChanged -= OnRealmChanged;
             mapPathEventBus.OnShowPinInMinimapEdge -= ShowPinInMinimapEdge;
             mapPathEventBus.OnHidePinInMinimapEdge -= HidePinInMinimapEdge;
-            sceneRestrictionsController.Dispose();
+            if (sceneRestrictionsController != null)
+                sceneRestrictionsController.Dispose();
         }
 
         protected override UniTask WaitForCloseIntentAsync(CancellationToken ct) =>


### PR DESCRIPTION
## What does this PR change?

We still dont have 100% repro steps, but seems like on certain situations, a wearable with no ABs does not get replaced properly by the default wearables and so, when it gets to the AttachToAvatar code, it breaks, as the Asset is null.
This just adds a simple remediation with error logging to avoid breaking the game in this situation.
When we find a proper repro step, we can make a proper fix to the underlying issue.

+I also fixed a small totally unrelated null ref on the minimap that I was getting when quitting the game during the loading screen.

...

## How to test the changes?

For now lets just do a smoke test. Once we get proper repro steps we will prepare a proper fix.