### PR TITLE
fix: missing texturefuse compression failure fallback

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
@@ -63,7 +63,7 @@ namespace DCL.WebRequests
                 return ExecuteNoCompressionAsync(webRequest, ct);
             }
 
-            private async UniTask<IOwnedTexture2D?> ExecuteNoCompressionAsync(GetTextureWebRequest webRequest, CancellationToken ct)
+            private UniTask<IOwnedTexture2D> ExecuteNoCompressionAsync(GetTextureWebRequest webRequest, CancellationToken ct)
             {
                 Texture2D? texture;
 
@@ -90,7 +90,7 @@ namespace DCL.WebRequests
                 texture.filterMode = filterMode;
                 texture.SetDebugName(webRequest.url);
                 ProfilingCounters.TexturesAmount.Value++;
-                return new IOwnedTexture2D.Const(texture);
+                return UniTask.FromResult((IOwnedTexture2D)new IOwnedTexture2D.Const(texture));
             }
 
             private async UniTask<IOwnedTexture2D?> ExecuteWithCompressionAsync(GetTextureWebRequest webRequest, CancellationToken ct)

--- a/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
@@ -60,17 +60,37 @@ namespace DCL.WebRequests
                 if (webRequest.isTextureCompressionEnabled)
                     return ExecuteWithCompressionAsync(webRequest, ct);
 
-                return ExecuteNoCompressionAsync(webRequest, ct)!;
+                return ExecuteNoCompressionAsync(webRequest, ct);
             }
 
-            private UniTask<IOwnedTexture2D> ExecuteNoCompressionAsync(GetTextureWebRequest webRequest, CancellationToken ct)
+            private async UniTask<IOwnedTexture2D?> ExecuteNoCompressionAsync(GetTextureWebRequest webRequest, CancellationToken ct)
             {
-                Texture2D? texture = DownloadHandlerTexture.GetContent(webRequest.UnityWebRequest);
+                Texture2D? texture;
+
+                if (webRequest.UnityWebRequest.downloadHandler is DownloadHandlerTexture)
+                {
+                    texture = DownloadHandlerTexture.GetContent(webRequest.UnityWebRequest);
+                }
+                else
+                {
+                    // If there's no DownloadHandlerTexture the texture needs to be created from scratch with the
+                    // downloaded tex data
+                    var data = webRequest.UnityWebRequest.downloadHandler?.data;
+                    if (data == null)
+                        throw new Exception("Texture content is empty");
+
+                    texture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+                    if (!texture.LoadImage(data))
+                    {
+                        throw new Exception($"Failed to load image from data: {webRequest.url}");
+                    }
+                }
+
                 texture.wrapMode = wrapMode;
                 texture.filterMode = filterMode;
                 texture.SetDebugName(webRequest.url);
                 ProfilingCounters.TexturesAmount.Value++;
-                return UniTask.FromResult((IOwnedTexture2D)new IOwnedTexture2D.Const(texture));
+                return new IOwnedTexture2D.Const(texture);
             }
 
             private async UniTask<IOwnedTexture2D?> ExecuteWithCompressionAsync(GetTextureWebRequest webRequest, CancellationToken ct)
@@ -89,8 +109,9 @@ namespace DCL.WebRequests
                                                   ct
                                               );
 
+                // Fallback to uncompressed texture if compression fails
                 if (result.Success == false)
-                    throw new Exception($"CreateTextureOp: Error loading texture url: {webRequest.url} - {result}");
+                    return await ExecuteNoCompressionAsync(webRequest, ct);
 
                 var texture = result.Value.Texture;
 


### PR DESCRIPTION
### WHY

Currently only MacOS has runtime texture compression enabled for non-asset-bundle textures.

When in Local Scene Development, creators use raw textures and some of them may fail while TextureFuse library tries to compress them, in that scenario the texture is left as `null` instead of continue using the uncompressed texture as fallback.

### WHAT

Fixed our usage of TextureFuse compression to fallback to using the uncompressed texture when compresison fails.

Fixes https://github.com/decentraland/creator-hub/issues/499

### TEST INSTRUCTIONS

Since runtime tex compression is only enabled for MacOS, **it only makes sense to test this PR on MacOS**.

1. Download [this test scene](https://github.com/user-attachments/files/19168072/light-memory-leak-test-main.zip) and uncomperss it somewhere
2. Enter the scene root folder and run `npm i` and then `npm run start -- --explorer-alpha`
3. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
4. Download the build from this PR and connect it to the running scene using running it from a new terminal like: `open Decentraland.app --args --realm http://127.0.0.1:8000 --position 0,0 --local-scene true --debug`
5. Check [the issue](https://github.com/decentraland/unity-explorer/pull/3546) description to confirm that now you see the expected shadowmask behaviour