### PR TITLE
Feat: live events map layer

### DIFF
--- a/Explorer/Assets/DCL/EventsApi/HttpEventsApiService.cs
+++ b/Explorer/Assets/DCL/EventsApi/HttpEventsApiService.cs
@@ -24,6 +24,17 @@ namespace DCL.EventsApi
             this.baseUrl = baseUrl;
         }
 
+        public async UniTask<IReadOnlyList<EventDTO>> GetEventsAsync(CancellationToken ct, bool onlyLiveEvents = false)
+        {
+            urlBuilder.Clear();
+            urlBuilder.AppendDomain(baseUrl);
+
+            if (onlyLiveEvents)
+                urlBuilder.AppendParameter(new URLParameter("list", "live"));
+
+            return await FetchEventListAsync(urlBuilder.Build(), ct);
+        }
+
         public async UniTask<IReadOnlyList<EventDTO>> GetEventsByParcelAsync(IEnumerable<Vector2Int> parcels, CancellationToken ct, bool onlyLiveEvents = false)
         {
             urlBuilder.Clear();

--- a/Explorer/Assets/DCL/EventsApi/IEventsApiService.cs
+++ b/Explorer/Assets/DCL/EventsApi/IEventsApiService.cs
@@ -7,6 +7,7 @@ namespace DCL.EventsApi
 {
     public interface IEventsApiService
     {
+        UniTask<IReadOnlyList<EventDTO>> GetEventsAsync(CancellationToken ct, bool onlyLiveEvents = false);
         UniTask<IReadOnlyList<EventDTO>> GetEventsByParcelAsync(IEnumerable<Vector2Int> parcels, CancellationToken ct, bool onlyLiveEvents = false);
 
         /// <param name="parcels">Parcel in format: "x,y"</param>

--- a/Explorer/Assets/DCL/MapRenderer/Addressables/MapRendererConfiguration.prefab
+++ b/Explorer/Assets/DCL/MapRenderer/Addressables/MapRendererConfiguration.prefab
@@ -221,6 +221,7 @@ Transform:
   - {fileID: 1705380967094917977}
   - {fileID: 1137272574085786475}
   - {fileID: 5609044988966314515}
+  - {fileID: 8846438800571672071}
   - {fileID: 3920442518738607191}
   - {fileID: 195609709436987355}
   - {fileID: 4085516147652670838}
@@ -248,6 +249,7 @@ MonoBehaviour:
   <SatelliteAtlasRoot>k__BackingField: {fileID: 1137272574085786475}
   <ColdUserMarkersRoot>k__BackingField: {fileID: 5609044988966314515}
   <HotUserMarkersRoot>k__BackingField: {fileID: 3920442518738607191}
+  <LiveEventsMarkersRoot>k__BackingField: {fileID: 8846438800571672071}
   <FriendUserMarkersRoot>k__BackingField: {fileID: 2512951518552392734}
   <ScenesOfInterestMarkersRoot>k__BackingField: {fileID: 195609709436987355}
   <CategoriesMarkersRoot>k__BackingField: {fileID: 4085516147652670838}
@@ -284,6 +286,37 @@ Transform:
   m_GameObject: {fileID: 5018920231902696988}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5694240695484966351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5199116833678669688
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8846438800571672071}
+  m_Layer: 27
+  m_Name: LiveEvents
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8846438800571672071
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5199116833678669688}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/CategoryScenesMarkersInstaller.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/CategoryScenesMarkersInstaller.cs
@@ -31,6 +31,7 @@ namespace DCL.MapRenderer.ComponentsFactory
             IMapRendererSettings settings,
             IPlacesAPIService placesAPI,
             ObjectPool<ClusterMarkerObject> clusterObjectsPool,
+            CategoryMarkerObject prefab,
             CancellationToken cancellationToken
         )
         {
@@ -38,7 +39,6 @@ namespace DCL.MapRenderer.ComponentsFactory
             assetsProvisioner = assetsProv;
             placesAPIService = placesAPI;
             this.writer = layerWriter;
-            CategoryMarkerObject? prefab = await GetPrefabAsync(cancellationToken);
 
             var objectsPool = new ObjectPool<CategoryMarkerObject>(
                 () => CreatePoolMethod(configuration, prefab, coordsUtils),
@@ -120,8 +120,5 @@ namespace DCL.MapRenderer.ComponentsFactory
 
         private static IClusterMarker CreateClusterMarker(IObjectPool<ClusterMarkerObject> objectsPool, IMapCullingController cullingController, ICoordsUtils coordsUtils) =>
             new ClusterMarker(objectsPool, cullingController, coordsUtils);
-
-        private async UniTask<CategoryMarkerObject> GetPrefabAsync(CancellationToken cancellationToken) =>
-            (await assetsProvisioner.ProvideMainAssetAsync(mapSettings.CategoryMarker, cancellationToken)).Value;
     }
 }

