### PR TITLE
fix: gltf collision layer update lost while loading (revisited)

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Components/GltfContainerAsset.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Components/GltfContainerAsset.cs
@@ -74,7 +74,7 @@ namespace ECS.Unity.GLTFContainer.Asset.Components
 
         public void Dispose()
         {
-            AssetData.Dereference();
+            AssetData?.Dereference();
 
             // Since NoCache is used for Raw GLTFs, we have to manually dispose of the Data
             if (AssetData is GLTFData)

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Components/GltfContainerComponent.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Components/GltfContainerComponent.cs
@@ -14,10 +14,9 @@ namespace ECS.Unity.GLTFContainer.Components
 
         public ColliderLayer VisibleMeshesCollisionMask;
         public ColliderLayer InvisibleMeshesCollisionMask;
-
         public AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention> Promise;
-
         public LoadingState State;
+        public bool NeedsColliderBoundsCheck;
 
         public GltfContainerComponent(ColliderLayer visibleMeshesCollisionMask, ColliderLayer invisibleMeshesCollisionMask, AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention> promise)
         {
@@ -25,6 +24,7 @@ namespace ECS.Unity.GLTFContainer.Components
             InvisibleMeshesCollisionMask = invisibleMeshesCollisionMask;
             Promise = promise;
             State = LoadingState.Unknown;
+            NeedsColliderBoundsCheck = true;
         }
 
         public static GltfContainerComponent CreateFaulty(ReportData reportData, Exception exception)

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/ConfigureGltfContainerColliders.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/ConfigureGltfContainerColliders.cs
@@ -26,6 +26,8 @@ namespace ECS.Unity.GLTFContainer.Systems
                 EnableColliders(asset.InvisibleColliders, component.InvisibleMeshesCollisionMask);
             else
                 DisableColliders(asset.InvisibleColliders);
+
+            component.NeedsColliderBoundsCheck = true;
         }
 
         internal static void SetupVisibleColliders(ref GltfContainerComponent component, GltfContainerAsset asset)
@@ -37,6 +39,8 @@ namespace ECS.Unity.GLTFContainer.Systems
             }
             else if (asset.DecodedVisibleSDKColliders != null)
                 DisableColliders(asset.DecodedVisibleSDKColliders);
