### PR TITLE
Fix: profile thumbnail loading inconsitencies

### DIFF
--- a/Explorer/Assets/DCL/Friends/UI/Prefabs/BlockedUser.prefab
+++ b/Explorer/Assets/DCL/Friends/UI/Prefabs/BlockedUser.prefab
@@ -553,6 +553,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8919628233407399618, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 9177864993776066132, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_Name
       value: BlockedUser
@@ -620,8 +624,6 @@ MonoBehaviour:
   <UserName>k__BackingField: {fileID: 8766517600456461327}
   <UserNameTag>k__BackingField: {fileID: 4439377754047818784}
   <VerifiedIcon>k__BackingField: {fileID: 8218420186549764868}
-  <ThumbnailBackground>k__BackingField: {fileID: 0}
-  <ProfileImageView>k__BackingField: {fileID: 0}
   <ProfilePicture>k__BackingField: {fileID: 1033530974263179573}
   <UnblockButton>k__BackingField: {fileID: 5048879491243901675}
   <ContextMenuButton>k__BackingField: {fileID: 5471597906867111241}

--- a/Explorer/Assets/DCL/Friends/UI/Prefabs/FriendListUser Variant.prefab
+++ b/Explorer/Assets/DCL/Friends/UI/Prefabs/FriendListUser Variant.prefab
@@ -890,6 +890,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8919628233407399618, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 9177864993776066132, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_Name
       value: FriendListUser Variant

--- a/Explorer/Assets/DCL/Friends/UI/Prefabs/RequestUser.prefab
+++ b/Explorer/Assets/DCL/Friends/UI/Prefabs/RequestUser.prefab
@@ -135,10 +135,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <Button>k__BackingField: {fileID: 4259715656478843361}
-  <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7,
-    type: 2}
-  <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36,
-    type: 2}
+  <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7, type: 2}
+  <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
 --- !u!1 &1104277341837610071
 GameObject:
   m_ObjectHideFlags: 0
@@ -274,10 +272,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <Button>k__BackingField: {fileID: 3451016736453679246}
-  <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7,
-    type: 2}
-  <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36,
-    type: 2}
+  <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7, type: 2}
+  <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
 --- !u!1 &1671170444579859960
 GameObject:
   m_ObjectHideFlags: 0
@@ -348,8 +344,7 @@ MonoBehaviour:
 '
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
-  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad,
-    type: 2}
+  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -485,8 +480,7 @@ MonoBehaviour:
   m_text: Read Message
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
-  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec,
-    type: 2}
+  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -622,8 +616,7 @@ MonoBehaviour:
   m_text: DELETE
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
-  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad,
-    type: 2}
+  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -759,8 +752,7 @@ MonoBehaviour:
   m_text: JAN 12
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
-  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec,
-    type: 2}
+  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -963,10 +955,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <Button>k__BackingField: {fileID: 2349608275359085897}
-  <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7,
-    type: 2}
-  <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36,
-    type: 2}
+  <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7, type: 2}
+  <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
 --- !u!1 &7508043306453600687
 GameObject:
   m_ObjectHideFlags: 0
@@ -1035,8 +1025,7 @@ MonoBehaviour:
   m_text: ACCEPT
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
-  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad,
-    type: 2}
+  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1187,287 +1176,234 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_SizeDelta.x
       value: 382
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_SizeDelta.y
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1549678179968827682, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 1549678179968827682, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1549678179968827682, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 1549678179968827682, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1549678179968827682, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 1549678179968827682, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1549678179968827682, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 1549678179968827682, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_SizeDelta.y
       value: 17.1
       objectReference: {fileID: 0}
