### PR TITLE
fix: sdk avatar shape emotes

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/DCL.SDKComponents.asmdef
+++ b/Explorer/Assets/DCL/SDKComponents/DCL.SDKComponents.asmdef
@@ -26,7 +26,8 @@
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:1300820cd310d4584b09afde765bdd16",
         "GUID:5ab29fa8ae5769b49ab29e390caca7a4",
-        "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b"
+        "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b",
+        "GUID:5eabe9a3d4dd19d42a16208ea5411062"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## WHY

Currently the SDK's AvatarShape component that allows the creation of NPCs is not supporting the triggering of emotes as described in t[he component's documentation](https://docs.decentraland.org/creator/development-guide/sdk7/npc-avatars/#animations).

## WHAT

Made minor change to start supporting the already existent emote field.

https://github.com/user-attachments/assets/dc0ccb17-b30b-4276-9fdf-3f37d98e9b0a

## TEST STEPS

1. Download the build from this PR
2. Open the build connecting to the `pravus.dcl.eth`world by following the instructions from [the wiki](https://github.com/decentraland/unity-explorer/wiki/How-To#command-arguments-custompr-builds) according to your OS, adding `--realm pravus.dcl.eth`.
3. Confirm that the scene loads an AvatarShape that has your own wearables (maybe some wearable is not visible or looks differently, that's OK and can be ignored)
4. Confirm that every time you click on the cube, the avatar shape of the scene player the different emotes you have equipped (don't test changing your emotes, the scene won't react to that as it only fetches the user info at the beginning)
