### PR TITLE
fix: Stuck at 40% due to avatar unable to instantiate

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/Wearable.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/Wearable.cs
@@ -33,7 +33,7 @@ namespace DCL.AvatarRendering.Wearables.Components
 
         public WearableType Type { get; private set; }
 
-        public bool IsLoading { get; private set; } = true;
+        public bool IsLoading { get; private set; }
 
         public void UpdateLoadingStatus(bool isLoading)
         {

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/FinalizeWearableLoadingSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/FinalizeWearableLoadingSystem.cs
@@ -119,19 +119,17 @@ namespace DCL.AvatarRendering.Wearables.Systems
                 
                 if (wearable.Model.Succeeded)
                 {
-                    ConcludeDTO();
+                    finishedDTOs++;
                     resolvedDTOs.Add(wearable);
                 }
                 else if (wearable.Model.Exception != null)
-                    ConcludeDTO();
-                else if (!wearable.IsLoading)
-                    missingPointers.Add(loadingIntentionPointer);
-
-                void ConcludeDTO()
-                {
-                    wearable.UpdateLoadingStatus(false);
                     finishedDTOs++;
+                else if (!wearable.IsLoading)
+                {
+                    wearable.UpdateLoadingStatus(true);
+                    missingPointers.Add(loadingIntentionPointer);
                 }
+
             }
 
             if (missingPointers.Count > 0)
@@ -310,10 +308,6 @@ namespace DCL.AvatarRendering.Wearables.Systems
                 new CommonLoadingArguments(realmData.Ipfs.EntitiesActiveEndpoint, cancellationTokenSource: intention.CancellationTokenSource));
 
             var promise = AssetPromise<WearablesDTOList, GetWearableDTOByPointersIntention>.Create(World, wearableDtoByPointersIntention, partitionComponent);
-
-            foreach (var pointerID in promise.LoadingIntention.Pointers)
-                if (storage.TryGetElement(pointerID, out var component))
-                    component.UpdateLoadingStatus(true);
             
             World.Create(promise, intention.BodyShape, partitionComponent);
         }


### PR DESCRIPTION
## What does this PR change?

Wearable DTOs request were canceled if you clicked fast enough on the authentication screen, before they were resolved. 

Then, the loading screen was waiting for the avatar to be instantiated to continue. But the canceled wearable DTOs requests were never retriggered by anyone, therefore leaving an unresolvavble state for the `GetWearablesByPointersIntention`. No DTO, no way to move forward with that intention

This PR corrects that by checking if a DTO is not loading, and if not, then add it to the `missingPointers` list

## How to test the changes?



1. Launch the explorer
2. Click as fast as you can before your avatar appears on the loading screen
3. You should never get stuck at 40%
4. Check general wearable loading (open backpack, close backpack before they load, press passports). Everything should go as expected

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

