### PR TITLE
Fix: Analytics | missing IP Address in the context of messages

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsController.cs
@@ -22,6 +22,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
         public AnalyticsController(
             IAnalyticsService analyticsService,
+            UserIPAddressService userIPAddressService,
             IAppArgs appArgs,
             AnalyticsConfiguration configuration,
             LauncherTraits launcherTraits,
@@ -35,7 +36,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
             SessionID = !string.IsNullOrEmpty(launcherTraits.SessionId) ? launcherTraits.SessionId : SystemInfo.deviceUniqueIdentifier + DateTime.Now.ToString("yyyyMMddHHmmssfff");
 
-            analytics.AddPlugin(new StaticCommonTraitsPlugin(appArgs, SessionID, launcherTraits.LauncherAnonymousId, buildData, dclVersion));
+            analytics.AddPlugin(new StaticCommonTraitsPlugin(appArgs, userIPAddressService, SessionID, launcherTraits.LauncherAnonymousId, buildData, dclVersion));
         }
 
         public void Initialize(IWeb3Identity? web3Identity)

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/BuildData/BuildData.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/BuildData/BuildData.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace DCL.PerformanceAndDiagnostics.Analytics
 {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DCL.Analytics.asmdef
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DCL.Analytics.asmdef
@@ -13,7 +13,9 @@
         "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b",
         "GUID:166b65e6dfc848bb9fb075f53c293a38",
         "GUID:c6e727f7851314e679212856f4ce3e53",
-        "GUID:04e9a70e2a3843908ecb2c5135189184"
+        "GUID:04e9a70e2a3843908ecb2c5135189184",
+        "GUID:4a12c0b1b77ec6b418a8d7bd5c925be3",
+        "GUID:8322ea9340a544c59ddc56d4793eac74"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Playgrounds/DCL.Analytics.Playgrounds.asmdef
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Playgrounds/DCL.Analytics.Playgrounds.asmdef
@@ -15,7 +15,8 @@
         "GUID:e11871a9242c44ec98ed3459ff7781d9",
         "GUID:8baf705856414dad9a73b3f382f1bc8b",
         "GUID:ecd9230b77a12534cbb829d1b5fcd665",
-        "GUID:04e9a70e2a3843908ecb2c5135189184"
+        "GUID:04e9a70e2a3843908ecb2c5135189184",
+        "GUID:4a12c0b1b77ec6b418a8d7bd5c925be3"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Playgrounds/PerformanceAnalyticsSystemPlayground.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Playgrounds/PerformanceAnalyticsSystemPlayground.cs
@@ -3,6 +3,7 @@ using DCL.Analytics.Systems;
 using DCL.PerformanceAndDiagnostics.Analytics.Services;
 using DCL.Profiling;
 using DCL.Utilities.Extensions;
+using DCL.WebRequests;
 using ECS;
 using ECS.SceneLifeCycle;
 using Global.AppArgs;
@@ -25,6 +26,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics.Playgrounds
                 World.Create(),
                 new AnalyticsController(
                     new DebugAnalyticsService(),
+                    new UserIPAddressService(IWebRequestController.DEFAULT),
                     new ApplicationParametersParser(),
                     analyticsConfiguration.EnsureNotNull(),
                     new LauncherTraits(),

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/UserIPAddressService.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/UserIPAddressService.cs
@@ -1,0 +1,96 @@
+﻿using CommunicationData.URLHelpers;
+using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
+using DCL.WebRequests;
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace DCL.PerformanceAndDiagnostics.Analytics
+{
+    public class UserIPAddressService
+    {
+        private const int REQUEST_TIMEOUT = 5;
+        private const int ATTEMPTS_COUNT = 1;
+
+        private readonly string[] ipv4Services = {
+            "https://checkip.amazonaws.com",
+            "https://api.ipify.org",
+            "https://api4.my-ip.io/ip",
+            "https://ipv4.icanhazip.com",
+            "https://ipinfo.io/ip",
+            "https://ip4.seeip.org",
+            "https://v4.ident.me/",
+            "https://ipv4.myexternalip.com/raw"
+        };
+
+        private readonly IWebRequestController webRequestController;
+
+        public string LocalIP { get; }
+        private string publicIP;
+
+        public UserIPAddressService(IWebRequestController webRequestController)
+        {
+            this.webRequestController = webRequestController;
+
+            LocalIP = GetLocalIPAddress();
+            publicIP = string.Empty;
+            GetPublicIPAddressAsync().Forget();
+        }
+
+        private static string GetLocalIPAddress()
+        {
+            IPHostEntry host = Dns.GetHostEntry(Dns.GetHostName());
+
+            foreach (IPAddress? ip in host.AddressList)
+                if (ip.AddressFamily == AddressFamily.InterNetwork)
+                    return ip.ToString();
+
+            return string.Empty;
+        }
+
+        public async UniTask<string> GetPublicIPAddressAsync(CancellationToken cancellationToken = default)
+        {
+            if (!string.IsNullOrEmpty(publicIP))
+                return publicIP;
+
+            foreach (string serviceUrl in ipv4Services)
+            {
+                try
+                {
+                    var commonArguments = new CommonArguments(
+                        URLAddress.FromString(serviceUrl),
+                        attemptsCount: ATTEMPTS_COUNT,
+                        timeout: REQUEST_TIMEOUT
+                    );
+
+                    publicIP = await webRequestController
+                                   .GetAsync(commonArguments, cancellationToken, ReportCategory.GENERIC_WEB_REQUEST)
+                                   .StoreTextAsync();
+
+                    if (!string.IsNullOrWhiteSpace(publicIP) && IsValidIPAddress(publicIP))
+                        return publicIP;
+
+                    publicIP = string.Empty;
+                }
+                catch (Exception ex)
+                {
+                    if (ex is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                        return string.Empty;
+
+                    ReportHub.LogWarning(ReportCategory.ANALYTICS, $"Failed to get IP from {serviceUrl}. Error: {ex.Message}");
+                }
+            }
+
+            ReportHub.LogWarning(ReportCategory.ANALYTICS, "Failed to get public IP address from any service");
+            return string.Empty;
+        }
+
+        private bool IsValidIPAddress(string ipAddress)
+        {
+            ipAddress = ipAddress.Trim();
+            return IPAddress.TryParse(ipAddress, out _);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/UserIPAddressService.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/UserIPAddressService.cs
@@ -69,7 +69,9 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
                                    .GetAsync(commonArguments, cancellationToken, ReportCategory.GENERIC_WEB_REQUEST)
                                    .StoreTextAsync();
 
-                    if (!string.IsNullOrWhiteSpace(publicIP) && IsValidIPAddress(publicIP))
+                    publicIP = publicIP.Trim('\r', '\n', ' ', '\t');
+
+                    if (!string.IsNullOrWhiteSpace(publicIP) && IPAddress.TryParse(publicIP, out _))
                         return publicIP;
 
                     publicIP = string.Empty;
@@ -85,12 +87,6 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
             ReportHub.LogWarning(ReportCategory.ANALYTICS, "Failed to get public IP address from any service");
             return string.Empty;
-        }
-
-        private bool IsValidIPAddress(string ipAddress)
-        {
-            ipAddress = ipAddress.Trim();
-            return IPAddress.TryParse(ipAddress, out _);
         }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/UserIPAddressService.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/UserIPAddressService.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 145f1c85216b449d8d163e9ea98fdd62
+timeCreated: 1741887774

--- a/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/Scripts/Global/Dynamic/BootstrapContainer.cs
@@ -165,7 +165,8 @@ namespace Global.Dynamic
                 LauncherTraits launcherTraits = LauncherTraits.FromAppArgs(appArgs);
                 IAnalyticsService service = CreateAnalyticsService(analyticsConfig, launcherTraits, container.ApplicationParametersParser, ct);
 
-                var analyticsController = new AnalyticsController(service, appArgs, analyticsConfig, launcherTraits, buildData, dclVersion);
+                UserIPAddressService publicUserIPAddressService = new UserIPAddressService(webRequestsContainer.WebRequestController);
+                var analyticsController = new AnalyticsController(service, publicUserIPAddressService, appArgs, analyticsConfig, launcherTraits, buildData, dclVersion);
                 var criticalLogsAnalyticsHandler = new CriticalLogsAnalyticsHandler(analyticsController);
 
                 return (new BootstrapAnalyticsDecorator(coreBootstrap, analyticsController), analyticsController);


### PR DESCRIPTION
# Pull Request Description
Fix #3240 

## What does this PR change?
- adds tracking for local and public user IP addresses in Analytics

### Test Steps
1. Verify you can load in the Genesis and see the world
2. Try to enter when using different VPNs 

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
