### PR TITLE
feat: improvements and fixes on places and events panel

### DIFF
--- a/Explorer/Assets/DCL/CommunicationData/URLHelpers/URLBuilder.cs
+++ b/Explorer/Assets/DCL/CommunicationData/URLHelpers/URLBuilder.cs
@@ -7,7 +7,7 @@ namespace CommunicationData.URLHelpers
     {
         private readonly StringBuilder stringBuilder = new ();
 
-        private byte parametersCount;
+        private ushort parametersCount;
 
         public URLDomain? URLDomain { get; private set; }
         public URLPath? URLPath { get; private set; }

--- a/Explorer/Assets/DCL/EventsApi/HttpEventsApiService.cs
+++ b/Explorer/Assets/DCL/EventsApi/HttpEventsApiService.cs
@@ -35,7 +35,7 @@ namespace DCL.EventsApi
             if (onlyLiveEvents)
                 urlBuilder.AppendParameter(new URLParameter("list", "live"));
 
-            return await FetchEventList(urlBuilder.Build(), ct);
+            return await FetchEventListAsync(urlBuilder.Build(), ct);
         }
 
         public async UniTask<IReadOnlyList<EventDTO>> GetEventsByParcelAsync(ISet<string> parcels, CancellationToken ct,
@@ -50,7 +50,7 @@ namespace DCL.EventsApi
             if (onlyLiveEvents)
                 urlBuilder.AppendParameter(new URLParameter("list", "live"));
 
-            return await FetchEventList(urlBuilder.Build(), ct);
+            return await FetchEventListAsync(urlBuilder.Build(), ct);
         }
 
         public async UniTask<IReadOnlyList<EventDTO>> GetEventsByParcelAsync(string parcel, CancellationToken ct,
@@ -63,7 +63,7 @@ namespace DCL.EventsApi
             if (onlyLiveEvents)
                 urlBuilder.AppendParameter(new URLParameter("list", "live"));
 
-            return await FetchEventList(urlBuilder.Build(), ct);
+            return await FetchEventListAsync(urlBuilder.Build(), ct);
         }
 
         public async UniTask MarkAsInterestedAsync(string eventId, CancellationToken ct)
@@ -106,7 +106,7 @@ namespace DCL.EventsApi
                 throw new EventsApiException($"Error on trying to create attend intention to event {eventId}");
         }
 
-        private async UniTask<IReadOnlyList<EventDTO>> FetchEventList(URLAddress url, CancellationToken ct)
+        private async UniTask<IReadOnlyList<EventDTO>> FetchEventListAsync(URLAddress url, CancellationToken ct)
         {
             ulong timestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 

--- a/Explorer/Assets/DCL/Navmap/Assets/PlacesAndEventsPanel.prefab
+++ b/Explorer/Assets/DCL/Navmap/Assets/PlacesAndEventsPanel.prefab
@@ -5614,12 +5614,13 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 3419414557097062756}
   m_Father: {fileID: 4340935152919255707}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 235, y: -312}
+  m_AnchoredPosition: {x: 235, y: -292}
   m_SizeDelta: {x: 430, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7641510317917214071
@@ -7530,6 +7531,64 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &3568982555550908672
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3419414557097062756}
+  - component: {fileID: 3607029762496531637}
+  m_Layer: 5
+  m_Name: Empty
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3419414557097062756
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3568982555550908672}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4516985848740419190}
+  - {fileID: 6585657230421048241}
+  m_Father: {fileID: 3478432760944954796}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -134}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3607029762496531637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3568982555550908672}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &3669117997552920930
 GameObject:
   m_ObjectHideFlags: 0
@@ -8863,7 +8922,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 9, y: 569.1}
+  m_SizeDelta: {x: 9, y: 322}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &3482031189242068114
 MonoBehaviour:
@@ -9428,7 +9487,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 172, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2476161483524775475
 CanvasRenderer:
@@ -11657,6 +11716,81 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5278140087959648995
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4516985848740419190}
+  - component: {fileID: 4461742333976341567}
+  - component: {fileID: 3270639640778282640}
+  m_Layer: 5
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4516985848740419190
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5278140087959648995}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3419414557097062756}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4461742333976341567
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5278140087959648995}
+  m_CullTransparentMesh: 1
+--- !u!114 &3270639640778282640
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5278140087959648995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: d2fa0f5c8bfc04fd2a4b3f2f54de954b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &5302696132036132425
 GameObject:
   m_ObjectHideFlags: 0
@@ -11975,7 +12109,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1183088136605210185
 RectTransform:
   m_ObjectHideFlags: 0
