### PR TITLE
style: fix menu button width

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Assets/OptionButton.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Assets/OptionButton.prefab
@@ -19,7 +19,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &4704582517862536994
 RectTransform:
   m_ObjectHideFlags: 0
@@ -179,7 +179,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 5, y: 24}
+  m_SizeDelta: {x: 6.5, y: 24}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7845843542528538602
 CanvasRenderer:


### PR DESCRIPTION
## What does this PR change?
PR created to fix the narrowed texture of the menu button used in the photos of the gallery.
<img width="316" alt="Screenshot 2025-03-06 at 13 15 33" src="https://github.com/user-attachments/assets/fe80fa5c-68e8-4343-84ce-cc0d112bb867" />

### Test Steps
1. Launch the explorer.
2. Open the Gallery.
3. Hover any of the photos and validate the menu icon shows as expected.