--- a/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/LiveEventsMarkersInstaller.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/LiveEventsMarkersInstaller.cs
@@ -1,0 +1,85 @@
+using Cysharp.Threading.Tasks;
+using DCL.AssetsProvision;
+using DCL.EventsApi;
+using DCL.MapRenderer.CoordsUtils;
+using DCL.MapRenderer.Culling;
+using DCL.MapRenderer.MapLayers;
+using DCL.MapRenderer.MapLayers.Categories;
+using DCL.PlacesAPIService;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.Pool;
+
+namespace DCL.MapRenderer.ComponentsFactory
+{
+    internal struct LiveEventsMarkersInstaller
+    {
+        private const int PREWARM_COUNT = 60;
+
+        private Dictionary<MapLayer, IMapLayerController> writer;
+        private IAssetsProvisioner assetsProvisioner;
+        private IMapRendererSettings mapSettings;
+        private IEventsApiService eventsApiService;
+
+        public async UniTask InstallAsync(
+            Dictionary<MapLayer, IMapLayerController> layerWriter,
+            List<IZoomScalingLayer> zoomScalingWriter,
+            MapRendererConfiguration configuration,
+            ICoordsUtils coordsUtils,
+            IMapCullingController cullingController,
+            IAssetsProvisioner assetsProv,
+            IMapRendererSettings settings,
+            IEventsApiService eventsApi,
+            ObjectPool<ClusterMarkerObject> clusterObjectsPool,
+            CategoryMarkerObject prefab,
+            CancellationToken cancellationToken
+        )
+        {
+            mapSettings = settings;
+            assetsProvisioner = assetsProv;
+            eventsApiService = eventsApi;
+            this.writer = layerWriter;
+
+            var objectsPool = new ObjectPool<CategoryMarkerObject>(
+                () => CreatePoolMethod(configuration, prefab, coordsUtils),
+                defaultCapacity: PREWARM_COUNT,
+                actionOnGet: obj => obj.gameObject.SetActive(true),
+                actionOnRelease: obj => obj.gameObject.SetActive(false));
+
+            LiveEventsMarkersController liveEventsMarkersController = new LiveEventsMarkersController(
+                eventsApiService,
+                objectsPool,
+                CreateMarker,
+                configuration.LiveEventsMarkersRoot,
+                coordsUtils,
+                cullingController,
+                mapSettings.CategoryIconMappings,
+                MapLayer.LiveEvents,
+                new ClusterController(cullingController, clusterObjectsPool, CreateClusterMarker, coordsUtils, MapLayer.LiveEvents, mapSettings.CategoryIconMappings)
+            );
+
+            await liveEventsMarkersController.InitializeAsync(cancellationToken);
+            writer.Add(MapLayer.LiveEvents, liveEventsMarkersController);
+            zoomScalingWriter.Add(liveEventsMarkersController);
+        }
+
+        private static CategoryMarkerObject CreatePoolMethod(MapRendererConfiguration configuration, CategoryMarkerObject prefab, ICoordsUtils coordsUtils)
+        {
+            CategoryMarkerObject categoryMarkerObject = Object.Instantiate(prefab, configuration.LiveEventsMarkersRoot);
+
+            for (var i = 0; i < categoryMarkerObject.renderers.Length; i++)
+                categoryMarkerObject.renderers[i].sortingOrder = MapRendererDrawOrder.LIVE_EVENTS;
+
+            categoryMarkerObject.title.sortingOrder = MapRendererDrawOrder.LIVE_EVENTS;
+            coordsUtils.SetObjectScale(categoryMarkerObject);
+            return categoryMarkerObject;
+        }
+
+        private static ICategoryMarker CreateMarker(IObjectPool<CategoryMarkerObject> objectsPool, IMapCullingController cullingController, ICoordsUtils coordsUtils) =>
+            new CategoryMarker(objectsPool, cullingController, coordsUtils);
+
+        private static IClusterMarker CreateClusterMarker(IObjectPool<ClusterMarkerObject> objectsPool, IMapCullingController cullingController, ICoordsUtils coordsUtils) =>
+            new ClusterMarker(objectsPool, cullingController, coordsUtils);
+    }
+}

