### PR TITLE
fix: sdk avatar shape transform interpolation not using global pos

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/SDKAvatarShapesMotionSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/SDKAvatarShapesMotionSystem.cs
@@ -47,7 +47,7 @@ namespace DCL.Character.CharacterMotion.Systems
         {
             UpdatePosition(deltaTime, characterTransformComponent, in characterInterpolationMovementComponent);
             UpdateRotation(deltaTime, characterTransformComponent, in characterInterpolationMovementComponent);
-            UpdateAnimations(deltaTime, view, characterTransformComponent, in characterInterpolationMovementComponent, ref animationComponent);
+            UpdateAnimations(deltaTime, view, in characterInterpolationMovementComponent, ref animationComponent);
             characterInterpolationMovementComponent.LastPosition = characterTransformComponent.Transform.position;
         }
 
@@ -113,11 +113,10 @@ namespace DCL.Character.CharacterMotion.Systems
         private static void UpdateAnimations(
             float deltaTime,
             IAvatarView view,
-            CharacterTransform characterTransformComponent,
             in CharacterInterpolationMovementComponent characterInterpolationMovementComponent,
             ref CharacterAnimationComponent animationComponent)
         {
-            float distanceToTarget = Vector3.Distance(characterTransformComponent.Transform.position, characterInterpolationMovementComponent.LastPosition);
+            float distanceToTarget = Vector3.Distance(characterInterpolationMovementComponent.TargetPosition, characterInterpolationMovementComponent.LastPosition);
             float movementBlendValue = 0;
 
             if (distanceToTarget > 0)

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Transforms/ExposedTransformUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Transforms/ExposedTransformUtils.cs
@@ -15,7 +15,7 @@ namespace ECS.Unity.Transforms
 
             return ecsToCrdtWriter.PutMessage<SDKTransform, (IExposedTransform, Vector3)>(static (c, data) =>
             {
-                c.Position.Value = ParcelMathHelper.GetSceneRelativePosition(data.Item1.Position.Value, data.Item2);
+                c.Position.Value = data.Item1.Position.Value.FromGlobalToSceneRelativePosition(data.Item2);
                 c.Rotation.Value = data.Item1.Rotation.Value;
             }, entity, (exposedTransform, scenePosition));
         }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ParcelMathHelper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ParcelMathHelper.cs
@@ -26,11 +26,16 @@ namespace Utility
             new (int2.x, int2.y);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector3 GetSceneRelativePosition(Vector3 position, Vector3 scenePosition) =>
-            position - scenePosition;
+        public static Vector3 FromGlobalToSceneRelativePosition(this Vector3 globalPosition, Vector3 sceneGlobalPosition) =>
+            globalPosition - sceneGlobalPosition;
 
