### PR TITLE
feat: add crash detection analytics event

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsConfiguration.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsConfiguration.asset
@@ -25,6 +25,8 @@ MonoBehaviour:
       isEnabled: 1
     - eventName: loading_error
       isEnabled: 1
+    - eventName: crash
+      isEnabled: 1
   - groupName: Map
     events:
     - eventName: map_jump_in

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
@@ -1,8 +1,8 @@
-﻿using DCL.Diagnostics;
-using DCL.Web3.Identities;
+﻿using DCL.Web3.Identities;
 using ECS;
 using Global.AppArgs;
 using Segment.Serialization;
+using System;
 using UnityEngine;
 using Utility;
 using static DCL.PerformanceAndDiagnostics.Analytics.IAnalyticsController;
@@ -14,6 +14,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
         private readonly IAnalyticsService analytics;
 
         public AnalyticsConfiguration Configuration { get; }
+        public string SessionID { get; }
 
         public AnalyticsController(
             IAnalyticsService analyticsService,
@@ -26,7 +27,10 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
             Configuration = configuration;
 
             Configuration.Initialize();
-            analytics.AddPlugin(new StaticCommonTraitsPlugin(appArgs, launcherTraits, buildData));
+
+            SessionID = !string.IsNullOrEmpty(launcherTraits.SessionId) ? launcherTraits.SessionId : SystemInfo.deviceUniqueIdentifier + DateTime.Now.ToString("yyyyMMddHHmmssfff");
+
+            analytics.AddPlugin(new StaticCommonTraitsPlugin(appArgs, SessionID, launcherTraits.LauncherAnonymousId, buildData));
         }
 
         public void Initialize(IWeb3Identity? web3Identity)

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
@@ -13,6 +13,7 @@
             public const string INITIAL_LOADING = "initial_loading";
             public const string PERFORMANCE_REPORT = "performance_report";
             public const string ERROR = "error";
