### PR TITLE
chore: Add textures array for naming

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayContainerFactory.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayContainerFactory.cs
@@ -20,7 +20,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
         {
             return new TextureArrayContainer( new TextureArrayMapping[]
             {
-                new (new TextureArrayHandler(defaultResolutionsDescriptors, BASE_MAP_TEX_ARR_INDEX, BASE_MAP_TEX_ARR,
+                new (new TextureArrayHandler("Scene_LOD", defaultResolutionsDescriptors, BASE_MAP_TEX_ARR_INDEX, BASE_MAP_TEX_ARR,
                         textureFormat, new Dictionary<TextureArrayKey, Texture>(), arraySizeForMissingResolutions, capacityForMissingResolutions),
                     MAINTEX_ORIGINAL_TEXTURE, MAIN_TEXTURE_RESOLUTION)
             });
@@ -31,7 +31,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             return new TextureArrayContainer(
                 new TextureArrayMapping[]
                 {
-                    new (new TextureArrayHandler(MAIN_TEXTURE_ARRAY_SIZE, BASE_MAP_TEX_ARR_INDEX, BASE_MAP_TEX_ARR, defaultResolutions, DEFAULT_BASEMAP_TEXTURE_FORMAT, defaultTextures), BASE_MAP_ORIGINAL_TEXTURE, MAIN_TEXTURE_RESOLUTION),
+                    new (new TextureArrayHandler("Avatar_PBR", MAIN_TEXTURE_ARRAY_SIZE, BASE_MAP_TEX_ARR_INDEX, BASE_MAP_TEX_ARR, defaultResolutions, DEFAULT_BASEMAP_TEXTURE_FORMAT, defaultTextures), BASE_MAP_ORIGINAL_TEXTURE, MAIN_TEXTURE_RESOLUTION),
                 });
         }
 
@@ -40,11 +40,11 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             var textureArrayMapping = new List<TextureArrayMapping>
             {
                 // Asset Bundle Wearables
-                new (new TextureArrayHandler(MAIN_TEXTURE_ARRAY_SIZE, MAINTEX_ARR_SHADER_INDEX, MAINTEX_ARR_TEX_SHADER, defaultResolutions, DEFAULT_BASEMAP_TEXTURE_FORMAT, defaultTextures),
+                new (new TextureArrayHandler("Avatar_Toon", MAIN_TEXTURE_ARRAY_SIZE, MAINTEX_ARR_SHADER_INDEX, MAINTEX_ARR_TEX_SHADER, defaultResolutions, DEFAULT_BASEMAP_TEXTURE_FORMAT, defaultTextures),
                     MAINTEX_ORIGINAL_TEXTURE, MAIN_TEXTURE_RESOLUTION),
-                new (new TextureArrayHandler(NORMAL_TEXTURE_ARRAY_SIZE, NORMAL_MAP_TEX_ARR_INDEX, NORMAL_MAP_TEX_ARR, defaultResolutions, DEFAULT_NORMALMAP_TEXTURE_FORMAT, defaultTextures),
+                new (new TextureArrayHandler("Avatar_Toon", NORMAL_TEXTURE_ARRAY_SIZE, NORMAL_MAP_TEX_ARR_INDEX, NORMAL_MAP_TEX_ARR, defaultResolutions, DEFAULT_NORMALMAP_TEXTURE_FORMAT, defaultTextures),
                     BUMP_MAP_ORIGINAL_TEXTURE_ID, NORMAL_TEXTURE_RESOLUTION),
-                new (new TextureArrayHandler(EMISSION_TEXTURE_ARRAY_SIZE, EMISSIVE_MAP_TEX_ARR_INDEX, EMISSIVE_MAP_TEX_ARR, defaultResolutions, DEFAULT_EMISSIVEMAP_TEXTURE_FORMAT, defaultTextures),
+                new (new TextureArrayHandler("Avatar_Toon", EMISSION_TEXTURE_ARRAY_SIZE, EMISSIVE_MAP_TEX_ARR_INDEX, EMISSIVE_MAP_TEX_ARR, defaultResolutions, DEFAULT_EMISSIVEMAP_TEXTURE_FORMAT, defaultTextures),
                     EMISSION_MAP_ORIGINAL_TEXTURE_ID, EMISSION_TEXTURE_RESOLUTION),
             };
 
@@ -53,11 +53,11 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
                 // Raw GLTF Wearables
                 textureArrayMapping.AddRange(new[]
                 {
-                    new TextureArrayMapping(new TextureArrayHandler(MAIN_TEXTURE_ARRAY_SIZE, MAINTEX_ARR_SHADER_INDEX, MAINTEX_ARR_TEX_SHADER, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
+                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Toon_Raw_GLTF", MAIN_TEXTURE_ARRAY_SIZE, MAINTEX_ARR_SHADER_INDEX, MAINTEX_ARR_TEX_SHADER, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
                         MAINTEX_ORIGINAL_TEXTURE, MAIN_TEXTURE_RESOLUTION),
-                    new TextureArrayMapping(new TextureArrayHandler(NORMAL_TEXTURE_ARRAY_SIZE, NORMAL_MAP_TEX_ARR_INDEX, NORMAL_MAP_TEX_ARR, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
+                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Toon_Raw_GLTF", NORMAL_TEXTURE_ARRAY_SIZE, NORMAL_MAP_TEX_ARR_INDEX, NORMAL_MAP_TEX_ARR, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
                         BUMP_MAP_ORIGINAL_TEXTURE_ID, NORMAL_TEXTURE_RESOLUTION),
-                    new TextureArrayMapping(new TextureArrayHandler(EMISSION_TEXTURE_ARRAY_SIZE, EMISSIVE_MAP_TEX_ARR_INDEX, EMISSIVE_MAP_TEX_ARR, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
+                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Toon_Raw_GLTF", EMISSION_TEXTURE_ARRAY_SIZE, EMISSIVE_MAP_TEX_ARR_INDEX, EMISSIVE_MAP_TEX_ARR, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
                         EMISSION_MAP_ORIGINAL_TEXTURE_ID, EMISSION_TEXTURE_RESOLUTION)
                 });
             }
@@ -70,9 +70,9 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             var textureArrayMapping = new List<TextureArrayMapping>
             {
                 // Asset Bundle Facial Feature Wearables
-                new (new TextureArrayHandler(FACIAL_FEATURES_TEXTURE_ARRAY_SIZE, MAINTEX_ARR_SHADER_INDEX, MAINTEX_ARR_TEX_SHADER, defaultResolutions, DEFAULT_BASEMAP_TEXTURE_FORMAT, defaultTextures),
+                new (new TextureArrayHandler("Avatar_Facial_Feature", FACIAL_FEATURES_TEXTURE_ARRAY_SIZE, MAINTEX_ARR_SHADER_INDEX, MAINTEX_ARR_TEX_SHADER, defaultResolutions, DEFAULT_BASEMAP_TEXTURE_FORMAT, defaultTextures),
                     MAINTEX_ORIGINAL_TEXTURE, FACIAL_FEATURES_TEXTURE_RESOLUTION),
-                new (new TextureArrayHandler(FACIAL_FEATURES_TEXTURE_ARRAY_SIZE, MASK_ARR_SHADER_ID, MASK_ARR_TEX_SHADER_ID, defaultResolutions, DEFAULT_BASEMAP_TEXTURE_FORMAT, defaultTextures),
+                new (new TextureArrayHandler("Avatar_Facial_Feature", FACIAL_FEATURES_TEXTURE_ARRAY_SIZE, MASK_ARR_SHADER_ID, MASK_ARR_TEX_SHADER_ID, defaultResolutions, DEFAULT_BASEMAP_TEXTURE_FORMAT, defaultTextures),
                     MASK_ORIGINAL_TEXTURE_ID, FACIAL_FEATURES_TEXTURE_RESOLUTION)
             };
 
@@ -81,9 +81,9 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
                 // Raw Facial Feature Wearables
                 textureArrayMapping.AddRange(new[]
                 {
-                    new TextureArrayMapping(new TextureArrayHandler(FACIAL_FEATURES_TEXTURE_ARRAY_SIZE, MAINTEX_ARR_SHADER_INDEX, MAINTEX_ARR_TEX_SHADER, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
+                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Facial_Feature_Raw_GLTF", FACIAL_FEATURES_TEXTURE_ARRAY_SIZE, MAINTEX_ARR_SHADER_INDEX, MAINTEX_ARR_TEX_SHADER, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
                         MAINTEX_ORIGINAL_TEXTURE, FACIAL_FEATURES_TEXTURE_RESOLUTION),
-                    new TextureArrayMapping(new TextureArrayHandler(FACIAL_FEATURES_TEXTURE_ARRAY_SIZE, MASK_ARR_SHADER_ID, MASK_ARR_TEX_SHADER_ID, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
+                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Facial_Feature_Raw_GLTF", FACIAL_FEATURES_TEXTURE_ARRAY_SIZE, MASK_ARR_SHADER_ID, MASK_ARR_TEX_SHADER_ID, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
                         MASK_ORIGINAL_TEXTURE_ID, FACIAL_FEATURES_TEXTURE_RESOLUTION)
                 });
             }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayHandler.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayHandler.cs
@@ -22,7 +22,10 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
 
         private readonly IReadOnlyDictionary<TextureArrayKey, Texture>? defaultTextures;
 
+        private readonly string domain;
+
         public TextureArrayHandler(
+            string domain,
             int minArraySize,
             int arrayID,
             int textureID,
@@ -37,6 +40,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             this.textureFormat = textureFormat;
             this.defaultTextures = defaultTextures;
             this.initialCapacityForEachResolution = initialCapacityForEachResolution;
+            this.domain = domain;
 
             handlersByResolution = new Dictionary<Vector2Int, TextureArraySlotHandler>(defaultResolutions.Count);
 
@@ -47,6 +51,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
 
 
         public TextureArrayHandler(
+            string domain,
             IReadOnlyList<TextureArrayResolutionDescriptor> textureArrayResolutionDescriptors,
             int arrayID,
             int textureID,
@@ -56,6 +61,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             int initialCapacityForEachResolution)
         {
             minArraySize = arraySizeForMissingResolutions;
+            this.domain = domain;
             this.arrayID = arrayID;
             this.textureID = textureID;
             this.textureFormat = textureFormat;
@@ -72,7 +78,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
         {
             var resolution = new Vector2Int(descriptor.Resolution, descriptor.Resolution);
 
-            var slotHandler = new TextureArraySlotHandler(resolution, descriptor.ArraySize, descriptor.InitialArrayCapacity, textureFormat);
+            var slotHandler = new TextureArraySlotHandler(domain, resolution, descriptor.ArraySize, descriptor.InitialArrayCapacity, textureFormat);
             handlersByResolution[resolution] = slotHandler;
 
             // When the handler is created initialize the default texture
@@ -92,7 +98,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
         private TextureArraySlotHandler CreateHandler(Vector2Int resolution)
         {
             //We are creating a considerably smaller array for non square resolutions. Shouldn't be a common case
-            var slotHandler = new TextureArraySlotHandler(resolution, resolution.x == resolution.y ? minArraySize : minArraySize / 10, initialCapacityForEachResolution, textureFormat);
+            var slotHandler = new TextureArraySlotHandler(domain, resolution, resolution.x == resolution.y ? minArraySize : minArraySize / 10, initialCapacityForEachResolution, textureFormat);
             handlersByResolution[resolution] = slotHandler;
 
             // When the handler is created initialize the default texture

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArraySlotHandler.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArraySlotHandler.cs
@@ -12,7 +12,9 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
         private int nextFreeIndex;
         private TextureFormat textureFormat;
 
-        public TextureArraySlotHandler(Vector2Int resolution, int minArraySize, int initialCapacity, TextureFormat textureFormat)
+        private string domain;
+
+        public TextureArraySlotHandler(string domain, Vector2Int resolution, int minArraySize, int initialCapacity, TextureFormat textureFormat)
         {
             this.minArraySize = minArraySize;
             this.resolution = resolution;
@@ -40,7 +42,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
         private Texture2DArray CreateTexture2DArray()
         {
             var texture2DArray = new Texture2DArray(resolution.x, resolution.y, minArraySize, textureFormat, false, false);
-            texture2DArray.name = $"TextureArray_x:{resolution.x}_y:{resolution.y}_minArraySize:{minArraySize}_textureFormat:{textureFormat}";
+            texture2DArray.name = $"TextureArray_domain:{domain}_x:{resolution.x}_y:{resolution.y}_minArraySize:{minArraySize}_textureFormat:{textureFormat}";
 
             texture2DArray.filterMode = FilterMode.Bilinear;
             texture2DArray.wrapMode = TextureWrapMode.Repeat;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArraySlotHandler.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArraySlotHandler.cs
@@ -19,6 +19,7 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             this.minArraySize = minArraySize;
             this.resolution = resolution;
             this.textureFormat = textureFormat;
+            this.domain = domain;
 
             arrays = new List<Texture2DArray>(initialCapacity);
             arrays.Add(CreateTexture2DArray());

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArraySlotHandler.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArraySlotHandler.cs
@@ -40,6 +40,8 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
         private Texture2DArray CreateTexture2DArray()
         {
             var texture2DArray = new Texture2DArray(resolution.x, resolution.y, minArraySize, textureFormat, false, false);
+            texture2DArray.name = $"TextureArray_x:{resolution.x}_y:{resolution.y}_minArraySize:{minArraySize}_textureFormat:{textureFormat}";
+
             texture2DArray.filterMode = FilterMode.Bilinear;
             texture2DArray.wrapMode = TextureWrapMode.Repeat;
             texture2DArray.anisoLevel = 9;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Adds texture array naming for better debugging

<img width="864" alt="image" src="https://github.com/user-attachments/assets/88ce3bd3-2fdc-4852-b305-b63dd7672e50" />


## Test Instructions
1. Nothing in particular. Smoke test. This should not modify runtime code


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
