### PR TITLE
fix: correct transparency while teleporting

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Facial_Features.mat
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Facial_Features.mat
@@ -131,7 +131,7 @@ Material:
     - _DstBlendAlpha: 0
     - _EndFadeDistance: 0
     - _EnvironmentReflections: 1
-    - _FadeDistance: 2
+    - _FadeDistance: 0
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossinessSource: 0
@@ -149,7 +149,7 @@ Material:
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
-    - _StartFadeDistance: 2
+    - _StartFadeDistance: 0
     - _Surface: 0
     - _WorkflowMode: 1
     - _ZWrite: 1

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Facial_Features.mat
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Facial_Features.mat
@@ -131,7 +131,6 @@ Material:
     - _DstBlendAlpha: 0
     - _EndFadeDistance: 0
     - _EnvironmentReflections: 1
-    - _FadeDistance: 0
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossinessSource: 0

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Facial_Features.mat
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Facial_Features.mat
@@ -129,8 +129,9 @@ Material:
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _DstBlendAlpha: 0
-    - _EndFadeDistance: 0.8
+    - _EndFadeDistance: 0
     - _EnvironmentReflections: 1
+    - _FadeDistance: 2
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossinessSource: 0
@@ -148,7 +149,7 @@ Material:
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
-    - _StartFadeDistance: 0
+    - _StartFadeDistance: 2
     - _Surface: 0
     - _WorkflowMode: 1
     - _ZWrite: 1

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Toon.mat
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Toon.mat
@@ -444,7 +444,6 @@ Material:
     - _EnergyConservingSpecularColor: 1
     - _EnvironmentReflections: 1
     - _FadeDirection: 0
-    - _FadeDistance: 0
     - _FadeThickness: 5
     - _Farthest_Distance: 100
     - _FirstShadeOverridden: 0

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Toon.mat
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Toon.mat
@@ -440,11 +440,11 @@ Material:
     - _EnableBlendModePreserveSpecularLighting: 1
     - _EnableFogOnTransparent: 1
     - _EnableGeometricSpecularAA: 0
-    - _EndFadeDistance: 0.8
+    - _EndFadeDistance: 0
     - _EnergyConservingSpecularColor: 1
     - _EnvironmentReflections: 1
     - _FadeDirection: 0
-    - _FadeDistance: 1
+    - _FadeDistance: 0
     - _FadeThickness: 5
     - _Farthest_Distance: 100
     - _FirstShadeOverridden: 0
@@ -564,7 +564,7 @@ Material:
     - _SpecularRampOuterMin: 0.702
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
-    - _StartFadeDistance: 2
+    - _StartFadeDistance: 0
     - _StencilComp: 0
     - _StencilMode: 0
     - _StencilNo: 1

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Toon.mat
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Avatar_Toon.mat
@@ -444,6 +444,7 @@ Material:
     - _EnergyConservingSpecularColor: 1
     - _EnvironmentReflections: 1
     - _FadeDirection: 0
+    - _FadeDistance: 1
     - _FadeThickness: 5
     - _Farthest_Distance: 100
     - _FirstShadeOverridden: 0
@@ -563,7 +564,7 @@ Material:
     - _SpecularRampOuterMin: 0.702
     - _SrcBlend: 1
     - _SrcBlendAlpha: 1
-    - _StartFadeDistance: 0
+    - _StartFadeDistance: 2
     - _StencilComp: 0
     - _StencilMode: 0
     - _StencilNo: 1

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
@@ -27,6 +27,11 @@
 
             return false;
         }
