### PR TITLE
fix: support ens names on teleport from chat

### DIFF
--- a/Explorer/Assets/DCL/Chat/Commands/ChatTeleporter.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ChatTeleporter.cs
@@ -1,6 +1,6 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
-using DCL.Chat.Commands;
+using DCL.CommunicationData.URLHelpers;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using ECS.SceneLifeCycle.Realm;
 using System;
@@ -50,8 +50,13 @@ namespace DCL.Chat.Commands
                 realmAddress = realm;
             else if (!paramUrls.TryGetValue(realm, out realmAddress))
             {
-                if (!realm.EndsWith(WORLD_SUFFIX))
+                // Dont modify realms like your.world.eth
+                if (!realm.IsEns()
+                    // Convert realms like olavra => olavra.dcl.eth
+                    && !realm.EndsWith(WORLD_SUFFIX))
+                {
                     realm += WORLD_SUFFIX;
+                }
 
                 realmAddress = GetWorldAddress(realm);
             }


### PR DESCRIPTION
## What does this PR change?

Fixes #3933 

During teleport from chat dont add `.dcl.eth` if the realm is considered an ens name, like: `your.world.eth`.

## Test Instructions
Use the `/goto` command from the chat to teleport to different realms:
- `/goto olavra`
- `/goto coffee.daohq.dappcraft.eth`
- `/goto https://peer.decentraland.org`
- `/goto olavra.dcl.eth`

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