@@ -14840,6 +14974,142 @@ MonoBehaviour:
     rgba: 4294967295
   m_fontSize: 12
   m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6859652781756413073
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6585657230421048241}
+  - component: {fileID: 2002443886944471823}
+  - component: {fileID: 8016586589010786925}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6585657230421048241
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6859652781756413073}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3419414557097062756}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -81}
+  m_SizeDelta: {x: 242, y: 29}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2002443886944471823
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6859652781756413073}
+  m_CullTransparentMesh: 1
+--- !u!114 &8016586589010786925
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6859652781756413073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: No Upcoming Events
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4279768342
+  m_fontColor: {r: 0.08627451, g: 0.08235294, b: 0.09411765, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -19015,6 +19285,7 @@ MonoBehaviour:
   <EventsTabButton>k__BackingField: {fileID: 1251594420067401240}
   <EventsTabContainer>k__BackingField: {fileID: 2737486664989542730}
   <EventsTabSelected>k__BackingField: {fileID: 6234270080758982578}
+  <EmptyEventsContainer>k__BackingField: {fileID: 3568982555550908672}
 --- !u!1 &8669883641916422303
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Navmap/EventInfoCardController.cs
+++ b/Explorer/Assets/DCL/Navmap/EventInfoCardController.cs
@@ -138,10 +138,10 @@ namespace DCL.Navmap
             UIAudioEventsBus.Instance.SendPlayAudioEvent(view.OnShowAudio);
 
             cts = new CancellationTokenSource();
-            FetchAndSetupPlaceInfo(parcel).Forget();
+            FetchAndSetupPlaceInfoAsync(parcel).Forget();
         }
 
-        private async UniTaskVoid FetchAndSetupPlaceInfo(Vector2Int parcel)
+        private async UniTaskVoid FetchAndSetupPlaceInfoAsync(Vector2Int parcel)
         {
             try
             {

--- a/Explorer/Assets/DCL/Navmap/INavmapBus.cs
+++ b/Explorer/Assets/DCL/Navmap/INavmapBus.cs
@@ -15,6 +15,8 @@ namespace DCL.Navmap
 
         UniTask SelectEventAsync(EventDTO @event, CancellationToken ct, PlacesData.PlaceInfo? place = null);
 
+        UniTask SearchForPlaceAsync(NavmapSearchPlaceFilter filter, NavmapSearchPlaceSorting sorting, CancellationToken ct);
+
         UniTask SearchForPlaceAsync(string place, NavmapSearchPlaceFilter filter, NavmapSearchPlaceSorting sorting, CancellationToken ct);
 
         UniTask GoBackAsync(CancellationToken ct);

--- a/Explorer/Assets/DCL/Navmap/NavmapCommandBus.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapCommandBus.cs
@@ -48,6 +48,9 @@ namespace DCL.Navmap
             commands.Push(command);
         }
 
+        public async UniTask SearchForPlaceAsync(NavmapSearchPlaceFilter filter, NavmapSearchPlaceSorting sorting, CancellationToken ct) =>
+            await SearchForPlaceAsync(string.Empty, filter, sorting, ct);
+
         public async UniTask SearchForPlaceAsync(string place, NavmapSearchPlaceFilter filter, NavmapSearchPlaceSorting sorting,
             CancellationToken ct)
         {

--- a/Explorer/Assets/DCL/Navmap/NavmapSearchBarController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapSearchBarController.cs
@@ -83,8 +83,17 @@ namespace DCL.Navmap
             view.clearSearchButton.onClick.RemoveAllListeners();
         }
 
-        public async UniTask SearchAndShowAsync(CancellationToken ct) =>
+        public async UniTask SearchAndShowAsync(string text, NavmapSearchPlaceFilter filter, NavmapSearchPlaceSorting sorting, CancellationToken ct)
+        {
+            currentSearchText = text;
+            currentPlaceFilter = filter;
+            currentPlaceSorting = sorting;
+            searchFiltersView.Toggle(sorting);
+            searchFiltersView.Toggle(filter);
+            view.inputField.SetTextWithoutNotify(text);
+
             await navmapBus.SearchForPlaceAsync(currentSearchText, currentPlaceFilter, currentPlaceSorting, ct);
+        }
 
         public void SetInputText(string text) =>
             view.inputField.SetTextWithoutNotify(text);
@@ -185,14 +194,8 @@ namespace DCL.Navmap
             searchCancellationToken = searchCancellationToken.SafeRestart();
             searchFiltersView.Toggle(filter);
 
-            SearchAsync(searchCancellationToken.Token).Forget();
-
-            return;
-
-            async UniTaskVoid SearchAsync(CancellationToken ct)
-            {
-                await navmapBus.SearchForPlaceAsync(currentSearchText, filter, currentPlaceSorting, ct);
-            }
+            navmapBus.SearchForPlaceAsync(currentSearchText, filter, currentPlaceSorting, searchCancellationToken.Token)
+                     .Forget();
         }
 
         private void Search(NavmapSearchPlaceSorting sorting)
