### PR TITLE
Don't modify the skybox material asset when animating the sky

### DIFF
--- a/Explorer/Assets/DCL/StylizedSkybox/Scripts/SkyboxController.cs
+++ b/Explorer/Assets/DCL/StylizedSkybox/Scripts/SkyboxController.cs
@@ -99,7 +99,7 @@ public class SkyboxController : MonoBehaviour
             // we will get annoying mystery changes in Git.
             skyboxMat = new Material(skyboxMat);
 #endif
-            skyboxMaterial = new Material(skyboxMat);
+            skyboxMaterial = skyboxMat;
         }
 
         if (dirLight != null)

--- a/Explorer/Assets/DCL/StylizedSkybox/Scripts/SkyboxController.cs
+++ b/Explorer/Assets/DCL/StylizedSkybox/Scripts/SkyboxController.cs
@@ -92,7 +92,15 @@ public class SkyboxController : MonoBehaviour
     public void Initialize(Material skyboxMat, Light dirLight, AnimationClip skyboxAnimationClip, FeatureFlagsCache featureFlagsCache)
     {
         if (skyboxMat != null)
-            skyboxMaterial = skyboxMat;
+        {
+#if UNITY_EDITOR
+
+            // Create a copy so that the original asset does not get modified by UpdateSkyboxColor. Else
+            // we will get annoying mystery changes in Git.
+            skyboxMat = new Material(skyboxMat);
+#endif
+            skyboxMaterial = new Material(skyboxMat);
+        }
 
         if (dirLight != null)
             DirectionalLight = dirLight;


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

This change cleans up one of the "random modified files show up in Git" annoyances.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Look up :)
3. The game should run exactly the same as without this change

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

