### PR TITLE
Disable loading timeout for local development

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/TeleportCharacterSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/TeleportCharacterSystem.cs
@@ -24,10 +24,13 @@ namespace DCL.CharacterMotion.Systems
     {
         private const int COUNTDOWN_FRAMES = 20;
 
+        private readonly bool enableTimeout;
         private readonly ISceneReadinessReportQueue sceneReadinessReportQueue;
 
-        internal TeleportCharacterSystem(World world, ISceneReadinessReportQueue sceneReadinessReportQueue) : base(world)
+        internal TeleportCharacterSystem(World world,
+            ISceneReadinessReportQueue sceneReadinessReportQueue, bool enableTimeout) : base(world)
         {
+            this.enableTimeout = enableTimeout;
             this.sceneReadinessReportQueue = sceneReadinessReportQueue;
         }
 
@@ -68,7 +71,7 @@ namespace DCL.CharacterMotion.Systems
 
                 // pending cases left
 
-                if (teleportIntent.TimedOut)
+                if (enableTimeout && teleportIntent.TimedOut)
                 {
                     var exception = new TimeoutException("Teleport timed out");
                     loadReport?.SetException(exception);

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Tests/TeleportCharacterSystemShould.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Tests/TeleportCharacterSystemShould.cs
@@ -28,7 +28,8 @@ namespace DCL.CharacterMotion.Tests
         [SetUp]
         public void Setup()
         {
-            system = new TeleportCharacterSystem(world, sceneReadinessReportQueue = Substitute.For<ISceneReadinessReportQueue>());
+            sceneReadinessReportQueue = Substitute.For<ISceneReadinessReportQueue>();
+            system = new TeleportCharacterSystem(world, sceneReadinessReportQueue, true);
             characterController = new GameObject().AddComponent<CharacterController>();
             camera = new GameObject().AddComponent<Camera>();
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -591,7 +591,7 @@ namespace Global.Dynamic
                     sceneThroughputBunch
                 ),
                 new WorldInfoPlugin(worldInfoHub, debugBuilder, chatHistory),
-                new CharacterMotionPlugin(assetsProvisioner, staticContainer.CharacterContainer.CharacterObject, debugBuilder, staticContainer.ComponentsContainer.ComponentPoolsRegistry, staticContainer.SceneReadinessReportQueue),
+                new CharacterMotionPlugin(assetsProvisioner, staticContainer.CharacterContainer.CharacterObject, debugBuilder, staticContainer.ComponentsContainer.ComponentPoolsRegistry, staticContainer.SceneReadinessReportQueue, localSceneDevelopment),
                 new InputPlugin(dclInput, dclCursor, unityEventSystem, assetsProvisioner, dynamicWorldDependencies.CursorUIDocument, multiplayerEmotesMessageBus, mvcManager, debugBuilder, dynamicWorldDependencies.RootUIDocument, dynamicWorldDependencies.ScenesUIDocument, dynamicWorldDependencies.CursorUIDocument, exposedGlobalDataContainer.ExposedCameraData),
                 new GlobalInteractionPlugin(dclInput, dynamicWorldDependencies.RootUIDocument, assetsProvisioner, staticContainer.EntityCollidersGlobalCache, exposedGlobalDataContainer.GlobalInputEvents, dclCursor, unityEventSystem, mvcManager),
                 new CharacterCameraPlugin(assetsProvisioner, realmSamplingData, exposedGlobalDataContainer.ExposedCameraData, debugBuilder, dynamicWorldDependencies.CommandLineArgs, dclInput),

--- a/Explorer/Assets/DCL/PluginSystem/Global/CharacterMotionPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/CharacterMotionPlugin.cs
@@ -22,6 +22,7 @@ namespace DCL.PluginSystem.Global
         private readonly IAssetsProvisioner assetsProvisioner;
         private readonly ICharacterObject characterObject;
         private readonly IDebugContainerBuilder debugContainerBuilder;
+        private readonly bool localSceneDevelopment;
         private readonly IComponentPoolsRegistry componentPoolsRegistry;
         private readonly ISceneReadinessReportQueue sceneReadinessReportQueue;
 
@@ -31,13 +32,15 @@ namespace DCL.PluginSystem.Global
             ICharacterObject characterObject,
             IDebugContainerBuilder debugContainerBuilder,
             IComponentPoolsRegistry componentPoolsRegistry,
-            ISceneReadinessReportQueue sceneReadinessReportQueue)
+            ISceneReadinessReportQueue sceneReadinessReportQueue,
+            bool localSceneDevelopment)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.characterObject = characterObject;
             this.debugContainerBuilder = debugContainerBuilder;
             this.componentPoolsRegistry = componentPoolsRegistry;
             this.sceneReadinessReportQueue = sceneReadinessReportQueue;
+            this.localSceneDevelopment = localSceneDevelopment;
         }
 
         public void Dispose()
@@ -69,7 +72,7 @@ namespace DCL.PluginSystem.Global
                 new HeadIKComponent());
 
             InterpolateCharacterSystem.InjectToWorld(ref builder);
-            TeleportCharacterSystem.InjectToWorld(ref builder, sceneReadinessReportQueue);
+            TeleportCharacterSystem.InjectToWorld(ref builder, sceneReadinessReportQueue, localSceneDevelopment);
             RotateCharacterSystem.InjectToWorld(ref builder);
             CalculateCharacterVelocitySystem.InjectToWorld(ref builder, debugContainerBuilder);
             CharacterAnimationSystem.InjectToWorld(ref builder);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change disables the loading screen timeout during local scene development so that scene loading is easier to debug.

## Test Instructions

1. Set yourself up for local scene development
2. Place and hit a breakpoint anywhere in the scene loading process
3. Wait two minutes
4. Resume execution
5. The loading should resume and not fail

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
