### PR TITLE
fix: Introduce scene web request controller

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/StaticSettings.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/StaticSettings.cs
@@ -48,7 +48,10 @@ namespace DCL.PluginSystem.Global
         [field: Space]
         [field: SerializeField] public int ScenesLoadingBudget { get; private set; } = 100;
         [field: SerializeField] public int AssetsLoadingBudget { get; private set; } = 50;
-        [field: SerializeField] public int WebRequestsBudget { get; private set; } = 20;
+        [field: SerializeField] public int CoreWebRequestsBudget { get; private set; } = 20;
+
+        [field: SerializeField] public int SceneWebRequestsBudget { get; private set; } = 5;
+
 
         [Serializable]
         public class PartitionSettingsRef : AssetReferenceT<PartitionSettingsAsset>

--- a/Explorer/Assets/DCL/PluginSystem/Global/StaticSettings.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/StaticSettings.cs
@@ -49,7 +49,6 @@ namespace DCL.PluginSystem.Global
         [field: SerializeField] public int ScenesLoadingBudget { get; private set; } = 100;
         [field: SerializeField] public int AssetsLoadingBudget { get; private set; } = 50;
         [field: SerializeField] public int CoreWebRequestsBudget { get; private set; } = 20;
-
         [field: SerializeField] public int SceneWebRequestsBudget { get; private set; } = 5;
 
 

--- a/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsContainer.cs
+++ b/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsContainer.cs
@@ -47,14 +47,12 @@ namespace DCL.WebRequests.Analytics
             var options = new ElementBindingOptions();
             var requestCompleteDebugMetric = new ElementBinding<ulong>(0);
             var cannotConnectToHostExceptionDebugMetric = new ElementBinding<ulong>(0);
-
             var sceneAvailableBudget = new ElementBinding<ulong>((ulong)sceneBudget);
-            var coreAvailableBudget = new ElementBinding<ulong>((ulong)sceneBudget);
-
+            var coreAvailableBudget = new ElementBinding<ulong>((ulong)coreBudget);
 
             var textureFuseRequestHub = new RequestHub(texturesFuse, isTextureCompressionEnabled);
 
-            var webRequestController = new WebRequestController(analyticsContainer, web3IdentityProvider, textureFuseRequestHub)
+            var coreWebRequestController = new WebRequestController(analyticsContainer, web3IdentityProvider, textureFuseRequestHub)
                                       .WithDebugMetrics(cannotConnectToHostExceptionDebugMetric, requestCompleteDebugMetric)
                                       .WithLog()
                                       .WithArtificialDelay(options)
@@ -70,7 +68,7 @@ namespace DCL.WebRequests.Analytics
             CreateWebRequestDelayUtility();
             CreateWebRequestsMetricsDebugUtility();
 
