### PR TITLE
fix: revert of #3096

### DIFF
--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/Tests/PrepareAssetBundleLoadingParametersSystemShould.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/AssetBundles/Tests/PrepareAssetBundleLoadingParametersSystemShould.cs
@@ -122,7 +122,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
         }
 
         [Test]
-        public void ReturnDifferentCacheValuesForDifferentVersions()
+        public void ReturnSameCacheValuesForDifferentVersions()
         {
             //First, we simulate creation of a scene and the resolving of one asset budnle
             string version = "v" + SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH;
@@ -146,7 +146,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
             string secondCacheableHash = intent.CommonArguments.GetCacheableURL();
 
             Assert.AreNotEqual(firstStandardURL, secondStandardURL);
-            Assert.AreNotEqual(firstCacheableHash, secondCacheableHash);
+            Assert.AreEqual(firstCacheableHash, secondCacheableHash);
         }
 
         [Test]

--- a/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
+++ b/Explorer/Assets/Scripts/SceneRunner/Scene/SceneAssetBundleManifest.cs
@@ -81,9 +81,11 @@ namespace SceneRunner.Scene
         public string GetSceneID() =>
             sceneID;
 
-        //Used for the OngoingRequests cache. We need to avoid the sceneID in this URL to able to reuse assets.
+        //Used for the OngoingRequests cache. We need to avoid version and sceneID in this URL to able to reuse assets.
         //The first loaded hash will be the one used for all the other requests
-        public URLAddress GetCacheableURL(string hash) =>
-            assetBundlesBaseUrl.Append(new URLPath($"{version}/{hash}"));
+        public URLAddress GetCacheableURL(string hash)
+        {
+            return assetBundlesBaseUrl.Append(new URLPath(hash));
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?

#3096 had to be reverted since version cannot be ignored. If it does, we get error as following

![image](https://github.com/user-attachments/assets/a093cdb2-5c39-4f50-8a84-49cdcb6bf755)

Since Unity tries to load a new asset bundle with the same GUID, even if the asset version is different

Therefore, if two assets have different versions, they will be shared.

## How to test the changes?

1. Launch the explorer
2. Do the happy path

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