+
+            component.NeedsColliderBoundsCheck = true;
         }
 
         private static void EnableColliders(List<SDKCollider> colliders, ColliderLayer colliderLayer)

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/LoadGltfContainerSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/LoadGltfContainerSystem.cs
@@ -49,6 +49,7 @@ namespace ECS.Unity.GLTFContainer.Systems
         private void StartLoading(in Entity entity, ref PBGltfContainer sdkComponent, ref PartitionComponent partitionComponent)
         {
             GltfContainerComponent component;
+            sdkComponent.IsDirty = false; // IsDirty is only relevant for ReConfiguration of the GLTFContainer
 
             if (!sceneData.TryGetHash(sdkComponent.Src, out string hash))
             {
@@ -63,7 +64,10 @@ namespace ECS.Unity.GLTFContainer.Systems
             {
                 // It's not the best idea to pass Transform directly but we rely on cancellation source to cancel if the entity dies
                 var promise = Promise.Create(World, new GetGltfContainerAssetIntention(sdkComponent.Src, hash, new CancellationTokenSource()), partitionComponent);
-                component = new GltfContainerComponent(sdkComponent.GetVisibleMeshesCollisionMask(), sdkComponent.GetInvisibleMeshesCollisionMask(), promise);
+                component = new GltfContainerComponent(
+                    sdkComponent.GetVisibleMeshesCollisionMask(),
+                    sdkComponent.GetInvisibleMeshesCollisionMask(),
+                    promise);
                 component.State = LoadingState.Loading;
                 World.Add(entity, component);
             }
@@ -78,55 +82,57 @@ namespace ECS.Unity.GLTFContainer.Systems
         {
             if (!sdkComponent.IsDirty) return;
 
-            switch (component.State)
+            // Clean-up is handled by ResetGltfContainerSystem so "InProgress" is not considered here
+            // Do nothing if finished with error
+
+            // The source is changed, should start downloading over again (change check at
+            // ResetGltfContainerSystem.InvalidatePromise() query)
+            if (component.State == LoadingState.Unknown)
             {
-                // The source is changed, should start downloading over again
-                case LoadingState.Unknown:
-                    if (!sceneData.TryGetHash(sdkComponent.Src, out string hash))
-                        component.SetFaulty(
-                            GetReportData(),
-                            new ArgumentException($"GLTF source {sdkComponent.Src} not found in the content")
-                        );
-                    else
-                    {
-                        var promise = Promise.Create(World, new GetGltfContainerAssetIntention(sdkComponent.Src, hash, new CancellationTokenSource()), partitionComponent);
-                        component.Promise = promise;
-                        component.State = LoadingState.Loading;
-                    }
+                sdkComponent.IsDirty = false;
 
-                    eventsBuffer.Add(entity, component);
+                if (!sceneData.TryGetHash(sdkComponent.Src, out string hash))
+                    component.SetFaulty(
+                        GetReportData(),
+                        new ArgumentException($"GLTF source {sdkComponent.Src} not found in the content")
+                    );
+                else
+                {
+                    var promise = Promise.Create(World, new GetGltfContainerAssetIntention(sdkComponent.Src, hash, new CancellationTokenSource()), partitionComponent);
+                    component.Promise = promise;
+                    component.State = LoadingState.Loading;
+                }
+
+                eventsBuffer.Add(entity, component);
+            }
+            else if (component.State == LoadingState.Finished)
+            {
+                sdkComponent.IsDirty = false;
+
+                Assert.IsTrue(component.Promise.Result.HasValue);
+
+                // if promise was unsuccessful nothing to do
+                StreamableLoadingResult<GltfContainerAsset> result = component.Promise.Result!.Value;
+                if (!result.Succeeded)
                     return;
 
-                // Clean-up is handled by ResetGltfContainerSystem so "InProgress" is not considered here
-                // Do nothing if finished with error
-                case LoadingState.Finished:
-                    Assert.IsTrue(component.Promise.Result.HasValue);
+                ColliderLayer visibleCollisionMask = sdkComponent.GetVisibleMeshesCollisionMask();
 
-                    // if promise was unsuccessful nothing to do
-                    StreamableLoadingResult<GltfContainerAsset> result = component.Promise.Result.Value;
+                if (visibleCollisionMask != component.VisibleMeshesCollisionMask)
+                {
+                    component.VisibleMeshesCollisionMask = visibleCollisionMask;
+                    ConfigureGltfContainerColliders.SetupVisibleColliders(ref component, result.Asset);
+                }
 
-                    if (!result.Succeeded)
-                        return;
+                ColliderLayer invisibleCollisionMask = sdkComponent.GetInvisibleMeshesCollisionMask();
 
-                    ColliderLayer visibleCollisionMask = sdkComponent.GetVisibleMeshesCollisionMask();
+                if (invisibleCollisionMask != component.InvisibleMeshesCollisionMask)
+                {
+                    component.InvisibleMeshesCollisionMask = invisibleCollisionMask;
+                    ConfigureGltfContainerColliders.SetupInvisibleColliders(ref component, result.Asset);
+                }
 
-                    if (visibleCollisionMask != component.VisibleMeshesCollisionMask)
-                    {
-                        component.VisibleMeshesCollisionMask = visibleCollisionMask;
-                        ConfigureGltfContainerColliders.SetupVisibleColliders(ref component, result.Asset);
-                    }
-
-                    ColliderLayer invisibleCollisionMask = sdkComponent.GetInvisibleMeshesCollisionMask();
-
-                    if (invisibleCollisionMask != component.InvisibleMeshesCollisionMask)
-                    {
-                        component.InvisibleMeshesCollisionMask = invisibleCollisionMask;
-                        ConfigureGltfContainerColliders.SetupInvisibleColliders(ref component, result.Asset);
-                    }
-
-                    entityCollidersSceneCache.Associate(in component, World.Reference(entity), sdkEntity);
-
-                    return;
+                entityCollidersSceneCache.Associate(in component, World.Reference(entity), sdkEntity);
             }
         }
     }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/ResetGltfContainerSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/ResetGltfContainerSystem.cs
@@ -82,7 +82,7 @@ namespace ECS.Unity.GLTFContainer.Systems
         }
 
         [Query]
