### PR TITLE
fix: Avoid to click in the same place map tab more than once

### DIFF
--- a/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
@@ -51,6 +51,7 @@ namespace DCL.Navmap
         private CancellationTokenSource? showPlaceGalleryCancellationToken;
         private Vector2Int? currentBaseParcel;
         private Vector2Int? destination;
+        private Section? currentSection;
 
         public PlaceInfoPanelController(PlaceInfoPanelView view,
             IWebRequestController webRequestController,
@@ -94,14 +95,14 @@ namespace DCL.Navmap
 
             view.EventsTabButton.onClick.AddListener(() =>
             {
-                Toggle(Section.EVENTS);
-                FetchAndShowEventsOfThePlace();
+                if (Toggle(Section.EVENTS))
+                    FetchAndShowEventsOfThePlace();
             });
 
             view.PhotosTabButton.onClick.AddListener(() =>
             {
-                Toggle(Section.PHOTOS);
-                FetchPhotos();
+                if (Toggle(Section.PHOTOS))
+                    FetchPhotos();
             });
 
             view.OverviewTabButton.onClick.AddListener(() => Toggle(Section.OVERVIEW));
@@ -179,8 +180,14 @@ namespace DCL.Navmap
             view.LiveEventContainer.SetActive(false);
         }
 
-        public void Toggle(Section section)
+        /// <summary>
+        /// Returns true if the section was toggled to a different one, false otherwise.
+        /// </summary>
+        public bool Toggle(Section section)
         {
+            if (currentSection == section)
+                return false;
+
             if (section != Section.PHOTOS)
             {
                 showPlaceGalleryCancellationToken?.SafeCancelAndDispose();
@@ -193,6 +200,9 @@ namespace DCL.Navmap
             view.OverviewTabSelected.SetActive(section == Section.OVERVIEW);
             view.PhotosTabContainer.SetActive(section == Section.PHOTOS);
             view.PhotosTabSelected.SetActive(section == Section.PHOTOS);
+
+            currentSection = section;
+            return true;
         }
 
         private void SetCategories(PlacesData.PlaceInfo place)


### PR DESCRIPTION
## What does this PR change?
Fix #3106 

Before this fix, when we clicked multiple times any of the place's tabs when being on the map, we saw how the same content was being loaded several times without necessity and in some times, like clicking in the "PHOTOS" tab, the content was being loaded duplicated and generating several errors.

![image](https://github.com/user-attachments/assets/7412ef59-25ad-474a-b719-1d92646227de)

This fix avoid to load again the content of a tab that is already selected, thus solving 2 things:
- Unnecessary calls to the APIs.
- The duplicated issue described in #3106

## How to test the changes?
1. Launch the explorer.
2. Open the map.
3. Select a place (ideally the place has to have some photos published in its "PHOTOS" tab, for example: metagamimall).
4. Navigate through its tabs (Overview, Photos and Events) and check that it's working as expected. Specially clicking several times on PHOTOS and checking that the content is not being duplicated.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md