### PR TITLE
fix: log profile thumbnail error on last attempt only

### DIFF
--- a/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
+++ b/Explorer/Assets/DCL/Profiles/ProfileThumbnailCache.cs
@@ -15,8 +15,8 @@ namespace DCL.Profiles
     {
         private struct RequestAttempts
         {
+            public const int MAX_ATTEMPTS = 5;
             private const int ATTEMPT_SECONDS_UNIT = 30;
-            private const int MAX_ATTEMPTS = 5;
 
             private int attempts;
             private DateTime nextAvailableAttempt;
@@ -81,13 +81,13 @@ namespace DCL.Profiles
 
             if (URLAddress.EMPTY.Equals(thumbnailUrl))
             {
-                tcs.TrySetResult(result);
+                FinalizeTask(tcs, result, userId);
                 return;
             }
 
             if (unsolvableThumbnails.Contains(userId) || !TestCooldownCondition(userId))
             {
-                tcs.TrySetResult(result);
+                FinalizeTask(tcs, result, userId);
                 return;
             }
 
@@ -98,7 +98,8 @@ namespace DCL.Profiles
                     new GetTextureArguments(TextureType.Albedo),
                     GetTextureWebRequest.CreateTexture(TextureWrapMode.Clamp),
                     ct,
-                    ReportCategory.UI
+                    ReportCategory.UI,
+                    suppressErrors: true
                 );
 
                 var texture = ownedTexture.Texture;
@@ -110,19 +111,21 @@ namespace DCL.Profiles
                 SetThumbnailIntoCache(userId, result);
                 failedThumbnails.Remove(userId);
             }
-            catch (OperationCanceledException){}
-            catch (Exception e)
+            catch (OperationCanceledException) { }
+            catch (Exception e) { HandleCooldownOnException(userId, e); }
+            finally
             {
-                ReportHub.LogException(e, new ReportData(ReportCategory.PROFILE));
-
-                HandleCooldown(userId);
+                FinalizeTask(tcs, result, userId);
             }
+        }
 
+        private void FinalizeTask(UniTaskCompletionSource<Sprite?> tcs, Sprite? result, string userId)
+        {
             currentThumbnailTasks.Remove(userId);
             tcs.TrySetResult(result);
         }
 
-        private void HandleCooldown(string userId)
+        private void HandleCooldownOnException(string userId, Exception e)
         {
             if (failedThumbnails.TryGetValue(userId, out RequestAttempts requestAttempts))
                 if (requestAttempts.CanIncreaseCooldown())
@@ -132,6 +135,10 @@ namespace DCL.Profiles
                 }
                 else
                 {
+                    ReportData reportData = new ReportData(ReportCategory.PROFILE);
+                    ReportHub.LogError(reportData, $"Failed to fetch user thumbnail for the {RequestAttempts.MAX_ATTEMPTS + 1}th time for wallet {userId}");
+                    ReportHub.LogException(e, reportData);
+
                     unsolvableThumbnails.Add(userId);
                     failedThumbnails.Remove(userId);
                 }

--- a/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
@@ -187,9 +187,10 @@ namespace DCL.WebRequests
             CancellationToken ct,
             ReportData reportData,
             WebRequestHeadersInfo? headersInfo = null,
-            WebRequestSignInfo? signInfo = null
+            WebRequestSignInfo? signInfo = null,
+            bool suppressErrors = false
         ) where TOp: struct, IWebRequestOp<GetTextureWebRequest, IOwnedTexture2D> =>
-            controller.SendAsync<GetTextureWebRequest, GetTextureArguments, TOp, IOwnedTexture2D>(commonArguments, args, webRequestOp, ct, reportData, headersInfo, signInfo);
+            controller.SendAsync<GetTextureWebRequest, GetTextureArguments, TOp, IOwnedTexture2D>(commonArguments, args, webRequestOp, ct, reportData, headersInfo, signInfo, suppressErrors: suppressErrors);
 
         /// <summary>
         ///     Make a request that is optimized for audio clip


### PR DESCRIPTION
# Pull Request Description

Fixes #3922

If the download of a profile thumbnail threw an exception, this was logged as soon as it happened.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR logs the exception on the latest attempt of the exponential backoff only, right before the thumbnail is marked as un-downloadable.

This also addresses a bug related to backoff itself: given a thumbnail that was on cooldown, the first new request while on cooldown created a task that was never removed from the dictionary, making the thumbnail practically unsolvable since the same completed task with a null result was always returned.
Now every task is properly removed from the dictionary upon completion.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Verify that profile thumbnails are properly solved as before
2. Verify that if a profile thumbnail fails to load (default avatar), no exception is logged

### Additional Testing Notes
- The exception is logged only on the 6th failed attempt (every attempt has 30secs of cooldown more then before -> 1=30s, 2=60s, 3=90s, ...)

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
