### PR TITLE
fix: fixed missing category icon in map navigation

### DIFF
--- a/Explorer/Assets/DCL/Navmap/ScriptableObjects/MapCategoryIconMapping.asset
+++ b/Explorer/Assets/DCL/Navmap/ScriptableObjects/MapCategoryIconMapping.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   - key: 0
     value: {fileID: 21300000, guid: 1fa6ee61db4734593a57f034d470aa07, type: 3}
   - key: 1
-    value: {fileID: 21300000, guid: 822c0f23908e14194a62675bd5bc1feb, type: 3}
+    value: {fileID: 21300000, guid: 99f0e3dfeacb848cbad99a8a70ce6fe2, type: 3}
   - key: 2
     value: {fileID: 21300000, guid: eab679ad39a8248519287117b76da3d4, type: 3}
   - key: 3
@@ -26,7 +26,7 @@ MonoBehaviour:
   - key: 5
     value: {fileID: 21300000, guid: 77e43a448cd4845b6842b4a494ae3a9d, type: 3}
   - key: 6
-    value: {fileID: 21300000, guid: a9cd8357592594142abb6567dfda987c, type: 3}
+    value: {fileID: 21300000, guid: 0e704045ff4344821b8b1df81c2c168b, type: 3}
   - key: 7
     value: {fileID: 21300000, guid: cacfd27c3541c4dffa43b796507107d2, type: 3}
   - key: 8


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #3869 
Added missing reference to crypto and music categories in navmap navigation

## Test Instructions

### Test Steps
1. Launch the explorer.
2. Open the map.
3. Click the categories 'Crypto' and 'Music' and verify that in the search section the icons appear correctly

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
