### PR TITLE
enable keywords on parent in editor

### DIFF
--- a/Explorer/Assets/DCL/Rendering/GPUInstancing/InstancingData/GPUInstancingMaterialsCache.cs
+++ b/Explorer/Assets/DCL/Rendering/GPUInstancing/InstancingData/GPUInstancingMaterialsCache.cs
@@ -19,10 +19,20 @@ namespace DCL.Rendering.GPUInstancing.InstancingData
                 ReportHub.Log(ReportCategory.GPU_INSTANCING, $"Creating new GPU Instanced sharedMaterial based on material: {sharedMat.name}");
 
                 var keyword = new LocalKeyword(sharedMat.shader, GPU_INSTANCING_KEYWORD);
-                sharedMat.DisableKeyword(keyword);
 
-                instancedMat = new Material(sharedMat) { name = $"{sharedMat.name}_GPUInstancingIndirect" };
+                if (Application.isEditor && sharedMat.parent != null)
+                {
+                    sharedMat.parent.EnableKeyword(keyword);
+
+                    instancedMat = new Material(sharedMat.parent.shader);
+                    instancedMat.CopyPropertiesFromMaterial(sharedMat);
+                }
+                else
+                    instancedMat = new Material(sharedMat) { name = $"{sharedMat.name}_GPUInstancingIndirect" };
+
+                sharedMat.DisableKeyword(keyword);
                 instancedMat.EnableKeyword(keyword);
+
                 instancingMaterials.Add(sharedMat, instancedMat);
             }
 

--- a/Explorer/Assets/DCL/Rendering/GPUInstancing/InstancingData/GPUInstancingMaterialsCache.cs
+++ b/Explorer/Assets/DCL/Rendering/GPUInstancing/InstancingData/GPUInstancingMaterialsCache.cs
@@ -19,16 +19,17 @@ namespace DCL.Rendering.GPUInstancing.InstancingData
                 ReportHub.Log(ReportCategory.GPU_INSTANCING, $"Creating new GPU Instanced sharedMaterial based on material: {sharedMat.name}");
 
                 var keyword = new LocalKeyword(sharedMat.shader, GPU_INSTANCING_KEYWORD);
+                instancedMat = new Material(sharedMat) { name = $"{sharedMat.name}_GPUInstancingIndirect" };
 
-                if (Application.isEditor && sharedMat.parent != null)
+#if UNITY_EDITOR
+                if (sharedMat.parent != null)
                 {
                     sharedMat.parent.EnableKeyword(keyword);
 
                     instancedMat = new Material(sharedMat.parent.shader);
                     instancedMat.CopyPropertiesFromMaterial(sharedMat);
                 }
-                else
-                    instancedMat = new Material(sharedMat) { name = $"{sharedMat.name}_GPUInstancingIndirect" };
+#endif
 
                 sharedMat.DisableKeyword(keyword);
                 instancedMat.EnableKeyword(keyword);

--- a/Explorer/Assets/DCL/Roads/Settings/IRoadSettingsAsset.cs
+++ b/Explorer/Assets/DCL/Roads/Settings/IRoadSettingsAsset.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using UnityEngine;
 using UnityEngine.AddressableAssets;
 
 namespace DCL.Roads.Settings

--- a/Explorer/Assets/DCL/Roads/Settings/RoadSettingsAsset.cs
+++ b/Explorer/Assets/DCL/Roads/Settings/RoadSettingsAsset.cs
@@ -23,7 +23,6 @@ namespace DCL.Roads.Settings
         IReadOnlyList<RoadDescription> IRoadSettingsAsset.RoadDescriptions => RoadDescriptions;
         IReadOnlyList<AssetReferenceGameObject> IRoadSettingsAsset.RoadAssetsReference => RoadAssetsReference;
 
-
 #if UNITY_EDITOR
         public void CollectGPUInstancingLODGroups(Vector2Int min, Vector2Int max)
         {


### PR DESCRIPTION
# Pull Request Description
In Editor material variants were creating errors for missing keywords. I added simple in-Editor workaround for that

### Test Steps
1. Verify that roads, bushes and grass are rendered as on dev 

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
