### PR TITLE
Feat: generic context menu - enable on components

### DIFF
--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListSectionUtilities.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListSectionUtilities.cs
@@ -45,35 +45,28 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             }
         }
 
-        internal static GenericContextMenu BuildContextMenu(FriendProfile friendProfile,
+        internal static (GenericContextMenu, GenericContextMenuElement) BuildContextMenu(
             FriendListContextMenuConfiguration contextMenuSettings,
             UserProfileContextMenuControlSettings userProfileContextMenuControlSettings,
-            IOnlineUsersProvider onlineUsersProvider,
-            IRealmNavigator realmNavigator,
-            IPassportBridge passportBridge,
-            string[] getUserPositionBuffer,
-            CancellationTokenSource? jumpToFriendLocationCts,
             bool includeUserBlocking,
-            bool isFriendInGame,
-            Action<Vector2Int>? parcelCalculatedCallback = null)
+            Action openProfilePassportCallback,
+            Action jumpToFriendCallback,
+            Action blockUserCallback)
         {
+            GenericContextMenuElement jumpInElement;
+
             GenericContextMenu contextMenu = new GenericContextMenu(contextMenuSettings.ContextMenuWidth, verticalLayoutPadding: CONTEXT_MENU_VERTICAL_LAYOUT_PADDING, elementsSpacing: CONTEXT_MENU_ELEMENTS_SPACING)
                                             .AddControl(userProfileContextMenuControlSettings)
                                             .AddControl(new SeparatorContextMenuControlSettings(CONTEXT_MENU_SEPARATOR_HEIGHT, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.left, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.right))
-                                            .AddControl(new ButtonContextMenuControlSettings(contextMenuSettings.ViewProfileText, contextMenuSettings.ViewProfileSprite, () => OpenProfilePassport(friendProfile, passportBridge)));
+                                            .AddControl(new ButtonContextMenuControlSettings(contextMenuSettings.ViewProfileText, contextMenuSettings.ViewProfileSprite, openProfilePassportCallback))
+                                            .AddControl(jumpInElement = new GenericContextMenuElement(new ButtonContextMenuControlSettings(contextMenuSettings.JumpToLocationText,
+                                                 contextMenuSettings.JumpToLocationSprite, jumpToFriendCallback), false))
+                                            .AddControl(new GenericContextMenuElement(new ButtonContextMenuControlSettings(contextMenuSettings.BlockText, contextMenuSettings.BlockSprite, blockUserCallback), includeUserBlocking));
 
-            if (isFriendInGame)
-                contextMenu.AddControl(new ButtonContextMenuControlSettings(contextMenuSettings.JumpToLocationText,
-                    contextMenuSettings.JumpToLocationSprite,
-                    () => JumpToFriendLocation(friendProfile.Address, jumpToFriendLocationCts, getUserPositionBuffer, onlineUsersProvider, realmNavigator, parcelCalculatedCallback)));
-
-            if (includeUserBlocking)
-                contextMenu.AddControl(new ButtonContextMenuControlSettings(contextMenuSettings.BlockText, contextMenuSettings.BlockSprite, () => BlockUserClicked(friendProfile)));
-
-            return contextMenu;
+            return (contextMenu, jumpInElement);
         }
 
-        private static void BlockUserClicked(FriendProfile profile)
+        internal static void BlockUserClicked(FriendProfile profile)
         {
             ReportHub.Log(LogType.Error, new ReportData(ReportCategory.FRIENDS), $"Block user button clicked for {profile.Address.ToString()}. Users should not be able to reach this");
         }

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
@@ -21,10 +21,12 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
         private readonly IOnlineUsersProvider onlineUsersProvider;
         private readonly IRealmNavigator realmNavigator;
         private readonly IFriendsConnectivityStatusTracker friendsConnectivityStatusTracker;
-        private readonly bool includeUserBlocking;
         private readonly string[] getUserPositionBuffer = new string[1];
+        private readonly GenericContextMenu contextMenu;
+        private readonly GenericContextMenuElement contextMenuJumpInButton;
 
         private CancellationTokenSource jumpToFriendLocationCts = new ();
+        private FriendProfile contextMenuFriendProfile;
 
         internal event Action<string>? OnlineFriendClicked;
         internal event Action<string, Vector2Int>? JumpInClicked;
@@ -48,9 +50,14 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             this.onlineUsersProvider = onlineUsersProvider;
             this.realmNavigator = realmNavigator;
             this.friendsConnectivityStatusTracker = friendsConnectivityStatusTracker;