-    - target: {fileID: 1549678179968827682, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 1549678179968827682, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2618141556115726300, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 2618141556115726300, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_fontColor.b
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2618141556115726300, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 2618141556115726300, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_fontColor.g
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2618141556115726300, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 2618141556115726300, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_fontColor.r
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2618141556115726300, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 2618141556115726300, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_fontColor32.rgba
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3311938696152138296, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 3311938696152138296, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_SizeDelta.x
       value: 40
       objectReference: {fileID: 0}
-    - target: {fileID: 3311938696152138296, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 3311938696152138296, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_SizeDelta.y
       value: 40
       objectReference: {fileID: 0}
-    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_SizeDelta.y
       value: 17.1
       objectReference: {fileID: 0}
-    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 5321243243872904382, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6422732380923386402, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 6422732380923386402, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8326481810206252948, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 8326481810206252948, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8326481810206252948, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 8326481810206252948, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8326481810206252948, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 8326481810206252948, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_SizeDelta.y
       value: 17
       objectReference: {fileID: 0}
-    - target: {fileID: 8326481810206252948, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 8326481810206252948, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8326481810206252948, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 8326481810206252948, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9177864993776066132, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - target: {fileID: 8919628233407399618, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9177864993776066132, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       propertyPath: m_Name
       value: RequestUser
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       insertIndex: 0
       addedObject: {fileID: 8861423366719641434}
-    - targetCorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       insertIndex: 1
       addedObject: {fileID: 3449187102796399413}
-    - targetCorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       insertIndex: 2
       addedObject: {fileID: 2348276441900935801}
-    - targetCorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       insertIndex: 3
       addedObject: {fileID: 2757506916148692559}
-    - targetCorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       insertIndex: -1
       addedObject: {fileID: 202271814073414568}
-    - targetCorrespondingSourceObject: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1457844496444948610}
-    - targetCorrespondingSourceObject: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       insertIndex: -1
       addedObject: {fileID: 5709242335431599844}
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 9177864993776066132, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 9177864993776066132, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2505166025248160618}
   m_SourcePrefab: {fileID: 100100000, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
 --- !u!114 &4540062364792409 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6028835980500036326, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 6028835980500036326, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
   m_PrefabInstance: {fileID: 6033305386341014719}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -1478,8 +1414,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!114 &436225456489151555 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6176497728483893500, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 6176497728483893500, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
   m_PrefabInstance: {fileID: 6033305386341014719}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3234931286704210667}
@@ -1490,14 +1425,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!1 &763565033389606557 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6422732380923386402, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 6422732380923386402, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
   m_PrefabInstance: {fileID: 6033305386341014719}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &3234931286704210667 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 9177864993776066132, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 9177864993776066132, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
   m_PrefabInstance: {fileID: 6033305386341014719}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &2505166025248160618
@@ -1519,8 +1452,6 @@ MonoBehaviour:
   <UserName>k__BackingField: {fileID: 8642155449442485091}
   <UserNameTag>k__BackingField: {fileID: 3736898434265359180}
   <VerifiedIcon>k__BackingField: {fileID: 8956048073426062440}
-  <ThumbnailBackground>k__BackingField: {fileID: 0}
-  <ProfileImageView>k__BackingField: {fileID: 0}
   <ProfilePicture>k__BackingField: {fileID: 4540062364792409}
   <ContextMenuButton>k__BackingField: {fileID: 5637797142498573802}
   <DeleteButton>k__BackingField: {fileID: 4259715656478843361}
@@ -1530,8 +1461,7 @@ MonoBehaviour:
   <HasMessageIndicator>k__BackingField: {fileID: 763565033389606557}
 --- !u!114 &3589982925530384438 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7091116879237502089, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 7091116879237502089, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
   m_PrefabInstance: {fileID: 6033305386341014719}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3234931286704210667}
@@ -1542,8 +1472,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!114 &3736898434265359180 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6946444103854276595, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 6946444103854276595, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
   m_PrefabInstance: {fileID: 6033305386341014719}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -1554,14 +1483,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!224 &6512027689777179457 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 713193711783360510, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
   m_PrefabInstance: {fileID: 6033305386341014719}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &8642155449442485091 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2618141556115726300, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 2618141556115726300, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
   m_PrefabInstance: {fileID: 6033305386341014719}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -1572,14 +1499,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!224 &8807323456142015557 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 2991372348764053754, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
   m_PrefabInstance: {fileID: 6033305386341014719}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &8956048073426062440 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 3454503966152282327, guid: 5dd1047f77ec242c3bb28f7edc2af796,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 3454503966152282327, guid: 5dd1047f77ec242c3bb28f7edc2af796, type: 3}
   m_PrefabInstance: {fileID: 6033305386341014719}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8849725491536618610
