### PR TITLE
fix: Increase the minimum memory limit in settings to go with our minimum requirements

### DIFF
--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
@@ -99,9 +99,8 @@ MonoBehaviour:
           isMultiselect: 0
           options:
           - Max
-          - 20
+          - 32
           - 16
-          - 10
           defaultOptionIndex: 1
         <Feature>k__BackingField: 6
     - rid: 5242998342527483906

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/MemoryLimitSettingController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/MemoryLimitSettingController.cs
@@ -18,12 +18,20 @@ namespace DCL.Settings.ModuleControllers
             this.view = view;
             this.systemMemoryCap = systemMemoryCap;
 
-            view.DropdownView.Dropdown.value = settingsDataStore.HasKey(MEMORY_CAP_DATA_STORE_KEY)
-                ? settingsDataStore.GetDropdownValue(MEMORY_CAP_DATA_STORE_KEY)
-                : GetIndexFromMemoryCap(systemMemoryCap.MemoryCapInMB);
-
+            if (settingsDataStore.HasKey(MEMORY_CAP_DATA_STORE_KEY))
+            {
+                int value = settingsDataStore.GetDropdownValue(MEMORY_CAP_DATA_STORE_KEY);
+                if (value < view.DropdownView.Dropdown.options.Count)
+                    view.DropdownView.Dropdown.value = value;
+                else
+                    GetIndexFromMemoryCap(systemMemoryCap.MemoryCapInMB);
+            }
+            else
+            {
+                GetIndexFromMemoryCap(systemMemoryCap.MemoryCapInMB);
+            }
+            
             view.DropdownView.Dropdown.onValueChanged.AddListener(SetMemoryLimitSettings);
-
             SetMemoryLimitSettings(view.DropdownView.Dropdown.value);
         }
 

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/MemoryLimitSettingController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/MemoryLimitSettingController.cs
@@ -20,34 +20,22 @@ namespace DCL.Settings.ModuleControllers
 
             if (settingsDataStore.HasKey(MEMORY_CAP_DATA_STORE_KEY))
             {
-                int value = settingsDataStore.GetDropdownValue(MEMORY_CAP_DATA_STORE_KEY);
-                if (value < view.DropdownView.Dropdown.options.Count)
-                    view.DropdownView.Dropdown.value = value;
-                else
-                    GetIndexFromMemoryCap(systemMemoryCap.MemoryCapInMB);
+                view.DropdownView.Dropdown.value = settingsDataStore.GetDropdownValue(MEMORY_CAP_DATA_STORE_KEY) < view.DropdownView.Dropdown.options.Count ? settingsDataStore.GetDropdownValue(MEMORY_CAP_DATA_STORE_KEY) : DefaultMemoryCap();
             }
             else
             {
-                GetIndexFromMemoryCap(systemMemoryCap.MemoryCapInMB);
+                view.DropdownView.Dropdown.value = DefaultMemoryCap();
             }
+
             
             view.DropdownView.Dropdown.onValueChanged.AddListener(SetMemoryLimitSettings);
             SetMemoryLimitSettings(view.DropdownView.Dropdown.value);
         }
 
-        private int GetIndexFromMemoryCap(long memoryCapInMB)
+        //The default value is the minimum that comes form the SO
+        private int DefaultMemoryCap()
         {
-            if (memoryCapInMB == SystemInfo.systemMemorySize)
-                return 0;
-
-            long capInGb = memoryCapInMB / 1024;
-
-            for (var i = 0; i < view.DropdownView.Dropdown.options.Count; i++)
-                if (int.TryParse(view.DropdownView.Dropdown.options[i].text, out int result)
-                    && result == capInGb)
-                    return i;
-
-            return 2;
+            return view.DropdownView.Dropdown.options.Count - 1;
         }
 
         public override void Dispose()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Our current minimum requirements is 16GB. It makes sense that our minimum settings is 16 as well

## Test Instructions
1. Check that the minimum ram that can be set through settings is 16. 
2. Check that with a fresh install, the default value is 16
3. Check that changing the numbers the memory limits is changed in the debug menu


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
