### PR TITLE
fix: remove highlight of entities that are no longer inside the scene world

### DIFF
--- a/Explorer/Assets/DCL/Interaction/Raycast/Components/HighlightComponent.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Components/HighlightComponent.cs
@@ -74,8 +74,8 @@ namespace DCL.Interaction.Raycast.Components
             currentEntity == nextEntity && isEnabled;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public readonly bool ReadyForMaterial() =>
-            isEnabled && nextEntity != EntityReference.Null;
+        public readonly bool ReadyForMaterial(World world) =>
+            isEnabled && nextEntity != EntityReference.Null && nextEntity.IsAlive(world);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SwitchEntity()
@@ -84,7 +84,7 @@ namespace DCL.Interaction.Raycast.Components
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool HasToResetLastEntity() =>
-            currentEntity != nextEntity && currentEntity != EntityReference.Null && isEnabled;
+        public bool HasToResetLastEntity(World world) =>
+            currentEntity != nextEntity && currentEntity != EntityReference.Null && isEnabled && nextEntity.IsAlive(world);
     }
 }

--- a/Explorer/Assets/DCL/Interaction/Systems/InteractionHighlightSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/InteractionHighlightSystem.cs
@@ -57,7 +57,9 @@ namespace DCL.Interaction.Systems
             if (highlightComponent.IsEmpty())
                 return;
 
-            RemoveHighlight(highlightComponent.CurrentEntityOrNull());
+            if (highlightComponent.CurrentEntityOrNull() != EntityReference.Null && highlightComponent.CurrentEntityOrNull().IsAlive(World))
+                RemoveHighlight(highlightComponent.CurrentEntityOrNull());
+
             highlightComponent.MoveNextAndRemoveMaterial();
         }
 
@@ -69,9 +71,9 @@ namespace DCL.Interaction.Systems
                 && (!highlightComponent.CurrentEntityOrNull().IsAlive(World) || World!.Has<DeleteEntityIntention>(highlightComponent.CurrentEntityOrNull())))
                 highlightComponent.Disable();
 
-            if (highlightComponent.ReadyForMaterial())
+            if (highlightComponent.ReadyForMaterial(World))
             {
-                if (highlightComponent.HasToResetLastEntity())
+                if (highlightComponent.HasToResetLastEntity(World))
                     RemoveHighlight(highlightComponent.CurrentEntityOrNull());
 
                 highlightComponent.SwitchEntity();


### PR DESCRIPTION
# Pull Request Description

Fixes #3460

The solution inside #3757 was incomplete.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR addresses all other possible cases where an entity that is no longer contained by the scene world, is manipulated in order to handle the highlight on the object.

### Test Steps
1. Head to `1,101` and start a solo game with no time limit
2. Verify that the client never hangs while playing chess
3. Verify that the highlight of the chess pieces works as expected
4. You are able to play as long as you want and complete multiple games

### Additional Testing Notes
- Moving each pawns 1 square forward 2 times each piece (so that all white and black pawns are adjacent to each other) and resetting the game makes testing many moves faster
- Check also that a full game works as expected

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
