### PR TITLE
Fix: disable compression for intel

### DIFF
--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -105,6 +105,9 @@ namespace Global.Dynamic
 
             bool compressionEnabled = IPlatform.DEFAULT.IsNot(IPlatform.Kind.Windows) || applicationParametersParser.HasFlag(AppArgsFlags.FORCE_TEXTURE_COMPRESSION);
 
+            if (IPlatform.DEFAULT.Is(IPlatform.Kind.Mac) && SystemInfo.processorType!.Contains("Intel", StringComparison.InvariantCultureIgnoreCase))
+                compressionEnabled = false;
+
             ITexturesFuse TextureFuseFactory() =>
                 ITexturesFuse.NewDefault();
 


### PR DESCRIPTION
## What does this PR change?

Disable the compression for intel for a while

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer on Intel Mac
2. Play happy path

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