-            this.includeUserBlocking = includeUserBlocking;
 
             userProfileContextMenuControlSettings = new UserProfileContextMenuControlSettings(systemClipboard, HandleContextMenuUserProfileButton);
+
+            var buildContextMenu = FriendListSectionUtilities.BuildContextMenu(view.ContextMenuSettings,
+                userProfileContextMenuControlSettings, includeUserBlocking, OpenProfilePassportCtx, JumpToFriendLocationCtx, BlockUserCtx);
+
+            contextMenu = buildContextMenu.Item1;
+            contextMenuJumpInButton = buildContextMenu.Item2;
 
             doubleCollectionRequestManager.JumpInClicked += JumpInClick;
             doubleCollectionRequestManager.ContextMenuClicked += ContextMenuClicked;
@@ -67,6 +74,15 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             requestManager.AtLeastOneFriendInCollections -= HideEmptyState;
             jumpToFriendLocationCts.SafeCancelAndDispose();
         }
+
+        private void JumpToFriendLocationCtx() =>
+            FriendListSectionUtilities.JumpToFriendLocation(contextMenuFriendProfile.Address, jumpToFriendLocationCts, getUserPositionBuffer, onlineUsersProvider, realmNavigator, parcel => JumpInClicked?.Invoke(contextMenuFriendProfile.Address, parcel));
+
+        private void OpenProfilePassportCtx() =>
+            FriendListSectionUtilities.OpenProfilePassport(contextMenuFriendProfile, passportBridge);
+
+        private void BlockUserCtx() =>
+            FriendListSectionUtilities.BlockUserClicked(contextMenuFriendProfile);
 
         private void ShowEmptyState()
         {
@@ -99,6 +115,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
         private void ContextMenuClicked(FriendProfile friendProfile, Vector2 buttonPosition, FriendListUserView elementView)
         {
             jumpToFriendLocationCts = jumpToFriendLocationCts.SafeRestart();
+            contextMenuFriendProfile = friendProfile;
 
             userProfileContextMenuControlSettings.SetInitialData(friendProfile.Name, friendProfile.Address, friendProfile.HasClaimedName,
                 view.ChatEntryConfiguration.GetNameColor(friendProfile.Name), UserProfileContextMenuControlSettings.FriendshipStatus.FRIEND,
@@ -108,11 +125,11 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
 
             bool isFriendOnline = friendsConnectivityStatusTracker.GetFriendStatus(friendProfile.Address) != OnlineStatus.OFFLINE;
 
+            contextMenuJumpInButton.Enabled = isFriendOnline;
+
             mvcManager.ShowAsync(GenericContextMenuController.IssueCommand(
                            new GenericContextMenuParameter(
-                               config: FriendListSectionUtilities.BuildContextMenu(friendProfile, view.ContextMenuSettings,
-                                   userProfileContextMenuControlSettings, onlineUsersProvider, realmNavigator, passportBridge,
-                                   getUserPositionBuffer, jumpToFriendLocationCts, includeUserBlocking, isFriendOnline, parcel => JumpInClicked?.Invoke(friendProfile.Address, parcel)),
+                               config: contextMenu,
                                anchorPosition: buttonPosition,
                                actionOnHide: () => elementView.CanUnHover = true,
                                closeTask: panelLifecycleTask?.Task))

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Requests/RequestsSectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Requests/RequestsSectionController.cs
@@ -45,10 +45,8 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Requests
             contextMenu = new GenericContextMenu(view.ContextMenuSettings.ContextMenuWidth, verticalLayoutPadding: CONTEXT_MENU_VERTICAL_LAYOUT_PADDING, elementsSpacing: CONTEXT_MENU_ELEMENTS_SPACING)
                          .AddControl(userProfileContextMenuControlSettings = new UserProfileContextMenuControlSettings(systemClipboard, HandleContextMenuUserProfileButton))
                          .AddControl(new SeparatorContextMenuControlSettings(CONTEXT_MENU_SEPARATOR_HEIGHT, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.left, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.right))
-                         .AddControl(new ButtonContextMenuControlSettings(view.ContextMenuSettings.ViewProfileText, view.ContextMenuSettings.ViewProfileSprite, () => OpenProfilePassport(lastClickedProfileCtx!)));
-
-            if (includeUserBlocking)
-                contextMenu.AddControl(new ButtonContextMenuControlSettings(view.ContextMenuSettings.BlockText, view.ContextMenuSettings.BlockSprite, () => BlockUserClicked(lastClickedProfileCtx!)));
+                         .AddControl(new ButtonContextMenuControlSettings(view.ContextMenuSettings.ViewProfileText, view.ContextMenuSettings.ViewProfileSprite, () => OpenProfilePassport(lastClickedProfileCtx!)))
+                         .AddControl(new GenericContextMenuElement(new ButtonContextMenuControlSettings(view.ContextMenuSettings.BlockText, view.ContextMenuSettings.BlockSprite, () => BlockUserClicked(lastClickedProfileCtx!)), includeUserBlocking));
 
             requestManager.DeleteRequestClicked += DeleteRequestClicked;
             requestManager.AcceptRequestClicked += AcceptRequestClicked;

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -103,7 +103,6 @@ namespace DCL.Passport
 
         private CameraReelGalleryController? cameraReelGalleryController;
         private Profile? ownProfile;
-        private Profile? targetProfile;
         private bool isOwnProfile;
         private string? currentUserId;
         private CancellationTokenSource? openPassportFromBadgeNotificationCts;
@@ -249,11 +248,9 @@ namespace DCL.Passport
                          .AddControl(userProfileContextMenuControlSettings)
                          .AddControl(contextMenuSeparator = new GenericContextMenuElement(new SeparatorContextMenuControlSettings(CONTEXT_MENU_SEPARATOR_HEIGHT, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.left, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.right), false))
                          .AddControl(contextMenuJumpInButton = new GenericContextMenuElement(new ButtonContextMenuControlSettings(viewInstance.JumpInText, viewInstance.JumpInSprite,
-                              () => FriendListSectionUtilities.JumpToFriendLocation(targetProfile!.UserId, jumpToFriendLocationCts, getUserPositionBuffer, onlineUsersProvider, realmNavigator,
-                                  parcel => JumpToFriendClicked?.Invoke(targetProfile.UserId, parcel))), false))
+                              () => FriendListSectionUtilities.JumpToFriendLocation(inputData.UserId, jumpToFriendLocationCts, getUserPositionBuffer, onlineUsersProvider, realmNavigator,
+                                  parcel => JumpToFriendClicked?.Invoke(inputData.UserId, parcel))), false))
                          .AddControl(contextMenuBlockUserButton = new GenericContextMenuElement(new ButtonContextMenuControlSettings(viewInstance.BlockText, viewInstance.BlockSprite, () => BlockUserClicked(inputData.UserId)), false));
-
-            ;
         }
 
         private void ShowContextMenu()
