### PR TITLE
fix: account for failed wearable while loading avatar

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearablePolymorphicBehaviour.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearablePolymorphicBehaviour.cs
@@ -376,7 +376,7 @@ namespace DCL.AvatarRendering.Wearables.Helpers
             {
                 StreamableLoadingResult<AttachmentAssetBase>? r = results[i];
 
-                if (r is not { Succeeded: true })
+                if (r is not { IsInitialized: true })
                     return false;
             }
 


### PR DESCRIPTION
# Pull Request Description

Fixes #3506 

When an equipped wearable fails to load with an exception, the system continuously tries to load it, stopping the whole avatar to be loaded.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR properly tests the load condition taking into account the fact that the wearable may have failed to be loaded for that avatar (in the issue case, it was a female only wearable that was being loaded onto a male avatar)

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

Use the `debug` arg to launch the E@

### Test Steps
1. Using the debug panel, under "Profile: Avatar Shape", load the wallet `0xd8e554279131622199408a102ec62e237491acef`
2. Verify that the avatar loads (skipping the shoes that are for the wrong avatar shape) and is visible
3. Verify that no other unknown issue tied to wearables are introduced


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
