### PR TITLE
fix: Force a terrain cache generation 

### DIFF
--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -27,7 +27,7 @@ namespace DCL.Landscape
         private const float ROOT_VERTICAL_SHIFT = -0.01f; // fix for not clipping with scene (potential) floor
 
         // increment this number if we want to force the users to generate a new terrain cache
-        private const int CACHE_VERSION = 9;
+        private const int CACHE_VERSION = 10;
 
         private const float PROGRESS_COUNTER_EMPTY_PARCEL_DATA = 0.1f;
         private const float PROGRESS_COUNTER_TERRAIN_DATA = 0.3f;


### PR DESCRIPTION
## What does this PR change?

Forces a terrain cache generation

The shore should look just fine

![image](https://github.com/user-attachments/assets/b2360e5b-2ecc-4177-b738-1c93d6fc42f8)


## How to test the changes?

1. Launch the explorer
2. Check in you cache that you now have the `terrain_cache_97_512_v10.data` file

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

