### PR TITLE
fix: correct enforce-approvals conditions

### DIFF
--- a/.github/workflows/enforce-group-approvals.yml
+++ b/.github/workflows/enforce-group-approvals.yml
@@ -12,7 +12,6 @@ jobs:
     if: >
       github.event.pull_request.draft == false &&
       github.event.review.state != 'changes_requested' &&
-      github.event.review.state != 'commented' &&
       github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
- remove `commented` state condition from if condition since it was causing to skip merge restrictions