### PR TITLE
fix: friends rpc connection with invalid identity

### DIFF
--- a/Explorer/Assets/DCL/Friends/WebSocketRpcTransport.cs
+++ b/Explorer/Assets/DCL/Friends/WebSocketRpcTransport.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using rpc_csharp.transport;
 using System;
 using System.Net.WebSockets;
@@ -81,6 +82,9 @@ namespace DCL.Friends
 
                         if (result.MessageType == WebSocketMessageType.Close)
                         {
+                            if (!string.IsNullOrEmpty(result.CloseStatusDescription))
+                                ReportHub.LogError(ReportCategory.FRIENDS, $"Friends web socket disconnected. {result.CloseStatusDescription}");
+
                             await CloseAsync(ct);
                             break;
                         }


### PR DESCRIPTION
## What does this PR change?

Changes consists on move all the friends subscriptions after the initial load is completed. At that point we are sure the user has a valid identity, so we can use it later when we try the connection with the friends server.

## Test Instructions
Try to login & logout with different accounts. Then check that all friends features are working, like friend & requests listing, send/receive/accept requests, etc..

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
