### PR TITLE
Fix: Pressing Enter was not opening the chat for typing

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -362,6 +362,7 @@ namespace DCL.Chat
             viewDependencies.DclInput.UI.Click.performed += OnUIClickPerformed;
             viewDependencies.DclInput.Shortcuts.ToggleNametags.performed += OnToggleNametagsShortcutPerformed;
             viewDependencies.DclInput.Shortcuts.OpenChatCommandLine.performed += OnOpenChatCommandLineShortcutPerformed;
+            viewDependencies.DclInput.UI.Submit.performed += OnSubmitShortcutPerformed;
 
             viewInstance.IsUnfolded = inputData.ShowUnfolded;
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Added a subscription to the key press event when the Chat controller is shown for the first time.

## Test Instructions

### Test Steps
1. Enter Decentraland.
2. When everything loads, press Enter.
3. The input box of the chat should gain the focus.
