### PR TITLE
fix: scene reload missing entity alive check

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/ECSReloadScene.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/ECSReloadScene.cs
@@ -83,9 +83,12 @@ namespace ECS.SceneLifeCycle
             //We wait until scene is fully disposed
             await UniTask.WaitUntil(() => currentScene.SceneStateProvider.State.Equals(SceneState.Disposed), cancellationToken: ct);
 
-            SceneLoadingState sceneLoadingState = world.Get<SceneLoadingState>(entity);
-            sceneLoadingState.VisualSceneState = VisualSceneState.UNINITIALIZED;
-            sceneLoadingState.PromiseCreated = false;
+            if (world.IsAlive(entity))
+            {
+                SceneLoadingState sceneLoadingState = world.Get<SceneLoadingState>(entity);
+                sceneLoadingState.VisualSceneState = VisualSceneState.UNINITIALIZED;
+                sceneLoadingState.PromiseCreated = false;
+            }
 
             if (localSceneDevelopment)
             {


### PR DESCRIPTION
### WHY

The scene reload (or at least the hot-reload) breaks the scene and it never loads again.

### WHAT

Added missing entity alive check before `world.Has()`.

### TEST INSTRUCTIONS

1. Download [this test scene](https://github.com/user-attachments/files/19582585/scene-reload-test.zip)
2. Enter the scene root folder and run `npm i` and then `npm run start -- --explorer-alpha`
3. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
4. Download the build from this PR and connect it to the running scene using [the console command](https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene) according to your OS
5. Once the scene loads, leave the Explorer running and in any text editor open `index.ts` file of the scene that you have running
6. Modify the `Vector3` value (for example change `position: Vector3.create(4, 1, 4)` to `position: Vector3.create(8, 1, 8)`), save the file and confirm that the scene gets automatically re-loaded in the Explorer that you left running in the previous step (you should see the Cube again after the reload
7. After the automatic reload finishes, repeat step 6 several more times to make sure hot-reload keeps working beyond the first one