### PR TITLE
fix: publish force render on profiles

### DIFF
--- a/Explorer/Assets/DCL/Profiles/ProfileBuilder.cs
+++ b/Explorer/Assets/DCL/Profiles/ProfileBuilder.cs
@@ -41,7 +41,6 @@ namespace DCL.Profiles
         private bool hasConnectedWeb3;
         private URLAddress? bodySnapshotUrl;
         private URLAddress? faceSnapshotUrl;
-        private Avatar? avatar;
 
         public ProfileBuilder From(Profile? profile)
         {
@@ -54,7 +53,7 @@ namespace DCL.Profiles
             skinColor = profile.Avatar.SkinColor;
             hairColor = profile.Avatar.HairColor;
             emotes = profile.Avatar.emotes;
-            forceRender = profile.Avatar.forceRender;
+            forceRender = profile.Avatar.forceRender.ToHashSet();
             bodySnapshotUrl = profile.Avatar.BodySnapshotUrl;
             faceSnapshotUrl = profile.Avatar.FaceSnapshotUrl;
             blocked = profile.blocked?.ToHashSet();
@@ -87,12 +86,6 @@ namespace DCL.Profiles
         public ProfileBuilder WithWearables(IEnumerable<URN> wearables)
         {
             this.wearables = wearables;
-            return this;
-        }
-
-        public ProfileBuilder WithAvatar(Avatar avatar)
-        {
-            this.avatar = avatar;
             return this;
         }
 
@@ -161,8 +154,7 @@ namespace DCL.Profiles
             profile.HasClaimedName = hasClaimedName;
             profile.HasConnectedWeb3 = hasConnectedWeb3;
 
-
-            var avatar = this.avatar ?? new Avatar();
+            var avatar = new Avatar();
             profile.Avatar = avatar;
 
             if (wearables != null)


### PR DESCRIPTION
## What does this PR change?

The profile wasn’t being published when only the `forceRender` property of a wearable was changed.

This happened because forceRender was being passed by reference. When the `ProfileBuilder` copied the profile using `builder.From(profile)`, it also copied the reference to forceRender. Later, during the build process, forceRender was modified, which unintentionally changed the original profile too.
As a result, the system couldn’t detect any changes (since it thought both profiles were the same), so it skipped publishing the updated profile to Catalyst.

### Test Steps
1. Go to the backpack and wear some wearables that hide other categories
2. Quit the backpack and save the profile
3. Restart the client
4. Open the backpack and only change the force render property on any hidden wearable
5. Quit the backpack
6. Restart the client
7. Check that the force render is applied on your avatar when you start

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
