### PR TITLE
fix: disable passport mutual friends if Friends FF is disabled

### DIFF
--- a/Explorer/Assets/DCL/Passport/Passport.asmdef
+++ b/Explorer/Assets/DCL/Passport/Passport.asmdef
@@ -43,7 +43,8 @@
         "GUID:166b65e6dfc848bb9fb075f53c293a38",
         "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b",
         "GUID:e9db755bba99425db4ca5d30e48b7429",
-        "GUID:e0eedfa2deb9406daf86fd8368728e39"
+        "GUID:e0eedfa2deb9406daf86fd8368728e39",
+        "GUID:5ab29fa8ae5769b49ab29e390caca7a4"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -235,6 +235,7 @@ namespace DCL.Passport
 
             viewInstance.PhotosSectionButton.gameObject.SetActive(enableCameraReel);
             viewInstance.FriendInteractionContainer.SetActive(enableFriendshipInteractions);
+            viewInstance.MutualFriends.Root.SetActive(enableFriendshipInteractions);
         }
 
         private void ShowContextMenu()

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -33,6 +33,7 @@ using DCL.UI.GenericContextMenu;
 using DCL.UI.GenericContextMenu.Controls.Configs;
 using DCL.Utilities;
 using DCL.Web3;
+using DCL.Web3.Identities;
 using DCL.WebRequests;
 using ECS.SceneLifeCycle.Realm;
 using MVC;
@@ -98,6 +99,7 @@ namespace DCL.Passport
         private readonly string[] getUserPositionBuffer = new string[1];
         private readonly IOnlineUsersProvider onlineUsersProvider;
         private readonly IRealmNavigator realmNavigator;
+        private readonly IWeb3IdentityCache web3IdentityCache;
 
         private CameraReelGalleryController? cameraReelGalleryController;
         private Profile? ownProfile;
@@ -156,6 +158,7 @@ namespace DCL.Passport
             IProfileThumbnailCache profileThumbnailCache,
             IOnlineUsersProvider onlineUsersProvider,
             IRealmNavigator realmNavigator,
+            IWeb3IdentityCache web3IdentityCache,
             int gridLayoutFixedColumnCount,
             int thumbnailHeight,
             int thumbnailWidth,
@@ -188,6 +191,7 @@ namespace DCL.Passport
             this.profileThumbnailCache = profileThumbnailCache;
             this.onlineUsersProvider = onlineUsersProvider;
             this.realmNavigator = realmNavigator;
+            this.web3IdentityCache = web3IdentityCache;
             this.gridLayoutFixedColumnCount = gridLayoutFixedColumnCount;
             this.thumbnailHeight = thumbnailHeight;
             this.thumbnailWidth = thumbnailWidth;
@@ -581,7 +585,7 @@ namespace DCL.Passport
             var config = viewInstance!.MutualFriends;
             config.Root.SetActive(false);
 
-            if (inputData.IsOwnProfile) return;
+            if (inputData.IsOwnProfile || (web3IdentityCache.Identity != null && web3IdentityCache.Identity.Address.Equals(inputData.UserId))) return;
             if (!friendServiceProxy.Configured) return;
 
             IFriendsService friendService = friendServiceProxy.Object!;

--- a/Explorer/Assets/DCL/PluginSystem/Global/PassportPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/PassportPlugin.cs
@@ -21,6 +21,7 @@ using DCL.Passport;
 using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.Utilities;
+using DCL.Web3.Identities;
 using DCL.WebRequests;
 using ECS;
 using ECS.SceneLifeCycle.Realm;
@@ -61,6 +62,7 @@ namespace DCL.PluginSystem.Global
         private readonly IProfileThumbnailCache profileThumbnailCache;
         private readonly IOnlineUsersProvider onlineUsersProvider;
         private readonly IRealmNavigator realmNavigator;
+        private readonly IWeb3IdentityCache web3IdentityCache;
         private readonly bool enableFriends;
         private readonly bool includeUserBlocking;
 
@@ -95,6 +97,7 @@ namespace DCL.PluginSystem.Global
             IProfileThumbnailCache profileThumbnailCache,
             IOnlineUsersProvider onlineUsersProvider,
             IRealmNavigator realmNavigator,
+            IWeb3IdentityCache web3IdentityCache,
             bool enableFriends,
             bool includeUserBlocking
         )
@@ -127,6 +130,7 @@ namespace DCL.PluginSystem.Global
             this.profileThumbnailCache = profileThumbnailCache;
             this.onlineUsersProvider = onlineUsersProvider;
             this.realmNavigator = realmNavigator;
+            this.web3IdentityCache = web3IdentityCache;
             this.enableFriends = enableFriends;
             this.includeUserBlocking = includeUserBlocking;
         }
@@ -180,6 +184,7 @@ namespace DCL.PluginSystem.Global
                 profileThumbnailCache,
                 onlineUsersProvider,
                 realmNavigator,
+                web3IdentityCache,
                 passportSettings.GridLayoutFixedColumnCount,
                 passportSettings.ThumbnailHeight,
                 passportSettings.ThumbnailWidth,

--- a/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/DynamicWorldContainer.cs
@@ -739,6 +739,7 @@ namespace Global.Dynamic
                     profileThumbnailCache,
                     onlineUsersProvider,
                     realmNavigator,
+                    identityCache,
                     includeFriends,
                     includeUserBlocking
                 ),


### PR DESCRIPTION
# Pull Request Description

When merging the Friends shape branch, the passport mutual friends section slipped in as it is always enabled with default values (3 thumbnails and the text saying 16 mutual friends), regardless of the FF enable.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR ties the activation of the root gameobject of the passport mutual friend to the value of the Friends feature flag.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [x] To mimic the enable of the Friends FF, run the explorer with `debug` and `friends` args 
- [x] Run the explorer without any arg to have the Friends feature disabled

### Test Steps
1. With the Friends feature disabled, open any passport different than yours and verify that the mutual friends section is not visible
2. With the Friends feature enabled, open any passport different than yours and verify that the mutual friends section is visible if you have in fact mutual friends with that person

### Additional Testing Notes
- Keep in mind that mutual friends are represented by a max amount of thumbnails of 3, the text portion is actually describing how many you have in common


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
