### PR TITLE
SimpleFetchApi: Task cancellation is not an error

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/FetchApi/LogSimpleFetchApi.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/FetchApi/LogSimpleFetchApi.cs
@@ -34,11 +34,13 @@ namespace SceneRuntime.Apis.Modules.FetchApi
                 ReportHub.Log(ReportCategory.GENERIC_WEB_REQUEST, $"SimpleFetchApi, Fetch request successes with: {args}");
                 return result;
             }
-            catch (Exception e)
+            catch (Exception ex) when (ex is not OperationCanceledException operationCancelled
+                                       || operationCancelled.CancellationToken != ct)
             {
-                var exception = new Exception($"SimpleFetchApi, cannot make request: {args}", e);
-                ReportHub.LogException(exception, ReportCategory.GENERIC_WEB_REQUEST);
-                throw exception;
+                ReportHub.LogError(ReportCategory.GENERIC_WEB_REQUEST,
+                    $"SimpleFetchApi, cannot make request:  {args}");
+
+                throw;
             }
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change makes SimpleFetchApi task cancellation not an error.

## Test Instructions

Cause a web request made by a scene be interrupted and observe that no exception is logged. Maybe leaving a scene while it is performing a web request will do this.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
