### PR TITLE
fix: chat spam performance issue & own profile picture

### DIFF
--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
@@ -31,14 +31,7 @@ namespace DCL.UI.ProfileElements
         public void Setup(Color userColor, string faceSnapshotUrl, string userId)
         {
             thumbnailBackground.color = userColor;
-            SetUpAsync().Forget();
-            return;
-
-            async UniTaskVoid SetUpAsync()
-            {
-                try { await LoadThumbnailAsync(faceSnapshotUrl, userId); }
-                catch (OperationCanceledException) { }
-            }
+            LoadThumbnailAsync(faceSnapshotUrl, userId).Forget();
         }
 
         public async UniTask SetupWithDependenciesAsync(ViewDependencies dependencies, Color userColor, string faceSnapshotUrl, string userId, CancellationToken ct)
@@ -103,7 +96,7 @@ namespace DCL.UI.ProfileElements
                 thumbnailImageView.ImageEnabled = true;
                 await thumbnailImageView.FadeInAsync(0.5f, cts.Token);
             }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException) { }
             catch (Exception)
             {
                 thumbnailImageView.SetImage(defaultEmptyThumbnail);

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
@@ -17,7 +17,6 @@ namespace DCL.UI.ProfileElements
         private ViewDependencies? viewDependencies;
         private CancellationTokenSource? cts;
         private string? currentThumbnailUrl;
-        private bool isLoading;
 
         public void InjectDependencies(ViewDependencies dependencies)
         {
@@ -83,7 +82,7 @@ namespace DCL.UI.ProfileElements
 
                 Sprite? sprite = viewDependencies!.GetProfileThumbnail(userId);
 
-                if (sprite != null && !isLoading)
+                if (sprite != null)
                 {
                     thumbnailImageView.SetImage(sprite);
                     thumbnailImageView.ImageEnabled = true;
@@ -96,7 +95,6 @@ namespace DCL.UI.ProfileElements
                 thumbnailImageView.IsLoading = true;
                 thumbnailImageView.ImageEnabled = false;
                 thumbnailImageView.Alpha = 0f;
-                isLoading = true;
 
                 sprite = await viewDependencies.GetProfileThumbnailAsync(userId, faceSnapshotUrl, cts.Token);
 
@@ -104,7 +102,6 @@ namespace DCL.UI.ProfileElements
                 thumbnailImageView.SetImage(sprite ? sprite! : defaultEmptyThumbnail);
                 thumbnailImageView.ImageEnabled = true;
                 await thumbnailImageView.FadeInAsync(0.5f, cts.Token);
-                isLoading = false;
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception)
@@ -113,7 +110,6 @@ namespace DCL.UI.ProfileElements
                 thumbnailImageView.ImageEnabled = true;
                 await thumbnailImageView.FadeInAsync(0.5f, cts.Token);
             }
-            finally { isLoading = false; }
         }
     }
 }

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
@@ -113,6 +113,7 @@ namespace DCL.UI.ProfileElements
                 thumbnailImageView.ImageEnabled = true;
                 await thumbnailImageView.FadeInAsync(0.5f, cts.Token);
             }
+            finally { isLoading = false; }
         }
     }
 }

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
@@ -17,6 +17,7 @@ namespace DCL.UI.ProfileElements
         private ViewDependencies? viewDependencies;
         private CancellationTokenSource? cts;
         private string? currentThumbnailUrl;
+        private bool isLoading;
 
         public void InjectDependencies(ViewDependencies dependencies)
         {
@@ -82,7 +83,7 @@ namespace DCL.UI.ProfileElements
 
                 Sprite? sprite = viewDependencies!.GetProfileThumbnail(userId);
 
-                if (sprite != null && !thumbnailImageView.IsLoading)
+                if (sprite != null && !isLoading)
                 {
                     thumbnailImageView.SetImage(sprite);
                     thumbnailImageView.ImageEnabled = true;
@@ -95,6 +96,7 @@ namespace DCL.UI.ProfileElements
                 thumbnailImageView.IsLoading = true;
                 thumbnailImageView.ImageEnabled = false;
                 thumbnailImageView.Alpha = 0f;
+                isLoading = true;
 
                 sprite = await viewDependencies.GetProfileThumbnailAsync(userId, faceSnapshotUrl, cts.Token);
 
@@ -102,13 +104,14 @@ namespace DCL.UI.ProfileElements
                 thumbnailImageView.SetImage(sprite ? sprite! : defaultEmptyThumbnail);
                 thumbnailImageView.ImageEnabled = true;
                 await thumbnailImageView.FadeInAsync(0.5f, cts.Token);
+                isLoading = false;
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception)
             {
                 thumbnailImageView.SetImage(defaultEmptyThumbnail);
                 thumbnailImageView.ImageEnabled = true;
-                await thumbnailImageView.FadeInAsync(1f, cts.Token);
+                await thumbnailImageView.FadeInAsync(0.5f, cts.Token);
             }
         }
     }


### PR DESCRIPTION
## What does this PR change?

Fixes a major performance issue while spamming the chat.
Profile pictures for own chat messages were not working because the loading state was not correctly calculated. The chat system sets the profile picture many times in a row and this provokes to cancel the operation in between. We dont consider the load state anymore in the process. We just set the sprite if its already in the cache.

## Test Instructions
Spam messages in the chat. Check that you can see your own profile picture. Check that you don't have performance issues.
Check profile pictures in other places, like friends, sidebar, passport, etc.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
