### PR TITLE
Chore: removed rigidbodies from terrain trees

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01 Variant.prefab
@@ -88,7 +88,8 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: 586ed44f1ca988c4b886ff5cb85d2999, type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6367646867474405593, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02 Variant.prefab
@@ -80,7 +80,8 @@ PrefabInstance:
       propertyPath: m_AnimateCrossFading
       value: 1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6367646867474405593, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03 Variant.prefab
@@ -88,7 +88,8 @@ PrefabInstance:
       propertyPath: m_LODs.Array.data[3].screenRelativeHeight
       value: 0.017368691
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6367646867474405593, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []


### PR DESCRIPTION
# Pull Request Description

This PR removes the rigidbody component from the tree used by the terrain, in order to obtain some juicy sub-ms.
This has been done as rigidbodies are not needed on the trees and they just consume CPU power

## Test Instructions

This PR shouldn't have any impact, to test it just verify that the terrain and the trees are correctly rendered and that the wind effect is still working fine


## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
