### PR TITLE
fix: Scroll speed in chat

### DIFF
--- a/Explorer/Assets/DCL/Chat/Assets/ChatMessageViewerElement.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/ChatMessageViewerElement.prefab
@@ -205,6 +205,7 @@ MonoBehaviour:
   scrollbarCanvasGroup: {fileID: 5299699939936977056}
   chatEntriesCanvasGroup: {fileID: 6636967551683476283}
   loopList: {fileID: 4226233381184064841}
+  scrollRect: {fileID: 5266907368250149817}
 --- !u!1 &1464650193662970722
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Chat/Chat.asmdef
+++ b/Explorer/Assets/DCL/Chat/Chat.asmdef
@@ -46,7 +46,8 @@
         "GUID:7cfe53a67dd47414fbe97d2e908fe310",
         "GUID:f3634757d00dab2429c6c11e69404e97",
         "GUID:166b65e6dfc848bb9fb075f53c293a38",
-        "GUID:246f0aa8b201240c8b816c1cd6ad4778"
+        "GUID:246f0aa8b201240c8b816c1cd6ad4778",
+        "GUID:d5368878df29ff849933a7d3586d18c6"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Chat/ChatMessageViewerElement.cs
+++ b/Explorer/Assets/DCL/Chat/ChatMessageViewerElement.cs
@@ -22,6 +22,8 @@ namespace DCL.Chat
     /// </summary>
     public class ChatMessageViewerElement : MonoBehaviour, IDisposable, IViewWithGlobalDependencies
     {
+        private const float SCROLL_OVERRIDE_WINDOWS = 0.15f;
+        private const float SCROLL_OVERRIDE_MAC_OS = 0.45f;
         public delegate void ChatMessageOptionsButtonClickedDelegate(string chatMessage, ChatEntryView chatEntryView);
         public delegate void ChatMessageViewerScrollPositionChangedDelegate(Vector2 newScrollPosition);
         public delegate Color CalculateUsernameColorDelegate(ChatMessage chatMessage);
@@ -123,7 +125,7 @@ namespace DCL.Chat
         {
             loopList.InitListView(0, OnGetItemByIndex);
             loopList.ScrollRect.onValueChanged.AddListener(OnScrollRectValueChanged);
-            scrollRect.SetScrollSensitivityBasedOnPlatform(0.15f, 0.45f);
+            scrollRect.SetScrollSensitivityBasedOnPlatform(SCROLL_OVERRIDE_WINDOWS, SCROLL_OVERRIDE_MAC_OS);
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/Chat/ChatMessageViewerElement.cs
+++ b/Explorer/Assets/DCL/Chat/ChatMessageViewerElement.cs
@@ -3,6 +3,7 @@ using DCL.Chat.History;
 using DCL.Profiles;
 using DCL.Diagnostics;
 using DCL.UI.Profiles.Helpers;
+using DCL.UI.Utilities;
 using DCL.Web3;
 using DG.Tweening;
 using MVC;
@@ -64,6 +65,9 @@ namespace DCL.Chat
         [SerializeField]
         private LoopListView2 loopList;
 
+        [SerializeField]
+        private ScrollRect scrollRect;
+
         // The latest amount of messages added to the chat that must be animated yet
         private int entriesPendingToAnimate;
 
@@ -119,6 +123,7 @@ namespace DCL.Chat
         {
             loopList.InitListView(0, OnGetItemByIndex);
             loopList.ScrollRect.onValueChanged.AddListener(OnScrollRectValueChanged);
+            scrollRect.SetScrollSensitivityBasedOnPlatform();
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/Chat/ChatMessageViewerElement.cs
+++ b/Explorer/Assets/DCL/Chat/ChatMessageViewerElement.cs
@@ -123,7 +123,7 @@ namespace DCL.Chat
         {
             loopList.InitListView(0, OnGetItemByIndex);
             loopList.ScrollRect.onValueChanged.AddListener(OnScrollRectValueChanged);
-            scrollRect.SetScrollSensitivityBasedOnPlatform();
+            scrollRect.SetScrollSensitivityBasedOnPlatform(0.15f, 0.45f);
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/UI/Utilities/ScrollRectExtensions.cs
+++ b/Explorer/Assets/DCL/UI/Utilities/ScrollRectExtensions.cs
@@ -8,12 +8,12 @@ namespace DCL.UI.Utilities
         private const int MACOS_SCROLL_SENSITIVITY = 3;
         private const int WINDOWS_SCROLL_SENSITIVITY = 1;
 
-        public static void SetScrollSensitivityBasedOnPlatform(this ScrollRect scrollRect)
+        public static void SetScrollSensitivityBasedOnPlatform(this ScrollRect scrollRect, float overrideWindows = WINDOWS_SCROLL_SENSITIVITY, float overrideMacOS = MACOS_SCROLL_SENSITIVITY)
         {
             if (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)
-                scrollRect.scrollSensitivity = MACOS_SCROLL_SENSITIVITY;
+                scrollRect.scrollSensitivity = overrideWindows;
             else
-                scrollRect.scrollSensitivity = WINDOWS_SCROLL_SENSITIVITY;
+                scrollRect.scrollSensitivity = overrideMacOS;
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Added scroll sensitivity change depending on platform for the Chat Scroll + added possibility to override default values in helper class.


## Test Instructions
Check that scrolling with the mouse wheel works correctly in the chat, both in Windows and Mac.