### PR TITLE
chore: remove GLTF container from exception reporting

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
@@ -54,8 +54,6 @@ MonoBehaviour:
       Severity: 4
     - Category: TEXTURES
       Severity: 4
-    - Category: GLTF_CONTAINER
-      Severity: 4
     - Category: MATERIALS
       Severity: 4
     - Category: PRIMITIVE_COLLIDERS
@@ -121,8 +119,6 @@ MonoBehaviour:
     - Category: STREAMABLE_LOADING
       Severity: 1
     - Category: TEXTURES
-      Severity: 1
-    - Category: GLTF_CONTAINER
       Severity: 1
     - Category: MATERIALS
       Severity: 1


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

We are polluting Sentry with errors in the form of 

`System.ArgumentException: GLTF source models/core_building/ not found in the content`

This doesn't add value to us, as they tend to be creator problems. Makes sense to remove this category from exception reporitng

## Test Instructions

Nothing to test

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
