### PR TITLE
fix: verify AB is not null before attempting unload

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetBundleData.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetBundleData.cs
@@ -81,8 +81,8 @@ namespace ECS.StreamableLoading.AssetBundles
             if(mainAsset!=null)
                 Object.DestroyImmediate(mainAsset, true);
 
-            if (!unloaded)
-                AssetBundle.UnloadAsync(unloadAllLoadedObjects: true);
+            if (unloaded) return;
+            if(AssetBundle && AssetBundle != null) AssetBundle.UnloadAsync(unloadAllLoadedObjects: true);
         }
 
         public T GetMainAsset<T>() where T : Object


### PR DESCRIPTION
# Pull Request Description

Ensures we do not attempt to unload the AB if already null.

Fixes: https://github.com/decentraland/unity-explorer/issues/3641

## Test Instructions

- Run the game
- Close the game
- Check Player.log
- Ensure it doesn't have the following in (towards the end)

`NullReferenceException: Object reference not set to an instance of an object.
  at ECS.StreamableLoading.AssetBundles.AssetBundleData.DestroyObject ()`

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