--- a/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/LiveEventsMarkersInstaller.cs.meta
+++ b/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/LiveEventsMarkersInstaller.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 57eb472b79374384b2e39a468a7dc8ea
+timeCreated: 1732296710

--- a/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererConfiguration.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererConfiguration.cs
@@ -20,6 +20,9 @@ namespace DCL.MapRenderer.ComponentsFactory
         public Transform HotUserMarkersRoot { get; private set; }
 
         [field: SerializeField]
+        public Transform LiveEventsMarkersRoot { get; private set; }
+
+        [field: SerializeField]
         public Transform FriendUserMarkersRoot { get; private set; }
 
         [field: SerializeField]

--- a/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererDrawOrder.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererDrawOrder.cs
@@ -17,8 +17,9 @@
         internal const int PIN_MARKER_OUTLINE = 18;
         internal const int PIN_MARKER = 19;
         internal const int PIN_MARKER_THUMBNAIL = 20;
-        internal const int PLAYER_MARKER = 21;
-        internal const int SEARCH_RESULTS = 22;
+        internal const int LIVE_EVENTS = 21;
+        internal const int PLAYER_MARKER = 22;
+        internal const int SEARCH_RESULTS = 23;
         internal const int PARCEL_HIGHLIGHT = 30;
 
     }

--- a/Explorer/Assets/DCL/MapRenderer/MapLayerIconMapping.asset
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayerIconMapping.asset
@@ -39,4 +39,6 @@ MonoBehaviour:
     value: {fileID: 21300000, guid: fa52936e6ce564a07ac976145f3d489a, type: 3}
   - key: 128
     value: {fileID: 21300000, guid: 832e2146c0b634ff78a73d0557cbd54a, type: 3}
