### PR TITLE
fix: block camera input

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -265,13 +265,13 @@ namespace DCL.Chat
         private void DisableUnwantedInputs()
         {
             world.AddOrGet(cameraEntity, new CameraBlockerComponent());
-            inputBlock.Disable(InputMapComponent.Kind.CAMERA , InputMapComponent.Kind.SHORTCUTS , InputMapComponent.Kind.PLAYER);
+            inputBlock.Disable(InputMapComponent.BLOCK_USER_INPUT);
         }
 
         private void EnableUnwantedInputs()
         {
             world.TryRemove<CameraBlockerComponent>(cameraEntity);
-            inputBlock.Enable(InputMapComponent.Kind.CAMERA , InputMapComponent.Kind.SHORTCUTS , InputMapComponent.Kind.PLAYER);
+            inputBlock.Enable(InputMapComponent.BLOCK_USER_INPUT);
         }
 
         private void OnSubmitAction(InputAction.CallbackContext obj)

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/ToggleInWorldCameraActivitySystem.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/ToggleInWorldCameraActivitySystem.cs
@@ -231,14 +231,12 @@ namespace DCL.InWorldCamera.Systems
             switch (to)
             {
                 case Kind.IN_WORLD_CAMERA:
-                    inputMapComponent.UnblockInput(Kind.IN_WORLD_CAMERA);
                     inputMapComponent.BlockInput(Kind.PLAYER);
                     inputMapComponent.BlockInput(Kind.SHORTCUTS);
                     break;
                 case Kind.PLAYER:
                     inputMapComponent.UnblockInput(Kind.PLAYER);
                     inputMapComponent.UnblockInput(Kind.SHORTCUTS);
-                    inputMapComponent.BlockInput(Kind.IN_WORLD_CAMERA);
                     break;
             }
         }

--- a/Explorer/Assets/DCL/Input/Component/InputMapComponent.cs
+++ b/Explorer/Assets/DCL/Input/Component/InputMapComponent.cs
@@ -9,6 +9,15 @@ namespace DCL.Input.Component
     {
         public static readonly IReadOnlyList<Kind> VALUES = EnumUtils.Values<Kind>();
 
+        public static readonly Kind[] BLOCK_USER_INPUT =
+        {
+            Kind.IN_WORLD_CAMERA,
+            Kind.CAMERA,
+            Kind.SHORTCUTS,
+            Kind.PLAYER
+        };
+
+
         [Flags]
         public enum Kind
         {

--- a/Explorer/Assets/DCL/Input/ECSInputBlock.cs
+++ b/Explorer/Assets/DCL/Input/ECSInputBlock.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Arch.Core;
 using DCL.Input.Component;
 using ECS.Abstract;
@@ -23,30 +24,6 @@ namespace DCL.Input
                 inputMapComponent.BlockInput(kind);
         }
 
-        public void Disable(InputMapComponent.Kind kind)
-        {
-            inputMap ??= globalWorld.CacheInputMap();
-            ref InputMapComponent inputMapComponent = ref inputMap.Value.GetInputMapComponent(globalWorld);
-            inputMapComponent.BlockInput(kind);
-        }
-
-        public void Disable(InputMapComponent.Kind kind, InputMapComponent.Kind kind2)
-        {
-            inputMap ??= globalWorld.CacheInputMap();
-            ref InputMapComponent inputMapComponent = ref inputMap.Value.GetInputMapComponent(globalWorld);
-            inputMapComponent.BlockInput(kind);
-            inputMapComponent.BlockInput(kind2);
-        }
-
-        public void Disable(InputMapComponent.Kind kind, InputMapComponent.Kind kind2, InputMapComponent.Kind kind3)
-        {
-            inputMap ??= globalWorld.CacheInputMap();
-            ref InputMapComponent inputMapComponent = ref inputMap.Value.GetInputMapComponent(globalWorld);
-            inputMapComponent.BlockInput(kind);
-            inputMapComponent.BlockInput(kind2);
-            inputMapComponent.BlockInput(kind3);
-        }
-
         public void Enable(params InputMapComponent.Kind[] kinds)
         {
             inputMap ??= globalWorld.CacheInputMap();
@@ -56,28 +33,18 @@ namespace DCL.Input
                 inputMapComponent.UnblockInput(kind);
         }
 
-        public void Enable(InputMapComponent.Kind kind)
+        public void EnableAll(params InputMapComponent.Kind[] except)
         {
             inputMap ??= globalWorld.CacheInputMap();
             ref InputMapComponent inputMapComponent = ref inputMap.Value.GetInputMapComponent(globalWorld);
-            inputMapComponent.UnblockInput(kind);
-        }
 
-        public void Enable(InputMapComponent.Kind kind, InputMapComponent.Kind kind2)
-        {
-            inputMap ??= globalWorld.CacheInputMap();
-            ref InputMapComponent inputMapComponent = ref inputMap.Value.GetInputMapComponent(globalWorld);
-            inputMapComponent.UnblockInput(kind);
-            inputMapComponent.UnblockInput(kind2);
-        }
+            foreach (var kind in InputMapComponent.VALUES)
+            {
+                if (except != null && except.Contains(kind))
+                    continue;
 
-        public void Enable(InputMapComponent.Kind kind, InputMapComponent.Kind kind2, InputMapComponent.Kind kind3)
-        {
-            inputMap ??= globalWorld.CacheInputMap();
-            ref InputMapComponent inputMapComponent = ref inputMap.Value.GetInputMapComponent(globalWorld);
-            inputMapComponent.UnblockInput(kind);
-            inputMapComponent.UnblockInput(kind2);
-            inputMapComponent.UnblockInput(kind3);
+                inputMapComponent.UnblockInput(kind);
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/Input/IInputBlock.cs
+++ b/Explorer/Assets/DCL/Input/IInputBlock.cs
@@ -5,14 +5,10 @@ namespace DCL.Input
     public interface IInputBlock
     {
         public void Disable(params InputMapComponent.Kind[] kinds);
-        public void Disable(InputMapComponent.Kind kind);
-        public void Disable(InputMapComponent.Kind kind, InputMapComponent.Kind kind2);
-        public void Disable(InputMapComponent.Kind kind, InputMapComponent.Kind kind2, InputMapComponent.Kind kind3);
 
         public void Enable(params InputMapComponent.Kind[] kinds);
-        public void Enable(InputMapComponent.Kind kind);
-        public void Enable(InputMapComponent.Kind kind, InputMapComponent.Kind kind2);
-        public void Enable(InputMapComponent.Kind kind, InputMapComponent.Kind kind2, InputMapComponent.Kind kind3);
+
+        public void EnableAll(params InputMapComponent.Kind[] except);
 
     }
 }

--- a/Explorer/Assets/DCL/Input/Systems/ApplyInputMapsSystem.cs
+++ b/Explorer/Assets/DCL/Input/Systems/ApplyInputMapsSystem.cs
@@ -61,6 +61,9 @@ namespace DCL.Input.Systems
                         case InputMapComponent.Kind.SHORTCUTS:
                             SetActionMapEnabled(isActive, dclInput.Shortcuts);
                             break;
+                        case InputMapComponent.Kind.IN_WORLD_CAMERA:
+                            SetActionMapEnabled(isActive, dclInput.InWorldCamera);
+                            break;
                     }
                 }
             }