-            return new WebRequestsContainer(webRequestController, sceneWebRequestController, analyticsContainer);
+            return new WebRequestsContainer(coreWebRequestController, sceneWebRequestController, analyticsContainer);
 
             void CreateWebRequestsMetricsDebugUtility()
             {
@@ -102,7 +100,7 @@ namespace DCL.WebRequests.Analytics
 
             void CreateStressTestUtility()
             {
-                var stressTestUtility = new WebRequestStressTestUtility(webRequestController);
+                var stressTestUtility = new WebRequestStressTestUtility(coreWebRequestController);
 
                 var count = new ElementBinding<int>(50);
                 var retriesCount = new ElementBinding<int>(3);

--- a/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsContainer.cs
+++ b/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsContainer.cs
@@ -32,7 +32,8 @@ namespace DCL.WebRequests.Analytics
             IWeb3IdentityCache web3IdentityProvider,
             ITexturesFuse texturesFuse,
             IDebugContainerBuilder debugContainerBuilder,
-            int totalBudget,
+            int coreBudget,
+            int sceneBudget,
             bool isTextureCompressionEnabled
         )
         {
@@ -53,12 +54,13 @@ namespace DCL.WebRequests.Analytics
                                       .WithDebugMetrics(cannotConnectToHostExceptionDebugMetric, requestCompleteDebugMetric)
                                       .WithLog()
                                       .WithArtificialDelay(options)
-                                      .WithBudget(totalBudget);
+                .WithBudget(coreBudget);
 
             var sceneWebRequestController = new WebRequestController(analyticsContainer, web3IdentityProvider, textureFuseRequestHub)
                 .WithDebugMetrics(cannotConnectToHostExceptionDebugMetric, requestCompleteDebugMetric)
                 .WithLog()
-                .WithBudget(5);
+                .WithArtificialDelay(options)
+                .WithBudget(sceneBudget);
 
             CreateStressTestUtility();
             CreateWebRequestDelayUtility();

--- a/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsContainer.cs
+++ b/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsContainer.cs
@@ -48,19 +48,23 @@ namespace DCL.WebRequests.Analytics
             var requestCompleteDebugMetric = new ElementBinding<ulong>(0);
             var cannotConnectToHostExceptionDebugMetric = new ElementBinding<ulong>(0);
 
+            var sceneAvailableBudget = new ElementBinding<ulong>((ulong)sceneBudget);
+            var coreAvailableBudget = new ElementBinding<ulong>((ulong)sceneBudget);
+
+
             var textureFuseRequestHub = new RequestHub(texturesFuse, isTextureCompressionEnabled);
 
             var webRequestController = new WebRequestController(analyticsContainer, web3IdentityProvider, textureFuseRequestHub)
                                       .WithDebugMetrics(cannotConnectToHostExceptionDebugMetric, requestCompleteDebugMetric)
                                       .WithLog()
                                       .WithArtificialDelay(options)
-                .WithBudget(coreBudget);
+                .WithBudget(coreBudget, coreAvailableBudget);
 
             var sceneWebRequestController = new WebRequestController(analyticsContainer, web3IdentityProvider, textureFuseRequestHub)
                 .WithDebugMetrics(cannotConnectToHostExceptionDebugMetric, requestCompleteDebugMetric)
                 .WithLog()
                 .WithArtificialDelay(options)
-                .WithBudget(sceneBudget);
+                .WithBudget(sceneBudget, sceneAvailableBudget);
 
             CreateStressTestUtility();
             CreateWebRequestDelayUtility();
@@ -75,6 +79,10 @@ namespace DCL.WebRequests.Analytics
                     .AddMarker("Requests cannot connect", cannotConnectToHostExceptionDebugMetric,
                         DebugLongMarkerDef.Unit.NoFormat)
                     .AddMarker("Requests complete", requestCompleteDebugMetric,
+                        DebugLongMarkerDef.Unit.NoFormat)
+                    .AddMarker("Core budget", coreAvailableBudget,
+                        DebugLongMarkerDef.Unit.NoFormat)
+                    .AddMarker("Scene budget", sceneAvailableBudget,
                         DebugLongMarkerDef.Unit.NoFormat);
             }
 

--- a/Explorer/Assets/DCL/WebRequests/BudgetedWebRequestController.cs
+++ b/Explorer/Assets/DCL/WebRequests/BudgetedWebRequestController.cs
@@ -1,4 +1,5 @@
 ﻿using Cysharp.Threading.Tasks;
+using DCL.DebugUtilities.UIBindings;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.WebRequests.RequestsHub;
 
@@ -8,27 +9,32 @@ namespace DCL.WebRequests
     {
         private readonly IWebRequestController origin;
         private readonly IReleasablePerformanceBudget totalBudget;
+        private readonly ElementBinding<ulong> debugBudget;
 
-        public BudgetedWebRequestController(IWebRequestController origin, int totalBudget)
+
+        public BudgetedWebRequestController(IWebRequestController origin, int totalBudget, ElementBinding<ulong> debugBudget)
         {
             this.origin = origin;
+            this.debugBudget = debugBudget;
             this.totalBudget = new ConcurrentLoadingPerformanceBudget(totalBudget);
         }
 
         public async UniTask<TResult?> SendAsync<TWebRequest, TWebRequestArgs, TWebRequestOp, TResult>(RequestEnvelope<TWebRequest, TWebRequestArgs> envelope, TWebRequestOp op) where TWebRequest: struct, ITypedWebRequest where TWebRequestArgs: struct where TWebRequestOp: IWebRequestOp<TWebRequest, TResult>
         {
             IAcquiredBudget totalBudgetAcquired;
-
+            
             // Try bypass total budget
             while (!totalBudget.TrySpendBudget(out totalBudgetAcquired))
                 await UniTask.Yield(envelope.Ct);
 
             try
             {
+                debugBudget.Value--;
                 return await origin.SendAsync<TWebRequest, TWebRequestArgs, TWebRequestOp, TResult>(envelope, op);
             }
             finally
             {
+                debugBudget.Value++;
                 totalBudgetAcquired.Dispose();
             }
         }

--- a/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
@@ -251,7 +251,9 @@ namespace DCL.WebRequests
             new DebugMetricsWebRequestController(origin, requestCannotConnectDebugMetric,
                 requestCompleteDebugMetric);
 
-        public static IWebRequestController WithBudget(this IWebRequestController origin, int totalBudget) =>
-            new BudgetedWebRequestController(origin, totalBudget);
+        public static IWebRequestController WithBudget(this IWebRequestController origin, int totalBudget, ElementBinding<ulong> debugBudget)
+        {
+            return new BudgetedWebRequestController(origin, totalBudget, debugBudget);
+        }
     }
 }