+
+        public void ResetDitherState()
+        {
+            currentDitherState = DITHER_STATE.UNINITIALIZED;
+        }
     }
 
     public enum DITHER_STATE

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
@@ -3,5 +3,37 @@
     public struct AvatarCachedVisibilityComponent
     {
         public bool IsVisible;
+        private DITHER_STATE currentDitherState;
+
+        public bool ShouldUpdateDitherState(float newDistance, float startFadeDithering, float endFadeDithering)
+        {
+            if (newDistance >= startFadeDithering && currentDitherState != DITHER_STATE.OPAQUE)
+            {
+                currentDitherState = DITHER_STATE.OPAQUE;
+                return true;
+            }
+
+            if (newDistance <= endFadeDithering && currentDitherState != DITHER_STATE.TRANSPARENT)
+            {
+                currentDitherState = DITHER_STATE.TRANSPARENT;
+                return true;
+            }
+
+            if (newDistance > endFadeDithering && newDistance < startFadeDithering)
+            {
+                currentDitherState = DITHER_STATE.DITHERING;
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    public enum DITHER_STATE
+    {
+        UNINITIALIZED,
+        TRANSPARENT,
+        DITHERING,
+        OPAQUE,
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -92,7 +92,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         {
             for (int i = 0; i < materials.Count; ++i)
             {
-                materials[i].usedMaterial.SetFloat(ComputeShaderConstants.SHADER_FADINGDISTANCE_PARAM_ID, distance);
+                materials[i].usedMaterial.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_PARAM_ID, distance);
             }
         }
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderConstants.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderConstants.cs
@@ -28,8 +28,10 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
         //Material properties
         public static readonly int BASE_COLOUR_SHADER_ID = Shader.PropertyToID("_BaseColor");
-        public static readonly int SHADER_FADINGDISTANCE_PARAM_ID = Shader.PropertyToID("_FadeDistance");
-        public static readonly int SHADER_FADINGDISTANCE_START_PARAM_ID = Shader.PropertyToID("_StartFadeDistance");
+        public static readonly int SHADER_FADING_DISTANCE_PARAM_ID = Shader.PropertyToID("_FadeDistance");
+        public static readonly int SHADER_FADING_DISTANCE_START_PARAM_ID = Shader.PropertyToID("_StartFadeDistance");
+        public static readonly int SHADER_FADING_DISTANCE_END_PARAM_ID = Shader.PropertyToID("_EndFadeDistance");
+
 
 
     }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -22,15 +22,17 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         private Plane[] planes;
 
         private GameObject playerCamera;
-        private readonly float ditheringLimit;
 
-        public AvatarShapeVisibilitySystem(World world, IRendererFeaturesCache outlineFeature, float startFadeDithering) : base(world)
+        private readonly float startFadeDithering;
+        private readonly float endFadeDithering;
+
+        public AvatarShapeVisibilitySystem(World world, IRendererFeaturesCache outlineFeature, float startFadeDithering, float endFadeDithering) : base(world)
         {
             this.outlineFeature = outlineFeature.GetRendererFeature<OutlineRendererFeature>();
             planes = new Plane[6];
 
-            //Add a small delta to be able to avoid rounding problems
-            ditheringLimit = startFadeDithering + 0.1f;
+            this.startFadeDithering = startFadeDithering;
+            this.endFadeDithering = endFadeDithering;
         }
 
         public override void Initialize()
@@ -93,21 +95,21 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         }
 
         [Query]
-        private void UpdateMainPlayerAvatarVisibilityOnCameraDistance(in AvatarCustomSkinningComponent skinningComponent, in PlayerComponent playerComponent)
+        private void UpdateMainPlayerAvatarVisibilityOnCameraDistance(in AvatarCustomSkinningComponent skinningComponent, in PlayerComponent playerComponent, ref AvatarCachedVisibilityComponent avatarCachedVisibility)
         {
             float currentDistance = (playerComponent.CameraFocus.position - playerCamera.transform.position).magnitude;
 
-            if (currentDistance <= ditheringLimit)
+            if (avatarCachedVisibility.ShouldUpdateDitherState(currentDistance, startFadeDithering, endFadeDithering))
                 skinningComponent.SetFadingDistance(currentDistance);
         }
 
         [Query]
         [None(typeof(PlayerComponent))]
-        private void UpdateNonPlayerAvatarVisibilityOnCameraDistance(in AvatarCustomSkinningComponent skinningComponent, in AvatarBase avatarBase)
+        private void UpdateNonPlayerAvatarVisibilityOnCameraDistance(in AvatarCustomSkinningComponent skinningComponent, in AvatarBase avatarBase, ref AvatarCachedVisibilityComponent avatarCachedVisibility)
         {
             float currentDistance = (avatarBase.HeadAnchorPoint.position - playerCamera.transform.position).magnitude;
 
-            if (currentDistance <= ditheringLimit)
+            if (avatarCachedVisibility.ShouldUpdateDitherState(currentDistance, startFadeDithering, endFadeDithering))
                 skinningComponent.SetFadingDistance(currentDistance);
         }
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -95,8 +95,14 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         }
 
         [Query]
