### PR TITLE
chore: lazy load the atlas map

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/MapRenderer.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapRenderer.cs
@@ -64,6 +64,7 @@ namespace DCL.MapRenderer
                 layers[MapLayer.SearchResults].SharedActive = true;
                 layers[MapLayer.LiveEvents].SharedActive = false;
                 layers[MapLayer.Category].SharedActive = false;
+                layers[MapLayer.ParcelsAtlas].SharedActive = false;
             }
             catch (OperationCanceledException)
             {
@@ -124,9 +125,12 @@ namespace DCL.MapRenderer
         {
             foreach (MapLayer mapLayer in ALL_LAYERS)
             {
-                if (!EnumUtils.HasFlag(mask, mapLayer) || !layers.TryGetValue(mapLayer, out MapLayerStatus mapLayerStatus) || mapLayerStatus.ActivityOwners.Count == 0 || mapLayerStatus.SharedActive == active)
+                if (!EnumUtils.HasFlag(mask, mapLayer))
                     continue;
 
+                if (!layers.TryGetValue(mapLayer, out var mapLayerStatus) || mapLayerStatus.ActivityOwners.Count == 0 || mapLayerStatus.SharedActive == active)
+                    continue;
+                    
                 mapLayerStatus.SharedActive = active;
 
                 // Cancel activation/deactivation flow


### PR DESCRIPTION
# Pull Request Description

The parcel atlas map takes approx 500 MB of memory to be downloaded

![image](https://github.com/user-attachments/assets/30f1feab-3453-4d8c-968d-227ff488acd2)

This is due to the lack of image compression and the missing power of 2 resolution.

Whatsmore, the parcel atlas map isn't commonly used, as it not the default one.

Therefore, this PR makes it lazy loadable, only accessible when the Parcel Atlas Map toggle is toggled.  

## Test Instructions

### Test Steps
1. Open the atlas map, and check that it loads on open. It should be clear how it appears one by one
2. Close it, and reopen it. It should still be there
3. Even if you close it while images appearing, it should be there next time you open it (or at least keep loading


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
