### PR TITLE
Fix: avoid delay in starting media stream

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/OpenMediaPromise.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/OpenMediaPromise.cs
@@ -3,6 +3,7 @@ using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.WebRequests;
 using System.Threading;
+using UnityEngine.Networking;
 
 namespace DCL.SDKComponents.MediaStream
 {
@@ -27,14 +28,37 @@ namespace DCL.SDKComponents.MediaStream
             isReachable = false;
             this.url = url;
 
-            isReachable = await webRequestController.IsHeadReachableAsync(reportData, URLAddress.FromString(this.url), ct);
+            isReachable = await webRequestController.IsHeadReachableAsync(reportData, URLAddress.FromString(this.url), ct, 5);
             //This is needed because some servers might not handle HEAD requests correctly and return 404 errors, even thou they are perfectly
             if (!isReachable)
-                isReachable = await webRequestController.IsGetReachableAsync(reportData, URLAddress.FromString(this.url), ct);
+                isReachable = await IsGetReachableAsync(ct);
 
             ReportHub.Log(ReportCategory.MEDIA_STREAM, $"Resource <{url}> isReachable = <{isReachable}>");
 
             status = Status.Resolved;
+        }
+
+        /*The following function is a temporary workardound for Issue #2485
+         *The streaming server was taking 3 minutes to fail with timeout in the IsHeadReachableAsync method, by adding a timeout it was getting stuck
+         *in the previous IsGetReachable async that was performing a get request, starting the stream and never ending
+         *There was no other way other then the new UnityWebRequest to start the request with the webrequestcontroller and interrupt it after a few bytes were received
+         * This will be soon replaced by the integration of HTTP2 library that will provide a clearer way to solve the problem
+         */
+        private async UniTask<bool> IsGetReachableAsync(CancellationToken ct)
+        {
+            UnityWebRequest isGetReachableRequest = UnityWebRequest.Get(this.url);
+            isGetReachableRequest.SendWebRequest().ToUniTask(cancellationToken: ct);
+
+            while (isGetReachableRequest.downloadedBytes == 0)
+            {
+                if (!string.IsNullOrEmpty(isGetReachableRequest.error))
+                    return false;
+
+                await UniTask.Yield();
+            }
+
+            isGetReachableRequest.Abort();
+            return true;
         }
 
         public bool IsReachableConsume(string url)

--- a/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
@@ -161,11 +161,11 @@ namespace DCL.WebRequests
             WebRequestSignInfo? signInfo = null) where TOp: struct, IWebRequestOp<GenericHeadRequest, TResult> =>
             controller.SendAsync<GenericHeadRequest, GenericHeadArguments, TOp, TResult>(commonArguments, arguments, webRequestOp, ct, reportCategory, headersInfo, signInfo);
 
-        public static async UniTask<bool> IsHeadReachableAsync(this IWebRequestController controller, ReportData reportData, URLAddress url, CancellationToken ct)
+        public static async UniTask<bool> IsHeadReachableAsync(this IWebRequestController controller, ReportData reportData, URLAddress url, CancellationToken ct, int timeout = 0)
         {
             await UniTask.SwitchToMainThread();
 
-            try { await HeadAsync<WebRequestUtils.NoOp<GenericHeadRequest>, WebRequestUtils.NoResult>(controller, new CommonArguments(url), new WebRequestUtils.NoOp<GenericHeadRequest>(), default(GenericHeadArguments), ct, reportData); }
+            try { await HeadAsync<WebRequestUtils.NoOp<GenericHeadRequest>, WebRequestUtils.NoResult>(controller, new CommonArguments(url, timeout: timeout, attemptsCount: 1), new WebRequestUtils.NoOp<GenericHeadRequest>(), default(GenericHeadArguments), ct, reportData); }
             catch (UnityWebRequestException unityWebRequestException)
             {
                 // Endpoint was unreacheable


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #2485
This PR allows a faster fail when trying to validate if a remote media stream resource is reachable or not.
On the technical side:
It adds a max timout of 5 seconds when trying to perform a head request as some servers that did not support that took 3+ minutes to return a gateway timout.
It also introduces a sample request that returns true if a few bytes are returned by the second request done to validate if a resource is available or not, to avoid getting a deadlock of a get request opening a stream

## Test Instructions


### Test Steps
1. Validate that the audio stream in 14,100 doesn't take 3+ minutes to start
2. Validate that video and audio streams in other scenes are working as before
