### PR TITLE
fix: UICanvasInformationSystem now sends canvas data twice

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UICanvasInformation/UICanvasInformationSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UICanvasInformation/UICanvasInformationSystem.cs
@@ -9,7 +9,6 @@ using DCL.ECSComponents;
 using Decentraland.Common;
 using ECS.Abstract;
 using ECS.Groups;
-using SceneRunner.Scene;
 using UnityEngine;
 
 namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
@@ -28,6 +27,8 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
             base.Initialize();
 
             interactableArea = new BorderRect { Bottom = 0, Left = 0, Right = 0, Top = 0 };
+
+            WriteToCRDT();
         }
 
         private UICanvasInformationSystem(World world, IECSToCRDTWriter ecsToCRDTWriter) : base(world)
@@ -55,12 +56,17 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
             lastScreenRealResolutionWidth = Screen.mainWindowDisplayInfo.width;
             lastViewportResolutionWidth = Screen.width;
 
+            WriteToCRDT();
+        }
+
+        private void WriteToCRDT()
+        {
             ecsToCRDTWriter.PutMessage<PBUiCanvasInformation, UICanvasInformationSystem>(static (component, system) =>
             {
                 component.InteractableArea = system.interactableArea;
                 component.Width = Screen.width;
                 component.Height = Screen.height;
-                component.DevicePixelRatio = system.lastScreenRealResolutionWidth / (float)system.lastViewportResolutionWidth;
+                component.DevicePixelRatio = Screen.mainWindowDisplayInfo.width / (float)Screen.width;
             }, SpecialEntitiesID.SCENE_ROOT_ENTITY, this);
         }
     }


### PR DESCRIPTION
## What does this PR change?

Before my previous changes the UICanvasInformationSystem was sending the PBUiCanvasInformation only during initialize, but once the scene started it would have PBUiCanvasInformation == null for some reason.
I thought it was because the CRDT was not working properly during initialize, but seems ti gets reset? I donno... we will look into it xD
For now, this fixes the issue by sending it both during initialize and again once the scene is ready :)

Please check with the onboarding scene as well as Rapture gallery (-88,-64) making sure both load and that the UI shows.