### PR TITLE
Implement IV8HostObject for JSTaskResolverResetable

### DIFF
--- a/Explorer/Assets/Scripts/SceneRuntime/Apis/JSTaskResolverResetable.cs
+++ b/Explorer/Assets/Scripts/SceneRuntime/Apis/JSTaskResolverResetable.cs
@@ -1,12 +1,22 @@
 ﻿using Cysharp.Threading.Tasks;
-using JetBrains.Annotations;
 using Microsoft.ClearScript;
+using Microsoft.ClearScript.V8.SplitProxy;
+using System;
 
 namespace SceneRuntime.Apis
 {
-    public class JSTaskResolverResetable
+    public class JSTaskResolverResetable : IV8HostObject
     {
         private AutoResetUniTaskCompletionSource source;
+
+        private readonly InvokeHostObject completed;
+        private readonly InvokeHostObject reject;
+
+        public JSTaskResolverResetable()
+        {
+            completed = Completed;
+            reject = Reject;
+        }
 
         public UniTask Task => source.Task;
 
@@ -15,16 +25,38 @@ namespace SceneRuntime.Apis
             source = AutoResetUniTaskCompletionSource.Create();
         }
 
-        [UsedImplicitly]
-        public void Completed()
+        private void Completed(ReadOnlySpan<V8Value.Decoded> args, V8Value result)
+        {
+            Completed();
+        }
+
+        private void Completed()
         {
             source.TrySetResult();
         }
 
-        [UsedImplicitly]
-        public void Reject(string message)
+        private void Reject(ReadOnlySpan<V8Value.Decoded> args, V8Value result)
+        {
+            string message = args[0].GetString();
+            Reject(message);
+        }
+
+        private void Reject(string message)
         {
             source.TrySetException(new ScriptEngineException(message));
+        }
+
+        void IV8HostObject.GetNamedProperty(StdString name, V8Value value, out bool isConst)
+        {
+            isConst = true;
+
+            if (name.Equals(nameof(Completed)))
+                value.SetHostObject(completed);
+            else if (name.Equals(nameof(Reject)))
+                value.SetHostObject(reject);
+            else
+                throw new NotImplementedException(
+                    $"Named property {name.ToString()} is not implemented");
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change implements the unsafe API for JSTaskResolverResetable. This gets rid of allocations.

## Test Instructions

Visit complex scenes with lots of scripting.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
