### PR TITLE
fix: LSD condition in RealmNavigator

### DIFF
--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -47,6 +47,7 @@ namespace DCL.Minimap
         private readonly IScenesCache scenesCache;
         private readonly IMapPathEventBus mapPathEventBus;
         private readonly ISceneRestrictionBusController sceneRestrictionBusController;
+        private readonly IRealmController realmController;
 
         private CancellationTokenSource cts;
         private MapRendererTrackPlayerPosition mapRendererTrackPlayerPosition;
@@ -66,7 +67,7 @@ namespace DCL.Minimap
             IMapRenderer mapRenderer,
             IMVCManager mvcManager,
             IPlacesAPIService placesAPIService,
-            IRealmData realmData,
+            IRealmController realmController,
             IChatMessagesBus chatMessagesBus,
             IRealmNavigator realmNavigator,
             IScenesCache scenesCache,
@@ -78,7 +79,8 @@ namespace DCL.Minimap
             this.mapRenderer = mapRenderer;
             this.mvcManager = mvcManager;
             this.placesAPIService = placesAPIService;
-            this.realmData = realmData;
+            this.realmController = realmController;
+            realmData = realmController.RealmData;
             this.chatMessagesBus = chatMessagesBus;
             this.realmNavigator = realmNavigator;
             this.scenesCache = scenesCache;
@@ -92,7 +94,7 @@ namespace DCL.Minimap
 
         private void OnRealmChanged(RealmType realmType)
         {
-            SetWorldMode(realmType is RealmType.World);
+            SetGenesisMode(realmType is RealmType.GenesisCity);
             previousParcelPosition = new Vector2Int(int.MaxValue, int.MaxValue);
         }
 
@@ -108,7 +110,7 @@ namespace DCL.Minimap
             viewInstance.SideMenuCanvasGroup.gameObject.SetActive(false);
             new SideMenuController(viewInstance.sideMenuView);
             sceneRestrictionsController = new SceneRestrictionsController(viewInstance.sceneRestrictionsView, sceneRestrictionBusController);
-            SetWorldMode(realmData.ScenesAreFixed);
+            SetGenesisMode(realmController.IsGenesis());
             realmNavigator.RealmChanged += OnRealmChanged;
             mapPathEventBus.OnShowPinInMinimapEdge += ShowPinInMinimapEdge;
             mapPathEventBus.OnHidePinInMinimapEdge += HidePinInMinimapEdge;
@@ -245,15 +247,15 @@ namespace DCL.Minimap
             }
         }
 
-        private void SetWorldMode(bool isWorldModeActivated)
+        private void SetGenesisMode(bool isGenesisModeActivated)
         {
             foreach (GameObject go in viewInstance!.objectsToActivateForGenesis)
-                go.SetActive(!isWorldModeActivated);
+                go.SetActive(isGenesisModeActivated);
 
             foreach (GameObject go in viewInstance.objectsToActivateForWorlds)
-                go.SetActive(isWorldModeActivated);
+                go.SetActive(!isGenesisModeActivated);
 
-            viewInstance.minimapAnimator.runtimeAnimatorController = isWorldModeActivated ? viewInstance.worldsAnimatorController : viewInstance.genesisCityAnimatorController;
+            viewInstance.minimapAnimator.runtimeAnimatorController = isGenesisModeActivated ?  viewInstance.genesisCityAnimatorController : viewInstance.worldsAnimatorController;
         }
 
         public override void Dispose()

--- a/Explorer/Assets/DCL/PluginSystem/Global/MinimapPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/MinimapPlugin.cs
@@ -23,7 +23,7 @@ namespace DCL.PluginSystem.Global
         private readonly IMVCManager mvcManager;
         private readonly MapRendererContainer mapRendererContainer;
         private readonly IPlacesAPIService placesAPIService;
-        private readonly IRealmData realmData;
+        private readonly IRealmController realmController;
         private readonly IRealmNavigator realmNavigator;
         private readonly IChatMessagesBus chatMessagesBus;
         private readonly IScenesCache scenesCache;
