### PR TITLE
Fix: 3 Unread Messages Badge Appears Randomly on App Start (#3570)

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -168,6 +168,7 @@ namespace DCL.Chat
             // Intro message
             // TODO: Use localization systems here:
             chatHistory.AddMessage(ChatChannel.NEARBY_CHANNEL, ChatMessage.NewFromSystem("Type /help for available commands."));
+            chatHistory.Channels[ChatChannel.NEARBY_CHANNEL].MarkAllMessagesAsRead();
 
             memberListCts = new CancellationTokenSource();
             UniTask.RunOnThreadPool(UpdateMembersDataAsync);

--- a/Explorer/Assets/DCL/Chat/ChatView.cs
+++ b/Explorer/Assets/DCL/Chat/ChatView.cs
@@ -528,6 +528,10 @@ namespace DCL.Chat
 
                 chatMessageViewer.ShowItem(chatMessageViewer.CurrentSeparatorIndex - 1); // It shows the first of the unread messages at least
 
+                // Corner case: The new line is visible without doing scroll, and is positioned at the top of the message list
+                if(IsScrollAtBottom && chatMessageViewer.CurrentSeparatorIndex >= currentChannel.Messages.Count - 2) // -2: There is a padding message at the top of the list, the separator will be beneath it
+                    chatMessageViewer.HideSeparator();
+
                 SetScrollToBottomVisibility(!IsScrollAtBottom);
 
                 if (chatMessageViewer.IsScrollAtBottom)

--- a/Explorer/Assets/DCL/Chat/History/ChatChannel.cs
+++ b/Explorer/Assets/DCL/Chat/History/ChatChannel.cs
@@ -120,6 +120,7 @@ namespace DCL.Chat.History
                 // Adding two elements to count as top and bottom padding
                 messages.Add(new ChatMessage(true));
                 messages.Add(new ChatMessage(true));
+                readMessages = 2; // both paddings
             }
 
             // Removing padding element and reversing list due to infinite scroll view behaviour


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

The padding messages were being considered as unread messages.
Additionally, now the conversation is set as read in the beginning.
The NEW line is now not shown when the messages are all visible and the line would be at the top.

## Test Instructions

### Test Steps
1. Enter Decentraland.
2. Once you are in Genesis Plaza, there must not be any unread message.

## Quality Checklist
- [x] Changes have been tested locally