### PR TITLE
fix: Videos are paused whenever they are not in camera even when there are less videos than the maximum allowed

### DIFF
--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -19,7 +19,7 @@
         public const string GENESIS_STARTING_PARCEL = "alfa-genesis-spawn-parcel";
         public const string SKYBOX_SETTINGS = "alfa-skybox-settings";
         public const string SKYBOX_SETTINGS_VARIANT = "settings";
-        public const string VIDEO_PRIORITIZATION = "video-prioritization";
+        public const string VIDEO_PRIORITIZATION = "alfa-video-prioritization";
 
         public const string CAMERA_REEL = "alpha-camera-reel";
     }

--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -19,6 +19,7 @@
         public const string GENESIS_STARTING_PARCEL = "alfa-genesis-spawn-parcel";
         public const string SKYBOX_SETTINGS = "alfa-skybox-settings";
         public const string SKYBOX_SETTINGS_VARIANT = "settings";
+        public const string VIDEO_PRIORITIZATION = "video-prioritization";
 
         public const string CAMERA_REEL = "alpha-camera-reel";
     }

--- a/Explorer/Assets/DCL/PluginSystem/World/MediaPlayerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MediaPlayerPlugin.cs
@@ -2,6 +2,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
 using DCL.CharacterCamera;
+using DCL.FeatureFlags;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.Optimization.Pools;
 using DCL.PluginSystem.Global;
@@ -33,6 +34,7 @@ namespace DCL.PluginSystem.World
         private MediaPlayer mediaPlayerPrefab;
         private MediaPlayerPluginWrapper mediaPlayerPluginWrapper;
         private ExposedCameraData exposedCameraData;
+        private FeatureFlagsCache featureFlagsCache;
 
         public MediaPlayerPlugin(
             ECSWorldSingletonSharedDependencies sharedDependencies,
@@ -42,7 +44,8 @@ namespace DCL.PluginSystem.World
             IWebRequestController webRequestController,
             CacheCleaner cacheCleaner,
             WorldVolumeMacBus worldVolumeMacBus,
-            ExposedCameraData exposedCameraData)
+            ExposedCameraData exposedCameraData,
+            FeatureFlagsCache featureFlagsCache)
         {
             this.frameTimeBudget = frameTimeBudget;
             this.sharedDependencies = sharedDependencies;
@@ -52,20 +55,21 @@ namespace DCL.PluginSystem.World
             this.cacheCleaner = cacheCleaner;
             this.worldVolumeMacBus = worldVolumeMacBus;
             this.exposedCameraData = exposedCameraData;
+            this.featureFlagsCache = featureFlagsCache;
         }
 
         public void Dispose() { }
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in ECSWorldInstanceSharedDependencies sharedDependencies, in PersistentEntities _, List<IFinalizeWorldSystem> finalizeWorldSystems, List<ISceneIsCurrentListener> sceneIsCurrentListeners)
         {
-            mediaPlayerPluginWrapper.InjectToWorld(ref builder, sharedDependencies.SceneData, sharedDependencies.SceneStateProvider, sharedDependencies.EcsToCRDTWriter, finalizeWorldSystems);
+            mediaPlayerPluginWrapper.InjectToWorld(ref builder, sharedDependencies.SceneData, sharedDependencies.SceneStateProvider, sharedDependencies.EcsToCRDTWriter, finalizeWorldSystems, featureFlagsCache);
         }
 
         public async UniTask InitializeAsync(MediaPlayerPluginSettings settings, CancellationToken ct)
         {
             VideoPrioritizationSettings videoPrioritizationSettings = (await assetsProvisioner.ProvideMainAssetAsync(settings.VideoPrioritizationSettings, ct: ct)).Value;
             mediaPlayerPrefab = (await assetsProvisioner.ProvideMainAssetAsync(settings.MediaPlayerPrefab, ct: ct)).Value.GetComponent<MediaPlayer>();
-            mediaPlayerPluginWrapper = new MediaPlayerPluginWrapper(sharedDependencies.ComponentPoolsRegistry, webRequestController, cacheCleaner, videoTexturePool, frameTimeBudget, mediaPlayerPrefab, worldVolumeMacBus, exposedCameraData, videoPrioritizationSettings);
+            mediaPlayerPluginWrapper = new MediaPlayerPluginWrapper(sharedDependencies.ComponentPoolsRegistry, webRequestController, cacheCleaner, videoTexturePool, frameTimeBudget, mediaPlayerPrefab, worldVolumeMacBus, exposedCameraData, videoPrioritizationSettings, featureFlagsCache);
 
         }
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/DCL.MediaPlayer.asmdef
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/DCL.MediaPlayer.asmdef
@@ -23,7 +23,8 @@
         "GUID:fa7b3fdbb04d67549916da7bd2af58ab",
         "GUID:1d75b3d8691c845b1a51082e81433dfc",
         "GUID:4307f53044263cf4b835bd812fc161a4",
