### PR TITLE
fix: Start camera in third person mode

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
@@ -351,7 +351,7 @@ MonoBehaviour:
     <Speed>k__BackingField: 5
     <DefaultPosition>k__BackingField: {x: 0, y: 10, z: 0}
   shoulderChangeSpeed: 4
-  <DefaultCameraMode>k__BackingField: 2
+  <DefaultCameraMode>k__BackingField: 1
   <Brain>k__BackingField: {fileID: 1924827267997815873}
 --- !u!1 &2902897560403827600
 GameObject:


### PR DESCRIPTION
## What does this PR change?

Starts camera in third person mode instead of drone

## How to test the changes?

1. Launch the explorer in worlds and GC
2. Check that the camera starts in third person mode

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

