### PR TITLE
Chore: ignore file:// paths

### DIFF
--- a/Explorer/Assets/Scripts/SceneRuntime/Factory/JsSource/CachedWebJsSources.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Factory/JsSource/CachedWebJsSources.cs
@@ -5,6 +5,7 @@ using ECS.StreamableLoading.Cache.Disk;
 using ECS.StreamableLoading.Cache.Generic;
 using ECS.StreamableLoading.Cache.InMemory;
 using SceneRuntime.Factory.WebSceneSource;
+using System;
 using System.Threading;
 
 namespace SceneRuntime.Factory.JsSource
@@ -24,6 +25,10 @@ namespace SceneRuntime.Factory.JsSource
         public async UniTask<string> SceneSourceCodeAsync(URLAddress path, CancellationToken ct)
         {
             string key = path.Value;
+
+            if (key.StartsWith("file://", StringComparison.Ordinal))
+                return await origin.SceneSourceCodeAsync(path, ct);
+
             var result = await cache.ContentOrFetchAsync(key, origin, static v => SceneSourceCodeAsync(v), ct);
             return result.Unwrap().Value.EnsureNotNull();
         }


### PR DESCRIPTION
## What does this PR change?

ignore local files for js sources in caching strategy since it doesn't make a sense to cache them on disk.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Play happy path

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

