### PR TITLE
Show where photo was saved

### DIFF
--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.asmdef
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.asmdef
@@ -8,7 +8,8 @@
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
         "GUID:91cf8206af184dac8e30eb46747e9939",
-        "GUID:3640f3c0b42946b0b8794a1ed8e06ca5"
+        "GUID:3640f3c0b42946b0b8794a1ed8e06ca5",
+        "GUID:fa7b3fdbb04d67549916da7bd2af58ab"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -5,13 +5,11 @@ using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.WebRequests;
 using SceneRuntime.Apis.Modules.SignedFetch.Messages;
 using System;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using UnityEngine;
+using Utility;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -68,7 +66,7 @@ namespace DCL.ApplicationVersionGuard
                 try
                 {
                     await UniTask.Delay(1000, cancellationToken: ct);
-                    ShellExecute(launcherPath);
+                    PlatformUtils.ShellExecute(launcherPath);
                 }
                 catch (Exception e)
                 {
@@ -163,55 +161,6 @@ namespace DCL.ApplicationVersionGuard
             return possiblePaths.FirstOrDefault(path => File.Exists(path)
                                                         || (Directory.Exists(path) && (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)));
         }
-
-        private static void ShellExecute(string fileName)
-        {
-#if UNITY_STANDALONE_WIN
-            if ((int)ShellExecute(IntPtr.Zero, null, fileName, null, null, SW_NORMAL) <= 16)
-            {
-                int error = Marshal.GetLastWin32Error();
-                var sb = new StringBuilder(1024);
-
-                uint length = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, IntPtr.Zero, error, 0, sb,
-                    sb.Capacity, IntPtr.Zero);
-
-                string message = length > 0 ? sb.ToString() : $"error {error}";
-                throw new Win32Exception(error, message.TrimEnd());
-            }
-#elif UNITY_STANDALONE_OSX
-            string cmd = "open \"" + fileName + "\"";
-            int code = ExecuteSystemCommand(cmd);
-            if (code != 0)
-            {
-                var sb = new StringBuilder(1024);
-
-                string message = code == -1 && strerror_r(code, sb, sb.Capacity) == 0
-                    ? sb.ToString()
-                    : "Unknown error";
-                throw new Exception($"error {code}: {message}");
-            }
-#endif
-        }
-
-#if UNITY_STANDALONE_WIN
-        [DllImport("kernel32", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern uint FormatMessage(uint dwFlags, IntPtr lpSource, int dwMessageId,
-            uint dwLanguageId, StringBuilder lpBuffer, int nSize, IntPtr Arguments);
-
-        private const uint FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
-
-        [DllImport("shell32", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern IntPtr ShellExecute(IntPtr hWnd, string lpOperation, string lpFile,
-            string lpParameters, string lpDirectory, int nShowCmd);
-
-        private const int SW_NORMAL = 1;
-#elif UNITY_STANDALONE_OSX
-        [DllImport("libc", EntryPoint = "system")]
-        private static extern int ExecuteSystemCommand([MarshalAs(UnmanagedType.LPStr)] string command);
-
-        [DllImport("libc")]
-        private static extern int strerror_r(int errnum, StringBuilder buf, int buflen);
-#endif
 
         [Serializable]
         private struct GitHubRelease

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
@@ -155,7 +155,9 @@ namespace DCL.InWorldCamera.CameraReelGallery
                 {
                     await ReelCommonActions.DownloadReelToFileAsync(response.url, ct);
                     ScreenshotDownloaded?.Invoke();
-                    view.cameraReelToastMessage?.ShowToastMessage(CameraReelToastMessageType.SUCCESS, reelGalleryStringMessages?.PhotoSuccessfullyDownloadedMessage);
+
+                    view.cameraReelToastMessage?.ShowToastMessage(CameraReelToastMessageType.DOWNLOAD,
+                        reelGalleryStringMessages?.PhotoSuccessfullyDownloadedMessage);
                 }
                 catch (Exception e)
                 {

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/CameraReelToast.asmdef
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/CameraReelToast.asmdef
@@ -2,8 +2,10 @@
     "name": "CameraReelToast",
     "rootNamespace": "",
     "references": [
+        "GUID:212dec3614823496d8f46a506aa5b831",
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:e169fa6683c924c7e99a85981a91d953",
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
         "GUID:fa7b3fdbb04d67549916da7bd2af58ab"
     ],
     "includePlatforms": [],

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/CameraReelToastMessage.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/CameraReelToastMessage.cs
@@ -10,13 +10,15 @@ namespace DCL.InWorldCamera.CameraReelToast
     public enum CameraReelToastMessageType
     {
         FAILURE,
-        SUCCESS
+        SUCCESS,
+        DOWNLOAD
     }
 
     public class CameraReelToastMessage : MonoBehaviour
     {
         [field: SerializeField] public WarningNotificationView SuccessToastView { get; private set; }
         [field: SerializeField] public WarningNotificationView FailureToastView { get; private set; }
+        [field: SerializeField] public DownloadNotificationView DownloadToastView { get; private set; }
         [field: SerializeField] public float SuccessToastDuration { get; private set; } = 3f;
         [field: SerializeField] public float FailureToastDuration { get; private set; } = 3f;
         [field: SerializeField] public string FailureToastDefaultMessage { get; private set; } = "There was an error while trying to process your request. Please try again!";
@@ -24,6 +26,7 @@ namespace DCL.InWorldCamera.CameraReelToast
 
         private CancellationTokenSource showSuccessCts = new ();
         private CancellationTokenSource showFailureCts = new ();
+        private CancellationTokenSource showDownloadCts = new ();
 
         private void HideSuccessNotification()
         {
@@ -39,10 +42,19 @@ namespace DCL.InWorldCamera.CameraReelToast
             FailureToastView.CanvasGroup.alpha = 0f;
         }
 
+        private void HideDownloadNotification()
+        {
+            showDownloadCts = showDownloadCts.SafeRestart();
+            var canvasGroup = DownloadToastView.NotificationView.CanvasGroup;
+            canvasGroup.DOKill();
+            canvasGroup.alpha = 0f;
+        }
+
         public void ShowToastMessage(CameraReelToastMessageType type, string? message = null)
         {
             HideSuccessNotification();
             HideFailureNotification();
+            HideDownloadNotification();
 
             switch (type)
             {
@@ -51,6 +63,15 @@ namespace DCL.InWorldCamera.CameraReelToast
                     break;
                 case CameraReelToastMessageType.FAILURE:
                     ShowNotificationAsync(message, FailureToastDefaultMessage, FailureToastView, FailureToastDuration, showFailureCts.Token).Forget();
+                    break;
+                case CameraReelToastMessageType.DOWNLOAD:
+                    DownloadToastView.OnShow();
+
+                    ShowNotificationAsync(message, SuccessToastDefaultMessage,
+                            DownloadToastView.NotificationView, FailureToastDuration,
+                            showFailureCts.Token)
+                       .Forget();
+
                     break;
             }
         }
@@ -67,6 +88,7 @@ namespace DCL.InWorldCamera.CameraReelToast
         {
             HideSuccessNotification();
             HideFailureNotification();
+            HideDownloadNotification();
         }
     }
 }

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/CameraReelToastMessage.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/CameraReelToastMessage.cs
@@ -65,7 +65,7 @@ namespace DCL.InWorldCamera.CameraReelToast
                     ShowNotificationAsync(message, FailureToastDefaultMessage, FailureToastView, FailureToastDuration, showFailureCts.Token).Forget();
                     break;
                 case CameraReelToastMessageType.DOWNLOAD:
-                    DownloadToastView.OnShow();
+                    DownloadToastView.PrepareToBeClicked();
 
                     ShowNotificationAsync(message, SuccessToastDefaultMessage,
                             DownloadToastView.NotificationView, FailureToastDuration,

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/DownloadNotificationView.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/DownloadNotificationView.cs
@@ -1,0 +1,33 @@
+﻿using DCL.InWorldCamera.ReelActions;
+using DCL.UI;
+using TMPro;
+using UnityEngine;
+using Utility;
+
+namespace DCL.InWorldCamera.CameraReelToast
+{
+    public sealed class DownloadNotificationView : MonoBehaviour
+    {
+        [SerializeField] private WarningNotificationView notificationView;
+        [SerializeField] private TMP_Text fileLocationText;
+
+        private bool wasClicked;
+
+        public WarningNotificationView NotificationView => notificationView;
+
+        internal void OnShow()
+        {
+            fileLocationText.text = ReelCommonActions.ReelsPath;
+            wasClicked = false;
+        }
+
+        public void OpenFileLocation()
+        {
+            if (wasClicked)
+                return;
+
+            PlatformUtils.ShellExecute(ReelCommonActions.ReelsPath);
+            wasClicked = true;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/DownloadNotificationView.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/DownloadNotificationView.cs
@@ -2,26 +2,31 @@
 using DCL.UI;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 using Utility;
 
 namespace DCL.InWorldCamera.CameraReelToast
 {
     public sealed class DownloadNotificationView : MonoBehaviour
     {
-        [SerializeField] private WarningNotificationView notificationView;
+        [SerializeField] private Button button;
         [SerializeField] private TMP_Text fileLocationText;
+        [SerializeField] private WarningNotificationView notificationView;
 
         private bool wasClicked;
 
-        public WarningNotificationView NotificationView => notificationView;
-
-        internal void OnShow()
+        private void Start()
         {
+            button.onClick.AddListener(OpenFileLocation);
             fileLocationText.text = ReelCommonActions.ReelsPath;
-            wasClicked = false;
         }
 
-        public void OpenFileLocation()
+        public WarningNotificationView NotificationView => notificationView;
+
+        public void PrepareToBeClicked() =>
+            wasClicked = false;
+
+        private void OpenFileLocation()
         {
             if (wasClicked)
                 return;

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/DownloadNotificationView.cs.meta
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/DownloadNotificationView.cs.meta
@@ -1,0 +1,11 @@
+﻿fileFormatVersion: 2
+guid: e80246de51fca2f47a990cee912d0ea4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/Prefabs/CameraReelToastMessage.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/Prefabs/CameraReelToastMessage.prefab
@@ -283,6 +283,62 @@ MonoBehaviour:
   <FailureToastDefaultMessage>k__BackingField: There was an error while trying to
     process your request. Please try again!
   <SuccessToastDefaultMessage>k__BackingField: Success!
+--- !u!1 &8010981549158094529
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8620269320281344089}
+  - component: {fileID: 5043238167186544836}
+  m_Layer: 5
+  m_Name: Spacer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8620269320281344089
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8010981549158094529}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5701802129777246385}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5043238167186544836
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8010981549158094529}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: 2
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &8195399429174502774
 GameObject:
   m_ObjectHideFlags: 0
@@ -1013,7 +1069,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7587919746443121769, guid: aae56f4776100974ba051333a3974811, type: 3}
       propertyPath: m_text
-      value: 'Photo saved to '
+      value: Photo successfully downloaded
       objectReference: {fileID: 0}
     - target: {fileID: 7587919746443121769, guid: aae56f4776100974ba051333a3974811, type: 3}
       propertyPath: m_margin.x
@@ -1057,6 +1113,9 @@ PrefabInstance:
       addedObject: {fileID: 1967787221647975183}
     - targetCorrespondingSourceObject: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
       insertIndex: 3
+      addedObject: {fileID: 8620269320281344089}
+    - targetCorrespondingSourceObject: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      insertIndex: 4
       addedObject: {fileID: 4380587157812278686}
     - targetCorrespondingSourceObject: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
       insertIndex: -1

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/Prefabs/CameraReelToastMessage.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/Prefabs/CameraReelToastMessage.prefab
@@ -1013,7 +1013,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7587919746443121769, guid: aae56f4776100974ba051333a3974811, type: 3}
       propertyPath: m_text
-      value: 'Photo successfully downloaded to '
+      value: 'Photo saved to '
       objectReference: {fileID: 0}
     - target: {fileID: 7587919746443121769, guid: aae56f4776100974ba051333a3974811, type: 3}
       propertyPath: m_margin.x

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/Prefabs/CameraReelToastMessage.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/Prefabs/CameraReelToastMessage.prefab
@@ -56,6 +56,62 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &6111031958005772294
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2994809827674191325}
+  - component: {fileID: 7910683081935050662}
+  m_Layer: 5
+  m_Name: Spacer (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2994809827674191325
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6111031958005772294}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5701802129777246385}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7910683081935050662
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6111031958005772294}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: 10
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &6355379381831421558
 GameObject:
   m_ObjectHideFlags: 0
@@ -112,6 +168,62 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &7054735460401398871
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1967787221647975183}
+  - component: {fileID: 4141174967496258229}
+  m_Layer: 5
+  m_Name: Spacer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1967787221647975183
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7054735460401398871}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5701802129777246385}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4141174967496258229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7054735460401398871}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: 6
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &7205955764813336134
 GameObject:
   m_ObjectHideFlags: 0
