### PR TITLE
style: credits copy updates

### DIFF
--- a/Explorer/Assets/DCL/MarketplaceCredits/Assets/Fields/MarketplaceCreditsTotalCreditsWidget.prefab
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Assets/Fields/MarketplaceCreditsTotalCreditsWidget.prefab
@@ -215,7 +215,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Expires in ? Days
+  m_text: Expire in ? Days
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
@@ -1516,7 +1516,7 @@ CanvasRenderer:
   m_CullTransparentMesh: 1
 --- !u!95 &5599152914247695427
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1530,6 +1530,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1

--- a/Explorer/Assets/DCL/MarketplaceCredits/Assets/Sections/MarketplaceCredits_ProgramEndedSection.prefab
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Assets/Sections/MarketplaceCredits_ProgramEndedSection.prefab
@@ -140,8 +140,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: The current run of Marketplace Credits Weekly Rewards (May X-July X) has
-    closed
+  m_text: The current run of Marketplace Credits Weekly Rewards (May 19-July 27)
+    has closed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsUtils.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsUtils.cs
@@ -54,7 +54,7 @@ namespace DCL.MarketplaceCredits
         public static string FormatCreditsExpireIn(uint timeLeftInSeconds)
         {
             uint days = timeLeftInSeconds / (60 * 60 * 24);
-            return $"Expires in {days} days";
+            return $"Expire in {days} days";
         }
 
         /// <summary>


### PR DESCRIPTION
## What does this PR change?
PR created to update a couple of texts in the UI. 

**Fix 1**
- The `S` letter was removed from the word `Expires`.
<img width="442" alt="Screenshot 2025-04-25 at 13 57 06" src="https://github.com/user-attachments/assets/a966260d-f7b3-4896-8227-c4fe50b9c60f" />

**Fix 2**
- The final dates were added to the modal indicating that the program has closed. Before we weren't showing any.
<img width="520" alt="Screenshot 2025-04-25 at 14 19 58" src="https://github.com/user-attachments/assets/4b73f82a-b0c6-414c-83ec-ab7d5bbbc10e" />

### Test Steps for fix 1
1. Launch the explorer
2. Open the marketplace credits panel. If you have credits in your balance, check that the word `Expires` doesn't have the `S` at the end anymore.
3. Fix 2 won't be possible to text in the build as this requires the program to get closed, but can be confirmed by checking the prefab in Unity.