+  - key: 8388608
+    value: {fileID: 21300000, guid: 98e1f4574749948e7ae1b009d34be37b, type: 3}
   defaultIcon: {fileID: 21300000, guid: fa52936e6ce564a07ac976145f3d489a, type: 3}

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents.meta
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: de32411890ee49af96a731e647b446a4
+timeCreated: 1732294940

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents/LiveEventsMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents/LiveEventsMarkersController.cs
@@ -1,0 +1,159 @@
+﻿using Cysharp.Threading.Tasks;
+using DCL.EventsApi;
+using DCL.MapRenderer.Culling;
+using DCL.PlacesAPIService;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.Pool;
+using ICoordsUtils = DCL.MapRenderer.CoordsUtils.ICoordsUtils;
+
+namespace DCL.MapRenderer.MapLayers.Categories
+{
+    internal class LiveEventsMarkersController : MapLayerControllerBase, IMapCullingListener<ICategoryMarker>, IMapLayerController, IZoomScalingLayer
+    {
+        private static readonly TimeSpan LIVE_EVENTS_POLLING_TIME = TimeSpan.FromMinutes(5);
+        private readonly MapLayer mapLayer;
+
+        internal delegate ICategoryMarker CategoryMarkerBuilder(
+            IObjectPool<CategoryMarkerObject> objectsPool,
+            IMapCullingController cullingController,
+            ICoordsUtils coordsUtils);
+
+        private readonly IObjectPool<CategoryMarkerObject> objectsPool;
+        private readonly CategoryMarkerBuilder builder;
+        private readonly CategoryIconMappingsSO categoryIconMappings;
+        private readonly IEventsApiService eventsApiService;
+        private readonly ClusterController clusterController;
+
+        private readonly Dictionary<Vector2Int, IClusterableMarker> markers = new();
+
+        private Vector2Int decodePointer;
+        private bool isEnabled;
+        private int zoomLevel = 1;
+        private float baseZoom = 1;
+        private float zoom = 1;
+        private bool arePlacesLoaded;
+
+        public LiveEventsMarkersController(
+            IEventsApiService eventsApiService,
+            IObjectPool<CategoryMarkerObject> objectsPool,
+            CategoryMarkerBuilder builder,
+            Transform instantiationParent,
+            ICoordsUtils coordsUtils,
+            IMapCullingController cullingController,
+            CategoryIconMappingsSO categoryIconMappings,
+            MapLayer mapLayer,
+            ClusterController clusterController)
+            : base(instantiationParent, coordsUtils, cullingController)
+        {
+            this.eventsApiService = eventsApiService;
+            this.objectsPool = objectsPool;
+            this.builder = builder;
+            this.categoryIconMappings = categoryIconMappings;
+            this.mapLayer = mapLayer;
+            this.clusterController = clusterController;
+        }
+
+        public UniTask InitializeAsync(CancellationToken cancellationToken)
+        {
+            LoadEventsPlacesAsync(cancellationToken).Forget();
+            return UniTask.CompletedTask;
+        }
+
+        private async UniTaskVoid LoadEventsPlacesAsync(CancellationToken ct)
+        {
+            do
+            {
+                foreach (ICategoryMarker marker in markers.Values)
+                {
+                    mapCullingController.StopTracking(marker);
+                    marker.OnBecameInvisible();
+                }
+                markers.Clear();
+                IReadOnlyList<EventDTO> events = await eventsApiService.GetEventsAsync(ct, onlyLiveEvents: true);
+                foreach (EventDTO eventDto in events)
+                {
+                    Vector2Int coords = new Vector2Int(eventDto.x, eventDto.y);
+                    if (markers.ContainsKey(coords))
+                        continue;
+
+                    ICategoryMarker marker = builder(objectsPool, mapCullingController, coordsUtils);
+                    marker.SetCategorySprite(categoryIconMappings.GetCategoryImage(mapLayer));
+                    marker.SetData(eventDto.name, coordsUtils.CoordsToPosition(coords));
+                    markers.Add(coords, marker);
+                    if(isEnabled)
+                        mapCullingController.StartTracking(marker, this);
+                }
+                await UniTask.Delay(LIVE_EVENTS_POLLING_TIME, DelayType.Realtime, cancellationToken: ct);
+            }
+            while (ct.IsCancellationRequested == false);
+        }
+
+        public void ApplyCameraZoom(float baseZoom, float zoom, int zoomLevel)
+        {
+            this.baseZoom = baseZoom;
+            this.zoom = zoom;
+            this.zoomLevel = zoomLevel;
+
+            if (isEnabled)
+                clusterController.UpdateClusters(zoomLevel, baseZoom, zoom, markers);
+
+            foreach (ICategoryMarker marker in markers.Values)
+                marker.SetZoom(coordsUtils.ParcelSize, baseZoom, zoom);
+
+            clusterController.ApplyCameraZoom(baseZoom, zoom);
+        }
+
+        public UniTask Disable(CancellationToken cancellationToken)
+        {
+            foreach (ICategoryMarker marker in markers.Values)
+            {
+                mapCullingController.StopTracking(marker);
+                marker.OnBecameInvisible();
+            }
+
+            clusterController.Disable();
+
+            isEnabled = false;
+            return UniTask.CompletedTask;
+        }
+
+        public UniTask Enable(CancellationToken cancellationToken)
+        {
+            foreach (ICategoryMarker marker in markers.Values)
+                mapCullingController.StartTracking(marker, this);
+
+            isEnabled = true;
+            clusterController.UpdateClusters(zoomLevel, baseZoom, zoom, markers);
+            return UniTask.CompletedTask;
+        }
+
+        public void ResetToBaseScale()
+        {
+            foreach (var marker in markers.Values)
+                marker.ResetScale(coordsUtils.ParcelSize);
+        }
+
+        protected override void DisposeImpl()
+        {
+            objectsPool.Clear();
+
+            foreach (ICategoryMarker marker in markers.Values)
+                marker.Dispose();
+
+            markers.Clear();
+        }
+
+        public void OnMapObjectBecameVisible(ICategoryMarker marker)
+        {
+            marker.OnBecameVisible();
+        }
+
+        public void OnMapObjectCulled(ICategoryMarker marker)
+        {
+            marker.OnBecameInvisible();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents/LiveEventsMarkersController.cs.meta
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents/LiveEventsMarkersController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 58360053b2b641e383620cc775b68a97
+timeCreated: 1732294973

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/MapLayer.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/MapLayer.cs
@@ -28,6 +28,7 @@ namespace DCL.MapRenderer.MapLayers
         PlayerMarker = 1 << 20,
         Path = 1 << 21,
         SearchResults = 1 << 22,
+        LiveEvents = 1 << 23,
 
         // Add yours
     }

--- a/Explorer/Assets/DCL/MapRenderer/MapRenderer.asmdef
+++ b/Explorer/Assets/DCL/MapRenderer/MapRenderer.asmdef
@@ -27,7 +27,8 @@
         "GUID:828002f0a2864c3cbbca4d1de01c7455",
         "GUID:91cf8206af184dac8e30eb46747e9939",
         "GUID:84651a3751eca9349aac36a66bba901b",
-        "GUID:5ba622ca6fb7e4a03870764b38e5493b"
+        "GUID:5ba622ca6fb7e4a03870764b38e5493b",
+        "GUID:98798e6d11df4325a3e60a800a0b5808"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -33,7 +33,7 @@ namespace DCL.Minimap
 {
     public partial class MinimapController : ControllerBase<MinimapView>, IMapActivityOwner
     {
-        private const MapLayer RENDER_LAYERS = MapLayer.SatelliteAtlas | MapLayer.PlayerMarker | MapLayer.ScenesOfInterest | MapLayer.Favorites | MapLayer.HotUsersMarkers | MapLayer.Pins | MapLayer.Path;
+        private const MapLayer RENDER_LAYERS = MapLayer.SatelliteAtlas | MapLayer.PlayerMarker | MapLayer.ScenesOfInterest | MapLayer.Favorites | MapLayer.HotUsersMarkers | MapLayer.Pins | MapLayer.Path | MapLayer.LiveEvents;
         private const float ANIMATION_TIME = 0.2f;
         private const string ORIGIN = "minimap";
 

--- a/Explorer/Assets/DCL/Navmap/Assets/FiltersContainer.prefab
+++ b/Explorer/Assets/DCL/Navmap/Assets/FiltersContainer.prefab
@@ -440,9 +440,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 5119889353484886677}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 108.47085, y: -14}
   m_SizeDelta: {x: 216.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7138881221958439100
@@ -712,9 +712,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1565061347236171997}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 108.47085, y: -14}
   m_SizeDelta: {x: 216.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2844464653037643769
@@ -849,10 +849,10 @@ RectTransform:
   - {fileID: 8135868133922197677}
   m_Father: {fileID: 2670080587961928477}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 129.97086, y: -81.66}
+  m_SizeDelta: {x: 259.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7672229402526894294
 MonoBehaviour:
@@ -1296,7 +1296,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2670080587961928477
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1314,10 +1314,10 @@ RectTransform:
   - {fileID: 2398750166639617410}
   m_Father: {fileID: 7584673811334993644}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 150, y: -480.07}
+  m_SizeDelta: {x: 260, y: 99.66}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &724151822655024107
 CanvasRenderer:
@@ -1415,9 +1415,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 4419017746793979208}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 108.47085, y: -14}
   m_SizeDelta: {x: 216.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1863758469103099680
@@ -1551,9 +1551,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 6277525558565347754}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 108.47085, y: -14}
   m_SizeDelta: {x: 216.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4813284392336898611
@@ -1882,7 +1882,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1221020112687060490
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1899,10 +1899,10 @@ RectTransform:
   - {fileID: 7692341750786482319}
   m_Father: {fileID: 3951365151227401682}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 129.97086, y: -81.66}
