### PR TITLE
fix: ui disappear when closing in world camera with button

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/UI/InWorldCameraController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/UI/InWorldCameraController.cs
@@ -127,8 +127,7 @@ namespace DCL.InWorldCamera.UI
             closeViewTask?.TrySetCanceled(ct);
             closeViewTask = new UniTaskCompletionSource();
 
-            return UniTask.WhenAny(closeViewTask.Task,
-                                        viewInstance!.CloseButton.OnClickAsync(ct));
+            return closeViewTask.Task;
         }
 
         public void PlayScreenshotFX(Texture2D image, float splashDuration, float middlePauseDuration, float transitionDuration)


### PR DESCRIPTION
# Pull Request Description

Fixes #3798 

When closing the in world camera view using its top right button, the whole UI disappears. This is caused because the panel controller was closing itself in the mvc system at the same time while the underlying system `ToggleInWorldCameraActivitySystem` was starting its closing process, skipping the normal flow.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR removes the button click as a condition for the controller to hide the view, letting the system `ToggleInWorldCameraActivitySystem` handle that.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Open the in world camera
2. Close it using the Esc/C shortcuts
3. Verify that all the UIs are still there and working properly as before
4. Open the in world camera
5. Close it using the X button on the top right (unlock the cursor first)
6. Same as .3

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