@@ -143,6 +255,7 @@ RectTransform:
   m_Children:
   - {fileID: 3737077591102904451}
   - {fileID: 4298821328858515220}
+  - {fileID: 5701802129777246385}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -164,11 +277,148 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <SuccessToastView>k__BackingField: {fileID: 5294310512652686942}
   <FailureToastView>k__BackingField: {fileID: 4687565653496383945}
+  <DownloadToastView>k__BackingField: {fileID: 3131754538136941156}
   <SuccessToastDuration>k__BackingField: 3
   <FailureToastDuration>k__BackingField: 3
   <FailureToastDefaultMessage>k__BackingField: There was an error while trying to
     process your request. Please try again!
   <SuccessToastDefaultMessage>k__BackingField: Success!
+--- !u!1 &8195399429174502774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4380587157812278686}
+  - component: {fileID: 2836728915057855843}
+  - component: {fileID: 4755172762721352907}
+  m_Layer: 5
+  m_Name: FileLocationText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4380587157812278686
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8195399429174502774}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5701802129777246385}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2836728915057855843
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8195399429174502774}
+  m_CullTransparentMesh: 1
+--- !u!114 &4755172762721352907
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8195399429174502774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: C:\Users\Ansis\Pictures
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294942784
+  m_fontColor: {r: 0.2509804, g: 0.627451, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 4
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 0
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 0
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 2.1601562, y: 0, z: -2.310913, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1001 &2762139471069636803
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -581,3 +831,418 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad5746687007427186ea77e4568f01cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &5971125346554916710
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6824922924571684293}
+    m_Modifications:
+    - target: {fileID: 1345367601989809507, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1345367601989809507, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1345367601989809507, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1345367601989809507, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1345367601989809507, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 1345367601989809507, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1345367601989809507, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3341115844978798891, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 26a52df623c514a6087f35458a11ab2d, type: 3}
+    - target: {fileID: 4292958671161261228, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_Alpha
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4397080764487562581, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_Name
+      value: DownloadNotification
+      objectReference: {fileID: 0}
+    - target: {fileID: 4953635589825674653, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4953635589825674653, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4953635589825674653, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4953635589825674653, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 4953635589825674653, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4953635589825674653, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5406206936782345790, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5406206936782345790, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5406206936782345790, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5406206936782345790, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5406206936782345790, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5406206936782345790, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5406206936782345790, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7587919746443121769, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_text
+      value: 'Photo successfully downloaded to '
+      objectReference: {fileID: 0}
+    - target: {fileID: 7587919746443121769, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_margin.x
+      value: 2.1601562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7587919746443121769, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_margin.z
+      value: -2.310913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7587919746443121769, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_TextStyleHashCode
+      value: -1183493901
+      objectReference: {fileID: 0}
+    - target: {fileID: 7587919746443121769, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_HorizontalAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8010844266177199773, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: <CloseButton>k__BackingField
+      value: 
+      objectReference: {fileID: 5693538146578284993}
+    - target: {fileID: 8645113524323352501, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062949895753582773, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: <Button>k__BackingField
+      value: 
+      objectReference: {fileID: 5693538146578284993}
+    m_RemovedComponents:
+    - {fileID: 6682898408974235409, guid: aae56f4776100974ba051333a3974811, type: 3}
+    - {fileID: 8144424893319433352, guid: aae56f4776100974ba051333a3974811, type: 3}
+    - {fileID: 1759175823378366520, guid: aae56f4776100974ba051333a3974811, type: 3}
+    - {fileID: 173351348610919351, guid: aae56f4776100974ba051333a3974811, type: 3}
+    - {fileID: 284020700512745204, guid: aae56f4776100974ba051333a3974811, type: 3}
+    - {fileID: 5686301129498788419, guid: aae56f4776100974ba051333a3974811, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      insertIndex: 0
+      addedObject: {fileID: 1967787221647975183}
+    - targetCorrespondingSourceObject: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      insertIndex: 3
+      addedObject: {fileID: 4380587157812278686}
+    - targetCorrespondingSourceObject: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2994809827674191325}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4397080764487562581, guid: aae56f4776100974ba051333a3974811, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7279440405735603417}
+    - targetCorrespondingSourceObject: {fileID: 4397080764487562581, guid: aae56f4776100974ba051333a3974811, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7737081470015658928}
+    - targetCorrespondingSourceObject: {fileID: 4397080764487562581, guid: aae56f4776100974ba051333a3974811, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3131754538136941156}
+    - targetCorrespondingSourceObject: {fileID: 4397080764487562581, guid: aae56f4776100974ba051333a3974811, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5693538146578284993}
+    - targetCorrespondingSourceObject: {fileID: 7977050033597622638, guid: aae56f4776100974ba051333a3974811, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5050942458545403824}
+  m_SourcePrefab: {fileID: 100100000, guid: aae56f4776100974ba051333a3974811, type: 3}
+--- !u!1 &4353184650230105608 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7977050033597622638, guid: aae56f4776100974ba051333a3974811, type: 3}
+  m_PrefabInstance: {fileID: 5971125346554916710}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5050942458545403824
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4353184650230105608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 24
+  m_MinHeight: 14
+  m_PreferredWidth: 24
+  m_PreferredHeight: 14
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &4463505624256991739 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8010844266177199773, guid: aae56f4776100974ba051333a3974811, type: 3}
+  m_PrefabInstance: {fileID: 5971125346554916710}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8059230519961279027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad5746687007427186ea77e4568f01cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &5701802129777246385 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+  m_PrefabInstance: {fileID: 5971125346554916710}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7492445118827658684 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3830084976308146906, guid: aae56f4776100974ba051333a3974811, type: 3}
+  m_PrefabInstance: {fileID: 5971125346554916710}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8059230519961279027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &8059230519961279027 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4397080764487562581, guid: aae56f4776100974ba051333a3974811, type: 3}
+  m_PrefabInstance: {fileID: 5971125346554916710}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7279440405735603417
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8059230519961279027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 6
+    m_Right: 6
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &7737081470015658928
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8059230519961279027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
+--- !u!114 &3131754538136941156
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8059230519961279027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e80246de51fca2f47a990cee912d0ea4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  notificationView: {fileID: 4463505624256991739}
+  fileLocationText: {fileID: 4755172762721352907}
+--- !u!114 &5693538146578284993
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8059230519961279027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7492445118827658684}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3131754538136941156}
+        m_TargetAssemblyTypeName: DCL.InWorldCamera.CameraReelToast.CameraReelDownloadToastMessageController,
+          CameraReelToast
+        m_MethodName: OpenFileLocation
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/Prefabs/CameraReelToastMessage.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelToast/Prefabs/CameraReelToastMessage.prefab
@@ -1246,8 +1246,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e80246de51fca2f47a990cee912d0ea4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  notificationView: {fileID: 4463505624256991739}
+  button: {fileID: 5693538146578284993}
   fileLocationText: {fileID: 4755172762721352907}
