### PR TITLE
fix: lazy load data of live events & pois

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
@@ -37,7 +37,6 @@ namespace DCL.MapRenderer.MapLayers.PointsOfInterest
         private readonly ClusterController clusterController;
         private readonly INavmapBus navmapBus;
         private readonly IPlacesAPIService placesAPIService;
-
         private readonly Dictionary<Vector2Int, IClusterableMarker> markers = new ();
         private readonly Dictionary<GameObject, ISceneOfInterestMarker> visibleMarkers = new ();
         private readonly List<Vector2Int> vectorCoords = new ();
@@ -47,6 +46,7 @@ namespace DCL.MapRenderer.MapLayers.PointsOfInterest
         private CancellationTokenSource deHighlightCt = new ();
         private ISceneOfInterestMarker? previousMarker;
 
+        private bool isDataInitialized;
         private bool isEnabled;
         private int zoomLevel = 1;
         private float baseZoom = 1;
@@ -72,40 +72,6 @@ namespace DCL.MapRenderer.MapLayers.PointsOfInterest
 
         public async UniTask InitializeAsync(CancellationToken cancellationToken)
         {
-            IReadOnlyList<string> pointsOfInterestCoordsAsync =
-                await placesAPIService.GetPointsOfInterestCoordsAsync(cancellationToken)
-                                      .SuppressAnyExceptionWithFallback(Array.Empty<string>(), ReportCategory.UI);
-            vectorCoords.Clear();
-
-            foreach (var s in pointsOfInterestCoordsAsync)
-            {
-                try { vectorCoords.Add(IpfsHelper.DecodePointer(s)); }
-                catch (Exception e) { ReportHub.LogException(e, ReportCategory.UI); }
-            }
-
-            using var placesByCoordsListAsync =
-                await placesAPIService.GetPlacesByCoordsListAsync(vectorCoords, cancellationToken, true)
-                                      .SuppressAnyExceptionWithFallback(EMPTY_PLACES, ReportCategory.UI);
-
-            // non-blocking retrieval of scenes of interest happens independently on the minimap rendering
-            foreach (PlacesData.PlaceInfo placeInfo in placesByCoordsListAsync.Value)
-            {
-                if (markers.ContainsKey(MapLayerUtils.GetParcelsCenter(placeInfo)))
-                    continue;
-
-                if (IsEmptyParcel(placeInfo))
-                    continue;
-
-                var marker = builder(objectsPool, mapCullingController, coordsUtils);
-                var centerParcel = MapLayerUtils.GetParcelsCenter(placeInfo);
-                var position = coordsUtils.CoordsToPosition(centerParcel);
-
-                marker.SetData(placeInfo.title, position, placeInfo);
-                markers.Add(MapLayerUtils.GetParcelsCenter(placeInfo), marker);
-
-                if (isEnabled)
-                    mapCullingController.StartTracking(marker, this);
-            }
         }
 
         protected override void DisposeImpl()
@@ -179,8 +145,14 @@ namespace DCL.MapRenderer.MapLayers.PointsOfInterest
             return UniTask.CompletedTask;
         }
 
-        public UniTask EnableAsync(CancellationToken cancellationToken)
+        public async UniTask EnableAsync(CancellationToken cancellationToken)
         {
+            if (!isDataInitialized)
+            {
+                await LoadDataAsync();
+                isDataInitialized = true;
+            }
+
             foreach (ISceneOfInterestMarker marker in markers.Values)
                 mapCullingController.StartTracking(marker, this);
 
@@ -192,7 +164,44 @@ namespace DCL.MapRenderer.MapLayers.PointsOfInterest
                     mapCullingController.StartTracking(clusterableMarker, this);
             }
 
-            return UniTask.CompletedTask;
+            async UniTask LoadDataAsync()
+            {
+                IReadOnlyList<string> pointsOfInterestCoordsAsync =
+                    await placesAPIService.GetPointsOfInterestCoordsAsync(cancellationToken)
+                                          .SuppressAnyExceptionWithFallback(Array.Empty<string>(), ReportCategory.UI);
+                vectorCoords.Clear();
+
+                foreach (string? s in pointsOfInterestCoordsAsync)
+                {
+                    try { vectorCoords.Add(IpfsHelper.DecodePointer(s)); }
+                    catch (Exception e) { ReportHub.LogException(e, ReportCategory.UI); }
+                }
+
+                using var placesByCoordsListAsync =
+                    await placesAPIService.GetPlacesByCoordsListAsync(vectorCoords, cancellationToken, true)
+                                          .SuppressAnyExceptionWithFallback(EMPTY_PLACES, ReportCategory.UI);
+
+                // Should we clear & dispose the markers before filling it?
+                // non-blocking retrieval of scenes of interest happens independently on the minimap rendering
+                foreach (PlacesData.PlaceInfo placeInfo in placesByCoordsListAsync.Value)
+                {
+                    if (markers.ContainsKey(MapLayerUtils.GetParcelsCenter(placeInfo)))
+                        continue;
+
+                    if (IsEmptyParcel(placeInfo))
+                        continue;
+
+                    var marker = builder(objectsPool, mapCullingController, coordsUtils);
+                    var centerParcel = MapLayerUtils.GetParcelsCenter(placeInfo);
+                    var position = coordsUtils.CoordsToPosition(centerParcel);
+
+                    marker.SetData(placeInfo.title, position, placeInfo);
+                    markers.Add(MapLayerUtils.GetParcelsCenter(placeInfo), marker);
+
+                    if (isEnabled)
+                        mapCullingController.StartTracking(marker, this);
+                }
+            }
         }
 
         public bool TryHighlightObject(GameObject gameObject, out IMapRendererMarker? mapMarker)

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
@@ -82,6 +82,7 @@ namespace DCL.MapRenderer.MapLayers.PointsOfInterest
                 marker.Dispose();
 
             markers.Clear();
+            isDataInitialized = false;
         }
 
         public void OnMapObjectBecameVisible(ISceneOfInterestMarker marker)


### PR DESCRIPTION
## What does this PR change?

This pr is related to https://github.com/decentraland/unity-explorer/pull/3608 but with a different approach.
Fixes #3403 

Also fixes exceptions like these when the identity is expired or non-existent:
```
InvalidOperationException: Identity is not found in the cache
```

Changes consist of postponing the load of the live events and points of interests when they are enabled by the map system. Previously it was being loaded during app start, at the creation of the containers provoking this kind of inconsistencies.

## Test Instructions
Check that the live events and point of interests works as expected, either in the map and minimap.
Try to logout and re-login checking everything keeps consistent in the map.
In the logs there shouldn't be any: `InvalidOperationException: Identity is not found in the cache`.

### Additional Testing Notes
- Try traversing the world without opening the map while checking the minimap consistency.
- You can also try to force an identity expiration. So you need to:
1. Run the client with args `--identity-expiration-duration 5`
2. At auth screen, select another account
3. Login with an account
4. Exit the app
5. Wait at least 5 seconds
6. Run the client without args
7. Re-login with any account
8. Check in the logs that you dont have any `InvalidOperationException: Identity is not found in the cache` during in the auth screen

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
