### PR TITLE
feat: satellite atlas shader to decrease saturation

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/Addressables/AtlasChunk.prefab
+++ b/Explorer/Assets/DCL/MapRenderer/Addressables/AtlasChunk.prefab
@@ -54,7 +54,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: fc2708b2cd9864e799f8cc6e6d93775e, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkController.cs
@@ -14,6 +14,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas.SatelliteAtlas
 {
     public class SatelliteChunkController : IChunkController
     {
+        private const float SATURATION_VALUE = 0.5f;
         private const string CHUNKS_API = "https://media.githubusercontent.com/media/genesis-city/genesis.city/master/map/latest/3/";
         private static readonly Color FINAL_COLOR = Color.white;
         private static readonly Color INITIAL_COLOR = new (0, 0, 0, 0);
@@ -25,6 +26,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas.SatelliteAtlas
         private CancellationTokenSource internalCts;
         private CancellationTokenSource linkedCts;
         private int webRequestAttempts;
+        private static readonly int SATURATION = Shader.PropertyToID("_Saturation");
 
         public SatelliteChunkController(SpriteRenderer prefab, IWebRequestController webRequestController, MapRendererTextureContainer textureContainer, Vector3 chunkLocalPosition, Vector2Int coordsCenter,
             int drawOrder)
@@ -33,6 +35,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas.SatelliteAtlas
             this.textureContainer = textureContainer;
             internalCts = new CancellationTokenSource();
 
+            prefab.material.SetFloat(SATURATION, SATURATION_VALUE);
             atlasChunk = prefab.GetComponent<AtlasChunk>();
             atlasChunk.transform.localPosition = chunkLocalPosition;
             atlasChunk.LoadingSpriteRenderer.sortingOrder = drawOrder;

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkController.cs
@@ -14,7 +14,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas.SatelliteAtlas
 {
     public class SatelliteChunkController : IChunkController
     {
-        private const float SATURATION_VALUE = 0.5f;
+        private const float SATURATION_VALUE = 0.7f;
         private const string CHUNKS_API = "https://media.githubusercontent.com/media/genesis-city/genesis.city/master/map/latest/3/";
         private static readonly Color FINAL_COLOR = Color.white;
         private static readonly Color INITIAL_COLOR = new (0, 0, 0, 0);

--- a/Explorer/Assets/DCL/UI/Shaders/DCL_Sprite-Default.shader
+++ b/Explorer/Assets/DCL/UI/Shaders/DCL_Sprite-Default.shader
@@ -1,0 +1,44 @@
+Shader "DCL/Sprites/Default"
+{
+    Properties
+    {
+        [PerRendererData] _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
+        [MaterialToggle] PixelSnap ("Pixel snap", Float) = 0
+        [HideInInspector] _RendererColor ("RendererColor", Color) = (1,1,1,1)
+        [HideInInspector] _Flip ("Flip", Vector) = (1,1,1,1)
+        [PerRendererData] _AlphaTex ("External Alpha", 2D) = "white" {}
+        [PerRendererData] _EnableExternalAlpha ("Enable External Alpha", Float) = 0
+        _Saturation ("Saturation" , Float) = 0
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "Queue"="Transparent"
+            "IgnoreProjector"="True"
+            "RenderType"="Transparent"
+            "PreviewType"="Plane"
+            "CanUseSpriteAtlas"="True"
+        }
+
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend One OneMinusSrcAlpha
+
+        Pass
+        {
+        CGPROGRAM
+            #pragma vertex SpriteVert
+            #pragma fragment SpriteFrag
+            #pragma target 2.0
+            #pragma multi_compile_instancing
+            #pragma multi_compile_local _ PIXELSNAP_ON
+            #pragma multi_compile _ ETC1_EXTERNAL_ALPHA
+            #include "DCL_UnitySprites.cginc"
+        ENDCG
+        }
+    }
+}

--- a/Explorer/Assets/DCL/UI/Shaders/DCL_Sprite-Default.shader.meta
+++ b/Explorer/Assets/DCL/UI/Shaders/DCL_Sprite-Default.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a49434af1b9eb4b3e8939f140ef0c160
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/UI/Shaders/DCL_UnitySprites.cginc
+++ b/Explorer/Assets/DCL/UI/Shaders/DCL_UnitySprites.cginc
@@ -1,0 +1,101 @@
+#ifndef DCL_UNITY_SPRITES_INCLUDED
+#define DCL_UNITY_SPRITES_INCLUDED
+
+#include "UnityCG.cginc"
+
+#ifdef UNITY_INSTANCING_ENABLED
+
+    UNITY_INSTANCING_BUFFER_START(PerDrawSprite)
+        // SpriteRenderer.Color while Non-Batched/Instanced.
+        UNITY_DEFINE_INSTANCED_PROP(fixed4, unity_SpriteRendererColorArray)
+        // this could be smaller but that's how bit each entry is regardless of type
+        UNITY_DEFINE_INSTANCED_PROP(fixed2, unity_SpriteFlipArray)
+    UNITY_INSTANCING_BUFFER_END(PerDrawSprite)
+
+    #define _RendererColor  UNITY_ACCESS_INSTANCED_PROP(PerDrawSprite, unity_SpriteRendererColorArray)
+    #define _Flip           UNITY_ACCESS_INSTANCED_PROP(PerDrawSprite, unity_SpriteFlipArray)
+
+#endif // instancing
+
+CBUFFER_START(UnityPerDrawSprite)
+#ifndef UNITY_INSTANCING_ENABLED
+    fixed4 _RendererColor;
+    fixed2 _Flip;
+#endif
+    float _EnableExternalAlpha;
+CBUFFER_END
+
+// Material Color.
+fixed4 _Color;
+float _Saturation;
+
+struct appdata_t
+{
+    float4 vertex   : POSITION;
+    float4 color    : COLOR;
+    float2 texcoord : TEXCOORD0;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+struct v2f
+{
+    float4 vertex   : SV_POSITION;
+    fixed4 color    : COLOR;
+    float2 texcoord : TEXCOORD0;
+    UNITY_VERTEX_OUTPUT_STEREO
+};
+
+inline float3 Unity_Saturation_float(float3 In, float Saturation)
+{
+    float luma = dot(In, float3(0.2126729, 0.7151522, 0.0721750));
+    return luma.xxx + Saturation.xxx * (In - luma.xxx);
+}
+
+inline float4 UnityFlipSprite(in float3 pos, in fixed2 flip)
+{
+    return float4(pos.xy * flip, pos.z, 1.0);
+}
+
+v2f SpriteVert(appdata_t IN)
+{
+    v2f OUT;
+
+    UNITY_SETUP_INSTANCE_ID (IN);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(OUT);
+
+    OUT.vertex = UnityFlipSprite(IN.vertex, _Flip);
+    OUT.vertex = UnityObjectToClipPos(OUT.vertex);
+    OUT.texcoord = IN.texcoord;
+    OUT.color = IN.color * _Color * _RendererColor;
+
+    #ifdef PIXELSNAP_ON
+    OUT.vertex = UnityPixelSnap (OUT.vertex);
+    #endif
+
+    return OUT;
+}
+
+sampler2D _MainTex;
+sampler2D _AlphaTex;
+
+fixed4 SampleSpriteTexture (float2 uv)
+{
+    fixed4 color = tex2D (_MainTex, uv);
+
+#if ETC1_EXTERNAL_ALPHA
+    fixed4 alpha = tex2D (_AlphaTex, uv);
+    color.a = lerp (color.a, alpha.r, _EnableExternalAlpha);
+#endif
+
+    return color;
+}
+
+fixed4 SpriteFrag(v2f IN) : SV_Target
+{
+    fixed4 c = SampleSpriteTexture (IN.texcoord) * IN.color;
+    c.rgb = Unity_Saturation_float(c.rgb, _Saturation);
+    c.rgb *= c.a;
+    return c;
+}
+
+#endif // DCL_UNITY_SPRITES_INCLUDED

--- a/Explorer/Assets/DCL/UI/Shaders/DCL_UnitySprites.cginc.meta
+++ b/Explorer/Assets/DCL/UI/Shaders/DCL_UnitySprites.cginc.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 95965655dd2314c12b20dbe892d612ce
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/UI/Shaders/SpriteWithSaturation.mat
+++ b/Explorer/Assets/DCL/UI/Shaders/SpriteWithSaturation.mat
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SpriteWithSaturation
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &6725902969034898458
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Explorer/Assets/DCL/UI/Shaders/SpriteWithSaturation.mat
+++ b/Explorer/Assets/DCL/UI/Shaders/SpriteWithSaturation.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: SpriteWithSaturation
-  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Shader: {fileID: 4800000, guid: a49434af1b9eb4b3e8939f140ef0c160, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
@@ -17,13 +17,16 @@ Material:
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
-  stringTagMap:
-    RenderType: Opaque
+  stringTagMap: {}
   disabledShaderPasses: []
   m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _BaseMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -82,6 +85,7 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - PixelSnap: 0
     - _AlphaClip: 0
     - _AlphaToMask: 0
     - _Blend: 0
@@ -95,6 +99,7 @@ Material:
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _DstBlendAlpha: 0
+    - _EnableExternalAlpha: 0
     - _EnvironmentReflections: 1
     - _GlossMapScale: 0
     - _Glossiness: 0
@@ -104,6 +109,7 @@ Material:
     - _Parallax: 0.005
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _Saturation: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
@@ -116,6 +122,8 @@ Material:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []
 --- !u!114 &6725902969034898458

--- a/Explorer/Assets/DCL/UI/Shaders/SpriteWithSaturation.mat.meta
+++ b/Explorer/Assets/DCL/UI/Shaders/SpriteWithSaturation.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc2708b2cd9864e799f8cc6e6d93775e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?

This PR introduces a shader that allows to change the saturation of the map chunks.

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open the map
3. Check that the satellite view is a bit washed out and not full saturation

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

