### PR TITLE
fix: navmap search result scroll speed

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGallery.asmdef
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGallery.asmdef
@@ -22,7 +22,8 @@
         "GUID:45f6fff651a0a514f8edfdaf9cce45af",
         "GUID:c6e727f7851314e679212856f4ce3e53",
         "GUID:e989cf34722384eb4ba00fd0ea3f8301",
-        "GUID:5462d37de7d4344df8aade58a45b403e"
+        "GUID:5462d37de7d4344df8aade58a45b403e",
+        "GUID:d5368878df29ff849933a7d3586d18c6"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
@@ -10,7 +10,7 @@ using DCL.InWorldCamera.CameraReelToast;
 using DCL.InWorldCamera.ReelActions;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Optimization.Pools;
-using DCL.UI.GenericContextMenu.Controls.Configs;
+using DCL.UI.Utilities;
 using DG.Tweening;
 using MVC;
 using System;
@@ -120,13 +120,10 @@ namespace DCL.InWorldCamera.CameraReelGallery
             this.systemClipboard = systemClipboard;
             this.webBrowser = webBrowser;
 
-            if (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)
-                this.view.scrollRect.scrollSensitivity *= MACOS_SCROLL_SENSITIVITY_SCALE_FACTOR;
+            this.view.scrollRect.SetScrollSensitivityBasedOnPlatform();
 
             if (optionButtonView is not null)
-            {
                 this.optionButtonController = new CameraReelOptionButtonController(optionButtonView, mvcManager!);
-            }
 
             reelGalleryPoolManager = new ReelGalleryPoolManager(view.thumbnailViewPrefab, view.monthGridPrefab, view.unusedThumbnailViewObject,
                 view.unusedGridViewObject, cameraReelScreenshotsStorage,

--- a/Explorer/Assets/DCL/Navmap/Navmap.asmdef
+++ b/Explorer/Assets/DCL/Navmap/Navmap.asmdef
@@ -39,7 +39,8 @@
         "GUID:f0968673e9444d64b49cde6a40d7df7a",
         "GUID:b5762faee0fa644b38047f2b625378a1",
         "GUID:c6e727f7851314e679212856f4ce3e53",
-        "GUID:809870cbfd80a7b46bcf72b178ab210b"
+        "GUID:809870cbfd80a7b46bcf72b178ab210b",
+        "GUID:d5368878df29ff849933a7d3586d18c6"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Navmap/SearchResultPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/SearchResultPanelController.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.PlacesAPIService;
 using DCL.UI;
+using DCL.UI.Utilities;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
@@ -30,6 +31,7 @@ namespace DCL.Navmap
 
             view.NextPageButton.onClick.AddListener(CycleToNextPage);
             view.PreviousPageButton.onClick.AddListener(CycleToPrevPage);
+            view.scrollView.SetScrollSensitivityBasedOnPlatform();
         }
 
         public void Show()

--- a/Explorer/Assets/DCL/UI/Utilities/ScrollRectExtensions.cs
+++ b/Explorer/Assets/DCL/UI/Utilities/ScrollRectExtensions.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace DCL.UI.Utilities
+{
+    public static class ScrollRectExtensions
+    {
+        private const int MACOS_SCROLL_SENSITIVITY = 3;
+        private const int WINDOWS_SCROLL_SENSITIVITY = 1;
+
+        public static void SetScrollSensitivityBasedOnPlatform(this ScrollRect scrollRect)
+        {
+            if (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)
+                scrollRect.scrollSensitivity = MACOS_SCROLL_SENSITIVITY;
+            else
+                scrollRect.scrollSensitivity = WINDOWS_SCROLL_SENSITIVITY;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/UI/Utilities/ScrollRectExtensions.cs.meta
+++ b/Explorer/Assets/DCL/UI/Utilities/ScrollRectExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c02ce36a371e4689a79c32db9ccc218d
+timeCreated: 1742569531


### PR DESCRIPTION
# Pull Request Description

Fixes #3588 

The scrolling speed of the scroll rect has a different feeling based on platform.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR sets a scrolling speed based on the current running platform.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Launch E@
2. Search for "games" in the navmap search bar
3. Verify that the scrolling speed of the results is acceptable

### Additional Testing Notes
- I couldn't reproduce a slow scrolling speed in current version `0.60`, therefore the PR could be unnecessary

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
