### PR TITLE
feat: friends analytics and request accepted splash screen

### DIFF
--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/FriendsPanelController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/FriendsPanelController.cs
@@ -13,6 +13,7 @@ using ECS.SceneLifeCycle.Realm;
 using MVC;
 using System;
 using System.Threading;
+using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.Pool;
 using Utility;
@@ -48,8 +49,8 @@ namespace DCL.Friends.UI.FriendPanel
         public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Persistent;
 
         public event Action? FriendsPanelOpened;
-        public event Action? OnlineFriendClicked;
-        public event Action? JumpToFriendClicked;
+        public event Action<string>? OnlineFriendClicked;
+        public event Action<string, Vector2Int>? JumpToFriendClicked;
 
         public FriendsPanelController(ViewFactoryMethod viewFactory,
             FriendsPanelView instantiatedView,
@@ -147,11 +148,11 @@ namespace DCL.Friends.UI.FriendPanel
             UnregisterCloseHotkey();
         }
 
-        private void OnlineFriendClick() =>
-            OnlineFriendClicked?.Invoke();
+        private void OnlineFriendClick(string targetAddress) =>
+            OnlineFriendClicked?.Invoke(targetAddress);
 
-        private void JumpToFriendClick() =>
-            JumpToFriendClicked?.Invoke();
+        private void JumpToFriendClick(string targetAddress, Vector2Int parcel) =>
+            JumpToFriendClicked?.Invoke(targetAddress, parcel);
 
         public UniTask InitAsync(CancellationToken ct)
         {

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/PersistentFriendPanelOpenerController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/PersistentFriendPanelOpenerController.cs
@@ -25,6 +25,8 @@ namespace DCL.Friends.UI.FriendPanel
 
         public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Persistent;
 
+        public event Action? FriendshipNotificationClicked;
+
         public PersistentFriendPanelOpenerController(ViewFactoryMethod viewFactory,
             IMVCManager mvcManager,
             DCLInput dclInput,
@@ -61,6 +63,8 @@ namespace DCL.Friends.UI.FriendPanel
             if (parameters.Length == 0 || parameters[0] is not FriendRequestAcceptedNotification)
                 return;
 
+            FriendshipNotificationClicked?.Invoke();
+
             FriendRequestAcceptedNotification friendRequestAcceptedNotification = (FriendRequestAcceptedNotification)parameters[0];
 
             passportBridge.ShowAsync(new Web3Address(friendRequestAcceptedNotification.Metadata.Sender.Address)).Forget();
@@ -70,6 +74,8 @@ namespace DCL.Friends.UI.FriendPanel
         {
             if (parameters.Length == 0 || parameters[0] is not FriendRequestReceivedNotification)
                 return;
+
+            FriendshipNotificationClicked?.Invoke();
 
             friendRequestReceivedCts = friendRequestReceivedCts.SafeRestart();
             ManageFriendRequestReceivedNotificationAsync((FriendRequestReceivedNotification)parameters[0], friendRequestReceivedCts.Token).Forget();

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListSectionUtilities.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListSectionUtilities.cs
@@ -3,6 +3,7 @@ using DCL.Diagnostics;
 using DCL.Multiplayer.Connectivity;
 using DCL.UI.GenericContextMenu.Controls.Configs;
 using ECS.SceneLifeCycle.Realm;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -21,7 +22,8 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             CancellationTokenSource? jumpToFriendLocationCts,
             string[] getUserPositionBuffer,
             IOnlineUsersProvider onlineUsersProvider,
-            IRealmNavigator realmNavigator)
+            IRealmNavigator realmNavigator,
+            Action<Vector2Int>? parcelCalculatedCallback = null)
         {
             jumpToFriendLocationCts = jumpToFriendLocationCts.SafeRestart();
             JumpToFriendLocationAsync(jumpToFriendLocationCts.Token).Forget();
@@ -39,6 +41,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
                 OnlineUserData userData = onlineData.First();
                 Vector2Int parcel = userData.position.ToParcel();
                 realmNavigator.TeleportToParcelAsync(parcel, ct, false).Forget();
+                parcelCalculatedCallback?.Invoke(parcel);
             }
         }
 
@@ -51,7 +54,8 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             string[] getUserPositionBuffer,
             CancellationTokenSource? jumpToFriendLocationCts,
             bool includeUserBlocking,