@@ -1590,113 +1515,91 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6512027689777179457}
     m_Modifications:
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_AnchorMin.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_SizeDelta.x
       value: 20
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_SizeDelta.y
       value: 30
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -26
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3813969249028053400, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 3813969249028053400, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_TargetGraphic
       value: 
       objectReference: {fileID: 7488346134653886422}
-    - target: {fileID: 5316031541966112930, guid: 3842f9478470e446ba63a9a79780d4fe,
-        type: 3}
+    - target: {fileID: 5316031541966112930, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
       propertyPath: m_Name
       value: ContextMenuButton
       objectReference: {fileID: 0}
@@ -1707,8 +1610,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
 --- !u!114 &5637797142498573802 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3813969249028053400, guid: 3842f9478470e446ba63a9a79780d4fe,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 3813969249028053400, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
   m_PrefabInstance: {fileID: 8849725491536618610}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -1719,8 +1621,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!114 &7488346134653886422 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2106410636135414692, guid: 3842f9478470e446ba63a9a79780d4fe,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 2106410636135414692, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
   m_PrefabInstance: {fileID: 8849725491536618610}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -1731,7 +1632,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!224 &8861423366719641434 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 11984575599866664, guid: 3842f9478470e446ba63a9a79780d4fe, type: 3}
   m_PrefabInstance: {fileID: 8849725491536618610}
   m_PrefabAsset: {fileID: 0}

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/VisiblePersonEntry.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/VisiblePersonEntry.prefab
@@ -651,6 +651,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: ProfileCard
       objectReference: {fileID: 0}
