### PR TITLE
fix: fixed background of notifications for reward incoming

### DIFF
--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuController.cs
@@ -239,6 +239,10 @@ namespace DCL.Notifications.NotificationsMenu
                     NotificationView nView = (NotificationView)notificationView;
                     nView.NotificationImageBackground.sprite = rarityBackgroundMapping.GetTypeImage(rewardAssignedNotification.Metadata.Rarity);
                     break;
+                case RewardInProgressNotification rewardInProgress:
+                    NotificationView rewardInProgressView = (NotificationView)notificationView;
+                    rewardInProgressView.NotificationImageBackground.sprite = rarityBackgroundMapping.GetTypeImage(rewardInProgress.Metadata.Rarity);
+                    break;
                 case FriendRequestReceivedNotification friendRequestReceivedNotification:
                     FriendsNotificationView friendNotificationView = (FriendsNotificationView)notificationView;
                     friendNotificationView.ConfigureFromReceivedNotificationData(friendRequestReceivedNotification);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #3925
Fixed the background of notifications of incoming rewards, before it was white, now it matches the rarity of the incoming item

## Test Instructions

### Test Steps
1. Log in
2. Check the notifications
3. Verify that all notifications related to wearables display the background with the rarity color, unlike before that only white backgrounds were displayed

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
