### PR TITLE
Set music and ambience to be streamed from disk

### DIFF
--- a/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Ambience - Ocean.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Ambience - Ocean.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Ambience - Woods - Day - No Wind 01.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Ambience - Woods - Day - No Wind 01.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Ambience - Woods - Day - No Wind 02.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Ambience - Woods - Day - No Wind 02.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Ambience - Woods - Day - No Wind 03.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Ambience - Woods - Day - No Wind 03.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Ambience - Woods - Night.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Ambience - Woods - Night.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Music - Authentication.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Music - Authentication.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Music - Builder.wav.meta
+++ b/Explorer/Assets/DCL/Audio/Sounds/Explorer Alpha 2024/Music - Builder.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change changes the built-in background music and ambience to be streamed from disk rather than loaded in memory. This will save us about 40 MB of RAM.

## Test Instructions

Listen to the background music for at least one full loop and listen for any cracks and pops.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
