### PR TITLE
feat: Create skip-version-check app arg

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -5,7 +5,7 @@
         public const string DEBUG = "debug";
         public const string DCL_EDITOR = "hub";
 
-        public const string ENABLE_VERSION_CONTROL = "versionControl";
+        public const string SKIP_VERSION_CHECK = "skip-version-check";
         public const string SIMULATE_VERSION = "simulateVersion";
 
         public const string SCENE_CONSOLE = "scene-console";

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -290,8 +290,8 @@ namespace Global.Dynamic
             DCLVersion currentVersion = DCLVersion.FromAppArgs(applicationParametersParser);
             bool runVersionControl = debugSettings.EnableVersionUpdateGuard;
 
-            if (applicationParametersParser.HasDebugFlag() && !Application.isEditor)
-                runVersionControl = applicationParametersParser.TryGetValue(AppArgsFlags.ENABLE_VERSION_CONTROL, out string? enforceDebugMode) && enforceDebugMode == "true";
+            if (!Application.isEditor)
+                runVersionControl = !applicationParametersParser.HasFlag(AppArgsFlags.SKIP_VERSION_CHECK);
 
             if (!runVersionControl)
                 return false;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Replace the current `versionControl` app arg by the new one `skip-version-check`. It also removes the necessity of combine it with the `debug` arg.

## Test Instructions
- Execute the build using `--skip-version-check` and confirm that the version check is skipped.
- Execute the build without using `--skip-version-check` and confirm that the version check is not skipped.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
