### PR TITLE
fix: remove reel related texture from memory when not used

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
@@ -517,6 +517,10 @@ namespace DCL.InWorldCamera.CameraReelGallery
         {
             ReleaseGridViews();
             monthViews.Clear();
+
+            foreach (KeyValuePair<CameraReelResponseCompact, Texture> row in reelThumbnailCache)
+                GameObject.Destroy(row.Value);
+
             reelThumbnailCache.Clear();
             beginVisible = 0;
             endVisible = 0;

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Components/ReelThumbnailController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Components/ReelThumbnailController.cs
@@ -53,6 +53,7 @@ namespace DCL.InWorldCamera.CameraReelGallery.Components
             view.loadingBrightView.StartLoadingAnimation(view.thumbnailImage.gameObject);
 
             Texture2D thumbnailTexture = await cameraReelScreenshotsStorage.GetScreenshotThumbnailAsync(CameraReelResponse.thumbnailUrl, token);
+            thumbnailTexture.Apply(false, true);
             float originalToSmallerRatio = thumbnailTexture.height * 1f / rectTransform.rect.height;
             float realWidth = originalToSmallerRatio * rectTransform.rect.width;
             float realWidthDiff = thumbnailTexture.width - realWidth;
@@ -63,7 +64,7 @@ namespace DCL.InWorldCamera.CameraReelGallery.Components
 
             view.thumbnailImage.DOFade(1f, view.thumbnailLoadedAnimationDuration).ToUniTask(cancellationToken: token).Forget();
 
-            ThumbnailLoaded?.Invoke(CameraReelResponse, view.thumbnailImage.texture);
+            ThumbnailLoaded?.Invoke(CameraReelResponse, thumbnailTexture);
             view.button.onClick.AddListener( () => ThumbnailClicked?.Invoke(CameraReelResponse));
             imageLoaded = true;
         }
@@ -82,11 +83,11 @@ namespace DCL.InWorldCamera.CameraReelGallery.Components
         {
             view.gameObject.SetActive(true);
             view.thumbnailImage.enabled = true;
-            view.thumbnailImage.texture = null;
         }
 
         public void PoolRelease(Transform parent)
         {
+            view.thumbnailImage.texture = null;
             view.transform.SetParent(parent, false);
             view.gameObject.SetActive(false);
             loadImageCts.SafeCancelAndDispose();

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailController.cs
@@ -147,8 +147,11 @@ namespace DCL.InWorldCamera.PhotoDetail
             HideDeleteModal();
 
             viewInstance.mainImageCanvasGroup.alpha = 0;
-            GameObject.Destroy(viewInstance!.mainImage.texture);
-            viewInstance!.mainImage.texture = null;
+            
+            if (viewInstance.mainImage.texture != null)
+                GameObject.Destroy(viewInstance.mainImage.texture);
+
+            viewInstance.mainImage.texture = null;
             PhotoDetailInfoController.Release();
         }
 

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailController.cs
@@ -147,6 +147,8 @@ namespace DCL.InWorldCamera.PhotoDetail
             HideDeleteModal();
 
             viewInstance.mainImageCanvasGroup.alpha = 0;
+            GameObject.Destroy(viewInstance!.mainImage.texture);
+            viewInstance!.mainImage.texture = null;
             PhotoDetailInfoController.Release();
         }
 
@@ -213,15 +215,20 @@ namespace DCL.InWorldCamera.PhotoDetail
         private async UniTaskVoid ShowReelAsync(int reelIndex, CancellationToken ct)
         {
             viewInstance!.mainImageCanvasGroup.alpha = 0;
-            viewInstance!.mainImageLoadingSpinner.gameObject.SetActive(true);
+            viewInstance.mainImageLoadingSpinner.gameObject.SetActive(true);
+
+            if (viewInstance.mainImage.texture != null)
+                GameObject.Destroy(viewInstance!.mainImage.texture);
+
             CameraReelResponseCompact reel = inputData.AllReels[reelIndex];
 
             UniTask detailInfoTask = PhotoDetailInfoController.ShowPhotoDetailInfoAsync(reel.id, ct);
             Texture2D reelTexture = await cameraReelScreenshotsStorage.GetScreenshotImageAsync(reel.url, false, ct);
-            viewInstance!.mainImage.texture = reelTexture;
+            reelTexture.Apply(false, true);
+            viewInstance.mainImage.texture = reelTexture;
             aspectRatioFitter.aspectRatio = reelTexture.width * 1f / reelTexture.height;
 
-            viewInstance!.mainImageLoadingSpinner.gameObject.SetActive(false);
+            viewInstance.mainImageLoadingSpinner.gameObject.SetActive(false);
             viewInstance.mainImageCanvasGroup.DOFade(1, viewInstance.imageFadeInDuration);
 
             await detailInfoTask;


### PR DESCRIPTION
# Pull Request Description

Fixes #3829 

After memory profiling the E@ it was noticed that reels (both compressed and uncompressed versions) stayed in memory even if they were not used.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR explicitly destroys/remove references (in the case of pooled objects) of every reel related texture when they are no longer used.

### Test Steps
1. Launch the E@
2. Verify that the reels work as before (in gallery, photo detail, users passports, navmpap places, etc)

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
