### PR TITLE
fix: improve github event handling

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -314,7 +314,9 @@ jobs:
           echo "SHA_SHORT=$(echo ${{ needs.prebuild.outputs.commit_sha }} | cut -c1-7)" >> $GITHUB_ENV
           echo "SAFE_BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}" >> $GITHUB_ENV
 
-          case "${GITHUB_EVENT_NAME}" in
+          EVENT_NAME="${{ github.event_name }}"
+          echo "Detected event: $EVENT_NAME"
+          case "$EVENT_NAME" in
             pull_request) echo "BUILD_PREFIX=pr" >> $GITHUB_ENV ;;
             push) echo "BUILD_PREFIX=pu" >> $GITHUB_ENV ;;
             merge_group) echo "BUILD_PREFIX=mg" >> $GITHUB_ENV ;;

--- a/Explorer/.gitignore
+++ b/Explorer/.gitignore
@@ -76,5 +76,5 @@ Assets/AddressableAssetsData/Windows.meta
 Assets/AddressableAssetsData/ProfileDataSourceSettings.asset
 Assets/AddressableAssetsData/ProfileDataSourceSettings.asset.meta
 
-# Disk Caching
+# Disk caching
 DiskCache/


### PR DESCRIPTION
- switched from GITHUB_EVENT_NAME env var to github.event_name expression
- more reliable across different workflow contexts (e.g. workflow_call)
- simplifies the logic and avoids edge cases with env parsing