### PR TITLE
fix: rename profile name editor feature flag name

### DIFF
--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -27,6 +27,6 @@
         public const string FRIENDS_USER_BLOCKING = "alfa-friends-user-blocking";
         public const string FRIENDS_ONLINE_STATUS = "alfa-friends-online-status";
 
-        public const string PROFILE_NAME_EDITOR = "profile-name-editor";
+        public const string PROFILE_NAME_EDITOR = "alfa-profile-name-editor";
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
It renames the profile name editor feature flag so it includes the prefix `alfa`.

## Test Instructions
Check that you cannot edit your name from the passport (since the feature flag is disabled).
If you restart the client with `--debug --profile-name-editor` you should be able to edit your profile name.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
