### PR TITLE
fix: be more specific when assigning facial feature materials

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/AvatarMaterialConfiguration.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/AvatarMaterialConfiguration.cs
@@ -33,9 +33,9 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
         private static readonly (string suffix, string category, int defaultSlotIndexUsed, GetFacialFeatureColor getColor)[] SUFFIX_CATEGORY_MAP =
         {
-            ("eyes", WearablesConstants.Categories.EYES, defaultSlotIndexUsed: 1, (in AvatarShapeComponent shape) => shape.EyesColor),
-            ("eyebrows", WearablesConstants.Categories.EYEBROWS, defaultSlotIndexUsed: 0, (in AvatarShapeComponent shape) => shape.HairColor),
-            ("mouth", WearablesConstants.Categories.MOUTH, defaultSlotIndexUsed: 0, (in AvatarShapeComponent shape) => shape.SkinColor),
+            ("Mask_Eyes", WearablesConstants.Categories.EYES, defaultSlotIndexUsed: 1, (in AvatarShapeComponent shape) => shape.EyesColor),
+            ("Mask_Eyebrows", WearablesConstants.Categories.EYEBROWS, defaultSlotIndexUsed: 0, (in AvatarShapeComponent shape) => shape.HairColor),
+            ("Mask_Mouth", WearablesConstants.Categories.MOUTH, defaultSlotIndexUsed: 0, (in AvatarShapeComponent shape) => shape.SkinColor),
         };
 
         public static AvatarCustomSkinningComponent.MaterialSetup SetupMaterial(Renderer meshRenderer, Material originalMaterial, int lastWearableVertCount, IAvatarMaterialPoolHandler poolHandler,
@@ -120,7 +120,7 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
             {
                 (string suffix, string category, int defaultSlotIndexUsed, GetFacialFeatureColor getColor) = SUFFIX_CATEGORY_MAP[i];
 
-                if (meshRenderer.name.Contains(suffix, StringComparison.OrdinalIgnoreCase))
+                if (meshRenderer.name.EndsWith(suffix))
                 {
                     result = true;
                     return DoFacialFeature(poolHandler, facialFeatures.Value[category], getColor(in avatarShapeComponent), defaultSlotIndexUsed);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This makes assigning facial features materials more exact so there's less of a chance that creators will run into the issue of facial features material being assigned incorrectly.
Previously if a mesh name contained "eyes, eyebrows, mouth", it would break. Now that's changed to "Mask_Eyes, Mask_Eyebrows, Mask_Mouth", which has to be the suffix (should only appear in our base models)

closes: #3249

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] Make sure you have access to the `urn:decentraland:matic:collections-v2:0x736e227684be1e65e15f8a2de2709fcc284a8b13:1` wearable

### Test Steps
1. Run the explorer
2. Equip the wearable
3. The head with the custom "cutesy texture" should be visible

### Additional Testing Notes
- Make sure you don't have something else equipped that would hide the wearable helmet, as that is a separate issue

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
