### PR TITLE
fix: Reuse media player on url change

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerCustomPool.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerCustomPool.cs
@@ -3,6 +3,7 @@ using RenderHeads.Media.AVProVideo;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Utility;
 using Object = UnityEngine.Object;
 
 namespace DCL.SDKComponents.MediaStream
@@ -18,16 +19,12 @@ namespace DCL.SDKComponents.MediaStream
         private readonly int tryCleanOfflineMediaPlayersDelayInMinutes = 2;
         private readonly float maxOfflineTimePossibleInSeconds = 300f;
 
-        private static bool applicationQuitting;
-
         public MediaPlayerCustomPool(MediaPlayer mediaPlayerPrefab)
         {
             this.mediaPlayerPrefab = mediaPlayerPrefab;
             rootContainerTransform = new GameObject("POOL_CONTAINER_MEDIA_PLAYER").transform;
             offlineMediaPlayers = new Dictionary<string, Queue<MediaPlayerInfo>>();
             TryUnloadAsync().Forget();
-
-            Application.quitting += () => applicationQuitting = true;
         }
 
         public MediaPlayer GetOrCreateReusableMediaPlayer(string url)
@@ -86,7 +83,7 @@ namespace DCL.SDKComponents.MediaStream
         public void ReleaseMediaPlayer(string url, MediaPlayer mediaPlayer)
         {
             //On quit, Unity may have already detroyed the MediaPlayer; so we might get a null-ref
-            if (applicationQuitting) return;
+            if (UnityObjectUtils.IsQuitting) return;
             
             mediaPlayer.Stop();
             mediaPlayer.enabled = false;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerCustomPool.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerCustomPool.cs
@@ -18,12 +18,16 @@ namespace DCL.SDKComponents.MediaStream
         private readonly int tryCleanOfflineMediaPlayersDelayInMinutes = 2;
         private readonly float maxOfflineTimePossibleInSeconds = 300f;
 
+        private static bool applicationQuitting;
+
         public MediaPlayerCustomPool(MediaPlayer mediaPlayerPrefab)
         {
             this.mediaPlayerPrefab = mediaPlayerPrefab;
             rootContainerTransform = new GameObject("POOL_CONTAINER_MEDIA_PLAYER").transform;
             offlineMediaPlayers = new Dictionary<string, Queue<MediaPlayerInfo>>();
             TryUnloadAsync().Forget();
+
+            Application.quitting += () => applicationQuitting = true;
         }
 
         public MediaPlayer GetOrCreateReusableMediaPlayer(string url)
@@ -81,6 +85,9 @@ namespace DCL.SDKComponents.MediaStream
 
         public void ReleaseMediaPlayer(string url, MediaPlayer mediaPlayer)
         {
+            //On quit, Unity may have already detroyed the MediaPlayer; so we might get a null-ref
+            if (applicationQuitting) return;
+            
             mediaPlayer.Stop();
             mediaPlayer.enabled = false;
             mediaPlayer.gameObject.SetActive(false);

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerUtils.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerUtils.cs
@@ -1,0 +1,11 @@
+namespace DCL.SDKComponents.MediaStream
+{
+    public class MediaPlayerUtils
+    {
+        public static void CleanUpMediaPlayer(ref MediaPlayerComponent mediaPlayerComponent, MediaPlayerCustomPool mediaPlayerPool)
+        {
+            mediaPlayerPool.ReleaseMediaPlayer(mediaPlayerComponent.URL, mediaPlayerComponent.MediaPlayer);
+            mediaPlayerComponent.Dispose();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerUtils.cs.meta
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerUtils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5a5c5afc66864dc1a54c3b2037637c2b
+timeCreated: 1743769516

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CleanUpMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CleanUpMediaPlayerSystem.cs
@@ -95,8 +95,7 @@ namespace DCL.SDKComponents.MediaStream
 
         private void CleanUpMediaPlayer(ref MediaPlayerComponent mediaPlayerComponent)
         {
-            mediaPlayerPool.ReleaseMediaPlayer(mediaPlayerComponent.URL, mediaPlayerComponent.MediaPlayer);
-            mediaPlayerComponent.Dispose();
+            MediaPlayerUtils.CleanUpMediaPlayer(ref mediaPlayerComponent, mediaPlayerPool);
         }
 
         public void FinalizeComponents(in Query query)

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -126,16 +126,15 @@ namespace DCL.SDKComponents.MediaStream
 
         private bool RequiresURLChange(in Entity entity, ref MediaPlayerComponent component, string url, IDirtyMarker sdkComponent)
         {
-            if (!sdkComponent.IsDirty) return false;
-
-            if (component.URL != url && (!sceneData.TryGetMediaUrl(url, out var localMediaUrl) || component.URL != localMediaUrl))
+            if (sdkComponent.IsDirty && component.URL != url && (!sceneData.TryGetMediaUrl(url, out var localMediaUrl) || component.URL != localMediaUrl))
             {
                 MediaPlayerUtils.CleanUpMediaPlayer(ref component, mediaPlayerPool);
+                sdkComponent.IsDirty = false;
                 World.Remove<MediaPlayerComponent>(entity);
+                return true;
             }
 
-            sdkComponent.IsDirty = false;
-            return true;
+            return false;
         }
 
         [Query]

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -34,6 +34,7 @@ namespace DCL.SDKComponents.MediaStream
         private readonly WorldVolumeMacBus worldVolumeMacBus;
         private float worldVolumePercentage = 1f;
         private float masterVolumePercentage = 1f;
+        private readonly MediaPlayerCustomPool mediaPlayerPool;
 
         public UpdateMediaPlayerSystem(
             World world,
@@ -41,13 +42,14 @@ namespace DCL.SDKComponents.MediaStream
             ISceneData sceneData,
             ISceneStateProvider sceneStateProvider,
             IPerformanceBudget frameTimeBudget,
-            WorldVolumeMacBus worldVolumeMacBus) : base(world)
+            WorldVolumeMacBus worldVolumeMacBus, MediaPlayerCustomPool mediaPlayerPool) : base(world)
         {
             this.webRequestController = webRequestController;
             this.sceneData = sceneData;
             this.sceneStateProvider = sceneStateProvider;
             this.frameTimeBudget = frameTimeBudget;
             this.worldVolumeMacBus = worldVolumeMacBus;
+            this.mediaPlayerPool = mediaPlayerPool;
 
             //This following part is a workaround applied for the MacOS platform, the reason
             //is related to the video and audio streams, the MacOS environment does not support
@@ -89,7 +91,7 @@ namespace DCL.SDKComponents.MediaStream
         }
 
         [Query]
-        private void UpdateAudioStream(ref MediaPlayerComponent component, PBAudioStream sdkComponent)
+        private void UpdateAudioStream(in Entity entity, ref MediaPlayerComponent component, PBAudioStream sdkComponent)
         {
             if (!frameTimeBudget.TrySpendBudget()) return;
 
@@ -98,13 +100,15 @@ namespace DCL.SDKComponents.MediaStream
                 float actualVolume = (sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME) * worldVolumePercentage * masterVolumePercentage;
                 component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
             }
+
+            if (RequiresURLChange(entity,  ref component, sdkComponent.Url, sdkComponent)) return;
 
             HandleComponentChange(ref component, sdkComponent, sdkComponent.Url, sdkComponent.HasPlaying, sdkComponent.Playing);
             ConsumePromise(ref component, sdkComponent.HasPlaying && sdkComponent.Playing);
         }
 
         [Query]
-        private void UpdateVideoStream(ref MediaPlayerComponent component, PBVideoPlayer sdkComponent)
+        private void UpdateVideoStream(in Entity entity, ref MediaPlayerComponent component, PBVideoPlayer sdkComponent)
         {
             if (!frameTimeBudget.TrySpendBudget()) return;
 
@@ -114,8 +118,24 @@ namespace DCL.SDKComponents.MediaStream
                 component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
             }
 
+            if (RequiresURLChange(entity,  ref component, sdkComponent.Src, sdkComponent)) return;
+
             HandleComponentChange(ref component, sdkComponent, sdkComponent.Src, sdkComponent.HasPlaying, sdkComponent.Playing, sdkComponent, static (mediaPlayer, sdk) => mediaPlayer.UpdatePlaybackProperties(sdk));
             ConsumePromise(ref component, false, sdkComponent, static (mediaPlayer, sdk) => mediaPlayer.SetPlaybackProperties(sdk));
+        }
+
+        private bool RequiresURLChange(in Entity entity, ref MediaPlayerComponent component, string url, IDirtyMarker sdkComponent)
+        {
+            if (!sdkComponent.IsDirty) return false;
+
+            if (component.URL != url && (!sceneData.TryGetMediaUrl(url, out var localMediaUrl) || component.URL != localMediaUrl))
+            {
+                MediaPlayerUtils.CleanUpMediaPlayer(ref component, mediaPlayerPool);
+                World.Remove<MediaPlayerComponent>(entity);
+            }
+
+            sdkComponent.IsDirty = false;
+            return true;
         }
 
         [Query]
@@ -143,19 +163,7 @@ namespace DCL.SDKComponents.MediaStream
         {
             if (!sdkComponent.IsDirty) return;
 
-            if (component.URL != url && (!sceneData.TryGetMediaUrl(url, out URLAddress localMediaUrl) || component.URL != localMediaUrl))
-            {
-                component.MediaPlayer.CloseCurrentStream();
-
-                UpdateStreamUrl(ref component, url);
-
-                if (component.State != VideoState.VsError)
-                {
-                    component.Cts = component.Cts.SafeRestart();
-                    component.OpenMediaPromise.UrlReachabilityResolveAsync(webRequestController, component.URL, GetReportData(), component.Cts.Token).Forget();
-                }
-            }
-            else if (component.State != VideoState.VsError)
+            if (component.State != VideoState.VsError)
             {
                 component.MediaPlayer.UpdatePlayback(hasPlaying, isPlaying);
 
@@ -188,21 +196,6 @@ namespace DCL.SDKComponents.MediaStream
                 component.SetState(string.IsNullOrEmpty(component.URL) ? VideoState.VsNone : VideoState.VsError);
                 component.MediaPlayer.CloseCurrentStream();
             }
-        }
-
-        private void UpdateStreamUrl(ref MediaPlayerComponent component, string url)
-        {
-            bool isValidStreamUrl = url.IsValidUrl();
-            bool isValidLocalPath = false;
-            if (!isValidStreamUrl)
-            {
-                isValidLocalPath = sceneData.TryGetMediaUrl(url, out URLAddress mediaUrl);
-                if(isValidLocalPath)
-                    url = mediaUrl;
-            }
-
-            component.URL = url;
-            component.SetState(isValidStreamUrl || isValidLocalPath || string.IsNullOrEmpty(url) ? VideoState.VsNone : VideoState.VsError);
         }
 
         protected override void OnDispose()

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/MediaPlayerPluginWrapper.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/MediaPlayerPluginWrapper.cs
@@ -57,7 +57,7 @@ namespace DCL.SDKComponents.MediaStream.Wrapper
 #if AV_PRO_PRESENT && !UNITY_EDITOR_LINUX && !UNITY_STANDALONE_LINUX
 
             CreateMediaPlayerSystem.InjectToWorld(ref builder, webRequestController, sceneData, mediaPlayerCustomPool, sceneStateProvider, frameTimeBudget);
-            UpdateMediaPlayerSystem.InjectToWorld(ref builder, webRequestController, sceneData, sceneStateProvider, frameTimeBudget, worldVolumeMacBus);
+            UpdateMediaPlayerSystem.InjectToWorld(ref builder, webRequestController, sceneData, sceneStateProvider, frameTimeBudget, worldVolumeMacBus, mediaPlayerCustomPool);
 
             if(featureFlagsCache.Configuration.IsEnabled(FeatureFlagsStrings.VIDEO_PRIORITIZATION))
                 UpdateMediaPlayerPrioritizationSystem.InjectToWorld(ref builder, exposedCameraData, videoPrioritizationSettings);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

- Correctly uses the media player pool when the URL changes. It now starts the cycle over
- Fixes [this ](https://decentraland.sentry.io/issues/6507381956/?project=4506075736047616&query=CleanUpMediaPlayer&referrer=issue-stream&sort=date&stream_index=0)raising Sentry issue

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites


### Test Steps
1. Use the change video LSD scene
2. Check that videos swap correctly and you here audio as well



## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
