### PR TITLE
fix: camera reel thumbnail element not being interactable (click and context menu button)

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Assets/ThumbnailElement.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Assets/ThumbnailElement.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 4395404846359650668}
   - component: {fileID: 5954271608757156520}
   - component: {fileID: 1873652860557502151}
-  - component: {fileID: 7425802945127696628}
   m_Layer: 5
   m_Name: Image
   m_TagString: Untagged
@@ -73,50 +72,6 @@ MonoBehaviour:
     y: 0
     width: 1
     height: 1
---- !u!114 &7425802945127696628
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2064386695120316503}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 1873652860557502151}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!1 &2832059930554306056
 GameObject:
   m_ObjectHideFlags: 0
@@ -163,6 +118,7 @@ GameObject:
   - component: {fileID: 8174522652015465086}
   - component: {fileID: 8365274367876713441}
   - component: {fileID: 1521568209500308742}
+  - component: {fileID: 3355456697447185489}
   m_Layer: 5
   m_Name: Outline
   m_TagString: Untagged
@@ -227,6 +183,50 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3355456697447185489
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4693459573345756047}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1873652860557502151}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &5861282376251455871
 GameObject:
   m_ObjectHideFlags: 0
@@ -259,9 +259,9 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4395404846359650668}
+  - {fileID: 8174522652015465086}
   - {fileID: 2524361969500198592}
   - {fileID: 3651668776247032185}
-  - {fileID: 8174522652015465086}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -312,7 +312,7 @@ MonoBehaviour:
   <thumbnailImage>k__BackingField: {fileID: 1873652860557502151}
   <loadingBrightView>k__BackingField: {fileID: 4151190356611495272}
   <optionButtonContainer>k__BackingField: {fileID: 3651668776247032185}
-  <button>k__BackingField: {fileID: 7425802945127696628}
+  <button>k__BackingField: {fileID: 3355456697447185489}
   <outline>k__BackingField: {fileID: 4693459573345756047}
   <optionButtonOffset>k__BackingField: {x: -10, y: -23, z: 0}
   <scaleFactorOnHover>k__BackingField: 1


### PR DESCRIPTION

## What does this PR change?

<!--
In case you are fixing any specific issue, please refer to it with `fix: #issue_number`.
In case you are implementing a new feature, please write a detailed description about it.
As an optional step, you can link or add any useful external documentation to give more context about the proposed changes (for example: design/architecture documents, figma links, screenshots, etc.).
-->

Fixes the camera reel thumbnails not being interactable. Clicking on one now correctly opens the Photo Detail UI and you are also able to open the relative context menu containing actions related to the reel.

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Open the camera reel
3. Check that the reels can now be clicked and the context menu can be opened as well
4. Do the same in the detail/photo section of a place in the map (no context menu is available there)
5. Do the same in the passport

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

