### PR TITLE
fix: notification redirect freezing avatar

### DIFF
--- a/Explorer/Assets/DCL/ExplorePanel/ExplorePanelController.cs
+++ b/Explorer/Assets/DCL/ExplorePanel/ExplorePanelController.cs
@@ -79,8 +79,7 @@ namespace DCL.ExplorePanel
         private void OnRewardAssigned(object[] parameters)
         {
             mvcManager.ShowAsync(IssueCommand(new ExplorePanelParameter(ExploreSections.Backpack))).Forget();
-            lastShownSection = ExploreSections.Backpack;
-            OnBackpackHotkeyPressed(default(InputAction.CallbackContext));
+            ShowSection(ExploreSections.Backpack);
         }
 
         public override void Dispose()


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

This fixes #2918 where the Explore panel was not being opened correctly from Notifications, blocking input / reopening the panel after teleporting.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open notifications panel
3. Click on a notification that redirects to backpack
4. Go to Map and teleport somewhere
5. Click on a notification again, explore panel should open instead of flashing and blocking input

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

