### PR TITLE
feat: add logs chat command

### DIFF
--- a/Explorer/Assets/DCL/Chat/Commands/LogsChatCommand.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/LogsChatCommand.cs
@@ -1,0 +1,30 @@
+using Cysharp.Threading.Tasks;
+using System;
+using System.Threading;
+using UnityEngine;
+
+namespace DCL.Chat.Commands
+{
+    public class LogsChatCommand : IChatCommand
+    {
+        public string Command => "logs";
+        public string Description => "<b>/logs </b>\n Opens the logs folder";
+
+        public UniTask<string> ExecuteCommandAsync(string[] parameters, CancellationToken ct)
+        {
+            string path =
+                Application.platform switch
+                {
+                    RuntimePlatform.WindowsPlayer => $@"file://{Environment.GetEnvironmentVariable("USERPROFILE")}\AppData\LocalLow\Decentraland\Explorer\",
+                    RuntimePlatform.WindowsEditor => $@"file://{Environment.GetEnvironmentVariable("LOCALAPPDATA")}\Unity\Editor\",
+                    RuntimePlatform.OSXPlayer => "file://~/Library/Logs/Decentraland/Explorer/",
+                    RuntimePlatform.OSXEditor => "file://~/Library/Logs/Unity/",
+                    _ => throw new NotSupportedException("Platform not supported."),
+                };
+
+            Application.OpenURL(path);
+
+            return UniTask.FromResult(string.Empty);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Chat/Commands/LogsChatCommand.cs.meta
+++ b/Explorer/Assets/DCL/Chat/Commands/LogsChatCommand.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3b94993b03cb4965b6ac59b30c232420
+timeCreated: 1744720269

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -500,7 +500,8 @@ namespace Global.Dynamic
                 new KillPortableExperienceChatCommand(staticContainer.PortableExperiencesController, staticContainer.FeatureFlagsCache),
                 new VersionChatCommand(dclVersion),
                 new RoomsChatCommand(roomHub),
-                new ClearChatCommand(chatCommandsBus)
+                new ClearChatCommand(chatCommandsBus),
+                new LogsChatCommand(),
             };
 
             chatCommands.Add(new HelpChatCommand(chatCommands, appArgs));


### PR DESCRIPTION
# Pull Request Description

This adds a /logs chat command that will open the logs folder. Depending on the platform / run type (build or editor) it opens one of these folders:

```
WindowsPlayer => @"file://%USERPROFILE%\AppData\LocalLow\Decentraland\Explorer\",
WindowsEditor => @"file://%LOCALAPPDATA%\Unity\Editor\",
OSXPlayer => "file://~/Library/Logs/Decentraland/Explorer/",
OSXEditor => "file://~/Library/Logs/Unity/",
```

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

Type in /logs and check if the right folder with the log file is opened on both platforms.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
