### PR TITLE
Chore: enabled terrain instancing

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Systems/LandscapeTerrainCullingSystem.cs
+++ b/Explorer/Assets/DCL/Landscape/Systems/LandscapeTerrainCullingSystem.cs
@@ -125,6 +125,7 @@ namespace DCL.Landscape.Systems
                     Terrain terrain = terrains[i];
                     terrain.drawHeightmap = visibility.IsVisible && landscapeData.drawTerrain;
                     terrain.drawTreesAndFoliage = visibility is { IsVisible: true, IsAtDistance: true } && landscapeData.drawTerrainDetails;
+                    terrain.drawInstanced = true;
                 }
 
                 Profiler.EndSample();


### PR DESCRIPTION
## What does this PR change?
This PR enables terrain instancing in order to reduce the number of draw calls to render the terrain by batching them.
This was suggested by Unity, and with the change we managed to reduce by 20% the amount of drawcalls for the terrain.

RenderDoc capture before, 42 draw calls:
![image (21)](https://github.com/user-attachments/assets/f58c8c23-c787-40fc-9c55-67b9c592842f)

RenderDoc capture after, 30 batches:
![image (22)](https://github.com/user-attachments/assets/28980a37-d385-4214-9fd5-318be861e1bd)


## Test Instructions

### Test Steps
Test1
1. Launch the explorer
2. Verify that the terrain is visible and works correctly
3. Teleport around and check that the terrain is okay in areas with no parcels

Test2
1. Clear the terrain cache
2. Launch the explorer
3. Verify that the terrain is visible and works correctly
4. Teleport around and check that the terrain is okay in areas with no parcels

### Additional Testing Notes
- Verify this in genesis city and in worlds as well

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
