### PR TITLE
fix: trigger empty friend list state if last user is deleted and normal state if one friend is created

### DIFF
--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListPagedDoubleCollectionRequestManager.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListPagedDoubleCollectionRequestManager.cs
@@ -26,6 +26,8 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
 
         public event Action<FriendProfile>? JumpInClicked;
         public event Action<FriendProfile, Vector2, FriendListUserView>? ContextMenuClicked;
+        public event Action? NoFriendsInCollections;
+        public event Action? AtLeastOneFriendInCollections;
 
         public FriendListPagedDoubleCollectionRequestManager(IFriendsService friendsService,
             IFriendsEventBus friendEventBus,
@@ -66,6 +68,8 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
 
         private void AddNewFriendProfile(FriendProfile friendProfile, OnlineStatus onlineStatus)
         {
+            int previousTotalCount = offlineFriends.Count + onlineFriends.Count;
+
             if (onlineStatus == OnlineStatus.OFFLINE)
             {
                 offlineFriends.Add(friendProfile);
@@ -76,6 +80,9 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
                 onlineFriends.Add(friendProfile);
                 FriendsSorter.SortFriendList(onlineFriends);
             }
+
+            if (previousTotalCount == 0)
+                AtLeastOneFriendInCollections?.Invoke();
         }
 
         private void FriendBecameOnline(FriendProfile friendProfile)
@@ -139,6 +146,9 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             onlineFriends.RemoveAll(friendProfile => friendProfile.Address.ToString().Equals(userid));
             offlineFriends.RemoveAll(friendProfile => friendProfile.Address.ToString().Equals(userid));
             RefreshLoopList();
+
+            if (offlineFriends.Count + onlineFriends.Count == 0)
+                NoFriendsInCollections?.Invoke();
         }
 
         protected override FriendProfile GetFirstCollectionElement(int index) =>

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
@@ -54,6 +54,8 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
 
             doubleCollectionRequestManager.JumpInClicked += JumpInClick;
             doubleCollectionRequestManager.ContextMenuClicked += ContextMenuClicked;
+            doubleCollectionRequestManager.NoFriendsInCollections += ShowEmptyState;
+            doubleCollectionRequestManager.AtLeastOneFriendInCollections += HideEmptyState;
         }
 
         public override void Dispose()
@@ -61,7 +63,21 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             base.Dispose();
             requestManager.ContextMenuClicked -= ContextMenuClicked;
             requestManager.JumpInClicked -= JumpInClick;
+            requestManager.NoFriendsInCollections -= ShowEmptyState;
+            requestManager.AtLeastOneFriendInCollections -= HideEmptyState;
             jumpToFriendLocationCts.SafeCancelAndDispose();
+        }
+
+        private void ShowEmptyState()
+        {
+            view.SetEmptyState(true);
+            view.SetScrollViewState(false);
+        }
+
+        private void HideEmptyState()
+        {
+            view.SetEmptyState(false);
+            view.SetScrollViewState(true);
         }
 
         private void HandleContextMenuUserProfileButton(string userId, UserProfileContextMenuControlSettings.FriendshipStatus friendshipStatus)


### PR DESCRIPTION

# Pull Request Description

There are two edge cases in the friend panel:
1. when a user removes the last friendship, the empty state is not triggered and the 2 sections (offline/online) are shown as empty instead
2. when a user that doesn't have any friend, and while being online a request they have made is accepted the empty state is not hidden, hiding the 2 sections

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR introduces two events to identify those two edge cases in order to make the UI react in the proper way, showing (or hiding) the empty state accordingly.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
Launch the explorer with the following args:

1. `debug`
1. `friends`

### Test Steps
1. Remove all friends you have in the panel and check that by removing the last one, the empty state is correctly shown
2. Add one friend and have them accepting your request while checking the friend panel. Check that the empty state is removed and the list with that user is shown

### Additional Testing Notes
- The empty state should look like this 
![image](https://github.com/user-attachments/assets/23b0cc70-9028-43bf-8513-5c941cf1693e)
- The list of users should look like this 
![image](https://github.com/user-attachments/assets/0d9333e8-df52-435b-ad35-f60bad4929e6)


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
