### PR TITLE
fix: update profile widgets on profile name change

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -568,6 +568,8 @@ namespace Global.Dynamic
 
             IMVCManagerMenusAccessFacade menusAccessFacade = new MVCManagerMenusAccessFacade(mvcManager, profileCache, friendServiceProxy, chatInputBus, includeUserBlocking);
 
+            var profileChangesBus = new ProfileChangesBusController();
+
             var viewDependencies = new ViewDependencies(dclInput, unityEventSystem, menusAccessFacade, clipboardManager, dclCursor, profileThumbnailCache, profileRepository, remoteMetadata, userBlockingCacheProxy);
 
             var realmNftNamesProvider = new RealmNftNamesProvider(staticContainer.WebRequestsContainer.WebRequestController,
@@ -633,7 +635,7 @@ namespace Global.Dynamic
                     initializationFlowContainer.InitializationFlow,
                     profileCache, dclInput,
                     globalWorld, playerEntity, includeCameraReel, includeFriends,
-                    chatHistory, viewDependencies, sharedSpaceManager),
+                    chatHistory, viewDependencies, sharedSpaceManager, profileChangesBus),
                 new ErrorPopupPlugin(mvcManager, assetsProvisioner),
                 connectionStatusPanelPlugin,
                 new MinimapPlugin(mvcManager, minimap),
@@ -704,7 +706,8 @@ namespace Global.Dynamic
                     appArgs,
                     viewDependencies,
                     userBlockingCacheProxy,
-                    sharedSpaceManager
+                    sharedSpaceManager,
+                    profileChangesBus
                 ),
                 new CharacterPreviewPlugin(staticContainer.ComponentsContainer.ComponentPoolsRegistry, assetsProvisioner, staticContainer.CacheCleaner),
                 new WebRequestsPlugin(staticContainer.WebRequestsContainer.AnalyticsContainer, debugBuilder),
@@ -779,6 +782,7 @@ namespace Global.Dynamic
                     identityCache,
                     viewDependencies,
                     realmNftNamesProvider,
+                    profileChangesBus,
                     includeFriends,
                     includeUserBlocking,
                     isNameEditorEnabled

--- a/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/ViewDependencies.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/ViewDependencies.cs
@@ -5,6 +5,7 @@ using DCL.Input;
 using DCL.Multiplayer.Profiles.Poses;
 using DCL.Profiles;
 using DCL.Utilities;
+using System;
 using System.Threading;
 using UnityEngine;
 
@@ -22,6 +23,8 @@ namespace MVC
         public readonly IClipboardManager ClipboardManager;
         public readonly ICursor Cursor;
         public readonly ObjectProxy<IUserBlockingCache> UserBlockingCacheProxy;
+
+        public Action<Profile?>? ProfileNameChanged;
 
         private readonly IProfileThumbnailCache thumbnailCache;
         private readonly IProfileRepository profileRepository;

--- a/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/ViewDependencies.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/ViewDependencies/ViewDependencies.cs
@@ -5,7 +5,6 @@ using DCL.Input;
 using DCL.Multiplayer.Profiles.Poses;
 using DCL.Profiles;
 using DCL.Utilities;
-using System;
 using System.Threading;
 using UnityEngine;
 
@@ -23,8 +22,6 @@ namespace MVC
         public readonly IClipboardManager ClipboardManager;
         public readonly ICursor Cursor;
         public readonly ObjectProxy<IUserBlockingCache> UserBlockingCacheProxy;
-
-        public Action<Profile?>? ProfileNameChanged;
 
         private readonly IProfileThumbnailCache thumbnailCache;
         private readonly IProfileRepository profileRepository;

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -111,6 +111,7 @@ namespace DCL.PluginSystem.Global
         private readonly IAppArgs appArgs;
         private readonly ObjectProxy<IUserBlockingCache> userBlockingCacheProxy;
         private readonly ISharedSpaceManager sharedSpaceManager;
+        private readonly IProfileChangesBus profileChangesBus;
 
         private readonly bool includeCameraReel;
 
@@ -172,7 +173,8 @@ namespace DCL.PluginSystem.Global
             bool includeCameraReel,
             IAppArgs appArgs, ViewDependencies viewDependencies,
             ObjectProxy<IUserBlockingCache> userBlockingCacheProxy,
-            ISharedSpaceManager sharedSpaceManager)
+            ISharedSpaceManager sharedSpaceManager,
+            IProfileChangesBus profileChangesBus)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.mvcManager = mvcManager;
@@ -222,6 +224,7 @@ namespace DCL.PluginSystem.Global
             this.viewDependencies = viewDependencies;
             this.userBlockingCacheProxy = userBlockingCacheProxy;
             this.sharedSpaceManager = sharedSpaceManager;
+            this.profileChangesBus = profileChangesBus;
         }
 
         public void Dispose()
