### PR TITLE
chore: correct video event error propagation on freeze check

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/VideoEventsSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/VideoEventsSystem.cs
@@ -99,10 +99,8 @@ namespace DCL.SDKComponents.MediaStream
                     state = mediaPlayerControl.IsSeeking() ? VideoState.VsSeeking : VideoState.VsBuffering;
 
                     // If the seeking/buffering never ends, update state with error so the scene can react
-                    if ((Time.realtimeSinceStartup - mediaPlayer.LastStateChangeTime) > MAX_VIDEO_FROZEN_SECONDS_BEFORE_ERROR &&
-                        mediaPlayer.LastPropagatedState != VideoState.VsPaused &&
-                        mediaPlayer.LastPropagatedState != VideoState.VsBuffering &&
-                        mediaPlayer.LastPropagatedState != VideoState.VsSeeking)
+                    if ((Time.realtimeSinceStartup - mediaPlayer.LastStateChangeTime) > MAX_VIDEO_FROZEN_SECONDS_BEFORE_ERROR
+                        && mediaPlayer.LastPropagatedState != VideoState.VsPaused)
                     {
                         state = VideoState.VsError;
                     }


### PR DESCRIPTION
## WHY

Currently the "video buffering/seeking" freeze check that propagates the ERROR video event is skipping the case it was originally implemented for: BUFFERING and SEEKING getting frozen for more than X seconds.

## WHAT

Removed wrongly placed checks for skipping the ERROR video event propagation for BUFFERING and SEEKING states (introduced at https://github.com/decentraland/unity-explorer/pull/2782).

As proof that the original fix from https://github.com/decentraland/unity-explorer/pull/2782 is still working as intended, the exact same test steps are provided below.

## How to test the changes?

1. Download this scene: https://github.com/decentraland-scenes/media-gallery-test  (alternatively [this other scene](https://github.com/user-attachments/files/17948061/video_prioritization_scene.zip)) and uncompress it somewhere
2. Enter the scene root folder and run `npm i` and then `npm run start -- --explorer-alpha`
4. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
5. Download the build from this PR and connect it to the running scene using [the console command](https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene) according to your OS.
6. There is a big cube and a small cube beneath every rectangle. Choose one rectangle and press the big cube below. The video will play.
7. Pause it when you want by pressing the same cube.
8. Wait for 15 seconds.
9. Press the cube again. The video should resume.
