### PR TITLE
fix: don't destroy terrain root go on dispose

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
@@ -51,10 +51,7 @@ namespace DCL.Landscape
 
         public void Dispose()
         {
-            if (!IsInitialized) return;
-
-            if (rootGo != null)
-                UnityObjectUtils.SafeDestroy(rootGo);
+            // If we destroy rootGo here it causes issues on application exit
         }
 
         public bool Contains(Vector2Int parcel)


### PR DESCRIPTION
# Pull Request Description

Fixes the crash we had when the app (build) was exited.

fixes #3985

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Removes the destroy call - it's not needed since this only runs on exit.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Launch Explorer
2. Wait for 10 minutes
3. Quit Explorer
4. There should be no crash popup on either platform.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