@@ -35,14 +35,14 @@ namespace DCL.PluginSystem.Global
         private readonly string startParcelInGenesis;
 
         public MinimapPlugin(IMVCManager mvcManager, MapRendererContainer mapRendererContainer, IPlacesAPIService placesAPIService,
-            IRealmData realmData, IChatMessagesBus chatMessagesBus, IRealmNavigator realmNavigator, IScenesCache scenesCache, MainUIView mainUIView,
+            IRealmController realmController, IChatMessagesBus chatMessagesBus, IRealmNavigator realmNavigator, IScenesCache scenesCache, MainUIView mainUIView,
             IMapPathEventBus mapPathEventBus, ISceneRestrictionBusController sceneRestrictionBusController,
             string startParcelInGenesis)
         {
             this.mvcManager = mvcManager;
             this.mapRendererContainer = mapRendererContainer;
             this.placesAPIService = placesAPIService;
-            this.realmData = realmData;
+            this.realmController = realmController;
             this.chatMessagesBus = chatMessagesBus;
             this.realmNavigator = realmNavigator;
             this.scenesCache = scenesCache;
@@ -75,7 +75,7 @@ namespace DCL.PluginSystem.Global
                 mapRendererContainer.MapRenderer,
                 mvcManager,
                 placesAPIService,
-                realmData,
+                realmController,
                 chatMessagesBus,
                 realmNavigator,
                 scenesCache,

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmController.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmController.cs
@@ -8,6 +8,7 @@ namespace ECS.SceneLifeCycle.Realm
     {
         GenesisCity,
         World,
+        LocalScene
     }
 
     public interface IRealmController
@@ -34,5 +35,8 @@ namespace ECS.SceneLifeCycle.Realm
     {
         public static bool IsGenesis(this IRealmController realmController) =>
             realmController.Type is RealmType.GenesisCity;
+        
+        public static bool IsLocalScene(this IRealmController realmController) =>
+            realmController.Type is RealmType.LocalScene;
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -560,7 +560,7 @@ namespace Global.Dynamic
                 new ErrorPopupPlugin(container.MvcManager, assetsProvisioner),
                 connectionStatusPanelPlugin,
                 new MinimapPlugin(container.MvcManager, container.MapRendererContainer, placesAPIService,
-                    staticContainer.RealmData, container.ChatMessagesBus, realmNavigator, staticContainer.ScenesCache,
+                    container.RealmController, container.ChatMessagesBus, realmNavigator, staticContainer.ScenesCache,
                     mainUIView, mapPathEventBus, staticContainer.SceneRestrictionBusController,
                     $"{dynamicWorldParams.StartParcel.x},{dynamicWorldParams.StartParcel.y}"),
                 new ChatPlugin(assetsProvisioner, container.MvcManager, container.ChatMessagesBus, chatHistory, entityParticipantTable, nametagsData, dclInput, unityEventSystem, mainUIView, staticContainer.InputBlock, globalWorld, playerEntity),

--- a/Explorer/Assets/Scripts/Global/Dynamic/Landscapes/Landscape.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/Landscapes/Landscape.cs
@@ -39,7 +39,12 @@ namespace Global.Dynamic.Landscapes
             if (landscapeEnabled == false)
                 return EnumResult<LandscapeError>.ErrorResult(LandscapeError.LandscapeDisabled);
 
-            if (IsGenesisRealm())
+            if (isLocalSceneDevelopment)
+            {
+                genesisTerrain.Hide();
+                await GenerateStaticScenesTerrainAsync(landscapeLoadReport, ct);
+            }
+            else if (realmController.IsGenesis())
             {
                 //TODO (Juani): The globalWorld terrain would be hidden. We need to implement the re-usage when going back
                 worldsTerrain.SwitchVisibility(false);
@@ -53,11 +58,7 @@ namespace Global.Dynamic.Landscapes
             else
             {
                 genesisTerrain.Hide();
-
-                if (isLocalSceneDevelopment)
-                    await GenerateStaticScenesTerrainAsync(landscapeLoadReport, ct);
-                else // World Fixed Scenes
-                    await GenerateFixedScenesTerrainAsync(landscapeLoadReport, ct);
+                await GenerateFixedScenesTerrainAsync(landscapeLoadReport, ct);
             }
 
             return EnumResult<LandscapeError>.SuccessResult();
@@ -118,7 +119,5 @@ namespace Global.Dynamic.Landscapes
             }
         }
 
-        private bool IsGenesisRealm() =>
-            !isLocalSceneDevelopment && realmController.RealmData is { Configured: true, ScenesAreFixed: false };
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/Landscapes/Landscape.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/Landscapes/Landscape.cs
@@ -39,12 +39,7 @@ namespace Global.Dynamic.Landscapes
             if (landscapeEnabled == false)
                 return EnumResult<LandscapeError>.ErrorResult(LandscapeError.LandscapeDisabled);
 
-            if (isLocalSceneDevelopment)
-            {
-                genesisTerrain.Hide();
-                await GenerateStaticScenesTerrainAsync(landscapeLoadReport, ct);
-            }
-            else if (realmController.IsGenesis())
+            if (realmController.IsGenesis())
             {
                 //TODO (Juani): The globalWorld terrain would be hidden. We need to implement the re-usage when going back
                 worldsTerrain.SwitchVisibility(false);
@@ -58,7 +53,11 @@ namespace Global.Dynamic.Landscapes
             else
             {
                 genesisTerrain.Hide();
-                await GenerateFixedScenesTerrainAsync(landscapeLoadReport, ct);
+
+                if (realmController.IsLocalScene())
+                    await GenerateStaticScenesTerrainAsync(landscapeLoadReport, ct);
+                else
+                    await GenerateFixedScenesTerrainAsync(landscapeLoadReport, ct);
             }
 
             return EnumResult<LandscapeError>.SuccessResult();

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmController.cs
@@ -57,7 +57,17 @@ namespace Global.Dynamic
 
         private readonly RealmNavigatorDebugView realmNavigatorDebugView;
 
-        public RealmType Type => IsGenesisRealm() ? RealmType.GenesisCity : RealmType.World;
+        public RealmType Type
+        {
+            get
+            {
+                if (isLocalSceneDevelopment)
+                    return RealmType.LocalScene;
+                if (realmData is { Configured: true, ScenesAreFixed: false })
+                    return RealmType.GenesisCity;
+                return RealmType.World;
+            }
+        }
 
         public URLDomain? CurrentDomain { get; private set; }
 
@@ -279,7 +289,5 @@ namespace Global.Dynamic
             return hostname;
         }
 
-        private bool IsGenesisRealm() =>
-            realmData is { Configured: true, ScenesAreFixed: false };
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmController.cs
@@ -280,6 +280,6 @@ namespace Global.Dynamic
         }
 
         private bool IsGenesisRealm() =>
