### PR TITLE
hotfix: explore panel reel input block in search bars

### DIFF
--- a/Explorer/Assets/DCL/Backpack/BackpackSearchController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackSearchController.cs
@@ -37,14 +37,12 @@ namespace DCL.Backpack
 
         private void RestoreInput(string text)
         {
-            inputBlock.Enable(InputMapComponent.Kind.SHORTCUTS);
-            inputBlock.Enable(InputMapComponent.Kind.IN_WORLD_CAMERA);
+            inputBlock.Enable(InputMapComponent.Kind.SHORTCUTS, InputMapComponent.Kind.IN_WORLD_CAMERA);
         }
 
         private void DisableShortcutsInput(string text)
         {
-            inputBlock.Disable(InputMapComponent.Kind.SHORTCUTS);
-            inputBlock.Disable(InputMapComponent.Kind.IN_WORLD_CAMERA);
+            inputBlock.Disable(InputMapComponent.Kind.SHORTCUTS, InputMapComponent.Kind.IN_WORLD_CAMERA);
         }
 
         private void OnSearchEvent(string searchString)

--- a/Explorer/Assets/DCL/Backpack/BackpackSearchController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackSearchController.cs
@@ -38,11 +38,13 @@ namespace DCL.Backpack
         private void RestoreInput(string text)
         {
             inputBlock.Enable(InputMapComponent.Kind.SHORTCUTS);
+            inputBlock.Enable(InputMapComponent.Kind.IN_WORLD_CAMERA);
         }
 
         private void DisableShortcutsInput(string text)
         {
             inputBlock.Disable(InputMapComponent.Kind.SHORTCUTS);
+            inputBlock.Disable(InputMapComponent.Kind.IN_WORLD_CAMERA);
         }
 
         private void OnSearchEvent(string searchString)

--- a/Explorer/Assets/DCL/Navmap/NavmapSearchBarController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapSearchBarController.cs
@@ -116,13 +116,11 @@ namespace DCL.Navmap
             if (isSelected)
             {
                 GetAndShowPreviousSearches();
-                inputBlock.Disable(InputMapComponent.Kind.SHORTCUTS);
-                inputBlock.Disable(InputMapComponent.Kind.IN_WORLD_CAMERA);
+                inputBlock.Disable(InputMapComponent.Kind.SHORTCUTS, InputMapComponent.Kind.IN_WORLD_CAMERA);
             }
             else
             {
-                inputBlock.Enable(InputMapComponent.Kind.SHORTCUTS);
-                inputBlock.Enable(InputMapComponent.Kind.IN_WORLD_CAMERA);
+                inputBlock.Enable(InputMapComponent.Kind.SHORTCUTS, InputMapComponent.Kind.IN_WORLD_CAMERA);
             }
         }
 

--- a/Explorer/Assets/DCL/Navmap/NavmapSearchBarController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapSearchBarController.cs
@@ -117,8 +117,13 @@ namespace DCL.Navmap
             {
                 GetAndShowPreviousSearches();
                 inputBlock.Disable(InputMapComponent.Kind.SHORTCUTS);
+                inputBlock.Disable(InputMapComponent.Kind.IN_WORLD_CAMERA);
             }
-            else { inputBlock.Enable(InputMapComponent.Kind.SHORTCUTS); }
+            else
+            {
+                inputBlock.Enable(InputMapComponent.Kind.SHORTCUTS);
+                inputBlock.Enable(InputMapComponent.Kind.IN_WORLD_CAMERA);
+            }
         }
 
         private async UniTask SearchAndShowAsync(string searchText)


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Block the camera reel related shortcuts while typing in the search bars of the navmap and the backpack

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer with `debug` and `camera-reel` flags
2. Open the navmap
3. Type in the search bar a string that contains the camera reel shortcuts (`K` and `C`)
4. Check that they don't trigger their respective functionalities
5. Do the same in the backpack search bar

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

