### PR TITLE
fix: remove submodules from .gitmodules and add links to our forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,3 @@
 [submodule "Explorer/Assets/git-submodules/unity-shared-dependencies"]
 	path = Explorer/Assets/git-submodules/unity-shared-dependencies
 	url = https://github.com/decentraland/unity-shared-dependencies.git
-[submodule "Explorer/Assets/Plugins/TexturesFuse/textures-server/astc-encoder"]
-	path = Explorer/Assets/Plugins/TexturesFuse/textures-server/astc-encoder
-	url = https://github.com/ARM-software/astc-encoder
-[submodule "Explorer/Assets/Plugins/TexturesFuse/textures-server/CompressonatorWorkaround/compressonator"]
-	path = Explorer/Assets/Plugins/TexturesFuse/textures-server/CompressonatorWorkaround/compressonator
-	url = git@github.com:GPUOpen-Tools/compressonator.git
-[submodule "Explorer/Assets/Plugins/TexturesFuse/textures-server/CompressonatorWorkaround/externals_repos/simde"]
-	path = Explorer/Assets/Plugins/TexturesFuse/textures-server/CompressonatorWorkaround/externals_repos/simde
-	url = git@github.com:simd-everywhere/simde.git

--- a/TexturesFuse/README.md
+++ b/TexturesFuse/README.md
@@ -10,6 +10,16 @@ Features:
 3. RGBA32, ASTC, BC5 texture formats support
 4. Easy access high-level API
 
+## Dependencies
+
+These repositories are required to compile TextureFuse:
+ - https://github.com/decentraland/astc-encoder
+   - Previous path: `TexturesFuse/textures-server/astc-encoder`
+ - https://github.com/decentraland/compressonator
+   - Previous path: `TexturesFuse/textures-server/CompressonatorWorkaround/compressonator`
+ - https://github.com/decentraland/simde
+   - Previous path: `TexturesFuse/textures-server/CompressonatorWorkaround/externals_repos/simde`
+
 ### C# API
 
 To use this plugin you need an instance of object with `ITexturesUnzip` interface.
@@ -51,13 +61,13 @@ It's not recommended to use if you are able to use ASTC or BC5 format on the tar
 Format provides ASTC compression.
 It is used as a general purpose format for albedo textures.
 TexturesFuse provides an access to adjust settings via `InitOptions` and `Swizzle` structs.
-To get more specific info visit encoder's git-page: https://github.com/ARM-software/astc-encoder.
+To get more specific info visit encoder's git-page: https://github.com/ARM-software/astc-encoder or our [fork](https://github.com/decentraland/astc-encoder).
 
 #### BC5
 
 Format provides BC5 compression.
 It is used as a format for normal maps.
-To get more specific info visit compressonator's git-page: https://github.com/GPUOpen-Tools/compressonator.
+To get more specific info visit compressonator's git-page: https://github.com/GPUOpen-Tools/compressonator or our [fork](https://github.com/decentraland/compressonator).
 
 ### Native API
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This removes old submodules from .gitmodules and adds links to our forks to the TexturesFuse readme.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Just a smoke test

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