-            bool isFriendInGame)
+            bool isFriendInGame,
+            Action<Vector2Int>? parcelCalculatedCallback = null)
         {
             GenericContextMenu contextMenu = new GenericContextMenu(contextMenuSettings.ContextMenuWidth, verticalLayoutPadding: CONTEXT_MENU_VERTICAL_LAYOUT_PADDING, elementsSpacing: CONTEXT_MENU_ELEMENTS_SPACING)
                                             .AddControl(userProfileContextMenuControlSettings)
@@ -61,7 +65,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             if (isFriendInGame)
                 contextMenu.AddControl(new ButtonContextMenuControlSettings(contextMenuSettings.JumpToLocationText,
                     contextMenuSettings.JumpToLocationSprite,
-                    () => JumpToFriendLocation(friendProfile.Address, jumpToFriendLocationCts, getUserPositionBuffer, onlineUsersProvider, realmNavigator)));
+                    () => JumpToFriendLocation(friendProfile.Address, jumpToFriendLocationCts, getUserPositionBuffer, onlineUsersProvider, realmNavigator, parcelCalculatedCallback)));
 
             if (includeUserBlocking)
                 contextMenu.AddControl(new ButtonContextMenuControlSettings(contextMenuSettings.BlockText, contextMenuSettings.BlockSprite, () => BlockUserClicked(friendProfile)));

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Requests/RequestsSectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Requests/RequestsSectionController.cs
@@ -99,18 +99,13 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Requests
             if (friendshipStatus == UserProfileContextMenuControlSettings.FriendshipStatus.REQUEST_SENT)
                 CancelFriendshipRequestAsync(friendshipOperationCts.Token).Forget();
             else if (friendshipStatus == UserProfileContextMenuControlSettings.FriendshipStatus.REQUEST_RECEIVED)
-                AcceptFriendshipAsync(friendshipOperationCts.Token).Forget();
+                mvcManager.ShowAsync(FriendRequestController.IssueCommand(new FriendRequestParams { OneShotFriendAccepted = lastClickedProfileCtx }), ct: friendshipOperationCts.Token).Forget();
 
             return;
 
             async UniTaskVoid CancelFriendshipRequestAsync(CancellationToken ct)
             {
                 await friendsService.CancelFriendshipAsync(userId, ct);
-            }
-
-            async UniTaskVoid AcceptFriendshipAsync(CancellationToken ct)
-            {
-                await friendsService.AcceptFriendshipAsync(userId, ct);
             }
         }
 
@@ -155,19 +150,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Requests
         {
             friendshipOperationCts = friendshipOperationCts.SafeRestart();
 
-            AcceptFriendshipAsync(friendshipOperationCts.Token).Forget();
-
-            async UniTaskVoid AcceptFriendshipAsync(CancellationToken ct)
-            {
-                try
-                {
-                    await friendsService.AcceptFriendshipAsync(request.From.Address, ct);
-                }
-                catch(Exception e)
-                {
-                    ReportHub.LogException(e, new ReportData(ReportCategory.FRIENDS));
-                }
-            }
+            mvcManager.ShowAsync(FriendRequestController.IssueCommand(new FriendRequestParams { OneShotFriendAccepted = request.From}), ct: friendshipOperationCts.Token).Forget();
         }
 
         private void ContextMenuClicked(FriendProfile friendProfile, Vector2 buttonPosition, RequestUserView elementView)

--- a/Explorer/Assets/DCL/Friends/UI/Requests/FriendRequestController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/Requests/FriendRequestController.cs
@@ -17,6 +17,8 @@ namespace DCL.Friends.UI.Requests
         private const int MUTUAL_PAGE_SIZE_BY_DESIGN = 3;
         private const int OPERATION_CONFIRMED_WAIT_TIME_MS = 5000;
         private const string DATE_FORMAT = "MMM dd";
+        private const string FRIEND_REQUEST_SENT_FORMAT = "Friend Request Sent To <color=#73D3D3>{0}</color>";
+        private const string FRIEND_REQUEST_ACCEPTED_FORMAT = "You And <color=#FF8362>{0}</color> Are Now Friends!";
 
         private readonly IWeb3IdentityCache identityCache;
         private readonly IFriendsService friendsService;
