### PR TITLE
Fix: re-logging while on GC causes failed login state

### DIFF
--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -128,7 +128,7 @@ namespace DCL.UserInAppInitializationFlow
                 {
                     // If we are coming from a logout, we teleport the user to Genesis Plaza and force realm change to reset the scene properly
                     var url = URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.Genesis));
-                    var changeRealmResult = await realmNavigator.TryChangeRealmAsync(url, ct, ignoreSameRealm:true);
+                    var changeRealmResult = await realmNavigator.TryChangeRealmAsync(url, ct, ignoreRealmChecks:true);
 
                     if (changeRealmResult.Success == false)
                         ReportHub.LogError(ReportCategory.AUTHENTICATION, changeRealmResult.AsResult().ErrorMessage!);

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -128,7 +128,7 @@ namespace DCL.UserInAppInitializationFlow
                 {
                     // If we are coming from a logout, we teleport the user to Genesis Plaza and force realm change to reset the scene properly
                     var url = URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.Genesis));
-                    var changeRealmResult = await realmNavigator.TryChangeRealmAsync(url, ct);
+                    var changeRealmResult = await realmNavigator.TryChangeRealmAsync(url, ct, ignoreSameRealm:true);
 
                     if (changeRealmResult.Success == false)
                         ReportHub.LogError(ReportCategory.AUTHENTICATION, changeRealmResult.AsResult().ErrorMessage!);

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
@@ -33,7 +33,8 @@ namespace ECS.SceneLifeCycle.Realm
         UniTask<EnumResult<ChangeRealmError>> TryChangeRealmAsync(
             URLDomain realm,
             CancellationToken ct,
-            Vector2Int parcelToTeleport = default
+            Vector2Int parcelToTeleport = default,
+            bool ignoreSameRealm = false
         );
 
         UniTask<Result> TeleportToParcelAsync(Vector2Int parcel, CancellationToken ct, bool isLocal);

--- a/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
+++ b/Explorer/Assets/Scripts/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
@@ -34,7 +34,7 @@ namespace ECS.SceneLifeCycle.Realm
             URLDomain realm,
             CancellationToken ct,
             Vector2Int parcelToTeleport = default,
-            bool ignoreSameRealm = false
+            bool ignoreRealmChecks = false
         );
 
         UniTask<Result> TeleportToParcelAsync(Vector2Int parcel, CancellationToken ct, bool isLocal);

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -128,13 +128,14 @@ namespace Global.Dynamic
         public async UniTask<EnumResult<ChangeRealmError>> TryChangeRealmAsync(
             URLDomain realm,
             CancellationToken ct,
-            Vector2Int parcelToTeleport = default
+            Vector2Int parcelToTeleport = default,
+            bool ignoreSameRealm = false
         )
         {
             if (ct.IsCancellationRequested)
                 return EnumResult<ChangeRealmError>.ErrorResult(ChangeRealmError.ChangeCancelled);
 
-            if (CheckIsNewRealm(realm) == false)
+            if (!ignoreSameRealm && CheckIsNewRealm(realm) == false)
                 return EnumResult<ChangeRealmError>.ErrorResult(ChangeRealmError.SameRealm);
 
             if (await realmController.IsReachableAsync(realm, ct) == false)

--- a/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/RealmNavigator.cs
@@ -129,16 +129,20 @@ namespace Global.Dynamic
             URLDomain realm,
             CancellationToken ct,
             Vector2Int parcelToTeleport = default,
-            bool ignoreSameRealm = false
+            bool ignoreRealmChecks = false
         )
         {
             if (ct.IsCancellationRequested)
                 return EnumResult<ChangeRealmError>.ErrorResult(ChangeRealmError.ChangeCancelled);
 
-            if (!ignoreSameRealm && CheckIsNewRealm(realm) == false)
+            //if the ignoreRealmChecks flag is set, we are coming from the logout screen, which means we dont care if we are
+            //in the same realm and also we know the realm was reacheable. This last part was added because this async check of the realm
+            //causes visual issues (login screen closes and GP is visible during some seconds while the request to check if the realm
+            //is reachable happen). This is a temporal fix.
+            if (!ignoreRealmChecks && CheckIsNewRealm(realm) == false)
                 return EnumResult<ChangeRealmError>.ErrorResult(ChangeRealmError.SameRealm);
 
-            if (await realmController.IsReachableAsync(realm, ct) == false)
+            if (!ignoreRealmChecks && await realmController.IsReachableAsync(realm, ct) == false)
                 return EnumResult<ChangeRealmError>.ErrorResult(ChangeRealmError.NotReachable);
 
             var operation = DoChangeRealmAsync(realm, realmController.CurrentDomain, parcelToTeleport);


### PR DESCRIPTION
## What does this PR change?

This solves this issue for now: #2990 

When we are in GC and logout and then login again, we get a failed login state because we are already in the same realm we are trying to re-load.
I added as a quick fix a flag to ignore this check when doing it from the logout flow, but the correct fix is to properly organize the re-login operation.
So this will be a stopgap solution until I can do that properly and make sure all works correctly.
...

## How to test the changes?

Log into the client, then logout and try to login again with any user (same or different). You should log properly and not be "kicked" out to the login screen as it was happening.