+  m_SizeDelta: {x: 259.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1536042986847783232
 MonoBehaviour:
@@ -2776,10 +2776,10 @@ RectTransform:
   - {fileID: 2346907910609759918}
   m_Father: {fileID: 2670080587961928477}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 129.97086, y: -44.91}
+  m_SizeDelta: {x: 259.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5986371784110361588
 MonoBehaviour:
@@ -2840,10 +2840,10 @@ RectTransform:
   - {fileID: 3019276496735571316}
   m_Father: {fileID: 4110921524507594348}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 129.97086, y: -44.91}
+  m_SizeDelta: {x: 259.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &8243949738086181336
 MonoBehaviour:
@@ -2904,10 +2904,10 @@ RectTransform:
   - {fileID: 5562328199476458998}
   m_Father: {fileID: 4110921524507594348}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 129.97086, y: -81.66}
+  m_SizeDelta: {x: 259.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2859661274780808505
 MonoBehaviour:
@@ -2951,7 +2951,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &880134079133075411
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2968,10 +2968,10 @@ RectTransform:
   - {fileID: 6452950426218897536}
   m_Father: {fileID: 3951365151227401682}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 129.97086, y: -118.41}
+  m_SizeDelta: {x: 259.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5722994849056728424
 MonoBehaviour:
@@ -3152,7 +3152,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8657963630228877504
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3167,10 +3167,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7584673811334993644}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 150, y: -539.66003}
+  m_SizeDelta: {x: 260, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5327321937927475720
 CanvasRenderer:
@@ -3242,10 +3242,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 2670080587961928477}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 56.33, y: -13.08}
+  m_SizeDelta: {x: 112.66, y: 18.16}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1953347215222248379
 CanvasRenderer:
