### PR TITLE
fix: stop remote emote on player blocked

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -91,7 +91,7 @@ namespace DCL.AvatarRendering.Emotes.Play
         // emotes that do not loop need to trigger some kind of cancellation, so we can take care of the emote props and sounds
         [Query]
         [None(typeof(CharacterEmoteIntent), typeof(DeleteEntityIntention))]
-        private void CancelEmotes(ref CharacterEmoteComponent emoteComponent, in IAvatarView avatarView)
+        private void CancelEmotes(ref CharacterEmoteComponent emoteComponent, in IAvatarView avatarView, in Entity entity)
         {
             bool wantsToCancelEmote = emoteComponent.StopEmote;
             emoteComponent.StopEmote = false;
@@ -109,7 +109,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             if (emoteReference == null)
                 return;
 
-            if (wantsToCancelEmote)
+            if (wantsToCancelEmote || World.Has<BlockedPlayerComponent>(entity))
             {
                 StopEmote(ref emoteComponent, avatarView);
                 return;

--- a/Explorer/Assets/DCL/Multiplayer/Emotes/MultiplayerEmotesMessageBus.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Emotes/MultiplayerEmotesMessageBus.cs
@@ -94,7 +94,10 @@ namespace DCL.Multiplayer.Emotes
             using (receivedMessage)
             {
                 if (cancellationTokenSource.Token.IsCancellationRequested || IsUserBlocked(receivedMessage.FromWalletId))
+                {
+                    messageDeduplication.RemoveWallet(receivedMessage.FromWalletId);
                     return;
+                }
 
                 Inbox(receivedMessage.FromWalletId, receivedMessage.Payload.Urn, receivedMessage.Payload.IncrementalId);
             }


### PR DESCRIPTION
# Pull Request Description

Fixes #3745 

When a user is emoting and they got blocked, the blocking user is still able to see the emote props (if it had any).

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR stops the remote emote for blocked players if they were emoting while the user blocked them. By doing so, the props disappear.
It also clears the `MultiplayerEmotesMessageBus.messageDeduplication` in order to be able to play a remote emote if the blocked user gets unblocked while emoting.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- This is easily tested if you can control 2 avatars A and B

### Test Steps
1. Place A and B in the same place
2. Start a looping emote with props with both A and B
3. From A, block B
4. Verify that A can't see B and their emote props (the same applies from B to A)
5. From A, unblock B
6. Verify that A can see B and that shortly after, the emote starts playing as normal (the same applies from B to A)


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