@@ -201,14 +204,8 @@ namespace DCL.Navmap
             searchCancellationToken = searchCancellationToken.SafeRestart();
             searchFiltersView.Toggle(sorting);
 
-            SearchAsync(searchCancellationToken.Token).Forget();
-
-            return;
-
-            async UniTaskVoid SearchAsync(CancellationToken ct)
-            {
-                await navmapBus.SearchForPlaceAsync(currentSearchText, currentPlaceFilter, sorting, ct);
-            }
+            navmapBus.SearchForPlaceAsync(currentSearchText, currentPlaceFilter, sorting, searchCancellationToken.Token)
+                     .Forget();
         }
     }
 }

--- a/Explorer/Assets/DCL/Navmap/NavmapSearchBarController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapSearchBarController.cs
@@ -83,16 +83,16 @@ namespace DCL.Navmap
             view.clearSearchButton.onClick.RemoveAllListeners();
         }
 
-        public async UniTask SearchAndShowAsync(string text, NavmapSearchPlaceFilter filter, NavmapSearchPlaceSorting sorting, CancellationToken ct)
+        public async UniTask DoDefaultSearch(CancellationToken ct)
         {
-            currentSearchText = text;
-            currentPlaceFilter = filter;
-            currentPlaceSorting = sorting;
-            searchFiltersView.Toggle(sorting);
-            searchFiltersView.Toggle(filter);
-            view.inputField.SetTextWithoutNotify(text);
+            currentSearchText = string.Empty;
+            currentPlaceFilter = NavmapSearchPlaceFilter.All;
+            currentPlaceSorting = NavmapSearchPlaceSorting.MostActive;
+            searchFiltersView.Toggle(currentPlaceFilter);
+            searchFiltersView.Toggle(currentPlaceSorting);
+            view.inputField.SetTextWithoutNotify(currentSearchText);
 
-            await navmapBus.SearchForPlaceAsync(currentSearchText, currentPlaceFilter, currentPlaceSorting, ct);
+            await navmapBus.SearchForPlaceAsync(currentPlaceFilter, currentPlaceSorting, ct);
         }
 
         public void SetInputText(string text) =>

--- a/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
@@ -275,11 +275,15 @@ namespace DCL.Navmap
 
             async UniTaskVoid FetchEventsAndShowThemAsync(CancellationToken ct)
             {
+                view.EmptyEventsContainer.SetActive(false);
+
                 SetAsLoadingState();
 
                 IReadOnlyList<EventDTO> events = await eventsApiService.GetEventsByParcelAsync(place!.Positions, ct);
 
                 ClearEventElements();
+
+                view.EmptyEventsContainer.SetActive(events.Count == 0);
 
                 foreach (EventDTO @event in events)
                 {

--- a/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
@@ -254,7 +254,7 @@ namespace DCL.Navmap
 
             async UniTaskVoid RateAsync(CancellationToken ct)
             {
-                await placesAPIService.RatePlace(isEnabled ? true : null, place!.id, ct);
+                await placesAPIService.RatePlaceAsync(isEnabled ? true : null, place!.id, ct);
                 likeButton.SetButtonState(isEnabled);
                 dislikeButton.SetButtonState(false);
             }
@@ -268,7 +268,7 @@ namespace DCL.Navmap
 
             async UniTaskVoid RateAsync(CancellationToken ct)
             {
-                await placesAPIService.RatePlace(isEnabled ? false : null, place!.id, ct);
+                await placesAPIService.RatePlaceAsync(isEnabled ? false : null, place!.id, ct);
                 likeButton.SetButtonState(false);
                 dislikeButton.SetButtonState(isEnabled);
             }

--- a/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL.Browser;
 using DCL.Chat.Commands;
 using DCL.Chat.MessageBus;
 using DCL.EventsApi;
@@ -27,6 +28,7 @@ namespace DCL.Navmap
         private readonly IEventsApiService eventsApiService;
         private readonly ObjectPool<EventElementView> eventElementPool ;
         private readonly SharePlacesAndEventsContextMenuController shareContextMenu;
+        private readonly IWebBrowser webBrowser;
         private readonly ImageController thumbnailImage;
         private readonly MultiStateButtonController dislikeButton;
         private readonly MultiStateButtonController likeButton;
@@ -49,7 +51,8 @@ namespace DCL.Navmap
             IChatMessagesBus chatMessagesBus,
             IEventsApiService eventsApiService,
             ObjectPool<EventElementView> eventElementPool,
-            SharePlacesAndEventsContextMenuController shareContextMenu)
+            SharePlacesAndEventsContextMenuController shareContextMenu,
+            IWebBrowser webBrowser)
         {
             this.view = view;
             this.placesAPIService = placesAPIService;
@@ -59,6 +62,7 @@ namespace DCL.Navmap
             this.eventsApiService = eventsApiService;
             this.eventElementPool = eventElementPool;
             this.shareContextMenu = shareContextMenu;
+            this.webBrowser = webBrowser;
             thumbnailImage = new ImageController(view.Thumbnail, webRequestController);
 
             mapPathEventBus.OnSetDestination += SetDestination;
@@ -119,6 +123,7 @@ namespace DCL.Navmap
             view.LikeRateLabel.text = $"{(place.like_rate_as_float ?? 0) * 100:F0}%";
             view.PlayerCountLabel.text = place.user_count.ToString();
             view.DescriptionLabel.text = place.description;
+            view.DescriptionLabel.ConvertUrlsToClickeableLinks(OpenUrl);
             view.CoordinatesLabel.text = place.base_position;
             view.ParcelCountLabel.text = place.Positions.Length.ToString();
             view.AppearsOnContainer.SetActive(place.categories.Length > 0);
@@ -237,6 +242,9 @@ namespace DCL.Navmap
             shareContextMenu.Set(place!);
             shareContextMenu.Show(view.SharePivot);
         }
