### PR TITLE
fix: apply camera restriction on virtual camera apply only

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Systems/MainCameraSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Systems/MainCameraSystem.cs
@@ -90,7 +90,6 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Systems
                     virtualCameraCRDTEntity.Value,
                     hasPreviousVirtualCamera ? previousVirtualCamera!.transform.position : cinemachineCurrentActiveCamPos
                 );
-                sceneRestrictionBusController.PushSceneRestriction(SceneRestriction.CreateCameraLocked(SceneRestrictionsAction.APPLIED));
             }
             else
             {
@@ -179,6 +178,8 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Systems
             mainCameraComponent.virtualCameraCRDTEntity = virtualCamCRDTEntity;
             mainCameraComponent.virtualCameraInstance = virtualCameraInstance;
             virtualCameraInstance.enabled = true;
+
+            sceneRestrictionBusController.PushSceneRestriction(SceneRestriction.CreateCameraLocked(SceneRestrictionsAction.APPLIED));
         }
 
         private void UpdateGlobalWorldCameraMode(bool isAnyVirtualCameraActive)


### PR DESCRIPTION
# Pull Request Description

Fixes #3629

Camera locked scene restriction was being pushed even if the virtual camera wasn't enabled the first time causing its counter to stack => the icon on the minimap was "always" visible.

![image](https://github.com/user-attachments/assets/c5d74867-8c77-4d2a-afdb-b5b294e61c0f)


## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR pushes the restriction only when the virtual camera is actually enabled, making the notification aligned with the actual restrictions.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Launch the E@ and verify that no scene restriction icon is visible
2. Go to `eax.dcl.eth` and verify that the camera area correctly push the restrictions only when you are inside the camera more areas
3. Test Color pop/Minesweeper (and other games that block your camera) and verify that the listed restrictions are consistent and removed if you stop playing

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
