### PR TITLE
chore: fix remove lambda capture allocation

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -19,10 +19,12 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
     {
         private readonly OutlineRendererFeature? outlineFeature;
         private SingleInstanceEntity camera;
+        private Plane[] planes;
 
         public AvatarShapeVisibilitySystem(World world, IRendererFeaturesCache outlineFeature) : base(world)
         {
             this.outlineFeature = outlineFeature.GetRendererFeature<OutlineRendererFeature>();
+            planes = new Plane[6];
         }
 
         public override void Initialize()
@@ -43,7 +45,7 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
 
         public bool IsVisibleInCamera(Camera camera, Bounds bounds)
         {
-            Plane[] planes = GeometryUtility.CalculateFrustumPlanes(camera);
+            GeometryUtility.CalculateFrustumPlanes(camera, planes);
             return GeometryUtility.TestPlanesAABB(planes, bounds);
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

The lambda was capturing the log strings which are not compiled out at runtime. It got worse with an increasing number of players:
before:
![before](https://github.com/user-attachments/assets/bc0d6a67-86e5-473f-aaf4-5fb5d647ab0c)

after:
(dissapeared from profiler)

Secondly this frustrum calculation was allocating per frame:

before:
![Alloc2](https://github.com/user-attachments/assets/9a1770b4-ce6d-48fe-bd48-2fd9137b0ea1)

after:
![image](https://github.com/user-attachments/assets/e261826d-692e-4fd3-ac3f-3d62ae9a27ab)

## Test Instructions
No major changes to functionality, just play the happy paths.

### Test Steps
1. Play Happy Paths

## Quality Checklist
- [x] Changes have been tested locally
- [x] Performance impact has been considered

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
