### PR TITLE
style: replace scene restriction warning icon for an info icon in the mini map

### DIFF
--- a/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
+++ b/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
@@ -700,8 +700,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -85.99994, y: -10.300049}
-  m_SizeDelta: {x: 0, y: 19}
+  m_AnchoredPosition: {x: -90, y: -10}
+  m_SizeDelta: {x: 0, y: 20}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &2996534693634811258
 CanvasRenderer:
@@ -729,7 +729,7 @@ MonoBehaviour:
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 3
-  m_Spacing: 6
+  m_Spacing: 2
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 1
@@ -2330,7 +2330,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 19.0937}
+  m_SizeDelta: {x: 0, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4471790232475835440
 CanvasRenderer:
@@ -2353,14 +2353,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.99607843, g: 0.63529414, b: 0.09019608, a: 1}
+  m_Color: {r: 0.9254902, g: 0.92156863, b: 0.92941177, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 11e50157680834b92b7f75220b425747, type: 3}
+  m_Sprite: {fileID: 21300000, guid: d63bc69a4cb0e4fd5b31fc3bd1f8e1fc, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -2430,7 +2430,7 @@ MonoBehaviour:
   m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
-  m_PreferredWidth: 20
+  m_PreferredWidth: 15
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
@@ -2599,7 +2599,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -100.7, y: -10.1}
-  m_SizeDelta: {x: 21, y: 21}
+  m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3297444035203583160
 CanvasRenderer:
@@ -2622,7 +2622,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.4}
+  m_Color: {r: 0.627451, g: 0.60784316, b: 0.65882355, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -2714,8 +2714,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+    rgba: 4294769916
+  m_fontColor: {r: 0.9882353, g: 0.9882353, b: 0.9882353, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -2732,8 +2732,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 15
-  m_fontSizeBase: 15
+  m_fontSize: 14
+  m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18

--- a/Explorer/Assets/DCL/Minimap/Assets/SceneRestrictionText.prefab
+++ b/Explorer/Assets/DCL/Minimap/Assets/SceneRestrictionText.prefab
@@ -67,8 +67,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: "\u2022 The camera is locked"
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
-  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Explorer/Assets/DCL/SceneRestrictionBusController/SceneRestriction/Assets/SceneRestrictionsToast.prefab
+++ b/Explorer/Assets/DCL/SceneRestrictionBusController/SceneRestriction/Assets/SceneRestrictionsToast.prefab
@@ -191,8 +191,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4279739134
-  m_fontColor: {r: 0.99607843, g: 0.63529414, b: 0.09019608, a: 1}
+    rgba: 4294769916
+  m_fontColor: {r: 0.9882353, g: 0.9882353, b: 0.9882353, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/Explorer/Assets/Textures/Common/TwinArrows.png
+++ b/Explorer/Assets/Textures/Common/TwinArrows.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29025b4108373ed8629075ccfc34e5a8eea447431165b7ba0ed1151ca8c0ef3d
-size 237
+oid sha256:42e764e7af8aeb68b3d18d2564bf12067e60ecd433a207c1640b2ed15aa7026b
+size 304


### PR DESCRIPTION
# Pull Request Description
This PR was created to update the mini map warning icon, which indicates the scene is restricting some features.
[This](https://www.figma.com/design/PXdXYmnNUOiMjyj8SaNkkQ/%F0%9F%97%BA%EF%B8%8F-Mini-map-%7C-Explorer-2.0-%7C-10-24?node-id=1-1209&t=8YP2LC3B2LiW5elY-1) is the new look and feel of the icon and the tooltip.
<img width="254" alt="Screenshot 2025-04-11 at 14 38 02" src="https://github.com/user-attachments/assets/9febe3ac-e400-4f9a-b5d0-2bc21a7de246" />

### Test Steps
1. Launch the Explorer.
2. Go to a scene where there is a feature restriction, as for example the MVFW runway when you enter the cinema mode.
3. Check the yellow warning icon in the mini map is now a white info icon. 
4. Click the icon to open the tooltip and check its title color is white instead of yellow, and that the bullet points text style are regular instead of semi-bold.