### PR TITLE
fix: emotes while moving

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller
@@ -82,11 +82,11 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 3
     m_ConditionEvent: MovementBlend
-    m_EventTreshold: 0.01
+    m_EventTreshold: 0.1
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -4050450968213979288}
   m_Solo: 0
-  m_Mute: 1
+  m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
   m_TransitionDuration: 0.25
@@ -1577,11 +1577,11 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 3
     m_ConditionEvent: MovementBlend
-    m_EventTreshold: 0.01
+    m_EventTreshold: 0.1
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -4050450968213979288}
   m_Solo: 0
-  m_Mute: 1
+  m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
   m_TransitionDuration: 0.25


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Cancel emote if the avatar is moving.
Previously we modified the avatar animator transitions so it doesn't consider the movement parameter anymore because peers were cancelling the emotes over time. The problem is that sometimes the avatar moves while emoting. The changes re-enables the transition but increasing the movement threshold.

## Test Instructions
Group together with other users. Play emotes. Emotes should not stop while standing still. Emotes should stop if the avatar moves. Also check steps/issue of this pr: https://github.com/decentraland/unity-explorer/pull/3714

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