+
+        private void OpenUrl(string url) =>
+            webBrowser.OpenUrl(url);
 
         private void OnLikeButtonClick(bool isEnabled)
         {

--- a/Explorer/Assets/DCL/Navmap/PlaceInfoPanelView.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceInfoPanelView.cs
@@ -108,6 +108,9 @@ namespace DCL.Navmap
         [field: SerializeField]
         public GameObject EventsTabSelected { get; private set; }
 
+        [field: SerializeField]
+        public GameObject EmptyEventsContainer { get; private set; }
+
         [Serializable]
         public struct AppearsOnCategory
         {

--- a/Explorer/Assets/DCL/Navmap/PlacesAndEventsPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlacesAndEventsPanelController.cs
@@ -13,6 +13,7 @@ namespace DCL.Navmap
         private readonly SearchResultPanelController searchResultController;
         private readonly PlaceInfoPanelController placeInfoPanelController;
         private readonly EventInfoPanelController eventInfoPanelController;
+        private readonly NavmapZoomController navmapZoomController;
 
         private CancellationTokenSource? searchPlacesCancellationToken;
         private CancellationTokenSource? collapseExpandCancellationToken;
@@ -22,18 +23,23 @@ namespace DCL.Navmap
             NavmapSearchBarController searchBarController,
             SearchResultPanelController searchResultController,
             PlaceInfoPanelController placeInfoPanelController,
-            EventInfoPanelController eventInfoPanelController)
+            EventInfoPanelController eventInfoPanelController,
+            NavmapZoomController navmapZoomController)
         {
             this.view = view;
             this.searchBarController = searchBarController;
             this.searchResultController = searchResultController;
             this.placeInfoPanelController = placeInfoPanelController;
             this.eventInfoPanelController = eventInfoPanelController;
+            this.navmapZoomController = navmapZoomController;
 
             view.CollapseButton.gameObject.SetActive(true);
             view.ExpandButton.gameObject.SetActive(false);
             view.CollapseButton.onClick.AddListener(Collapse);
             view.ExpandButton.onClick.AddListener(Expand);
+
+            view.PointerEnter += DisableMapZoom;
+            view.PointerExit += EnableMapZoom;
         }
 
         public void Show()
@@ -94,6 +100,12 @@ namespace DCL.Navmap
                      .ToUniTask(cancellationToken: collapseExpandCancellationToken.Token)
                      .Forget();
         }