+  notificationView: {fileID: 4463505624256991739}
 --- !u!114 &5693538146578284993
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1291,17 +1292,4 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7492445118827658684}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 3131754538136941156}
-        m_TargetAssemblyTypeName: DCL.InWorldCamera.CameraReelToast.CameraReelDownloadToastMessageController,
-          CameraReelToast
-        m_MethodName: OpenFileLocation
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailController.cs
@@ -147,7 +147,7 @@ namespace DCL.InWorldCamera.PhotoDetail
             HideDeleteModal();
 
             viewInstance.mainImageCanvasGroup.alpha = 0;
-            
+
             if (viewInstance.mainImage.texture != null)
                 GameObject.Destroy(viewInstance.mainImage.texture);
 
@@ -172,7 +172,10 @@ namespace DCL.InWorldCamera.PhotoDetail
                 {
                     await ReelCommonActions.DownloadReelToFileAsync(inputData.AllReels[currentReelIndex].url, ct);
                     ScreenshotDownloaded?.Invoke();
-                    viewInstance!.cameraReelToastMessage?.ShowToastMessage(CameraReelToastMessageType.SUCCESS, photoDetailStringMessages.PhotoSuccessfullyDownloadedMessage);
+
+                    viewInstance!.cameraReelToastMessage?.ShowToastMessage(
+                        CameraReelToastMessageType.DOWNLOAD,
+                        photoDetailStringMessages.PhotoSuccessfullyDownloadedMessage);
                 }
                 catch (Exception e)
                 {

--- a/Explorer/Assets/DCL/InWorldCamera/ReelActions/ReelCommonActions.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/ReelActions/ReelCommonActions.cs
@@ -4,7 +4,6 @@ using DCL.Clipboard;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using System;
 using System.IO;
-using System.Text;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -14,6 +13,7 @@ namespace DCL.InWorldCamera.ReelActions
     public static class ReelCommonActions
     {
         private const string DECENTRALAND_REELS_HOME_FOLDER = "Downloads";
+        private static string reelsPath;
 
         /// <summary>
         ///     Opens a browser tab on x.com with a tweet ready to be posted containing the reel url.
@@ -52,23 +52,29 @@ namespace DCL.InWorldCamera.ReelActions
                     throw new Exception($"Error while downloading reel: {webRequest.error}");
 
                 Texture2D texture = DownloadHandlerTexture.GetContent(webRequest);
-                StringBuilder absolutePathBuilder = new StringBuilder();
                 byte[] imageBytes = texture.EncodeToPNG();
-
-                absolutePathBuilder.Append(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile))
-                                   .Append("/")
-                                   .Append(DECENTRALAND_REELS_HOME_FOLDER)
-                                   .Append("/")
-                                   .Append(Path.GetFileName(uri.LocalPath))
-                                   .Replace(" ", "\\ ");
-
-                string absolutePath = absolutePathBuilder.ToString();
-                string directoryPath = Path.GetDirectoryName(absolutePath);
+                string directoryPath = ReelsPath;
+                string absolutePath = Path.Combine(ReelsPath, Path.GetFileName(uri.LocalPath));
 
                 if (!string.IsNullOrEmpty(directoryPath) && !Directory.Exists(directoryPath))
                     Directory.CreateDirectory(directoryPath);
 
                 await File.WriteAllBytesAsync(absolutePath, imageBytes, ct);
+            }
+        }
+
+        public static string ReelsPath
+        {
+            get
+            {
+                if (reelsPath == null)
+                {
+                    reelsPath = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                        DECENTRALAND_REELS_HOME_FOLDER);
+                }
+
+                return reelsPath;
             }
         }
     }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/PlatformUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/PlatformUtils.cs