-            !isLocalSceneDevelopment && realmData is { Configured: true, ScenesAreFixed: false };
+            realmData is { Configured: true, ScenesAreFixed: false };
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -253,13 +253,13 @@ namespace Global.Dynamic
             Vector2Int parcelToTeleport
         )
         {
-            bool isGenesis = realmController.IsGenesis();
+            bool isWorld = realmController.Type is RealmType.World;
             WaitForSceneReadiness? waitForSceneReadiness;
             
-            if (isGenesis)
-                waitForSceneReadiness = await teleportController.TeleportToSceneSpawnPointAsync(parcelToTeleport, teleportLoadReport, ct);
-            else
+            if (isWorld)
                 waitForSceneReadiness = await TeleportToWorldSpawnPointAsync(parcelToTeleport, teleportLoadReport, ct);
+            else
+                waitForSceneReadiness = await teleportController.TeleportToSceneSpawnPointAsync(parcelToTeleport, teleportLoadReport, ct);
                 
             // add camera sampling data to the camera entity to start partitioning
             Assert.IsTrue(cameraEntity.Configured);

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -253,14 +253,14 @@ namespace Global.Dynamic
             Vector2Int parcelToTeleport
         )
         {
-            bool isWorld = realmController.Type is RealmType.World;
+            bool isGenesis = realmController.IsGenesis();
             WaitForSceneReadiness? waitForSceneReadiness;
-
-            if (isWorld)
-                waitForSceneReadiness = await TeleportToWorldSpawnPointAsync(parcelToTeleport, teleportLoadReport, ct);
-            else
+            
+            if (isGenesis)
                 waitForSceneReadiness = await teleportController.TeleportToSceneSpawnPointAsync(parcelToTeleport, teleportLoadReport, ct);
-
+            else
+                waitForSceneReadiness = await TeleportToWorldSpawnPointAsync(parcelToTeleport, teleportLoadReport, ct);
+                
             // add camera sampling data to the camera entity to start partitioning
             Assert.IsTrue(cameraEntity.Configured);
             globalWorld.Add(cameraEntity.Object, cameraSamplingData);
@@ -328,7 +328,7 @@ namespace Global.Dynamic
         public void SwitchMiscVisibilityAsync()
         {
             var type = realmController.Type;
-            bool isGenesis = type is RealmType.GenesisCity;
+            bool isGenesis = realmController.IsGenesis();
 
             RealmChanged?.Invoke(type);
             mapRenderer.SetSharedLayer(MapLayer.PlayerMarker, isGenesis);

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -255,12 +255,12 @@ namespace Global.Dynamic
         {
             bool isWorld = realmController.Type is RealmType.World;
             WaitForSceneReadiness? waitForSceneReadiness;
-            
+
             if (isWorld)
                 waitForSceneReadiness = await TeleportToWorldSpawnPointAsync(parcelToTeleport, teleportLoadReport, ct);
             else
                 waitForSceneReadiness = await teleportController.TeleportToSceneSpawnPointAsync(parcelToTeleport, teleportLoadReport, ct);
-                
+
             // add camera sampling data to the camera entity to start partitioning
             Assert.IsTrue(cameraEntity.Configured);
             globalWorld.Add(cameraEntity.Object, cameraSamplingData);


### PR DESCRIPTION
## What does this PR change?

- Introduces the `LocalScene` realm type to bound certain results that required it, and it was not enough with worlds or genesis (ie: terrain generation)

## How to test the changes?

1. Launch the explorer
2. Check that the terrain and minimap are correct
3. Teleport to a world
4. Check that the terrain and minimap are correct for the world
5. Teleport back to Genesis
6. Once again, check that the terrain and minimap are correct for Genesis
7. Launch the explorer with a local scene. Check that the scene loads, the minimap is gone and the terrain is correct

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