-        private void InvalidatePromise(Entity entity, ref PBGltfContainer sdkComponent, ref GltfContainerComponent component)
+        private void InvalidatePromise(Entity entity, in PBGltfContainer sdkComponent, ref GltfContainerComponent component)
         {
             if (sdkComponent.IsDirty && !string.Equals(sdkComponent.Src, component.Name, StringComparison.OrdinalIgnoreCase))
             {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
@@ -126,7 +126,7 @@ namespace ECS.Unity.SceneBoundsChecker
                     // While the collider remains inactive, the bounds will continue to be zero, causing incorrect calculations.
                     // Therefore, it is necessary to force the collider to be activated at least once
                     sdkCollider.ForceActiveBySceneBounds(auxiliaryBounds.extents == Vector3.zero
-                                                         || (auxiliaryBounds.max.y <= sceneGeometry.Height && sceneGeometry.CircumscribedPlanes.Contains(auxiliaryBounds)));
+                                                         || (auxiliaryBounds.max.y <= sceneGeometry.Height && sceneGeometry.CircumscribedPlanes.Contains(sdkCollider.Collider.bounds)));
 
                     // write the structure back
                     colliders[i] = sdkCollider;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/SceneBoundsChecker/CheckColliderBoundsSystem.cs
@@ -48,7 +48,6 @@ namespace ECS.Unity.SceneBoundsChecker
         {
             int tick = physicsTickEntity.Tick;
             if (tick == lastFixedFrameChecked) return;
-
             lastFixedFrameChecked = tick;
 
             CheckPrimitives();
@@ -94,14 +93,18 @@ namespace ECS.Unity.SceneBoundsChecker
 
             // Process all colliders
 
-            // Visible meshes colliders are created on demand
+            // Updates on the PBGltfContainer may reconfigure its colliders and they will need to be
+            // processed again here even when the Transform didn't change
             if (asset.DecodedVisibleSDKColliders != null)
-                ProcessColliders(asset.DecodedVisibleSDKColliders);
+                ProcessColliders(asset.DecodedVisibleSDKColliders, force: component.NeedsColliderBoundsCheck);
 
-            ProcessColliders(asset.InvisibleColliders);
+            ProcessColliders(asset.InvisibleColliders, force: component.NeedsColliderBoundsCheck);
+
+            component.NeedsColliderBoundsCheck = false;
+
             return;
 
-            void ProcessColliders(List<SDKCollider> colliders)
+            void ProcessColliders(List<SDKCollider> colliders, bool force = false)
             {
                 for (var i = 0; i < colliders.Count; i++)
                 {
@@ -112,7 +115,7 @@ namespace ECS.Unity.SceneBoundsChecker
                     if (!sdkCollider.IsActiveByEntity)
                         continue;
 
-                    if (!sdkCollider.HasMoved())
+                    if (!sdkCollider.HasMoved() && !force)
                         continue;
 
                     // We use an auxiliary bounds object as Unity physics may take at least an extra frame to
@@ -123,7 +126,7 @@ namespace ECS.Unity.SceneBoundsChecker
                     // While the collider remains inactive, the bounds will continue to be zero, causing incorrect calculations.
                     // Therefore, it is necessary to force the collider to be activated at least once
                     sdkCollider.ForceActiveBySceneBounds(auxiliaryBounds.extents == Vector3.zero
-                                                         || (auxiliaryBounds.max.y <= sceneGeometry.Height && sceneGeometry.CircumscribedPlanes.Contains(sdkCollider.Collider.bounds)));
+                                                         || (auxiliaryBounds.max.y <= sceneGeometry.Height && sceneGeometry.CircumscribedPlanes.Contains(auxiliaryBounds)));
 
                     // write the structure back
                     colliders[i] = sdkCollider;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/SceneBoundsChecker/SDKCollider.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/SceneBoundsChecker/SDKCollider.cs
@@ -49,7 +49,7 @@ namespace ECS.Unity.SceneBoundsChecker
             {
                 Transform = null;
             }
-            
+
             ResolveColliderActivity();
         }
 
@@ -91,6 +91,6 @@ namespace ECS.Unity.SceneBoundsChecker
 
             return false;
         }
-       
+
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/SceneBoundsChecker/Tests/ColliderBoundsCheckerShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/SceneBoundsChecker/Tests/ColliderBoundsCheckerShould.cs
@@ -1,10 +1,18 @@
-﻿using DCL.ECSComponents;
+﻿using Arch.Core;
+using DCL.ECSComponents;
 using DCL.Time;
 using ECS.Prioritization.Components;
+using ECS.StreamableLoading;
+using ECS.StreamableLoading.Common;
+using ECS.StreamableLoading.Common.Components;
 using ECS.TestSuite;
+using ECS.Unity.GLTFContainer.Asset.Components;
+using ECS.Unity.GLTFContainer.Components;
 using ECS.Unity.PrimitiveColliders.Components;
 using NSubstitute;
 using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading;
 using UnityEngine;
 using Utility;
 
@@ -14,6 +22,8 @@ namespace ECS.Unity.SceneBoundsChecker.Tests
     {
         private IPartitionComponent scenePartition;
         private BoxCollider collider;
+        private ParcelMathHelper.SceneGeometry sceneGeometry;
+        private GameObject testRoot;
 
         [SetUp]
         public void Setup()
@@ -21,16 +31,22 @@ namespace ECS.Unity.SceneBoundsChecker.Tests
             scenePartition = Substitute.For<IPartitionComponent>();
             scenePartition.Bucket.Returns(CheckColliderBoundsSystem.BUCKET_THRESHOLD);
 
+            sceneGeometry = new ParcelMathHelper.SceneGeometry(
+                Vector3.zero,
+                new ParcelMathHelper.SceneCircumscribedPlanes(-50f, 50f, -50f, 50f),
+                50.0f);
+
             IPhysicsTickProvider physicsTickProvider = Substitute.For<IPhysicsTickProvider>();
             physicsTickProvider.Tick.Returns(2);
 
             system = new CheckColliderBoundsSystem(
                 world,
                 scenePartition,
-                new ParcelMathHelper.SceneGeometry(Vector3.zero, new ParcelMathHelper.SceneCircumscribedPlanes(-50f, 50f, -50f, 50f), 50.0f),
+                sceneGeometry,
                 physicsTickProvider);
 
             collider = new GameObject(nameof(ColliderBoundsCheckerShould)).AddComponent<BoxCollider>();
+            testRoot = new GameObject("TestRoot");
         }
 
         [TearDown]
@@ -38,6 +54,9 @@ namespace ECS.Unity.SceneBoundsChecker.Tests
         {
             UnityObjectUtils.SafeDestroyGameObject(collider);
             collider = null;
+
+            UnityObjectUtils.SafeDestroy(testRoot);
+            testRoot = null;
         }
 
         [Test]
@@ -146,6 +165,193 @@ namespace ECS.Unity.SceneBoundsChecker.Tests
             system.Update(0);
 
             Assert.IsTrue(collider.enabled);
+        }
+
+        [Test]
+        public void ProcessGltfColliderOnEntityMovement()
+        {
+            // Create a collider GameObject
+            var colliderObj = new GameObject("TestCollider");
+            var boxCollider = colliderObj.AddComponent<BoxCollider>();
+            boxCollider.transform.position = Vector3.zero;
+
+            // Create an SDKCollider properly
+            var sdkCollider = new SDKCollider(boxCollider);
+            sdkCollider.IsActiveByEntity = true;
+
+            // Create and set up the mock asset with the SDKCollider in a list
+            var mockAssetData = Substitute.For<IStreamableRefCountData>();
+            var gltfAsset = GltfContainerAsset.Create(testRoot, mockAssetData);
+            gltfAsset.InvisibleColliders.Add(sdkCollider);
+
+            // Move the collider to cause HasMoved() to return true
+            boxCollider.transform.position = new Vector3(10, 10, 10);
+            boxCollider.transform.hasChanged = true;
+
+            // Create a promise and component properly
+            var intent = new GetGltfContainerAssetIntention("test-src", "test-hash", new CancellationTokenSource());
+            var assetPromise = AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(
+                world, intent, PartitionComponent.TOP_PRIORITY);
+
+            // Need to make the promise ready with our asset
+            // First, get the entity associated with the promise
+            Entity promiseEntity = assetPromise.Entity;
+
+            // Add our test result to that entity
+            var result = new StreamableLoadingResult<GltfContainerAsset>(gltfAsset);
+            world.Add(promiseEntity, result);
+
+            // Create the GltfContainerComponent with State = Loading first
+            var component = new GltfContainerComponent(ColliderLayer.ClNone, ColliderLayer.ClNone, assetPromise);
+            component.State = LoadingState.Loading;
+
+            // Create entity with the component
+            var pbComponent = new PBGltfContainer { IsDirty = false };
+            var entity = world.Create(component, pbComponent, PartitionComponent.TOP_PRIORITY);
+
+            // Important: We need to retrieve the result before setting state to Finished
+            // This simulates what happens in FinalizeGltfContainerLoadingSystem
+            bool resultRetrieved = component.Promise.TryGetResult(world, out _);
+            Assert.IsTrue(resultRetrieved, "Failed to retrieve result from promise");
+
+            // Now we can set state to Finished
+            component.State = LoadingState.Finished;
+            world.Set(entity, component);
+
+            // Update the system
+            system.Update(0);
+
+            // Check if the collider was processed - it should be active since it's within bounds
+            Assert.IsTrue(gltfAsset.InvisibleColliders[0].IsActiveBySceneBounds);
+
+            // Clean up
+            UnityObjectUtils.SafeDestroy(colliderObj);
+        }
+
+        [Test]
+        public void ProcessGltfColliderWhenNeedsColliderBoundsCheckIsTrue()
+        {
+            // Create a collider GameObject
+            var colliderObj = new GameObject("TestCollider");
+            var boxCollider = colliderObj.AddComponent<BoxCollider>();
+
+            // Set position and mark hasChanged as false to simulate no movement
+            boxCollider.transform.position = new Vector3(10, 10, 10);
+            boxCollider.transform.hasChanged = false;
+
+            // Create an SDKCollider
+            var sdkCollider = new SDKCollider(boxCollider);
+            sdkCollider.IsActiveByEntity = true;
+
+            // Create and set up the mock asset
+            var mockAssetData = Substitute.For<IStreamableRefCountData>();
+            var gltfAsset = GltfContainerAsset.Create(testRoot, mockAssetData);
+
+            // Initialize DecodedVisibleSDKColliders if needed
+            if (gltfAsset.DecodedVisibleSDKColliders == null)
+            {
+                gltfAsset.DecodedVisibleSDKColliders = new List<SDKCollider>();
+            }
+            gltfAsset.DecodedVisibleSDKColliders.Add(sdkCollider);
+
+            // Create a promise and component properly
+            var intent = new GetGltfContainerAssetIntention("test-src", "test-hash", new CancellationTokenSource());
+            var assetPromise = AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(
+                world, intent, PartitionComponent.TOP_PRIORITY);
+
+            // Add our test result to the promise entity
+            Entity promiseEntity = assetPromise.Entity;
+            var result = new StreamableLoadingResult<GltfContainerAsset>(gltfAsset);
+            world.Add(promiseEntity, result);
+
+            // Create the GltfContainerComponent with Finished state and NeedsColliderBoundsCheck set to true
+            var component = new GltfContainerComponent(ColliderLayer.ClNone, ColliderLayer.ClNone, assetPromise);
+            component.State = LoadingState.Finished;
+            component.NeedsColliderBoundsCheck = true; // Set the flag to true - this is the key change
+            
+            // Ensure the result is available 
+            bool resultRetrieved = component.Promise.TryGetResult(world, out _);
+            Assert.IsTrue(resultRetrieved, "Failed to retrieve result from promise");
+
+            // Create entity with the component
+            var entity = world.Create(component, new PBGltfContainer { IsDirty = false }, PartitionComponent.TOP_PRIORITY);
+
+            // Update the system - it should process the collider due to NeedsColliderBoundsCheck being true
+            system.Update(0);
+
+            // Check if the collider was processed and active
+            Assert.IsTrue(gltfAsset.DecodedVisibleSDKColliders[0].IsActiveBySceneBounds, 
+                "Collider should be processed due to NeedsColliderBoundsCheck flag");
+            
+            // Verify the flag was reset after processing
+            component = world.Get<GltfContainerComponent>(entity);
+            Assert.IsFalse(component.NeedsColliderBoundsCheck, "NeedsColliderBoundsCheck should be reset after processing");
+
+            // Clean up
+            UnityObjectUtils.SafeDestroy(colliderObj);
+        }
+        
+        [Test]
+        public void DoNotProcessGltfColliderWhenNeedsColliderBoundsCheckIsFalse()
+        {
+            // Create a collider GameObject
+            var colliderObj = new GameObject("TestCollider");
+            var boxCollider = colliderObj.AddComponent<BoxCollider>();
+
+            // Set position and mark hasChanged as false to simulate no movement
+            boxCollider.transform.position = new Vector3(10, 10, 10);
+            boxCollider.transform.hasChanged = false;
+
+            // Create an SDKCollider
+            var sdkCollider = new SDKCollider(boxCollider);
+            sdkCollider.IsActiveByEntity = true;
+            
+            // Explicitly set IsActiveBySceneBounds to false to verify it doesn't change
+            sdkCollider.ForceActiveBySceneBounds(false);
+
+            // Create and set up the mock asset
+            var mockAssetData = Substitute.For<IStreamableRefCountData>();
+            var gltfAsset = GltfContainerAsset.Create(testRoot, mockAssetData);
+
+            // Initialize DecodedVisibleSDKColliders
+            if (gltfAsset.DecodedVisibleSDKColliders == null)
+            {
+                gltfAsset.DecodedVisibleSDKColliders = new List<SDKCollider>();
+            }
+            gltfAsset.DecodedVisibleSDKColliders.Add(sdkCollider);
+
+            // Create a promise and component properly
+            var intent = new GetGltfContainerAssetIntention("test-src", "test-hash", new CancellationTokenSource());
+            var assetPromise = AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(
+                world, intent, PartitionComponent.TOP_PRIORITY);
+
+            // Add our test result to the promise entity
+            Entity promiseEntity = assetPromise.Entity;
+            var result = new StreamableLoadingResult<GltfContainerAsset>(gltfAsset);
+            world.Add(promiseEntity, result);
+
+            // Create the GltfContainerComponent with Finished state and NeedsColliderBoundsCheck set to false
+            var component = new GltfContainerComponent(ColliderLayer.ClNone, ColliderLayer.ClNone, assetPromise);
+            component.State = LoadingState.Finished;
+            component.NeedsColliderBoundsCheck = false; // Set the flag to false - key for this test
+            
+            // Ensure the result is available 
+            bool resultRetrieved = component.Promise.TryGetResult(world, out _);
+            Assert.IsTrue(resultRetrieved, "Failed to retrieve result from promise");
+
+            // Create entity with the component
+            var entity = world.Create(component, new PBGltfContainer { IsDirty = false }, PartitionComponent.TOP_PRIORITY);
+
+            // Update the system - it should NOT process the collider since NeedsColliderBoundsCheck is false
+            // and the transform hasn't moved
+            system.Update(0);
+
+            // Check if the collider remains inactive - it should not be processed
+            Assert.IsFalse(gltfAsset.DecodedVisibleSDKColliders[0].IsActiveBySceneBounds, 
+                "Collider should not be processed when NeedsColliderBoundsCheck is false and transform hasn't moved");
+
+            // Clean up
+            UnityObjectUtils.SafeDestroy(colliderObj);
         }
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/World/GltfContainerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/GltfContainerPlugin.cs
@@ -92,8 +92,6 @@ namespace DCL.PluginSystem.World
                 buffer, sharedDependencies.SceneStateProvider, globalDeps.MemoryBudget, loadingStatus,
                 persistentEntities.SceneContainer);
 
