### PR TITLE
fix: Make the minimap icons reset its scale when the fullscreen map closes

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Clusters/ClusterController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Clusters/ClusterController.cs
@@ -158,5 +158,11 @@ namespace DCL.MapRenderer.MapLayers.Cluster
 
             return false;
         }
+
+        public void ResetToBaseScale()
+        {
+            foreach (var marker in clusteredMarkers)
+                marker.ResetScale(coordsUtils.ParcelSize);
+        }
     }
 }

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/IZoomScalingLayer.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/IZoomScalingLayer.cs
@@ -2,6 +2,9 @@
 {
     public interface IZoomScalingLayer
     {
+        // Property to block the zoom on the layer
+        bool ZoomBlocked { get; set; }
+
         void ApplyCameraZoom(float baseZoom, float newZoom, int zoomLevel);
 
         void ResetToBaseScale();

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Pins/PinMarkerController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Pins/PinMarkerController.cs
@@ -21,6 +21,8 @@ namespace DCL.MapRenderer.MapLayers.Pins
 {
     internal class PinMarkerController : MapLayerControllerBase, IMapCullingListener<IPinMarker>, IMapLayerController, IZoomScalingLayer
     {
+        public bool ZoomBlocked { get; set; }
+
         internal delegate IPinMarker PinMarkerBuilder(
             IObjectPool<PinMarkerObject> objectsPool,
             IMapCullingController cullingController);
@@ -156,6 +158,9 @@ namespace DCL.MapRenderer.MapLayers.Pins
 
         public void ApplyCameraZoom(float baseZoom, float zoom, int zoomLevel)
         {
+            if (ZoomBlocked)
+                return;
+
             foreach (IPinMarker marker in markers.Values)
                 marker.SetZoom(coordsUtils.ParcelSize, baseZoom, zoom);
         }

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/PlayerMarker/PlayerMarkerController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/PlayerMarker/PlayerMarkerController.cs
@@ -104,8 +104,13 @@ namespace DCL.MapRenderer.MapLayers.PlayerMarker
             playerMarker.SetRotation(Quaternion.AngleAxis(rotation.eulerAngles.y, Vector3.back));
         }
 
+        public bool ZoomBlocked { get; set; }
+
         public void ApplyCameraZoom(float baseZoom, float zoom, int zoomLevel)
         {
+            if (ZoomBlocked)
+                return;
+
             playerMarker.SetZoom(baseZoom, zoom);
         }
 

--- a/Explorer/Assets/DCL/MapRenderer/MapPath/MapPathController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapPath/MapPathController.cs
@@ -14,6 +14,8 @@ namespace DCL.MapRenderer
 {
     public class MapPathController : MapLayerControllerBase, IMapCullingListener<IPinMarker>, IMapLayerController, IZoomScalingLayer
     {
+        public bool ZoomBlocked { get; set; }
+
         internal delegate IPinMarker PinMarkerBuilder(IObjectPool<PinMarkerObject> objectsPool, IMapCullingController cullingController);
         private const float ARRIVAL_TOLERANCE_SQUARED = 50;
         private const float MINIMAP_RADIUS = 134;
@@ -180,6 +182,9 @@ namespace DCL.MapRenderer
 
         public void ApplyCameraZoom(float baseZoom, float newZoom, int zoomLevel)
         {
+            if (ZoomBlocked)
+                return;
+
             internalPinMarker.SetZoom(coordsUtils.ParcelSize, baseZoom, newZoom);
             mapPathRenderer.SetZoom(baseZoom, newZoom);
         }

--- a/Explorer/Assets/DCL/MapRenderer/MapRenderer.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapRenderer.cs
@@ -77,6 +77,10 @@ namespace DCL.MapRenderer
             const int MIN_ZOOM = 5;
             const int MAX_ZOOM = 300;
 
+            // Each time we open the fullscreen map, we unblock zoom for all layers
+            foreach (IZoomScalingLayer layer in zoomScalingLayers)
+                layer.ZoomBlocked = false;
+
             // Clamp texture to the maximum size allowed, preserving aspect ratio
             Vector2Int zoomValues = cameraInput.ZoomValues;
             zoomValues.x = Mathf.Max(zoomValues.x, MIN_ZOOM);
@@ -99,8 +103,12 @@ namespace DCL.MapRenderer
             mapCameraController.OnReleasing -= ReleaseCamera;
             mapCameraController.ZoomChanged -= OnCameraZoomChanged;
 
+            // Each time we close the fullscreen map, we reset the scale for all layers and block its zoom
             foreach (IZoomScalingLayer layer in zoomScalingLayers)
+            {
                 layer.ResetToBaseScale();
+                layer.ZoomBlocked = true;
+            }
 
             DisableLayers(owner, mapCameraController.EnabledLayers);
             mapCameraPool.Release(mapCameraController);


### PR DESCRIPTION
## What does this PR change?
Fix #3101 

When we opened the fullscreen navmap and closed it, some icons were left with a wrong scale.

![image](https://github.com/user-attachments/assets/606a16e6-79dc-47e8-a497-050d82667291)

## How to test the changes?
1. Launch the explorer.
2. Open the fullscreen navmap.
3. Search Dollhouse and jump in there.
4. Check that the icons in the minimap have a correct size.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md