-        private void UpdateMainPlayerAvatarVisibilityOnCameraDistance(in AvatarCustomSkinningComponent skinningComponent, in PlayerComponent playerComponent, ref AvatarCachedVisibilityComponent avatarCachedVisibility)
+        private void UpdateMainPlayerAvatarVisibilityOnCameraDistance(in AvatarCustomSkinningComponent skinningComponent, in PlayerComponent playerComponent, ref AvatarCachedVisibilityComponent avatarCachedVisibility, ref AvatarShapeComponent avatarShapeComponent)
         {
+            if (avatarShapeComponent.IsDirty)
+            {
+                avatarCachedVisibility.ResetDitherState();
+                return;
+            }
+
             float currentDistance = (playerComponent.CameraFocus.position - playerCamera.transform.position).magnitude;
 
             if (avatarCachedVisibility.ShouldUpdateDitherState(currentDistance, startFadeDithering, endFadeDithering))
@@ -105,8 +111,14 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
 
         [Query]
         [None(typeof(PlayerComponent))]
-        private void UpdateNonPlayerAvatarVisibilityOnCameraDistance(in AvatarCustomSkinningComponent skinningComponent, in AvatarBase avatarBase, ref AvatarCachedVisibilityComponent avatarCachedVisibility)
+        private void UpdateNonPlayerAvatarVisibilityOnCameraDistance(in AvatarCustomSkinningComponent skinningComponent, in AvatarBase avatarBase, ref AvatarCachedVisibilityComponent avatarCachedVisibility, ref AvatarShapeComponent avatarShapeComponent)
         {
+            if (avatarShapeComponent.IsDirty)
+            {
+                avatarCachedVisibility.ResetDitherState();
+                return;
+            }
+
             float currentDistance = (avatarBase.HeadAnchorPoint.position - playerCamera.transform.position).magnitude;
 
             if (avatarCachedVisibility.ShouldUpdateDitherState(currentDistance, startFadeDithering, endFadeDithering))

--- a/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
@@ -215,19 +215,26 @@ namespace DCL.PluginSystem.Global
 
         private async UniTask CreateMaterialPoolPrewarmedAsync(AvatarShapeSettings settings, CancellationToken ct)
         {
-            ProvidedAsset<Material> toonMaterial = await assetsProvisioner.ProvideMainAssetAsync(settings.CelShadingMaterial, ct: ct);
-            ProvidedAsset<Material> faceFeatureMaterial = await assetsProvisioner.ProvideMainAssetAsync(settings.FaceFeatureMaterial, ct: ct);
+            Material toonMaterial = (await assetsProvisioner.ProvideMainAssetAsync(settings.CelShadingMaterial, ct: ct)).Value;
+            Material faceFeatureMaterial = (await assetsProvisioner.ProvideMainAssetAsync(settings.FaceFeatureMaterial, ct: ct)).Value;
+
+#if UNITY_EDITOR
+
+            //Avoid generating noise in editor git by creating a copy of the material
+            toonMaterial = new Material(toonMaterial);
+            faceFeatureMaterial = new Material(faceFeatureMaterial);
+#endif
 
             //Set initial dither properties obtained through settings
-            toonMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_START_PARAM_ID, startFadeDistanceDithering);
-            faceFeatureMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_START_PARAM_ID, startFadeDistanceDithering);
+            toonMaterial.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_START_PARAM_ID, startFadeDistanceDithering);
+            faceFeatureMaterial.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_START_PARAM_ID, startFadeDistanceDithering);
 
-            toonMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_END_PARAM_ID, endFadeDistanceDithering);
-            faceFeatureMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_PARAM_ID, startFadeDistanceDithering);
+            toonMaterial.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_END_PARAM_ID, endFadeDistanceDithering);
+            faceFeatureMaterial.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_PARAM_ID, startFadeDistanceDithering);
 
             avatarMaterialPoolHandler = new AvatarMaterialPoolHandler(new List<Material>
             {
-                toonMaterial.Value, faceFeatureMaterial.Value
+                toonMaterial, faceFeatureMaterial,
             }, settings.defaultMaterialCapacity, textureArrayContainerFactory);
         }
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
@@ -232,6 +232,10 @@ namespace DCL.PluginSystem.Global
             toonMaterial.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_END_PARAM_ID, endFadeDistanceDithering);
             faceFeatureMaterial.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_PARAM_ID, startFadeDistanceDithering);
 