@@ -301,7 +298,6 @@ namespace DCL.Passport
         protected override void OnViewClose()
         {
             passportErrorsController!.Hide(true);
-            targetProfile = null;
 
             inputBlock.Enable(InputMapComponent.Kind.SHORTCUTS, InputMapComponent.Kind.CAMERA, InputMapComponent.Kind.PLAYER, InputMapComponent.Kind.IN_WORLD_CAMERA);
 
@@ -555,7 +551,6 @@ namespace DCL.Passport
                 ReportHub.Log(LogType.Error, new ReportData(ReportCategory.FRIENDS), $"Failed to show context menu button for user {inputData.UserId}. Profile is null.");
                 return;
             }
-            targetProfile = profile;
 
             Sprite? thumbnailSprite = await profileThumbnailCache.GetThumbnailAsync(profile, ct);
 

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -103,6 +103,7 @@ namespace DCL.Passport
 
         private CameraReelGalleryController? cameraReelGalleryController;
         private Profile? ownProfile;
+        private Profile? targetProfile;
         private bool isOwnProfile;
         private string? currentUserId;
         private CancellationTokenSource? openPassportFromBadgeNotificationCts;
@@ -117,6 +118,9 @@ namespace DCL.Passport
         private PassportSection alreadyLoadedSections;
         private BadgesDetails_PassportModuleController? badgesDetailsPassportModuleController;
         private GenericContextMenu contextMenu;
+        private GenericContextMenuElement contextMenuSeparator;
+        private GenericContextMenuElement contextMenuJumpInButton;
+        private GenericContextMenuElement contextMenuBlockUserButton;
 
         private UniTaskCompletionSource? contextMenuCloseTask;
         private CancellationTokenSource jumpToFriendLocationCts = new ();
