### PR TITLE
fix: Colliders too close to the scene limits (but inside them) were being deactivated

### DIFF
--- a/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
+++ b/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
@@ -149,8 +149,10 @@ namespace Utility
             Vector3 min = bounds.min;
             Vector3 max = bounds.max;
 
-            return boundingPlanes.MinX < min.x && boundingPlanes.MaxX > max.x
-                                               && boundingPlanes.MinZ < min.z && boundingPlanes.MaxZ > max.z;
+            return Mathf.Ceil(boundingPlanes.MinX) <= Mathf.Ceil(min.x) &&
+                   Mathf.Ceil(boundingPlanes.MaxX) >= Mathf.Ceil(max.x) &&
+                   Mathf.Ceil(boundingPlanes.MinZ) <= Mathf.Ceil(min.z) &&
+                   Mathf.Ceil(boundingPlanes.MaxZ) >= Mathf.Ceil(max.z);
         }
 
         /// <summary>

--- a/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
+++ b/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
@@ -9,6 +9,7 @@ namespace Utility
     {
         public const int PARCEL_SIZE = 16;
         public const float SQR_PARCEL_SIZE = PARCEL_SIZE * PARCEL_SIZE;
+        private const float BOUNDS_OFFSET_EPSILON = 0.1f;
 
         public static readonly SceneGeometry UNDEFINED_SCENE_GEOMETRY = new (
             Vector3.zero,
@@ -146,13 +147,12 @@ namespace Utility
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Contains(this in SceneCircumscribedPlanes boundingPlanes, Bounds bounds)
         {
-            Vector3 min = bounds.min;
-            Vector3 max = bounds.max;
+            bounds.Expand(-BOUNDS_OFFSET_EPSILON);
 
-            return Mathf.Ceil(boundingPlanes.MinX) <= Mathf.Ceil(min.x) &&
-                   Mathf.Ceil(boundingPlanes.MaxX) >= Mathf.Ceil(max.x) &&
-                   Mathf.Ceil(boundingPlanes.MinZ) <= Mathf.Ceil(min.z) &&
-                   Mathf.Ceil(boundingPlanes.MaxZ) >= Mathf.Ceil(max.z);
+            return boundingPlanes.MinX < bounds.min.x &&
+                   boundingPlanes.MaxX > bounds.max.x &&
+                   boundingPlanes.MinZ < bounds.min.z &&
+                   boundingPlanes.MaxZ > bounds.max.z;
         }
 
         /// <summary>


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #1737 

In some scenes (like in "Meta GamiMall") the colliders that were too close to the scene bound limits (but inside them) were being deactivated.

![image](https://github.com/user-attachments/assets/ab1c8ecd-f0de-4333-a7d3-5bb0d1d348cc)
![image](https://github.com/user-attachments/assets/5d53f4fc-1e8c-4d5e-ad2f-377ca924e657)
![image](https://github.com/user-attachments/assets/5e2e3bb1-aba8-4cd2-bc7f-513dde08b447)

This was happening due to the comparison between decimals that we were doing. Now, in order to apply a small margin to this comparison, we apply a rounding so we asure the we manage correctly these scenarios where a collider is too close to a bound limit.

## Test Instructions
### Prerequisites
None.

### Test Steps
1. Go to Meta GamiMall (`145, 60`)
2. Board the Shuttle Pad and start the journey.
3. Check that the platform never loses its collider.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
