### PR TITLE
fix: disable highlight on entities that have been removed from the World

### DIFF
--- a/Explorer/Assets/DCL/Interaction/Systems/InteractionHighlightSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/InteractionHighlightSystem.cs
@@ -66,7 +66,7 @@ namespace DCL.Interaction.Systems
         private void UpdateHighlights(ref HighlightComponent highlightComponent)
         {
             if (highlightComponent.CurrentEntityOrNull() != EntityReference.Null
-                && World!.Has<DeleteEntityIntention>(highlightComponent.CurrentEntityOrNull()))
+                && (!highlightComponent.CurrentEntityOrNull().IsAlive(World) || World!.Has<DeleteEntityIntention>(highlightComponent.CurrentEntityOrNull())))
                 highlightComponent.Disable();
 
             if (highlightComponent.ReadyForMaterial())


### PR DESCRIPTION
# Pull Request Description

Fixes #3460

Add a check for the entity of the highlight component to test if it is still inside `World`, avoiding a subsequent `NRE` in `World.Has<>()`

### Test Steps
1. Go to `1,101`
2. Play a solo game
3. Verify that it never freezes and you are able to finish the game

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
