### PR TITLE
Let Protobuf use optimized JavaScript types

### DIFF
--- a/Explorer/Assets/Scripts/SceneRuntime/ModuleHub/SceneModuleHub.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/ModuleHub/SceneModuleHub.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.ClearScript.V8;
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace SceneRuntime.ModuleHub
 {
@@ -16,13 +17,25 @@ namespace SceneRuntime.ModuleHub
 
         public void LoadAndCompileJsModules(IReadOnlyDictionary<string, string> sources)
         {
-            foreach (string filename in sources.Keys)
+            foreach (KeyValuePair<string, string> source in sources)
             {
-                // Compile the module using the V8ScriptEngine
-                V8Script script = engine.Compile(sources[filename]!)!;
+                V8Script script = engine.Compile(source.Value);
+                string moduleName = $"system/{source.Key}";
+                string extension = Path.GetExtension(moduleName);
 
-                // Add the compiled script to a dictionary with the module name as the key
-                jsNodulesCompiledScripts.Add($"system/{filename}", script);
+                // "system/foo.js"
+                jsNodulesCompiledScripts.Add(moduleName, script);
+
+                // "system/foo"
+                if (!string.IsNullOrEmpty(extension))
+                    jsNodulesCompiledScripts.Add(moduleName[..^extension.Length], script);
+
+                // We added a "system/" prefix to all our modules, but protobufjs, a third party
+                // library, is not aware of that and is looking for buffer and long in the wrong place.
+                if (source.Key == "buffer.js")
+                    jsNodulesCompiledScripts.Add("buffer", script);
+                else if (source.Key == "long.js")
+                    jsNodulesCompiledScripts.Add("long", script);
             }
         }
 
@@ -33,18 +46,10 @@ namespace SceneRuntime.ModuleHub
         /// <returns>The compiled V8Script for the specified module name.</returns>
         public V8Script ModuleScript(string moduleName)
         {
-            // Check if the module name is in the dictionary of compiled scripts
             if (jsNodulesCompiledScripts.TryGetValue(moduleName, out V8Script code))
                 return code!;
-
-            // If not, try appending ".js" to the module name
-            string moduleNameWithJs = moduleName + ".js";
-
-            if (jsNodulesCompiledScripts.TryGetValue(moduleNameWithJs, out code))
-                return code!;
-
-            // If we don't find a match, throw an exception
-            throw new ArgumentException($"Module '{moduleName}' not found.");
+            else
+                throw new ArgumentException($"Module '{moduleName}' not found.");
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

We renamed all our modules some time ago, and so Protobuf could not find them anymore. Besides the eyesore in the log, it's a performance degradation because Protobuf then falls back to regular arrays. This change adds a special case for the modules Protobuf wants.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Play normally
3. The game should run at least as well as without this change

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

