### PR TITLE
feat: fade transition at profile pictures

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/ViewDependencies.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/ViewDependencies.cs
@@ -27,10 +27,13 @@ namespace MVC
         private readonly IProfileRepository profileRepository;
         private readonly IRemoteMetadata remoteMetadata;
 
-        public async UniTask<Sprite> GetThumbnailAsync(string userId, string thumbnailUrl, CancellationToken ct) =>
+        public async UniTask<Sprite?> GetThumbnailAsync(string userId, string thumbnailUrl, CancellationToken ct) =>
             await thumbnailCache.GetThumbnailAsync(userId, thumbnailUrl, ct);
 
-        public async UniTask<Profile> GetProfileAsync(string walletId, CancellationToken ct) =>
+        public Sprite? GetSprite(string userId) =>
+            thumbnailCache.GetThumbnail(userId);
+
+        public async UniTask<Profile?> GetProfileAsync(string walletId, CancellationToken ct) =>
             await profileRepository.GetAsync(walletId, 0, remoteMetadata.GetLambdaDomainOrNull(walletId), ct);
 
         public ViewDependencies(DCLInput dclInput, IEventSystem eventSystem, IMVCManagerMenusAccessFacade globalUIViews, IClipboardManager clipboardManager, ICursor cursor,

--- a/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/ViewDependencies.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/ViewDependencies.cs
@@ -27,10 +27,10 @@ namespace MVC
         private readonly IProfileRepository profileRepository;
         private readonly IRemoteMetadata remoteMetadata;
 
-        public async UniTask<Sprite?> GetThumbnailAsync(string userId, string thumbnailUrl, CancellationToken ct) =>
+        public async UniTask<Sprite?> GetProfileThumbnailAsync(string userId, string thumbnailUrl, CancellationToken ct) =>
             await thumbnailCache.GetThumbnailAsync(userId, thumbnailUrl, ct);
 
-        public Sprite? GetSprite(string userId) =>
+        public Sprite? GetProfileThumbnail(string userId) =>
             thumbnailCache.GetThumbnail(userId);
 
         public async UniTask<Profile?> GetProfileAsync(string walletId, CancellationToken ct) =>

--- a/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/csc.rsp
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable

--- a/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/csc.rsp.meta
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/csc.rsp.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f41d7734838848349f04f0a2d8d34b48
+timeCreated: 1742318202

--- a/Explorer/Assets/DCL/Profiles/IProfileThumbnailCache.cs
+++ b/Explorer/Assets/DCL/Profiles/IProfileThumbnailCache.cs
@@ -6,6 +6,7 @@ namespace DCL.Profiles
 {
     public interface IProfileThumbnailCache
     {
+        Sprite? GetThumbnail(string userId);
         UniTask<Sprite?> GetThumbnailAsync(string userId, string thumbnailUrl, CancellationToken ct = default);
     }
 }

--- a/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
+++ b/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
@@ -23,9 +23,12 @@ namespace DCL.Profiles
             this.webRequestController = webRequestController;
         }
 
+        public Sprite? GetThumbnail(string userId) =>
+            thumbnails.GetValueOrDefault(userId);
+
         public async UniTask<Sprite?> GetThumbnailAsync(string userId, string thumbnailUrl, CancellationToken ct)
         {
-            Sprite? sprite = GetThumbnailFromCache(userId);
+            Sprite? sprite = GetThumbnail(userId);
             if (sprite != null)
                 return sprite;
 
@@ -59,9 +62,6 @@ namespace DCL.Profiles
                 return null;
             }
         }
-
-        private Sprite? GetThumbnailFromCache(string userId) =>
-            thumbnails.GetValueOrDefault(userId);
 
         private void SetThumbnailIntoCache(string userId, Sprite sprite) =>
             thumbnails[userId] = sprite;

--- a/Explorer/Assets/DCL/UI/ImageView.cs
+++ b/Explorer/Assets/DCL/UI/ImageView.cs
@@ -1,3 +1,5 @@
+using Cysharp.Threading.Tasks;
+using System.Threading;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -21,6 +23,15 @@ namespace DCL.UI
             set => Image.enabled = value;
         }
 
+        public float Alpha
+        {
+            set
+            {
+                Color color = Image.color;
+                Image.color = new Color(color.r, color.g, color.b, value);
+            }
+        }
+
         public void SetImage(Sprite sprite)
         {
             Image.enabled = true;
@@ -30,5 +41,22 @@ namespace DCL.UI
 
         public void SetColor(Color color) =>
             Image.color = color;
+
+        public async UniTask FadeInAsync(float duration, CancellationToken ct)
+        {
+            Color color = Image.color;
+            float t = 0f;
+            float from = color.a;
+
+            while (t < duration)
+            {
+                ct.ThrowIfCancellationRequested();
+                Alpha = Mathf.Lerp(from, 1f, t / duration);
+                t += Time.deltaTime;
+                await UniTask.NextFrame(ct);
+            }
+
+            Alpha = 1f;
+        }
     }
 }

