### PR TITLE
feat: streaming feature notifications support

### DIFF
--- a/Explorer/Assets/DCL/Notifications/Serialization/NotificationJsonDtoConverter.cs
+++ b/Explorer/Assets/DCL/Notifications/Serialization/NotificationJsonDtoConverter.cs
@@ -22,6 +22,8 @@ namespace DCL.Notifications.Serialization
         private const string STREAMING_TIME_EXCEEDED = "streaming_time_exceeded";
         private const string STREAMING_PLACE_UPDATED = "streaming_place_updated";
 
+        private static readonly JArray EMPTY_J_ARRAY = new ();
+
         private readonly List<string> excludedTypes = new ();
 
         public NotificationJsonDtoConverter(bool includeFriendsNotifications)
@@ -47,7 +49,7 @@ namespace DCL.Notifications.Serialization
             if (reader.TokenType == JsonToken.Null)
                 return null;
 
-            var notificationsList = JObject.Load(reader).Value<JArray>("notifications") as IEnumerable<JToken> ?? Array.Empty<JToken>();
+            var notificationsList = JObject.Load(reader).Value<JArray>("notifications") ?? EMPTY_J_ARRAY;
             existingValue ??= new List<INotification>();
 
             foreach (var item in notificationsList)

--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/NotificationType.cs
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/NotificationType.cs
@@ -30,8 +30,16 @@ namespace DCL.NotificationsBusController.NotificationTypes
         BADGE_GRANTED,
         SOCIAL_SERVICE_FRIENDSHIP_REQUEST,
         SOCIAL_SERVICE_FRIENDSHIP_ACCEPTED,
+
         //Internal notification types
         INTERNAL_ARRIVED_TO_DESTINATION,
         CREDITS_GOAL_COMPLETED,
+
+        //Streaming feature notification types,
+        STREAMING_KEY_RESET,
+        STREAMING_KEY_REVOKE,
+        STREAMING_KEY_EXPIRED,
+        STREAMING_TIME_EXCEEDED,
+        STREAMING_PLACE_UPDATED,
     }
 }

--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/StreamingFeatureNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/StreamingFeatureNotification.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace DCL.NotificationsBusController.NotificationTypes
+{
+    public class StreamingFeatureNotification : NotificationBase
+    {
+        [JsonProperty("metadata")]
+        public StreamingFeatureNotificationMetadata Metadata { get; set; }
+
+        public override string GetHeader() =>
+            Metadata.Title;
+
+        public override string GetTitle() =>
+            Metadata.Description;
+    }
+
+
+    [Serializable]
+    public struct StreamingFeatureNotificationMetadata
+    {
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("address")]
+        public string Address { get; set; }
+
+        [JsonProperty("isWorld")]
+        public bool IsWorld { get; set; }
+
+        [JsonProperty("position")]
+        public string Position { get; set; }
+
+        [JsonProperty("worldName")]
+        public string WorldName { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+    }}

--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/StreamingFeatureNotification.cs.meta
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/StreamingFeatureNotification.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 28ecffb51ffc463cb56884b01aa37c2c
+timeCreated: 1745599160


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Processes new notification types that came with `Streaming Feature`

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] Have your own scene with streaming support
- [ ] Start/Stop/Reset the streaming key to get corresponding notifications on the top of your screen
- [ ] Test in zone

### Test Steps
1. Enter your scene
2. Start/Stop/Reset the streaming key to get corresponding notifications on the top of your screen

### Additional Testing Notes
- Icon is not supported on backend side yet

## Quality Checklist
- [+] Changes have been tested locally

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
