### PR TITLE
Clean up warnings in UI style sheets

### DIFF
--- a/Explorer/Assets/DCL/Interaction/HoverCanvas/UI/HoverCanvasStyleSheet.uss
+++ b/Explorer/Assets/DCL/Interaction/HoverCanvas/UI/HoverCanvasStyleSheet.uss
@@ -26,12 +26,12 @@
 .tooltipIcon {
     height: 65%;
     width: 18px;
-    margin-left: 2;
+    margin-left: 2px;
 }
 
 .tooltipHintText {
     max-height: 70%;
-    margin-left: 3;
+    margin-left: 3px;
 }
 
 .alignedTooltipGap {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/Assets/DebugUtilitiesStyle.uss
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/Assets/DebugUtilitiesStyle.uss
@@ -16,19 +16,19 @@
 }
 
 DebugContainer {
-    margin: 4;
+    margin: 4px;
 }
 
 .debug-text--header {
     -unity-font-style: bold;
-    font-size: 12;
+    font-size: 12px;
 }
 
 DebugWidget {
     border-top-width: 1px;
     border-top-color: antiquewhite;
-    padding-top: 1;
-    padding-bottom: 2;
+    padding-top: 1px;
+    padding-bottom: 2px;
 }
 
 #DebugButton {
@@ -68,7 +68,7 @@ DebugDropdownElement {
 }
 
 DebugControl {
-    margin-bottom: 2;
+    margin-bottom: 2px;
 }
 
 DebugControl > #Left {
@@ -88,29 +88,29 @@ DebugControl > #Right {
 }
 
 DebugHintElement.debug-hint--before {
-    margin-bottom: -4;
+    margin-bottom: -4px;
 
-    padding-bottom: 2;
+    padding-bottom: 2px;
     border-radius: 0;
-    border-top-left-radius: 3;
-    border-top-right-radius: 3;
-    border-top-width: 1;
-    border-left-width: 1;
-    border-right-width: 1;
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+    border-top-width: 1px;
+    border-left-width: 1px;
+    border-right-width: 1px;
     border-bottom-width: 0;
     border-color: rgba(255, 255, 255, 0.5);
 }
 
 DebugHintElement.debug-hint--after {
-    margin-top: -4;
+    margin-top: -4px;
 
-    padding-bottom: 2;
+    padding-bottom: 2px;
     border-radius: 0;
-    border-bottom-left-radius: 3;
-    border-bottom-right-radius: 3;
-    border-bottom-width: 1;
-    border-left-width: 1;
-    border-right-width: 1;
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    border-right-width: 1px;
     border-top-width: 0;
     border-color: rgba(255, 255, 255, 0.5);
 }
@@ -122,7 +122,7 @@ DebugHintElement > #Sign {
 
 .unity-text-element {
     color: white;
-    font-size: 12;
+    font-size: 12px;
     padding: 1px 1px 2px 2px;
     margin: 1px 1px 2px 1px;
 }
@@ -146,7 +146,7 @@ DebugHintElement > #Sign {
 }
 
 DebugToggleElement > .unity-toggle {
-    margin: 1;
+    margin: 1px;
     padding: 0;
 }
 
@@ -156,7 +156,7 @@ DebugToggleElement > .unity-toggle #unity-checkmark {
     padding: 1px;
     border-radius: 3px;
     border-color: rgba(18, 0, 131, 0.59);
-    border-width: 2;
+    border-width: 2px;
     -unity-font-style: normal;
 }
 
@@ -167,7 +167,7 @@ DropdownField {
 DropdownField > VisualElement {
     border-radius: 3px;
     border-color: rgba(18, 0, 131, 0.59);
-    border-width: 2;
+    border-width: 2px;
     -unity-font-style: normal;
     padding: 1px;
     background-color: rgba(255, 255, 255, 0.75);
@@ -175,7 +175,7 @@ DropdownField > VisualElement {
 
 .unity-base-popup-field__text {
     color: #2e2e2e; 
-    margin: 1;
+    margin: 1px;
     padding: 0;
 }
 
@@ -184,7 +184,7 @@ DropdownField > VisualElement {
 }
 
 .unity-base-text-field {
-    margin: 1;
+    margin: 1px;
     padding: 0;
 }
 
@@ -194,7 +194,7 @@ DropdownField > VisualElement {
     padding: 1px;
     border-radius: 3px;
     border-color: rgba(18, 0, 131, 0.59);
-    border-width: 2;
+    border-width: 2px;
     -unity-font-style: normal;
 }
 
@@ -203,18 +203,18 @@ DropdownField > VisualElement {
     margin: 0;
     color: #2e2e2e;
     -unity-text-align: middle-right;
-    font-size: 11;
+    font-size: 11px;
 }
 
 .unity-foldout__content {
     padding-top: 5px;
     margin-left: 7px;
-    padding-right: 3;
+    padding-right: 3px;
 }
 
 .debug-text--normal {
     -unity-font-style: normal;
-    font-size: 11;
+    font-size: 11px;
     margin: 1px;
     padding: 1px;
 }
@@ -226,7 +226,7 @@ DropdownField > VisualElement {
     border-radius: 3px;
     border-width: 0;
     color: #2e2e2e;
-    font-size: 11;
+    font-size: 11px;
     -unity-font-style: normal;
 }
 
@@ -256,7 +256,7 @@ Vector2IntField > VisualElement > .unity-composite-field__field-spacer {
 }
 
 .debug-hint--info > #Sign {
-    background-image: url('project://database/Assets/DCL/DebugUtilities/Views/Assets/info.png');
+    background-image: url('project://database/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/Assets/info.png');
 }
 
 .debug-hint--warning > Label {
@@ -264,7 +264,7 @@ Vector2IntField > VisualElement > .unity-composite-field__field-spacer {
 }
 
 .debug-hint--warning > #Sign {
-    background-image: url('project://database/Assets/DCL/DebugUtilities/Views/Assets/warning.png');
+    background-image: url('project://database/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/Assets/warning.png');
 }
 
 .debug-hint--error > Label {
@@ -272,7 +272,7 @@ Vector2IntField > VisualElement > .unity-composite-field__field-spacer {
 }
 
 .debug-hint--error > #Sign {
-    background-image: url('project://database/Assets/DCL/DebugUtilities/Views/Assets/error.png');
+    background-image: url('project://database/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/Assets/error.png');
 }
 
 .unity-slider {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change fixes warnings logged by Unity when importing these USS files.

## Test Instructions

Check that the hover tooltip when you mouse over objects in the world (for example, the Best Rated scenes gallery in the plaza) looks the same as before.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
