### PR TITLE
style: fix photos hover animation

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Assets/ThumbnailElement.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Assets/ThumbnailElement.prefab
@@ -314,9 +314,9 @@ MonoBehaviour:
   <optionButtonContainer>k__BackingField: {fileID: 3651668776247032185}
   <button>k__BackingField: {fileID: 7425802945127696628}
   <outline>k__BackingField: {fileID: 4693459573345756047}
-  <optionButtonOffset>k__BackingField: {x: -11, y: -23, z: 0}
-  <scaleFactorOnHover>k__BackingField: 1.01
-  <scaleAnimationDuration>k__BackingField: 0.3
+  <optionButtonOffset>k__BackingField: {x: -10, y: -23, z: 0}
+  <scaleFactorOnHover>k__BackingField: 1
+  <scaleAnimationDuration>k__BackingField: 0
   <thumbnailLoadedAnimationDuration>k__BackingField: 0.3
 --- !u!1001 &686625780324777799
 PrefabInstance:

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Assets/ThumbnailElement.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Assets/ThumbnailElement.prefab
@@ -149,7 +149,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -10, y: -10}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 1, y: 1}
 --- !u!1 &4693459573345756047
@@ -187,7 +187,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 4, y: 4}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8365274367876713441
 CanvasRenderer:
@@ -217,8 +217,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 4bc8ac5f2d268405da4ed45362da582a, type: 3}
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -258,10 +258,10 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8174522652015465086}
   - {fileID: 4395404846359650668}
   - {fileID: 2524361969500198592}
   - {fileID: 3651668776247032185}
+  - {fileID: 8174522652015465086}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Explorer/Assets/DCL/InWorldCamera/Textures/SquaredOutline.png
+++ b/Explorer/Assets/DCL/InWorldCamera/Textures/SquaredOutline.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7abf33a83ae732701ebfcea3bd0e0e98edddd3a9dc92a889fc004f1e969386c
+size 170

--- a/Explorer/Assets/DCL/InWorldCamera/Textures/SquaredOutline.png.meta
+++ b/Explorer/Assets/DCL/InWorldCamera/Textures/SquaredOutline.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 4bc8ac5f2d268405da4ed45362da582a
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 0
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 10, y: 10, z: 10, w: 10}
+  spriteGenerateFallbackPhysicsShape: 0
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 32
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 1537655665
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What does this PR change?
This PR was created to fix the hover animation of the photos: removes the scale on hover, erasing the issue of not seeing side of the outline when a photo is inside and next to mask edge (as happens in the Profile and in the Scene's Info Cards in the map). Also, replaces the texture which emulated an outline for a real outline. The final result is a neat hover animation which works in every context.

BEFORE
https://github.com/user-attachments/assets/105f4300-c4fa-4919-9ff4-f91635956f5d

Screenshots of the outline getting chopped in the map and profile card
<img width="238" alt="Screenshot 2025-01-29 at 14 26 52" src="https://github.com/user-attachments/assets/5a84aaf4-7900-4d15-b19d-926a10d98e69" />
<img width="188" alt="Screenshot 2025-01-29 at 14 27 05" src="https://github.com/user-attachments/assets/2720220d-49cd-4a69-b967-ae21d42f341f" />

AFTER
https://github.com/user-attachments/assets/7c7c5450-c2da-49bc-b8f4-98a22cb80a0d

## How to test the changes?
1. Launch the explorer
2. Go to the gallery and hover any photo. Check the scale animation was removed and that the outline appears inside the photo edges instead of outside.
3. Go to the map and open the info card of a scene which contains photos (Genesis Plaza, for example). Go to the photos section, then repeat the action from task 2.
4. Open your profile card (if you don't have any public photo, set one as public). Go to the photos section, then repeat the action from task 2.