@@ -257,7 +259,7 @@ namespace DCL.Friends.UI.Requests
                     await ShowOperationConfirmationAsync(
                         ViewState.CONFIRMED_SENT,
                         viewInstance.sentConfirmed, request.To,
-                        "Friend Request Sent To <color=#73D3D3>{0}</color>",
+                        FRIEND_REQUEST_SENT_FORMAT,
                         ct);
 
                     Close();
@@ -300,7 +302,7 @@ namespace DCL.Friends.UI.Requests
                 await ShowOperationConfirmationAsync(
                     ViewState.CONFIRMED_ACCEPTED,
                     viewInstance!.acceptedConfirmed, target,
-                    "You And <color=#FF8362>{0}</color> Are Now Friends!",
+                    FRIEND_REQUEST_ACCEPTED_FORMAT,
                     ct);
 
                 Close();

--- a/Explorer/Assets/DCL/Friends/UI/Requests/FriendRequestController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/Requests/FriendRequestController.cs
@@ -65,7 +65,7 @@ namespace DCL.Friends.UI.Requests
             viewInstance.cancel.CloseButton.onClick.AddListener(Close);
 
             viewInstance.received.BackButton.onClick.AddListener(Close);
-            viewInstance.received.AcceptButton.onClick.AddListener(Accept);
+            viewInstance.received.AcceptButton.onClick.AddListener(() => Accept(inputData.Request!.From));
             viewInstance.received.RejectButton.onClick.AddListener(Reject);
             viewInstance.received.CloseButton.onClick.AddListener(Close);
         }
@@ -76,7 +76,9 @@ namespace DCL.Friends.UI.Requests
 
             Web3Address selfAddress = identityCache.EnsuredIdentity().Address;
 
-            if (fr == null)
+            if (inputData.OneShotFriendAccepted != null)
+                Accept(inputData.OneShotFriendAccepted);
+            else if (fr == null)
             {
                 if (inputData.DestinationUser == null)
                     throw new Exception("Destination user must be set for new friend request");
@@ -285,7 +287,7 @@ namespace DCL.Friends.UI.Requests
             }
         }
 
-        private void Accept()
+        private void Accept(FriendProfile target)
         {
             requestOperationCancellationToken = requestOperationCancellationToken.SafeRestart();
             AcceptThenCloseAsync(requestOperationCancellationToken.Token).Forget();
@@ -293,11 +295,11 @@ namespace DCL.Friends.UI.Requests
 
             async UniTaskVoid AcceptThenCloseAsync(CancellationToken ct)
             {
-                await friendsService.AcceptFriendshipAsync(inputData.Request!.From.Address, ct);
+                await friendsService.AcceptFriendshipAsync(target.Address, ct);
 
                 await ShowOperationConfirmationAsync(
                     ViewState.CONFIRMED_ACCEPTED,
-                    viewInstance!.acceptedConfirmed, inputData.Request.From,
+                    viewInstance!.acceptedConfirmed, target,
                     "You And <color=#FF8362>{0}</color> Are Now Friends!",
                     ct);
 

--- a/Explorer/Assets/DCL/Friends/UI/Requests/FriendRequestParams.cs
+++ b/Explorer/Assets/DCL/Friends/UI/Requests/FriendRequestParams.cs
@@ -12,5 +12,9 @@ namespace DCL.Friends.UI.Requests
         /// Needed in case request is null
         /// </summary>
         public Web3Address? DestinationUser;
+        /// <summary>
+        /// Needed in case the request was accepted from another flow, and we need to display the modal
+        /// </summary>
+        public FriendProfile? OneShotFriendAccepted;
     }
 }

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -124,6 +124,7 @@ namespace DCL.Passport
         public event Action<string, bool>? PassportOpened;
         public event Action<string, bool, string>? BadgesSectionOpened;
         public event Action<string, bool>? BadgeSelected;