--- a/Explorer/Assets/DCL/UI/ImageView.cs
+++ b/Explorer/Assets/DCL/UI/ImageView.cs
@@ -15,6 +15,7 @@ namespace DCL.UI
 
         public bool IsLoading
         {
+            get => LoadingObject.activeSelf;
             set => LoadingObject.SetActive(value);
         }
 

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
@@ -31,7 +31,14 @@ namespace DCL.UI.ProfileElements
         public void Setup(Color userColor, string faceSnapshotUrl, string userId)
         {
             thumbnailBackground.color = userColor;
-            LoadThumbnailAsync(faceSnapshotUrl, userId).Forget();
+            SetUpAsync().Forget();
+            return;
+
+            async UniTaskVoid SetUpAsync()
+            {
+                try { await LoadThumbnailAsync(faceSnapshotUrl, userId); }
+                catch (OperationCanceledException) { }
+            }
         }
 
         public async UniTask SetupWithDependenciesAsync(ViewDependencies dependencies, Color userColor, string faceSnapshotUrl, string userId, CancellationToken ct)

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
@@ -80,7 +80,7 @@ namespace DCL.UI.ProfileElements
             {
                 ct.ThrowIfCancellationRequested();
 
-                Sprite? sprite = viewDependencies!.GetSprite(userId);
+                Sprite? sprite = viewDependencies!.GetProfileThumbnail(userId);
 
                 if (sprite != null && !thumbnailImageView.IsLoading)
                 {
@@ -96,7 +96,7 @@ namespace DCL.UI.ProfileElements
                 thumbnailImageView.ImageEnabled = false;
                 thumbnailImageView.Alpha = 0f;
 
-                sprite = await viewDependencies.GetThumbnailAsync(userId, faceSnapshotUrl, cts.Token);
+                sprite = await viewDependencies.GetProfileThumbnailAsync(userId, faceSnapshotUrl, cts.Token);
 
                 currentThumbnailUrl = faceSnapshotUrl;
                 thumbnailImageView.SetImage(sprite ? sprite! : defaultEmptyThumbnail);

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
@@ -1,5 +1,4 @@
 ﻿using Cysharp.Threading.Tasks;
-using DCL.Profiles;
 using MVC;
 using System;
 using System.Threading;
@@ -17,6 +16,17 @@ namespace DCL.UI.ProfileElements
 
         private ViewDependencies viewDependencies;
         private CancellationTokenSource cts;
+        private string currentlyLoadedThumbnail;
+
+        public void InjectDependencies(ViewDependencies dependencies)
+        {
+            viewDependencies = dependencies;
+        }
+
+        public void Dispose()
+        {
+            cts.SafeCancelAndDispose();
+        }
 
         public void Setup(Color userColor, string faceSnapshotUrl, string userId)
         {
@@ -55,33 +65,29 @@ namespace DCL.UI.ProfileElements
 
         private async UniTask LoadThumbnailAsync(string faceSnapshotUrl, string userId, CancellationToken ct = default)
         {
+            if (currentlyLoadedThumbnail == faceSnapshotUrl) return;
+
             try
             {
                 cts = ct != default ? cts.SafeRestartLinked(ct) : cts.SafeRestart();
                 thumbnailImageView.IsLoading = true;
                 thumbnailImageView.ImageEnabled = false;
+                thumbnailImageView.Alpha = 0f;
 
                 Sprite sprite = await viewDependencies.GetThumbnailAsync(userId, faceSnapshotUrl, cts.Token);
 
                 thumbnailImageView.SetImage(sprite ? sprite : defaultEmptyThumbnail);
                 thumbnailImageView.ImageEnabled = true;
+                currentlyLoadedThumbnail = faceSnapshotUrl;
+                await thumbnailImageView.FadeInAsync(0.5f, cts.Token);
             }
+            catch (OperationCanceledException) { throw; }
             catch (Exception)
             {
                 thumbnailImageView.SetImage(defaultEmptyThumbnail);
                 thumbnailImageView.ImageEnabled = true;
+                await thumbnailImageView.FadeInAsync(1f, cts.Token);
             }
-
-        }
-
-        public void InjectDependencies(ViewDependencies dependencies)
-        {
-            viewDependencies = dependencies;
-        }
-
-        public void Dispose()
-        {
-            cts.SafeCancelAndDispose();
         }
     }
 }

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/csc.rsp
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/csc.rsp.meta
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/csc.rsp.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 99c3c0ae3a314b88b1e7554adf0356e9
+timeCreated: 1742318358


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Adds a fade transition when a profile picture is displayed.

## Test Instructions
You should see a fade transition on each profile picture if we need to download the thumbnail (not loaded in the cache).
You can check either through the friends feature, your own profile picture at the side bar, mutual friends at passport, chat.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