@@ -240,6 +244,16 @@ namespace DCL.Passport
             viewInstance.PhotosSectionButton.gameObject.SetActive(enableCameraReel);
             viewInstance.FriendInteractionContainer.SetActive(enableFriendshipInteractions);
             viewInstance.MutualFriends.Root.SetActive(enableFriendshipInteractions);
+
+            contextMenu = new GenericContextMenu(CONTEXT_MENU_WIDTH, CONTEXT_MENU_OFFSET, CONTEXT_MENU_VERTICAL_LAYOUT_PADDING, CONTEXT_MENU_ELEMENTS_SPACING)
+                         .AddControl(userProfileContextMenuControlSettings)
+                         .AddControl(contextMenuSeparator = new GenericContextMenuElement(new SeparatorContextMenuControlSettings(CONTEXT_MENU_SEPARATOR_HEIGHT, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.left, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.right), false))
+                         .AddControl(contextMenuJumpInButton = new GenericContextMenuElement(new ButtonContextMenuControlSettings(viewInstance.JumpInText, viewInstance.JumpInSprite,
+                              () => FriendListSectionUtilities.JumpToFriendLocation(targetProfile!.UserId, jumpToFriendLocationCts, getUserPositionBuffer, onlineUsersProvider, realmNavigator,
+                                  parcel => JumpToFriendClicked?.Invoke(targetProfile.UserId, parcel))), false))
+                         .AddControl(contextMenuBlockUserButton = new GenericContextMenuElement(new ButtonContextMenuControlSettings(viewInstance.BlockText, viewInstance.BlockSprite, () => BlockUserClicked(inputData.UserId)), false));
+
+            ;
         }
 
         private void ShowContextMenu()
@@ -287,6 +301,7 @@ namespace DCL.Passport
         protected override void OnViewClose()
         {
             passportErrorsController!.Hide(true);
+            targetProfile = null;
 
             inputBlock.Enable(InputMapComponent.Kind.SHORTCUTS, InputMapComponent.Kind.CAMERA, InputMapComponent.Kind.PLAYER, InputMapComponent.Kind.IN_WORLD_CAMERA);
 
@@ -540,22 +555,15 @@ namespace DCL.Passport
                 ReportHub.Log(LogType.Error, new ReportData(ReportCategory.FRIENDS), $"Failed to show context menu button for user {inputData.UserId}. Profile is null.");
                 return;
             }
+            targetProfile = profile;
 
             Sprite? thumbnailSprite = await profileThumbnailCache.GetThumbnailAsync(profile, ct);
 
             viewInstance!.ContextMenuButton.gameObject.SetActive(true);
 
