### PR TITLE
Fix: system info not being send

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
@@ -31,11 +31,12 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
         public void Initialize(IWeb3Identity? web3Identity)
         {
-            TrackSystemInfo();
             analytics.Identify(web3Identity?.Address ?? "not cached");
-            analytics.Flush();
-
             isInitialized = true;
+
+            TrackSystemInfo();
+
+            analytics.Flush();
         }
 
         public void SetCommonParam(IRealmData realmData, IWeb3IdentityCache? identityCache, IExposedTransform playerTransform)
@@ -74,7 +75,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
         private void TrackSystemInfo()
         {
-            analytics.Track(AnalyticsEvents.General.SYSTEM_INFO_REPORT, new JsonObject
+            Track(AnalyticsEvents.General.SYSTEM_INFO_REPORT, new JsonObject
             {
                 ["device_model"] = SystemInfo.deviceModel, // "XPS 17 9720 (Dell Inc.)"
                 ["operating_system"] = SystemInfo.operatingSystem, // "Windows 11  (10.0.22631) 64bit"


### PR DESCRIPTION
## What does this PR change?

So events can be send before `Identify`. Thus, moved Tracked system info after `Identify` and assure it won't happen
