### PR TITLE
Change the chat entry prefabs to how Super Scroll View wants them

### DIFF
--- a/Explorer/Assets/DCL/Chat/Assets/ChatEntry.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/ChatEntry.prefab
@@ -87,13 +87,14 @@ GameObject:
   - component: {fileID: 39980002243492371}
   - component: {fileID: 2827836955777514274}
   - component: {fileID: 6055564883027669942}
+  - component: {fileID: -5745685080700441914}
   m_Layer: 5
   m_Name: ChatEntry
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &383342559985163451
 RectTransform:
   m_ObjectHideFlags: 0
@@ -110,11 +111,11 @@ RectTransform:
   - {fileID: 5758505306808974931}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: -138}
   m_SizeDelta: {x: 2, y: 74}
-  m_Pivot: {x: 0, y: 1}
+  m_Pivot: {x: 0, y: 0}
 --- !u!222 &39980002243492371
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -159,6 +160,18 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!114 &-5745685080700441914
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 315238571471859014}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbcbd7952202d4d44a555aea5af2a351, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &357537411374976974
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Chat/Assets/ChatEntryOwn.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/ChatEntryOwn.prefab
@@ -873,13 +873,14 @@ GameObject:
   - component: {fileID: 8487783883954388931}
   - component: {fileID: 5943306044626337522}
   - component: {fileID: 2399595943982069350}
+  - component: {fileID: -539915943301067793}
   m_Layer: 5
   m_Name: ChatEntryOwn
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8076444965380626795
 RectTransform:
   m_ObjectHideFlags: 0
@@ -896,11 +897,11 @@ RectTransform:
   - {fileID: 4228583114638211971}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: -3.1999512}
   m_SizeDelta: {x: 0, y: 74}
-  m_Pivot: {x: 0, y: 1}
+  m_Pivot: {x: 0, y: 0}
 --- !u!222 &8487783883954388931
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -945,6 +946,18 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!114 &-539915943301067793
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8150196112421136534}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbcbd7952202d4d44a555aea5af2a351, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8174651243816208185
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Chat/Assets/SystemChatEntry.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/SystemChatEntry.prefab
@@ -514,13 +514,14 @@ GameObject:
   - component: {fileID: 5134452323717697246}
   - component: {fileID: 6985445914565398511}
   - component: {fileID: 1424972135909640059}
+  - component: {fileID: 4866470503882333944}
   m_Layer: 5
   m_Name: SystemChatEntry
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &4800516901492795510
 RectTransform:
   m_ObjectHideFlags: 0
@@ -541,7 +542,7 @@ RectTransform:
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 148.79999}
   m_SizeDelta: {x: 1.7210072, y: 74}
-  m_Pivot: {x: 0, y: 1}
+  m_Pivot: {x: 0, y: 0}
 --- !u!222 &5134452323717697246
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -586,6 +587,18 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!114 &4866470503882333944
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4868610521581754763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbcbd7952202d4d44a555aea5af2a351, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4898129314729653796
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Super Scroll View keeps modifying these prefabs whenever play mode is entered, and that is an annoyance. After reading its source code, I believe that these prefabs should be that way all along. This change commits that.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Test the chat UI. Send and receive messages, and whatever else.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