+
+        private void EnableMapZoom() =>
+            navmapZoomController.SetBlockZoom(false);
+
+        private void DisableMapZoom() =>
+            navmapZoomController.SetBlockZoom(true);
 
         public enum Section
         {

--- a/Explorer/Assets/DCL/Navmap/PlacesAndEventsPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlacesAndEventsPanelController.cs
@@ -48,7 +48,11 @@ namespace DCL.Navmap
             searchResultController.Show();
 
             searchPlacesCancellationToken = searchPlacesCancellationToken.SafeRestart();
-            searchBarController.SearchAndShowAsync(searchPlacesCancellationToken.Token).Forget();
+
+            searchBarController.SearchAndShowAsync("",
+                                    NavmapSearchPlaceFilter.All, NavmapSearchPlaceSorting.MostActive,
+                                    searchPlacesCancellationToken.Token)
+                               .Forget();
         }
 
         public void Toggle(Section section)
@@ -78,7 +82,7 @@ namespace DCL.Navmap
             view.CollapseButton.gameObject.SetActive(true);
             view.ExpandButton.gameObject.SetActive(false);
 
-            RectTransform transform = (RectTransform) view.transform;
+            RectTransform transform = (RectTransform)view.transform;
 
             collapseExpandCancellationToken = collapseExpandCancellationToken.SafeRestart();
 
@@ -92,7 +96,7 @@ namespace DCL.Navmap
             view.CollapseButton.gameObject.SetActive(false);
             view.ExpandButton.gameObject.SetActive(true);
 
-            RectTransform transform = (RectTransform) view.transform;
+            RectTransform transform = (RectTransform)view.transform;
 
             collapseExpandCancellationToken = collapseExpandCancellationToken.SafeRestart();
 

--- a/Explorer/Assets/DCL/Navmap/PlacesAndEventsPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlacesAndEventsPanelController.cs
@@ -49,9 +49,7 @@ namespace DCL.Navmap
 
             searchPlacesCancellationToken = searchPlacesCancellationToken.SafeRestart();
 
-            searchBarController.SearchAndShowAsync("",
-                                    NavmapSearchPlaceFilter.All, NavmapSearchPlaceSorting.MostActive,
-                                    searchPlacesCancellationToken.Token)
+            searchBarController.DoDefaultSearch(searchPlacesCancellationToken.Token)
                                .Forget();
         }
 

--- a/Explorer/Assets/DCL/Navmap/PlacesAndEventsPanelView.cs
+++ b/Explorer/Assets/DCL/Navmap/PlacesAndEventsPanelView.cs
@@ -1,9 +1,11 @@
+using System;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace DCL.Navmap
 {
-    public class PlacesAndEventsPanelView : MonoBehaviour
+    public class PlacesAndEventsPanelView : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
     {
         [field: SerializeField]
         public Button ExpandButton { get; private set; }
@@ -22,5 +24,14 @@ namespace DCL.Navmap
 
         [field: SerializeField]
         public SharePlacesAndEventsContextMenuView ShareContextMenuView { get; private set; }
+
+        public event Action? PointerEnter;
+        public event Action? PointerExit;
+
+        public void OnPointerEnter(PointerEventData eventData) =>
+            PointerEnter?.Invoke();
+
+        public void OnPointerExit(PointerEventData eventData) =>
+            PointerExit?.Invoke();
     }
 }

--- a/Explorer/Assets/DCL/Navmap/SearchForPlaceAndShowResultsCommand.cs
+++ b/Explorer/Assets/DCL/Navmap/SearchForPlaceAndShowResultsCommand.cs
@@ -53,8 +53,8 @@ namespace DCL.Navmap
             placesAndEventsPanelController.Toggle(PlacesAndEventsPanelController.Section.SEARCH);
             searchResultPanelController.SetLoadingState();
 
-            await ProcessPlaces(ct);
-            await ProcessLiveEvents(ct);
+            await ProcessPlacesAsync(ct);
+            await ProcessLiveEventsAsync(ct);
         }
 
         public void Undo()
@@ -71,7 +71,7 @@ namespace DCL.Navmap
             placesWithLiveEvents = null;
         }
 
-        private async UniTask ProcessLiveEvents(CancellationToken ct)
+        private async UniTask ProcessLiveEventsAsync(CancellationToken ct)
         {
             if (places == null) return;
 
@@ -101,7 +101,7 @@ namespace DCL.Navmap
             searchResultPanelController.SetLiveEvents(placesWithLiveEvents);
         }
 