+    - target: {fileID: 1886905237088769880, guid: 9a2033d34fc1748a7ae18ca05ce0b7ad, type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1896983162516398156, guid: 9a2033d34fc1748a7ae18ca05ce0b7ad, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
@@ -61,6 +61,7 @@ namespace DCL.UI.ProfileElements
         public void SetDefaultThumbnail()
         {
             thumbnailImageView.SetImage(defaultEmptyThumbnail);
+            currentUserId = null;
         }
 
         private async UniTask SetThumbnailImageWithAnimationAsync(Sprite sprite, CancellationToken ct)

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
@@ -16,7 +16,7 @@ namespace DCL.UI.ProfileElements
 
         private ViewDependencies? viewDependencies;
         private CancellationTokenSource? cts;
-        private string? currentThumbnailUrl;
+        private string? currentUserId;
 
         public void InjectDependencies(ViewDependencies dependencies)
         {
@@ -30,20 +30,20 @@ namespace DCL.UI.ProfileElements
 
         public void Setup(Color userColor, string faceSnapshotUrl, string userId)
         {
-            thumbnailBackground.color = userColor;
+            SetupOnlyColor(userColor);
             LoadThumbnailAsync(faceSnapshotUrl, userId).Forget();
         }
 
         public async UniTask SetupWithDependenciesAsync(ViewDependencies dependencies, Color userColor, string faceSnapshotUrl, string userId, CancellationToken ct)
         {
-            viewDependencies = dependencies;
-            thumbnailBackground.color = userColor;
+            InjectDependencies(dependencies);
+            SetupOnlyColor(userColor);
             await LoadThumbnailAsync(faceSnapshotUrl, userId, ct);
         }
 
         public void SetupWithDependencies(ViewDependencies dependencies, Color userColor, string faceSnapshotUrl, string userId)
         {
-            viewDependencies = dependencies;
+            InjectDependencies(dependencies);
             Setup(userColor, faceSnapshotUrl, userId);
         }
 
@@ -63,11 +63,19 @@ namespace DCL.UI.ProfileElements
             thumbnailImageView.SetImage(defaultEmptyThumbnail);
         }
 
+        private async UniTask SetThumbnailImageWithAnimationAsync(Sprite sprite, CancellationToken ct)
+        {
+            thumbnailImageView.SetImage(sprite);
+            thumbnailImageView.ImageEnabled = true;
+            await thumbnailImageView.FadeInAsync(0.5f, ct);
+        }
+
         private async UniTask LoadThumbnailAsync(string faceSnapshotUrl, string userId, CancellationToken ct = default)
         {
-            cts = ct != default ? cts.SafeRestartLinked(ct) : cts.SafeRestart();
+            if (userId.Equals(currentUserId)) return;
 
-            if (currentThumbnailUrl == faceSnapshotUrl) return;
+            cts = ct != default ? cts.SafeRestartLinked(ct) : cts.SafeRestart();
+            currentUserId = userId;
 
             try
             {
@@ -78,30 +86,29 @@ namespace DCL.UI.ProfileElements
                 if (sprite != null)
                 {
                     thumbnailImageView.SetImage(sprite);
-                    thumbnailImageView.ImageEnabled = true;
-                    thumbnailImageView.IsLoading = false;
+                    SetLoadingState(false);
                     thumbnailImageView.Alpha = 1f;
-                    currentThumbnailUrl = faceSnapshotUrl;
                     return;
                 }
 
-                thumbnailImageView.IsLoading = true;
-                thumbnailImageView.ImageEnabled = false;
+                SetLoadingState(true);
                 thumbnailImageView.Alpha = 0f;
 
-                sprite = await viewDependencies.GetProfileThumbnailAsync(userId, faceSnapshotUrl, cts.Token);
+                sprite = await viewDependencies!.GetProfileThumbnailAsync(userId, faceSnapshotUrl, cts.Token);
 
-                currentThumbnailUrl = faceSnapshotUrl;
-                thumbnailImageView.SetImage(sprite ? sprite! : defaultEmptyThumbnail);
-                thumbnailImageView.ImageEnabled = true;
-                await thumbnailImageView.FadeInAsync(0.5f, cts.Token);
+                if (sprite == null)
+                    currentUserId = null;
+
+                await SetThumbnailImageWithAnimationAsync(sprite ? sprite! : defaultEmptyThumbnail, cts.Token);
             }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException)
+            {
+                currentUserId = null;
+            }
             catch (Exception)
             {
-                thumbnailImageView.SetImage(defaultEmptyThumbnail);
-                thumbnailImageView.ImageEnabled = true;
-                await thumbnailImageView.FadeInAsync(0.5f, cts.Token);
+                currentUserId = null;
+                await SetThumbnailImageWithAnimationAsync(defaultEmptyThumbnail, cts.Token);
             }
         }
     }


### PR DESCRIPTION
# Pull Request Description

Fixes #3762 

Profile thumbnail images sometime appeared as if they failed to load (especially in the nearby users section). This is caused by the UI redrawing and cancelling the loading process multiple times.

Also, the loading spinners in the PhotoDetail panel and in the friend list panel are not animating while waiting for the thumbnail.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR prevents the cancellation of the loading task when we are trying to redraw the same user, letting the normal loading flow to continue and solve the thumbnails.

Regarding the animation, the wrong material was being used therefore the shader that animates the spinner wasn't working.


### Test Steps
Verify that all thumbnails are loaded (also, the loading spinners should be animating while loading) in the following panels:
1. Friend list
2. Nearby users panel of the chat
3. Photo detail of the reels

### Additional Testing Notes
- If any thumbnail is not visible (the default avatar should be shown), verify that there's an exception in the logs for that wallet

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
