### PR TITLE
fix: align to specs profile component of passport's context menu

### DIFF
--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -207,7 +207,7 @@ namespace DCL.Passport
             notificationBusController.SubscribeToNotificationTypeReceived(NotificationType.BADGE_GRANTED, OnBadgeNotificationReceived);
             notificationBusController.SubscribeToNotificationTypeClick(NotificationType.BADGE_GRANTED, OnBadgeNotificationClicked);
 
-            userProfileContextMenuControlSettings = new UserProfileContextMenuControlSettings(ExecuteFriendshipOperationFromContextMenu);
+            userProfileContextMenuControlSettings = new UserProfileContextMenuControlSettings((_, _) => { });
         }
 
         private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index, Action<CameraReelResponseCompact> reelDeleteIntention) =>
@@ -566,26 +566,13 @@ namespace DCL.Passport
             contextMenuSeparator.Enabled = contextMenuJumpInButton.Enabled || contextMenuBlockUserButton.Enabled;
 
             userProfileContextMenuControlSettings.SetInitialData(profile.Name, profile.UserId, profile.HasClaimedName,
-                profile.UserNameColor, ConvertFriendshipStatus(friendshipStatus),
+                profile.UserNameColor, UserProfileContextMenuControlSettings.FriendshipStatus.DISABLED,
                 profile.Avatar.FaceSnapshotUrl);
         }
 
         private static void BlockUserClicked(string userId)
         {
             ReportHub.Log(LogType.Error, new ReportData(ReportCategory.FRIENDS), $"Block user button clicked for {userId}. Users should not be able to reach this");
-        }
-
-        private UserProfileContextMenuControlSettings.FriendshipStatus ConvertFriendshipStatus(FriendshipStatus friendshipStatus)
-        {
-            return friendshipStatus switch
-            {
-                FriendshipStatus.NONE => UserProfileContextMenuControlSettings.FriendshipStatus.NONE,
-                FriendshipStatus.FRIEND => UserProfileContextMenuControlSettings.FriendshipStatus.FRIEND,
-                FriendshipStatus.REQUEST_SENT => UserProfileContextMenuControlSettings.FriendshipStatus.REQUEST_SENT,
-                FriendshipStatus.REQUEST_RECEIVED => UserProfileContextMenuControlSettings.FriendshipStatus.REQUEST_RECEIVED,
-                FriendshipStatus.BLOCKED => UserProfileContextMenuControlSettings.FriendshipStatus.BLOCKED,
-                _ => UserProfileContextMenuControlSettings.FriendshipStatus.NONE
-            };
         }
 
         private void ShowMutualFriends()
@@ -635,20 +622,6 @@ namespace DCL.Passport
             viewInstance.AddFriendButton.gameObject.SetActive(false);
             viewInstance.CancelFriendButton.gameObject.SetActive(false);
             viewInstance.RemoveFriendButton.gameObject.SetActive(false);
-        }
-
-        private void ExecuteFriendshipOperationFromContextMenu(string profile,
-            UserProfileContextMenuControlSettings.FriendshipStatus friendshipStatus)
-        {
-            switch (friendshipStatus)
-            {
-                case UserProfileContextMenuControlSettings.FriendshipStatus.REQUEST_SENT:
-                    CancelFriendRequest();
-                    break;
-                case UserProfileContextMenuControlSettings.FriendshipStatus.REQUEST_RECEIVED:
-                    AcceptFriendship();
-                    break;
-            }
         }
 
         private void RemoveFriend()


### PR DESCRIPTION
# Pull Request Description

Fixes #3525 

According to specs, the interaction button of the profile component of the passport context menu should't allow to interact with the friendship status

<img width="731" alt="image" src="https://github.com/user-attachments/assets/7a0fc2f3-0dfe-44bd-8e5d-dd78aa228d31" />


## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR removes the button in the component in order to align the E@ to the specs

<img width="297" alt="image" src="https://github.com/user-attachments/assets/61a53446-1859-4e46-bb1f-cb95547e3499" />


## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Launch the E@ and verify that the profile component of the Passport's context menu never (regardless the friendship status) has the button to interact with the friendship with that person


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
