### PR TITLE
Change EngineApiWrapper to IV8HostObject

### DIFF
--- a/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/PoolableByteArray.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/PoolableByteArray.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using UnityEngine.Assertions;
 
 namespace CrdtEcsBridge.PoolsProviders
 {
@@ -47,8 +46,11 @@ namespace CrdtEcsBridge.PoolsProviders
             IsDisposed = true;
         }
 
-        public IEnumerator<byte> GetEnumerator() =>
-            Length <= 0 ? ((IEnumerable<byte>)System.Array.Empty<byte>()).GetEnumerator() : new Enumerator(this);
+        public Enumerator GetEnumerator() =>
+            new Enumerator(this);
+
+        IEnumerator<byte> IEnumerable<byte>.GetEnumerator() =>
+            GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() =>
             GetEnumerator();

--- a/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/PoolableSDKObservableEventArray.cs
+++ b/Explorer/Assets/Scripts/CrdtEcsBridge/PoolsProviders/PoolableSDKObservableEventArray.cs
@@ -41,8 +41,11 @@ namespace CrdtEcsBridge.PoolsProviders
             IsDisposed = true;
         }
 
-        public IEnumerator<SDKObservableEvent> GetEnumerator() =>
-            Length <= 0 ? ((IEnumerable<SDKObservableEvent>)System.Array.Empty<SDKObservableEvent>()).GetEnumerator() : new Enumerator(this);
+        public Enumerator GetEnumerator() =>
+            new Enumerator(this);
+
+        IEnumerator<SDKObservableEvent> IEnumerable<SDKObservableEvent>.GetEnumerator() =>
+            GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() =>
             GetEnumerator();

--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/EngineApi/SDKObservableEvents/SDKObservableEventsEngineApiWrapper.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/EngineApi/SDKObservableEvents/SDKObservableEventsEngineApiWrapper.cs
@@ -1,5 +1,5 @@
 ﻿using CrdtEcsBridge.PoolsProviders;
-using JetBrains.Annotations;
+using Microsoft.ClearScript.V8.SplitProxy;
 using SceneRunner.Scene.ExceptionsHandling;
 using SceneRuntime.Apis.Modules.CommunicationsControllerApi.SDKMessageBus;
 using SceneRuntime.Apis.Modules.EngineApi.SDKObservableEvents.Events;
@@ -12,15 +12,20 @@ namespace SceneRuntime.Apis.Modules.EngineApi.SDKObservableEvents
         private readonly ISDKObservableEventsEngineApi engineApi;
         private readonly ISDKMessageBusCommsControllerAPI commsApi;
 
+        private readonly InvokeHostObject subscribeToSDKObservableEvent;
+        private readonly InvokeHostObject unsubscribeFromSDKObservableEvent;
+
         public SDKObservableEventsEngineApiWrapper(ISDKObservableEventsEngineApi api, ISDKMessageBusCommsControllerAPI commsApi, IInstancePoolsProvider instancePoolsProvider, ISceneExceptionsHandler exceptionsHandler) : base(api, instancePoolsProvider, exceptionsHandler)
         {
             engineApi = api;
             this.commsApi = commsApi;
+
+            subscribeToSDKObservableEvent = SubscribeToSDKObservableEvent;
+            unsubscribeFromSDKObservableEvent = UnsubscribeFromSDKObservableEvent;
         }
 
         // Used for SDK Observables + SDK Comms MessageBus
-        [UsedImplicitly]
-        public override ScriptableSDKObservableEventArray? SendBatch()
+        protected override ScriptableSDKObservableEventArray? SendBatch()
         {
             // If there are no subscriptions at all there is nothing to handle
             if (engineApi.IsAnySubscription() == false)
@@ -60,16 +65,39 @@ namespace SceneRuntime.Apis.Modules.EngineApi.SDKObservableEvents
             commsApi.ClearMessages();
         }
 
-        [UsedImplicitly]
-        public void SubscribeToSDKObservableEvent(string eventId)
+        private void SubscribeToSDKObservableEvent(ReadOnlySpan<V8Value.Decoded> args, V8Value result)
+        {
+            string eventId = args[0].GetString();
+            SubscribeToSDKObservableEvent(eventId);
+        }
+
+        private void SubscribeToSDKObservableEvent(string eventId)
         {
             engineApi.TryAddSubscription(eventId);
         }
 
-        [UsedImplicitly]
-        public void UnsubscribeFromSDKObservableEvent(string eventId)
+        private void UnsubscribeFromSDKObservableEvent(ReadOnlySpan<V8Value.Decoded> args,
+            V8Value result)
+        {
+            string eventId = args[0].GetString();
+            UnsubscribeFromSDKObservableEvent(eventId);
+        }
+
+        private void UnsubscribeFromSDKObservableEvent(string eventId)
         {
             engineApi.RemoveSubscriptionIfExists(eventId);
+        }
+
+        protected override void GetNamedProperty(StdString name, V8Value value, out bool isConst)
+        {
+            isConst = true;
+
+            if (name.Equals(nameof(SubscribeToSDKObservableEvent)))
+                value.SetHostObject(subscribeToSDKObservableEvent);
+            else if (name.Equals(nameof(UnsubscribeFromSDKObservableEvent)))
+                value.SetHostObject(unsubscribeFromSDKObservableEvent);
+            else
+                base.GetNamedProperty(name, value, out isConst);
         }
     }
 }