--- a/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenController.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenController.cs
@@ -256,12 +256,12 @@ namespace DCL.SceneLoadingScreens
 
         private void BlockUnwantedInputs()
         {
-            inputBlock.Disable(InputMapComponent.Kind.CAMERA, InputMapComponent.Kind.SHORTCUTS, InputMapComponent.Kind.PLAYER);
+            inputBlock.Disable(InputMapComponent.BLOCK_USER_INPUT);
         }
 
         private void UnblockUnwantedInputs()
         {
-            inputBlock.Enable(InputMapComponent.Kind.CAMERA, InputMapComponent.Kind.SHORTCUTS, InputMapComponent.Kind.PLAYER);
+            inputBlock.Enable(InputMapComponent.BLOCK_USER_INPUT);
         }
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -261,8 +261,9 @@ namespace Global.Dynamic
         {
             // We enable Inputs through the inputBlock so the block counters can be properly updated and the component Active flags are up-to-date as well
             // We restore all inputs except EmoteWheel and FreeCamera as they should be disabled by default
-            staticContainer!.InputBlock.Enable(InputMapComponent.Kind.IN_WORLD_CAMERA, InputMapComponent.Kind.SHORTCUTS,
-                InputMapComponent.Kind.PLAYER, InputMapComponent.Kind.EMOTES, InputMapComponent.Kind.CAMERA);
+            staticContainer!.InputBlock.EnableAll(InputMapComponent.Kind.FREE_CAMERA,
+                InputMapComponent.Kind.EMOTE_WHEEL);
+            
         }
 
         [ContextMenu(nameof(ValidateSettingsAsync))]

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -261,7 +261,8 @@ namespace Global.Dynamic
         {
             // We enable Inputs through the inputBlock so the block counters can be properly updated and the component Active flags are up-to-date as well
             // We restore all inputs except EmoteWheel and FreeCamera as they should be disabled by default
-            staticContainer!.InputBlock.Enable(InputMapComponent.Kind.SHORTCUTS, InputMapComponent.Kind.PLAYER, InputMapComponent.Kind.EMOTES, InputMapComponent.Kind.CAMERA);
+            staticContainer!.InputBlock.Enable(InputMapComponent.Kind.IN_WORLD_CAMERA, InputMapComponent.Kind.SHORTCUTS,
+                InputMapComponent.Kind.PLAYER, InputMapComponent.Kind.EMOTES, InputMapComponent.Kind.CAMERA);
         }
 
         [ContextMenu(nameof(ValidateSettingsAsync))]


### PR DESCRIPTION
## What does this PR change?

Stops the in-world-camera from spawning when using the chat or in the loading screen


## How to test the changes?


1. Launch the explorer with in world camera feature on
2. Select the chat. Press C. The in world camera should not open
3. Deselect the chat. Press C. The world camera should open
4. Teleport anywhere. While loading screen is on, press C. The world camera should not open
5. When arriving to destination, press C. The camera should open

Try the regular input blocks as well (Shortcuts, Movement, Camera, FreeCamera, Emotes and EmotesWheel). They should all behave the same

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

