### PR TITLE
fix: tweaks to suggestion box to correct missalignment

### DIFF
--- a/Explorer/Assets/DCL/UI/InputSuggestions/InputSuggestionBox.prefab
+++ b/Explorer/Assets/DCL/UI/InputSuggestions/InputSuggestionBox.prefab
@@ -34,7 +34,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -0.0000038146973}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &2784217737781059484
@@ -52,8 +52,8 @@ MonoBehaviour:
   m_Padding:
     m_Left: 0
     m_Right: 0
-    m_Top: 6
-    m_Bottom: 6
+    m_Top: 0
+    m_Bottom: 0
   m_ChildAlignment: 1
   m_Spacing: 0
   m_ChildForceExpandWidth: 0
@@ -647,8 +647,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 8132716015261979228}
   m_HandleRect: {fileID: 879671387160664398}
   m_Direction: 2
-  m_Value: 0
-  m_Size: 1
+  m_Value: 1
+  m_Size: 0.88235295
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -688,8 +688,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -4}
-  m_SizeDelta: {x: 0, y: -8}
+  m_AnchoredPosition: {x: 0, y: -8}
+  m_SizeDelta: {x: 0, y: -16}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &1942452310773789503
 CanvasRenderer:

--- a/Explorer/Assets/DCL/UI/InputSuggestions/InputSuggestionPanelView.cs
+++ b/Explorer/Assets/DCL/UI/InputSuggestions/InputSuggestionPanelView.cs
@@ -171,7 +171,6 @@ namespace DCL.UI.SuggestionPanel
             }
 
             ScrollViewRect.sizeDelta = new Vector2(ScrollViewRect.sizeDelta.x, scrollViewHeight);
-            scrollViewComponent.verticalNormalizedPosition = 1;
 
             //if the suggestion type is different, we release all items from the pool,
             //otherwise, we only release the elements that are over the found suggestion amount.
@@ -213,6 +212,8 @@ namespace DCL.UI.SuggestionPanel
                     usedPoolItems.Add(suggestionElement);
                 }
             }
+
+            scrollViewComponent.verticalNormalizedPosition = 1;
         }
 
         private void SetSelection(int index)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
The margins on the asset were conflicting with the padding and it caused a slight visual issue.


## Test Instructions
Check that this doesnt happen:
![image](https://github.com/user-attachments/assets/889278e5-7957-4850-a537-20b93c99c81f)

Now margins on the top and bottom should be equal, both for emoticons and profile suggestions, also margins should remain correct when there are more than one suggestion.
Also fixed a small issue when selecting suggestions after deleting a letter, for example, write `:hel`, the helicopter will be selected, then delete `el` and type `e` again, the first suggestion on top should be selected and showing, instead of being in a random position.