### PR TITLE
Fix: Sometimes videos start at zero when the scene is loaded for the first time

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerExtensions.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerExtensions.cs
@@ -72,10 +72,8 @@ namespace DCL.SDKComponents.MediaStream
             // If there are no seekable/buffered times, and we try to seek, AVPro may mistakenly play it from the start.
             await UniTask.WaitUntil(() => control.GetBufferedTimes().Count > 0);
 
-#if (UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX)
-            // The only way found to make the video initialization consistent and reliable on MacOS even after a scene reload
+            // The only way found to make the video initialization consistent and reliable even after a scene reload
             await UniTask.Delay(TimeSpan.FromSeconds(1f));
-#endif
 
             control.SetLooping(sdkVideoPlayer is { HasLoop: true, Loop: true }); // default: false
             control.SetPlaybackRate(sdkVideoPlayer.HasPlaybackRate ? sdkVideoPlayer.PlaybackRate : MediaPlayerComponent.DEFAULT_PLAYBACK_RATE);


### PR DESCRIPTION
## What does this PR change?

It comes from here: https://github.com/decentraland/unity-explorer/issues/2880
It's just an extra prevention so the problem happens less often (currently we cannot reproduce it). It's not a definitive solution. It was already applied on Mac and now it has been extended to Windows builds.

## How to test the changes?

It can't be reproduced. However, if you want to make sure it does not break existing things, you can do smoke testing like in this PR: https://github.com/decentraland/unity-explorer/pull/2955