### PR TITLE
fix: bring back the loading logo

### DIFF
--- a/Explorer/Assets/Scenes/Main.unity
+++ b/Explorer/Assets/Scenes/Main.unity
@@ -355,7 +355,7 @@ Animator:
   m_GameObject: {fileID: 214014215}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 11e3e096626ac0548912411d33ae8192, type: 2}
   m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Brings back the loading logo before the authetication screen

## Test Instructions

See that the loading logo is visible while in Splash Screen


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