@@ -3378,10 +3378,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 4110921524507594348}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 37.57, y: -13.08}
+  m_SizeDelta: {x: 75.14, y: 18.16}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &345844483248948154
 CanvasRenderer:
@@ -3680,7 +3680,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6277525558565347754
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3697,10 +3697,10 @@ RectTransform:
   - {fileID: 8087457060559394862}
   m_Father: {fileID: 3951365151227401682}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 129.97086, y: -155.16}
+  m_SizeDelta: {x: 259.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4499157906340546109
 MonoBehaviour:
@@ -3896,9 +3896,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1221020112687060490}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 108.47085, y: -14}
   m_SizeDelta: {x: 216.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4218024658490196119
@@ -4526,9 +4526,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 880134079133075411}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 108.47085, y: -14}
   m_SizeDelta: {x: 216.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7408460678542939920
@@ -4647,7 +4647,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8887006499742060092
 RectTransform:
   m_ObjectHideFlags: 0
@@ -4662,10 +4662,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7584673811334993644}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 150, y: -420.48}
+  m_SizeDelta: {x: 260, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &175328228694952657
 CanvasRenderer:
@@ -4969,7 +4969,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &4110921524507594348
 RectTransform:
   m_ObjectHideFlags: 0
@@ -4987,10 +4987,10 @@ RectTransform:
   - {fileID: 4419017746793979208}
   m_Father: {fileID: 7584673811334993644}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 150, y: -599.25006}
+  m_SizeDelta: {x: 260, y: 99.66}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3745638201536871265
 CanvasRenderer:
