### PR TITLE
Fix/UI action before authentication

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -41,7 +41,9 @@ using System;
 using System.Linq;
 using System.Threading;
 using TMPro;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.UIElements;

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -41,6 +41,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using TMPro;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.UIElements;
@@ -243,7 +244,7 @@ namespace Global.Dynamic
                     if (!await ShowUntrustedRealmConfirmationAsync(ct))
                     {
 #if UNITY_EDITOR
-                        UnityEditor.EditorApplication.isPlaying = false;
+                        EditorApplication.isPlaying = false;
 #else
                         Application.Quit();
 #endif
@@ -351,12 +352,15 @@ namespace Global.Dynamic
         {
             // We disable Inputs directly because otherwise before login (so before the Input component was created and the system that handles it is working)
             // all inputs will be valid, and it allows for weird behaviour, including opening menus that are not ready to be open yet.
-            staticContainer!.InputProxy.StrictObject.Shortcuts.Disable();
-            staticContainer.InputProxy.StrictObject.Player.Disable();
-            staticContainer.InputProxy.StrictObject.Emotes.Disable();
-            staticContainer.InputProxy.StrictObject.EmoteWheel.Disable();
-            staticContainer.InputProxy.StrictObject.FreeCamera.Disable();
-            staticContainer.InputProxy.StrictObject.Camera.Disable();
+            DCLInput dclInput = staticContainer!.InputProxy.StrictObject;
+
+            dclInput.Shortcuts.Disable();
+            dclInput.Player.Disable();
+            dclInput.Emotes.Disable();
+            dclInput.EmoteWheel.Disable();
+            dclInput.FreeCamera.Disable();
+            dclInput.Camera.Disable();
+            dclInput.UI.Disable();
         }
 
         private void RestoreInputs()
@@ -365,6 +369,8 @@ namespace Global.Dynamic
             // We restore all inputs except EmoteWheel and FreeCamera as they should be disabled by default
             staticContainer!.InputBlock.EnableAll(InputMapComponent.Kind.FREE_CAMERA,
                 InputMapComponent.Kind.EMOTE_WHEEL);
+
+            staticContainer.InputProxy.StrictObject.UI.Enable();
         }
 
         private static IDiskCache<PartialLoadingState> NewInstancePartialDiskCache(IAppArgs appArgs, RealmLaunchSettings launchSettings)

--- a/Explorer/Assets/DCL/Infrastructure/MVC/AssemblyInfo.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/AssemblyInfo.cs
@@ -4,3 +4,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("DCL.PlayMode.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("MVC")]
+[assembly: InternalsVisibleTo("MVC.Tests")]

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerShould.cs
@@ -2,7 +2,7 @@ using MVC.PopupsController.PopupCloser;
 using NSubstitute;
 using NUnit.Framework;
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,6 +18,7 @@ namespace MVC.Tests
         public void Setup()
         {
             windowsStackManager = Substitute.For<IWindowsStackManager>();
+            windowsStackManager.PushFullscreen(Arg.Any<IController>()).Returns(new FullscreenPushInfo(new List<IController>(), new CanvasOrdering()));
             popupCloserView = Substitute.For<IPopupCloserView>();
             mvcManager = new MVCManager(windowsStackManager, new CancellationTokenSource(), popupCloserView);
         }

--- a/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/IWindowsStackManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/IWindowsStackManager.cs
@@ -17,6 +17,11 @@
 
         PersistentPushInfo PushPersistent(IController controller);
 
+        /// <summary>
+        ///     Persistent view should be removed on emergency only
+        /// </summary>
+        void RemovePersistent(IController controller);
+
         OverlayPushInfo PushOverlay(IController controller);
 
         void PopOverlay(IController controller);

--- a/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/WindowStackManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/WindowStackManager.cs
@@ -10,7 +10,7 @@ namespace MVC
         internal IController fullscreenController { get; private set; }
         internal IController topController { get; private set; }
 
-        public IController TopMostPopup => popupStack.LastOrDefault();
+        public IController? TopMostPopup => popupStack.LastOrDefault();
         public IController CurrentFullscreenController => fullscreenController;
 
         public PopupPushInfo PushPopup(IController controller)
@@ -50,6 +50,11 @@ namespace MVC
             return new PersistentPushInfo(new CanvasOrdering(CanvasOrdering.SortingLayer.Persistent, -20));
         }
 
+        public void RemovePersistent(IController controller)
+        {
+            persistentStack.Remove(controller);
+        }
+
         public OverlayPushInfo PushOverlay(IController controller)
         {
             topController = controller;
@@ -72,9 +77,9 @@ namespace MVC
     {
         public readonly CanvasOrdering ControllerOrdering;
         public readonly CanvasOrdering PopupCloserOrdering;
-        public readonly IController PreviousController;
+        public readonly IController? PreviousController;
 
-        public PopupPushInfo(CanvasOrdering controllerOrdering, CanvasOrdering popupCloserOrdering, IController previousController)
+        public PopupPushInfo(CanvasOrdering controllerOrdering, CanvasOrdering popupCloserOrdering, IController? previousController)
         {
             this.ControllerOrdering = controllerOrdering;
             this.PopupCloserOrdering = popupCloserOrdering;
@@ -85,9 +90,9 @@ namespace MVC
     public readonly struct PopupPopInfo
     {
         public readonly CanvasOrdering PopupCloserOrdering;
-        public readonly IController NewTopMostController;
+        public readonly IController? NewTopMostController;
 
-        public PopupPopInfo(CanvasOrdering popupCloserOrdering, IController newTopMostController)
+        public PopupPopInfo(CanvasOrdering popupCloserOrdering, IController? newTopMostController)
         {
             this.PopupCloserOrdering = popupCloserOrdering;
             this.NewTopMostController = newTopMostController;

--- a/Explorer/Assets/DCL/PluginSystem/Global/MainUIPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/MainUIPlugin.cs
@@ -33,7 +33,7 @@ namespace DCL.PluginSystem.Global
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments) { }
 
-        public async UniTask InitializeAsync(Settings settings, CancellationToken ct)
+        public UniTask InitializeAsync(Settings settings, CancellationToken ct)
         {
             var mainUIController = new MainUIController(
                 () =>
@@ -48,6 +48,7 @@ namespace DCL.PluginSystem.Global
             );
 
             mvcManager.RegisterController(mainUIController);
+            return UniTask.CompletedTask;
         }
 
         public class Settings : IDCLPluginSettings { }


### PR DESCRIPTION
## Source of the issue

UI Actions are enabled before the authentication process is finished: thus, it was possible to invoke the chat controller by pressing "Enter" before the context has properly set up.

## Consequences

The faulty Persistent Controller was stuck in the stack, when other fullscreen view were appearing and disappearing they were invoking "Focus" on the initialized view that referred to the null fields causing an exception.