### PR TITLE
fix: hyperlink detection for single character domain names

### DIFF
--- a/Explorer/Assets/DCL/Chat/MessageBus/MultiplayerChatMessagesBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/MultiplayerChatMessagesBus.cs
@@ -15,7 +15,7 @@ namespace DCL.Chat.MessageBus
 {
     public class MultiplayerChatMessagesBus : IChatMessagesBus
     {
-        private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{3,15}(?:#[A-Za-z0-9]{4})?)(?=\s|$)", RegexOptions.Compiled);
+        private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{3,15}(?:#[A-Za-z0-9]{4})?)(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
 
         private readonly IMessagePipesHub messagePipesHub;
         private readonly IProfileRepository profileRepository;

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
@@ -10,7 +10,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 {
     public class ChatMessagesBusAnalyticsDecorator : IChatMessagesBus
     {
-        private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{3,15}(?:#[A-Za-z0-9]{4})?)(?=\s|$)", RegexOptions.Compiled);
+        private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{3,15}(?:#[A-Za-z0-9]{4})?)(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
 
         private readonly IChatMessagesBus core;
         private readonly IAnalyticsController analytics;

--- a/Explorer/Assets/DCL/UI/TextFormatter/HyperlinkTextFormatter.cs
+++ b/Explorer/Assets/DCL/UI/TextFormatter/HyperlinkTextFormatter.cs
@@ -16,7 +16,7 @@ namespace DCL.UI.InputFieldFormatting
         private const string OWN_PROFILE_CLOSING_STYLE = "</color>";
 
         private static readonly Regex RICH_TEXT_TAG_REGEX = new (@"<(?!\/?(b|i)(>|\s))[^>]+>", RegexOptions.Compiled);
-        private static readonly Regex WEBSITE_REGEX = new (@"(?<=^|\s)(https?:\/\/)([a-zA-Z0-9-]+\.)*[a-zA-Z0-9][a-zA-Z0-9-]+\.[a-zA-Z]{2,}(\/[^\s]*)?(?=\s|$)",
+        private static readonly Regex WEBSITE_REGEX = new (@"(?<=^|\s)(https?:\/\/)([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(\/[^\s]*)?(?=\s|$)",
             RegexOptions.Compiled);
         private static readonly Regex SCENE_REGEX = new (@"(?<=^|\s)(-?\d{1,3}),(-?\d{1,3})(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
         private static readonly Regex WORLD_REGEX = new (@"(?<=^|\s)*[a-zA-Z0-9]*\.dcl\.eth(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);


### PR DESCRIPTION
…ed by some characters

# Pull Request Description

The REGEX for websites used for hyperlink formatting expected at least 2 characters for the domain name, that has been reduced to a single character now. May god have mercy on our souls.
Also fixed a small issue with detecting mentions when the username was followed by a punctuation sign like !.,?

## Test Instructions
Try websites that have only one character in their domain like https://x.com or any other? also try links inside said domain, like links to specific users or posts inside x (lets just call it Twitter?)