### PR TITLE
Fix: Meta GamiMall | player pushed out of platform

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/InterpolateCharacterSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/InterpolateCharacterSystem.cs
@@ -2,7 +2,6 @@
 using Arch.System;
 using Arch.SystemGroups;
 using DCL.Character.CharacterMotion.Components;
-using DCL.CharacterCamera;
 using DCL.CharacterMotion.Components;
 using DCL.CharacterMotion.Platforms;
 using DCL.CharacterMotion.Settings;
@@ -61,11 +60,12 @@ namespace DCL.CharacterMotion.Systems
 
             Vector3 slopeModifier = ApplySlopeModifier.Execute(in settings, in rigidTransform, in movementInput, in jump, characterController, dt);
 
+            characterController.transform.position += rigidTransform.PlatformDelta;
+            Physics.SyncTransforms();
             CollisionFlags collisionFlags = characterController.Move(
                 movementDelta
                 + gravityDelta
-                + slopeModifier
-                + rigidTransform.PlatformDelta);
+                + slopeModifier);
 
             Vector3 deltaMovement = characterTransform.position - prevPos;
             bool hasGroundedFlag = deltaMovement.y <= 0 && EnumUtils.HasFlag(collisionFlags, CollisionFlags.Below);


### PR DESCRIPTION
# Pull Request Description
Fix #3378 

FPS drops were causing issue of player being pushed from the platform. It was because application of platform delta between these 2 frames was done via characterController.Move

## What does this PR change?
- similarly to web explorer, changed application of platform delta from `characterController.Move` to direct application to the position

## Test Instructions
To easily test it you need to create FPS drop. This can be achieved by repositioning application in the OS when it is in Windowed mode (dragging it by the top bar)

### Test Steps
1. Go to Meta GamiMall  - `/goto 147,60`
2. Start the pad and stay on it while it is going through the track
3. Make FPS drop 
4. Verify that you avatar is always presented on the pad and FPS lags are not pushing it away from it

### Additional Testing Notes
- Pad is not alligning its direction to the track direction, so on the spiral path your position feel is also not aligned. But on the straight paths it can be more clearly verified that you stays on the same position on the pad

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