-        "GUID:fc37ca6521833154cab08ec51af097d9"
+        "GUID:fc37ca6521833154cab08ec51af097d9",
+        "GUID:ace653ac543d483ba8abee112a3ba2a6"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/DCL.MediaPlayer.PluginWrapper.asmdef
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/DCL.MediaPlayer.PluginWrapper.asmdef
@@ -20,7 +20,8 @@
         "GUID:543b8f091a5947a3880b7f2bca2358bd",
         "GUID:1d75b3d8691c845b1a51082e81433dfc",
         "GUID:fa7b3fdbb04d67549916da7bd2af58ab",
-        "GUID:fc37ca6521833154cab08ec51af097d9"
+        "GUID:fc37ca6521833154cab08ec51af097d9",
+        "GUID:ace653ac543d483ba8abee112a3ba2a6"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/Scripts/Global/StaticContainer.cs
+++ b/Explorer/Assets/Scripts/Global/StaticContainer.cs
@@ -242,7 +242,7 @@ namespace Global
                 container.CharacterContainer.CreateWorldPlugin(componentsContainer.ComponentPoolsRegistry),
                 new AnimatorPlugin(),
                 new TweenPlugin(),
-                new MediaPlayerPlugin(sharedDependencies, videoTexturePool, sharedDependencies.FrameTimeBudget, container.assetsProvisioner, container.WebRequestsContainer.WebRequestController, container.CacheCleaner, worldVolumeMacBus, exposedGlobalDataContainer.ExposedCameraData),
+                new MediaPlayerPlugin(sharedDependencies, videoTexturePool, sharedDependencies.FrameTimeBudget, container.assetsProvisioner, container.WebRequestsContainer.WebRequestController, container.CacheCleaner, worldVolumeMacBus, exposedGlobalDataContainer.ExposedCameraData, container.FeatureFlagsCache),
                 new CharacterTriggerAreaPlugin(globalWorld, container.MainPlayerAvatarBaseProxy, exposedGlobalDataContainer.ExposedCameraData.CameraEntityProxy, container.CharacterContainer.CharacterObject, componentsContainer.ComponentPoolsRegistry, container.assetsProvisioner, container.CacheCleaner, exposedGlobalDataContainer.ExposedCameraData, container.SceneRestrictionBusController, web3IdentityProvider),
                 new InteractionsAudioPlugin(container.assetsProvisioner),
                 new MapPinPlugin(globalWorld, container.FeatureFlagsCache),


### PR DESCRIPTION
This change is related to this shape:

Until now, videos that were out of camera, too far from camera or looked too small on screen, where paused to save CPU. That behaviour has now changed as described below:

## What does this PR change?

If the amount of videos in the scene is equal to or less than the maximum limit established for the current quality level, prioritization will not be applied, they all will keep playing even if they are not in camera or are too far. If there are more videos than the maximum, then a number of videos equal to the maximum will always be playing disregarding any priority or condition.
Added a new feature flag ("alfa-video-prioritization") so the entire video prioritization feature can be disabled from outside the application.

## How to test the changes?

1. Download this scene: https://drive.google.com/file/d/126iHcEKbDoZgRQexA_Nv_5Na2lHjzjE-/view?usp=sharing and uncompress it somewhere
2. Enter the scene root folder and run npm i and then npm run start -- --explorer-alpha
3. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
4. Download the build from this PR and connect it to the running scene using [the console command](https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene) according to your OS.
5. Launch the explorer.
6. Click on the Play all videos button in the UI (be sure the avatar is inside the scene, otherwise the UI will not appear).

**Test 1: The maximum limit works**

1. Walk around and look at the screens.

Some of the screens should pause and other resume as you aim at them.

**Test 2: Changing the quality level changes the maximum**

1. Open the Graphics settings.
2. Change the level of quality.
3. Look at the screens in the scene.

When level is Low, only 1 screen must play the video at a time; when it is medium, only 5; when it is high they can be up to 10.

**Test 3: You can pause and play a video manually**

1. Choose one video at 0,0.
2. There is a cube beneath of it, click on it. It should pause the video.
3. Click on it again. It should play the video again.

**Test 4: Paused videos are not played automatically**

1. Choose one screen at 0,0.
2. There is a cube beneath of it, click on it. It should pause the video.
3. Now turn the camera until the screen is out of camera.
4. Look at the screen again.

The paused video should not resume.

**Test 5: Videos out of camera are not paused (I)**

1. Choose one screen at 0,0.
2. Now turn the camera until the screen is almost out of camera, so you can still see a small part of it.

The video should keep playing.

**Test 6: Videos out of camera are not paused (II)**

1. Look towards a place so you don't see any video.

An amount of videos equal to the maximum allowed should keep playing.

**Test 7: Moving far from videos do not pause them**

1. Move to 0,2.
2. Look at any group of videos.
3. Walk towards 0,4 or farther while still looking at the videos.

Videos are not paused.