### PR TITLE
Fix: Scope Filestream

### DIFF
--- a/Explorer/Assets/Scripts/ECS/StreamableLoading/Cache/Disk/DiskCache.cs
+++ b/Explorer/Assets/Scripts/ECS/StreamableLoading/Cache/Disk/DiskCache.cs
@@ -63,10 +63,14 @@ namespace ECS.StreamableLoading.Cache.Disk
                 if (File.Exists(path) == false)
                     return EnumResult<SlicedOwnedMemory<byte>?, TaskError>.SuccessResult(null);
 
-                await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
-                var data = new SlicedOwnedMemory<byte>(MemoryPool<byte>.Shared!.Rent((int)stream.Length)!, (int)stream.Length);
+                SlicedOwnedMemory<byte> data;
 
-                int _ = await stream.ReadAsync(data.Memory, token);
+                {
+                    await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+                    data = new SlicedOwnedMemory<byte>(MemoryPool<byte>.Shared!.Rent((int)stream.Length)!, (int)stream.Length);
+                    int _ = await stream.ReadAsync(data.Memory, token);
+                }
+
                 diskCleanUp.NotifyUsed(fileName);
                 return EnumResult<SlicedOwnedMemory<byte>?, TaskError>.SuccessResult(data);
             }


### PR DESCRIPTION
## What does this PR change?

There is an error with file access in disk cache
![image](https://github.com/user-attachments/assets/2e2eb5d0-4733-4daf-99d5-8b7cfae0e7fc)

The real cause was that SetLastAccessTimeUtc fails when the file is being used. There is no mention in the [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.file.setlastaccesstimeutc?view=netcore-3.1) that It's not required on Mac but it is on Windows.
I put the scope to limit the FileStream and close it before the NotifyUsed call. It made the error gone in Editor on windows.

```
                SlicedOwnedMemory<byte> data;

                {
                    await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
                    data = new SlicedOwnedMemory<byte>(MemoryPool<byte>.Shared!.Rent((int)stream.Length)!, (int)stream.Length);
                    int _ = await stream.ReadAsync(data.Memory, token);
                }

                diskCleanUp.NotifyUsed(fileName);
```
...

## How to test the changes?

<!--
Explain how to test the feature (or fix) for someone who doesn't know anything about this implementation:
-->

1. Launch the explorer
2. Play happy path

## Our Code Review Standards

https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md

