### PR TITLE
Feat: add custom text when going back from tutorial world to genesis

### DIFF
--- a/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
+++ b/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
@@ -2941,6 +2941,7 @@ MonoBehaviour:
   <sceneRestrictionsView>k__BackingField: {fileID: 6087439276851581053}
   <minimapAnimator>k__BackingField: {fileID: 5048152786859444568}
   <goToGenesisCityButton>k__BackingField: {fileID: 7701158923936790273}
+  <goToGenesisCityText>k__BackingField: {fileID: 5367621127198247767}
   <genesisCityAnimatorController>k__BackingField: {fileID: 9100000, guid: 1ca5d010fc5aeae41a709d95fe3ed97e, type: 2}
   <worldsAnimatorController>k__BackingField: {fileID: 22100000, guid: 5f31e812e7f7ede4d846df460b12fa81, type: 2}
   <objectsToActivateForGenesis>k__BackingField:
@@ -4645,6 +4646,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3152644595163223519, guid: 83437f351686bca419378abea4d2ed07, type: 3}
   m_PrefabInstance: {fileID: 7678860058044281840}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5367621127198247767 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2372645419648989351, guid: 83437f351686bca419378abea4d2ed07, type: 3}
+  m_PrefabInstance: {fileID: 7678860058044281840}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5697610981568348086 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2702495720024624198, guid: 83437f351686bca419378abea4d2ed07, type: 3}

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -33,7 +33,8 @@ namespace DCL.Minimap
     public partial class MinimapController : ControllerBase<MinimapView>, IMapActivityOwner
     {
         private const MapLayer RENDER_LAYERS = MapLayer.SatelliteAtlas | MapLayer.PlayerMarker | MapLayer.ScenesOfInterest | MapLayer.Favorites | MapLayer.HotUsersMarkers | MapLayer.Pins | MapLayer.Path | MapLayer.LiveEvents;
-
+        private const string DEFAULT_BACK_FROM_WORLD_TEXT = "JUMP BACK TO GENESIS CITY";
+        private static readonly Dictionary<string, string> CUSTOM_BACK_FROM_WORLD_TEXTS = new () { {"onboardingdcl.dcl.eth", "EXIT TUTORIAL"} };
         private const float ANIMATION_TIME = 0.2f;
 
         private readonly IMapRenderer mapRenderer;
@@ -257,6 +258,9 @@ namespace DCL.Minimap
 
             foreach (GameObject go in viewInstance.objectsToActivateForWorlds)
                 go.SetActive(!isGenesisModeActivated);
+
+            if (!isGenesisModeActivated)
+                viewInstance.goToGenesisCityText.text = CUSTOM_BACK_FROM_WORLD_TEXTS.GetValueOrDefault(realmData.RealmName, DEFAULT_BACK_FROM_WORLD_TEXT);
 
             viewInstance.minimapAnimator.runtimeAnimatorController = isGenesisModeActivated ? viewInstance.genesisCityAnimatorController : viewInstance.worldsAnimatorController;
         }

--- a/Explorer/Assets/DCL/Minimap/MinimapView.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapView.cs
@@ -62,6 +62,9 @@ namespace DCL.Minimap
         internal Button goToGenesisCityButton { get; private set; }
 
         [field: SerializeField]
+        internal TMP_Text goToGenesisCityText { get; private set; }
+
+        [field: SerializeField]
         internal RuntimeAnimatorController genesisCityAnimatorController { get; private set; }
 
         [field: SerializeField]


### PR DESCRIPTION
## What does this PR change?
Fix #3414
Adds a new text for the back to genesis button when in the onboarding tutorial world:
<img width="303" alt="Screenshot 2025-03-03 at 13 49 09" src="https://github.com/user-attachments/assets/3eba9f0f-e8bb-4c16-a8fe-2610fd1fbb5f" />


## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. Login
2. Go to onboarding world
3. Check that the button in the minimap to go back to genesis city says "EXIT TUTORIAL"
4. Check that in other worlds it says "JUMP BACK TO GENESIS CITY" instead

### Additional Testing Notes
- verify both with an old user and a new user entering dcl for the first time

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