@@ -363,7 +366,7 @@ namespace DCL.PluginSystem.Global
 
             ExplorePanelController explorePanelController = new
                 ExplorePanelController(viewFactoryMethod, navmapController, settingsController, backpackSubPlugin.backpackController!, cameraReelController,
-                    new ProfileWidgetController(() => explorePanelView.ProfileWidget, web3IdentityCache, profileRepository, viewDependencies),
+                    new ProfileWidgetController(() => explorePanelView.ProfileWidget, web3IdentityCache, profileRepository, viewDependencies, profileChangesBus),
                     new ProfileMenuController(() => explorePanelView.ProfileMenuView, web3IdentityCache, profileRepository, world, playerEntity, webBrowser, web3Authenticator, userInAppInitializationFlow, profileCache, mvcManager, viewDependencies),
                     dclInput, inputHandler, notificationsBusController, inputBlock, includeCameraReel, sharedSpaceManager);
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
@@ -50,6 +50,7 @@ namespace DCL.PluginSystem.Global
         private readonly IChatHistory chatHistory;
         private readonly ViewDependencies viewDependencies;
         private readonly ISharedSpaceManager sharedSpaceManager;
+        private readonly IProfileChangesBus profileChangesBus;
 
         public SidebarPlugin(
             IAssetsProvisioner assetsProvisioner,
@@ -71,7 +72,8 @@ namespace DCL.PluginSystem.Global
             bool includeFriends,
             IChatHistory chatHistory,
             ViewDependencies viewDependencies,
-            ISharedSpaceManager sharedSpaceManager)
+            ISharedSpaceManager sharedSpaceManager,
+            IProfileChangesBus profileChangesBus)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.mvcManager = mvcManager;
@@ -93,6 +95,7 @@ namespace DCL.PluginSystem.Global
             this.chatHistory = chatHistory;
             this.viewDependencies = viewDependencies;
             this.sharedSpaceManager = sharedSpaceManager;
+            this.profileChangesBus = profileChangesBus;
         }
 
         public void Dispose() { }
@@ -116,7 +119,7 @@ namespace DCL.PluginSystem.Global
                 mvcManager,
                 notificationsBusController,
                 new NotificationsMenuController(mainUIView.SidebarView.NotificationsMenuView, notificationsRequestController, notificationsBusController, notificationIconTypes, webRequestController, rarityBackgroundMapping, web3IdentityCache),
-                new ProfileWidgetController(() => mainUIView.SidebarView.ProfileWidget, web3IdentityCache, profileRepository, viewDependencies),
+                new ProfileWidgetController(() => mainUIView.SidebarView.ProfileWidget, web3IdentityCache, profileRepository, viewDependencies, profileChangesBus),
                 new ProfileMenuController(() => mainUIView.SidebarView.ProfileMenuView, web3IdentityCache, profileRepository, world, playerEntity, webBrowser, web3Authenticator, userInAppInitializationFlow, profileCache, mvcManager, viewDependencies),
                 new SkyboxMenuController(() => mainUIView.SidebarView.SkyboxMenuView, settings.SkyboxSettingsAsset),
                 new ControlsPanelController(() => controlsPanelView, mvcManager, input),

--- a/Explorer/Assets/DCL/Profiles/IProfileChangesBus.cs
+++ b/Explorer/Assets/DCL/Profiles/IProfileChangesBus.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace DCL.Profiles
+{
+    public interface IProfileChangesBus : IDisposable
+    {
+        void PushProfileNameChange(Profile profile);
+        void SubscribeToProfileNameChange(ProfileChangesBusController.ProfileChangedDelegate callback);
+        void UnsubscribeToProfileNameChange(ProfileChangesBusController.ProfileChangedDelegate callback);
+    }
+}

--- a/Explorer/Assets/DCL/Profiles/IProfileChangesBus.cs.meta
+++ b/Explorer/Assets/DCL/Profiles/IProfileChangesBus.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 09232d8da31e4e459d620e3f27029a12
+timeCreated: 1744874592

--- a/Explorer/Assets/DCL/Profiles/ProfileChangesBusController.cs
+++ b/Explorer/Assets/DCL/Profiles/ProfileChangesBusController.cs
@@ -1,0 +1,22 @@
+
+namespace DCL.Profiles
+{
+    public class ProfileChangesBusController : IProfileChangesBus
+    {
+        public delegate void ProfileChangedDelegate(Profile profile);
+
+        private ProfileChangedDelegate? profileChangedDelegate;
+
+        public void Dispose() =>
+            profileChangedDelegate = null;
+
+        public void PushProfileNameChange(Profile profile) =>
+            profileChangedDelegate?.Invoke(profile);
+
+        public void SubscribeToProfileNameChange(ProfileChangedDelegate callback) =>
+            profileChangedDelegate += callback;
+
+        public void UnsubscribeToProfileNameChange(ProfileChangedDelegate callback) =>
+            profileChangedDelegate -= callback;
+    }
+}

