### PR TITLE
fix: username color shenanigans

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -191,7 +191,7 @@ namespace DCL.Nametags
             NametagView nametagView = nametagViewPool.Get();
             nametagView.gameObject.name = avatarShape.ID;
             nametagView.Id = avatarShape.ID;
-            nametagView.Username.color = profile?.UserNameColor ?? ProfileNameColorHelper.GetNameColor(avatarShape.Name);
+            nametagView.Username.color = profile?.UserNameColor != Color.white? profile!.UserNameColor : ProfileNameColorHelper.GetNameColor(avatarShape.Name);
             nametagView.InjectConfiguration(chatBubbleConfigurationSo);
 
             int walletIdLastDigitsIndex = avatarShape.ID.Length - 4;

--- a/Explorer/Assets/DCL/Profiles/Components/Profile.cs
+++ b/Explorer/Assets/DCL/Profiles/Components/Profile.cs
@@ -55,7 +55,7 @@ namespace DCL.Profiles
         /// <summary>
         ///     The color calculated for this username
         /// </summary>
-        public Color UserNameColor { get; internal set; }
+        public Color UserNameColor { get; internal set; } = Color.white;
 
         /// <summary>
         ///     The name of the user after passing character validation, without the # part

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -132,6 +132,7 @@ namespace DCL.Profiles.Self
                                                .Build();
 
             newProfile.UserId = web3IdentityCache.Identity.Address;
+            newProfile.UserNameColor = ProfileNameColorHelper.GetNameColor(profile.DisplayName);
 
             await profileRepository.SetAsync(newProfile, publish: true, ct);
             return await profileRepository.GetAsync(newProfile.UserId, newProfile.Version, ct);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Added a default color for the profile and a check for that color when setting the own nametag, in this case it will calculate the color if the color is the default.

## Test Instructions
Test that the own nametag has a visible name, particularly for new users. The color should remain constant after changing wearables or teleporting as well.