### PR TITLE
Fix: camera not colliding with terrain  

### DIFF
--- a/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
@@ -179,7 +179,7 @@ namespace DCL.Interaction.Raycast.Systems
 
             // The range of Unity Layers is narrower than the range of SDK Layers
             // so we need to raycast against all (even if the query type is hit first) and then filter our each individual raycast hit
-            int hitsCount = Physics.RaycastNonAlloc(ray, SHARED_RAYCAST_HIT_ARRAY, Mathf.Min(sdkComponent.MaxDistance, ParcelMathHelper.PARCEL_SIZE), collisionMask);
+            int hitsCount = Physics.RaycastNonAlloc(ray, SHARED_RAYCAST_HIT_ARRAY, sdkComponent.MaxDistance, collisionMask);
 
             switch (sdkComponent.QueryType)
             {

--- a/Explorer/Assets/DCL/Landscape/Assets/Bushes/Bush01/Bush01 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Bushes/Bush01/Bush01 Variant.prefab
@@ -76,10 +76,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Bush01 Variant
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 7a5b23ea474707949ac1958443314f0f, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     - target: {fileID: 1731458092625035100, guid: 7a5b23ea474707949ac1958443314f0f, type: 3}
       propertyPath: m_CastShadows
       value: 0

--- a/Explorer/Assets/DCL/Landscape/Assets/Bushes/Bush02/Bush02 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Bushes/Bush02/Bush02 Variant.prefab
@@ -72,10 +72,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Bush02 Variant
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 7ee2877b90d2bc048b88aacb57ee6dcc, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     - target: {fileID: 1218912716677395249, guid: 7ee2877b90d2bc048b88aacb57ee6dcc, type: 3}
       propertyPath: m_Layer
       value: 17

--- a/Explorer/Assets/DCL/Landscape/Assets/Props/Clifs/Cliff01.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Props/Clifs/Cliff01.prefab
@@ -10,7 +10,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -9106685881181532893, guid: c771be5f50b31304fa9980668f783ee3, type: 3}
       propertyPath: m_Layer
-      value: 17
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: c771be5f50b31304fa9980668f783ee3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -54,15 +54,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -1193357806157634257, guid: c771be5f50b31304fa9980668f783ee3, type: 3}
       propertyPath: m_Layer
-      value: 17
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: c771be5f50b31304fa9980668f783ee3, type: 3}
       propertyPath: m_Name
       value: Cliff01
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: c771be5f50b31304fa9980668f783ee3, type: 3}
-      propertyPath: m_Layer
-      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 1261924544524588286, guid: c771be5f50b31304fa9980668f783ee3, type: 3}
       propertyPath: m_Convex

--- a/Explorer/Assets/DCL/Landscape/Assets/Props/Clifs/CliffCorner01.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Props/Clifs/CliffCorner01.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5269277411466337069}
   - component: {fileID: 9041747563325808690}
-  m_Layer: 17
+  m_Layer: 0
   m_Name: CliifCornerCollider1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -63,7 +63,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3061367277733943166}
   - component: {fileID: 826257924585515266}
-  m_Layer: 17
+  m_Layer: 0
   m_Name: CliifCornerCollider2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -116,7 +116,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8326474700448206459}
   - component: {fileID: 3490759420474402742}
-  m_Layer: 17
+  m_Layer: 0
   m_Name: CliifCornerCollider3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -213,7 +213,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -4790495569549799813, guid: f75ba278d35f95c46900da753beb0801, type: 3}
       propertyPath: m_Layer
-      value: 17
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -4511982668719631190, guid: f75ba278d35f95c46900da753beb0801, type: 3}
       propertyPath: m_Enabled
@@ -231,17 +231,13 @@ PrefabInstance:
       propertyPath: m_Name
       value: CliffCorner01
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: f75ba278d35f95c46900da753beb0801, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     - target: {fileID: 2072665671247181702, guid: f75ba278d35f95c46900da753beb0801, type: 3}
       propertyPath: m_Layer
       value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 3559932644224978066, guid: f75ba278d35f95c46900da753beb0801, type: 3}
       propertyPath: m_Layer
-      value: 17
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Explorer/Assets/DCL/Landscape/Assets/Rocks/Rock01/Rock01 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Rocks/Rock01/Rock01 Variant.prefab
@@ -123,10 +123,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Rock01 Variant
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 9ddca728df9c124449d9b86a651b3896, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     - target: {fileID: 4742473837712756890, guid: 9ddca728df9c124449d9b86a651b3896, type: 3}
       propertyPath: m_Enabled
       value: 1

--- a/Explorer/Assets/DCL/Landscape/Assets/Rocks/Rock02/Rock02 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Rocks/Rock02/Rock02 Variant.prefab
@@ -123,10 +123,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Rock02 Variant
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 00f5b1975cb058a4691c829eb047a63e, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     - target: {fileID: 4265913260784404769, guid: 00f5b1975cb058a4691c829eb047a63e, type: 3}
       propertyPath: m_Layer
       value: 17

--- a/Explorer/Assets/DCL/Landscape/Assets/Rocks/Rock03/Rock03 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Rocks/Rock03/Rock03 Variant.prefab
@@ -119,10 +119,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Rock03 Variant
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 031a91abfb9eed844b8cb2123869ef73, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     - target: {fileID: 2746085254141620243, guid: 031a91abfb9eed844b8cb2123869ef73, type: 3}
       propertyPath: m_CastShadows
       value: 0

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree01/Tree01 Variant.prefab
@@ -72,10 +72,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Tree01 Variant
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     - target: {fileID: 1218912716677395249, guid: 1cc28936fb720cd469a6755539529d40, type: 3}
       propertyPath: m_Layer
       value: 17

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree02/Tree02 Variant.prefab
@@ -96,10 +96,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Tree02 Variant
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     - target: {fileID: 1218912716677395249, guid: ef75b96575e6f4f47a635b6fad41f46a, type: 3}
       propertyPath: m_Layer
       value: 17

--- a/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03 Variant.prefab
+++ b/Explorer/Assets/DCL/Landscape/Assets/Trees/Tree03/Tree03 Variant.prefab
@@ -88,10 +88,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Tree03 Variant
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     - target: {fileID: 966206684026294590, guid: 856e12e0f12cc1847acb7dacb5ed9bd7, type: 3}
       propertyPath: m_Layer
       value: 17

--- a/Explorer/Assets/DCL/Landscape/TerrainFactory.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainFactory.cs
@@ -10,7 +10,7 @@ namespace DCL.Landscape
 {
     public class TerrainFactory
     {
-        private const string TERRAIN_LAYER = "Floor";
+        private const string TERRAIN_LAYER = "Default";
         private const string BORDERS_LAYER = "InvisibleColliders";
 
         private readonly TerrainGenerationData terrainGenData;


### PR DESCRIPTION
# Pull Request Description
Fix https://github.com/decentraland/unity-explorer/issues/3818

- Brought terrain colliders back to `Default` layer
- removed Clamp maxDistance for Raycast

## Test Instructions
As in the mentioned bug-ticket

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