-        public static Vector3 GetGlobalPosition(Vector2Int sceneBaseParcel, Vector3 sceneRelativePosition) =>
-            sceneBaseParcel.ParcelToPositionFlat() + sceneRelativePosition;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 FromGlobalToSceneRelativePosition(this Vector3 globalPosition, Vector2Int sceneBaseParcelCoords) =>
+            globalPosition - sceneBaseParcelCoords.ParcelToPositionFlat();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 FromSceneRelativeToGlobalPosition(this Vector3 sceneRelativePosition, Vector2Int sceneBaseParcelCoords) =>
+            sceneBaseParcelCoords.ParcelToPositionFlat() + sceneRelativePosition;
 
         public static Vector3 GetPositionByParcelPosition(Vector2Int parcelPosition, bool adaptYPositionToTerrain = false)
         {

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ParcelMathHelper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ParcelMathHelper.cs
@@ -29,6 +29,9 @@ namespace Utility
         public static Vector3 GetSceneRelativePosition(Vector3 position, Vector3 scenePosition) =>
             position - scenePosition;
 
+        public static Vector3 GetGlobalPosition(Vector2Int sceneBaseParcel, Vector3 sceneRelativePosition) =>
+            sceneBaseParcel.ParcelToPositionFlat() + sceneRelativePosition;
+
         public static Vector3 GetPositionByParcelPosition(Vector2Int parcelPosition, bool adaptYPositionToTerrain = false)
         {
             var position = new Vector3(parcelPosition.x * PARCEL_SIZE, 0.0f, parcelPosition.y * PARCEL_SIZE);

--- a/Explorer/Assets/DCL/Interaction/Utility/RaycastUtils.cs
+++ b/Explorer/Assets/DCL/Interaction/Utility/RaycastUtils.cs
@@ -83,7 +83,7 @@ namespace DCL.Interaction.Utility
             target.MeshName = colliderName;
             target.Length = unityHit.distance;
             target.GlobalOrigin.Set(globalOrigin);
-            target.Position.Set(ParcelMathHelper.GetSceneRelativePosition(unityHit.point, sceneRootPosition));
+            target.Position.Set(unityHit.point.FromGlobalToSceneRelativePosition(sceneRootPosition));
             target.NormalHit.Set(unityHit.normal);
             target.Direction.Set(direction);
         }

--- a/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
@@ -28,7 +28,7 @@ namespace DCL.PluginSystem.World
             ResetDirtyFlagSystem<PBAvatarShape>.InjectToWorld(ref builder);
             var avatarShapeHandlerSystem = AvatarShapeHandlerSystem.InjectToWorld(ref builder, globalWorld);
             finalizeWorldSystems.Add(avatarShapeHandlerSystem);
-            UpdateAvatarShapeInterpolateMovementSystem.InjectToWorld(ref builder, globalWorld);
+            UpdateAvatarShapeInterpolateMovementSystem.InjectToWorld(ref builder, globalWorld, sharedDependencies.SceneData.SceneShortInfo.BaseParcel);
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/UpdateAvatarShapeInterpolateMovementSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/UpdateAvatarShapeInterpolateMovementSystem.cs
@@ -10,6 +10,8 @@ using ECS.Abstract;
 using ECS.Groups;
 using ECS.Unity.AvatarShape.Components;
 using ECS.Unity.Transforms.Systems;
+using UnityEngine;
+using Utility;
 
 namespace DCL.SDKComponents.AvatarShape.Systems
 {
@@ -19,10 +21,12 @@ namespace DCL.SDKComponents.AvatarShape.Systems
     public partial class UpdateAvatarShapeInterpolateMovementSystem : BaseUnityLoopSystem
     {
         private readonly World globalWorld;
+        private readonly Vector2Int sceneBaseParcel;
 
-        private UpdateAvatarShapeInterpolateMovementSystem(World world, World globalWorld) : base(world)
+        private UpdateAvatarShapeInterpolateMovementSystem(World world, World globalWorld, Vector2Int sceneBaseParcel) : base(world)
         {
             this.globalWorld = globalWorld;
+            this.sceneBaseParcel = sceneBaseParcel;
         }
 
         protected override void Update(float t)
@@ -71,7 +75,7 @@ namespace DCL.SDKComponents.AvatarShape.Systems
             if (!hasCharacterInterpolationMovement)
                 return;
 
-            characterInterpolationMovementComponent.TargetPosition = sdkTransform.Position;
+            characterInterpolationMovementComponent.TargetPosition = ParcelMathHelper.GetGlobalPosition(sceneBaseParcel, sdkTransform.Position);
             characterInterpolationMovementComponent.TargetRotation = sdkTransform.Rotation;
             characterInterpolationMovementComponent.IsPositionManagedByTween = isPositionManagedByTween;
             characterInterpolationMovementComponent.IsRotationManagedByTween = isRotationManagedByTween;

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/UpdateAvatarShapeInterpolateMovementSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/UpdateAvatarShapeInterpolateMovementSystem.cs
@@ -75,8 +75,8 @@ namespace DCL.SDKComponents.AvatarShape.Systems
             if (!hasCharacterInterpolationMovement)
                 return;
 
-            characterInterpolationMovementComponent.TargetPosition = ParcelMathHelper.GetGlobalPosition(sceneBaseParcel, sdkTransform.Position);
-            characterInterpolationMovementComponent.TargetRotation = sdkTransform.Rotation;
+            characterInterpolationMovementComponent.TargetPosition = sdkTransform.Position.Value.FromSceneRelativeToGlobalPosition(sceneBaseParcel);
+            characterInterpolationMovementComponent.TargetRotation = sdkTransform.Rotation.Value;
             characterInterpolationMovementComponent.IsPositionManagedByTween = isPositionManagedByTween;
             characterInterpolationMovementComponent.IsRotationManagedByTween = isRotationManagedByTween;
         }


### PR DESCRIPTION
### WHY

Currently when we auto-interpolate SDK Avatar Shapes after their SDK `Transform` is manipulated by the scene (instead of using the `Tween` component), we are not converting the scene-relative position to global.

Using `Tween` it works as expected because the `Tween` systems logic already takes care of the position conversions.

Issue: https://github.com/decentraland/unity-explorer/issues/3647

That's why for any scene that is not in 0,0 the avatar shape interpolates to a target position relative to 0,0 when it should be interpolating to a target position relative to the base parcel of the scene...

https://github.com/user-attachments/assets/51026a62-ba27-46f5-9207-1aafc264f5de

### WHAT

Added missing position conversion to global when reading SDKTransform for interpolation

### TEST INSTRUCTIONS

1. Download the build from this PR and open it going to `pravus.dcl.eth`
2. Inside that world scene, click on the cube and it will turn into a sphere
3. Keep clicking on the sphere making the avatar shape called "Dagon" move between the different points in the scene
4. Confirm that every time the "Dagon" avatar finishes moving it always ends up inside the scene and doesn't go far away
5. (Optionally) you can confirm the bug by entering the world with the latest release and see how "Dagon" goes far away.