### PR TITLE
fix: sdk lightsource shadowmask memory leak

### DIFF
--- a/Explorer/Assets/DCL/MapPins/Systems/MapPinLoaderSystem.cs
+++ b/Explorer/Assets/DCL/MapPins/Systems/MapPinLoaderSystem.cs
@@ -143,7 +143,7 @@ namespace DCL.SDKComponents.MapPins.Systems
 
             TextureComponent textureComponentValue = textureComponent.Value;
 
-            if (TextureComponentUtils.Equals(ref textureComponentValue, ref promise))
+            if (TextureComponentUtils.Equals(textureComponentValue, promise))
                 return false;
 
             DereferenceTexture(ref promise);

--- a/Explorer/Assets/DCL/SDKComponents/LightSource/Systems/LightSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/LightSource/Systems/LightSourceSystem.cs
@@ -123,6 +123,7 @@ namespace DCL.SDKComponents.LightSource.Systems
                 }
                 else
                 {
+                    DereferenceTexture(ref lightSourceComponent.TextureMaskPromise);
                     lightSourceInstance.cookie = null;
                 }
             }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIBackground/UIBackgroundInstantiationSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIBackground/UIBackgroundInstantiationSystem.cs
@@ -138,7 +138,7 @@ namespace DCL.SDKComponents.SceneUI.Systems.UIBackground
 
             // If data inside promise has not changed just reuse the same promise
             // as creating and waiting for a new one can be expensive
-            if (TextureComponentUtils.Equals(ref textureComponentValue, ref promise))
+            if (TextureComponentUtils.Equals(textureComponentValue, promise))
                 return;
 
             // If component is being reused forget the previous promise

--- a/Explorer/Assets/Scripts/ECS/Unity/Textures/Utils/TextureComponentUtils.cs
+++ b/Explorer/Assets/Scripts/ECS/Unity/Textures/Utils/TextureComponentUtils.cs
@@ -6,18 +6,18 @@ namespace DCL.SDKComponents.Utils
 {
     public static class TextureComponentUtils
     {
-        public static bool Equals(ref TextureComponent textureComponent, ref Promise? promise)
+        public static bool Equals(in TextureComponent textureComponent, in Promise? promise)
         {
             if (promise == null)
                 return false;
 
-            Promise promiseValue = promise.Value;
-            GetTextureIntention intention = promiseValue.LoadingIntention;
-
-            return textureComponent.FileHash == promiseValue.LoadingIntention.FileHash &&
-                   textureComponent.Src == intention.Src &&
-                   textureComponent.WrapMode == intention.WrapMode &&
-                   textureComponent.FilterMode == intention.FilterMode;
+            return Equals(textureComponent, promise.Value.LoadingIntention);
         }
+
+        public static bool Equals(in TextureComponent textureComponent, in GetTextureIntention intention) =>
+            textureComponent.FileHash == intention.FileHash &&
+            textureComponent.Src == intention.Src &&
+            textureComponent.WrapMode == intention.WrapMode &&
+            textureComponent.FilterMode == intention.FilterMode;
     }
 }


### PR DESCRIPTION
### WHY

Any change to a LightSource that is using a shadowmask will be re-creating the texture in memory on every change, creating a huge memory leak.

### WHAT

Fixed shadowmask texture promise cleanup

### TEST STEPS

...
