### PR TITLE
Duct tape a null reference when exiting play mode

### DIFF
--- a/Explorer/Assets/DCL/ApplicationBlocklistGuard/BlockedScreenController.cs
+++ b/Explorer/Assets/DCL/ApplicationBlocklistGuard/BlockedScreenController.cs
@@ -24,6 +24,9 @@ namespace DCL.ApplicationBlocklistGuard
 
         public override void Dispose()
         {
+            if (viewInstance == null)
+                return;
+
             viewInstance.CloseButton.onClick.RemoveListener(OnExitClicked);
             viewInstance.SupportButton.onClick.RemoveListener(OnSupportClicked);
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change adds a null check in BlockedScreenController.Dispose.

## Test Instructions

1. In Unity editor
2. Enter play mode
3. Exit play mode
4. See that no NullReferenceException occurs in BlockedScreenController.Dispose

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
