### PR TITLE
Fix: player fall on scene reload 

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
@@ -1290,17 +1290,17 @@ MonoBehaviour:
   m_TransparentLayers:
     serializedVersion: 2
     m_Bits: 66086
-  m_MinimumDistanceFromTarget: 0.1
+  m_MinimumDistanceFromTarget: 0.01
   m_AvoidObstacles: 1
   m_DistanceLimit: 0
   m_MinimumOcclusionTime: 0
-  m_CameraRadius: 0.35
-  m_Strategy: 0
+  m_CameraRadius: 0.3
+  m_Strategy: 1
   m_MaximumEffort: 4
   m_SmoothingTime: 0.3
   m_Damping: 0.5
-  m_DampingWhenOccluded: 0.2
-  m_OptimalTargetDistance: 0.5
+  m_DampingWhenOccluded: 0.1
+  m_OptimalTargetDistance: 0
 --- !u!114 &5294527864094199746
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1683,17 +1683,17 @@ MonoBehaviour:
   m_TransparentLayers:
     serializedVersion: 2
     m_Bits: 66086
-  m_MinimumDistanceFromTarget: 0.1
+  m_MinimumDistanceFromTarget: 0.01
   m_AvoidObstacles: 1
   m_DistanceLimit: 0
   m_MinimumOcclusionTime: 0
   m_CameraRadius: 0.5
-  m_Strategy: 0
+  m_Strategy: 1
   m_MaximumEffort: 4
   m_SmoothingTime: 0.3
   m_Damping: 0.5
-  m_DampingWhenOccluded: 0.2
-  m_OptimalTargetDistance: 0.5
+  m_DampingWhenOccluded: 0.1
+  m_OptimalTargetDistance: 0
 --- !u!114 &8869747115766645440
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2088,7 +2088,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.1
+  near clip plane: 0.01
   far clip plane: 5000
   field of view: 60
   orthographic: 0

--- a/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
@@ -1294,7 +1294,7 @@ MonoBehaviour:
   m_AvoidObstacles: 1
   m_DistanceLimit: 0
   m_MinimumOcclusionTime: 0
-  m_CameraRadius: 0.2
+  m_CameraRadius: 0.35
   m_Strategy: 0
   m_MaximumEffort: 4
   m_SmoothingTime: 0.3
@@ -1687,7 +1687,7 @@ MonoBehaviour:
   m_AvoidObstacles: 1
   m_DistanceLimit: 0
   m_MinimumOcclusionTime: 0
-  m_CameraRadius: 0.2
+  m_CameraRadius: 0.5
   m_Strategy: 0
   m_MaximumEffort: 4
   m_SmoothingTime: 0.3

--- a/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
@@ -1290,17 +1290,17 @@ MonoBehaviour:
   m_TransparentLayers:
     serializedVersion: 2
     m_Bits: 66086
-  m_MinimumDistanceFromTarget: 0.01
+  m_MinimumDistanceFromTarget: 0.1
   m_AvoidObstacles: 1
   m_DistanceLimit: 0
   m_MinimumOcclusionTime: 0
-  m_CameraRadius: 0.3
-  m_Strategy: 1
+  m_CameraRadius: 0.2
+  m_Strategy: 0
   m_MaximumEffort: 4
   m_SmoothingTime: 0.3
   m_Damping: 0.5
-  m_DampingWhenOccluded: 0.1
-  m_OptimalTargetDistance: 0
+  m_DampingWhenOccluded: 0.2
+  m_OptimalTargetDistance: 0.5
 --- !u!114 &5294527864094199746
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1683,17 +1683,17 @@ MonoBehaviour:
   m_TransparentLayers:
     serializedVersion: 2
     m_Bits: 66086
-  m_MinimumDistanceFromTarget: 0.01
+  m_MinimumDistanceFromTarget: 0.1
   m_AvoidObstacles: 1
   m_DistanceLimit: 0
   m_MinimumOcclusionTime: 0
-  m_CameraRadius: 0.5
-  m_Strategy: 1
+  m_CameraRadius: 0.2
+  m_Strategy: 0
   m_MaximumEffort: 4
   m_SmoothingTime: 0.3
   m_Damping: 0.5
-  m_DampingWhenOccluded: 0.1
-  m_OptimalTargetDistance: 0
+  m_DampingWhenOccluded: 0.2
+  m_OptimalTargetDistance: 0.5
 --- !u!114 &8869747115766645440
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2088,7 +2088,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.01
+  near clip plane: 0.1
   far clip plane: 5000
   field of view: 60
   orthographic: 0

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/InterpolateCharacterSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/InterpolateCharacterSystem.cs
@@ -5,6 +5,7 @@ using DCL.Character.CharacterMotion.Components;
 using DCL.CharacterMotion.Components;
 using DCL.CharacterMotion.Platforms;
 using DCL.CharacterMotion.Settings;
+using DCL.Chat.Commands;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
 using UnityEngine;
@@ -33,7 +34,7 @@ namespace DCL.CharacterMotion.Systems
         }
 
         [Query]
