### PR TITLE
fix: killpx does bad things

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/PortableExperiences/ECSPortableExperiencesController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/PortableExperiences/ECSPortableExperiencesController.cs
@@ -25,10 +25,6 @@ namespace PortableExperiences.Controller
 {
     public class ECSPortableExperiencesController : IPortableExperiencesController
     {
-        private static readonly QueryDescription CLEAR_QUERY = new QueryDescription().WithAny<RealmComponent, GetSceneDefinition, GetSceneDefinitionList,
-                                                                                          SceneDefinitionComponent, EmptySceneComponent>()
-                                                                                     .WithAll<PortableExperienceComponent, DeleteEntityIntention>();
-
         private readonly IWeb3IdentityCache web3IdentityCache;
         private readonly IWebRequestController webRequestController;
         private readonly IScenesCache scenesCache;
@@ -182,9 +178,6 @@ namespace PortableExperiences.Controller
             if (PortableExperienceEntities.TryGetValue(ens, out Entity portableExperienceEntity))
             {
                 world.Add<DeleteEntityIntention>(portableExperienceEntity);
-
-                for (var i = 0; i < globalWorld.FinalizeWorldSystems.Count; i++)
-                    globalWorld.FinalizeWorldSystems[i].FinalizeComponents(world.Query(in CLEAR_QUERY));
 
                 PortableExperienceEntities.Remove(ens);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Removed a call to FinalizeWorldSystems from the UnloadPortableExperienceByEns method, as it was finalizing systems that should not be finalized. This was introduced at some point to cleanup MapPins, but seems to be not needed anymore. And is not doing what it should be doing.


## Test Instructions
Check that quest map pins are removed when you /killpx globalpx