### PR TITLE
Chore: increase terrain chunks size

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Data/TerrainData.asset
+++ b/Explorer/Assets/DCL/Landscape/Data/TerrainData.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   parcelSize: 16
   terrainSize: 4800
-  chunkSize: 512
+  chunkSize: 1024
   heightScaleNerf: 0.25
   seed: 97
   terrainHoleEdgeSize: 0.5

--- a/Explorer/Assets/DCL/Landscape/TerrainFactory.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainFactory.cs
@@ -10,6 +10,7 @@ namespace DCL.Landscape
 {
     public class TerrainFactory
     {
+        private const int ALPHAMAP_RESOLUTION = 512;
         private readonly TerrainGenerationData terrainGenData;
 
         private TreePrototype[] treePrototypes;
@@ -85,6 +86,7 @@ namespace DCL.Landscape
             Terrain terrain = Terrain.CreateTerrainGameObject(terrainData)
                                      .GetComponent<Terrain>();
 
+            terrain.treeBillboardDistance = 0; //setting to zero as we use LODGroups from speedtree
             terrain.shadowCastingMode = ShadowCastingMode.Off;
             terrain.materialTemplate = material;
             terrain.detailObjectDistance = 200;
@@ -99,14 +101,14 @@ namespace DCL.Landscape
         }
 
         public TerrainData CreateTerrainData(int terrainChunkSize, float maxHeight) =>
-            CreateTerrainData(terrainChunkSize, terrainChunkSize, terrainChunkSize, maxHeight);
+            CreateTerrainData(terrainChunkSize, terrainChunkSize, maxHeight);
 
-        private TerrainData CreateTerrainData(int heightmapResolution, int alphamapResolution, int terrainChunkSize, float maxHeight)
+        private TerrainData CreateTerrainData(int heightmapResolution, int terrainChunkSize, float maxHeight)
         {
             var terrainData = new TerrainData
             {
                 heightmapResolution = heightmapResolution + 1,
-                alphamapResolution = alphamapResolution,
+                alphamapResolution = ALPHAMAP_RESOLUTION,
                 size = new Vector3(terrainChunkSize, Mathf.Max(maxHeight, 0.1f), terrainChunkSize),
                 terrainLayers = terrainGenData.terrainLayers,
                 treePrototypes = GetTreePrototypes(),

--- a/Explorer/Assets/DCL/Landscape/TerrainFactory.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainFactory.cs
@@ -10,7 +10,6 @@ namespace DCL.Landscape
 {
     public class TerrainFactory
     {
-        private const int ALPHAMAP_RESOLUTION = 512;
         private readonly TerrainGenerationData terrainGenData;
 
         private TreePrototype[] treePrototypes;
@@ -101,14 +100,14 @@ namespace DCL.Landscape
         }
 
         public TerrainData CreateTerrainData(int terrainChunkSize, float maxHeight) =>
-            CreateTerrainData(terrainChunkSize, terrainChunkSize, maxHeight);
+            CreateTerrainData(terrainChunkSize, terrainChunkSize, terrainChunkSize, maxHeight);
 
-        private TerrainData CreateTerrainData(int heightmapResolution, int terrainChunkSize, float maxHeight)
+        private TerrainData CreateTerrainData(int heightmapResolution, int alphamapResolution, int terrainChunkSize, float maxHeight)
         {
             var terrainData = new TerrainData
             {
                 heightmapResolution = heightmapResolution + 1,
-                alphamapResolution = ALPHAMAP_RESOLUTION,
+                alphamapResolution = alphamapResolution,
                 size = new Vector3(terrainChunkSize, Mathf.Max(maxHeight, 0.1f), terrainChunkSize),
                 terrainLayers = terrainGenData.terrainLayers,
                 treePrototypes = GetTreePrototypes(),

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -27,7 +27,7 @@ namespace DCL.Landscape
         private const float ROOT_VERTICAL_SHIFT = -0.01f; // fix for not clipping with scene (potential) floor
 
         // increment this number if we want to force the users to generate a new terrain cache
-        private const int CACHE_VERSION = 10;
+        private const int CACHE_VERSION = 11;
 
         private const float PROGRESS_COUNTER_EMPTY_PARCEL_DATA = 0.1f;
         private const float PROGRESS_COUNTER_TERRAIN_DATA = 0.3f;

--- a/Explorer/Assets/DCL/Landscape/Worlds/TerrainModel.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/TerrainModel.cs
@@ -7,7 +7,7 @@ namespace DCL.Landscape
     {
         // Note: [units] = Unity units (1 unit = 1 meter)
 
-        private const int MAX_CHUNK_SIZE = 512; // Maximum size of a chunk in Unity [units]
+        private const int MAX_CHUNK_SIZE = 1024; // Maximum size of a chunk in Unity [units]
         private const int MIN_CHUNKS_PER_SIDE = 2; // Minimum number of chunks along one side of terrain, ensuring at least a 2x2 grid
 
         public readonly int2 MinParcel;


### PR DESCRIPTION
## What does this PR change?

Did someone say extra 375MB+ of memory? Yes!
This PR doubles the size of the chunks of terrain, minimising the memory footprint caused by two main things:
* Reduced by 3/4 the Terrain tree billboards Render Textures (that we might be able to remove in a separate PR entirely)
* Reduced by 3/4 the Terrain basemap and metallic map textures

Following some screenshots that prove the reduced memory allocations with no performance impact:
Memory snapshot before and after improvements:
![image (23)](https://github.com/user-attachments/assets/4772aefa-cd38-4bc2-af85-d693a3825ede)

![image (25)](https://github.com/user-attachments/assets/85e08f96-f55a-4e6e-90cb-a4bdd64c9c9c)

Terrain tree billboards Render Textures before and after improvements:
![image (24)](https://github.com/user-attachments/assets/f88efadb-d235-4a08-8454-f9d82a871d5b)

![image (27)](https://github.com/user-attachments/assets/70c72f7c-318f-4b1a-9c78-2d9df4f5fd63)

Terrain basemap and metallic map textures before and after improvements:
![image (28)](https://github.com/user-attachments/assets/dbd13ad3-8f52-44d5-8735-7342f859c055)

![image (29)](https://github.com/user-attachments/assets/6c8d9741-b975-4abe-beac-baad7fdafb4e)

Profile analyzer before and after:
![image (30)](https://github.com/user-attachments/assets/508d8d6b-6fa8-43a3-8ff4-b7b0f428187b)

![image (31)](https://github.com/user-attachments/assets/8c1ab1a8-e5dd-425a-b358-08b4382045f4)


## Test Instructions

To test this PR we just need a sanity check of the terrain

### Test Steps
1. Enter genesis city
2. Walk around and verify the terrain is visible as before
3. Jump in a world and check the terrain to make sure nothing changed

Verify how much of a change there is in tree and rocks distribution, if there are big differences between prod and this branch in the amount of trees in the most tree populated areas


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
