### PR TITLE
fix: passport reels empty state not triggering for user own passport

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
@@ -309,7 +309,7 @@ namespace DCL.InWorldCamera.CameraReelGallery
         {
             PrepareShowGallery(ct);
 
-            storageStatus ??= await cameraReelStorageService.GetUserGalleryStorageInfoAsync(walletAddress, ct);
+            storageStatus ??= await cameraReelStorageService.UnsignedGetUserGalleryStorageInfoAsync(walletAddress, ct);
 
             if (storageStatus.Value.ScreenshotsAmount == 0)
             {

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelStorageService/CameraReelImagesMetadataRemoteDatabase.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelStorageService/CameraReelImagesMetadataRemoteDatabase.cs
@@ -44,6 +44,21 @@ namespace DCL.InWorldCamera.CameraReelStorageService
             return responseData;
         }
 
+        public async UniTask<CameraReelStorageResponse> UnsignedGetStorageInfoAsync(string userAddress, CancellationToken ct)
+        {
+            URLAddress url = urlBuilder.AppendDomain(userDomain)
+                                       .AppendSubDirectory(URLSubdirectory.FromString(userAddress))
+                                       .Build();
+
+            urlBuilder.Clear();
+
+            CameraReelStorageResponse responseData = await webRequestController
+                                                          .GetAsync(url, ct, ReportCategory.CAMERA_REEL)
+                                                          .CreateFromJson<CameraReelStorageResponse>(WRJsonParser.Unity);
+
+            return responseData;
+        }
+
         public async UniTask<CameraReelResponse> GetScreenshotsMetadataAsync(string uuid, CancellationToken ct)
         {
             URLAddress url = urlBuilder.AppendDomain(imageDomain)

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelStorageService/CameraReelRemoteStorageService.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelStorageService/CameraReelRemoteStorageService.cs
@@ -31,6 +31,14 @@ namespace DCL.InWorldCamera.CameraReelStorageService
             return StorageStatus;
         }
 
+        public async UniTask<CameraReelStorageStatus> UnsignedGetUserGalleryStorageInfoAsync(string userAddress, CancellationToken ct = default)
+        {
+            CameraReelStorageResponse response = await imagesMetadataDatabase.UnsignedGetStorageInfoAsync(userAddress, ct);
+
+            StorageStatus = new CameraReelStorageStatus(response.currentImages, response.maxImages);
+            return StorageStatus;
+        }
+
         public async UniTask<CameraReelStorageStatus> GetPlaceGalleryStorageInfoAsync(string placeId, CancellationToken ct = default)
         {
             CameraReelResponsesCompact response = await imagesMetadataDatabase.GetCompactPlaceScreenshotsAsync(placeId, 0, 0, ct);

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelStorageService/ICameraReelImagesMetadataDatabase.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelStorageService/ICameraReelImagesMetadataDatabase.cs
@@ -7,6 +7,7 @@ namespace DCL.InWorldCamera.CameraReelStorageService
     public interface ICameraReelImagesMetadataDatabase
     {
         UniTask<CameraReelStorageResponse> GetStorageInfoAsync(string userAddress, CancellationToken ct);
+        UniTask<CameraReelStorageResponse> UnsignedGetStorageInfoAsync(string userAddress, CancellationToken ct);
 
         UniTask<CameraReelResponses> GetScreenshotsAsync(string userAddress, int limit, int offset, CancellationToken ct);
         UniTask<CameraReelResponse> GetScreenshotsMetadataAsync(string uuid, CancellationToken ct);

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelStorageService/ICameraReelStorageService.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelStorageService/ICameraReelStorageService.cs
@@ -13,6 +13,7 @@ namespace DCL.InWorldCamera.CameraReelStorageService
         event Action<CameraReelResponse, CameraReelStorageStatus, string>? ScreenshotUploaded;
 
         UniTask<CameraReelStorageStatus> GetUserGalleryStorageInfoAsync(string userAddress, CancellationToken ct = default);
+        UniTask<CameraReelStorageStatus> UnsignedGetUserGalleryStorageInfoAsync(string userAddress, CancellationToken ct = default);
         UniTask<CameraReelStorageStatus> GetPlaceGalleryStorageInfoAsync(string userAddress, CancellationToken ct = default);
 
         UniTask<CameraReelResponses> GetScreenshotGalleryAsync(string userAddress, int limit, int offset, CancellationToken ct = default);

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
@@ -30,10 +30,11 @@ using MVC;
 using System;
 using System.Threading;
 using UnityEngine;
-using UnityEngine.UI;
 using UnityEngine.AddressableAssets;
+using UnityEngine.UIElements;
 using Utility;
 using static DCL.PluginSystem.Global.InWorldCameraPlugin;
+using Button = UnityEngine.UI.Button;
 using CaptureScreenshotSystem = DCL.InWorldCamera.Systems.CaptureScreenshotSystem;
 using EmitInWorldCameraInputSystem = DCL.InWorldCamera.Systems.EmitInWorldCameraInputSystem;
 using MoveInWorldCameraSystem = DCL.InWorldCamera.Systems.MoveInWorldCameraSystem;
@@ -66,6 +67,7 @@ namespace DCL.PluginSystem.Global
         private readonly URLDomain assetBundleURL;
         private readonly ICursor cursor;
         private readonly Button sidebarButton;
+        private readonly UIDocument rootUIDocument;
         private readonly Arch.Core.World globalWorld;
         private readonly IDebugContainerBuilder debugContainerBuilder;
 
@@ -77,17 +79,19 @@ namespace DCL.PluginSystem.Global
         private CharacterController followTarget;
 
         public InWorldCameraPlugin(DCLInput input, SelfProfile selfProfile,
-            RealmData realmData, Entity playerEntity, IPlacesAPIService placesAPIService, ICharacterObject characterObject, ICoroutineRunner coroutineRunner,
+            RealmData realmData, Entity playerEntity, IPlacesAPIService placesAPIService,
+            ICharacterObject characterObject, ICoroutineRunner coroutineRunner,
             ICameraReelStorageService cameraReelStorageService, ICameraReelScreenshotsStorage cameraReelScreenshotsStorage, IMVCManager mvcManager,
             ISystemClipboard systemClipboard, IDecentralandUrlsSource decentralandUrlsSource, IWebBrowser webBrowser, IWebRequestController webRequestController,
-            IProfileRepository profileRepository, IRealmNavigator realmNavigator, IAssetsProvisioner assetsProvisioner,
+            IProfileRepository profileRepository,
+            IRealmNavigator realmNavigator, IAssetsProvisioner assetsProvisioner,
             IWearableStorage wearableStorage, IWearablesProvider wearablesProvider,
             URLDomain assetBundleURL,
             ICursor cursor,
             Button sidebarButton,
+            UIDocument rootUIDocument,
             Arch.Core.World globalWorld,
-            IDebugContainerBuilder debugContainerBuilder
-       )
+            IDebugContainerBuilder debugContainerBuilder)
         {
             this.input = input;
             this.selfProfile = selfProfile;
@@ -111,6 +115,7 @@ namespace DCL.PluginSystem.Global
             this.assetBundleURL = assetBundleURL;
             this.cursor = cursor;
             this.sidebarButton = sidebarButton;
+            this.rootUIDocument = rootUIDocument;
             this.globalWorld = globalWorld;
             this.debugContainerBuilder = debugContainerBuilder;
 
@@ -171,7 +176,7 @@ namespace DCL.PluginSystem.Global
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments)
         {
-            ToggleInWorldCameraActivitySystem.InjectToWorld(ref builder, settings.TransitionSettings, inWorldCameraController, followTarget, debugContainerBuilder, cursor, mvcManager, input.InWorldCamera);
+            ToggleInWorldCameraActivitySystem.InjectToWorld(ref builder, settings.TransitionSettings, inWorldCameraController, followTarget, debugContainerBuilder, cursor, mvcManager, input.InWorldCamera, rootUIDocument);
             EmitInWorldCameraInputSystem.InjectToWorld(ref builder, input.InWorldCamera);
             MoveInWorldCameraSystem.InjectToWorld(ref builder, settings.MovementSettings, characterObject.Controller.transform, cursor);
             CaptureScreenshotSystem.InjectToWorld(ref builder, recorder, playerEntity, metadataBuilder, coroutineRunner, cameraReelStorageService, inWorldCameraController);

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/ToggleInWorldCameraActivitySystem.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/ToggleInWorldCameraActivitySystem.cs
@@ -15,6 +15,7 @@ using DCL.InWorldCamera.UI;
 using ECS.Abstract;
 using MVC;
 using UnityEngine;
+using UnityEngine.UIElements;
 using static DCL.Input.Component.InputMapComponent;
 
 namespace DCL.InWorldCamera.Systems
@@ -35,6 +36,7 @@ namespace DCL.InWorldCamera.Systems
         private readonly ICursor cursor;
         private readonly IMVCManager mvcManager;
         private readonly DCLInput.InWorldCameraActions inputSchema;
+        private readonly UIDocument sceneUIRoot;
 
         private SingleInstanceEntity camera;
         private SingleInstanceEntity inputMap;
@@ -50,7 +52,9 @@ namespace DCL.InWorldCamera.Systems
             CharacterController followTarget,
             IDebugContainerBuilder debugContainerBuilder,
             ICursor cursor,
-            IMVCManager mvcManager, DCLInput.InWorldCameraActions inputSchema) : base(world)
+            IMVCManager mvcManager,
+            DCLInput.InWorldCameraActions inputSchema,
+            UIDocument sceneUIRoot) : base(world)
         {
             this.settings = settings;
             this.hudController = hudController;
@@ -59,6 +63,7 @@ namespace DCL.InWorldCamera.Systems
             this.cursor = cursor;
             this.mvcManager = mvcManager;
             this.inputSchema = inputSchema;
+            this.sceneUIRoot = sceneUIRoot;
 
             behindUpOffset = Vector3.up * settings.BehindUpOffset;
         }
@@ -123,6 +128,7 @@ namespace DCL.InWorldCamera.Systems
 
             hudController.Hide();
             mvcManager.SetAllViewsCanvasActive(except: hudController, true);
+            sceneUIRoot.rootVisualElement.parent.style.display = DisplayStyle.Flex;
 
             SwitchToThirdPersonCamera();
 
@@ -145,6 +151,7 @@ namespace DCL.InWorldCamera.Systems
 
             hudController.Show();
             mvcManager.SetAllViewsCanvasActive(except: hudController, false);
+            sceneUIRoot.rootVisualElement.parent.style.display = DisplayStyle.None;
 
             SwitchToInWorldCamera();
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -767,6 +767,7 @@ namespace Global.Dynamic
                     assetBundlesURL,
                     dclCursor,
                     mainUIView.SidebarView.EnsureNotNull().InWorldCameraButton,
+                    dynamicWorldDependencies.RootUIDocument,
                     globalWorld,
                     debugBuilder));
 


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Fix the empty state when the user's own passport doesn't contain any public reel.

It was working on other users passport because the get request was signed with a different wallet than the requested one, therefore the BE was correctly returning only the amount of public reels.

The problem on the user's passport was because the get request was signed with the same wallet as the requested one, returning all reels (public and private). If no reel was public, the grid was empty but the non-zero amount of reels wasn't triggering the empty state.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer with `debug` and `camera-reel` flags
2. Check that if you don't have any public reel, your reels passport section is correctly displaying the empty state (background + image + text saying that the list is empty)
3. Check that the same applies to other users passport

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

