### PR TITLE
Feat: TexturesFuse fallback

### DIFF
--- a/Explorer/Assets/Plugins/TexturesFuse/TexturesServerWrap/Unzips/FallbackTexturesFuse.cs
+++ b/Explorer/Assets/Plugins/TexturesFuse/TexturesServerWrap/Unzips/FallbackTexturesFuse.cs
@@ -1,0 +1,41 @@
+using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
+using System;
+using System.Threading;
+using Utility.Types;
+
+namespace Plugins.TexturesFuse.TexturesServerWrap.Unzips
+{
+    internal class FallbackTexturesFuse : ITexturesFuse
+    {
+        private readonly ITexturesFuse origin;
+        private readonly ITexturesFuse fallback;
+
+        public FallbackTexturesFuse(ITexturesFuse origin) : this(origin, new ManagedTexturesFuse()) { }
+
+        public FallbackTexturesFuse(ITexturesFuse origin, ITexturesFuse fallback)
+        {
+            this.origin = origin;
+            this.fallback = fallback;
+        }
+
+        public async UniTask<EnumResult<IOwnedTexture2D, NativeMethods.ImageResult>> TextureFromBytesAsync(IntPtr bytes, int bytesLength, TextureType type, CancellationToken token)
+        {
+            var result = await origin.TextureFromBytesAsync(bytes, bytesLength, type, token);
+
+            if (result.Success == false && result.Error!.Value.State is NativeMethods.ImageResult.ErrorUnknown)
+            {
+                ReportHub.LogError(ReportCategory.TEXTURES, $"ErrorUnknown occured during the main compression: {result.Error.Value.Message}");
+                result = await fallback.TextureFromBytesAsync(bytes, bytesLength, type, token);
+            }
+
+            return result;
+        }
+
+        public void Dispose()
+        {
+            origin.Dispose();
+            fallback.Dispose();
+        }
+    }
+}

--- a/Explorer/Assets/Plugins/TexturesFuse/TexturesServerWrap/Unzips/FallbackTexturesFuse.cs.meta
+++ b/Explorer/Assets/Plugins/TexturesFuse/TexturesServerWrap/Unzips/FallbackTexturesFuse.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: debcbdf38af64ca88e8f51717bbc06d2
+timeCreated: 1733925946


### PR DESCRIPTION
Why?

In some cases user's hardware may be not reachable. Use default Unity's LoadImage method

## How to test the changes?

1. Launch the explorer
2. Play happy path

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

