### PR TITLE
chore: moved environment selection to EntryPoint

### DIFF
--- a/Explorer/Assets/Scenes/Main.unity
+++ b/Explorer/Assets/Scenes/Main.unity
@@ -474,6 +474,7 @@ MonoBehaviour:
     useRemoteAssetsBundles: 1
     isolateSceneCommunication: 0
     portableExperiencesEnsToLoadAtGameStart: []
+  decentralandEnvironment: 0
   debugViewsCatalog:
     <Widget>k__BackingField: {fileID: 9197481963319205126, guid: f3bf08b2b62097d4aa0574f7bafa4a86, type: 3}
     <ControlContainer>k__BackingField: {fileID: 9197481963319205126, guid: 6da3ff28c8a87e0428fa07019c15fa2f, type: 3}

--- a/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
@@ -81,6 +81,7 @@ namespace Global.Dynamic
             ICompressShaders compressShaders,
             IRealmUrls realmUrls,
             World world,
+            DecentralandEnvironment decentralandEnvironment,
             CancellationToken ct)
         {
             var browser = new UnityAppWebBrowser(decentralandUrlsSource);
@@ -98,7 +99,7 @@ namespace Global.Dynamic
                 ApplicationParametersParser = applicationParametersParser,
                 DebugSettings = debugSettings,
                 WorldVolumeMacBus = new WorldVolumeMacBus(),
-                Environment = sceneLoaderSettings.DecentralandEnvironment
+                Environment = decentralandEnvironment
             };
 
             await bootstrapContainer.InitializeContainerAsync<BootstrapContainer, BootstrapSettings>(settingsContainer, ct, async container =>

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicSceneLoaderSettings.cs
@@ -9,20 +9,8 @@ namespace Global.Dynamic
     [CreateAssetMenu(fileName = "DynamicSceneLoaderSettings", menuName = "DCL/Various/Dynamic Scene LoaderSettings")]
     public class DynamicSceneLoaderSettings : ScriptableObject
     {
-        [field: SerializeField] public DecentralandEnvironment DecentralandEnvironment { get; private set; }
         [field: SerializeField] public List<string> Realms { get; private set; }
         [field: SerializeField] public List<string> Web3WhitelistMethods { get; private set; }
 
-        public void ApplyConfig(IAppArgs applicationParametersParser)
-        {
-            if (applicationParametersParser.TryGetValue(AppArgsFlags.ENVIRONMENT, out string? environment))
-                ParseEnvironment(environment!);
-        }
-
-        private void ParseEnvironment(string environment)
-        {
-            if (Enum.TryParse(environment, true, out DecentralandEnvironment env))
-                DecentralandEnvironment = env;
-        }
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -9,6 +9,7 @@ using DCL.Browser.DecentralandUrls;
 using DCL.DebugUtilities;
 using DCL.Diagnostics;
 using DCL.Input.Component;
+using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.Platforms;
 using DCL.PluginSystem;
@@ -18,7 +19,6 @@ using DCL.Utilities;
 using DCL.Utilities.Extensions;
 using DCL.Web3.Accounts.Factory;
 using DCL.Web3.Identities;
-using DCL.WebRequests;
 using DCL.WebRequests.Analytics;
 using Global.AppArgs;
 using Global.Dynamic.RealmUrl;
@@ -41,6 +41,9 @@ namespace Global.Dynamic
     {
         [Header("Startup Config")] [SerializeField]
         private RealmLaunchSettings launchSettings = null!;
+
+        [Space]
+        [SerializeField] private DecentralandEnvironment decentralandEnvironment;
 
         [Space]
         [SerializeField] private DebugViewsCatalog debugViewsCatalog = new ();
@@ -100,6 +103,18 @@ namespace Global.Dynamic
             ReportHub.Log(ReportCategory.ENGINE, "OnDestroy successfully finished");
         }
 
+        public void ApplyConfig(IAppArgs applicationParametersParser)
+        {
+            if (applicationParametersParser.TryGetValue(AppArgsFlags.ENVIRONMENT, out string? environment))
+                ParseEnvironment(environment!);
+        }
+
+        private void ParseEnvironment(string environment)
+        {
+            if (Enum.TryParse(environment, true, out DecentralandEnvironment env))
+                decentralandEnvironment = env;
+        }
+
         private async UniTask InitializeFlowAsync(CancellationToken ct)
         {
             IAppArgs applicationParametersParser = new ApplicationParametersParser(
@@ -129,13 +144,13 @@ namespace Global.Dynamic
 
             ISystemMemoryCap memoryCap = new SystemMemoryCap(MemoryCapMode.MAX_SYSTEM_MEMORY); // we use max memory on the loading screen
 
-            settings.ApplyConfig(applicationParametersParser);
+            ApplyConfig(applicationParametersParser);
             launchSettings.ApplyConfig(applicationParametersParser);
 
             World world = World.Create();
 
             var splashScreen = new SplashScreen(splashScreenAnimation, splashRoot, debugSettings.ShowSplash, splashScreenText);
-            var decentralandUrlsSource = new DecentralandUrlsSource(settings.DecentralandEnvironment, launchSettings.IsLocalSceneDevelopmentRealm);
+            var decentralandUrlsSource = new DecentralandUrlsSource(decentralandEnvironment, launchSettings.IsLocalSceneDevelopmentRealm);
 
             var texturesFuse = TextureFuseFactory();
 
@@ -161,6 +176,7 @@ namespace Global.Dynamic
                    .WithLog("Load Guard"),
                 realmUrls,
                 world,
+                decentralandEnvironment,
                 destroyCancellationToken
             );
 


### PR DESCRIPTION
## What does this PR change?

Moves the environment dropdown from an inner config to the EntryPoint
<img width="495" alt="Screenshot 2025-01-22 at 11 25 45" src="https://github.com/user-attachments/assets/65ff1fff-4fcb-42a3-8a54-bdb8cbbed483" />

...

## How to test the changes?

Just a quick smoke test that login works fine

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

