### PR TITLE
Fix: disable compression for windows

### DIFF
--- a/Explorer/Assets/Plugins/TexturesFuse/TexturesServerWrap/Unzips/ITexturesFuse.cs
+++ b/Explorer/Assets/Plugins/TexturesFuse/TexturesServerWrap/Unzips/ITexturesFuse.cs
@@ -98,7 +98,7 @@ namespace Plugins.TexturesFuse.TexturesServerWrap.Unzips
 
             ITexturesFuse NewWorker() =>
                 IPlatform.DEFAULT.Is(IPlatform.Kind.Windows)
-                    ? new AttemptsTexturesFuse(new NodeTexturesFuse())
+                    ? new ManagedTexturesFuse() //new AttemptsTexturesFuse(new NodeTexturesFuse())
                     : new TexturesFuse(init, options, true);
 
             return new PooledTexturesFuse(


### PR DESCRIPTION
## Why?

There is a problem with the compression speed on Windows for some users.

## How to test the changes?

1. Launch the explorer
2. Play happy path, loading screen should take less than 1 minute as before the textures optimisation

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

