### PR TITLE
fix: reel gallery scroll element visibility + unify scrolling speeds

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatMessageViewerElement.cs
+++ b/Explorer/Assets/DCL/Chat/ChatMessageViewerElement.cs
@@ -22,8 +22,6 @@ namespace DCL.Chat
     /// </summary>
     public class ChatMessageViewerElement : MonoBehaviour, IDisposable, IViewWithGlobalDependencies
     {
-        private const float SCROLL_OVERRIDE_WINDOWS = 0.15f;
-        private const float SCROLL_OVERRIDE_MAC_OS = 0.45f;
         public delegate void ChatMessageOptionsButtonClickedDelegate(string chatMessage, ChatEntryView chatEntryView);
         public delegate void ChatMessageViewerScrollPositionChangedDelegate(Vector2 newScrollPosition);
         public delegate Color CalculateUsernameColorDelegate(ChatMessage chatMessage);
@@ -125,7 +123,7 @@ namespace DCL.Chat
         {
             loopList.InitListView(0, OnGetItemByIndex);
             loopList.ScrollRect.onValueChanged.AddListener(OnScrollRectValueChanged);
-            scrollRect.SetScrollSensitivityBasedOnPlatform(SCROLL_OVERRIDE_WINDOWS, SCROLL_OVERRIDE_MAC_OS);
+            scrollRect.SetScrollSensitivityBasedOnPlatform();
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
@@ -56,7 +56,6 @@ namespace DCL.InWorldCamera.CameraReelGallery
         private const int GRID_POOL_DEFAULT_CAPACITY = 10;
         private const int GRID_POOL_MAX_SIZE = 500;
         private const int ANIMATION_DELAY = 300;
-        private const int MACOS_SCROLL_SENSITIVITY_SCALE_FACTOR = 5;
 
         private static readonly ListObjectPool<CameraReelResponseCompact> CAMERA_REEL_RESPONSES_POOL = new ();
 
@@ -79,8 +78,6 @@ namespace DCL.InWorldCamera.CameraReelGallery
         private bool isDragging;
         private float previousY = 1f;
         private CancellationTokenSource loadNextPageCts = new ();
-        private CancellationTokenSource showSuccessCts = new ();
-        private CancellationTokenSource showFailureCts = new ();
         private CancellationTokenSource setPublicCts = new ();
         private CancellationTokenSource deleteScreenshotCts = new ();
         private CancellationTokenSource downloadScreenshotCts = new ();
@@ -167,6 +164,7 @@ namespace DCL.InWorldCamera.CameraReelGallery
                 }
             }
 
+            downloadScreenshotCts = downloadScreenshotCts.SafeRestart();
             DownloadAndOpenAsync(downloadScreenshotCts.Token).Forget();
         }
 
@@ -405,6 +403,10 @@ namespace DCL.InWorldCamera.CameraReelGallery
 
         private void OnScrollRectValueChanged(Vector2 value)
         {
+            //Exclude visibility computation when scrolling over the top or bottom of the scroll rect due to elasticity
+            if (view.scrollRect is { verticalNormalizedPosition: >= 1f, velocity: { y: > 0f } } or { verticalNormalizedPosition: <= 0f, velocity: { y: < 0f } })
+                return;
+
             HandleElementsVisibility(value.y > previousY ? ScrollDirection.UP : ScrollDirection.DOWN);
             CheckNeedsToLoadMore();
 

--- a/Explorer/Assets/DCL/UI/Utilities/ScrollRectExtensions.cs
+++ b/Explorer/Assets/DCL/UI/Utilities/ScrollRectExtensions.cs
@@ -5,8 +5,8 @@ namespace DCL.UI.Utilities
 {
     public static class ScrollRectExtensions
     {
-        private const int MACOS_SCROLL_SENSITIVITY = 3;
-        private const int WINDOWS_SCROLL_SENSITIVITY = 1;
+        private const float MACOS_SCROLL_SENSITIVITY = 0.45f;
+        private const float WINDOWS_SCROLL_SENSITIVITY = 0.15f;
 
         public static void SetScrollSensitivityBasedOnPlatform(this ScrollRect scrollRect, float overrideWindows = WINDOWS_SCROLL_SENSITIVITY, float overrideMacOS = MACOS_SCROLL_SENSITIVITY)
         {


### PR DESCRIPTION
# Pull Request Description

Fixes #3698 

Avoid calculating reel visibility inside the scroll rect when its elasticity allows the reels to be hidden away off the screen.

Uniforms the scrolling speed of:
- chat
- reel gallery (even in places and passports)
- navmap search results

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- Make sure to have some reels in the gallery, at least 13

### Test Steps
1. Verify that scrolling against the top/bottom doesn't affect the reel visibility
2. Verify that you are able to scroll up/down without loosing any reel visibility
3. Test that the reel gallery scrolling speed is appropriate
4. Test that the navmap search result scrolling speed is appropriate

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
