### PR TITLE
fix: signed headers

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
@@ -1,6 +1,8 @@
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Web3.Chains;
+using DCL.Web3.Identities;
 using DCL.WebRequests;
 using DCL.WebRequests.GenericDelete;
 using ECS;
@@ -25,28 +27,83 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
         private readonly IDecentralandUrlsSource decentralandUrlsSource;
         private readonly ISceneData sceneData;
         private readonly IRealmData realmData;
+        private readonly IWeb3IdentityCache identityCache;
         private readonly CancellationTokenSource cancellationTokenSource = new ();
 
         public SignedFetchWrap(
             IWebRequestController webController,
             IDecentralandUrlsSource decentralandUrlsSource,
             ISceneData sceneData,
-            IRealmData realmData)
+            IRealmData realmData,
+            IWeb3IdentityCache identityCache)
         {
             this.webController = webController;
             this.decentralandUrlsSource = decentralandUrlsSource;
             this.sceneData = sceneData;
             this.realmData = realmData;
+            this.identityCache = identityCache;
+        }
+
+        public void Dispose()
+        {
+            cancellationTokenSource.SafeCancelAndDispose();
         }
 
         [UsedImplicitly]
-        public object Headers(SignedFetchRequest signedFetchRequest)
+        public object GetSignedHeaders(string url, string body, string headers, string method)
         {
-            string jsonMetaData = signedFetchRequest.init?.body ?? string.Empty;
+            Dictionary<string, string>? deserializedHeaders = JsonConvert.DeserializeObject<Dictionary<string, string>>(headers);
 
-            return new WebRequestHeadersInfo()
-                  .WithSign(jsonMetaData, DateTime.UtcNow.UnixTimeAsMilliseconds())
-                  .AsMutableDictionary();
+            GetHeadersResponse response = GetSignedHeaders(new SignedFetchRequest
+            {
+                url = url,
+                init = new FlatFetchInit
+                {
+                    body = body,
+                    headers = deserializedHeaders ?? new Dictionary<string, string>(),
+                    method = string.IsNullOrEmpty(method) ? "get" : method,
+                },
+            });
+
+            return response;
+        }
+
+        private GetHeadersResponse GetSignedHeaders(SignedFetchRequest request)
+        {
+            string? method = request.init?.method?.ToLower();
+            ulong unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
+            string? hashBody = null;
+
+            if (request.init != null)
+                if (!string.IsNullOrEmpty(request.init.body))
+                    hashBody = sha256_hash(request.init.body);
+
+            string signatureMetadata = CreateSignatureMetadata(hashBody);
+
+            var headers = new WebRequestHeadersInfo(request.init?.headers)
+                         .WithSign(signatureMetadata, unixTimestamp)
+                         .AsMutableDictionary();
+
+            var signInfo = WebRequestSignInfo.NewFromRaw(
+                signatureMetadata,
+                request.url,
+                unixTimestamp,
+                method ?? string.Empty
+            );
+
+            using AuthChain authChain = identityCache.EnsuredIdentity().Sign(signInfo.StringToSign);
+            var authChainIndex = 0;
+
+            foreach (AuthLink link in authChain)
+            {
+                headers[$"x-identity-auth-chain-{authChainIndex}"] = link.ToJson();
+                authChainIndex++;
+            }
+
+            return new GetHeadersResponse
+            {
+                headers = headers,
+            };
         }
 
         [UsedImplicitly]
@@ -66,18 +123,18 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
             });
         }
 
