### PR TITLE
fix: update enforce-approvals trigger

### DIFF
--- a/.github/workflows/enforce-group-approvals.yml
+++ b/.github/workflows/enforce-group-approvals.yml
@@ -3,7 +3,7 @@ name: Enforce QA and DEV Approvals
 on:
   pull_request:
     branches: [dev]
-    types: [labeled, unlabeled]
+    types: [labeled, unlabeled, synchronize]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
- workflow will now trigger whenever commits are pushed to the PR branch (including when merging dev into it)