-        private async UniTask ProcessPlaces(CancellationToken ct)
+        private async UniTask ProcessPlacesAsync(CancellationToken ct)
         {
             searchBarController.SetInputText(searchText);
             searchBarController.Interactable = true;

--- a/Explorer/Assets/DCL/PlacesAPIService/IPlacesAPIClient.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/IPlacesAPIClient.cs
@@ -40,7 +40,7 @@ namespace DCL.PlacesAPIService
 
         UniTask SetPlaceFavoriteAsync(string placeUUID, bool isFavorite, CancellationToken ct);
 
-        UniTask RatePlace(bool? isUpvote, string placeUUID, CancellationToken ct);
+        UniTask RatePlaceAsync(bool? isUpvote, string placeUUID, CancellationToken ct);
 
         UniTask<List<string>> GetPointsOfInterestCoordsAsync(CancellationToken ct);
 

--- a/Explorer/Assets/DCL/PlacesAPIService/IPlacesAPIService.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/IPlacesAPIService.cs
@@ -27,7 +27,7 @@ namespace DCL.PlacesAPIService
 
         UniTask<List<PlacesData.CategoryPlaceData>> GetPlacesByCategoryListAsync(string category, CancellationToken ct);
 
-        UniTask RatePlace(bool? isUpvote, string placeUUID, CancellationToken ct);
+        UniTask RatePlaceAsync(bool? isUpvote, string placeUUID, CancellationToken ct);
 
         UniTask SetPlaceFavoriteAsync(string placeUUID, bool isFavorite, CancellationToken ct);
 

--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIClient.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIClient.cs
@@ -257,7 +257,7 @@ namespace DCL.PlacesAPIService
                                       .WithCustomExceptionAsync(static exc => new PlacesAPIException(exc, "Error setting place favorite:"));
         }
 
-        public async UniTask RatePlace(bool? isUpvote, string placeUUID, CancellationToken ct)
+        public async UniTask RatePlaceAsync(bool? isUpvote, string placeUUID, CancellationToken ct)
         {
             string url = baseURL + "/{0}/likes";
             const string LIKE_PAYLOAD = "{\"like\": true}";

--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
@@ -11,17 +11,14 @@ namespace DCL.PlacesAPIService
     {
         private static readonly ListObjectPool<Vector2Int> COORDS_TO_REQ_POOL = new ();
 
-        internal readonly Dictionary<string, PlacesData.PlaceInfo> placesById = new ();
-        internal readonly Dictionary<Vector2Int, PlacesData.PlaceInfo> placesByCoords = new ();
-        internal readonly Dictionary<string, bool> localFavorites = new ();
-
+        private readonly Dictionary<string, PlacesData.PlaceInfo> placesById = new ();
+        private readonly Dictionary<Vector2Int, PlacesData.PlaceInfo> placesByCoords = new ();
+        private readonly Dictionary<string, bool> localFavorites = new ();
         private readonly IPlacesAPIClient client;
-
         private readonly CancellationTokenSource disposeCts = new ();
 
-        //Favorites
-        internal bool composedFavoritesDirty = true;
-        internal UniTaskCompletionSource<PlacesData.IPlacesAPIResponse>? serverFavoritesCompletionSource;
+        private bool composedFavoritesDirty = true;
+        private UniTaskCompletionSource<PlacesData.IPlacesAPIResponse>? serverFavoritesCompletionSource;
         private List<string>? pointsOfInterestCoords;
         private DateTime serverFavoritesLastRetrieval = DateTime.MinValue;
 
@@ -186,18 +183,9 @@ namespace DCL.PlacesAPIService
             await client.SetPlaceFavoriteAsync(placeUUID, isFavorite, ct);
         }
 
-        public async UniTask RatePlace(bool? isUpvote, string placeUUID, CancellationToken ct)
+        public async UniTask RatePlaceAsync(bool? isUpvote, string placeUUID, CancellationToken ct)
         {
-            await client.RatePlace(isUpvote, placeUUID, ct);
-        }
-
-        private void TryCachePlace(PlacesData.PlaceInfo? placeInfo)
-        {
-            if (placeInfo == null)
-                return;
-
-            placesById[placeInfo.id] = placeInfo;
-            foreach (Vector2Int placeInfoPosition in placeInfo.Positions) { placesByCoords[placeInfoPosition] = placeInfo; }
+            await client.RatePlaceAsync(isUpvote, placeUUID, ct);
         }
 
         public async UniTask<IReadOnlyList<string>> GetPointsOfInterestCoordsAsync(CancellationToken ct, bool renewCache = false)
@@ -215,6 +203,15 @@ namespace DCL.PlacesAPIService
         {
             disposeCts.Cancel();
             disposeCts.Dispose();
+        }
+
+        private void TryCachePlace(PlacesData.PlaceInfo? placeInfo)
+        {
+            if (placeInfo == null)
+                return;
+
+            placesById[placeInfo.id] = placeInfo;
+            foreach (Vector2Int placeInfoPosition in placeInfo.Positions) { placesByCoords[placeInfoPosition] = placeInfo; }
         }
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -248,6 +248,8 @@ namespace DCL.PluginSystem.Global
             INavmapBus navmapBus = new NavmapCommandBus(CreateSearchPlaceCommand,
                 CreateShowPlaceCommand, CreateShowEventCommand);
 
+            NavmapZoomController zoomController = new (navmapView.zoomView, dclInput);
+
             ObjectPool<PlaceElementView> placeElementsPool = await InitializePlaceElementsPool(navmapView.SearchBarResultPanel, ct);
             ObjectPool<EventElementView> eventElementsPool = await InitializeEventElementsForPlacePool(navmapView.PlacesAndEventsPanelView.PlaceInfoPanelView, ct);
             ObjectPool<EventScheduleElementView> eventScheduleElementsPool = await InitializeEventScheduleElementsPool(navmapView.PlacesAndEventsPanelView.EventInfoPanelView, ct);
@@ -271,9 +273,8 @@ namespace DCL.PluginSystem.Global
                 userCalendar, shareContextMenu, webBrowser);
 
             placesAndEventsPanelController = new PlacesAndEventsPanelController(navmapView.PlacesAndEventsPanelView,
-                searchBarController, searchResultPanelController, placeInfoPanelController, eventInfoPanelController);
-
-            NavmapZoomController zoomController = new (navmapView.zoomView, dclInput);
+                searchBarController, searchResultPanelController, placeInfoPanelController, eventInfoPanelController,
+                zoomController);
 
             IMapRenderer mapRenderer = mapRendererContainer.MapRenderer;
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -250,9 +250,9 @@ namespace DCL.PluginSystem.Global
 
             NavmapZoomController zoomController = new (navmapView.zoomView, dclInput);
 