+            //Default should be visible
+            toonMaterial.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_PARAM_ID, startFadeDistanceDithering);
+            faceFeatureMaterial.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_PARAM_ID, startFadeDistanceDithering);
+
             avatarMaterialPoolHandler = new AvatarMaterialPoolHandler(new List<Material>
             {
                 toonMaterial, faceFeatureMaterial,

--- a/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
@@ -79,6 +79,8 @@ namespace DCL.PluginSystem.Global
         private readonly AvatarTransformMatrixJobWrapper avatarTransformMatrixJobWrapper;
 
         private float startFadeDistanceDithering;
+        private float endFadeDistanceDithering;
+
 
         public AvatarPlugin(
             IComponentPoolsRegistry poolsRegistry,
@@ -130,6 +132,7 @@ namespace DCL.PluginSystem.Global
         {
             chatBubbleConfiguration = (await assetsProvisioner.ProvideMainAssetAsync(settings.ChatBubbleConfiguration, ct)).Value;
             startFadeDistanceDithering = settings.startFadeDistanceDithering;
+            endFadeDistanceDithering = settings.endFadeDistanceDithering;
 
             await CreateAvatarBasePoolAsync(settings, ct);
             await CreateNametagPoolAsync(settings, ct);
@@ -168,7 +171,7 @@ namespace DCL.PluginSystem.Global
             FinishAvatarMatricesCalculationSystem.InjectToWorld(ref builder, skinningStrategy,
                 avatarTransformMatrixJobWrapper);
 
-            AvatarShapeVisibilitySystem.InjectToWorld(ref builder, rendererFeaturesCache, startFadeDistanceDithering);
+            AvatarShapeVisibilitySystem.InjectToWorld(ref builder, rendererFeaturesCache, startFadeDistanceDithering, endFadeDistanceDithering);
             AvatarCleanUpSystem.InjectToWorld(ref builder, frameTimeCapBudget, vertOutBuffer, avatarMaterialPoolHandler,
                 avatarPoolRegistry, computeShaderPool, attachmentsAssetsCache, mainPlayerAvatarBaseProxy,
                 avatarTransformMatrixJobWrapper);
@@ -216,11 +219,11 @@ namespace DCL.PluginSystem.Global
             ProvidedAsset<Material> faceFeatureMaterial = await assetsProvisioner.ProvideMainAssetAsync(settings.FaceFeatureMaterial, ct: ct);
 
             //Set initial dither properties obtained through settings
-            toonMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADINGDISTANCE_START_PARAM_ID, startFadeDistanceDithering);
-            faceFeatureMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADINGDISTANCE_START_PARAM_ID, startFadeDistanceDithering);
+            toonMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_START_PARAM_ID, startFadeDistanceDithering);
+            faceFeatureMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_START_PARAM_ID, startFadeDistanceDithering);
 
-            toonMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADINGDISTANCE_PARAM_ID, startFadeDistanceDithering);
-            faceFeatureMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADINGDISTANCE_PARAM_ID, startFadeDistanceDithering);
+            toonMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_END_PARAM_ID, endFadeDistanceDithering);
+            faceFeatureMaterial.Value.SetFloat(ComputeShaderConstants.SHADER_FADING_DISTANCE_PARAM_ID, startFadeDistanceDithering);
 
             avatarMaterialPoolHandler = new AvatarMaterialPoolHandler(new List<Material>
             {
@@ -260,6 +263,9 @@ namespace DCL.PluginSystem.Global
 
             [field: SerializeField]
             public float startFadeDistanceDithering = 2;
+
+            [field: SerializeField]
+            public float endFadeDistanceDithering = 0.8f;
 
             [field: SerializeField]
             public int defaultMaterialCapacity = 100;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?


When introducing this optimization, I introduced a bug which keeps transparency while doing abrupt changes (something that happened while teleport).

This improves the robustness of the solution through an enum, while keeping the performance optimization.

<img width="1728" alt="Screenshot 2025-03-10 at 8 12 22 AM" src="https://github.com/user-attachments/assets/15196ce3-693e-453f-a375-e95eba3ef57f" />



## Test Instructions


### Test Steps
1. Teleport while having dithering. You should be opaque when getting to destination
2. Teleport transparent. You should be transparent when getting to the destination
3. Instantiate 50 avatars in `olavra.dcl.eth`. Check that dithering is fine
4. On a peer, change a wearable and see that transprency works as expected


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
