### PR TITLE
Fix: in world camera storage full

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelStorageService/CameraReelRemoteStorageService.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelStorageService/CameraReelRemoteStorageService.cs
@@ -35,8 +35,7 @@ namespace DCL.InWorldCamera.CameraReelStorageService
         {
             CameraReelStorageResponse response = await imagesMetadataDatabase.UnsignedGetStorageInfoAsync(userAddress, ct);
 
-            StorageStatus = new CameraReelStorageStatus(response.currentImages, response.maxImages);
-            return StorageStatus;
+            return new CameraReelStorageStatus(response.currentImages, response.maxImages);
         }
 
         public async UniTask<CameraReelStorageStatus> GetPlaceGalleryStorageInfoAsync(string placeId, CancellationToken ct = default)

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
@@ -27,6 +27,7 @@ using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.Rendering.GPUInstancing;
 using DCL.UI.SharedSpaceManager;
+using DCL.Web3.Identities;
 using DCL.WebRequests;
 using ECS;
 using ECS.SceneLifeCycle.Realm;
@@ -103,7 +104,8 @@ namespace DCL.PluginSystem.Global
             ViewDependencies viewDependencies,
             GPUInstancingService gpuInstancingBuffers,
             ExposedCameraData exposedCameraData,
-            ISharedSpaceManager sharedSpaceManager)
+            ISharedSpaceManager sharedSpaceManager,
+            IWeb3IdentityCache web3IdentityCache)
         {
             this.input = input;
             this.selfProfile = selfProfile;
@@ -134,7 +136,9 @@ namespace DCL.PluginSystem.Global
             this.gpuInstancingBuffers = gpuInstancingBuffers;
             this.exposedCameraData = exposedCameraData;
             this.sharedSpaceManager = sharedSpaceManager;
+
             factory = new InWorldCameraFactory();
+            web3IdentityCache.OnIdentityChanged += () => cameraReelStorageService.GetUserGalleryStorageInfoAsync(web3IdentityCache.Identity!.Address, CancellationToken.None).Forget();
         }
 
         public void Dispose()

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
@@ -79,6 +79,7 @@ namespace DCL.PluginSystem.Global
         private readonly GPUInstancingService gpuInstancingBuffers;
         private readonly ExposedCameraData exposedCameraData;
         private readonly ISharedSpaceManager sharedSpaceManager;
+        private readonly IWeb3IdentityCache web3IdentityCache;
 
         private ScreenRecorder recorder;
         private GameObject hud;
@@ -136,9 +137,10 @@ namespace DCL.PluginSystem.Global
             this.gpuInstancingBuffers = gpuInstancingBuffers;
             this.exposedCameraData = exposedCameraData;
             this.sharedSpaceManager = sharedSpaceManager;
+            this.web3IdentityCache = web3IdentityCache;
 
             factory = new InWorldCameraFactory();
-            web3IdentityCache.OnIdentityChanged += () => cameraReelStorageService.GetUserGalleryStorageInfoAsync(web3IdentityCache.Identity!.Address, CancellationToken.None).Forget();
+            web3IdentityCache.OnIdentityChanged += FetchCameraReelStorage;
         }
 
         public void Dispose()
@@ -200,6 +202,14 @@ namespace DCL.PluginSystem.Global
             CaptureScreenshotSystem.InjectToWorld(ref builder, recorder, playerEntity, metadataBuilder, coroutineRunner, cameraReelStorageService, inWorldCameraController, exposedCameraData);
 
             CleanupScreencaptureCameraSystem.InjectToWorld(ref builder);
+        }
+
+        private void FetchCameraReelStorage()
+        {
+            if (web3IdentityCache.Identity == null)
+                return;
+
+            cameraReelStorageService.GetUserGalleryStorageInfoAsync(web3IdentityCache.Identity.Address, CancellationToken.None).Forget();
         }
 
         [Serializable]

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -825,7 +825,8 @@ namespace Global.Dynamic
                     viewDependencies,
                     staticContainer.GPUInstancingService,
                     exposedGlobalDataContainer.ExposedCameraData,
-                    sharedSpaceManager));
+                    sharedSpaceManager,
+                    identityCache));
 
             if (includeFriends)
             {


### PR DESCRIPTION
# Pull Request Description
Fixes #3515 

Sometimes even though the user has plenty of space for camera reels, they cannot take screenshots because they are presented with the error of "storage full".

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR addresses two edge cases that can cause this issue:
1. When looking at the public reels of another user using their passport, you could "inject" their status to yours. So, if they were "full", you would also be considered "full"
2. If upon startup of the E@ there wasn't any identity set (aka you needed to login) and you didn't go to your personal gallery before going to camera mode, you would get the "storage full" error message (this means: no identity set and as soon as you got into GP, you went into camera mode)

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Verify that you get the "storage full" error message only if you have actually consumed all the space available to you

### Additional Testing Notes
- You can check the described 2nd edge case against current live build and this. Make sure to log out and then close the client (log out/log in does not count, you need to restart)

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
