### PR TITLE
chore: optimize avatar visibility shape system

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Facial_Features.mat
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Facial_Features.mat
@@ -148,7 +148,7 @@ Material:
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
-    - _StartFadeDistance: 2
+    - _StartFadeDistance: 0
     - _Surface: 0
     - _WorkflowMode: 1
     - _ZWrite: 1

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Toon.mat
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Toon.mat
@@ -563,7 +563,7 @@ Material:
     - _SpecularRampOuterMin: 0.702
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
-    - _StartFadeDistance: 2
+    - _StartFadeDistance: 0
     - _StencilComp: 0
     - _StencilMode: 0
     - _StencilNo: 1

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -64,7 +64,6 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         internal readonly List<MaterialSetup> materials;
         internal readonly UnityEngine.ComputeShader computeShaderInstance;
 
-        private static readonly int SHADER_FADINGDISTANCE_PARAM_ID = Shader.PropertyToID("_FadeDistance");
         private bool disposed;
 
         /// <summary>
@@ -93,7 +92,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         {
             for (int i = 0; i < materials.Count; ++i)
             {
-                materials[i].usedMaterial.SetFloat(SHADER_FADINGDISTANCE_PARAM_ID, distance);
+                materials[i].usedMaterial.SetFloat(ComputeShaderConstants.SHADER_FADINGDISTANCE_PARAM_ID, distance);
             }
         }
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderConstants.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderConstants.cs
@@ -28,5 +28,9 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
         //Material properties
         public static readonly int BASE_COLOUR_SHADER_ID = Shader.PropertyToID("_BaseColor");
+        public static readonly int SHADER_FADINGDISTANCE_PARAM_ID = Shader.PropertyToID("_FadeDistance");
+        public static readonly int SHADER_FADINGDISTANCE_START_PARAM_ID = Shader.PropertyToID("_StartFadeDistance");
+
+
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -29,7 +29,7 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
             this.outlineFeature = outlineFeature.GetRendererFeature<OutlineRendererFeature>();
             planes = new Plane[6];
 
-            //Add a small delta to be able to set the correct start value
+            //Add a small delta to be able to avoid rounding problems
             ditheringLimit = startFadeDithering + 0.1f;
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

During the stress test, I found out that one of our most consuming system was `AvatarShapeVisibilitySystem`. When you have many avatars, you have to update the value of the fade distance for every material every frame

<img width="1728" alt="Screenshot 2025-03-06 at 4 06 51 PM" src="https://github.com/user-attachments/assets/3555cf50-d651-4ed4-898a-5418441f25ec" />


What this PR does is:

- Extract the `StartFadeDistance` value to `AvatarSettings`
- Set the value only where its under the `StartFadeDistance`. Any other value different than that, doesnt make sense to update

As a result, a gain of `1.53 ms` is visible when deep profiling on the example frames shown

<img width="1728" alt="Screenshot 2025-03-06 at 4 12 11 PM" src="https://github.com/user-attachments/assets/26af5e18-36e2-4bf7-bf4d-ee7d81ea5401" />



## Test Instructions

### Test Steps
1. Go to `olavra.dcl.eth` to avoid noise
2. Instanatiate 50 non network avatars
3. Check that dithering works fine for all of them and yourself

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
