### PR TITLE
chore: improve local scene dev initialization times

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -15,6 +15,7 @@
         public const string COMMS_ADAPTER = "comms-adapter";
         public const string LOCAL_SCENE = "local-scene";
         public const string POSITION = "position";
+        public const string SKIP_AUTH_SCREEN = "skip-auth-screen";
 
         public const string FORCED_EMOTES = "self-force-emotes";
         public const string SELF_PREVIEW_EMOTES = "self-preview-emotes";

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
@@ -102,7 +102,8 @@ namespace DCL.UserInAppInitializationFlow
                     startUpOps,
                     reLoginOps,
                     checkOnboardingStartupOperation,
-                    bootstrapContainer.IdentityCache),
+                    bootstrapContainer.IdentityCache.EnsureNotNull(),
+                    appArgs),
             };
         }
     }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
@@ -101,7 +101,8 @@ namespace DCL.UserInAppInitializationFlow
                     chatHistory,
                     startUpOps,
                     reLoginOps,
-                    checkOnboardingStartupOperation),
+                    checkOnboardingStartupOperation,
+                    bootstrapContainer.IdentityCache),
             };
         }
     }


### PR DESCRIPTION
### WHY

Currently the initial time to boot the Explorer in Local Scene Development mode is high, we need to reduce it to improve the devexp of scene content creators.

Current measurements for Local Scene Development initialization, on a Macbook Pro M2, loading a MVFW2025 scene:
Loading stage: Init / stageDuration: `0`
Loading stage: AuthenticationScreenShowing / stageDuration: `0.00262022` <- **at this point the auth/log-in screen appears**
Loading stage: ProfileLoading / stageDuration: `04.50859` <- **loading screen “starts” after this stage, this stage duration here is basically the time it takes to click on “jump into decentraland” in the log-in screen**
Loading stage: PlayerAvatarLoading / stageDuration: `0.001014709`
Loading stage: LandscapeLoading / stageDuration: `0.05128098`
Loading stage: OnboardingChecking / stageDuration: `0.1711655`
Loading stage: PlayerTeleporting / stageDuration: `0.0001716614`
Loading stage: LiveKitConnectionEnsuring / stageDuration: `5.152447`
Loading stage: GlobalPXsLoading / stageDuration: `2.221977`
Loading stage: Completed / stageDuration: `0.0007629395`

### WHAT

The current iteration is to enable skipping the auth/login screen with a new app argument (if the cached identity is expired or non-existent, the auth screen will appear nonetheless)

Also fixed the Auth screen not appearing when disabled in the debugSettings but having a non-existent or expired identity in the cache.

### TEST INSTRUCTIONS

...