--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/EngineApi/SDKObservableEvents/ScriptableSDKObservableEventArray.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/Modules/EngineApi/SDKObservableEvents/ScriptableSDKObservableEventArray.cs
@@ -1,59 +1,87 @@
-using DCL.Diagnostics;
-using Microsoft.ClearScript.Util;
-using SceneRuntime.Apis.Modules.EngineApi.SDKObservableEvents.Events;
-using System.Collections;
-using System.Collections.Generic;
 using CrdtEcsBridge.PoolsProviders;
+using Microsoft.ClearScript;
+using Microsoft.ClearScript.V8.SplitProxy;
+using System;
 
 namespace SceneRuntime.Apis.Modules.EngineApi.SDKObservableEvents
 {
-    public class ScriptableSDKObservableEventArray : IScriptableEnumerator<SDKObservableEvent>
+    public class ScriptableSDKObservableEventArray : IV8HostObject, IDisposable
     {
-        private readonly IEnumerator<SDKObservableEvent> enumerator;
         private PoolableSDKObservableEventArray array;
-
-        public SDKObservableEvent Current => enumerator.Current;
-
-        public SDKObservableEvent ScriptableCurrent => Current;
-
-        object IEnumerator.Current => Current;
-
-        object IScriptableEnumerator.ScriptableCurrent => ScriptableCurrent;
 
         public ScriptableSDKObservableEventArray(PoolableSDKObservableEventArray array)
         {
             this.array = array;
-            enumerator = array.GetEnumerator();
         }
 
         public void Dispose()
         {
-            enumerator.Dispose();
             array.Dispose();
         }
 
-        public bool MoveNext()
+        void IV8HostObject.GetEnumerator(V8Value result) =>
+            result.SetHostObject(new Enumerator(this));
+
+        private sealed class Enumerator : IV8HostObject
         {
-            if (array.IsDisposed)
+            private PoolableSDKObservableEventArray.Enumerator enumerator;
+            private readonly ScriptObject factory;
+            private readonly InvokeHostObject scriptableMoveNext;
+            private readonly InvokeHostObject scriptableDispose;
+
+            public Enumerator(ScriptableSDKObservableEventArray array)
             {
-                ReportHub.LogError(ReportCategory.CRDT_ECS_BRIDGE, "Trying to move next on a disposed ScriptableSDKObservableEventArray");
-                return false;
+                enumerator = array.array.GetEnumerator();
+                scriptableMoveNext = ScriptableMoveNext;
+                scriptableDispose = ScriptableDispose;
+
+                // TODO: Don't create a new factory function every time.
+                factory = (ScriptObject)ScriptEngine.Current.Evaluate(@"
+                    (function(eventId, eventData) {
+                        return {
+                            generic: {
+                                eventId: eventId,
+                                eventData: eventData
+                            }
+                        };
+                    })
+                ");
             }
 
-            return enumerator.MoveNext();
-        }
+            private void ScriptableMoveNext(ReadOnlySpan<V8Value.Decoded> args, V8Value result) =>
+                result.SetBoolean(enumerator.MoveNext());
 
-        public void Reset()
-        {
-            enumerator.Reset();
-        }
+            private void ScriptableDispose(ReadOnlySpan<V8Value.Decoded> args, V8Value result)
+            {
+                enumerator.Dispose();
+                factory.Dispose();
+            }
 
-        public bool ScriptableMoveNext() =>
-            MoveNext();
-
-        public void ScriptableDispose()
-        {
-            Dispose();
+            void IV8HostObject.GetNamedProperty(StdString name, V8Value value, out bool isConst)
+            {
+                if (name.Equals("ScriptableCurrent"))
+                {
+                    var current = enumerator.Current;
+                    using var fields = new StdV8ValueArray(2);
+                    fields[0].SetString(current.generic.eventId);
+                    fields[1].SetString(current.generic.eventData);
+                    new V8Object(factory).Invoke(fields, value);
+                    isConst = false;
+                }
+                else if (name.Equals(nameof(ScriptableMoveNext)))
+                {
+                    value.SetHostObject(scriptableMoveNext);
+                    isConst = true;
+                }
+                else if (name.Equals(nameof(ScriptableDispose)))
+                {
+                    value.SetHostObject(scriptableDispose);
+                    isConst = true;
+                }
+                else
+                    throw new NotImplementedException(
+                        $"Named property {name.ToString()} is not implemented");
+            }
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

This change changes EngineApiWrapper and related types to implement IV8HostObject interface that skips all ClearScript logic for calls coming from JavaScript. This mainly reduces GC allocations.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Visit demanding and complex scenes
3. The game should at least as well as before

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

