### PR TITLE
fix: always check for clean build label

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -157,6 +157,7 @@ jobs:
               clean_build=$(echo "${{ join(github.event.pull_request.labels.*.name, ' ') }}" | grep -qw 'clean-build' && echo true || echo false)
             fi
           fi
+          echo "Set clean_build to: $clean_build"
           echo "clean_build=${clean_build}" >> $GITHUB_OUTPUT
 
           if [ "${{ github.event.inputs.cache_strategy }}" ]; then

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -144,17 +144,19 @@ jobs:
       - name: Set default values
         id: set_defaults
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "Checking all PR labels..."
-            clean_build=$(echo "${{ join(...) }}" | grep -q 'clean-build' && echo true || echo false)
+          # Clean build logic
+          if [ "${{ github.event.inputs.clean_build }}" ]; then
+            clean_build=${{ github.event.inputs.clean_build }}
           elif [ "${{ inputs.clean_build }}" ]; then
             clean_build=${{ inputs.clean_build }}
-          elif [ "${{ github.event.label.name }}" == "clean-build" ]; then
-            clean_build=true
           else
             clean_build=false
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "Checking PR labels: ${{ join(github.event.pull_request.labels.*.name, ', ') }}"
+              # Proper label check with spaces
+              clean_build=$(echo "${{ join(github.event.pull_request.labels.*.name, ' ') }}" | grep -qw 'clean-build' && echo true || echo false)
+            fi
           fi
-          echo "Set clean_build to: $clean_build"
           echo "clean_build=${clean_build}" >> $GITHUB_OUTPUT
 
           if [ "${{ github.event.inputs.cache_strategy }}" ]; then

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -144,8 +144,9 @@ jobs:
       - name: Set default values
         id: set_defaults
         run: |
-          if [ "${{ github.event.inputs.clean_build }}" ]; then
-            clean_build=${{ github.event.inputs.clean_build }}
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "Checking all PR labels..."
+            clean_build=$(echo "${{ join(...) }}" | grep -q 'clean-build' && echo true || echo false)
           elif [ "${{ inputs.clean_build }}" ]; then
             clean_build=${{ inputs.clean_build }}
           elif [ "${{ github.event.label.name }}" == "clean-build" ]; then


### PR DESCRIPTION
## What does this PR change?

Before we only passed the `clean-build` flag when the label was added, on next run the label was not respected. 
With this change it will always check for the label and set `clean-build` properly

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. ...

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

