### PR TITLE
fix: Missing pieces of road in some locations

### DIFF
--- a/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
+++ b/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
@@ -23129,7 +23129,7 @@ MonoBehaviour:
     Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
     RoadModel: Road_E
   - RoadCoordinate: {x: 7, y: -136}
-    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
     RoadModel: Road_0
   - RoadCoordinate: {x: 7, y: -137}
     Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}

--- a/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
+++ b/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
@@ -23168,7 +23168,7 @@ MonoBehaviour:
     Rotation: {x: 0, y: 0.70710677, z: 0, w: -0.70710677}
     RoadModel: Fork_0
   - RoadCoordinate: {x: 16, y: -133}
-    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
     RoadModel: Road_E
   - RoadCoordinate: {x: 16, y: -150}
     Rotation: {x: 0, y: 1, z: 0, w: 0}

--- a/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
+++ b/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
@@ -23179,6 +23179,39 @@ MonoBehaviour:
   - RoadCoordinate: {x: 58, y: -150}
     Rotation: {x: 0, y: 1, z: 0, w: 0}
     RoadModel: Road_0
+  - RoadCoordinate: {x: 24, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_B
+  - RoadCoordinate: {x: 26, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_B
+  - RoadCoordinate: {x: 27, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_A
+  - RoadCoordinate: {x: 28, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_B
+  - RoadCoordinate: {x: 30, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_B
+  - RoadCoordinate: {x: 31, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_E
+  - RoadCoordinate: {x: 42, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_0
+  - RoadCoordinate: {x: 44, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_0
+  - RoadCoordinate: {x: 45, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_C
+  - RoadCoordinate: {x: 46, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_0
+  - RoadCoordinate: {x: 47, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_C
   <RoadAssetsReference>k__BackingField:
   - m_AssetGUID: 2d6ac3b70dd761a428bae0e655a93ebc
     m_SubObjectName: 

--- a/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
+++ b/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
@@ -23156,13 +23156,13 @@ MonoBehaviour:
     Rotation: {x: 0, y: 1, z: 0, w: 0}
     RoadModel: Road_0
   - RoadCoordinate: {x: 16, y: -137}
-    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
     RoadModel: Road_C
   - RoadCoordinate: {x: 16, y: -136}
-    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
     RoadModel: Road_B
   - RoadCoordinate: {x: 16, y: -135}
-    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
     RoadModel: Road_C
   - RoadCoordinate: {x: 16, y: -134}
     Rotation: {x: 0, y: 1, z: 0, w: 0}

--- a/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
+++ b/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
@@ -23107,6 +23107,78 @@ MonoBehaviour:
   - RoadCoordinate: {x: 13, y: 0}
     Rotation: {x: 0, y: 1, z: 0, w: 0}
     RoadModel: 13,0
+  - RoadCoordinate: {x: 16, y: -121}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_A
+  - RoadCoordinate: {x: 8, y: -121}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_A
+  - RoadCoordinate: {x: 8, y: -124}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_D
+  - RoadCoordinate: {x: 8, y: -127}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_C
+  - RoadCoordinate: {x: 7, y: -133}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_E
+  - RoadCoordinate: {x: 7, y: -134}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Fork_D
+  - RoadCoordinate: {x: 7, y: -135}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_E
+  - RoadCoordinate: {x: 7, y: -136}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_0
+  - RoadCoordinate: {x: 7, y: -137}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_A
+  - RoadCoordinate: {x: 7, y: -138}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Corner_0
+  - RoadCoordinate: {x: 8, y: -138}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_E
+  - RoadCoordinate: {x: 8, y: -141}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_C
+  - RoadCoordinate: {x: 8, y: -144}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_A
+  - RoadCoordinate: {x: 9, y: -144}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_0
+  - RoadCoordinate: {x: 16, y: -141}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_C
+  - RoadCoordinate: {x: 16, y: -144}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_0
+  - RoadCoordinate: {x: 16, y: -137}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_C
+  - RoadCoordinate: {x: 16, y: -136}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_B
+  - RoadCoordinate: {x: 16, y: -135}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_C
+  - RoadCoordinate: {x: 16, y: -134}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Fork_0
+  - RoadCoordinate: {x: 16, y: -133}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_E
+  - RoadCoordinate: {x: 16, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_0
+  - RoadCoordinate: {x: 57, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_A
+  - RoadCoordinate: {x: 58, y: -150}
+    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    RoadModel: Road_0
   <RoadAssetsReference>k__BackingField:
   - m_AssetGUID: 2d6ac3b70dd761a428bae0e655a93ebc
     m_SubObjectName: 

--- a/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
+++ b/Explorer/Assets/DCL/Roads/Settings/RoadData.asset
@@ -23120,19 +23120,19 @@ MonoBehaviour:
     Rotation: {x: 0, y: 1, z: 0, w: 0}
     RoadModel: Road_C
   - RoadCoordinate: {x: 7, y: -133}
-    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
     RoadModel: Road_E
   - RoadCoordinate: {x: 7, y: -134}
-    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    Rotation: {x: 0, y: 0.70710677, z: 0, w: -0.70710677}
     RoadModel: Fork_D
   - RoadCoordinate: {x: 7, y: -135}
-    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
     RoadModel: Road_E
   - RoadCoordinate: {x: 7, y: -136}
     Rotation: {x: 0, y: 1, z: 0, w: 0}
     RoadModel: Road_0
   - RoadCoordinate: {x: 7, y: -137}
-    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
     RoadModel: Road_A
   - RoadCoordinate: {x: 7, y: -138}
     Rotation: {x: 0, y: 1, z: 0, w: 0}
@@ -23165,7 +23165,7 @@ MonoBehaviour:
     Rotation: {x: 0, y: 0.70710677, z: 0, w: 0.70710677}
     RoadModel: Road_C
   - RoadCoordinate: {x: 16, y: -134}
-    Rotation: {x: 0, y: 1, z: 0, w: 0}
+    Rotation: {x: 0, y: 0.70710677, z: 0, w: -0.70710677}
     RoadModel: Fork_0
   - RoadCoordinate: {x: 16, y: -133}
     Rotation: {x: 0, y: 1, z: 0, w: 0}


### PR DESCRIPTION
## What does this PR change?
fix #2419 

## How to test the changes?
1. Launch the explorer
2. As the issue ticket describes, visit the next coords: `15,-135`, `58.-150`
3. And check that the missing roads appears.

**NOTE**: Take into account that it would be normal that these roads appear still empty in the map view. They will be updated there later, when we update the stellite view (this is a different process).

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md