### PR TITLE
Fix:  Camera Reel | switching back to previous camera mode

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/ToggleInWorldCameraActivitySystem.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/ToggleInWorldCameraActivitySystem.cs
@@ -42,6 +42,7 @@ namespace DCL.InWorldCamera.Systems
         private ICinemachinePreset cinemachinePreset;
         private CinemachineVirtualCamera inWorldVirtualCamera;
         private bool wasDebugVisible;
+        private CameraMode prevCameraMode;
 
         public ToggleInWorldCameraActivitySystem(
             World world,
@@ -182,18 +183,13 @@ namespace DCL.InWorldCamera.Systems
             inWorldVirtualCamera.LookAt = null;
             followTarget.enabled = false;
 
-            float distanceToThirdPersonView =
-                Mathf.Abs(cinemachinePreset.ThirdPersonCameraData.Camera.transform.localPosition.z - inWorldVirtualCamera.transform.localPosition.z);
-
-            float distanceToDroneCameraView =
-                Mathf.Abs(cinemachinePreset.DroneViewCameraData.Camera.transform.localPosition.z - inWorldVirtualCamera.transform.localPosition.z);
-
-            camera.GetCameraComponent(World).Mode = targetMode ?? (distanceToDroneCameraView < distanceToThirdPersonView ? CameraMode.DroneView : CameraMode.ThirdPerson);
+            camera.GetCameraComponent(World).Mode = targetMode ?? prevCameraMode;
         }
 
         private void SwitchToInWorldCamera()
         {
             ref CameraComponent cameraComponent = ref camera.GetCameraComponent(World);
+            prevCameraMode = cameraComponent.Mode;
 
             ref CinemachineCameraState cameraState = ref World.Get<CinemachineCameraState>(camera);
             cameraState.CurrentCamera.enabled = false;


### PR DESCRIPTION
# Pull Request Description
Fix #3360

When transitioning to InWorld Camera and then back, camera was not switching to previous mode and was going only to ThirdPerson or Drone mode (depending on distance).

## What does this PR change?
- add caching for previous position and transition to it

## Test Instructions
check related bug-ticket and comments there

- Enable InWorld Camera from different camera modes - First Person, Third Person, Drone camera
- Verify that after switching back, it always goes to the mode from which you enabled InWorld Camera.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