-            ObjectPool<PlaceElementView> placeElementsPool = await InitializePlaceElementsPool(navmapView.SearchBarResultPanel, ct);
-            ObjectPool<EventElementView> eventElementsPool = await InitializeEventElementsForPlacePool(navmapView.PlacesAndEventsPanelView.PlaceInfoPanelView, ct);
-            ObjectPool<EventScheduleElementView> eventScheduleElementsPool = await InitializeEventScheduleElementsPool(navmapView.PlacesAndEventsPanelView.EventInfoPanelView, ct);
+            ObjectPool<PlaceElementView> placeElementsPool = await InitializePlaceElementsPoolAsync(navmapView.SearchBarResultPanel, ct);
+            ObjectPool<EventElementView> eventElementsPool = await InitializeEventElementsForPlacePoolAsync(navmapView.PlacesAndEventsPanelView.PlaceInfoPanelView, ct);
+            ObjectPool<EventScheduleElementView> eventScheduleElementsPool = await InitializeEventScheduleElementsPoolAsync(navmapView.PlacesAndEventsPanelView.EventInfoPanelView, ct);
 
             searchResultPanelController = new SearchResultPanelController(navmapView.SearchBarResultPanel,
                 placeElementsPool, navmapBus);
@@ -309,7 +309,7 @@ namespace DCL.PluginSystem.Global
             inputHandler = new ExplorePanelInputHandler(dclInput, mvcManager);
         }
 
-        private async UniTask<ObjectPool<PlaceElementView>> InitializePlaceElementsPool(SearchResultPanelView view, CancellationToken ct)
+        private async UniTask<ObjectPool<PlaceElementView>> InitializePlaceElementsPoolAsync(SearchResultPanelView view, CancellationToken ct)
         {
             PlaceElementView asset = (await assetsProvisioner.ProvideInstanceAsync(view.ResultRef, ct: ct)).Value;
 
@@ -328,7 +328,7 @@ namespace DCL.PluginSystem.Global
             }
         }
 
-        private async UniTask<ObjectPool<EventElementView>> InitializeEventElementsForPlacePool(PlaceInfoPanelView view, CancellationToken ct)
+        private async UniTask<ObjectPool<EventElementView>> InitializeEventElementsForPlacePoolAsync(PlaceInfoPanelView view, CancellationToken ct)
         {
             EventElementView asset = (await assetsProvisioner.ProvideInstanceAsync(view.EventElementViewRef, ct: ct)).Value;
 
@@ -347,7 +347,7 @@ namespace DCL.PluginSystem.Global
             }
         }
 
