### PR TITLE
style: fix 'Gallery' title in the menu

### DIFF
--- a/Explorer/Assets/Locales/Localization Tables/UI Text Localization Table_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/UI Text Localization Table_en.asset
@@ -37,7 +37,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 136891422374617088
-    m_Localized: Camera Reel
+    m_Localized: Gallery
     m_Metadata:
       m_Items: []
   references:


### PR DESCRIPTION
## What does this PR change?
Fixes the title of the ex-camera reel section.

**BEFORE**
![image](https://github.com/user-attachments/assets/f0529682-4a96-467e-8d82-2891222af2b8)

**AFTER**
<img width="247" alt="Screenshot 2025-01-14 at 10 22 21" src="https://github.com/user-attachments/assets/8cf872d3-46ed-46dc-98dc-f891a28639a9" />


## How to test the changes?
1. Launch the explorer
2. Press [K] to open the menu 'Gallery' section, or click the button within the side bar. Validate the title is now correct.