### PR TITLE
 chore: Adds realm debug tab to standard debug menu

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Builders/IDebugContainerBuilder.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Builders/IDebugContainerBuilder.cs
@@ -28,6 +28,7 @@ namespace DCL.DebugUtilities
             public const string PERFORMANCE = "Performance";
             public const string MEMORY = "Memory";
             public const string CURRENT_SCENE = "Current scene";
+            public const string REALM = "Realm";
         }
     }
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/DebugUtilitiesContainer.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/DebugUtilitiesContainer.cs
@@ -46,6 +46,7 @@ namespace DCL.DebugUtilities
                             IDebugContainerBuilder.Categories.ROOM_ISLAND,
                             IDebugContainerBuilder.Categories.PERFORMANCE,
                             IDebugContainerBuilder.Categories.MEMORY,
+                            IDebugContainerBuilder.Categories.REALM
                         }
                 )
             );

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigatorDebugView.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigatorDebugView.cs
@@ -17,7 +17,7 @@ namespace Global.Dynamic
             currentCatalystContent = new ElementBinding<string>("");
 
             debugContainerBuilder
-                .TryAddWidget("Realm")?
+                .TryAddWidget(IDebugContainerBuilder.Categories.REALM)?
                 .AddCustomMarker(new ElementBinding<string>("Current Realm"))
                 .AddCustomMarker(currentRealmName)
                 .AddCustomMarker(new ElementBinding<string>("Current Lambdas Catalyst"))


### PR DESCRIPTION
## What does this PR change?

Adds the realm debug tab to the regular debug menu
## How to test the changes?


1. Launch the explorer no debug
2. Do `/debug'
3. Check that the realm tab is there

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