+            public const string CRASH = "crash";
             public const string LOADING_ERROR = "loading_error";
         }
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/CrashDetector.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/CrashDetector.cs
@@ -1,0 +1,42 @@
+using Segment.Serialization;
+using UnityEngine;
+
+namespace DCL.PerformanceAndDiagnostics.Analytics
+{
+    /// <summary>
+    /// Detects non-graceful application exits and reports them to the analytics service
+    /// </summary>
+    public class CrashDetector : MonoBehaviour
+    {
+        private const string PREFS_FLAG = "CrashDetector.flag";
+        private const string PREFS_SESSION_ID = "CrashDetector.sessionID";
+
+        public static void Initialize(IAnalyticsController analyticsController)
+        {
+            if (PlayerPrefs.HasKey(PREFS_FLAG))
+            {
+                // Application crashed on previous run
+                string previousSessionID = PlayerPrefs.GetString(PREFS_SESSION_ID, string.Empty);
+
+                analyticsController.Track(AnalyticsEvents.General.CRASH, new JsonObject
+                {
+                    { "previous_session_id", previousSessionID }
+                });
+            }
+
+            PlayerPrefs.SetString(PREFS_FLAG, string.Empty);
+            PlayerPrefs.SetString(PREFS_SESSION_ID, analyticsController.SessionID);
+            PlayerPrefs.Save();
+
+            var go = new GameObject("CrashDetector");
+            go.AddComponent<CrashDetector>();
+            DontDestroyOnLoad(go);
+        }
+
+        private void OnApplicationQuit()
+        {
+            PlayerPrefs.DeleteKey(PREFS_FLAG);
+            PlayerPrefs.Save();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/CrashDetector.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/CrashDetector.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1c0fbf85862444ea8de998d998873ec3
+timeCreated: 1737390575

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/IAnalyticsController.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/IAnalyticsController.cs
@@ -13,6 +13,8 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
         AnalyticsConfiguration Configuration { get; }
 
+        string SessionID { get; }
+
         public static IAnalyticsController Null => NullAnalytics.Instance;
 
         void Initialize(IWeb3Identity? web3Identity);
@@ -32,6 +34,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
             public static IAnalyticsController Instance => INSTANCE.Value;
 
             public AnalyticsConfiguration Configuration => ScriptableObject.CreateInstance<AnalyticsConfiguration>();
+            public string SessionID => string.Empty;
 
             private NullAnalytics() { }
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/StaticCommonTraitsPlugin.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/StaticCommonTraitsPlugin.cs
@@ -23,10 +23,11 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
         public override PluginType Type => PluginType.Enrichment;
 
-        public StaticCommonTraitsPlugin(IAppArgs appArgs, LauncherTraits launcherTraits, BuildData buildData)
+        public StaticCommonTraitsPlugin(IAppArgs appArgs, string sessionId, string launcherAnonymousId, BuildData buildData)
         {
-            sessionId = !string.IsNullOrEmpty(launcherTraits.SessionId) ? launcherTraits.SessionId : SystemInfo.deviceUniqueIdentifier + DateTime.Now.ToString("yyyyMMddHHmmssfff");
-            launcherAnonymousId = launcherTraits.LauncherAnonymousId;
+            this.sessionId = sessionId;
+            this.launcherAnonymousId = launcherAnonymousId;
+
             runtime = ChooseRuntime(appArgs);
             installSource = buildData.InstallSource;
         }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Builders/IDebugContainerBuilder.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Builders/IDebugContainerBuilder.cs
@@ -27,6 +27,7 @@ namespace DCL.DebugUtilities
             public const string ROOM_SCENE = "Room: Scene";
             public const string ROOM_THROUGHPUT = "Room: Throughput";
             public const string PERFORMANCE = "Performance";
+            public const string CRASH = "Crash";
             public const string MEMORY = "Memory";
             public const string CURRENT_SCENE = "Current scene";
             public const string REALM = "Realm";

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/ECS/DebugViewProfilingSystem.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/ECS/DebugViewProfilingSystem.cs
@@ -13,6 +13,7 @@ using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using UnityEngine;
+using UnityEngine.Diagnostics;
 using static DCL.Utilities.ConversionUtils;
 
 namespace DCL.Profiling.ECS
@@ -111,6 +112,13 @@ namespace DCL.Profiling.ECS
                             .AddCustomMarker("Js-Heap Total Exec [MB]:", jsHeapTotalExecutable = new ElementBinding<string>(string.Empty))
                             .AddCustomMarker("Js Heap Limit per engine [MB]:", jsHeapLimit = new ElementBinding<string>(string.Empty))
                             .AddCustomMarker("Js Engines Count:", jsEnginesCount = new ElementBinding<string>(string.Empty));
+
+                debugBuilder.TryAddWidget(IDebugContainerBuilder.Categories.CRASH)?
+                            .AddSingleButton("FatalError", () => { Utils.ForceCrash(ForcedCrashCategory.FatalError); })
+                            .AddSingleButton("Abort", () => { Utils.ForceCrash(ForcedCrashCategory.Abort); })
+                            .AddSingleButton("MonoAbort", () => { Utils.ForceCrash(ForcedCrashCategory.MonoAbort); })
+                            .AddSingleButton("AccessViolation", () => { Utils.ForceCrash(ForcedCrashCategory.AccessViolation); })
+                            .AddSingleButton("PureVirtualFunction", () => { Utils.ForceCrash(ForcedCrashCategory.PureVirtualFunction); });
             }
         }
 

--- a/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
@@ -108,7 +108,11 @@ namespace Global.Dynamic
                 (container.VerifiedEthereumApi, container.Web3Authenticator) = CreateWeb3Dependencies(sceneLoaderSettings, web3AccountFactory, identityCache, browser, container, decentralandUrlsSource);
 
                 if (container.enableAnalytics)
+                {
                     container.Analytics!.Initialize(container.IdentityCache.Identity);
+
+                    CrashDetector.Initialize(container.Analytics);
+                }
 
                 bool enableSceneDebugConsole = realmLaunchSettings.IsLocalSceneDevelopmentRealm || applicationParametersParser.HasFlag(AppArgsFlags.SCENE_CONSOLE);
                 container.DiagnosticsContainer = DiagnosticsContainer.Create(container.ReportHandlingSettings, enableSceneDebugConsole);


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

We now detect non-graceful exits of the application and report them as an analytics event.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Trigger a crash / kill it with task manager
3. Reopen explorer
4. Verify that a "crash" event was sent with the session ID of the previous run

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

