### PR TITLE
fix: invalidate expired identity

### DIFF
--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/FriendsPanelController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/FriendsPanelController.cs
@@ -12,7 +12,6 @@ using System;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEngine.Pool;
 using Utility;
 
 namespace DCL.Friends.UI.FriendPanel
@@ -142,30 +141,8 @@ namespace DCL.Friends.UI.FriendPanel
         private void JumpToFriendClick(string targetAddress, Vector2Int parcel) =>
             JumpToFriendClicked?.Invoke(targetAddress, parcel);
 
-        public UniTask InitAsync(CancellationToken ct)
-        {
-            var tasks = ListPool<UniTask>.Get();
-
-            try
-            {
-                tasks.Add(requestsSectionController.InitAsync(ct));
-
-                // TODO: Remove it after the server's connectivity stream works as expected
-                // This call forces to load at least the first page of friends (around 50)
-                // Currently, as a mid-term solution, we poll connectivity status for each of the friends we have asked to the server through the archipelago api
-                // If we do not request any friends then we will get no connectivity updates
-                // This approach will work for most of the users (except those who have more than 50 friends whose going to get partial updates)
-                // When server's rpc stream works, it will automatically send connectivity updates for each friend no matter if we previously asked for it or not
-                // if (friendSectionControllerConnectivity != null)
-                //     tasks.Add(friendSectionControllerConnectivity.InitAsync(ct));
-
-                return UniTask.WhenAll(tasks);
-            }
-            finally
-            {
-                ListPool<UniTask>.Release(tasks);
-            }
-        }
+        public UniTask InitAsync(CancellationToken ct) =>
+            requestsSectionController.InitAsync(ct);
 
         public void Reset()
         {

--- a/Explorer/Assets/DCL/Web3/Identities/ProxyIdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/ProxyIdentityCache.cs
@@ -42,7 +42,12 @@ namespace DCL.Web3.Identities
                 IWeb3Identity? storedIdentity = storage.Identity;
 
                 if (storedIdentity != null)
+                {
+                    if (storedIdentity.IsExpired)
+                        return null;
+
                     memory.Identity = storedIdentity;
+                }
 
                 return memory.Identity;
             }

--- a/Explorer/Assets/DCL/Web3/Identities/ProxyIdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/ProxyIdentityCache.cs
@@ -43,6 +43,9 @@ namespace DCL.Web3.Identities
 
                 if (storedIdentity != null)
                 {
+                    // Since an expired identity is like non having one at all
+                    // we return an invalid one to force the systems to not use it
+                    // as not all of them are validating its expiration
                     if (storedIdentity.IsExpired)
                         return null;
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes #3659 

Invalidates the identity loaded by local storage if its expired. It prevents several systems to use the auth chain (which is already invalid) reducing inconsistencies and error reports. Some of the systems affected:
- analytics
- places
- events
- camera reel
- friends

It also delays a call to the blocked list to the friend service during initialization, and introduces a minor refactor to decouple the service from the cache.

## Test Instructions



### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
