### PR TITLE
fix: threadsafe pool

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/ThreadSafePool/ThreadSafeObjectPool.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/ThreadSafePool/ThreadSafeObjectPool.cs
@@ -33,7 +33,11 @@ namespace DCL.Optimization.ThreadSafePool
 
         public PooledObject<T> Get(out T v)
         {
-            lock (objectPoolImplementation) { return objectPoolImplementation.Get(out v); }
+            lock (objectPoolImplementation)
+            {
+                v = objectPoolImplementation.Get()!;
+                return new PooledObject<T>(v, this);
+            }
         }
 
         public void Release(T element)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

I've been getting weird Exceptions in HashNamings that uses ThreadSafePool for StringBuilder, after a research I found out that ThreadSafePool was not truly thread-safe because when `public PooledObject<T> Get(out T v)` is called the instance that PooledObject refers to is not thread-safe but is an underlying instance of `ExtendedObjectPool` which doesn't have any lock statement on its `Release()` implementation

Fixed by referring to the thread-safe object in `PooledObject`

```
NullReferenceException: Object reference not set to an instance of an object
ECS.StreamableLoading.Cache.Disk.HashNamings+<>c.<.cctor>b__2_1 (System.Text.StringBuilder sb) (at Assets/Scripts/ECS/StreamableLoading/Cache/Disk/HashNamings.cs:17)
UnityEngine.Pool.ObjectPool`1[T].Release (T element) (at /Users/bokken/build/output/unity/unity/Runtime/Export/ObjectPool/ObjectPools.cs:108)
UnityEngine.Pool.PooledObject`1[T].System.IDisposable.Dispose () (at /Users/bokken/build/output/unity/unity/Runtime/Export/ObjectPool/PooledObject.cs:33)
ECS.StreamableLoading.Cache.Disk.HashNamings.HashNameFrom (DCL.Optimization.Hashing.HashKey key, System.String extension) (at Assets/Scripts/ECS/StreamableLoading/Cache/Disk/HashNamings.cs:44)
ECS.StreamableLoading.AssetBundles.LoadAssetBundleSystem.ProcessCompletedDataAsync (ECS.StreamableLoading.Common.Components.StreamableLoadingState state, ECS.StreamableLoading.AssetBundles.GetAssetBundleIntention intention, ECS.Prioritization.Components.IPartitionComponent partition, System.Threading.CancellationToken ct) (at Assets/Scripts/ECS/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs:56)
Cysharp.Threading.Tasks.UniTask+ExceptionResultSource`1[T].GetResult (System.Int16 token) (at ./Library/PackageCache/com.cysharp.unitask@73d86259ce/Runtime/UniTask.Factory.cs:255)
Cysharp.Threading.Tasks.UniTask`1+Awaiter[T].GetResult () (at ./Library/PackageCache/com.cysharp.unitask@73d86259ce/Runtime/UniTask.cs:653)
ECS.StreamableLoading.Common.Systems.PartialDownloadSystemBase`2[TData,TIntention].FlowInternalAsync (TIntention intention, ECS.StreamableLoading.Common.Components.StreamableLoadingState state, ECS.Prioritization.Components.IPartitionComponent partition, System.Threading.CancellationToken ct) (at Assets/Scripts/ECS/StreamableLoading/Common/Systems/PartialDownloadSystemBase.cs:134)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1[TResult].GetResult (System.Int16 token) (at ./Library/PackageCache/com.cysharp.unitask@73d86259ce/Runtime/UniTaskCompletionSource.cs:244)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2[TStateMachine,T].GetResult (System.Int16 token) (at ./Library/PackageCache/com.cysharp.unitask@73d86259ce/Runtime/CompilerServices/StateMachineRunner.cs:342)
Cysharp.Threading.Tasks.UniTask`1+Awaiter[T].GetResult () (at ./Library/PackageCache/com.cysharp.unitask@73d86259ce/Runtime/UniTask.cs:653)
ECS.StreamableLoading.Common.Systems.AssetsLoadingUtility.RepeatLoopAsync[TIntention,TState,TAsset] (TIntention intention, TState state, ECS.Prioritization.Components.IPartitionComponent partition, ECS.StreamableLoading.Common.Systems.AssetsLoadingUtility+InternalFlowDelegate`3[TAsset,TState,TIntention] flow, DCL.Diagnostics.ReportData reportData, System.Threading.CancellationToken ct) (at Assets/Scripts/ECS/StreamableLoading/Common/Systems/AssetsLoadingUtility.cs:39)
Rethrow as EcsSystemException: [GLTF_CONTAINER] (-9, -9): [CreateGltfAssetFromAssetBundleSystem]
UnityEngine.DebugLogHandler:LogException(Exception, Object)
DCL.Diagnostics.DebugLogReportHandler:LogExceptionInternal(EcsSystemException) (at Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Handlers/DebugLogReportHandler.cs:91)
DCL.Diagnostics.DebugLogReportHandler:LogExceptionInternal(Exception, ReportData, Object) (at Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Handlers/DebugLogReportHandler.cs:102)
DCL.Diagnostics.ReportHandlerBase:LogException(Exception, ReportData, Object) (at Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Handlers/ReportHandlerBase.cs:49)
DCL.Diagnostics.ReportHubLogger:LogException(Exception, ReportData, ReportHandler) (at Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportHubLogger.cs:126)
DCL.Diagnostics.ReportHub:LogException(Exception, ReportData, ReportHandler) (at Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportHub.cs:153)
ECS.StreamableLoading.Common.Components.StreamableLoadingResult`1:.ctor(ReportData, Exception) (at Assets/Scripts/ECS/StreamableLoading/Common/Components/StreamableLoadingResult.cs:57)
ECS.Unity.GLTFContainer.Asset.Systems.CreateGltfAssetFromAssetBundleSystem:ConvertFromAssetBundle(Entity&, GetGltfContainerAssetIntention&, StreamableLoadingResult`1&) (at Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs:60)
ECS.Unity.GLTFContainer.Asset.Systems.CreateGltfAssetFromAssetBundleSystem:ConvertFromAssetBundleQuery(World) (at Arch.System.SourceGenerator/Arch.System.SourceGenerator.QueryGenerator/CreateGltfAssetFromAssetBundleSystem.ConvertFromAssetBundle(in Entity, ref GetGltfContainerAssetIntention, ref StreamableLoadingResult{AssetBundleData}).g.cs:37)
ECS.Unity.GLTFContainer.Asset.Systems.CreateGltfAssetFromAssetBundleSystem:Update(Single) (at Assets/Scripts/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs:39)
ECS.Abstract.BaseUnityLoopSystem:Update(Single&) (at Assets/Scripts/ECS/Abstract/BaseUnityLoopSystem.cs:56)
Arch.SystemGroups.ExecutionNode`1:Update(Single&, Boolean) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/ExecutionNode.cs:78)
Arch.SystemGroups.CustomGroupBase`1:UpdateInternal(Single&, Boolean) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/Groups/CustomGroupBase.cs:119)
Arch.SystemGroups.DefaultGroup`1:Update(Single&, Boolean) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/Groups/DefaultGroup.cs:46)
Arch.SystemGroups.ExecutionNode`1:Update(Single&, Boolean) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/ExecutionNode.cs:74)
Arch.SystemGroups.CustomGroupBase`1:UpdateInternal(Single&, Boolean) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/Groups/CustomGroupBase.cs:119)
ECS.Groups.SyncedGroup:Update(Single&, Boolean) (at Assets/Scripts/ECS/Groups/SyncedGroup.cs:72)
Arch.SystemGroups.ExecutionNode`1:Update(Single&, Boolean) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/ExecutionNode.cs:74)
Arch.SystemGroups.SystemGroup:Update(Info&) (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/SystemGroup.cs:107)
Arch.SystemGroups.DefaultSystemGroups.PresentationSystemGroup:Update() (at ./Library/PackageCache/com.arch.systemgroups@bd58275fb1/DefaultSystemGroups/PresentationSystemGroup.cs:23)
ECS.Prioritization.PartitionedWorldsAggregate:TriggerUpdate() (at Assets/Scripts/ECS/Prioritization/PartitionedWorldsAggregate.cs:42)
```


## Test Instructions

### Test Steps
1. Everything works as before

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [+] Changes have been tested locally

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