-        private async UniTask<ObjectPool<EventScheduleElementView>> InitializeEventScheduleElementsPool(EventInfoPanelView view, CancellationToken ct)
+        private async UniTask<ObjectPool<EventScheduleElementView>> InitializeEventScheduleElementsPoolAsync(EventInfoPanelView view, CancellationToken ct)
         {
             EventScheduleElementView asset = (await assetsProvisioner.ProvideInstanceAsync(view.ScheduleElementRef, ct: ct)).Value;
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -264,11 +264,11 @@ namespace DCL.PluginSystem.Global
 
             placeInfoPanelController = new PlaceInfoPanelController(navmapView.PlacesAndEventsPanelView.PlaceInfoPanelView,
                 webRequestController, placesAPIService, mapPathEventBus, navmapBus, chatMessagesBus, eventsApiService,
-                eventElementsPool, shareContextMenu);
+                eventElementsPool, shareContextMenu, webBrowser);
 
             eventInfoPanelController = new EventInfoPanelController(navmapView.PlacesAndEventsPanelView.EventInfoPanelView,
                 webRequestController, navmapBus, chatMessagesBus, eventsApiService, eventScheduleElementsPool,
-                userCalendar, shareContextMenu);
+                userCalendar, shareContextMenu, webBrowser);
 
             placesAndEventsPanelController = new PlacesAndEventsPanelController(navmapView.PlacesAndEventsPanelView,
                 searchBarController, searchResultPanelController, placeInfoPanelController, eventInfoPanelController);

--- a/Explorer/Assets/DCL/UI/TMP_Text_ClickeableLink.cs
+++ b/Explorer/Assets/DCL/UI/TMP_Text_ClickeableLink.cs
@@ -1,0 +1,36 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace DCL.UI
+{
+    [RequireComponent(typeof(TMP_Text))]
+    public class TMP_Text_ClickeableLink : MonoBehaviour, IPointerClickHandler
+    {
+        private TMP_Text text = null!;
+
+        public event Action<string>? OnLinkClicked;
+
+        private void Awake()
+        {
+            text = GetComponent<TMP_Text>();
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            // Detect if a link was clicked
+            int linkIndex = TMP_TextUtilities.FindIntersectingLink(text, eventData.position, null);
+
+            if (linkIndex == -1) return;
+            TMP_LinkInfo linkInfo = text.textInfo.linkInfo[linkIndex];
+
+            string url = linkInfo.GetLinkID();
+
+            OnLinkClicked?.Invoke(url);
+        }
+
+        public void ClearHookedEvents() =>
+            OnLinkClicked = null;
+    }
+}

--- a/Explorer/Assets/DCL/UI/TMP_Text_ClickeableLink.cs.meta
+++ b/Explorer/Assets/DCL/UI/TMP_Text_ClickeableLink.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: aa79a46ad7d14748b3e248214931267e
+timeCreated: 1731958696

--- a/Explorer/Assets/DCL/UI/TextMeshProExtensions.cs
+++ b/Explorer/Assets/DCL/UI/TextMeshProExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Text.RegularExpressions;
+using TMPro;
+using Utility;
+
+namespace DCL.UI
+{
+    public static class TextMeshProExtensions
+    {
+        private static readonly Regex URL_REGEX = new (@"\bhttps://[^\s/$.?#].[^\s]*\b");
+
+        public static void ConvertUrlsToClickeableLinks(this TMP_Text tmp, Action<string> onLinkClicked,
+            string style = "<color=#0000FF><u>{0}</u></color>",
+            bool clearHookedEvents = true)
+        {
+            TMP_Text_ClickeableLink clickeableLink = tmp.gameObject.TryAddComponent<TMP_Text_ClickeableLink>();
+
+            if (clearHookedEvents)
+                clickeableLink.ClearHookedEvents();
+
+            tmp.text = URL_REGEX.Replace(tmp.text, match =>
+            {
+                string url = match.Value;
+                return string.Format(style, $"<link={url}>{url}</link>");
+            });
+
+            clickeableLink.OnLinkClicked += onLinkClicked;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/UI/TextMeshProExtensions.cs.meta
+++ b/Explorer/Assets/DCL/UI/TextMeshProExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ebd4d25c5ef24c109950b3343ca724c1
+timeCreated: 1731958220


### PR DESCRIPTION
## What does this PR change?

- fix http request missing auth-chain for "set as interested" on an event 
- empty state on events tab
- add links to urls in the places & events descriptions
- fix http request for getting events of Genesis Plaza (more than parcel 255 parameters)
- disable/enable map zoom when the pointer enters/exits the side panel area
- make a clean search after the map is re-opened

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