-            contextMenu = new GenericContextMenu(CONTEXT_MENU_WIDTH, CONTEXT_MENU_OFFSET, CONTEXT_MENU_VERTICAL_LAYOUT_PADDING, CONTEXT_MENU_ELEMENTS_SPACING)
-                                     .AddControl(userProfileContextMenuControlSettings)
-                                     .AddControl(new SeparatorContextMenuControlSettings(CONTEXT_MENU_SEPARATOR_HEIGHT, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.left, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.right));
-
-            if (friendOnlineStatusCacheProxy.Object!.GetFriendStatus(inputData.UserId) != OnlineStatus.OFFLINE)
-                contextMenu.AddControl(new ButtonContextMenuControlSettings(viewInstance.JumpInText, viewInstance.JumpInSprite,
-                    () => FriendListSectionUtilities.JumpToFriendLocation(profile.UserId, jumpToFriendLocationCts, getUserPositionBuffer, onlineUsersProvider, realmNavigator,
-                        parcel => JumpToFriendClicked?.Invoke(profile.UserId, parcel))));
-
-            if (friendshipStatus != FriendshipStatus.BLOCKED && includeUserBlocking)
-                contextMenu.AddControl(new ButtonContextMenuControlSettings(viewInstance.BlockText, viewInstance.BlockSprite, () => BlockUserClicked(inputData.UserId)));
+            contextMenuJumpInButton.Enabled = friendOnlineStatusCacheProxy.Object!.GetFriendStatus(inputData.UserId) != OnlineStatus.OFFLINE;
+            contextMenuBlockUserButton.Enabled = friendshipStatus != FriendshipStatus.BLOCKED && includeUserBlocking;
+            contextMenuSeparator.Enabled = contextMenuJumpInButton.Enabled || contextMenuBlockUserButton.Enabled;
 
             userProfileContextMenuControlSettings.SetInitialData(profile.Name, profile.UserId, profile.HasClaimedName,
                 viewInstance.ChatEntryConfiguration.GetNameColor(profile.Name), ConvertFriendshipStatus(friendshipStatus),

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controls/Configs/GenericContextMenu.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controls/Configs/GenericContextMenu.cs
@@ -8,7 +8,10 @@ namespace DCL.UI.GenericContextMenu.Controls.Configs
     /// </summary>
     public class GenericContextMenu
     {
-        internal readonly List<IContextMenuControlSettings> contextMenuSettings = new ();
+        private static readonly RectOffset DEFAULT_VERTICAL_LAYOUT_PADDING = new (8, 8, 4, 12);
+        private static readonly Vector2 DEFAULT_OFFSET_FROM_TARGET = new (11, 18);
+
+        internal readonly List<GenericContextMenuElement> contextMenuSettings = new ();
         internal readonly Vector2 offsetFromTarget;
         internal readonly float width;
         internal readonly RectOffset verticalLayoutPadding;
@@ -22,15 +25,40 @@ namespace DCL.UI.GenericContextMenu.Controls.Configs
         public GenericContextMenu(float width = 186, Vector2? offsetFromTarget = null, RectOffset verticalLayoutPadding = null, int elementsSpacing = 1)
         {
             this.width = width;
-            this.offsetFromTarget = offsetFromTarget ?? new Vector2(11, 18);
-            this.verticalLayoutPadding = verticalLayoutPadding ?? new RectOffset(8, 8, 4, 12);
+            this.offsetFromTarget = offsetFromTarget ?? DEFAULT_OFFSET_FROM_TARGET;
+            this.verticalLayoutPadding = verticalLayoutPadding ?? DEFAULT_VERTICAL_LAYOUT_PADDING;
             this.elementsSpacing = elementsSpacing;
         }
 
         public GenericContextMenu AddControl(IContextMenuControlSettings settings)
         {
-            contextMenuSettings.Add(settings);
+            contextMenuSettings.Add(new GenericContextMenuElement(settings));
             return this;
+        }
+
+        public GenericContextMenu AddControl(GenericContextMenuElement element)
+        {
+            contextMenuSettings.Add(element);
+            return this;
+        }
+    }
+
+    public class GenericContextMenuElement
+    {
+        internal readonly IContextMenuControlSettings setting;
+
+        public bool Enabled { get; set; }
+
+        public GenericContextMenuElement(IContextMenuControlSettings setting, bool defaultEnabled)
+        {
+            this.setting = setting;
+            this.Enabled = defaultEnabled;
+        }
+
+        public GenericContextMenuElement(IContextMenuControlSettings setting)
+        {
+            this.setting = setting;
+            this.Enabled = true;
         }
     }
 }

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
@@ -66,9 +66,11 @@ namespace DCL.UI.GenericContextMenu
 
             for (var i = 0; i < inputData.Config.contextMenuSettings.Count; i++)
             {
-                IContextMenuControlSettings config = inputData.Config.contextMenuSettings[i];
+                GenericContextMenuElement config = inputData.Config.contextMenuSettings[i];
 
-                GenericContextMenuComponentBase component = controlsPoolManager.GetContextMenuComponent(config, i);
+                if (!config.Enabled) continue;
+
+                GenericContextMenuComponentBase component = controlsPoolManager.GetContextMenuComponent(config.setting, i);
 
                 component.RegisterCloseListener(TriggerContextMenuClose);
 


### PR DESCRIPTION
# Pull Request Description

Many use cases of the context menu need to be able to include/remove certain components based on runtime values that cannot be defined in the constructor. 

Instead of instantiating a new `GenericContextMenu` object every time to accomodate those cases, an `Enabled` bool value is introduced on every component in order to allow the user to create an instance once and then change this value to control how the context menu looks and which functionalities it exposes based on those runtime values.

The method `AddControl` of the class `GenericContextMenu` has a retro-compatible overload that wraps the instatiation of this new class type. This overload can also be applied to every use case where the user don't need to control the visibility of a certain context menu component.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR modifies the `GenericContextMenu` class by changing the type of `contextMenuSettings` to a new type `List<GenericContextMenuElement>` which holds the old reference to a `IContextMenuControlSettings` component and adds an `Enabled` property.

This also migrates all the Friends feature context menus to this new feature to eliminate all the allocations that were present before.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] In order to check the Friends context menus, launch the explorer with the `debug` and `friends` args


### Test Steps
1. Check that all context menus work as expected

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
