### PR TITLE
feat: GetExplorerInformation export

### DIFF
--- a/Explorer/Assets/StreamingAssets/Js/Modules/Runtime.js
+++ b/Explorer/Assets/StreamingAssets/Js/Modules/Runtime.js
@@ -22,3 +22,11 @@ module.exports.getSceneInformation = function (message) {
         baseUrl: result.baseUrl
     }
 }
+
+module.exports.getExplorerInformation = async function (body) {
+    return {
+        agent: 'unity-explorer',
+        platform: 'desktop',
+        configurations: {}
+    }
+}


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes #3048

Exports the `GetExplorerInformation` function so the client can return the unity values

## Test Instructions

### Test Steps
1. Create a local test scene with a debug log of the new export. Something like 

```
  console.log("LOG  " + (await getExplorerInformation({})).agent)
  console.log("LOG  2 " + (await getExplorerInformation({})).platform)
```

You should see

```
LOG `unity-explorer`
LOG 2 `desktop`
```


## Quality Checklist
- [X] Changes have been tested locally


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
