### PR TITLE
fix: remove option to show messages from blocked users

### DIFF
--- a/Explorer/Assets/DCL/Friends/UserBlockingCache.cs
+++ b/Explorer/Assets/DCL/Friends/UserBlockingCache.cs
@@ -19,7 +19,15 @@ namespace DCL.Friends
 
         public ReadOnlyHashSet<string> BlockedUsers { get; }
         public ReadOnlyHashSet<string> BlockedByUsers { get; }
-        public bool HideChatMessages { get; set; }
+
+        // This property is fixed to true since we currently don't want to show chat messages from blocked users in any shape or form.
+        // This can change in the future, so all the logic that is already in place will stay the same for such times.
+        public bool HideChatMessages
+        {
+            get => true;
+
+            set { }
+        }
 
         public UserBlockingCache(IFriendsService friendsService,
             IFriendsEventBus eventBus)

--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
@@ -48,10 +48,7 @@ MonoBehaviour:
       - rid: 3126482891795070976
       - rid: 3126482891795070977
   <ChatSectionConfig>k__BackingField:
-    <SettingsGroups>k__BackingField:
-    - <GroupTitle>k__BackingField: Messages
-      <Modules>k__BackingField:
-      - rid: 7563415536206086146
+    <SettingsGroups>k__BackingField: []
   references:
     version: 2
     RefIds:
@@ -262,16 +259,6 @@ MonoBehaviour:
           - 144
           defaultOptionIndex: 0
         <Feature>k__BackingField: 5
-    - rid: 7563415536206086146
-      type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
-      data:
-        <View>k__BackingField: {fileID: 1404863613082391807, guid: 39458b71e0ed84549b1b280c4fb1f105, type: 3}
-        <Config>k__BackingField:
-          <ModuleName>k__BackingField: Hide Blocked User Chat Input
-          <Description>k__BackingField: 
-          <IsEnabled>k__BackingField: 1
-          defaultIsOn: 0
-        <Feature>k__BackingField: 2
     - rid: 7621844939572510720
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:


### PR DESCRIPTION
# Pull Request Description

Fixes #3696

Remove the option to choose to show messages from blocked players.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Make `UserBlockingCache.HideChatMessages` always return true + remove the setting from the option menu through the scriptable object so that you cannot interact with it.

### Test Steps
1. Block a user
2. Have that user send a chat message
3. Verify that you don't see their messages
4. Verify that you don't have any way to disable the option (aka show the message as blocked)

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
