### PR TITLE
Fixed disk cache max size to avoid constant cleanup

### DIFF
--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Cache/Disk/CleanUp/LRUDiskCleanUp.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Cache/Disk/CleanUp/LRUDiskCleanUp.cs
@@ -16,7 +16,7 @@ namespace ECS.StreamableLoading.Cache.Disk.CleanUp
         /// </summary>
         private readonly FileSystemEnumerable<CacheFileInfo> files;
 
-        public LRUDiskCleanUp(CacheDirectory cacheDirectory, long maxCacheSizeBytes = 1024 ^ 3) //1GB
+        public LRUDiskCleanUp(CacheDirectory cacheDirectory, long maxCacheSizeBytes = 1024 * 1024 * 1024) //1GB
         {
             this.cacheDirectory = cacheDirectory;
             this.maxCacheSizeBytes = maxCacheSizeBytes;


### PR DESCRIPTION
## What does this PR change?

There was a small issue with the cleanup of the disk cache, the max size of the folder was set to 1024 ^ 3 that in c# is 1027, not 1024 power of 3 😆 
...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Play around and test as it was done with the disk cache PR

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

