### PR TITLE
chore: disable animation for GLTF's when offscreen

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/Animator/Systems/LegacyAnimationPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Animator/Systems/LegacyAnimationPlayerSystem.cs
@@ -101,6 +101,7 @@ namespace DCL.SDKComponents.Animator.Systems
 
             animation.playAutomatically = true;
             animation.enabled = true;
+            animation.cullingType = AnimationCullingType.BasedOnRenderers;
             animation.Stop();
 
             // Putting the component in play state if playAutomatically was true at that point.

--- a/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
@@ -91,6 +91,10 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
             using (PoolExtensions.Scope<List<Animation>> animationScope = GltfContainerAsset.ANIMATIONS_POOL.AutoScope())
             {
                 instance.GetComponentsInChildren(true, animationScope.Value);
+                foreach (Animation sAnimation in animationScope.Value)
+                {
+                    sAnimation.cullingType = AnimationCullingType.BasedOnRenderers;
+                }
                 result.Animations.AddRange(animationScope.Value);
             }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Introduces animation culling to GLTFs and SDK legacy animations which improves performance.

Before:
![image](https://github.com/user-attachments/assets/c22c6d77-634c-44a3-983b-70314960d224)

After:
![image](https://github.com/user-attachments/assets/cc08973a-233b-443f-b3b8-8630e75a1ff0)


## Test Instructions

1. Test happy path
2. Pay close attention to animations (on the scenes, not avatars) . They will no longer animate when offscreen, ensure they perform as expected and do not introduce any unsightly visual artifacts (such as suddenly beginning starting/stopping animation). If its minor, it may be an OK trade-off.

## Quality Checklist
- [x] Changes have been tested locally
- [x] Performance impact has been considered

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
