### PR TITLE
fix: fixed character name max characters in name editor

### DIFF
--- a/Explorer/Assets/DCL/UI/Profiles/Names/Assets/ProfileNameEditor.prefab
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/Assets/ProfileNameEditor.prefab
@@ -341,7 +341,7 @@ MonoBehaviour:
   m_CharacterValidation: 0
   m_RegexValue: 
   m_GlobalPointSize: 14
-  m_CharacterLimit: 0
+  m_CharacterLimit: 15
   m_OnEndEdit:
     m_PersistentCalls:
       m_Calls: []


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #3992 

Sets a maximum length in the name editor input box to limit the character name length to 15

## Test Instructions

### Test Steps
1. Open 0.65
2. Go to your profile
3. Click on the pencil
4. Edit your name to non-unique username
5. Start writing different letters and verify the input stops at 15 characters

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
