### PR TITLE
Chore: centrilized app args flags 

### DIFF
--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -19,9 +19,6 @@ namespace DCL.ApplicationVersionGuard
 {
     public class ApplicationVersionGuard
     {
-        public const string ENABLE_VERSION_CONTROL_CLI_ARG = "versionControl";
-        public const string SIMULATE_VERSION_CLI_ARG = "simulateVersion";
-
         private const string LAUNCHER_EXECUTABLE_NAME = "Decentraland Launcher";
         private const string LAUNCHER_PATH_MAC = "/Applications/" + LAUNCHER_EXECUTABLE_NAME + ".app";
         private const string LAUNCHER_PATH_WIN_MAIN = @"C:\Program Files\Decentraland Launcher\" + LAUNCHER_EXECUTABLE_NAME + ".exe";

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/ApplicationParamsEmoteProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/ApplicationParamsEmoteProvider.cs
@@ -26,7 +26,7 @@ namespace DCL.AvatarRendering.Emotes
             IEmoteProvider.OwnedEmotesRequestOptions requestOptions,
             List<IEmote> output)
         {
-            if (!appArgs.TryGetValue("self-preview-emotes", out string? emotesCsv))
+            if (!appArgs.TryGetValue(AppArgsFlags.SELF_PREVIEW_EMOTES, out string? emotesCsv))
                 return await source.GetOwnedEmotesAsync(userId, ct, requestOptions, output);
 
             URN[] pointers = emotesCsv!.Split(',', StringSplitOptions.RemoveEmptyEntries)

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/ApplicationParametersWearablesProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/ApplicationParametersWearablesProvider.cs
@@ -41,7 +41,7 @@ namespace DCL.AvatarRendering.Wearables
             string? name = null,
             List<IWearable>? results = null)
         {
-            if (!appArgs.TryGetValue("self-preview-wearables", out string? wearablesCsv))
+            if (!appArgs.TryGetValue(AppArgsFlags.SELF_PREVIEW_WEARABLES, out string? wearablesCsv))
                 return await source.GetAsync(pageSize, pageNumber, ct, sortingField, orderBy, category, collectionType, name, results);
 
             URN[] pointers = wearablesCsv!.Split(',', StringSplitOptions.RemoveEmptyEntries)

--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsProviderExtensions.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsProviderExtensions.cs
@@ -9,9 +9,6 @@ namespace DCL.FeatureFlags
 {
     public static class FeatureFlagsProviderExtensions
     {
-        private const string ARG_URL = "feature-flags-url";
-        private const string ARG_HOSTNAME = "feature-flags-hostname";
-
         public static async UniTask<FeatureFlagsConfiguration> InitializeAsync(
             this IFeatureFlagsProvider featureFlagsProvider,
             IDecentralandUrlsSource decentralandUrlsSource,
@@ -25,10 +22,10 @@ namespace DCL.FeatureFlags
             // #!/bin/bash
             // ./Decentraland.app --feature-flags-url https://feature-flags.decentraland.zone --feature-flags-hostname localhost
 
-            if(appParameters.TryGetValue(ARG_URL, out string featureFlagsUrl))
+            if(appParameters.TryGetValue(AppArgsFlags.FeatureFlags.URL, out string featureFlagsUrl))
                 options.URL = URLDomain.FromString(featureFlagsUrl);
 
-            if(appParameters.TryGetValue(ARG_HOSTNAME, out string hostName))
+            if(appParameters.TryGetValue(AppArgsFlags.FeatureFlags.HOSTNAME, out string hostName))
                 options.Hostname = hostName;
 
             options.UserId = userAddress;

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/StaticCommonTraitsPlugin.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/StaticCommonTraitsPlugin.cs
@@ -8,7 +8,6 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 {
     public class StaticCommonTraitsPlugin : EventPlugin
     {
-        private const string DCL_EDITOR = "dcl-editor";
         private const string UNITY_EDITOR = "unity-editor";
         private const string DEBUG = "debug";
         private const string RELEASE = "release";
@@ -37,8 +36,8 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
             if (Application.isEditor)
                 return UNITY_EDITOR;
 
-            if (appArgs.HasFlag(DCL_EDITOR))
-                return DCL_EDITOR;
+            if (appArgs.HasFlag(AppArgsFlags.DCL_EDITOR))
+                return AppArgsFlags.DCL_EDITOR;
 
             if (Debug.isDebugBuild || appArgs.HasDebugFlag())
                 return DEBUG;

--- a/Explorer/Assets/DCL/PluginSystem/Global/MultiplayerMovementPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/MultiplayerMovementPlugin.cs
@@ -21,7 +21,6 @@ namespace DCL.PluginSystem.Global
 {
     public class MultiplayerMovementPlugin : IDCLGlobalPlugin<MultiplayerCommunicationSettings>
     {
-        private const string COMPRESSION_ARG_FLAG = "compression";
         private readonly IAssetsProvisioner assetsProvisioner;
         private readonly MultiplayerMovementMessageBus messageBus;
         private readonly IDebugContainerBuilder debugBuilder;
@@ -72,7 +71,7 @@ namespace DCL.PluginSystem.Global
 
         private void ConfigureCompressionUsage()
         {
-            if (appArgs.TryGetValue(COMPRESSION_ARG_FLAG, out string? compression))
+            if (appArgs.TryGetValue(AppArgsFlags.Multiplayer.COMPRESSION, out string? compression))
             {
                 this.settings.Value.UseCompression = compression == "true";
                 return;

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/CheckOnboardingStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/CheckOnboardingStartupOperation.cs
@@ -18,9 +18,7 @@ namespace DCL.UserInAppInitializationFlow.StartupOperations
     public class CheckOnboardingStartupOperation : IStartupOperation
     {
         private const int TUTORIAL_STEP_DONE_MARK = 256;
-        private const string APP_PARAMETER_REALM = "realm";
-        private const string APP_PARAMETER_LOCAL_SCENE = "local-scene";
-        private const string APP_PARAMETER_POSITION = "position";
+
 
         private readonly ILoadingStatus loadingStatus;
         private readonly ISelfProfile selfProfile;
@@ -59,7 +57,7 @@ namespace DCL.UserInAppInitializationFlow.StartupOperations
         private async UniTask CheckOnboardingAsync(CancellationToken ct)
         {
             // It the app is open from any external way, we will ignore the onboarding flow
-            if (appParameters.HasFlag(APP_PARAMETER_REALM) || appParameters.HasFlag(APP_PARAMETER_POSITION) || appParameters.HasFlag(APP_PARAMETER_LOCAL_SCENE))
+            if (appParameters.HasFlag(AppArgsFlags.REALM) || appParameters.HasFlag(AppArgsFlags.POSITION) || appParameters.HasFlag(AppArgsFlags.LOCAL_SCENE))
                 return;
 
             isProfilePendingToBeUpdated = false;

--- a/Explorer/Assets/Scripts/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/AppArgsFlags.cs
@@ -1,0 +1,41 @@
+﻿namespace Global.AppArgs
+{
+    public static class AppArgsFlags
+    {
+        public const string DEBUG = "debug";
+        public const string DCL_EDITOR = "dcl-editor";
+
+        public const string ENABLE_VERSION_CONTROL = "versionControl";
+        public const string SIMULATE_VERSION = "simulateVersion";
+
+        public const string SCENE_CONSOLE = "scene-console";
+
+        public const string ENVIRONMENT = "dclenv";
+        public const string REALM = "realm";
+        public const string LOCAL_SCENE = "local-scene";
+        public const string POSITION = "position";
+
+        public const string FORCED_EMOTES = "self-force-emotes";
+        public const string SELF_PREVIEW_EMOTES = "self-preview-emotes";
+        public const string SELF_PREVIEW_WEARABLES = "self-preview-wearables";
+
+        public const string CAMERA_REEL = "camera-reel";
+
+        public static class Multiplayer
+        {
+            public const string COMPRESSION = "compression";
+        }
+
+        public static class FeatureFlags
+        {
+            public const string URL = "feature-flags-url";
+            public const string HOSTNAME = "feature-flags-hostname";
+        }
+
+        public static class Analytics
+        {
+            public const string SESSION_ID = "session_id";
+            public const string LAUNCHER_ID = "launcher_anonymous_id";
+        }
+    }
+}

--- a/Explorer/Assets/Scripts/Global/AppArgs/AppArgsFlags.cs.meta
+++ b/Explorer/Assets/Scripts/Global/AppArgs/AppArgsFlags.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 52f824711e444b9890881c0fbe309ef3
+timeCreated: 1731926863

--- a/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/ApplicationParametersParser.cs
@@ -14,7 +14,7 @@ namespace Global.AppArgs
 
         private static readonly IReadOnlyDictionary<string, string> ALWAYS_IN_EDITOR = new Dictionary<string, string>
         {
-            [IAppArgs.DEBUG_FLAG] = string.Empty,
+            [AppArgsFlags.DEBUG] = string.Empty,
         };
 
         public ApplicationParametersParser() : this(Environment.GetCommandLineArgs()) { }

--- a/Explorer/Assets/Scripts/Global/AppArgs/IAppArgs.cs
+++ b/Explorer/Assets/Scripts/Global/AppArgs/IAppArgs.cs
@@ -4,8 +4,6 @@ namespace Global.AppArgs
 {
     public interface IAppArgs
     {
-        public const string DEBUG_FLAG = "debug";
-
         bool HasFlag(string flagName);
 
         bool TryGetValue(string flagName, out string? value);
@@ -16,6 +14,6 @@ namespace Global.AppArgs
     public static class AppArgsExtensions
     {
         public static bool HasDebugFlag(this IAppArgs args) =>
-            args.HasFlag(IAppArgs.DEBUG_FLAG);
+            args.HasFlag(AppArgsFlags.DEBUG);
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
@@ -96,7 +96,7 @@ namespace Global.Dynamic
                 (container.Bootstrap, container.Analytics) = await CreateBootstrapperAsync(debugSettings, applicationParametersParser, container, container.settings, realmLaunchSettings, world, container.settings.BuildData, ct);
                 (container.IdentityCache, container.VerifiedEthereumApi, container.Web3Authenticator) = CreateWeb3Dependencies(sceneLoaderSettings, web3AccountFactory, browser, container, decentralandUrlsSource);
 
-                bool enableSceneDebugConsole = realmLaunchSettings.IsLocalSceneDevelopmentRealm || applicationParametersParser.HasFlag("scene-console");
+                bool enableSceneDebugConsole = realmLaunchSettings.IsLocalSceneDevelopmentRealm || applicationParametersParser.HasFlag(AppArgsFlags.SCENE_CONSOLE);
                 container.DiagnosticsContainer = container.enableAnalytics
                     ? DiagnosticsContainer.Create(container.ReportHandlingSettings, enableSceneDebugConsole, (ReportHandler.DebugLog, new CriticalLogsAnalyticsHandler(container.Analytics)))
                     : DiagnosticsContainer.Create(container.ReportHandlingSettings, enableSceneDebugConsole);
@@ -134,8 +134,8 @@ namespace Global.Dynamic
             {
                 IAnalyticsService service = CreateAnalyticsService(analyticsConfig, ct);
 
-                appArgs.TryGetValue("launcher_anonymous_id", out string? launcherAnonymousId);
-                appArgs.TryGetValue("session_id", out string? sessionId);
+                appArgs.TryGetValue(AppArgsFlags.Analytics.LAUNCHER_ID, out string? launcherAnonymousId);
+                appArgs.TryGetValue(AppArgsFlags.Analytics.SESSION_ID, out string? sessionId);
 
                 LauncherTraits launcherTraits = new LauncherTraits
                 {

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.cs
@@ -9,15 +9,13 @@ namespace Global.Dynamic
     [CreateAssetMenu(fileName = "DynamicSceneLoaderSettings", menuName = "SO/DynamicSceneLoaderSettings")]
     public class DynamicSceneLoaderSettings : ScriptableObject
     {
-        private const string ENV_PARAM = "dclenv";
-
         [field: SerializeField] public DecentralandEnvironment DecentralandEnvironment { get; private set; }
         [field: SerializeField] public List<string> Realms { get; private set; }
         [field: SerializeField] public List<string> Web3WhitelistMethods { get; private set; }
 
         public void ApplyConfig(IAppArgs applicationParametersParser)
         {
-            if (applicationParametersParser.TryGetValue(ENV_PARAM, out string? environment))
+            if (applicationParametersParser.TryGetValue(AppArgsFlags.ENVIRONMENT, out string? environment))
                 ParseEnvironment(environment!);
         }
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -97,8 +97,6 @@ namespace Global.Dynamic
 {
     public class DynamicWorldContainer : DCLWorldContainer<DynamicWorldSettings>
     {
-        private const string PARAMS_FORCED_EMOTES_FLAG = "self-force-emotes";
-
         private ECSReloadScene? reloadSceneController;
         private LocalSceneDevelopmentController? localSceneDevelopmentController;
         private IWearablesProvider? wearablesProvider;
@@ -638,7 +636,7 @@ namespace Global.Dynamic
 
             globalPlugins.AddRange(staticContainer.SharedPlugins);
 
-            if (appArgs.HasFlag("camera-reel"))
+            if (appArgs.HasFlag(AppArgsFlags.CAMERA_REEL))
                 globalPlugins.Add(new InWorldCameraPlugin(dclInput, assetsProvisioner, selfProfile, staticContainer.RealmData, playerEntity, placesAPIService, staticContainer.CharacterContainer.CharacterObject, coroutineRunner, staticContainer.WebRequestsContainer.WebRequestController, bootstrapContainer.DecentralandUrlsSource));
 
             if (dynamicWorldParams.EnableAnalytics)
@@ -685,7 +683,7 @@ namespace Global.Dynamic
 
         private static void ParseParamsForcedEmotes(IAppArgs appParams, ref List<URN> parsedEmotes)
         {
-            if (appParams.TryGetValue(PARAMS_FORCED_EMOTES_FLAG, out string? csv) && !string.IsNullOrEmpty(csv))
+            if (appParams.TryGetValue(AppArgsFlags.FORCED_EMOTES, out string? csv) && !string.IsNullOrEmpty(csv))
                 parsedEmotes.AddRange(csv.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(emote => new URN(emote)));
         }
     }

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -182,13 +182,13 @@ namespace Global.Dynamic
 
         private async UniTask<bool> DoesApplicationRequireVersionUpdateAsync(IAppArgs applicationParametersParser, SplashScreen splashScreen, CancellationToken ct)
         {
-            applicationParametersParser.TryGetValue(ApplicationVersionGuard.SIMULATE_VERSION_CLI_ARG, out string? version);
+            applicationParametersParser.TryGetValue(AppArgsFlags.SIMULATE_VERSION, out string? version);
             string? currentVersion = version ?? Application.version;
 
             bool runVersionControl = debugSettings.EnableVersionUpdateGuard;
 
             if (applicationParametersParser.HasDebugFlag() && !Application.isEditor)
-                runVersionControl = applicationParametersParser.TryGetValue(ApplicationVersionGuard.ENABLE_VERSION_CONTROL_CLI_ARG, out string? enforceDebugMode) && enforceDebugMode == "true";
+                runVersionControl = applicationParametersParser.TryGetValue(AppArgsFlags.ENABLE_VERSION_CONTROL, out string? enforceDebugMode) && enforceDebugMode == "true";
 
             if (!runVersionControl)
                 return false;

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmLaunchSettings.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmLaunchSettings.cs
@@ -15,10 +15,6 @@ namespace Global.Dynamic
     [Serializable]
     public class RealmLaunchSettings
     {
-        private const string APP_PARAMETER_REALM = "realm";
-        private const string APP_PARAMETER_LOCAL_SCENE = "local-scene";
-        private const string APP_PARAMETER_POSITION = "position";
-
         [Serializable]
         public struct PredefinedScenes
         {
@@ -91,10 +87,10 @@ namespace Global.Dynamic
 
         public void ApplyConfig(IAppArgs applicationParameters)
         {
-            if (applicationParameters.TryGetValue(APP_PARAMETER_REALM, out string? realm))
+            if (applicationParameters.TryGetValue(AppArgsFlags.REALM, out string? realm))
                 ParseRealmAppParameter(applicationParameters, realm);
 
-            if (applicationParameters.TryGetValue(APP_PARAMETER_POSITION, out string? position))
+            if (applicationParameters.TryGetValue(AppArgsFlags.POSITION, out string? position))
                 ParsePositionAppParameter(position);
         }
 
@@ -102,7 +98,7 @@ namespace Global.Dynamic
         {
             if (string.IsNullOrEmpty(realmParamValue)) return;
 
-            bool isLocalSceneDevelopment = appParameters.TryGetValue(APP_PARAMETER_LOCAL_SCENE, out string localSceneParamValue)
+            bool isLocalSceneDevelopment = appParameters.TryGetValue(AppArgsFlags.LOCAL_SCENE, out string localSceneParamValue)
                                     && ParseLocalSceneParameter(localSceneParamValue)
                                     && IsRealmAValidUrl(realmParamValue);
 


### PR DESCRIPTION
## What does this PR change?

CLI app args flags were scattered through the code and sometime presented as "magic strings". Sometimes it leadedeven to duplication. I extracted it into one static class, so it is easier to see which params we have already and what can be used.

## How to test the changes?

1. Launch the explorer with some command line arguments and verify it works as previously 
Examples: "`--debug`", "`--versionControl`" and "`--simulateVersion`"