+        public event Action<string, Vector2Int>? JumpToFriendClicked;
 
         public PassportController(
             ViewFactoryMethod viewFactory,
@@ -544,7 +545,9 @@ namespace DCL.Passport
                                      .AddControl(new SeparatorContextMenuControlSettings(CONTEXT_MENU_SEPARATOR_HEIGHT, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.left, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.right));
 
             if (friendOnlineStatusCacheProxy.Object!.GetFriendStatus(inputData.UserId) != OnlineStatus.OFFLINE)
-                contextMenu.AddControl(new ButtonContextMenuControlSettings(viewInstance.JumpInText, viewInstance.JumpInSprite, () => FriendListSectionUtilities.JumpToFriendLocation(profile.UserId, jumpToFriendLocationCts, getUserPositionBuffer, onlineUsersProvider, realmNavigator)));
+                contextMenu.AddControl(new ButtonContextMenuControlSettings(viewInstance.JumpInText, viewInstance.JumpInSprite,
+                    () => FriendListSectionUtilities.JumpToFriendLocation(profile.UserId, jumpToFriendLocationCts, getUserPositionBuffer, onlineUsersProvider, realmNavigator,
+                        parcel => JumpToFriendClicked?.Invoke(profile.UserId, parcel))));
 
             if (friendshipStatus != FriendshipStatus.BLOCKED && includeUserBlocking)
                 contextMenu.AddControl(new ButtonContextMenuControlSettings(viewInstance.BlockText, viewInstance.BlockSprite, () => BlockUserClicked(inputData.UserId)));

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsConfiguration.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsConfiguration.asset
@@ -99,6 +99,26 @@ MonoBehaviour:
       isEnabled: 1
     - eventName: verification_requested
       isEnabled: 1
+  - groupName: Friends
+    events:
+    - eventName: friends_panel_opened
+      isEnabled: 1
+    - eventName: online_friend_clicked
+      isEnabled: 1
+    - eventName: jump_to_friend_clicked
+      isEnabled: 1
+    - eventName: notification_clicked
+      isEnabled: 1
+    - eventName: friend_request_sent
+      isEnabled: 1
+    - eventName: friend_request_canceled
+      isEnabled: 1
+    - eventName: friend_request_accepted
+      isEnabled: 1
+    - eventName: friend_request_rejected
+      isEnabled: 1
+    - eventName: friendship_deleted
+      isEnabled: 1
   useLocalEnvVariableFallback: 0
   flushSize: 20
   flushInterval: 30

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
@@ -87,7 +87,7 @@
             public const string OPEN_FRIENDS_PANEL = "friends_panel_opened";
             public const string ONLINE_FRIEND_CLICKED = "online_friend_clicked";
             public const string JUMP_TO_FRIEND_CLICKED = "jump_to_friend_clicked";
-            public const string FRIENDSHIP_NOTIFICATION_CLICKED = "friendship_notification_clicked";
+            public const string FRIENDSHIP_NOTIFICATION_CLICKED = "notification_clicked";
         }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
@@ -81,5 +81,13 @@
             public const string LOGIN_REQUESTED = "login_requested";
             public const string VERIFICATION_REQUESTED = "verification_requested";
         }
+
+        public static class Friends
+        {
+            public const string OPEN_FRIENDS_PANEL = "friends_panel_opened";
+            public const string ONLINE_FRIEND_CLICKED = "online_friend_clicked";
+            public const string JUMP_TO_FRIEND_CLICKED = "jump_to_friend_clicked";
+            public const string FRIENDSHIP_NOTIFICATION_CLICKED = "friendship_notification_clicked";
+        }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
@@ -88,6 +88,12 @@
             public const string ONLINE_FRIEND_CLICKED = "online_friend_clicked";
             public const string JUMP_TO_FRIEND_CLICKED = "jump_to_friend_clicked";
             public const string FRIENDSHIP_NOTIFICATION_CLICKED = "notification_clicked";
+
+            public const string REQUEST_SENT = "friend_request_sent";
+            public const string REQUEST_CANCELED = "friend_request_canceled";
+            public const string REQUEST_ACCEPTED = "friend_request_accepted";
+            public const string REQUEST_REJECTED = "friend_request_rejected";
+            public const string FRIENDSHIP_DELETED = "friendship_deleted";
         }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/DCL.AnalyticsDecorators.asmdef
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/DCL.AnalyticsDecorators.asmdef
@@ -30,7 +30,8 @@
         "GUID:254c118155004a75a699a9410d44311f",
         "GUID:166b65e6dfc848bb9fb075f53c293a38",
         "GUID:c6e727f7851314e679212856f4ce3e53",