--- a/Explorer/Assets/DCL/Profiles/ProfileChangesBusController.cs.meta
+++ b/Explorer/Assets/DCL/Profiles/ProfileChangesBusController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e4e4caa52df941bb9056e6faba73c905
+timeCreated: 1744874623

--- a/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
@@ -35,6 +35,7 @@ namespace DCL.UI.ProfileNames
         public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Popup;
 
         public event Action? NameChanged;
+        public event Action<Profile?>? NameChangedWithProfile;
         public event Action? NameClaimRequested;
 
         public ProfileNameEditorController(ViewFactoryMethod viewFactory,
@@ -241,8 +242,9 @@ namespace DCL.UI.ProfileNames
 
                     try
                     {
-                        await selfProfile.UpdateProfileAsync(profile, ct);
+                        Profile? updatedProfile = await selfProfile.UpdateProfileAsync(profile, ct);
                         NameChanged?.Invoke();
+                        NameChangedWithProfile?.Invoke(updatedProfile);
                     }
                     catch (Exception e) when (e is not OperationCanceledException) { ReportHub.LogException(e, ReportCategory.PROFILE); }
                 }
@@ -274,8 +276,9 @@ namespace DCL.UI.ProfileNames
 
                     try
                     {
-                        await selfProfile.UpdateProfileAsync(profile, ct);
+                        Profile? updatedProfile = await selfProfile.UpdateProfileAsync(profile, ct);
                         NameChanged?.Invoke();
+                        NameChangedWithProfile?.Invoke(updatedProfile);
                     }
                     catch (Exception e) when (e is not OperationCanceledException) { ReportHub.LogException(e, ReportCategory.PROFILE); }
                 }

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileWidgetController.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileWidgetController.cs
@@ -58,7 +58,7 @@ namespace DCL.UI.ProfileElements
             if (profile == null) return;
 
             SetupProfileData(profile);
-            viewInstance!.ProfilePictureView.Setup(profile.UserNameColor, profile.Avatar.FaceSnapshotUrl, profile.UserId);
+            viewInstance!.ProfilePictureView.SetupWithDependencies(viewDependencies, profile.UserNameColor, profile.Avatar.FaceSnapshotUrl, profile.UserId);
         }
 
         private async UniTaskVoid LoadAsync(CancellationToken ct)

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileWidgetController.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileWidgetController.cs
@@ -56,10 +56,8 @@ namespace DCL.UI.ProfileElements
         protected override UniTask WaitForCloseIntentAsync(CancellationToken ct) =>
             UniTask.Never(ct);
 
-        private void ProfileNameChanged(Profile? profile)
+        private void ProfileNameChanged(Profile profile)
         {
-            if (profile == null) return;
-
             SetupProfileData(profile);
             viewInstance!.ProfilePictureView.SetupWithDependencies(viewDependencies, profile.UserNameColor, profile.Avatar.FaceSnapshotUrl, profile.UserId);
         }

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileWidgetController.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileWidgetController.cs
@@ -14,6 +14,7 @@ namespace DCL.UI.ProfileElements
         private readonly IWeb3IdentityCache identityCache;
         private readonly IProfileRepository profileRepository;
         private readonly ViewDependencies viewDependencies;
+        private readonly IProfileChangesBus profileChangesBus;
 
         private CancellationTokenSource? loadProfileCts;
 
@@ -22,24 +23,26 @@ namespace DCL.UI.ProfileElements
         public ProfileWidgetController(ViewFactoryMethod viewFactory,
             IWeb3IdentityCache identityCache,
             IProfileRepository profileRepository,
-            ViewDependencies viewDependencies
+            ViewDependencies viewDependencies,
+            IProfileChangesBus profileChangesBus
         ) : base(viewFactory)
         {
             this.identityCache = identityCache;
             this.profileRepository = profileRepository;
             this.viewDependencies = viewDependencies;
+            this.profileChangesBus = profileChangesBus;
         }
 
         public override void Dispose()
         {
-            base.Dispose();
+            profileChangesBus.UnsubscribeToProfileNameChange(ProfileNameChanged);
 
-            viewDependencies.ProfileNameChanged -= ProfileNameChanged;
+            base.Dispose();
         }
 
         protected override void OnViewInstantiated()
         {
-            viewDependencies.ProfileNameChanged += ProfileNameChanged;
+            profileChangesBus.SubscribeToProfileNameChange(ProfileNameChanged);
         }
 
         protected override void OnBeforeViewShow()


### PR DESCRIPTION
# Pull Request Description

Fixes #3776 

When a profile name change is performed, it is not reflected in the widgets (explore panel and sidebar) with the new name and color.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR creates a new `Action` in the name editor controller that is invoked when the profile is updated. Through the `ViewDependencies` object this is propagated to `ProfileWidgetController` so that it can update `ProfilePictureView` accordingly.


## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Follow the repro steps of the issue verifying that the widgets get updated (both in the explore panel and the sidebar)


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