-        [None(typeof(PlayerTeleportIntent), typeof(DeleteEntityIntention), typeof(PlayerTeleportIntent.JustTeleported))]
+        [None(typeof(ReloadSceneChatCommand.SceneReloadComponent), typeof(PlayerTeleportIntent), typeof(DeleteEntityIntention), typeof(PlayerTeleportIntent.JustTeleported))]
         private void Interpolate(
             [Data] float dt,
             in ICharacterControllerSettings settings,

--- a/Explorer/Assets/DCL/Chat/Commands/DCL.Chat.Commands.asmdef
+++ b/Explorer/Assets/DCL/Chat/Commands/DCL.Chat.Commands.asmdef
@@ -19,7 +19,8 @@
         "GUID:f5e7a521f3ce2254b8967e989b8a9ee5",
         "GUID:1d2c76eb8b48e0b40940e8b31a679ce1",
         "GUID:04e9a70e2a3843908ecb2c5135189184",
-        "GUID:7175400a68914a45acecc9fb068de3b8"
+        "GUID:7175400a68914a45acecc9fb068de3b8",
+        "GUID:286980af24684da6acc1caa413039811"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Chat/Commands/ReloadSceneChatCommand.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ReloadSceneChatCommand.cs
@@ -36,14 +36,18 @@ namespace DCL.Chat.Commands
         {
             globalWorld.Add<SceneReloadComponent>(playerEntity);
 
-            bool isSuccess = await reloadScene.TryReloadSceneAsync(ct);
-            await UniTask.WaitUntil(sceneReadyCondition, cancellationToken: ct);
-
-            globalWorld.Remove<SceneReloadComponent>(playerEntity);
-
-            return isSuccess
-                ? "🟢 Current scene has been reloaded"
-                : "🔴 You need to be in a SDK7 scene to reload it.";
+            try
+            {
+                bool isSuccess = await reloadScene.TryReloadSceneAsync(ct);
+                await UniTask.WaitUntil(sceneReadyCondition, cancellationToken: ct);
+                return isSuccess
+                    ? "🟢 Current scene has been reloaded"
+                    : "🔴 You need to be in a SDK7 scene to reload it.";
+            }
+            finally
+            {
+                globalWorld.Remove<SceneReloadComponent>(playerEntity);
+            }
         }
 
         public struct SceneReloadComponent {}

--- a/Explorer/Assets/DCL/Chat/Commands/ReloadSceneChatCommand.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ReloadSceneChatCommand.cs
@@ -1,6 +1,6 @@
-﻿using System.Threading;
+﻿using Arch.Core;
+using System.Threading;
 using Cysharp.Threading.Tasks;
-using DCL.Chat.Commands;
 using ECS.SceneLifeCycle;
 
 namespace DCL.Chat.Commands
@@ -17,18 +17,28 @@ namespace DCL.Chat.Commands
         public string Description => "<b>/reload </b>\n  Reload the current scene";
 
         private readonly ECSReloadScene reloadScene;
+        private readonly World globalWorld;
+        private readonly Entity playerEntity;
 
-        public ReloadSceneChatCommand(ECSReloadScene reloadScene)
+        public ReloadSceneChatCommand(ECSReloadScene reloadScene, World globalWorld, Entity playerEntity)
         {
             this.reloadScene = reloadScene;
+            this.globalWorld = globalWorld;
+            this.playerEntity = playerEntity;
         }
 
         public async UniTask<string> ExecuteCommandAsync(string[] parameters, CancellationToken ct)
         {
+            globalWorld.Add<SceneReloadComponent>(playerEntity);
+
             if (await reloadScene.TryReloadSceneAsync(ct))
                 return "🟢 Current scene has been reloaded";
 
+            globalWorld.Remove<SceneReloadComponent>(playerEntity);
+
             return "🔴 You need to be in a SDK7 scene to reload it.";
         }
+
+        public struct SceneReloadComponent {}
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -496,7 +496,7 @@ namespace Global.Dynamic
                 new WorldChatCommand(chatTeleporter),
                 new DebugPanelChatCommand(debugBuilder, chatCommandsBus),
                 new ShowEntityChatCommand(worldInfoHub),
-                new ReloadSceneChatCommand(reloadSceneController),
+                new ReloadSceneChatCommand(reloadSceneController, globalWorld, playerEntity),
                 new LoadPortableExperienceChatCommand(staticContainer.PortableExperiencesController, staticContainer.FeatureFlagsCache),
                 new KillPortableExperienceChatCommand(staticContainer.PortableExperiencesController, staticContainer.FeatureFlagsCache),
                 new VersionChatCommand(dclVersion),

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -496,7 +496,7 @@ namespace Global.Dynamic
                 new WorldChatCommand(chatTeleporter),
                 new DebugPanelChatCommand(debugBuilder, chatCommandsBus),
                 new ShowEntityChatCommand(worldInfoHub),
-                new ReloadSceneChatCommand(reloadSceneController, globalWorld, playerEntity),
+                new ReloadSceneChatCommand(reloadSceneController, globalWorld, playerEntity, staticContainer.ScenesCache),
                 new LoadPortableExperienceChatCommand(staticContainer.PortableExperiencesController, staticContainer.FeatureFlagsCache),
                 new KillPortableExperienceChatCommand(staticContainer.PortableExperiencesController, staticContainer.FeatureFlagsCache),
                 new VersionChatCommand(dclVersion),

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/ECS/DebugViewProfilingSystem.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/ECS/DebugViewProfilingSystem.cs
@@ -26,7 +26,6 @@ namespace DCL.Profiling.ECS
         private readonly IRealmData realmData;
         private readonly IProfiler profiler;
         private readonly MemoryBudget memoryBudget;
-        private readonly CurrentSceneInfo currentSceneInfo;
 
         private readonly PerformanceBottleneckDetector bottleneckDetector = new ();
 


### PR DESCRIPTION
# Pull Request Description
Fix #3389

## What does this PR change?
- add temporal component during scene reload, so character interpolation system is not executed and player doesn't fall

## Test Instructions
See mentioned above bug-ticket

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
