### PR TITLE
fix: include correct commit hash in PR builds

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -4,6 +4,9 @@ inputs:
   tag:
     description: 'Formatted version tag. If not set, it uses the latest version tag (v[0-9]*)'
     required: false
+   commit_sha:
+    description: 'The commit SHA to use for versioning'
+    required: true
 outputs:
   latest_version:
     description: 'Latest available version tag in repo'
@@ -66,7 +69,12 @@ runs:
         fi
 
         # Get the shortened commit hash
-        SHORT_COMMIT_HASH=$(echo "$GITHUB_SHA" | cut -c1-7)
+        # Use the commit SHA from input or fallback to GITHUB_SHA
+        if [ -n "${{ inputs.commit_sha }}" ]; then
+          SHORT_COMMIT_HASH=$(echo "${{ inputs.commit_sha }}" | cut -c1-7)
+        else
+          SHORT_COMMIT_HASH=$(echo "$GITHUB_SHA" | cut -c1-7)
+        fi
 
         # Full version with commit hash
         FULLVER="v${MAJOR}.${MINOR}.$((BUILD))-${NAME}-${BRANCH_NAME}-${SHORT_COMMIT_HASH}"

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -32,6 +32,9 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Fetch main branch and tags
+      run: git fetch --tags origin main
+
     - name: Get latest version tag
       if: ${{ !inputs.tag }}
       id: get_latest_version_tag

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -4,7 +4,7 @@ inputs:
   tag:
     description: 'Formatted version tag. If not set, it uses the latest version tag (v[0-9]*)'
     required: false
-   commit_sha:
+  commit_sha:
     description: 'The commit SHA to use for versioning'
     required: true
 outputs:

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -32,13 +32,13 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Fetch main branch and tags
-      run: git fetch --tags origin main
-
     - name: Get latest version tag
       if: ${{ !inputs.tag }}
       id: get_latest_version_tag
-      run: echo "tag=$(git describe --tags --match='v[0-9]*' --long main)" >> $GITHUB_OUTPUT
+      run: |
+        git fetch --tags origin main
+        tag=$(git describe --tags --match='v[0-9]*' --long main)
+        echo "tag=$tag" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Parse version tag

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -35,7 +35,7 @@ runs:
     - name: Get latest version tag
       if: ${{ !inputs.tag }}
       id: get_latest_version_tag
-      run: echo "tag=$(git describe --tags --match='v[0-9]*' --long)" >> $GITHUB_OUTPUT
+      run: echo "tag=$(git describe --tags --match='v[0-9]*' --long main)" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Parse version tag

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -36,7 +36,7 @@ runs:
       if: ${{ !inputs.tag }}
       id: get_latest_version_tag
       run: |
-        git fetch --tags origin main
+        git fetch origin main:main --tags
         tag=$(git describe --tags --match='v[0-9]*' --long main)
         echo "tag=$tag" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -113,6 +113,11 @@ jobs:
         id: get_commit_sha
         run: echo "commit_sha=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_OUTPUT
 
+      - name: Debug Commit SHA
+        run: |
+          echo "Commit SHA from Checkout: $(git rev-parse HEAD)"
+          echo "Ref from Pull Request: ${{ github.event.pull_request.head.sha }}"
+
       - name: Get Sentry parameters
         id: get_sentry
         run: |

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -115,8 +115,10 @@ jobs:
 
       - name: Debug Commit SHA
         run: |
-          echo "Commit SHA from Checkout: $(git rev-parse HEAD)"
-          echo "Ref from Pull Request: ${{ github.event.pull_request.head.sha }}"
+          echo "GITHUB_SHA: $GITHUB_SHA"
+          echo "Shortened Commit from git rev-parse: $(git rev-parse --short $GITHUB_SHA)"
+          echo "Full Commit from git rev-parse: $(git rev-parse $GITHUB_SHA)"
+          echo "HEAD Commit: $(git rev-parse HEAD)"
 
       - name: Get Sentry parameters
         id: get_sentry
@@ -208,6 +210,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -115,6 +115,7 @@ jobs:
 
       - name: Debug Commit SHA
         run: |
+          echo "Ref from Pull Request: ${{ github.event.pull_request.head.sha }}"
           echo "GITHUB_SHA: $GITHUB_SHA"
           echo "Shortened Commit from git rev-parse: $(git rev-parse --short $GITHUB_SHA)"
           echo "Full Commit from git rev-parse: $(git rev-parse $GITHUB_SHA)"

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -105,7 +105,12 @@ jobs:
       
       - name: Get commit SHA
         id: get_commit_sha
-        run: echo "commit_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "commit_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          else
+            echo "commit_sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
+          fi
 
       - name: Debug Commit SHA
         run: |
@@ -213,7 +218,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -102,16 +102,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: 'main'
-          
-      - name: Get version
-        id: get_version
-        if: ${{ github.event.inputs.version == '' && inputs.version == '' }}
-        uses: ./.github/actions/version
-
+      
       - name: Get commit SHA
         id: get_commit_sha
-        run: echo "commit_sha=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_OUTPUT
+        run: echo "commit_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
 
       - name: Debug Commit SHA
         run: |
@@ -121,6 +115,14 @@ jobs:
           echo "Full Commit from git rev-parse: $(git rev-parse $GITHUB_SHA)"
           echo "HEAD Commit: $(git rev-parse HEAD)"
 
+      - name: Get version
+        id: get_version
+        if: ${{ github.event.inputs.version == '' && inputs.version == '' }}
+        uses: ./.github/actions/version
+        with:
+          commit_sha: ${{ steps.get_commit_sha.outputs.commit_sha }}
+
+          
       - name: Get Sentry parameters
         id: get_sentry
         run: |

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -115,8 +115,6 @@ jobs:
       - name: Debug Commit SHA
         run: |
           echo "Ref from Pull Request: ${{ github.event.pull_request.head.sha }}"
-          echo "GITHUB_SHA: $GITHUB_SHA"
-          echo "Shortened Commit from git rev-parse: $(git rev-parse --short $GITHUB_SHA)"
           echo "Full Commit from git rev-parse: $(git rev-parse $GITHUB_SHA)"
           echo "HEAD Commit: $(git rev-parse HEAD)"
 


### PR DESCRIPTION
## What does this PR change?

We have noticed that with build from PR the hash added to version in the build was not pointing to the correct one, make it hard for QA and devs to validate the fixes.

The issue occurs because GitHub Actions uses a merge commit when a workflow is triggered by a pull_request event. This merge commit is generated dynamically by GitHub to simulate what the branch would look like after merging into the base branch. As a result, the checkout step fetches and checks out this temporary merge commit instead of the exact commit from the source branch.

To fix it I had to override the checkout action, and also made changes in the get-version action to always use tags from main so we can easier test changes to workflows.

## How to test the changes?

Check that the build version is matching with commit hash from last commit.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

