### PR TITLE
Chore: initial analytics identification by cached wallet value 

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
@@ -24,7 +24,11 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
             Configuration = configuration;
 
             analytics.AddPlugin(new StaticCommonTraitsPlugin(appArgs, launcherTraits, buildData));
-            analytics.Identify(SystemInfo.deviceUniqueIdentifier!);
+        }
+
+        public void Initialize(IWeb3Identity? web3Identity)
+        {
+            analytics.Identify(web3Identity?.Address ?? "not cached");
             analytics.Flush();
         }
 
@@ -47,6 +51,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
             if (identity != null)
             {
                 analytics.Flush();
+
                 analytics.Identify(identity.Address, new JsonObject
                     {
                         ["dcl_eth_address"] = identity.Address != null ? identity.Address.ToString() : UNDEFINED,

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/IAnalyticsController.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/IAnalyticsController.cs
@@ -14,6 +14,10 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
         AnalyticsConfiguration Configuration { get; }
 
+        public static IAnalyticsController Null => NullAnalytics.Instance;
+
+        void Initialize(IWeb3Identity? web3Identity);
+
         void SetCommonParam(IRealmData realmData, IWeb3IdentityCache? identityCache, IExposedTransform playerTransform);
 
         void Track(string eventName, JsonObject? properties = null);
@@ -22,17 +26,15 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
         void Flush();
 
-        public static IAnalyticsController Null => NullAnalytics.Instance;
-
         private sealed class NullAnalytics : IAnalyticsController
         {
-            private NullAnalytics() { }
-
             private static readonly Lazy<NullAnalytics> INSTANCE = new (() => new NullAnalytics());
 
             public static IAnalyticsController Instance => INSTANCE.Value;
 
             public AnalyticsConfiguration Configuration => ScriptableObject.CreateInstance<AnalyticsConfiguration>();
+
+            private NullAnalytics() { }
 
             public void Initialize(IWeb3Identity? web3Identity) { }
 
@@ -44,8 +46,6 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
             public void Flush() { }
         }
-
-        void Initialize(IWeb3Identity? web3Identity);
     }
 
     public static class AnalyticsExtensions

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/IAnalyticsController.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/IAnalyticsController.cs
@@ -34,6 +34,8 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
             public AnalyticsConfiguration Configuration => ScriptableObject.CreateInstance<AnalyticsConfiguration>();
 
+            public void Initialize(IWeb3Identity? web3Identity) { }
+
             public void SetCommonParam(IRealmData _, IWeb3IdentityCache? __, IExposedTransform ___) { }
 
             public void Track(string _, JsonObject? __ = null) { }
@@ -42,6 +44,8 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
             public void Flush() { }
         }
+
+        void Initialize(IWeb3Identity? web3Identity);
     }
 
     public static class AnalyticsExtensions

--- a/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
@@ -96,6 +96,9 @@ namespace Global.Dynamic
                 (container.Bootstrap, container.Analytics) = await CreateBootstrapperAsync(debugSettings, applicationParametersParser, container, container.settings, realmLaunchSettings, world, container.settings.BuildData, ct);
                 (container.IdentityCache, container.VerifiedEthereumApi, container.Web3Authenticator) = CreateWeb3Dependencies(sceneLoaderSettings, web3AccountFactory, browser, container, decentralandUrlsSource);
 
+                if(container.enableAnalytics)
+                    container.Analytics!.Initialize(container.IdentityCache.Identity);
+
                 bool enableSceneDebugConsole = realmLaunchSettings.IsLocalSceneDevelopmentRealm || applicationParametersParser.HasFlag(AppArgsFlags.SCENE_CONSOLE);
                 container.DiagnosticsContainer = container.enableAnalytics
                     ? DiagnosticsContainer.Create(container.ReportHandlingSettings, enableSceneDebugConsole, (ReportHandler.DebugLog, new CriticalLogsAnalyticsHandler(container.Analytics)))

--- a/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
@@ -96,7 +96,7 @@ namespace Global.Dynamic
                 (container.Bootstrap, container.Analytics) = await CreateBootstrapperAsync(debugSettings, applicationParametersParser, container, container.settings, realmLaunchSettings, world, container.settings.BuildData, ct);
                 (container.IdentityCache, container.VerifiedEthereumApi, container.Web3Authenticator) = CreateWeb3Dependencies(sceneLoaderSettings, web3AccountFactory, browser, container, decentralandUrlsSource);
 
-                if(container.enableAnalytics)
+                if (container.enableAnalytics)
                     container.Analytics!.Initialize(container.IdentityCache.Identity);
 
                 bool enableSceneDebugConsole = realmLaunchSettings.IsLocalSceneDevelopmentRealm || applicationParametersParser.HasFlag(AppArgsFlags.SCENE_CONSOLE);


### PR DESCRIPTION
## What does this PR change?

We were doing initial identification in Analytics using just deviceId. However, cached wallet can be used without affecting Analytics events chain. 

## How to test the changes?

Just a smoke test. Also try to clear cache and enter with no cached initial wallet.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

