### PR TITLE
chore: print system information on startup.

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/SystemInfoUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/SystemInfoUtils.cs
@@ -10,7 +10,7 @@ namespace DCL.Diagnostics
             var stringBuilder = new StringBuilder();
 
             stringBuilder.Clear();
-            AppendHeader(ref stringBuilder, "DEVICE INFORMATION");
+            AppendHeader(stringBuilder, "DEVICE INFORMATION");
 
             // Device & OS
             stringBuilder.AppendFormat("Device Model: {0}\n", SystemInfo.deviceModel);
@@ -21,14 +21,14 @@ namespace DCL.Diagnostics
             stringBuilder.AppendFormat("Device Unique ID: {0}\n\n", SystemInfo.deviceUniqueIdentifier);
 
             // CPU & Memory
-            AppendHeader(ref stringBuilder, "HARDWARE");
+            AppendHeader(stringBuilder, "HARDWARE");
             stringBuilder.AppendFormat("Processor Type: {0}\n", SystemInfo.processorType);
             stringBuilder.AppendFormat("Processor Count: {0}\n", SystemInfo.processorCount);
             stringBuilder.AppendFormat("Processor Frequency: {0} MHz\n", SystemInfo.processorFrequency);
             stringBuilder.AppendFormat("System Memory Size: {0} MB\n\n", SystemInfo.systemMemorySize);
 
             // Graphics
-            AppendHeader(ref stringBuilder, "GRAPHICS");
+            AppendHeader(stringBuilder, "GRAPHICS");
             stringBuilder.AppendFormat("Graphics Device Name: {0}\n", SystemInfo.graphicsDeviceName);
             stringBuilder.AppendFormat("Graphics Device Type: {0}\n", SystemInfo.graphicsDeviceType);
             stringBuilder.AppendFormat("Graphics Memory Size: {0} MB\n", SystemInfo.graphicsMemorySize);
@@ -37,7 +37,7 @@ namespace DCL.Diagnostics
             stringBuilder.AppendFormat("Supports Ray Tracing: {0}\n\n", SystemInfo.supportsRayTracing);
 
             // Unity & Application
-            AppendHeader(ref stringBuilder, "APPLICATION");
+            AppendHeader(stringBuilder, "APPLICATION");
             stringBuilder.AppendFormat("Unity Version: {0}\n", Application.unityVersion);
             stringBuilder.AppendFormat("Company Name: {0}\n", Application.companyName);
             stringBuilder.AppendFormat("Product Name: {0}\n", Application.productName);
@@ -52,7 +52,7 @@ namespace DCL.Diagnostics
             ReportHub.LogProductionInfo(stringBuilder.ToString());
         }
 