--- a/Explorer/Assets/Scripts/Global/Dynamic/Bootstraper.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/Bootstraper.cs
@@ -246,7 +246,7 @@ namespace Global.Dynamic
                 in staticContainer,
                 bootstrapContainer.DecentralandUrlsSource,
                 bootstrapContainer.IdentityCache,
-                staticContainer.WebRequestsContainer.WebRequestController,
+                staticContainer.WebRequestsContainer.SceneWebRequestController,
                 dynamicWorldContainer.RealmController.RealmData,
                 dynamicWorldContainer.ProfileRepository,
                 dynamicWorldContainer.RoomHub,

--- a/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/MainSceneLoader.cs
@@ -171,7 +171,7 @@ namespace Global.Dynamic
             var identityCache = new IWeb3IdentityCache.Default(web3AccountFactory);
             var debugContainerBuilder = DebugUtilitiesContainer.Create(debugViewsCatalog, applicationParametersParser.HasDebugFlag()).Builder;
             var staticSettings = (globalPluginSettingsContainer as IPluginSettingsContainer).GetSettings<StaticSettings>();
-            var webRequestsContainer = WebRequestsContainer.Create(identityCache, texturesFuse, debugContainerBuilder, staticSettings.WebRequestsBudget, compressionEnabled);
+            var webRequestsContainer = WebRequestsContainer.Create(identityCache, texturesFuse, debugContainerBuilder, staticSettings.CoreWebRequestsBudget, staticSettings.SceneWebRequestsBudget, compressionEnabled);
             var realmUrls = new RealmUrls(launchSettings, new RealmNamesMap(webRequestsContainer.WebRequestController), decentralandUrlsSource);
 
             var diskCache = NewInstanceDiskCache(applicationParametersParser, launchSettings);

--- a/Explorer/Assets/Scripts/Global/Tests/PlayMode/IntegrationTestsSuite.cs
+++ b/Explorer/Assets/Scripts/Global/Tests/PlayMode/IntegrationTestsSuite.cs
@@ -67,7 +67,7 @@ namespace Global.Tests.PlayMode
                 assetProvisioner,
                 Substitute.For<IReportsHandlingSettings>(),
                 Substitute.For<IDebugContainerBuilder>(),
-                WebRequestsContainer.Create(new IWeb3IdentityCache.Default(), ITexturesFuse.NewTestInstance(), Substitute.For<IDebugContainerBuilder>(), 1000, false),
+                WebRequestsContainer.Create(new IWeb3IdentityCache.Default(), ITexturesFuse.NewTestInstance(), Substitute.For<IDebugContainerBuilder>(), 1000, 1000, false),
                 ITexturesFuse.NewTestInstance(),
                 globalSettingsContainer,
                 diagnosticsContainer,


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Introduces a Scene Web Request Controller. 

This re-routes requests through a different controller, allowing to have a different and isolated budget from the core web request controller.

As an initial value, the scene web request controller have been set to 5. Any given scene cannot have more than 5 simultaneos web requests.

## Test Instructions


### Test Steps
1. Two scenes are blowing up the web requests (`LaLigaLand (-150,64)` and `DCL 5 year birthday party (-137,52)` )
2. Teleport to both of those scenes. Probably the debug metric for `Scene Budget` will stay at 0; that's expected. But everything around you should load just fine
3. Teleport back to any scene. That metric should return to 5

![image](https://github.com/user-attachments/assets/37f871de-92ea-4c96-85bb-027b33a0662f)




## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
