### PR TITLE
fix: wearables thumbnails stops loading after switching panels

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
@@ -32,7 +32,11 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
         private void CompleteWearableABThumbnailDownload(Entity entity, ref IAvatarAttachment wearable, ref AssetBundlePromise promise)
         {
             if (promise.TryForgetWithEntityIfCancelled(entity, World!))
+            {
+                wearable.ThumbnailAssetResult = null;
                 return;
+            }
+
 
             if (promise.TryConsume(World, out var result))
             {
@@ -45,12 +49,14 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
         private void CompleteWearableThumbnailDownload(Entity entity, ref IAvatarAttachment wearable, ref Promise promise)
         {
             if (promise.TryForgetWithEntityIfCancelled(entity, World!))
+            {
+                wearable.ThumbnailAssetResult = null;
                 return;
+            }
 
             if (promise.TryConsume(World, out StreamableLoadingResult<Texture2DData> result))
             {
                 wearable.ThumbnailAssetResult = result.ToFullRectSpriteData(LoadThumbnailsUtils.DEFAULT_THUMBNAIL);
-
                 World.Destroy(entity);
             }
         }


### PR DESCRIPTION
## What does this PR change?

Long story short, I found that after doing some clicking around in the backpack when the wearables thumbnails havent finished loading yet, you could "lock" some wearables in a perpetual "loading" state, where the thumbnail would not load and you could also not preview them nor see the EQUIP/UNEQUIP button.

After a lot of digging, from our side the problem was that when requesting a cancellation of the loading in the `ResolveAvatarAttachmentThumbnailSystem `we would do this: `promise.TryForgetWithEntityIfCancelled` and that would remove the entity and whatnot BUT we would keep the `wearable.ThumbnailAssetResult` as not null. Which meant that when the thumbnail was requested again to the `ECSThumbnailProvider`, we would never go past this check `promiseAlreadyCreated = avatarAttachment.ThumbnailAssetResult != null;` because in theory, the promise was created, and we had no way to check if it was cancelled except by the presence or not of this `ThumbnailAssetResult`.

So the solution ended up being simply nulling `ThumbnailAssetResult`  when we cancel the promise.

...

## How to test the changes?

Go to the backpack and before the wearable thumbnails have been created, try switching to different bodyparts or pages, it should always, in the end, load all thumbnails when before it would not xD

This is how it looked in dev before the fix:

https://github.com/user-attachments/assets/5036d4e0-fc1a-4e98-adf7-1f937507cb7a


This is how it looks afterwards:

https://github.com/user-attachments/assets/777d3f19-a5f8-4b51-8092-f3b3cd7e0cef



This should fix this issue: https://github.com/decentraland/unity-explorer/issues/2597