@@ -1,3 +1,7 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
 using UnityEngine;
 
 namespace Utility
@@ -22,5 +26,56 @@ namespace Utility
 
             return platformSuffix;
         }
+
+        public static void ShellExecute(string fileName)
+        {
+#if UNITY_STANDALONE_WIN
+            if ((int)ShellExecute(IntPtr.Zero, null, fileName, null, null, SW_NORMAL) <= 16)
+            {
+                int error = Marshal.GetLastWin32Error();
+                var sb = new StringBuilder(1024);
+
+                uint length = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, IntPtr.Zero, error, 0, sb,
+                    sb.Capacity, IntPtr.Zero);
+
+                string message = length > 0 ? sb.ToString() : $"error {error}";
+                throw new Win32Exception(error, message.TrimEnd());
+            }
+#elif UNITY_STANDALONE_OSX
+            string cmd = "open \"" + fileName + "\"";
+            int code = ExecuteSystemCommand(cmd);
+            if (code != 0)
+            {
+                var sb = new StringBuilder(1024);
+
+                string message = code == -1 && strerror_r(code, sb, sb.Capacity) == 0
+                    ? sb.ToString()
+                    : "Unknown error";
+                throw new Exception($"error {code}: {message}");
+            }
+#else
+            throw new NotImplementedException();
+#endif
+        }
+
+#if UNITY_STANDALONE_WIN
+        [DllImport("kernel32", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern uint FormatMessage(uint dwFlags, IntPtr lpSource, int dwMessageId,
+            uint dwLanguageId, StringBuilder lpBuffer, int nSize, IntPtr Arguments);
+
+        private const uint FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
+
+        [DllImport("shell32", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr ShellExecute(IntPtr hWnd, string lpOperation, string lpFile,
+            string lpParameters, string lpDirectory, int nShowCmd);
+
+        private const int SW_NORMAL = 1;
+#elif UNITY_STANDALONE_OSX
+        [DllImport("libc", EntryPoint = "system")]
+        private static extern int ExecuteSystemCommand([MarshalAs(UnmanagedType.LPStr)] string command);
+
+        [DllImport("libc")]
+        private static extern int strerror_r(int errnum, StringBuilder buf, int buflen);
+#endif
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
@@ -728,7 +728,7 @@ MonoBehaviour:
           m_EditorAssetChanged: 0
         <ShareToXMessage>k__BackingField: Check out what I'm doing in @decentraland
           right now and join me!
-        <PhotoSuccessfullyDownloadedMessage>k__BackingField: 'Photo saved to '
+        <PhotoSuccessfullyDownloadedMessage>k__BackingField: Photo successfully downloaded
         <LinkCopiedMessage>k__BackingField: Link copied!
         <CategoryIconsMapping>k__BackingField:
           m_AssetGUID: 4a2a7b610414b45c1b576946ce094877

--- a/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
@@ -728,7 +728,7 @@ MonoBehaviour:
           m_EditorAssetChanged: 0
         <ShareToXMessage>k__BackingField: Check out what I'm doing in @decentraland
           right now and join me!
-        <PhotoSuccessfullyDownloadedMessage>k__BackingField: Photo successfully downloaded
+        <PhotoSuccessfullyDownloadedMessage>k__BackingField: 'Photo saved to '
         <LinkCopiedMessage>k__BackingField: Link copied!
         <CategoryIconsMapping>k__BackingField:
           m_AssetGUID: 4a2a7b610414b45c1b576946ce094877


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change has the "photo downloaded" notification say where the photo was downloaded to, and clicking it will now open your file browser to that folder. This fixes #3534.

## Test Instructions

Save a photo and click the notification.
![image](https://github.com/user-attachments/assets/b3485673-fdc1-448f-84b7-4ddfdb22c739)

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
