### PR TITLE
fix: dont stop the audio source on sdk update

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/AudioSourceExtensions.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/AudioSourceExtensions.cs
@@ -29,13 +29,6 @@ namespace DCL.SDKComponents.AudioSources
                 audioSource.spatialBlend = pbAudioSource.Global ? 0 : 1;
             else
                 audioSource.spatialBlend = 1;
-
-            if (audioSource.clip == null) return;
-
-            audioSource.Stop();
-
-            if (pbAudioSource.HasPlaying && pbAudioSource.Playing)
-                audioSource.Play();
         }
 
         public static float GetVolume(this PBAudioSource pbAudioSource) =>

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
@@ -28,7 +28,7 @@ namespace DCL.SDKComponents.AudioSources
         private readonly IComponentPool<AudioSource> audioSourcesPool;
         private readonly World world;
         private readonly ISceneData sceneData;
-        private readonly AudioMixerGroup[] worldGroup;
+        private readonly AudioMixerGroup[]? worldGroup;
         private readonly ISceneStateProvider sceneStateProvider;
 
         internal UpdateAudioSourceSystem(World world, ISceneData sceneData, IComponentPoolsRegistry poolsRegistry,
@@ -68,12 +68,23 @@ namespace DCL.SDKComponents.AudioSources
             if (audioSourceComponent.AudioSourceAssigned == false)
                 audioSourceComponent.SetAudioSource(audioSourcesPool.Get()!, (worldGroup is { Length: > 0 } ? worldGroup[0] : null)!);
 
-            audioSourceComponent.AudioSource!.FromPBAudioSourceWithClip(sdkAudioSource, clip: promiseResult.Asset);
+            AudioSource? audioSource = audioSourceComponent.AudioSource;
+
+            if (audioSource != null)
+            {
+                audioSource.FromPBAudioSourceWithClip(sdkAudioSource, clip: promiseResult.Asset!);
+
+                audioSource.Stop();
+
+                if (audioSource.clip != null)
+                    if (sdkAudioSource is {HasPlaying: true, Playing: true })
+                        audioSource.Play();
+            }
 
             // Reset isDirty as we just applied the PBAudioSource to the AudioSource
             sdkAudioSource.IsDirty = false;
 
-            Transform transform = audioSourceComponent.AudioSource!.transform;
+            Transform transform = audioSource!.transform;
             transform.SetParent(entityTransform.Transform, false);
             transform.ResetLocalTRS();
 
@@ -110,6 +121,7 @@ namespace DCL.SDKComponents.AudioSources
             if (component.AudioSourceAssigned)
                 component.AudioSource!.ApplyPBAudioSource(sdkComponent);
 
+            // Don't play if the audio clip needs to change
             if (component.AudioClipUrl != sdkComponent.AudioClipUrl)
             {
                 component.CleanUp(world);
@@ -117,6 +129,21 @@ namespace DCL.SDKComponents.AudioSources
 
                 if (AudioUtils.TryCreateAudioClipPromise(world, sceneData, sdkComponent.AudioClipUrl!, partitionComponent, out Promise? clipPromise))
                     component.ClipPromise = clipPromise!.Value;
+            }
+            else
+            {
+                AudioSource? audioSource = component.AudioSource;
+
+                if (audioSource?.clip != null)
+                {
+                    if (sdkComponent is {HasPlaying: true, Playing: true })
+                    {
+                        if (!audioSource.isPlaying)
+                            audioSource.Play();
+                    }
+                    else
+                        audioSource.Stop();
+                }
             }
 
             sdkComponent.IsDirty = false;


### PR DESCRIPTION
## What does this PR change?

Fixes #4043 

An example code that should modify the audio volume without stopping it:

```
import { AudioSource, engine, Entity, PBAudioSource, Transform } from "@dcl/sdk/ecs";

let currentMusic: Entity | undefined;
let prevMusic: Entity | undefined;

let music1: Entity | undefined;
let music2: Entity | undefined;

const music1Url = "assets/scene/Audio/any_audio.mp3";
const music2Url = "assets/scene/Audio/other_adio.mp3";

export function setup() {
    music1 = engine.addEntity();

    Transform.create(music1, {
        position: { x: 0, y: 0, z: 0 }
    });

    AudioSource.create(music1, {
        audioClipUrl: music1Url,
        playing: false,
        loop: true,
        volume: 1,
        global: true
    });

    music2 = engine.addEntity();

    Transform.create(music2, {
        position: { x: 0, y: 0, z: 0 }
    });

    AudioSource.create(music2, {
        audioClipUrl: music2Url,
        playing: false,
        loop: true,
        volume: 1,
        global: true
    });

    engine.addSystem(crossfade);
}

export function toggleCrossfadeMusic() {
    if (music1 === currentMusic) {
        playCrossfade(music2!);
    } else {
        playCrossfade(music1!);
    }
}

function playCrossfade(music: Entity) {
    prevMusic = currentMusic;
    currentMusic = music;

    const audio = AudioSource.getMutable(music);

    audio.volume = 0;
    audio.playing = true;
    audio.global = true;
}

function crossfade(dt: number) {
    const DURATION = 10;
    const MAX_VOLUME = 1;

    if (currentMusic) {
        const audio = AudioSource.getMutable(currentMusic);
        
        audio.playing = true;
        audio.global = true;

        if (!audio.volume) {
            audio.volume = 0;
        }

        if (audio.volume < MAX_VOLUME) {
            audio.volume += (MAX_VOLUME * dt) / DURATION;
        }
    
        if (audio.volume >= MAX_VOLUME) {
            audio.volume = MAX_VOLUME;
        }
    }

    if (prevMusic) {
        const audio = AudioSource.getMutable(prevMusic);

        if (!audio.playing) return;

        if (!audio.volume) {
            audio.volume = 0;
        } else {
            audio.volume -= (MAX_VOLUME * dt) / DURATION;
        }

        if (audio.volume <= 0) {
            audio.volume = 0;
            audio.playing = false;
        }
    }
}
```

### Test Steps
1. Run the scene linked in the issue
2. Hit the crossfade button as many times as you want
3. You should listen the music transitioning
4. Also make an overall run on scene that have audio sources
5. Check that audio works as expected

### Prerequisites
Know how to run a scene in local scene development.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
