### PR TITLE
fix: Wrong message when we try to share a photo in X

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/ReelActions/ReelCommonActions.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/ReelActions/ReelCommonActions.cs
@@ -21,7 +21,7 @@ namespace DCL.InWorldCamera.ReelActions
         /// </summary>
         public static void ShareReelToX(string shareToXMessage, string reelId, IDecentralandUrlsSource decentralandUrlsSource, ISystemClipboard systemClipboard, IWebBrowser webBrowser)
         {
-            string description = shareToXMessage.Replace(" ", "%20");
+            string description = shareToXMessage;
             string url = $"{decentralandUrlsSource.Url(DecentralandUrl.CameraReelLink)}/{reelId}";
             string xUrl = $"https://x.com/intent/post?text={description}&hashtags=DCLCamera&url={url}";
 


### PR DESCRIPTION
## What does this PR change?
Fix #3216 

When a user attempted to share a gallery picture from DCL to an X account, there was a lot of wrong characters on the text.

![image](https://github.com/user-attachments/assets/50b03971-bf38-4202-8f83-79c875d6b72c)

## How to test the changes?
1. Launch the explorer.
2. Go to your gallery.
3. Select the 3 dots of one picture.
4. Share on X.
5. Check that X opens and the text is correct.

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md