### PR TITLE
fix: switching user while on GP wont restart the scene properly

### DIFF
--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/DCL.UserInAppInitializationFlow.asmdef
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/DCL.UserInAppInitializationFlow.asmdef
@@ -33,7 +33,8 @@
         "GUID:3640f3c0b42946b0b8794a1ed8e06ca5",
         "GUID:f1eaef1b40a68e74cb90cbedebf57bbf",
         "GUID:8c4c611b27046bc4a848721d1fdd4a9f",
-        "GUID:4725c02394ab4ce19f889e4e8001f989"
+        "GUID:4725c02394ab4ce19f889e4e8001f989",
+        "GUID:e25ef972de004615a22937e739de2def"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -119,8 +119,8 @@ namespace DCL.UserInAppInitializationFlow
 
                 if (parameters.FromLogout)
                 {
-                    // If we are coming from a logout, we teleport the user to Genesis Plaza
-                    var teleportResult = await realmNavigator.TryInitializeTeleportToParcelAsync(Vector2Int.zero, ct);
+                    // If we are coming from a logout, we teleport the user to Genesis Plaza and force realm change to reset the scene properly
+                    var teleportResult = await realmNavigator.TryInitializeTeleportToParcelAsync(Vector2Int.zero, ct, forceChangeRealm: true);
                     // Restart livekit connection
                     await roomHub.StartAsync().Timeout(TimeSpan.FromSeconds(10));
                     result = teleportResult.Success ? teleportResult : Result.ErrorResult(teleportResult.ErrorMessage);

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
@@ -28,7 +28,7 @@ namespace ECS.SceneLifeCycle.Realm
         UniTask<bool> CheckRealmIsReacheableAsync(URLDomain realm, CancellationToken ct);
 
         UniTask<Result> TryInitializeTeleportToParcelAsync(Vector2Int parcel, CancellationToken ct,
-            bool isLocal = false);
+            bool isLocal = false, bool forceChangeRealm = false);
 
         UniTask InitializeTeleportToSpawnPointAsync(AsyncLoadProcessReport teleportLoadReport, CancellationToken ct, Vector2Int parcelToTeleport = default);
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -278,7 +278,7 @@ namespace Global.Dynamic
         }
 
         public async UniTask<Result> TryInitializeTeleportToParcelAsync(Vector2Int parcel, CancellationToken ct,
-            bool isLocal = false)
+            bool isLocal = false, bool forceChangeRealm = false)
         {
             ct.ThrowIfCancellationRequested();
 
@@ -286,7 +286,7 @@ namespace Global.Dynamic
             if (!parcelCheckResult.Success)
                 return parcelCheckResult;
 
-            if (!isLocal && !IsGenesisRealm())
+            if (forceChangeRealm || (!isLocal && !IsGenesisRealm()))
             {
                 var url = URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.Genesis));
                 return await TryChangeRealmAsync(url, ct, parcel);


### PR DESCRIPTION
## What does this PR change?

I noticed that if we are on GP and we switch user, the scene is not properly reset. This causes the dispenser to block claiming for the following users if the first one already claimed it.
I just added a forceChangeRealm bool when calling the teleport to GP, so we do change realm (with all the associated processes) even if we are already there.
This fixes this issue and potentially other issues caused by this.
...

Log into GP with one user. Claim a wearable in the dispenser, you should get the message saying that the wearable is incoming and that it be sent to you soon. If you try again it will say you already claimed it.
Then, log out and change user. You will be teleported again to GP where you need to try to claim the wearable in the dispenser again. You will get the same message saying the wearable is incoming and you should receive it if you didnt have it already.

Previously, if you tried to claim it with a second user after trying to claim it with one user, you would get a "you already claimed this wearable" message and would not be able to claim it unless you restarted the game or went to a world and back.

Could be related to this issue:
https://github.com/decentraland/unity-explorer/issues/2616