### PR TITLE
fix: own profile color doesnt get re-calculated when changing profile

### DIFF
--- a/Explorer/Assets/DCL/NameTags/NametagView.cs
+++ b/Explorer/Assets/DCL/NameTags/NametagView.cs
@@ -23,7 +23,6 @@ namespace DCL.Nametags
         private const float DEFAULT_BUBBLE_ANIMATION_OUT_DURATION = 0.35f;
         private const float DEFAULT_SINGLE_EMOJI_EXTRA_HEIGHT = 0.1f;
         private const float DEFAULT_SINGLE_EMOJI_SIZE = 3.5f;
-        private const int EMOJI_LENGTH = 10;
         private const int DEFAULT_OPACITY_MAX_DISTANCE = 20;
         private const int DEFAULT_ADDITIONAL_MS_PER_CHARACTER = 20;
         private const int DEFAULT_BUBBLE_IDLE_TIME_MS = 5000;

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -6,6 +6,7 @@ using DCL.AvatarRendering.Loading.Components;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.AvatarRendering.Wearables.Equipped;
 using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.UI.Profiles.Helpers;
 using DCL.Utilities.Extensions;
 using DCL.Web3.Identities;
 using System;
@@ -109,7 +110,8 @@ namespace DCL.Profiles.Self
             if (newProfile.Avatar.IsSameAvatar(profile.Avatar))
                 return profile;
 
-            OwnProfile = profile;
+            newProfile.UserNameColor = ProfileNameColorHelper.GetNameColor(profile.DisplayName);
+            OwnProfile = newProfile;
 
             await profileRepository.SetAsync(newProfile, publish, ct);
             return await profileRepository.GetAsync(newProfile.UserId, newProfile.Version, ct);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Added a line on the SelfProfile that re-calculated the profile color when changing the profile.
Also found that we were assigning as OwnProfile the previous profile instead of the new one? So I changed that, but please correct me if im wrong with that xD just seemed odd that we were assigning back the previous profile...


## Test Instructions
* The issue triggered after changing wearables and teleporting back and forth. So try doing that xD
Teleport, change a wearable, wait until its changed, teleport again, etc. 
The nametag should remain with the correct color and all.