-        "GUID:f3634757d00dab2429c6c11e69404e97"
+        "GUID:f3634757d00dab2429c6c11e69404e97",
+        "GUID:ead265f036164eb7899edc341131f4d5"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/FriendServiceAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/FriendServiceAnalyticsDecorator.cs
@@ -1,0 +1,90 @@
+using Cysharp.Threading.Tasks;
+using DCL.Friends;
+using Segment.Serialization;
+using System.Threading;
+
+namespace DCL.PerformanceAndDiagnostics.Analytics
+{
+    public class FriendServiceAnalyticsDecorator : IFriendsService
+    {
+        private readonly IFriendsService core;
+        private readonly IAnalyticsController analytics;
+
+        public FriendServiceAnalyticsDecorator(IFriendsService core, IAnalyticsController analytics)
+        {
+            this.core = core;
+            this.analytics = analytics;
+        }
+        public void Dispose()
+        {
+            core.Dispose();
+        }
+
+        public UniTask<PaginatedFriendsResult> GetFriendsAsync(int pageNum, int pageSize, CancellationToken ct) =>
+            core.GetFriendsAsync(pageNum, pageSize, ct);
+
+        public UniTask<PaginatedFriendsResult> GetMutualFriendsAsync(string userId, int pageNum, int pageSize, CancellationToken ct) =>
+            core.GetMutualFriendsAsync(userId, pageNum, pageSize, ct);
+
+        public UniTask<FriendshipStatus> GetFriendshipStatusAsync(string userId, CancellationToken ct) =>
+            core.GetFriendshipStatusAsync(userId, ct);
+
+        public UniTask<PaginatedFriendRequestsResult> GetReceivedFriendRequestsAsync(int pageNum, int pageSize, CancellationToken ct) =>
+            core.GetReceivedFriendRequestsAsync(pageNum, pageSize, ct);
+
+        public UniTask<PaginatedFriendRequestsResult> GetSentFriendRequestsAsync(int pageNum, int pageSize, CancellationToken ct) =>
+            core.GetSentFriendRequestsAsync(pageNum, pageSize, ct);
+
+        public async UniTask RejectFriendshipAsync(string friendId, CancellationToken ct)
+        {
+            await core.RejectFriendshipAsync(friendId, ct);
+
+            analytics.Track(AnalyticsEvents.Friends.REQUEST_REJECTED, new JsonObject
+            {
+                {"receiver_id", friendId}
+            });
+        }
+
+        public async UniTask CancelFriendshipAsync(string friendId, CancellationToken ct)
+        {
+            await core.CancelFriendshipAsync(friendId, ct);
+
+            analytics.Track(AnalyticsEvents.Friends.REQUEST_CANCELED, new JsonObject
+            {
+                {"receiver_id", friendId}
+            });
+        }
+
+        public async UniTask AcceptFriendshipAsync(string friendId, CancellationToken ct)
+        {
+            await core.AcceptFriendshipAsync(friendId, ct);
+
+            analytics.Track(AnalyticsEvents.Friends.REQUEST_ACCEPTED, new JsonObject
+            {
+                {"receiver_id", friendId}
+            });
+        }
+
+        public async UniTask DeleteFriendshipAsync(string friendId, CancellationToken ct)
+        {
+            await core.DeleteFriendshipAsync(friendId, ct);
+
+            analytics.Track(AnalyticsEvents.Friends.FRIENDSHIP_DELETED, new JsonObject
+            {
+                {"receiver_id", friendId}
+            });
+        }
+
+        public async UniTask<FriendRequest> RequestFriendshipAsync(string friendId, string messageBody, CancellationToken ct)
+        {
+            FriendRequest result = await core.RequestFriendshipAsync(friendId, messageBody, ct);
+
+            analytics.Track(AnalyticsEvents.Friends.REQUEST_SENT, new JsonObject
+            {
+                {"receiver_id", friendId}
+            });
+
+            return result;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/FriendServiceAnalyticsDecorator.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/FriendServiceAnalyticsDecorator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5b0a021e865a4b3daec744668270f2ed
+timeCreated: 1739891094

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/MVCManagerAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/MVCManagerAnalyticsDecorator.cs
@@ -1,6 +1,7 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCL.AuthenticationScreenFlow;
 using DCL.Chat;
+using DCL.ExplorePanel;
 using DCL.Friends.UI.FriendPanel;
 using DCL.InWorldCamera.PhotoDetail;
 using DCL.Passport;
@@ -38,6 +39,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
                 { typeof(SidebarController), CreateAnalytics<SidebarController>(c => new SupportAnalytics(analytics, c)) },
                 { typeof(FriendsPanelController), CreateAnalytics<FriendsPanelController>(c => new FriendsPanelAnalytics(analytics, c)) },
                 { typeof(PersistentFriendPanelOpenerController), CreateAnalytics<PersistentFriendPanelOpenerController>(c => new PersistentFriendPanelOpenerAnalytics(analytics, c)) },
+                { typeof(ExplorePanelController), CreateAnalytics<ExplorePanelController>(c => new ExplorePanelAnalytics(analytics, c)) },
             };
 
             Func<IController, IDisposable> CreateAnalytics<T>(Func<T, IDisposable> factory) where T: IController =>

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/MVCManagerAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/MVCManagerAnalyticsDecorator.cs
@@ -1,7 +1,7 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCL.AuthenticationScreenFlow;
 using DCL.Chat;
-using DCL.ExplorePanel;
+using DCL.Friends.UI.FriendPanel;
 using DCL.InWorldCamera.PhotoDetail;
 using DCL.Passport;
 using DCL.PerformanceAndDiagnostics.Analytics.EventBased;
@@ -10,7 +10,6 @@ using MVC;
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using UnityEngine;
 
 namespace DCL.PerformanceAndDiagnostics.Analytics
 {
@@ -37,6 +36,8 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
                 { typeof(PassportController), CreateAnalytics<PassportController>(c => new PassportAnalytics(analytics, c)) },
                 { typeof(AuthenticationScreenController), CreateAnalytics<AuthenticationScreenController>(c => new AuthenticationScreenAnalytics(analytics, c)) },
                 { typeof(SidebarController), CreateAnalytics<SidebarController>(c => new SupportAnalytics(analytics, c)) },
+                { typeof(FriendsPanelController), CreateAnalytics<FriendsPanelController>(c => new FriendsPanelAnalytics(analytics, c)) },
+                { typeof(PersistentFriendPanelOpenerController), CreateAnalytics<PersistentFriendPanelOpenerController>(c => new PersistentFriendPanelOpenerAnalytics(analytics, c)) },
             };
 
             Func<IController, IDisposable> CreateAnalytics<T>(Func<T, IDisposable> factory) where T: IController =>

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/DCL.Analytics.EventBased.asmdef
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/DCL.Analytics.EventBased.asmdef
@@ -23,7 +23,8 @@
         "GUID:9ca29a7d75ab84bab806a20bbd350fd8",
         "GUID:f82471a6db95848d88faad2ceb31c9c9",
         "GUID:887770ff22b647ac864047b3c1af9a8b",
-        "GUID:c6e727f7851314e679212856f4ce3e53"
+        "GUID:c6e727f7851314e679212856f4ce3e53",
+        "GUID:ead265f036164eb7899edc341131f4d5"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/FriendsPanelAnalytics.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/FriendsPanelAnalytics.cs
@@ -1,0 +1,37 @@
+using DCL.Friends.UI.FriendPanel;
+using System;
+
+namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
+{
+    public class FriendsPanelAnalytics : IDisposable
+    {
+        private readonly IAnalyticsController analytics;
+        private readonly FriendsPanelController friendsPanelController;
+
+        public FriendsPanelAnalytics(IAnalyticsController analytics, FriendsPanelController controller)
+        {
+            this.analytics = analytics;
+            this.friendsPanelController = controller;
+
+            friendsPanelController.FriendsPanelOpened += TrackFriendPanelOpen;
+            friendsPanelController.OnlineFriendClicked += TrackOnlineFriendClicked;
+            friendsPanelController.JumpToFriendClicked += JumpToFriendClicked;
+        }
+
+        public void Dispose()
+        {
+            friendsPanelController.FriendsPanelOpened -= TrackFriendPanelOpen;
+            friendsPanelController.OnlineFriendClicked -= TrackOnlineFriendClicked;
+            friendsPanelController.JumpToFriendClicked -= JumpToFriendClicked;
+        }
+
+        private void TrackFriendPanelOpen() =>
+            analytics.Track(AnalyticsEvents.Friends.OPEN_FRIENDS_PANEL);
+
+        private void TrackOnlineFriendClicked() =>
+            analytics.Track(AnalyticsEvents.Friends.ONLINE_FRIEND_CLICKED);
+
+        private void JumpToFriendClicked() =>
+            analytics.Track(AnalyticsEvents.Friends.JUMP_TO_FRIEND_CLICKED);
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/FriendsPanelAnalytics.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/FriendsPanelAnalytics.cs
@@ -1,5 +1,7 @@
 using DCL.Friends.UI.FriendPanel;
+using Segment.Serialization;
 using System;
+using UnityEngine;
 
 namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
 {
@@ -28,10 +30,17 @@ namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
         private void TrackFriendPanelOpen() =>
             analytics.Track(AnalyticsEvents.Friends.OPEN_FRIENDS_PANEL);
 
-        private void TrackOnlineFriendClicked() =>
-            analytics.Track(AnalyticsEvents.Friends.ONLINE_FRIEND_CLICKED);
+        private void TrackOnlineFriendClicked(string targetAddress) =>
+            analytics.Track(AnalyticsEvents.Friends.ONLINE_FRIEND_CLICKED, new JsonObject
+            {
+                {"receiver_id", targetAddress}
+            });
 
-        private void JumpToFriendClicked() =>
-            analytics.Track(AnalyticsEvents.Friends.JUMP_TO_FRIEND_CLICKED);
+        private void JumpToFriendClicked(string targetAddress, Vector2Int parcel) =>
+            analytics.Track(AnalyticsEvents.Friends.JUMP_TO_FRIEND_CLICKED, new JsonObject
+            {
+                {"receiver_id", targetAddress},
+                {"friend_position", parcel.ToString()},
+            });
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/FriendsPanelAnalytics.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/FriendsPanelAnalytics.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dd4683f43a2c494f912367fe42d922c2
+timeCreated: 1739870593

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/PassportAnalytics.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/PassportAnalytics.cs
@@ -1,6 +1,7 @@
 ﻿using DCL.Passport;
 using Segment.Serialization;
 using System;
+using UnityEngine;
 
 namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
 {
@@ -17,14 +18,23 @@ namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
             this.passportController.PassportOpened += OnPassportOpened;
             this.passportController.BadgesSectionOpened += OnBadgesSectionOpened;
             this.passportController.BadgeSelected += OnBadgeSelected;
+            this.passportController.JumpToFriendClicked += JumpToFriendClicked;
         }
 
         public void Dispose()
         {
             passportController.PassportOpened -= OnPassportOpened;
             passportController.BadgesSectionOpened -= OnBadgesSectionOpened;
-            this.passportController.BadgeSelected -= OnBadgeSelected;
+            passportController.BadgeSelected -= OnBadgeSelected;
+            passportController.JumpToFriendClicked -= JumpToFriendClicked;
         }
+
+        private void JumpToFriendClicked(string targetAddress, Vector2Int parcel) =>
+            analytics.Track(AnalyticsEvents.Friends.JUMP_TO_FRIEND_CLICKED, new JsonObject
+            {
+                {"receiver_id", targetAddress},
+                {"friend_position", parcel.ToString()},
+            });
 
         private void OnBadgeSelected(string id, bool isOwnPassport)
         {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/PersistentFriendPanelOpenerAnalytics.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/PersistentFriendPanelOpenerAnalytics.cs
@@ -1,0 +1,29 @@
+using DCL.Friends.UI.FriendPanel;
+using System;
+
+namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
+{
+    public class PersistentFriendPanelOpenerAnalytics : IDisposable
+    {
+        private readonly IAnalyticsController analytics;
+        private readonly PersistentFriendPanelOpenerController panelOpenerController;
+
+        public PersistentFriendPanelOpenerAnalytics(IAnalyticsController analytics,
+            PersistentFriendPanelOpenerController panelOpenerController)
+        {
+            this.analytics = analytics;
+            this.panelOpenerController = panelOpenerController;
+
+            panelOpenerController.FriendshipNotificationClicked += TrackFriendshipNotificationClicked;
+        }
+
+        public void Dispose()
+        {
+            panelOpenerController.FriendshipNotificationClicked -= TrackFriendshipNotificationClicked;
+        }
+
+        private void TrackFriendshipNotificationClicked() =>
+            analytics.Track(AnalyticsEvents.Friends.FRIENDSHIP_NOTIFICATION_CLICKED);
+
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/PersistentFriendPanelOpenerAnalytics.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/PersistentFriendPanelOpenerAnalytics.cs
@@ -1,4 +1,5 @@
 using DCL.Friends.UI.FriendPanel;
+using Segment.Serialization;
 using System;
 
 namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
@@ -23,7 +24,10 @@ namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
         }
 
         private void TrackFriendshipNotificationClicked() =>
-            analytics.Track(AnalyticsEvents.Friends.FRIENDSHIP_NOTIFICATION_CLICKED);
+            analytics.Track(AnalyticsEvents.Friends.FRIENDSHIP_NOTIFICATION_CLICKED, new JsonObject
+            {
+                {"notification_type", "friends"}
+            });
 
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/PersistentFriendPanelOpenerAnalytics.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/PersistentFriendPanelOpenerAnalytics.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e28775fd4e60475da2edddd76394c7ca
+timeCreated: 1739874236

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Playgrounds/AnalyticsConfiguration Playground.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Playgrounds/AnalyticsConfiguration Playground.asset
@@ -23,6 +23,10 @@ MonoBehaviour:
       isEnabled: 1
     - eventName: error
       isEnabled: 1
+    - eventName: crash
+      isEnabled: 1
+    - eventName: loading_error
+      isEnabled: 1
   - groupName: Map
     events:
     - eventName: map_jump_in
@@ -45,6 +49,8 @@ MonoBehaviour:
       isEnabled: 1
     - eventName: chat_bubble_switched
       isEnabled: 1
+    - eventName: open_support
+      isEnabled: 1
   - groupName: Wearables
     events:
     - eventName: used_emote
@@ -62,6 +68,36 @@ MonoBehaviour:
     - eventName: badges_tab_opened
       isEnabled: 1
     - eventName: badge_ui_click
+      isEnabled: 1
+  - groupName: CameraReel
+    events:
+    - eventName: open_camera
+      isEnabled: 1
+    - eventName: take_photo
+      isEnabled: 1
+    - eventName: open_camera_reel
+      isEnabled: 1
+    - eventName: open_photo
+      isEnabled: 1
+    - eventName: share_photo
+      isEnabled: 1
+    - eventName: download_photo
+      isEnabled: 1
+    - eventName: delete_photo
+      isEnabled: 1
+    - eventName: photo_to_marketplace
+      isEnabled: 1
+    - eventName: photo_jump_to
+      isEnabled: 1
+  - groupName: Authentication
+    events:
+    - eventName: logged_in_cached
+      isEnabled: 1
+    - eventName: logged_in
+      isEnabled: 1
+    - eventName: login_requested
+      isEnabled: 1
+    - eventName: verification_requested
       isEnabled: 1
   useLocalEnvVariableFallback: 0
   flushSize: 20

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -803,7 +803,9 @@ namespace Global.Dynamic
                     includeUserBlocking,
                     appArgs,
                     staticContainer.FeatureFlagsCache,
-                    sidebarActionsBus));
+                    sidebarActionsBus,
+                    dynamicWorldParams.EnableAnalytics,
+                    bootstrapContainer.Analytics));
             }
 
             if (dynamicWorldParams.EnableAnalytics)


### PR DESCRIPTION
# Pull Request Description

The initial PR for the Friends feature was missing minor details and analytics were skipped entirely. This PR addresses the request accepted splash screen and the analytics.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR introduces some of the missing stuff from the Friend feature such as:
1. Friends analytics
2. Missing friend request accepted splash screen if you interact from the shortcut buttons or the context menu

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
Launch the explorer with the following args:
1. `debug`
2. `friends`

### Test Steps
1. Generate a friend request from another account with you as the target
2. Verify that accepting it triggers the splash screen in both the quick action button and the context menu


### Additional Testing Notes
- Analytics cannot be tested as the corresponding feature flag for the Friends feature is not yet enabled


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
