### PR TITLE
fix: make sure minimum chat bubbles width is name length to avoid cutoffs

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatEntryMessageBubbleElement.cs
+++ b/Explorer/Assets/DCL/Chat/ChatEntryMessageBubbleElement.cs
@@ -99,12 +99,15 @@ namespace DCL.Chat
                 emojisCount = GetEmojisCount(messageText);
             }
 
+            float userNamePreferredWidth = usernameElement.GetUserNamePreferredWidth(configurationSo.BackgroundWidthOffset, configurationSo.VerifiedBadgeWidth);
+
             if (nameTotalLength > (needsEmojiCount && emojisCount > 0 ? parsedTextLength + emojisCount : parsedTextLength))
-                return usernameElement.GetUserNamePreferredWidth(configurationSo.BackgroundWidthOffset, configurationSo.VerifiedBadgeWidth);
+                return userNamePreferredWidth;
+
             Vector2 preferredValues = messageContentText.GetPreferredValues(messageText, configurationSo.MaxEntryWidth, 0);
 
             if (preferredValues.x < configurationSo.MaxEntryWidth - configurationSo.BackgroundWidthOffset)
-                return preferredValues.x + configurationSo.BackgroundWidthOffset;
+                return Mathf.Max(preferredValues.x + configurationSo.BackgroundWidthOffset, userNamePreferredWidth);
 
             return configurationSo.MaxEntryWidth;
         }


### PR DESCRIPTION
# Pull Request Description

Fixes #3958

Due to `TMP_Text.GetPreferredValues()` some chat message backdrop entries appeared to be shorter than the message because of the calculation of the width in relation to the user name length.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes sure that the calculated width in always >= then the calculate username length so that no message will have the backdrop shorter then the username text, as seen in the issue.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Type messages of various lengths and characters (some letters need more width than others) and verify that no chat bubble appears cropped

### Additional Testing Notes
- The issue can be replicated on a different branch by changing name into the unclaimed name `MommaCuddelz` and typing the message `love the fit crow` as shown in the issue. An even worse example is to type `iiiiiiiiiiiiiiiii`
- The issue can be replicated especially typing an amount of characters that is the same as our name (in the example above 17 `i` because userName + `#` + `4 wallet digits` = 17
- The test steps can be checked against current live

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
