### PR TITLE
Fix: Meta-GamiMall platform collider dissapears

### DIFF
--- a/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
+++ b/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
@@ -147,8 +147,8 @@ namespace Utility
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Contains(this in SceneCircumscribedPlanes boundingPlanes, Bounds bounds)
         {
-            float shrinkAmount = Mathf.Min(bounds.size.x * 0.5f,
-                Mathf.Min(bounds.size.z * 0.5f, BOUNDS_OFFSET_EPSILON));
+            float shrinkAmount = Mathf.Min(bounds.size.x / 2,
+                Mathf.Min(bounds.size.z / 2, BOUNDS_OFFSET_EPSILON));
 
             bounds.Expand(-shrinkAmount);
 

--- a/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
+++ b/Explorer/Assets/Scripts/Utility/ParcelMathHelper.cs
@@ -9,7 +9,7 @@ namespace Utility
     {
         public const int PARCEL_SIZE = 16;
         public const float SQR_PARCEL_SIZE = PARCEL_SIZE * PARCEL_SIZE;
-        private const float BOUNDS_OFFSET_EPSILON = 0.1f;
+        private const float BOUNDS_OFFSET_EPSILON = 0.3f;
 
         public static readonly SceneGeometry UNDEFINED_SCENE_GEOMETRY = new (
             Vector3.zero,
@@ -147,12 +147,13 @@ namespace Utility
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Contains(this in SceneCircumscribedPlanes boundingPlanes, Bounds bounds)
         {
-            bounds.Expand(-BOUNDS_OFFSET_EPSILON);
+            float shrinkAmount = Mathf.Min(bounds.size.x * 0.5f,
+                Mathf.Min(bounds.size.z * 0.5f, BOUNDS_OFFSET_EPSILON));
 
-            return boundingPlanes.MinX < bounds.min.x &&
-                   boundingPlanes.MaxX > bounds.max.x &&
-                   boundingPlanes.MinZ < bounds.min.z &&
-                   boundingPlanes.MaxZ > bounds.max.z;
+            bounds.Expand(-shrinkAmount);
+
+            return bounds.min.x >= boundingPlanes.MinX && bounds.max.x <= boundingPlanes.MaxX &&
+                   bounds.min.z >= boundingPlanes.MinZ && bounds.max.z <= boundingPlanes.MaxZ;
         }
 
         /// <summary>


### PR DESCRIPTION
# Pull Request Description

Collider on the platform was still out of scene bounds in some places and get disabled, which prevent platform for going further.

## What does this PR change?
I just increased offset and add a check so bounds are not inverted in case when they are smaller than the offset.

## Test Instructions
1. Go to Meta GamiMall `/goto 147,60`
2. Jump on the shuttle pad and start going through the track
3. Do the full ride (it last more than 2 minutes) - verify you can always stay on the platform and finish the ride 

### Additional Testing Notes
Note: issue with not able to stand in the center of the platform is out of the scope of the testing. Main test scope here is that you can finish the ride.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Performance impact has been considered

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