-            ResetDirtyFlagSystem<PBGltfContainer>.InjectToWorld(ref builder);
-
             var cleanUpGltfContainerSystem =
                 CleanUpGltfContainerSystem.InjectToWorld(ref builder, assetsCache, sharedDependencies.EntityCollidersSceneCache);
 


### PR DESCRIPTION
### WHY

Related Issue: https://github.com/decentraland/unity-explorer/issues/3728

Recently implemented PR https://github.com/decentraland/unity-explorer/pull/3748 introduced a bug in which some scenes collider didn't enable correctly on scene initialization, so the original fix for instantiated GLTFContainer subsequent property updates had to be reverted.

### WHAT

* Re-added fix implemented at https://github.com/decentraland/unity-explorer/pull/3748
* Added 1-liner fix (from old https://github.com/decentraland/unity-explorer/pull/2718 PR) lost when implementing https://github.com/decentraland/unity-explorer/pull/3748 -> commit: https://github.com/decentraland/unity-explorer/pull/3881/commits/2b537b81d9089bad4d3dcd3733d6317c5ffe851a

### TEST INSTRUCTIONS

1. Download the build from this PR and open it with the following parameters:
**WinOS**
`"C:\Users\[YOUR-USER]\Downloads\Decentraland_windows64\Decentraland.exe" --realm pravus.dcl.eth --scene-console true --debug`
**MacOS**
`open Decentraland.app --args --realm pravus.dcl.eth --scene-console true --debug`
2. Once you are inside the world, step on top of the white plane and open the scene console using the BACKQUOTE KEY (`)
3. Confirm that you see a number on the "Ray hit:" logs, instead of "undefined"
4. Then confirm that the Book mesh that is next to the white plane swaps to a different monster mesh when clicked, and if the monster mesh is clicked it swaps back to the book mesh.
5. Enter Genesis City at `-109,-93` (Bitcinema) and also at WonderMine and MVFW scenes and confirm the broken floor-collider issues don't happen.

https://github.com/user-attachments/assets/a94ddc6b-7861-4079-94e1-2f9477b59d97