### PR TITLE
feat: add direct parameter to context object to collect ip's

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DynamicCommonTraitsPlugin.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DynamicCommonTraitsPlugin.cs
@@ -29,6 +29,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
             trackEvent.Context["realm"] = realmData is not { Configured: true } ? NOT_CONFIGURED : realmData.RealmName;
             trackEvent.Context["parcel"] = playerTransform == null? NOT_CONFIGURED : playerTransform.Position.ToParcel().ToString();
             trackEvent.Context["position"] = playerTransform == null? NOT_CONFIGURED : playerTransform.Position.Value.ToShortString();
+            trackEvent.Context["direct"] = true;
 
             return trackEvent;
         }


### PR DESCRIPTION
## What does this PR change?

Add `direct` parameter in context field for Segment Tracking. This tells segment to collect the IP of the request server-side.

...

## How to test the changes?

1. Launch the explorer
2. Go to debugger tab in Explorer V2 source, check if IP's are being collected for events tracked in the explorer.

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

