### PR TITLE
fix: exponential backoff on thumbnail download error

### DIFF
--- a/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
+++ b/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
@@ -99,19 +99,24 @@ namespace DCL.Profiles
             {
                 ReportHub.LogException(e, new ReportData(ReportCategory.PROFILE));
 
-                if (failedThumbnails.TryGetValue(userId, out RequestAttempts requestAttempts))
-                    if (requestAttempts.CanIncreaseCooldown())
-                        requestAttempts.IncreaseCooldown();
-                    else
-                    {
-                        unsolvableThumbnails.Add(userId);
-                        failedThumbnails.Remove(userId);
-                    }
-                else
-                    failedThumbnails[userId] = RequestAttempts.FirstAttempt();
+                HandleCooldown(userId);
 
                 return null;
             }
+        }
+
+        private void HandleCooldown(string userId)
+        {
+            if (failedThumbnails.TryGetValue(userId, out RequestAttempts requestAttempts))
+                if (requestAttempts.CanIncreaseCooldown())
+                    requestAttempts.IncreaseCooldown();
+                else
+                {
+                    unsolvableThumbnails.Add(userId);
+                    failedThumbnails.Remove(userId);
+                }
+            else
+                failedThumbnails[userId] = RequestAttempts.FirstAttempt();
         }
 
         private bool TestCooldownCondition(string userId) =>

--- a/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
+++ b/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
@@ -31,8 +31,8 @@ namespace DCL.Profiles
 
             public void IncreaseCooldown()
             {
-                nextAvailableAttempt = DateTime.Now.AddSeconds(ATTEMPT_SECONDS_UNIT * attempts);
                 attempts++;
+                nextAvailableAttempt = DateTime.Now.AddSeconds(ATTEMPT_SECONDS_UNIT * attempts);
             }
 
             public bool CanRetry() =>

--- a/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
+++ b/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
@@ -13,10 +13,41 @@ namespace DCL.Profiles
 {
     public class ProfileThumbnailCache : IProfileThumbnailCache
     {
+        private struct RequestAttempts
+        {
+            private const int ATTEMPT_SECONDS_UNIT = 30;
+            private const int MAX_ATTEMPTS = 5;
+
+            private int attempts;
+            private DateTime nextAvailableAttempt;
+
+            private RequestAttempts(int attempts, DateTime nextAttempt)
+            {
+                this.attempts = attempts;
+                this.nextAvailableAttempt = nextAttempt;
+            }
+
+            public bool CanIncreaseCooldown() => attempts < MAX_ATTEMPTS;
+
+            public void IncreaseCooldown()
+            {
+                nextAvailableAttempt = DateTime.Now.AddSeconds(ATTEMPT_SECONDS_UNIT * attempts);
+                attempts++;
+            }
+
+            public bool CanRetry() =>
+                DateTime.Now >= nextAvailableAttempt;
+
+            public static RequestAttempts FirstAttempt() =>
+                new (1, DateTime.Now.AddSeconds(ATTEMPT_SECONDS_UNIT));
+        }
+
         private const int PIXELS_PER_UNIT = 50;
 
         private readonly IWebRequestController webRequestController;
         private readonly Dictionary<string, Sprite> thumbnails = new ();
+        private readonly Dictionary<string, RequestAttempts> failedThumbnails = new ();
+        private readonly HashSet<string> unsolvableThumbnails = new ();
 
         public ProfileThumbnailCache(IWebRequestController webRequestController)
         {
@@ -39,6 +70,8 @@ namespace DCL.Profiles
         {
             if (URLAddress.EMPTY.Equals(thumbnailUrl)) return null;
 
+            if (unsolvableThumbnails.Contains(userId) || !TestCooldownCondition(userId)) return null;
+
             try
             {
                 IOwnedTexture2D ownedTexture = await webRequestController.GetTextureAsync(
@@ -54,6 +87,7 @@ namespace DCL.Profiles
                 Sprite downloadedSprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height),
                     VectorUtilities.OneHalf, PIXELS_PER_UNIT, 0, SpriteMeshType.FullRect, Vector4.one, false);
                 SetThumbnailIntoCache(userId, downloadedSprite);
+                failedThumbnails.Remove(userId);
 
                 return downloadedSprite;
             }
@@ -63,10 +97,25 @@ namespace DCL.Profiles
             }
             catch (Exception e)
             {
-                ReportHub.LogException(e, new ReportData(ReportCategory.FRIENDS));
+                ReportHub.LogException(e, new ReportData(ReportCategory.PROFILE));
+
+                if (failedThumbnails.TryGetValue(userId, out RequestAttempts requestAttempts))
+                    if (requestAttempts.CanIncreaseCooldown())
+                        requestAttempts.IncreaseCooldown();
+                    else
+                    {
+                        unsolvableThumbnails.Add(userId);
+                        failedThumbnails.Remove(userId);
+                    }
+                else
+                    failedThumbnails[userId] = RequestAttempts.FirstAttempt();
+
                 return null;
             }
         }
+
+        private bool TestCooldownCondition(string userId) =>
+            !failedThumbnails.TryGetValue(userId, out RequestAttempts requestAttempts) || requestAttempts.CanRetry();
 
         private void SetThumbnailIntoCache(string userId, Sprite sprite) =>
             thumbnails[userId] = sprite;

--- a/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
+++ b/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
@@ -109,7 +109,10 @@ namespace DCL.Profiles
         {
             if (failedThumbnails.TryGetValue(userId, out RequestAttempts requestAttempts))
                 if (requestAttempts.CanIncreaseCooldown())
+                {
                     requestAttempts.IncreaseCooldown();
+                    failedThumbnails[userId] = requestAttempts;
+                }
                 else
                 {
                     unsolvableThumbnails.Add(userId);


### PR DESCRIPTION
# Pull Request Description

Fixes #3681

When a profile thumbnail fails to be downloaded (e.g. the backend is offline), every time the E@ needs it, it still tries to download it (causing error spam) every time.

For example if a message in the chat requires a thumbnail that failed, every new message causes the chat to be redrawn, sending a new request for the missing profile pic that will likely fail. This floods the log with exceptions for the failed download.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR introduces an exponential backoff on every thumbnail that fails. The first time, a new attempt is allowed after 30seconds (for all requests made in those 30 seconds, an empty image is returned), then 60, 90 and so on up to a maximum of 5 attempts. After those it is flagged as unsolvable and no attempts will be made. 
This means that for every failing thumbnail a maximum of 5 error logs will be created in span of 7.5 minutes.

### Test Steps
1. Verify that spamming chat messages don't cause the log to flooded of exceptions
2. Verify that every time a profile thumbnail is displayed, if it fails, errors are logged according to the description above

### Additional Testing Notes
- Keep in mind that the download of profile thumbnails fails rarely, which means that testing this could require many attempts (close and re-launch the E@)
- Seeing a gray profile thumbnail doesn't mean that the request failed (it should be of a white background if it failed), just that for problem tied to the BE, that user profile pic actually points to an actual gray square image

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
