### PR TITLE
Move InternalJobIndex to PartitionComponent

### DIFF
--- a/Explorer/Assets/Scripts/ECS/Prioritization/Components/PartitionComponent.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Components/PartitionComponent.cs
@@ -53,6 +53,8 @@ namespace ECS.Prioritization.Components
         /// </summary>
         public bool IsBehind { get; set; }
 
+        public int InternalJobIndex { get; set; } = -1;
+
         public bool Equals(IPartitionComponent other) =>
             Bucket == other.Bucket && IsBehind == other.IsBehind;
 

--- a/Explorer/Assets/Scripts/ECS/Prioritization/Components/PartitionComponent.cs
+++ b/Explorer/Assets/Scripts/ECS/Prioritization/Components/PartitionComponent.cs
@@ -53,8 +53,6 @@ namespace ECS.Prioritization.Components
         /// </summary>
         public bool IsBehind { get; set; }
 
-        public int InternalJobIndex { get; set; } = -1;
-
         public bool Equals(IPartitionComponent other) =>
             Bucket == other.Bucket && IsBehind == other.IsBehind;
 

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/PartitionDataContainer.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Components/PartitionDataContainer.cs
@@ -93,4 +93,9 @@ namespace ECS.SceneLifeCycle.Components
             parcelCorners.Add(parcelCornersData);
         }
     }
+
+    public sealed class InternalJobIndexComponent
+    {
+        public int InternalJobIndex;
+    }
 }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneDefinition/Components/SceneDefinitionComponent.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/SceneDefinition/Components/SceneDefinitionComponent.cs
@@ -20,8 +20,6 @@ namespace ECS.SceneLifeCycle.SceneDefinition
         public ParcelMathHelper.SceneGeometry SceneGeometry { get; }
         public bool IsPortableExperience { get; }
 
-        public int InternalJobIndex { get; set; }
-
         public SceneDefinitionComponent(
             SceneEntityDefinition definition,
             IReadOnlyList<Vector2Int> parcels,
@@ -35,7 +33,6 @@ namespace ECS.SceneLifeCycle.SceneDefinition
             IpfsPath = ipfsPath;
             IsSDK7 = isSDK7;
             SceneGeometry = sceneGeometry;
-            InternalJobIndex = -1;
             IsPortableExperience = isPortableExperience;
         }
     }

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/PartitionSceneEntitiesSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/PartitionSceneEntitiesSystem.cs
@@ -118,13 +118,15 @@ namespace ECS.SceneLifeCycle.Systems
                 partitionComponent.RawSqrDistance = float.MaxValue;
 
                 if (partitionComponent.InternalJobIndex < 0)
+                {
                     partitionComponent.InternalJobIndex = partitionDataContainer.CurrentPartitionIndex;
 
-                partitionDataContainer.SetPartitionData(new PartitionData
-                {
-                    IsDirty = readOnlyCameraSamplingData.IsDirty,
-                    RawSqrDistance = -1,
-                });
+                    partitionDataContainer.SetPartitionData(new PartitionData
+                    {
+                        IsDirty = readOnlyCameraSamplingData.IsDirty,
+                        RawSqrDistance = -1,
+                    });
+                }
             }
 
             World.Add(entity, partitionComponent);

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/PartitionSceneEntitiesSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Systems/PartitionSceneEntitiesSystem.cs
@@ -100,7 +100,6 @@ namespace ECS.SceneLifeCycle.Systems
         private void PartitionNewEntity(in Entity entity, ref SceneDefinitionComponent definition)
         {
             PartitionComponent partitionComponent = partitionComponentPool.Get();
-            World.Add(entity, partitionComponent);
 
             if (definition.IsPortableExperience)
             {
@@ -109,23 +108,26 @@ namespace ECS.SceneLifeCycle.Systems
                 partitionComponent.IsBehind = false;
                 partitionComponent.RawSqrDistance = 1;
                 partitionComponent.IsDirty = true;
-                return;
+            }
+            else
+            {
+                AddCorners(ref definition);
+
+                partitionComponent.Bucket = (byte)lastBucketIndex;
+                partitionComponent.IsBehind = true;
+                partitionComponent.RawSqrDistance = float.MaxValue;
+
+                if (partitionComponent.InternalJobIndex < 0)
+                    partitionComponent.InternalJobIndex = partitionDataContainer.CurrentPartitionIndex;
+
+                partitionDataContainer.SetPartitionData(new PartitionData
+                {
+                    IsDirty = readOnlyCameraSamplingData.IsDirty,
+                    RawSqrDistance = -1,
+                });
             }
 
-            AddCorners(ref definition);
-
-            partitionComponent.Bucket = (byte)lastBucketIndex;
-            partitionComponent.IsBehind = true;
-            partitionComponent.RawSqrDistance = float.MaxValue;
-
-            if (partitionComponent.InternalJobIndex < 0)
-                partitionComponent.InternalJobIndex = partitionDataContainer.CurrentPartitionIndex;
-
-            partitionDataContainer.SetPartitionData(new PartitionData
-            {
-                IsDirty = readOnlyCameraSamplingData.IsDirty,
-                RawSqrDistance = -1,
-            });
+            World.Add(entity, partitionComponent);
         }
 
         protected void AddCorners(ref SceneDefinitionComponent definition)

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Tests/PartitionSceneEntitiesSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Tests/PartitionSceneEntitiesSystemShould.cs
@@ -19,6 +19,7 @@ namespace ECS.SceneLifeCycle.Tests
         private IPartitionSettings partitionSettings;
         private IReadOnlyCameraSamplingData samplingData;
         private IComponentPool<PartitionComponent> componentPool;