-        private static String sha256_hash(String value) {
-            StringBuilder Sb = new StringBuilder();
+        private static string sha256_hash(string value) {
+            StringBuilder sb = new StringBuilder();
 
-            using (SHA256 hash = SHA256Managed.Create()) {
+            using (SHA256 hash = SHA256.Create()) {
                 Encoding enc = Encoding.UTF8;
-                Byte[] result = hash.ComputeHash(enc.GetBytes(value));
+                byte[] result = hash.ComputeHash(enc.GetBytes(value));
 
-                foreach (Byte b in result)
-                    Sb.Append(b.ToString("x2"));
+                foreach (byte b in result)
+                    sb.Append(b.ToString("x2"));
             }
 
-            return Sb.ToString();
+            return sb.ToString();
         }
 
         private object SignedFetch(SignedFetchRequest request)
@@ -86,7 +143,12 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
 
             string? method = request.init?.method?.ToLower();
             ulong unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
-            string hashBody = request.init.body.Length > 0 ? sha256_hash(request.init.body) : null;
+            string? hashBody = null;
+
+            if (request.init != null)
+                if (!string.IsNullOrEmpty(request.init.body))
+                    hashBody = sha256_hash(request.init.body);
+
             string signatureMetadata = CreateSignatureMetadata(hashBody);
 
             var headers = new WebRequestHeadersInfo(request.init?.headers)
@@ -124,8 +186,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                                 new FlatFetchResponse<GenericPostRequest>(),
                                 GenericPostArguments.CreateJsonOrDefault(request.init?.body),
                                 cancellationTokenSource.Token,
-                                headersInfo:
-                                headers,
+                                headersInfo: headers,
                                 signInfo: signInfo,
                                 reportCategory: GetReportData());
 
@@ -190,11 +251,6 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
         private ReportData GetReportData() =>
             new (ReportCategory.SCENE_FETCH_REQUEST, sceneShortInfo: sceneData.SceneShortInfo);
 
-        public void Dispose()
-        {
-            cancellationTokenSource.SafeCancelAndDispose();
-        }
-
         private string CreateSignatureMetadata(string? hashPayload)
         {
             Vector2Int parcel = sceneData.SceneEntityDefinition.metadata.scene.DecodedBase;
@@ -244,6 +300,12 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                 public string protocol;
                 public string serverName;
             }
+        }
+
+        [Serializable]
+        public struct GetHeadersResponse
+        {
+            public Dictionary<string, string> headers;
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
@@ -54,7 +54,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
         {
             Dictionary<string, string>? deserializedHeaders = JsonConvert.DeserializeObject<Dictionary<string, string>>(headers);
 
-            GetHeadersResponse response = GetSignedHeaders(new SignedFetchRequest
+            string response = GetSignedHeaders(new SignedFetchRequest
             {
                 url = url,
                 init = new FlatFetchInit
@@ -68,7 +68,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
             return response;
         }
 
-        private GetHeadersResponse GetSignedHeaders(SignedFetchRequest request)
+        private string GetSignedHeaders(SignedFetchRequest request)
         {
             string? method = request.init?.method?.ToLower();
             ulong unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
@@ -100,10 +100,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                 authChainIndex++;
             }
 
-            return new GetHeadersResponse
-            {
-                headers = headers,
-            };
+            return JsonConvert.SerializeObject(headers);
         }
 
         [UsedImplicitly]
@@ -300,12 +297,6 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                 public string protocol;
                 public string serverName;
             }
-        }
-
-        [Serializable]
-        public struct GetHeadersResponse
-        {
-            public Dictionary<string, string> headers;
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/ISceneRuntime.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/ISceneRuntime.cs
@@ -77,7 +77,7 @@ namespace SceneRuntime
             sceneRuntime.RegisterEngineAPI(engineApi, instancePoolsProvider, exceptionsHandler);
             sceneRuntime.RegisterPlayers(roomHub, profileRepository, remoteMetadata);
             sceneRuntime.RegisterSceneApi(sceneApi);
-            sceneRuntime.RegisterSignedFetch(webRequestController, decentralandUrlsSource, sceneData, realmData);
+            sceneRuntime.RegisterSignedFetch(webRequestController, decentralandUrlsSource, sceneData, realmData, web3IdentityCache);
             sceneRuntime.RegisterRestrictedActionsApi(restrictedActionsAPI);
             sceneRuntime.RegisterUserActions(restrictedActionsAPI);
             sceneRuntime.RegisterRuntime(runtime, exceptionsHandler, realmData.IsLocalSceneDevelopment);
@@ -115,7 +115,7 @@ namespace SceneRuntime
             sceneRuntime.RegisterEngineAPI(engineApi, commsApiImplementation, instancePoolsProvider, exceptionsHandler);
             sceneRuntime.RegisterPlayers(roomHub, profileRepository, remoteMetadata);
             sceneRuntime.RegisterSceneApi(sceneApi);
-            sceneRuntime.RegisterSignedFetch(webRequestController, decentralandUrlsSource, sceneData, realmData);
+            sceneRuntime.RegisterSignedFetch(webRequestController, decentralandUrlsSource, sceneData, realmData, web3IdentityCache);
             sceneRuntime.RegisterRestrictedActionsApi(restrictedActionsAPI);
             sceneRuntime.RegisterUserActions(restrictedActionsAPI);
             sceneRuntime.RegisterRuntime(runtime, exceptionsHandler, realmData.IsLocalSceneDevelopment);
@@ -156,10 +156,11 @@ namespace SceneRuntime
             IWebRequestController webRequestController,
             IDecentralandUrlsSource decentralandUrlsSource,
             ISceneData sceneData,
-            IRealmData realmData
+            IRealmData realmData,
+            IWeb3IdentityCache web3IdentityCache
         )
         {
-            sceneRuntime.Register("UnitySignedFetch", new SignedFetchWrap(webRequestController, decentralandUrlsSource, sceneData, realmData));
+            sceneRuntime.Register("UnitySignedFetch", new SignedFetchWrap(webRequestController, decentralandUrlsSource, sceneData, realmData, web3IdentityCache));
         }
 
         private static void RegisterRestrictedActionsApi(this ISceneRuntime sceneRuntime, IRestrictedActionsAPI api)

--- a/Explorer/Assets/DCL/WebRequests/WebRequestSignInfo.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestSignInfo.cs
@@ -19,10 +19,10 @@ namespace DCL.WebRequests
             this.stringToSign = stringToSign;
         }
 
