### PR TITLE
fix: sdk local scene dev hot-reload

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/ECSReloadScene.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/ECSReloadScene.cs
@@ -17,7 +17,6 @@ namespace ECS.SceneLifeCycle
     public class ECSReloadScene : IReloadScene
     {
         private readonly IScenesCache scenesCache;
-        private readonly ICacheCleaner cacheCleaner;
 
         private readonly Entity playerEntity;
         private readonly World world;
@@ -26,14 +25,12 @@ namespace ECS.SceneLifeCycle
         public ECSReloadScene(IScenesCache scenesCache,
             World world,
             Entity playerEntity,
-            bool localSceneDevelopment,
-            ICacheCleaner cacheCleaner)
+            bool localSceneDevelopment)
         {
             this.scenesCache = scenesCache;
             this.world = world;
             this.playerEntity = playerEntity;
             this.localSceneDevelopment = localSceneDevelopment;
-            this.cacheCleaner = cacheCleaner;
         }
 
         public async UniTask<bool> TryReloadSceneAsync(CancellationToken ct)
@@ -96,9 +93,6 @@ namespace ECS.SceneLifeCycle
                     });
 
                 Resources.UnloadUnusedAssets();
-
-                // Nothing can be called after cacheCleaner.UnloadCache(), as that code becomes unreachable.
-                cacheCleaner.UnloadCache(false);
             }
             else
             {

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -350,7 +350,7 @@ namespace Global.Dynamic
                 staticContainer.WebRequestsContainer.WebRequestController
             );
 
-            var reloadSceneController = new ECSReloadScene(staticContainer.ScenesCache, globalWorld, playerEntity, localSceneDevelopment, staticContainer.CacheCleaner);
+            var reloadSceneController = new ECSReloadScene(staticContainer.ScenesCache, globalWorld, playerEntity, localSceneDevelopment);
 
             LocalSceneDevelopmentController? localSceneDevelopmentController = localSceneDevelopment ? new LocalSceneDevelopmentController(reloadSceneController, dynamicWorldParams.LocalSceneDevelopmentRealm) : null;
 


### PR DESCRIPTION
### WHY

Hot-reload is not working beyond the 1st reload.

### WHAT

Removed unneeded CacheCleaner usage that randomly breaks hot-reload. (introduced recently at https://github.com/decentraland/unity-explorer/pull/3595)

### TEST INSTRUCTIONS (hot-reload)

1. Download [this test scene](https://github.com/decentraland/sdk7-test-scenes/tree/main/scenes/54%2C-55-Testing-3d-models)
2. Enter the scene root folder and run `npm i` and then `npm run start -- --explorer-alpha`
3. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
4. Download the build from this PR and connect it to the running scene using [the console command](https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene) according to your OS
5. Once the scene loads, leave the Explorer running and in any text editor open [the index.ts file](https://github.com/decentraland/sdk7-test-scenes/blob/main/scenes/54%2C-55-Testing-3d-models/src/index.ts) of the scene that you have running
6. Modify any Vector3 value (for example change `Vector3.create(32, 0, 32)` to `Vector3.create(15, 0, 15)`), save the file and confirm that the scene gets automatically re-loaded in the Explorer that you left running in the previous step
7. After the automatic reload finishes, repeat step 6 several more times to make sure hot-reload keeps working beyond the first one
