### PR TITLE
fix: minimap flash

### DIFF
--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -182,6 +182,8 @@ namespace DCL.Minimap
                 mapRendererTrackPlayerPosition = new MapRendererTrackPlayerPosition(mapCameraController);
                 viewInstance.mapRendererTargetImage.texture = mapCameraController.GetRenderTexture();
                 viewInstance.pixelPerfectMapRendererTextureProvider.Activate(mapCameraController);
+
+                //Once the render target image is ready to be shown, we enable the minimap
                 viewInstance.SetCanvasActive(true);
                 GetPlaceInfoAsync(position);
             }

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -72,11 +72,7 @@ namespace DCL.Minimap
             IMapPathEventBus mapPathEventBus,
             ISceneRestrictionBusController sceneRestrictionBusController,
             string startParcelInGenesis
-        ) : base(() =>
-        {
-            minimapView.gameObject.SetActive(true);
-            return minimapView;
-        })
+        ) : base(() => minimapView)
         {
             this.mapRenderer = mapRenderer;
             this.mvcManager = mvcManager;
@@ -88,6 +84,7 @@ namespace DCL.Minimap
             this.mapPathEventBus = mapPathEventBus;
             this.sceneRestrictionBusController = sceneRestrictionBusController;
             this.startParcelInGenesis = startParcelInGenesis;
+            minimapView.SetCanvasActive(false);
         }
 
         public void HookPlayerPositionTrackingSystem(TrackPlayerPositionSystem system) =>
@@ -185,6 +182,7 @@ namespace DCL.Minimap
                 mapRendererTrackPlayerPosition = new MapRendererTrackPlayerPosition(mapCameraController);
                 viewInstance.mapRendererTargetImage.texture = mapCameraController.GetRenderTexture();
                 viewInstance.pixelPerfectMapRendererTextureProvider.Activate(mapCameraController);
+                viewInstance.SetCanvasActive(true);
                 GetPlaceInfoAsync(position);
             }
             else


### PR DESCRIPTION
## What does this PR change?

Fixes this [comment](https://github.com/decentraland/unity-explorer/issues/2974#issuecomment-2531904034)

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Check that the minimap doesnt show a white image after the loading screen is gone
3. Teleport to a world. Check that the minimap changes to the world look correctly
4. Launch the explorer in a realm through `args`
5. Check that the minimap doesn't flash the genesis map after the loading screen is gone
6. Teleport to Genesis City. Check that the minimap is fine
7. Start with a new user. Check the same steps as in 5 and 6

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

