### PR TITLE
fix: nre on audio group unmute

### DIFF
--- a/Explorer/Assets/DCL/Audio/AudioMixerVolumesController.cs
+++ b/Explorer/Assets/DCL/Audio/AudioMixerVolumesController.cs
@@ -1,3 +1,4 @@
+using DCL.Diagnostics;
 using System;
 using System.Collections.Generic;
 using UnityEngine.Audio;
@@ -61,7 +62,11 @@ namespace DCL.Audio
 
                 if (mutedGroups.Contains(groupParamString))
                 {
-                    audioMixer.SetFloat(groupParamString, originalVolumes[groupParamString]);
+                    if (originalVolumes.TryGetValue(groupParamString, out float originalVolume))
+                        audioMixer.SetFloat(groupParamString, originalVolume);
+                    else
+                        ReportHub.LogError(ReportCategory.AUDIO, "Cannot unmute audio mixer group: missing original volume. Probably the group was not previously muted..");
+
                     mutedGroups.Remove(groupParamString);
                 }
                 break;

--- a/Explorer/Assets/DCL/Audio/AudioMixerVolumesController.cs
+++ b/Explorer/Assets/DCL/Audio/AudioMixerVolumesController.cs
@@ -55,8 +55,6 @@ namespace DCL.Audio
         {
             var groupParamString = groupParam.ToString();
 
-            if (string.IsNullOrEmpty(groupParamString)) return;
-
             foreach (string exposedParam in allExposedParams)
             {
                 if (exposedParam != groupParamString)

--- a/Explorer/Assets/DCL/Audio/AudioMixerVolumesController.cs
+++ b/Explorer/Assets/DCL/Audio/AudioMixerVolumesController.cs
@@ -55,6 +55,8 @@ namespace DCL.Audio
         {
             var groupParamString = groupParam.ToString();
 
+            if (string.IsNullOrEmpty(groupParamString)) return;
+
             foreach (string exposedParam in allExposedParams)
             {
                 if (exposedParam != groupParamString)


### PR DESCRIPTION
## What does this PR change?

Fixes an exception thrown during loading process:

```
NullReferenceException: Object reference not set to an instance of an object.
  at DCL.Audio.AudioMixerVolumesController.UnmuteGroup (DCL.Audio.AudioMixerExposedParam groupParam) [0x00000] in <00000000000000000000000000000000>:0 
  at DCL.SceneLoadingScreens.SceneLoadingScreenController.OnViewClose () [0x00000] in <00000000000000000000000000000000>:0 
  at MVC.ControllerBase`2[TView,TInputData].HideViewAsync (System.Threading.CancellationToken ct) [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskMethodBuilder.Start[TStateMachine] (TStateMachine& stateMachine) [0x00000] in <00000000000000000000000000000000>:0 
  at MVC.ControllerBase`2[TView,TInputData].HideViewAsync (System.Threading.CancellationToken ct) [0x00000] in <00000000000000000000000000000000>:0 
  at MVC.MVCManager.ShowTopAsync[TView,TInputData] (MVC.ShowCommand`2[TView,TInputData] command, MVC.IController controller, System.Threading.CancellationToken ct) [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1[TStateMachine].Run () [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1[TResult].TrySetResult (TResult result) [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1[TStateMachine].SetResult () [0x00000] in <00000000000000000000000000000000>:0 
  at MVC.ControllerBase`2[TView,TInputData].LaunchViewLifeCycleAsync (MVC.CanvasOrdering ordering, TInputData data, System.Threading.CancellationToken ct) [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1[TStateMachine].Run () [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1[TResult].TrySetResult (TResult result) [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1[TStateMachine].SetResult () [0x00000] in <00000000000000000000000000000000>:0 
  at DCL.SceneLoadingScreens.SceneLoadingScreenController.WaitForCloseIntentAsync (System.Threading.CancellationToken ct) [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1[TStateMachine].Run () [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1[TResult].TrySetException (System.Exception error) [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.UniTask+WhenAllPromise+<>c.<.ctor>b__3_0 (System.Object state) [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1[TResult].TrySetException (System.Exception error) [0x00000] in <00000000000000000000000000000000>:0 
  at DCL.SceneLoadingScreens.SceneLoadingScreenController.WaitUntilWorldIsLoadedAsync (System.Single progressProportion, System.Threading.CancellationToken ct) [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1[TStateMachine].Run () [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1[TResult].TrySetException (System.Exception error) [0x00000] in <00000000000000000000000000000000>:0 
  at DCL.SceneLoadingScreens.SceneLoadingScreenController+<>c__DisplayClass23_0.<WaitUntilWorldIsLoadedAsync>g__UpdateProgressBarAsync|0 () [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1[TStateMachine].Run () [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1[TResult].TrySetCanceled (System.Threading.CancellationToken cancellationToken) [0x00000] in <00000000000000000000000000000000>:0 
  at Cysharp.Threading.Tasks.AsyncReactiveProperty`1+Enumerator[T].CancellationCallback (System.Object state) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.CancellationTokenSource.CancellationCallbackCoreWork (System.Threading.CancellationCallbackCoreWorkArguments args) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers (System.Boolean throwOnFirstException) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.CancellationTokenSource.NotifyCancellation (System.Boolean throwOnFirstException) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.CancellationTokenSource.CancellationCallbackCoreWork (System.Threading.CancellationCallbackCoreWorkArguments args) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers (System.Boolean throwOnFirstException) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.CancellationTokenSource.NotifyCancellation (System.Boolean throwOnFirstException) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.CancellationTokenSource.CancellationCallbackCoreWork (System.Threading.CancellationCallbackCoreWorkArguments args) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers (System.Boolean throwOnFirstException) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Threading.CancellationTokenSource.NotifyCancellation (System.Boolean throwOnFirstException) [0x00000] in <00000000000000000000000000000000>:0 
```

## Test Instructions
Run the initial loading process until you reach the scene in-world. Check everything works as expected, specially with the audio volume.


## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
