### PR TITLE
fix: expose "current scene" in normal debug container

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/DebugUtilitiesContainer.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/DebugUtilitiesContainer.cs
@@ -40,6 +40,7 @@ namespace DCL.DebugUtilities
                         ? null
                         : new HashSet<string>
                         {
+                            IDebugContainerBuilder.Categories.CURRENT_SCENE,
                             IDebugContainerBuilder.Categories.ROOM_INFO,
                             IDebugContainerBuilder.Categories.ROOM_SCENE,
                             IDebugContainerBuilder.Categories.ROOM_THROUGHPUT,


### PR DESCRIPTION
# Pull Request Description

Fixes #4017

The "Current scene" debug section is only exposed if the full debug mode is enabled (running the E@ with `--debug` flag).

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR enables the section in the normal debug panel (activated in-game with `/debug`).

![image](https://github.com/user-attachments/assets/1706e9b2-6b88-4a90-b18b-bc9dc5992884)


## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Run the E@ normally
2. Verify that the "Current scene" section is present and working


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
