### PR TITLE
fix: Set a max height for nametags

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -31,6 +31,7 @@ namespace DCL.Nametags
     {
         private const float NAMETAG_SCALE_MULTIPLIER = 0.15f;
         private const string NAMETAG_DEFAULT_WALLET_ID = "0000";
+        private const float NAMETAG_MAX_HEIGHT = 4f;
 
         private readonly IObjectPool<NametagView> nametagViewPool;
         private readonly ChatEntryConfigurationSO chatEntryConfiguration;
@@ -164,7 +165,7 @@ namespace DCL.Nametags
 //            avatarBounds.DrawInEditor(Color.red);
 //#endif
 
-            UpdateTagPosition(nametagView, camera.Camera, characterTransform.Position + new Vector3(0.0f, avatarSkinningComponent.LocalBounds.max.y, 0.0f));
+            UpdateTagPosition(nametagView, camera.Camera, characterTransform.Position + new Vector3(0.0f, Mathf.Min(avatarSkinningComponent.LocalBounds.max.y, NAMETAG_MAX_HEIGHT), 0.0f));
             UpdateTagTransparencyAndScale(nametagView, camera.Camera, characterTransform.Position);
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #3144 
Fix #2108 

This PR set a max height limit for the avatars tagname, so regardless of the wrongly creation of the equipped wearable, the tagname is always gonna be placed as a maximum height of `4` meters.

We discovered that there are some wearables that have a bounding box wrongly set that makes our nametag be placed in a very far height, for example:

### Red Glasses
https://github.com/user-attachments/assets/d3f0c3c6-19a9-4de2-bd11-9a1b5a3e54e5

### Soccer Cleats
https://github.com/user-attachments/assets/7594612b-3ef5-4549-a808-355e1da3c295

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
None.

### Test Steps
1. Open your backpack.
2. Equip the "Red Glasses" wearable.
3. Close the backpack.
4. Observe that your nametag doesn't disappear of the screen and its height is set to a maximum height of 4 meters.
5. Repeat the 1-4 steps but with the "Soccer Cleats" wearable.

### Additional Testing Notes
These are 2 wearables that we have identified as wrongly created in terms of height and that would be solved with this fix, but there could be other wearables that are experimenting the same, so it would be nice if you can test several wearables and check that none of them are making our tagname disappear 👍 

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
