### PR TITLE
fix: unreleased wearables preview breaking with 2K texture resolution

### DIFF
--- a/Explorer/Assets/DCL/Utilities/TextureUtilities.cs
+++ b/Explorer/Assets/DCL/Utilities/TextureUtilities.cs
@@ -13,37 +13,49 @@ public static class TextureUtilities
         return GraphicsFormat.R32G32B32A32_SFloat;
     }
 
-    public static Texture2D EnsureRGBA32Format(Texture2D sourceTexture)
+    /// <summary>
+    /// Ensures a texture is in RGBA32 format and optionally resizes it if it exceeds the resolution cap.
+    /// The resizing maintains the original aspect ratio by scaling the larger dimension to the cap and adjusting the other dimension proportionally.
+    /// </summary>
+    /// <param name="sourceTexture">The source texture to process</param>
+    /// <param name="resolutionCap">Maximum allowed dimension (width or height). Defaults to 1024 (same cap used in Asset Bundles Converter).</param>
+    /// <returns>A new texture in RGBA32 format with dimensions respecting the resolution cap</returns>
+    public static Texture2D EnsureRGBA32Format(Texture2D sourceTexture, int resolutionCap = 1024)
     {
-        if (sourceTexture.format == TextureFormat.RGBA32)
+        int targetWidth = sourceTexture.width;
+        int targetHeight = sourceTexture.height;
+
+        if (targetWidth > resolutionCap || targetHeight > resolutionCap)
+        {
+            // Calculate new dimensions while maintaining aspect ratio
+            float aspectRatio = (float)targetWidth / targetHeight;
+            if (targetWidth > targetHeight)
+            {
+                targetWidth = resolutionCap;
+                targetHeight = Mathf.RoundToInt(resolutionCap / aspectRatio);
+            }
+            else
+            {
+                targetHeight = resolutionCap;
+                targetWidth = Mathf.RoundToInt(resolutionCap * aspectRatio);
+            }
+        }
+        else if (sourceTexture.format == TextureFormat.RGBA32)
+        {
+            // If no resizing needed and format is already RGBA32, return original
             return sourceTexture;
+        }
 
         Texture2D rgba32Texture = new Texture2D(
-            sourceTexture.width,
-            sourceTexture.height,
+            targetWidth,
+            targetHeight,
             TextureFormat.RGBA32,
             false,
             false);
 
-        if (sourceTexture.isReadable)
-        {
-            try
-            {
-                rgba32Texture.SetPixels(sourceTexture.GetPixels());
-                rgba32Texture.Apply();
-                return rgba32Texture;
-            }
-            catch (Exception e)
-            {
-                ReportHub.LogError(ReportCategory.TEXTURES, $"Error getting pixels: {e.Message}. Falling back to RenderTexture approach.");
-                // Fall through to RenderTexture approach
-            }
-        }
-
-        // For non-readable textures, use RenderTexture approach
         RenderTexture rt = RenderTexture.GetTemporary(
-            sourceTexture.width,
-            sourceTexture.height,
+            targetWidth,
+            targetHeight,
             0,
             RenderTextureFormat.ARGB32);
 


### PR DESCRIPTION
### WHY

Marketplace builder collection wearables with textures above 1024x1024 resolution were breaking the preview due to the excessive TextureArray data allocation, since the AB Converter optimizes those textures capping them at 1k resolution.

### WHAT

Refactored raw gltf wearables textures patch to apply the same AB Converter patch on their resolution.

### TESTING
* To test this new feature you will need to create a collection in the wearables builder section of the marketplace at https://decentraland.org/builder/collections/
* Here I provide 2 test wearables that have to be loaded into the collection: [2048-res-tex-test-wearables.zip](https://github.com/user-attachments/files/19447509/2048-res-tex-test-wearables.zip)
* After you have a collection created in the marketplace builder section, copy its collection ID which can be found in the URL of your collection, for example it looks like: `3062136a-065d-4d94-b28c-f57d6ef04860`, **make sure you are copying the COLLECTION id, not the ITEM ID from 1 specific item of the collection**.


#### Test Steps

1. Download the build from this PR
2. Open the build with the new app param injecting YOUR COLLECTION ID, example:
**MacOS**
`open Decentraland.app --args --debug --self-preview-builder-collections YOUR-COLLECTION-ID-GOES-HERE`
**WinOS**
`"C:\Users\[YOUR-USER]\Downloads\Decentraland_windows64\Decentraland.exe" --debug --self-preview-builder-collections YOUR-COLLECTION-ID-GOES-HERE`
3. After you enter the virtual world, confirm that when opening the Backpack you see the items from your collection and you can equip/unequip them (give them some time to load after equipping them, as they are raw GLTFs).