+        private IComponentPool<InternalJobIndexComponent> internalJobIndexPool;
 
         [SetUp]
         public void SetUp()
@@ -32,9 +33,14 @@ namespace ECS.SceneLifeCycle.Tests
             samplingData = Substitute.For<IReadOnlyCameraSamplingData>();
             componentPool = Substitute.For<IComponentPool<PartitionComponent>>();
             componentPool.Get().Returns(_ => new PartitionComponent());
+            internalJobIndexPool = Substitute.For<IComponentPool<InternalJobIndexComponent>>();
+            internalJobIndexPool.Get().Returns(_ => new InternalJobIndexComponent());
+
             IRealmPartitionSettings realmPartitionSettings = Substitute.For<IRealmPartitionSettings>();
 
-            system = new PartitionSceneEntitiesSystem(world, componentPool, partitionSettings, samplingData, new PartitionDataContainer(), realmPartitionSettings);
+            system = new PartitionSceneEntitiesSystem(world, componentPool, internalJobIndexPool,
+                partitionSettings, samplingData, new PartitionDataContainer(), realmPartitionSettings);
+
             system.partitionDataContainer.Restart();
         }
 

--- a/Explorer/Assets/Scripts/Global/ComponentsContainer.cs
+++ b/Explorer/Assets/Scripts/Global/ComponentsContainer.cs
@@ -5,11 +5,12 @@ using DCL.ECS7;
 using DCL.ECSComponents;
 using DCL.Optimization.Pools;
 using ECS.Prioritization.Components;
+using ECS.SceneLifeCycle.Components;
+using ECS.SceneLifeCycle.Systems;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.Pool;
 using RaycastHit = DCL.ECSComponents.RaycastHit;
 
 namespace Global
@@ -157,6 +158,11 @@ namespace Global
             yield return (typeof(PartitionComponent),
                 new ComponentPool.WithDefaultCtor<PartitionComponent>(
                     component => component.Clear()));
+
+            // Internal Job Index Component
+            yield return (typeof(InternalJobIndexComponent),
+                new ComponentPool.WithDefaultCtor<InternalJobIndexComponent>(
+                    maxSize: PartitionSceneEntitiesSystem.DEPLOYED_SCENES_LIMIT));
         }
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/GlobalWorldFactory.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/GlobalWorldFactory.cs
@@ -158,7 +158,14 @@ namespace Global.Dynamic
             ControlSceneUpdateLoopSystem.InjectToWorld(ref builder, realmPartitionSettings, destroyCancellationSource.Token, scenesCache, sceneReadinessReportQueue);
 
             IComponentPool<PartitionComponent> partitionComponentPool = componentPoolsRegistry.GetReferenceTypePool<PartitionComponent>();
-            PartitionSceneEntitiesSystem.InjectToWorld(ref builder, partitionComponentPool, partitionSettings, cameraSamplingData, staticContainer.PartitionDataContainer, staticContainer.RealmPartitionSettings);
+
+            IComponentPool<InternalJobIndexComponent> internalJobIndexPool = componentPoolsRegistry
+               .GetReferenceTypePool<InternalJobIndexComponent>();
+
+            PartitionSceneEntitiesSystem.InjectToWorld(ref builder, partitionComponentPool,
+                internalJobIndexPool, partitionSettings, cameraSamplingData,
+                staticContainer.PartitionDataContainer, staticContainer.RealmPartitionSettings);
+
             PartitionGlobalAssetEntitiesSystem.InjectToWorld(ref builder, partitionComponentPool, partitionSettings, cameraSamplingData);
 
             CheckCameraQualifiedForRepartitioningSystem.InjectToWorld(ref builder, partitionSettings, realmData, cameraSamplingData);


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

This change moves the InternalJobIndex property from ScenePartitionComponent to PartitionComponent. Reasons:
* ScenePartitionComponent is a value type, so every new instance is new, but PartitionComponent is a pooled reference type. Without this change, a new InternalJobIndex would be assigned to each new ScenePartitionComponent until we run out (the partition data buffer is preallocated to 90000 items). With this change, the job indices and partition datas are reused because the partition component instances are reused.
* InternalJobIndex points to a PartitionData. I believe that PartitionData better belongs to PartitionComponent and not SceneDefinitionComponent.

Do note that this is just the second in a series of many pull requests to refactor and optimize the partition components. The first one was https://github.com/decentraland/unity-explorer/pull/2833

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Play normally
3. The game should work exactly the same as without this change

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

