### PR TITLE
Fix: prevent double dispose

### DIFF
--- a/Explorer/Assets/DCL/Web3/Identities/MemoryMappedFilePlayerPrefsIdentityProviderKeyStrategy.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/MemoryMappedFilePlayerPrefsIdentityProviderKeyStrategy.cs
@@ -40,6 +40,7 @@ namespace DCL.Web3.Identities
         private readonly int selfPID;
         private readonly ProcessName selfProcessName;
 
+        private bool disposed;
         private string? storedKey;
 
         public MemoryMappedFilePlayerPrefsIdentityProviderKeyStrategy()
@@ -52,12 +53,16 @@ namespace DCL.Web3.Identities
             mutex = new PMutex(MUTEX_NAME);
             selfPID = Process.GetCurrentProcess().Id;
             selfProcessName = new ProcessName(selfPID);
+            disposed = false;
         }
 
         public string PlayerPrefsKey
         {
             get
             {
+                if (disposed)
+                    throw new ObjectDisposedException("Object is already disposed");
+
                 if (storedKey == null)
                     RegisterSelf();
 
@@ -118,6 +123,10 @@ namespace DCL.Web3.Identities
 
         public void Dispose()
         {
+            if (disposed)
+                throw new ObjectDisposedException("Object is already disposed");
+
+            disposed = true;
             UnregisterSelf();
             memoryMappedFile.Dispose();
             mutex.Dispose();

--- a/Explorer/Assets/DCL/Web3/Identities/MemoryMappedFilePlayerPrefsIdentityProviderKeyStrategy.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/MemoryMappedFilePlayerPrefsIdentityProviderKeyStrategy.cs
@@ -124,7 +124,14 @@ namespace DCL.Web3.Identities
         public void Dispose()
         {
             if (disposed)
-                throw new ObjectDisposedException("Object is already disposed");
+            {
+                ReportHub.LogWarning(
+                    ReportCategory.PROFILE,
+                    $"Attempt to dispose an already disposed object {nameof(MemoryMappedFilePlayerPrefsIdentityProviderKeyStrategy)}"
+                );
+
+                return;
+            }
 
             disposed = true;
             UnregisterSelf();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Fixes [#3535 System.NullReferenceException: Object reference not set to an instance of an object.](https://github.com/decentraland/unity-explorer/issues/3535)

Prevents double dispose of MMF key.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Launch DCL normally
2. Jump into Genesis and play 2-3 mins
3. Force quit (alt+f4 or cmd+Q) 
4. Observe no error in the Player.log file that are related to MemoryMappedFilePlayerPrefsIdentityProviderKeyStrategy

## Quality Checklist
- [+] Changes have been tested locally

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
