### PR TITLE
fix: Remove avatar clean up defer deletion

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarCleanUpSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarCleanUpSystem.cs
@@ -83,16 +83,8 @@ namespace DCL.AvatarRendering.AvatarShape.Systems
         private void DestroyAvatar(ref AvatarShapeComponent avatarShapeComponent, ref AvatarTransformMatrixComponent avatarTransformMatrixComponent,
             AvatarBase avatarBase, ref AvatarCustomSkinningComponent skinningComponent, ref DeleteEntityIntention deleteEntityIntention)
         {
-            // Use frame budget for destruction as well
-            if (!instantiationFrameTimeBudget.TrySpendBudget())
-            {
-                avatarBase.gameObject.SetActive(false);
-                deleteEntityIntention.DeferDeletion = true;
-                return;
-            }
-
-            InternalDestroyAvatar(ref avatarShapeComponent, ref skinningComponent, ref avatarTransformMatrixComponent, avatarBase);
             deleteEntityIntention.DeferDeletion = false;
+            InternalDestroyAvatar(ref avatarShapeComponent, ref skinningComponent, ref avatarTransformMatrixComponent, avatarBase);
         }
 
         private void InternalDestroyAvatar(ref AvatarShapeComponent avatarShapeComponent,

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -90,7 +90,7 @@ namespace DCL.AvatarRendering.Emotes.Play
 
         // emotes that do not loop need to trigger some kind of cancellation, so we can take care of the emote props and sounds
         [Query]
-        [None(typeof(CharacterEmoteIntent))]
+        [None(typeof(CharacterEmoteIntent), typeof(DeleteEntityIntention))]
         private void CancelEmotes(ref CharacterEmoteComponent emoteComponent, in IAvatarView avatarView)
         {
             bool wantsToCancelEmote = emoteComponent.StopEmote;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/LifeCycle/Components/DeleteEntityIntention.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/LifeCycle/Components/DeleteEntityIntention.cs
@@ -7,8 +7,5 @@
     public struct DeleteEntityIntention
     {
         public bool DeferDeletion;
-
-        public static DeleteEntityIntention DeferredDeletion => new ()
-            { DeferDeletion = true };
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/IncreasingRadius/ResolveSceneStateByIncreasingRadiusSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/IncreasingRadius/ResolveSceneStateByIncreasingRadiusSystem.cs
@@ -277,7 +277,11 @@ namespace ECS.SceneLifeCycle.IncreasingRadius
             sceneState.VisualSceneState = VisualSceneState.UNINITIALIZED;
             sceneState.PromiseCreated = false;
             sceneState.FullQuality = false;
-            World.Add(entity, DeleteEntityIntention.DeferredDeletion);
+
+            //We mark it as Defer because, down the line, the entity wont be deleted.
+            //Either the LOD or the SceneFacade will be removed, but the Entity with the
+            //SceneDefinitionComponent should persist
+            World.Add(entity, new DeleteEntityIntention { DeferDeletion = true });
         }
 
         private void UpdateLoadingState(IIpfsRealm ipfsRealm, in Entity entity, in SceneDefinitionComponent sceneDefinitionComponent, in PartitionComponent partitionComponent,

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -621,8 +621,6 @@ namespace Global.Dynamic
                     nametagsData,
                     defaultTexturesContainer.TextureArrayContainerFactory,
                     wearableCatalog,
-                    remoteEntities,
-                    staticContainer.CharacterContainer.Transform,
                     userBlockingCacheProxy),
                 new MainUIPlugin(mvcManager, mainUIView, includeFriends, sharedSpaceManager),
                 new ProfilePlugin(profileRepository, profileCache, staticContainer.CacheCleaner),

--- a/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
@@ -74,8 +74,6 @@ namespace DCL.PluginSystem.Global
 
         private readonly DefaultFaceFeaturesHandler defaultFaceFeaturesHandler;
         private readonly TextureArrayContainerFactory textureArrayContainerFactory;
-        private readonly RemoteEntities remoteEntities;
-        private readonly ExposedTransform playerTransform;
         private readonly IWearableStorage wearableStorage;
 
         private readonly AvatarTransformMatrixJobWrapper avatarTransformMatrixJobWrapper;
@@ -98,8 +96,6 @@ namespace DCL.PluginSystem.Global
             NametagsData nametagsData,
             TextureArrayContainerFactory textureArrayContainerFactory,
             IWearableStorage wearableStorage,
-            RemoteEntities remoteEntities,
-            ExposedTransform playerTransform,
             ObjectProxy<IUserBlockingCache> userBlockingCacheProxy
         )
         {
@@ -114,8 +110,6 @@ namespace DCL.PluginSystem.Global
             this.rendererFeaturesCache = rendererFeaturesCache;
             this.nametagsData = nametagsData;
             this.textureArrayContainerFactory = textureArrayContainerFactory;
-            this.remoteEntities = remoteEntities;
-            this.playerTransform = playerTransform;
             this.wearableStorage = wearableStorage;
             this.userBlockingCacheProxy = userBlockingCacheProxy;
             componentPoolsRegistry = poolsRegistry;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

We got the following exception during the most recent stress test

```
MissingReferenceException: The object of type 'Animator' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
```

This reflects that an `avatarBase`, which has been returned to the pool and deleted by the `CacheCleaner`, is still persisting in ECS.

And Im unable to get to the very origin of this problem. One possibility could be that the defer deletion of the avatar causes a problem somewhere.

There isnt a reason to keep the performance budget on deletion, since it shouldnt be a super common operation. So, to remove one possible error, Im removing it on this PR

Took the opportunity as well to clarify why Scene entities require a `DeferDeletion` in a comment

## Test Instructions

### Test Steps
1. Open backpack and change wearables. See that everything works fine in the backpack and ingame
2. Instantiate and destroy avatars in Olavra. See that everything works fine
3. Get some friends and go to GP. Appear and dissapear, Change wearables. See that everything is fine

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
