### PR TITLE
Fix: street assets disappear when explorer loses focus

### DIFF
--- a/Explorer/Assets/DCL/Rendering/GPUInstancing/GPUInstancingService.cs
+++ b/Explorer/Assets/DCL/Rendering/GPUInstancing/GPUInstancingService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using UnityEngine;
+using UnityEngine.Rendering;
 using Utility;
 
 namespace DCL.Rendering.GPUInstancing
@@ -139,14 +140,8 @@ namespace DCL.Rendering.GPUInstancing
 
         public void RenderIndirect()
         {
-            if (renderCamera == null || !Application.isFocused)
+            if (renderCamera == null || !OnDemandRendering.willCurrentFrameRender)
                 return;
-
-#if UNITY_EDITOR
-            var currentWindow = UnityEditor.EditorWindow.focusedWindow;
-            if (currentWindow != null && currentWindow.GetType().ToString() != "UnityEditor.GameView")
-                return;
-#endif
 
             foreach ((GPUInstancingLODGroupWithBuffer candidate, GPUInstancingBuffers buffers) in candidatesBuffersTable)
             {


### PR DESCRIPTION
# Pull Request Description
Fix #3871

## What does this PR change?
Changed from isFocused check to willRender

## Test Instructions
See related bug ticket. 

Additionally compare with prod this behaviour:
1. Run app
2. Make application out of focus and fully covered by some other app or folder. 
3. Leave it like that for several minutes.
4. Bring DCL explorer application back to the focus
5. DCL explorer app should start running smooth, without big initial app switch freeze and/or crash

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