-        private static void AppendHeader(ref StringBuilder stringBuilder, string header)
+        private static void AppendHeader(StringBuilder stringBuilder, string header)
         {
             stringBuilder.AppendLine("==================");
             stringBuilder.AppendLine(header);

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/SystemInfoUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/SystemInfoUtils.cs
@@ -5,7 +5,7 @@ namespace DCL.Diagnostics
 {
     public static class SystemInfoUtils
     {
-        public static void Log()
+        public static void Log(string version)
         {
             var stringBuilder = new StringBuilder();
 
@@ -41,7 +41,7 @@ namespace DCL.Diagnostics
             stringBuilder.AppendFormat("Unity Version: {0}\n", Application.unityVersion);
             stringBuilder.AppendFormat("Company Name: {0}\n", Application.companyName);
             stringBuilder.AppendFormat("Product Name: {0}\n", Application.productName);
-            stringBuilder.AppendFormat("Version: {0}\n", Application.version);
+            stringBuilder.AppendFormat("Version: {0}\n", version);
             stringBuilder.AppendFormat("Target Frame Rate: {0}\n", Application.targetFrameRate);
             stringBuilder.AppendFormat("Screen Resolution: {0}x{1}@{2}Hz\n",
             Screen.currentResolution.width,

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/SystemInfoUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/SystemInfoUtils.cs
@@ -1,0 +1,59 @@
+﻿using System.Text;
+using UnityEngine.Device;
+
+namespace DCL.Diagnostics
+{
+    public static class SystemInfoUtils
+    {
+        public static void Log()
+        {
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.Clear();
+            stringBuilder.AppendLine("DEVICE INFORMATION");
+            stringBuilder.AppendLine("==================\n");
+
+            // Device & OS
+            stringBuilder.AppendFormat("Device Model: {0}\n", SystemInfo.deviceModel);
+            stringBuilder.AppendFormat("Device Name: {0}\n", SystemInfo.deviceName);
+            stringBuilder.AppendFormat("Operating System: {0}\n", SystemInfo.operatingSystem);
+            stringBuilder.AppendFormat("System Language: {0}\n", Application.systemLanguage);
+            stringBuilder.AppendFormat("Device Type: {0}\n", SystemInfo.deviceType);
+            stringBuilder.AppendFormat("Device Unique ID: {0}\n\n", SystemInfo.deviceUniqueIdentifier);
+
+            // CPU & Memory
+            stringBuilder.AppendLine("HARDWARE");
+            stringBuilder.AppendLine("=========\n");
+            stringBuilder.AppendFormat("Processor Type: {0}\n", SystemInfo.processorType);
+            stringBuilder.AppendFormat("Processor Count: {0}\n", SystemInfo.processorCount);
+            stringBuilder.AppendFormat("Processor Frequency: {0} MHz\n", SystemInfo.processorFrequency);
+            stringBuilder.AppendFormat("System Memory Size: {0} MB\n\n", SystemInfo.systemMemorySize);
+
+            // Graphics
+            stringBuilder.AppendLine("GRAPHICS");
+            stringBuilder.AppendLine("========\n");
+            stringBuilder.AppendFormat("Graphics Device Name: {0}\n", SystemInfo.graphicsDeviceName);
+            stringBuilder.AppendFormat("Graphics Device Type: {0}\n", SystemInfo.graphicsDeviceType);
+            stringBuilder.AppendFormat("Graphics Memory Size: {0} MB\n", SystemInfo.graphicsMemorySize);
+            stringBuilder.AppendFormat("Graphics Device Version: {0}\n", SystemInfo.graphicsDeviceVersion);
+            stringBuilder.AppendFormat("Max Texture Size: {0}\n", SystemInfo.maxTextureSize);
+            stringBuilder.AppendFormat("Supports Ray Tracing: {0}\n\n", SystemInfo.supportsRayTracing);
+
+            // Unity & Application
+            stringBuilder.AppendLine("APPLICATION");
+            stringBuilder.AppendLine("===========\n");
+            stringBuilder.AppendFormat("Unity Version: {0}\n", Application.unityVersion);
+            stringBuilder.AppendFormat("Company Name: {0}\n", Application.companyName);
+            stringBuilder.AppendFormat("Product Name: {0}\n", Application.productName);
+            stringBuilder.AppendFormat("Version: {0}\n", Application.version);
+            stringBuilder.AppendFormat("Target Frame Rate: {0}\n", Application.targetFrameRate);
+            stringBuilder.AppendFormat("Screen Resolution: {0}x{1}@{2}Hz\n",
+            Screen.currentResolution.width,
+            Screen.currentResolution.height,
+            Screen.currentResolution.refreshRateRatio);
+
+
+            ReportHub.LogProductionInfo(stringBuilder.ToString());
+        }
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/SystemInfoUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/SystemInfoUtils.cs
@@ -10,8 +10,7 @@ namespace DCL.Diagnostics
             var stringBuilder = new StringBuilder();
 
             stringBuilder.Clear();
-            stringBuilder.AppendLine("DEVICE INFORMATION");
-            stringBuilder.AppendLine("==================\n");
+            AppendHeader(ref stringBuilder, "DEVICE INFORMATION");
 
             // Device & OS
             stringBuilder.AppendFormat("Device Model: {0}\n", SystemInfo.deviceModel);
@@ -22,16 +21,14 @@ namespace DCL.Diagnostics
             stringBuilder.AppendFormat("Device Unique ID: {0}\n\n", SystemInfo.deviceUniqueIdentifier);
 
             // CPU & Memory
-            stringBuilder.AppendLine("HARDWARE");
-            stringBuilder.AppendLine("=========\n");
+            AppendHeader(ref stringBuilder, "HARDWARE");
             stringBuilder.AppendFormat("Processor Type: {0}\n", SystemInfo.processorType);
             stringBuilder.AppendFormat("Processor Count: {0}\n", SystemInfo.processorCount);
             stringBuilder.AppendFormat("Processor Frequency: {0} MHz\n", SystemInfo.processorFrequency);
             stringBuilder.AppendFormat("System Memory Size: {0} MB\n\n", SystemInfo.systemMemorySize);
 
             // Graphics
-            stringBuilder.AppendLine("GRAPHICS");
-            stringBuilder.AppendLine("========\n");
+            AppendHeader(ref stringBuilder, "GRAPHICS");
             stringBuilder.AppendFormat("Graphics Device Name: {0}\n", SystemInfo.graphicsDeviceName);
             stringBuilder.AppendFormat("Graphics Device Type: {0}\n", SystemInfo.graphicsDeviceType);
             stringBuilder.AppendFormat("Graphics Memory Size: {0} MB\n", SystemInfo.graphicsMemorySize);
@@ -40,8 +37,7 @@ namespace DCL.Diagnostics
             stringBuilder.AppendFormat("Supports Ray Tracing: {0}\n\n", SystemInfo.supportsRayTracing);
 
             // Unity & Application
-            stringBuilder.AppendLine("APPLICATION");
-            stringBuilder.AppendLine("===========\n");
+            AppendHeader(ref stringBuilder, "APPLICATION");
             stringBuilder.AppendFormat("Unity Version: {0}\n", Application.unityVersion);
             stringBuilder.AppendFormat("Company Name: {0}\n", Application.companyName);
             stringBuilder.AppendFormat("Product Name: {0}\n", Application.productName);
@@ -54,6 +50,13 @@ namespace DCL.Diagnostics
 
 
             ReportHub.LogProductionInfo(stringBuilder.ToString());
+        }
+
+        private static void AppendHeader(ref StringBuilder stringBuilder, string header)
+        {
+            stringBuilder.AppendLine("==================");
+            stringBuilder.AppendLine(header);
+            stringBuilder.AppendLine("==================\n");
         }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/SystemInfoUtils.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/SystemInfoUtils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9f8f66f83da149df98f72b72dd39be8c
+timeCreated: 1739377235

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -78,6 +78,8 @@ namespace Global.Dynamic
 
         private void Awake()
         {
+            SystemInfoUtils.Log();
+
             InitializeFlowAsync(destroyCancellationToken).Forget();
         }
 
@@ -317,7 +319,7 @@ namespace Global.Dynamic
 
         private static IDiskCache NewInstanceDiskCache(IAppArgs appArgs)
         {
-            if (appArgs.HasFlag(AppArgsFlags.DISABLE_DISK_CACHE))
+            //if (appArgs.HasFlag(AppArgsFlags.DISABLE_DISK_CACHE))
             {
                 ReportHub.Log(ReportData.UNSPECIFIED, $"Disable disk cache, flag --{AppArgsFlags.DISABLE_DISK_CACHE} is passed");
                 return new IDiskCache.Fake();

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -78,7 +78,7 @@ namespace Global.Dynamic
 
         private void Awake()
         {
-            SystemInfoUtils.Log();
+
 
             InitializeFlowAsync(destroyCancellationToken).Forget();
         }
@@ -132,6 +132,9 @@ namespace Global.Dynamic
 #endif
             );
 
+            DCLVersion dclVersion = DCLVersion.FromAppArgs(applicationParametersParser);
+            SystemInfoUtils.Log(dclVersion.Version);
+
             bool compressionEnabled = IPlatform.DEFAULT.IsNot(IPlatform.Kind.Windows) || applicationParametersParser.HasFlag(AppArgsFlags.FORCE_TEXTURE_COMPRESSION);
 
             if (IPlatform.DEFAULT.Is(IPlatform.Kind.Mac) && SystemInfo.processorType!.Contains("Intel", StringComparison.InvariantCultureIgnoreCase))
@@ -170,7 +173,7 @@ namespace Global.Dynamic
 
             var diskCache = NewInstanceDiskCache(applicationParametersParser);
 
-            DCLVersion dclVersion = DCLVersion.FromAppArgs(applicationParametersParser);
+
 
             bootstrapContainer = await BootstrapContainer.CreateAsync(
                 debugSettings,

--- a/Explorer/Assets/Scripts/Global/Versioning/DCLVersion.cs
+++ b/Explorer/Assets/Scripts/Global/Versioning/DCLVersion.cs
@@ -21,7 +21,6 @@ namespace Global.Versioning
                 ?? inEditorVersion
                 ?? UnityEngine.Application.version;
 
-            ReportHub.LogProductionInfo($"Current Decentraland version: {currentVersion}");
             return new DCLVersion(currentVersion);
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

It prints full device information to Player.log

![image](https://github.com/user-attachments/assets/85caa399-6dd4-4661-835f-d9563f17db81)


## Test Instructions

1. Run explorer
2. Verify that Player.log contains the device information

## Quality Checklist
- [x] Changes have been tested locally
- [x] Performance impact has been considered

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
