### PR TITLE
chore: landscape terrain toggling with app arg

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -16,6 +16,7 @@
         public const string LOCAL_SCENE = "local-scene";
         public const string POSITION = "position";
         public const string SKIP_AUTH_SCREEN = "skip-auth-screen";
+        public const string LANDSCAPE_TERRAIN_ENABLED = "landscape-terrain-enabled";
 
         public const string FORCED_EMOTES = "self-force-emotes";
         public const string SELF_PREVIEW_EMOTES = "self-preview-emotes";

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/IAppArgs.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/IAppArgs.cs
@@ -16,5 +16,11 @@ namespace Global.AppArgs
     {
         public static bool HasDebugFlag(this IAppArgs args, bool checkDebugBuild = true) =>
             (checkDebugBuild && Debug.isDebugBuild) || args.HasFlag(AppArgsFlags.DEBUG);
+
+        public static bool HasFlagWithValueTrue(this IAppArgs args, string flagName) =>
+            args.TryGetValue(flagName, out var flagValue) && flagValue == "true";
+
+        public static bool HasFlagWithValueFalse(this IAppArgs args, string flagName) =>
+            args.TryGetValue(flagName, out var flagValue) && flagValue == "false";
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -724,7 +724,6 @@ namespace Global.Dynamic
                 new NftPromptPlugin(assetsProvisioner, webBrowser, mvcManager, nftInfoAPIClient, staticContainer.WebRequestsContainer.WebRequestController, dclCursor),
                 staticContainer.CharacterContainer.CreateGlobalPlugin(),
                 staticContainer.QualityContainer.CreatePlugin(),
-                terrainContainer.CreatePlugin(staticContainer, bootstrapContainer, mapRendererContainer, debugBuilder),
                 new MultiplayerMovementPlugin(
                     assetsProvisioner,
                     multiplayerMovementMessageBus,
@@ -737,8 +736,6 @@ namespace Global.Dynamic
                     staticContainer.RealmData,
                     remoteMetadata,
                     staticContainer.FeatureFlagsCache),
-                lodContainer.LODPlugin,
-                lodContainer.RoadPlugin,
                 new AudioPlaybackPlugin(terrainContainer.GenesisTerrain, assetsProvisioner, dynamicWorldParams.EnableLandscape),
                 new RealmDataDirtyFlagPlugin(staticContainer.RealmData),
                 new NotificationPlugin(
@@ -786,6 +783,15 @@ namespace Global.Dynamic
                 new GPUInstancingPlugin(staticContainer.GPUInstancingService, assetsProvisioner, staticContainer.RealmData, staticContainer.LoadingStatus, exposedGlobalDataContainer.ExposedCameraData),
 
             };
+
+            if (!appArgs.HasDebugFlag() || !appArgs.HasFlagWithValueFalse(AppArgsFlags.LANDSCAPE_TERRAIN_ENABLED))
+                globalPlugins.Add(terrainContainer.CreatePlugin(staticContainer, bootstrapContainer, mapRendererContainer, debugBuilder));
+
+            if (!localSceneDevelopment)
+            {
+                globalPlugins.Add(lodContainer.LODPlugin);
+                globalPlugins.Add(lodContainer.RoadPlugin);
+            }
 
             globalPlugins.AddRange(staticContainer.SharedPlugins);
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/StaticCommonTraitsPlugin.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/StaticCommonTraitsPlugin.cs
@@ -42,7 +42,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
             if (Application.isEditor)
                 return UNITY_EDITOR;
 
-            if (appArgs.TryGetValue(AppArgsFlags.DCL_EDITOR, out var dclEditorValue) && dclEditorValue == "true")
+            if (appArgs.HasFlagWithValueTrue(AppArgsFlags.DCL_EDITOR))
                 return DCL_EDITOR; // We send "dcl-editor" instead of "hub" to track it better on the analytics data side
 
             if (appArgs.HasDebugFlag())

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -90,8 +90,7 @@ namespace DCL.UserInAppInitializationFlow
             do
             {
                 bool shouldShowAuthentication = parameters.ShowAuthentication &&
-                                                (!appArgs.TryGetValue(AppArgsFlags.SKIP_AUTH_SCREEN, out string? argValue)
-                                                || argValue == "false") ;
+                                                !appArgs.HasFlagWithValueTrue(AppArgsFlags.SKIP_AUTH_SCREEN);
 
                 // Force show authentication if there's no valid identity in the cache
                 if (!shouldShowAuthentication)


### PR DESCRIPTION
### WHY

After [researching](https://github.com/decentraland/unity-explorer/pull/3668) which global plugins (unrelated to local scene dev) can be disabled to improve the Local Scene Development devexp, the LOD and LANDSCAPE-TERRAIN were identified as the only ones that actually bring some gains (in memory and performance, not initialization times).

### WHAT

* Disabled LOD plugin for LSD
* Implemented support for new flag to toggle Landscape plugin (`landscape-terrain-enabled`)
* Updated a couple of app args checks with new utility method

### TEST INSTRUCTIONS

1. Download the build from this PR and open it normally, confirm that the terrain/landscape appears normally in Genesis City
2. Clone the [test scenes repo](https://github.com/decentraland/sdk7-test-scenes) and enter any of the scenes inside `/scenes/`
3. In the scene folder of your choosing, run `npm i` and then `npm run start -- --explorer-alpha`
4. Close the Explorer that auto-opened. Leave the scene running in the console/terminal
5. Open build from this PR connecting it to the running scene using (make sure you update the `--position 0,0` value with the real coordinates of the test scene that you can see in the test scene folder name):
**WinOS**
`"C:\Users\[YOUR-USER]\Downloads\Decentraland_windows64\Decentraland.exe" --realm http://127.0.0.1:8000 --position 0,0 --local-scene true --debug --landscape-terrain-enabled false`
**MacOS**
`open Decentraland.app --args --realm http://127.0.0.1:8000 --position 0,0 --local-scene true --debug --landscape-terrain-enabled false`
6. Confirm that the local scene starts but the Landscape is not enabled
7. Close the build and now open it using (make sure you update the `--position 0,0` value with the real coordinates of the test scene that you can see in the test scene folder name):
**WinOS**
`"C:\Users\[YOUR-USER]\Downloads\Decentraland_windows64\Decentraland.exe" --realm http://127.0.0.1:8000 --position 0,0 --local-scene true --debug --landscape-terrain-enabled true`
**MacOS**
`open Decentraland.app --args --realm http://127.0.0.1:8000 --position 0,0 --local-scene true --debug --landscape-terrain-enabled true`
8. Confirm that the local scene starts but the Landscape is enabled

