### PR TITLE
fix: added safe access to emote isLooping

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Emote.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Emote.cs
@@ -46,7 +46,7 @@ namespace DCL.AvatarRendering.Emotes
             ((IAvatarAttachment<EmoteDTO>)this).ToString();
 
         public bool IsLooping() =>
-            Model.Asset.metadata.emoteDataADR74.loop;
+            Model.Asset is { metadata: { emoteDataADR74: { loop: true } } };
 
         public bool HasSameClipForAllGenders()
         {

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Emote.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Emote.cs
@@ -46,6 +46,8 @@ namespace DCL.AvatarRendering.Emotes
             ((IAvatarAttachment<EmoteDTO>)this).ToString();
 
         public bool IsLooping() =>
+            //as the Asset is nullable the loop property might be retrieved in situations in which the Asset has not been yet loaded
+            //to avoid a breaking null reference we provide safe access to the loop property by using the is pattern
             Model.Asset is { metadata: { emoteDataADR74: { loop: true } } };
 
         public bool HasSameClipForAllGenders()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #3664
Avoids a rare possible null reference when accessing the isLooping metadata of emotes

### Test Steps
1. Login with any account
2. Play different emotes, both looping and not looping
3. Verify they all work as expected
4. Verify emotes on other users also work as before

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
