### PR TITLE
Remove a reference to an asset that does not exist

### DIFF
--- a/Explorer/Assets/AddressableAssetsData/AssetGroups/Essentials.asset
+++ b/Explorer/Assets/AddressableAssetsData/AssetGroups/Essentials.asset
@@ -127,11 +127,6 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
-  - m_GUID: 43daf6965002847a19f241e71b28fd9b
-    m_Address: Assets/DCL/InWorldCamera/CameraReelGallery/Assets/ContextMenuSO/ReelGalleryContextMenuConfig.asset
-    m_ReadOnly: 0
-    m_SerializedLabels: []
-    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 4a2a7b610414b45c1b576946ce094877
     m_Address: NftCategoryIcons
     m_ReadOnly: 0


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

I'm trying to cut down on the Git status pollution with this change. When entering play mode, Essentials.asset is modified to remove a reference to ReelGalleryContextMenuConfig, an asset that does not exist in the dev branch yet. I'm guessing a change to Essentials.asset was committed by mistake.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Test the photo reel gallery?

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

