### PR TITLE
fix: log spam about profile picture masking

### DIFF
--- a/Explorer/Assets/Textures/Common/Container24.png.meta
+++ b/Explorer/Assets/Textures/Common/Container24.png.meta
@@ -3,7 +3,7 @@ guid: 99428d9ed6da74af2966fb29d960e48f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -21,7 +21,7 @@ TextureImporter:
     heightScale: 0.25
     normalMapFilter: 0
     flipGreenChannel: 0
-  isReadable: 0
+  isReadable: 1
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0


### PR DESCRIPTION
## What does this PR change?

Fixes #3729 at least the masking problem in the client (the image propagation issue should be taken by platform team).

The fix consists on making the `Container24.png` read/write enabled.

## Test Instructions
Check that profile pictures works as expected. Places on which you can encounter them: chat, friends, passport, camera reel. You should not see any logs like this:
```
[WARN] SoftMasking Issue with Texture: Also, related to the profile picture, there is a warning in the logs about SoftMask not being able to read the texture for the profile image.
```

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