-        public static WebRequestSignInfo? NewFromUrl(string url, ulong unixTimestamp, string method) =>
+        public static WebRequestSignInfo NewFromUrl(string url, ulong unixTimestamp, string method) =>
             NewFromRaw(string.Empty, url, unixTimestamp, method);
 
-        public static WebRequestSignInfo? NewFromRaw(string rawToSign, string url, ulong unixTimestamp, string method)
+        public static WebRequestSignInfo NewFromRaw(string rawToSign, string url, ulong unixTimestamp, string method)
         {
             string path = new Uri(url).AbsolutePath;
             string payload = $"{method}:{path}:{unixTimestamp}:{(string.IsNullOrEmpty(rawToSign) ? "{}" : rawToSign)}".ToLowerInvariant();

--- a/Explorer/Assets/StreamingAssets/Js/Modules/SignedFetch.js
+++ b/Explorer/Assets/StreamingAssets/Js/Modules/SignedFetch.js
@@ -30,5 +30,9 @@ module.exports.getHeaders = async function(message) {
         method = message.init.method ?? ''
     }
     
-    return UnitySignedFetch.GetSignedHeaders(message.url, body, headers, method);
+    const json = UnitySignedFetch.GetSignedHeaders(message.url, body, headers, method);
+    
+    return {
+        headers: JSON.parse(json)
+    }
 }

--- a/Explorer/Assets/StreamingAssets/Js/Modules/SignedFetch.js
+++ b/Explorer/Assets/StreamingAssets/Js/Modules/SignedFetch.js
@@ -4,6 +4,7 @@ module.exports.signedFetch = async function(message) {
     let body = ''
     let headers = ''
     let method = ''
+    
     if (message.init != undefined) {
         body = message.init.body ?? ''
         headers = JSON.stringify(message.init.headers)
@@ -19,5 +20,15 @@ module.exports.signedFetch = async function(message) {
 }
 
 module.exports.getHeaders = async function(message) {
-    return UnitySignedFetch.Headers(message)
+    let body = ''
+    let headers = ''
+    let method = ''
+    
+    if (message.init != undefined) {
+        body = message.init.body ?? ''
+        headers = JSON.stringify(message.init.headers)
+        method = message.init.method ?? ''
+    }
+    
+    return UnitySignedFetch.GetSignedHeaders(message.url, body, headers, method);
 }


### PR DESCRIPTION
## What does this PR change?

Fixes the call to get signed headers from the sdk. Scene example:
```
import { getHeaders } from "~system/SignedFetch";

async function main() {
    const a = await getHeaders({ 
        url: 'https://comms-gatekeeper.decentraland.zone/scene-stream-access'
    });
    
    console.log('getHeadears response', JSON.stringify(a || ''));
}

main().catch(reason => console.log(reason));
```

## Test Instructions
Im not aware of any scene deployed to prod using this feature. Just do a smoke test.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