@@ -5088,9 +5088,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 2398750166639617410}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 108.47085, y: -14}
   m_SizeDelta: {x: 216.9417, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2585886612233087642
@@ -5297,7 +5297,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.x
@@ -5305,7 +5305,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_SizeDelta.x
@@ -5345,11 +5345,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 259.9417
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -14
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -5419,7 +5419,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.x
@@ -5427,7 +5427,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_SizeDelta.x
@@ -5467,11 +5467,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 259.9417
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -14
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -5674,7 +5674,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.x
@@ -5682,7 +5682,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_SizeDelta.x
@@ -5722,11 +5722,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 259.9417
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -14
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -5796,7 +5796,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.x
@@ -5804,7 +5804,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_SizeDelta.x
@@ -5844,11 +5844,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 259.9417
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -14
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -5918,7 +5918,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.x
@@ -5926,7 +5926,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_SizeDelta.x
@@ -5966,11 +5966,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 259.9417
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -14
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6439,7 +6439,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.x
@@ -6447,7 +6447,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_SizeDelta.x
@@ -6487,11 +6487,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 259.9417
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -14
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6561,7 +6561,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.x
@@ -6569,7 +6569,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_SizeDelta.x
@@ -6609,11 +6609,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 259.9417
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -14
       objectReference: {fileID: 0}
     - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Explorer/Assets/DCL/Navmap/FilterPanel/NavmapFilterPanelView.cs
+++ b/Explorer/Assets/DCL/Navmap/FilterPanel/NavmapFilterPanelView.cs
@@ -57,6 +57,7 @@ namespace DCL.Navmap.FilterPanel
             poisToggle.onValueChanged.AddListener((isOn) => OnToggleClicked(MapLayer.ScenesOfInterest, isOn));
             peopleToggle.onValueChanged.AddListener((isOn) => OnToggleClicked(MapLayer.HotUsersMarkers, isOn));
             favoritesToggle.onValueChanged.AddListener((isOn) => OnToggleClicked(MapLayer.Favorites, isOn));
+            liveEventsToggle.onValueChanged.AddListener((isOn) => OnToggleClicked(MapLayer.LiveEvents, isOn));
 
             satelliteButton.onValueChanged.AddListener(ToggleSatelliteMap);
             parcelButton.onValueChanged.AddListener(ToggleParcelMap);

--- a/Explorer/Assets/DCL/Navmap/NavmapController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapController.cs
@@ -26,7 +26,7 @@ namespace DCL.Navmap
         private const string EMPTY_PARCEL_NAME = "Empty parcel";
         private const string WORLDS_WARNING_MESSAGE = "This is the Genesis City map. If you jump into any of this places you will leave the world you are currently visiting.";
         private const MapLayer ACTIVE_MAP_LAYERS =
-            MapLayer.SatelliteAtlas | MapLayer.ParcelsAtlas | MapLayer.PlayerMarker | MapLayer.ParcelHoverHighlight | MapLayer.ScenesOfInterest | MapLayer.Favorites | MapLayer.HotUsersMarkers | MapLayer.Pins | MapLayer.SearchResults |
+            MapLayer.SatelliteAtlas | MapLayer.ParcelsAtlas | MapLayer.PlayerMarker | MapLayer.ParcelHoverHighlight | MapLayer.ScenesOfInterest | MapLayer.Favorites | MapLayer.HotUsersMarkers | MapLayer.Pins | MapLayer.SearchResults | MapLayer.LiveEvents |
             MapLayer.Art | MapLayer.Business | MapLayer.Casino | MapLayer.Crypto | MapLayer.Education | MapLayer.Fashion | MapLayer.Game | MapLayer.Music | MapLayer.Shop | MapLayer.Social | MapLayer.Sports;
 
         private readonly NavmapView navmapView;

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -194,7 +194,7 @@ namespace Global.Dynamic
                 // Init other containers
                 container.DefaultTexturesContainer = await DefaultTexturesContainer.CreateAsync(settingsContainer, assetsProvisioner, ct).ThrowOnFail();
                 container.LODContainer = await LODContainer.CreateAsync(assetsProvisioner, bootstrapContainer.DecentralandUrlsSource, staticContainer, settingsContainer, staticContainer.RealmData, container.DefaultTexturesContainer.TextureArrayContainerFactory, debugBuilder, dynamicWorldParams.EnableLOD, ct).ThrowOnFail();
-                container.MapRendererContainer = await MapRendererContainer.CreateAsync(settingsContainer, staticContainer, bootstrapContainer.DecentralandUrlsSource, assetsProvisioner, placesAPIService, mapPathEventBus, notificationsBusController, teleportBusController, sharedNavmapCommandBus, ct);
+                container.MapRendererContainer = await MapRendererContainer.CreateAsync(settingsContainer, staticContainer, bootstrapContainer.DecentralandUrlsSource, assetsProvisioner, placesAPIService, eventsApiService, mapPathEventBus, notificationsBusController, teleportBusController, sharedNavmapCommandBus, ct);
             }
 
             try { await InitializeContainersAsync(dynamicWorldDependencies.SettingsContainer, ct); }

--- a/Explorer/Assets/Scripts/Global/Dynamic/MapRendererContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MapRendererContainer.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using Utility.TeleportBus;
+using DCL.EventsApi;
 
 namespace Global.Dynamic
 {
@@ -34,6 +35,7 @@ namespace Global.Dynamic
             IDecentralandUrlsSource decentralandUrlsSource,
             IAssetsProvisioner assetsProvisioner,
             IPlacesAPIService placesAPIService,
+            IEventsApiService eventsAPIService,
             IMapPathEventBus mapPathEventBus,
             INotificationsBusController notificationsBusController,
             ITeleportBusController teleportBusController,
@@ -51,6 +53,7 @@ namespace Global.Dynamic
                     decentralandUrlsSource,
                     c.TextureContainer,
                     placesAPIService,
+                    eventsAPIService,
                     mapPathEventBus,
                     teleportBusController,
                     notificationsBusController,


### PR DESCRIPTION
## What does this PR change?

This PR adds a layer that contains all current live events, it refreshes every 5 minutes with a new request to the events endpoint

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open the map
3. Verify if there are any live events being displayed (check the events website if there are any live)
4. Check that toggling on and off the live events in the filters panel they are toggled on and off

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

