### PR TITLE
fix: fixed domain validation when no post domain SLASH char is provided

### DIFF
--- a/Explorer/Assets/DCL/Utilities/Extensions/StringExtensions.cs
+++ b/Explorer/Assets/DCL/Utilities/Extensions/StringExtensions.cs
@@ -28,6 +28,11 @@ namespace DCL.Utilities.Extensions
                 return false;
 
             int domainEndIndex = restOfUrlSpan.IndexOf(SLASH);
+
+            //Validates the rest of the url as domain when no SLASH char is found Ex: lvpr.tv?v=videoId
+            if (domainEndIndex == -1)
+                return IsValid(restOfUrlSpan);
+
             return domainEndIndex == 0 || IsValid(restOfUrlSpan[..domainEndIndex]); // Check for the domain
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #3432
This Issue fixes a specific case of domain validation failure when handling video streams.
Video players were validating a domain and the function was breaking when the domain doesn't contain a / character after the domain, like: "https://lvpr.tv?v=9974hj8adxn8j21u". In this case the domain validation was breaking with a 
`ArgumentOutOfRangeException: Specified argument was out of the range of valid values.`
Blocking the scene from loading

## Test Instructions

### Test Steps
1. Login in decentraland
2. Teleport to -116,-69
3. Verify that the loading doesn't get stuck and that the scene loads fine
Because this PR adds a specific validation verify in other scenes that video streams are working as before by comparing their execution to be the same between prod and this PR

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
