### PR TITLE
Implement shell execute ourselves

### DIFF
--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -179,7 +179,17 @@ namespace DCL.ApplicationVersionGuard
                 throw new Win32Exception(error, message.TrimEnd());
             }
 #elif UNITY_STANDALONE_OSX
-                // TODO: Do the same thing on OSX.
+            string cmd = "open \"" + fileName + "\"";
+            int code = System(cmd);
+            if (code != 0)
+            {
+                var sb = new StringBuilder(1024);
+
+                string message = code == -1 && strerror_r(code, sb, sb.Capacity) == 0
+                    ? sb.ToString()
+                    : "Unknown error";
+                throw new Exception($"error {code}: {message}");
+            }
 #endif
         }
 
@@ -196,7 +206,11 @@ namespace DCL.ApplicationVersionGuard
 
         private const int SW_NORMAL = 1;
 #elif UNITY_STANDALONE_OSX
-        // TODO: OSX dynlib imports go here.
+        [DllImport("__Internal", EntryPoint = "system")]
+        private static extern int System(string command);
+
+        [DllImport("libc")]
+        private static extern int strerror_r(int errnum, StringBuilder buf, int buflen);
 #endif
 
         [Serializable]

--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -5,9 +5,11 @@ using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.WebRequests;
 using SceneRuntime.Apis.Modules.SignedFetch.Messages;
 using System;
-using System.Diagnostics;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using UnityEngine;
 
@@ -63,17 +65,10 @@ namespace DCL.ApplicationVersionGuard
             }
             else
             {
-                ProcessStartInfo startInfo = PrepareLauncherStartInfo(launcherPath);
-                startInfo.UseShellExecute = true; // Ensure the process runs independently
-
-                await UniTask.Delay(1000, cancellationToken: ct);
-
                 try
                 {
-                    Process process = Process.Start(startInfo);
-
-                    if (process == null)
-                        ReportHub.Log("Failed to start launcher process.", ReportCategory.VERSION_CONTROL);
+                    await UniTask.Delay(1000, cancellationToken: ct);
+                    ShellExecute(launcherPath);
                 }
                 catch (Exception e)
                 {
@@ -135,30 +130,6 @@ namespace DCL.ApplicationVersionGuard
                    };
         }
 
-        private static ProcessStartInfo PrepareLauncherStartInfo(string launcherPath)
-        {
-            var startInfo = new ProcessStartInfo
-            {
-                UseShellExecute = true,
-            };
-
-            switch (Application.platform)
-            {
-                case RuntimePlatform.WindowsEditor:
-                case RuntimePlatform.WindowsPlayer:
-                    startInfo.FileName = launcherPath;
-                    return startInfo;
-                case RuntimePlatform.OSXEditor:
-                case RuntimePlatform.OSXPlayer:
-                    startInfo.FileName = "open";
-                    startInfo.Arguments = $"-n \"{launcherPath}\"";
-                    return startInfo;
-                default:
-                    ReportHub.LogError(ReportCategory.VERSION_CONTROL, "Unsupported platform for launching the application.");
-                    return startInfo;
-            }
-        }
-
         private static string? GetLauncherPath()
         {
             string[] possiblePaths;
@@ -192,6 +163,41 @@ namespace DCL.ApplicationVersionGuard
             return possiblePaths.FirstOrDefault(path => File.Exists(path)
                                                         || (Directory.Exists(path) && (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)));
         }
+
+        private static void ShellExecute(string fileName)
+        {
+#if UNITY_STANDALONE_WIN
+            if ((int)ShellExecute(IntPtr.Zero, null, fileName, null, null, SW_NORMAL) <= 16)
+            {
+                int error = Marshal.GetLastWin32Error();
+                var sb = new StringBuilder(1024);
+
+                uint length = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, IntPtr.Zero, error, 0, sb,
+                    sb.Capacity, IntPtr.Zero);
+
+                string message = length > 0 ? sb.ToString() : $"error {error}";
+                throw new Win32Exception(error, message.TrimEnd());
+            }
+#elif UNITY_STANDALONE_OSX
+                // TODO: Do the same thing on OSX.
+#endif
+        }
+
+#if UNITY_STANDALONE_WIN
+        [DllImport("kernel32", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern uint FormatMessage(uint dwFlags, IntPtr lpSource, int dwMessageId,
+            uint dwLanguageId, StringBuilder lpBuffer, int nSize, IntPtr Arguments);
+
+        private const uint FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
+
+        [DllImport("shell32", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr ShellExecute(IntPtr hWnd, string lpOperation, string lpFile,
+            string lpParameters, string lpDirectory, int nShowCmd);
+
+        private const int SW_NORMAL = 1;
+#elif UNITY_STANDALONE_OSX
+        // TODO: OSX dynlib imports go here.
+#endif
 
         [Serializable]
         private struct GitHubRelease

--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -180,7 +180,7 @@ namespace DCL.ApplicationVersionGuard
             }
 #elif UNITY_STANDALONE_OSX
             string cmd = "open \"" + fileName + "\"";
-            int code = System(cmd);
+            int code = ExecuteSystemCommand(cmd);
             if (code != 0)
             {
                 var sb = new StringBuilder(1024);
@@ -206,8 +206,8 @@ namespace DCL.ApplicationVersionGuard
 
         private const int SW_NORMAL = 1;
 #elif UNITY_STANDALONE_OSX
-        [DllImport("__Internal", EntryPoint = "system")]
-        private static extern int System(string command);
+        [DllImport("libc", EntryPoint = "system")]
+        private static extern int ExecuteSystemCommand([MarshalAs(UnmanagedType.LPStr)] string command);
 
         [DllImport("libc")]
         private static extern int strerror_r(int errnum, StringBuilder buf, int buflen);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change implements shell execute for Windows and OSX so that we can launch the launcher from the game so that it can update the game. Fixes issue #3295.

## Test Instructions

Launch the game with the simulateVersion argument set to some old version and choose "update" when prompted.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
