### PR TITLE
fix: Unknown camera mode Enum breaks scenes

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/CameraMode.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/CameraMode.cs
@@ -2,15 +2,14 @@
 {
     public enum CameraMode : byte
     {
-        Unknown = 0,
-        FirstPerson = 1,
-        ThirdPerson = 2,
-        DroneView = 3,
-        SDKCamera = 4,
+        FirstPerson = 0,
+        ThirdPerson = 1,
+        DroneView = 2,
+        SDKCamera = 3,
 
         /// <summary>
         ///     Free-fly, does not follow character, intercepts controls designated for character movement
         /// </summary>
-        Free = 5,
+        Free = 4,
     }
 }

--- a/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
@@ -453,12 +453,8 @@ MonoBehaviour:
     <Camera>k__BackingField: {fileID: 4997933640858091397}
     <Speed>k__BackingField: 10
     <DefaultPosition>k__BackingField: {x: 0, y: 25, z: 0}
-  inWorldCameraData:
-    <Camera>k__BackingField: {fileID: 8825178219543001937}
-    <Speed>k__BackingField: 5
-    <DefaultPosition>k__BackingField: {x: 0, y: 10, z: 0}
   shoulderChangeSpeed: 4
-  <DefaultCameraMode>k__BackingField: 2
+  <DefaultCameraMode>k__BackingField: 1
   <Brain>k__BackingField: {fileID: 1924827267997815873}
 --- !u!1 &2902897560403827600
 GameObject:


### PR DESCRIPTION
## What does this PR change?

We found that in some scenes that did camera changes, having the Unknown as 0 in the CameraMode enum, broke the camera.
This removes it because best practices are for losers xDD
...

## How to test the changes?

Got to any minigame with camera change like (-121,-59) and play it and then exit it, the camera should return to normal instead of sending you to the extratosphere :) 

Fixes: https://github.com/decentraland/unity-explorer/issues/2828