### PR TITLE
fix: Videos that play at a given time are starting at zero

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/VideoStateByPriorityComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/VideoStateByPriorityComponent.cs
@@ -24,11 +24,6 @@ namespace DCL.SDKComponents.MediaStream
         public readonly Entity Entity;
 
         /// <summary>
-        /// Half of the size of the mesh renderer (or mesh renderer group that consume the same video texture).
-        /// </summary>
-        public readonly float HalfSize;
-
-        /// <summary>
         /// Whether the video should be playing according to its priority.
         /// </summary>
         public bool IsPlaying;
@@ -43,10 +38,9 @@ namespace DCL.SDKComponents.MediaStream
         /// </summary>
         public MeshRenderer? DebugPrioritySign;
 
-        public VideoStateByPriorityComponent(Entity entity, float halfSize, bool wantsToPlay)
+        public VideoStateByPriorityComponent(Entity entity, bool wantsToPlay)
         {
             Entity = entity;
-            HalfSize = halfSize;
             WantsToPlay = wantsToPlay;
 
             Score = 0.0f;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerPrioritizationSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerPrioritizationSystem.cs
@@ -140,10 +140,10 @@ namespace DCL.SDKComponents.MediaStream
                 if (mediaPlayer.MediaPlayer.Control.IsPlaying())
                 {
                     videoStateByPriority.WantsToPlay = true;
-                    videoStateByPriority.MediaPlayStartTime = Time.realtimeSinceStartup;
+                    videoStateByPriority.MediaPlayStartTime = Time.realtimeSinceStartup - (float)mediaPlayer.MediaPlayer.Control.GetCurrentTime();
 
 #if DEBUG_VIDEO_PRIORITIES
-                    ReportHub.Log(GetReportData(),"Video: PLAYED MANUALLY");
+                    ReportHub.Log(GetReportData(),$"Video: PLAYED MANUALLY: {videoStateByPriority.MediaPlayStartTime} // {mediaPlayer.MediaPlayer.Control.GetCurrentTime()}");
 #endif
                 }
                 else
@@ -257,7 +257,7 @@ namespace DCL.SDKComponents.MediaStream
                 videoStateByPriority.IsPlaying = true;
 
 #if DEBUG_VIDEO_PRIORITIES
-                ReportHub.Log(GetReportData(),"VIDEO RESUMED BY PRIORITY: " + videoStateByPriority.Entity.Id + " t:" + seekTime);
+                ReportHub.Log(GetReportData(),$"VIDEO RESUMED BY PRIORITY:  [{videoStateByPriority.Entity.Id}]  t: {seekTime} // {mediaPlayer.MediaPlayer.Control.GetCurrentTime()} -- {videoStateByPriority.MediaPlayStartTime}");
 #endif
             }
             else if(!mustPlay && (videoStateByPriority.IsPlaying || mediaPlayer.MediaPlayer.Control.IsPlaying()))
@@ -270,7 +270,7 @@ namespace DCL.SDKComponents.MediaStream
                 videoStateByPriority.IsPlaying = false;
 
 #if DEBUG_VIDEO_PRIORITIES
-                ReportHub.Log(GetReportData(),"VIDEO CULLED BY PRIORITY: " + videoStateByPriority.Entity.Id);
+                ReportHub.Log(GetReportData(),$"VIDEO CULLED BY PRIORITY: [{videoStateByPriority.Entity.Id}]  t: {mediaPlayer.MediaPlayer.Control.GetCurrentTime()}");
 #endif
             }
         }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerPrioritizationSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerPrioritizationSystem.cs
@@ -93,13 +93,7 @@ namespace DCL.SDKComponents.MediaStream
         [None(typeof(VideoStateByPriorityComponent))]
         private void AddVideoStatesByPriority(Entity entity, in MediaPlayerComponent mediaPlayer, in VideoTextureConsumer videoTextureConsumer)
         {
-            // Using the diagonal of the box instead of the height, meshes that occupy "the same" area on screen should have the same priority
-            float videoMeshLocalSize = (videoTextureConsumer.BoundsMax - videoTextureConsumer.BoundsMin).magnitude;
-
-            VideoStateByPriorityComponent newVideoStateByPriority = new VideoStateByPriorityComponent(
-                                                                            entity,
-                                                                            videoMeshLocalSize * 0.5f,
-                                                                            mediaPlayer.IsPlaying);
+            VideoStateByPriorityComponent newVideoStateByPriority = new VideoStateByPriorityComponent(entity, mediaPlayer.IsPlaying);
 
 #if DEBUG_VIDEO_PRIORITIES
             // Adds a colored cube to a corner of the video mesh renderer which shows the priority of the video
@@ -189,7 +183,9 @@ namespace DCL.SDKComponents.MediaStream
                     // Skips videos that are too far
                     if (distance <= videoPrioritizationSettings.MaximumDistanceLimit)
                     {
-                        float screenSize = Mathf.Clamp01(CalculateObjectHeightRelativeToScreenHeight(videoStateByPriority.HalfSize, distance));
+                        // Using the diagonal of the box instead of the height, meshes that occupy "the same" area on screen should have the same priority
+                        float videoMeshLocalSize = (videoTextureConsumer.BoundsMax - videoTextureConsumer.BoundsMin).magnitude;
+                        float screenSize = Mathf.Clamp01(CalculateObjectHeightRelativeToScreenHeight(videoMeshLocalSize, distance));
 
                         // Skips videos that are too small on screen
                         if (screenSize >= videoPrioritizationSettings.MinimumSizeLimit)
@@ -202,7 +198,7 @@ namespace DCL.SDKComponents.MediaStream
                                                          dotProduct * videoPrioritizationSettings.AngleWeight;
 
 #if DEBUG_VIDEO_PRIORITIES
-                            ReportHub.Log(GetReportData(),$"VIDEO ENTITY[{videoStateByPriority.Entity.Id}] Dist: {distance} HSize:{videoStateByPriority.HalfSize} / {CalculateObjectHeightRelativeToScreenHeight(videoStateByPriority.HalfSize, distance)} Dot:{dotProduct} SCORE:{videoStateByPriority.Score}");
+                            ReportHub.Log(GetReportData(),$"VIDEO ENTITY[{videoStateByPriority.Entity.Id}] Dist: {distance} HSize:{videoMeshLocalSize} / {CalculateObjectHeightRelativeToScreenHeight(videoMeshLocalSize, distance)} Dot:{dotProduct} SCORE:{videoStateByPriority.Score}");
 #endif
 
                             // Sorts the playing video list by score, on insertion


### PR DESCRIPTION
## What does this PR change?

Now when entering a scene that has a video that plays automatically at a given time, it does it correctly instead of starting at zero.
Additionally, sometimes when the scene contained a video that was shared by several meshes, it was not playing at all and now it does.

## How to test the changes?

1. Download this scene: https://github.com/decentraland-scenes/dcl_music_fest_2024_stage 
2. Enter the scene root folder and run `npm i` and then `npm run start -- --explorer-alpha`
4. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
5. Download the build from this PR and connect it to the running scene using [the console command](https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene) according to your OS.
6. In the --position argument, write -66,-56 instead of 0,0.
7. Go to the file \src\modules\showMgmt\scheduleSetup.ts. Around line 66, you should see the word "startTime:" and a number. Replace the number with the word: testStartTime
8. Launch the explorer. You should appear at the music festival.

The video of the dj you be there, and should not be at the beginning.
Close the explorer and launch it again several times to check that the problem does not happen again.