### PR TITLE
fix: prevent negative index while scrolling against scroll limit in reel gallery

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
@@ -426,6 +426,10 @@ namespace DCL.InWorldCamera.CameraReelGallery
                     endVisible = i;
                 } else
                     DisableThumbnailImage(thumbnailImages[i]);
+
+            //If no image is visible (achieved while scrolling against the scroll limit), set beginVisible to 0
+            if (beginVisible < 0)
+                beginVisible = 0;
         }
 
         private void CheckNeedsToLoadMore()


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Prevent the negative `beginVisible` index when scrolling against the scroll limit. This can happen when the scroll is so strong that no reel is visible due to the view going above/beyond the actual elements.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer with `debug` and `camera-reel` flags
2. Open the reel gallery
3. Scroll up or down intensively so that no reel is visible
4. Check that if you let go the scrolling, everything works as expected with no errors

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

