### PR TITLE
style: block user prompt UI polish

### DIFF
--- a/Explorer/Assets/DCL/Friends/UI/Prefabs/BlockUserPrompt.prefab
+++ b/Explorer/Assets/DCL/Friends/UI/Prefabs/BlockUserPrompt.prefab
@@ -153,7 +153,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &7022765743951405940
 RectTransform:
   m_ObjectHideFlags: 0
@@ -242,6 +242,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1516325156285413336}
+  - {fileID: 2341661032434315255}
   - {fileID: 2460288348171835703}
   - {fileID: 7022765743951405940}
   - {fileID: 2613355438361360692}
@@ -402,7 +403,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -15, y: 15}
+  m_AnchoredPosition: {x: -11, y: 13}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8962785595569755692
@@ -477,8 +478,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 63.999985, y: 27.5}
-  m_SizeDelta: {x: -128, y: 95}
+  m_AnchoredPosition: {x: 102, y: 29}
+  m_SizeDelta: {x: -204, y: 95}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &5452612272459903063
 CanvasRenderer:
@@ -619,9 +620,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 198, y: -23}
+  m_AnchoredPosition: {x: 103.00001, y: -0.000030517578}
   m_SizeDelta: {x: 190, y: 46}
-  m_Pivot: {x: 1, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5382010859213503056
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -779,9 +780,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -198, y: -23}
+  m_AnchoredPosition: {x: -103, y: -0.000030517578}
   m_SizeDelta: {x: 190, y: 46}
-  m_Pivot: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5134895454367656137
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1014,9 +1015,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 198, y: -23}
+  m_AnchoredPosition: {x: 103.00001, y: -0.000030517578}
   m_SizeDelta: {x: 190, y: 46}
-  m_Pivot: {x: 1, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3259846218028516889
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1170,8 +1171,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 63.999985, y: 27.5}
-  m_SizeDelta: {x: -128, y: 95}
+  m_AnchoredPosition: {x: 102, y: 29}
+  m_SizeDelta: {x: -204, y: 95}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &8790137622692784861
 CanvasRenderer:
@@ -1274,6 +1275,81 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4090778810363832888
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2341661032434315255}
+  - component: {fileID: 8405246215584740832}
+  - component: {fileID: 3150460039085939873}
+  m_Layer: 0
+  m_Name: Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2341661032434315255
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4090778810363832888}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4472997674435783033}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 80}
+  m_SizeDelta: {x: 288.0077, y: 86.6273}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8405246215584740832
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4090778810363832888}
+  m_CullTransparentMesh: 1
+--- !u!114 &3150460039085939873
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4090778810363832888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.5019608}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5ba853d2b424843f69d5d02155581a54, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4437094938096570384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1747,8 +1823,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 63.999985, y: 86}
-  m_SizeDelta: {x: -128, y: 48}
+  m_AnchoredPosition: {x: 102, y: 96}
+  m_SizeDelta: {x: -204, y: 56}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &6638102284540626860
 CanvasRenderer:
@@ -1808,9 +1884,9 @@ MonoBehaviour:
   m_fontSize: 20
   m_fontSizeBase: 20
   m_fontWeight: 400
-  m_enableAutoSizing: 0
+  m_enableAutoSizing: 1
   m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_fontSizeMax: 20
   m_fontStyle: 0
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 256

--- a/Explorer/Assets/Textures/Common/LockGreen.png
+++ b/Explorer/Assets/Textures/Common/LockGreen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7555ee79903364d7a51df1abb98bd5d3d37f973cc9876cc4d6460840630160f0
-size 906
+oid sha256:c11cb838dac9fceb4d8e71668fc77c66a677ed6ed34af63811a3c969f12348f0
+size 843


### PR DESCRIPTION
## What does this PR change?
This PR aligns the block/unblock prompt with the original design from [Figma](https://www.figma.com/design/2UQLtYTpDhBgaRafZJxj00/%F0%9F%97%BA%EF%B8%8F-Friends-%7C-Explorer-2.0-%7C-01%2F25?node-id=255-26025&t=3yqWiqNdZXggi9Ak-1). As shown in the screenshot, the body text box extends beyond the margin on both sides compared to the buttons breaking the guidelines. The 'floor light effect' behind the image is also missing.

<img width="445" alt="Screenshot 2025-03-20 at 13 32 59" src="https://github.com/user-attachments/assets/263b9fe8-0f4f-43f8-a459-5e786d5285c6" />
<img width="443" alt="Screenshot 2025-03-20 at 13 34 44" src="https://github.com/user-attachments/assets/23f82448-e32a-4059-878c-234b67132d95" />

This PR also fixes the pivot point of the action buttons. As shown in the video, the buttons currently scale from the bottom corner instead of the center.
https://github.com/user-attachments/assets/6998910c-7713-4aa3-82c7-58469136b479

### Test Steps
1. Launch the client.
2. Attempt to block a friend from your friends list. Verify that the prompt’s body text box does not exceed the margin limits of the buttons. Mouse hover both buttons and ensure the scale animation comes from the center. Then, click `Block`.
3. Repeat step 2 in the `Unblock` context.
