### PR TITLE
fix: Marketplace button in Backpack  is not interactive

### DIFF
--- a/Explorer/Assets/DCL/Backpack/Assets/Backpack.prefab
+++ b/Explorer/Assets/DCL/Backpack/Assets/Backpack.prefab
@@ -1890,6 +1890,7 @@ GameObject:
   - component: {fileID: 3168000095091751209}
   - component: {fileID: 975189055920484738}
   - component: {fileID: 1075718228187515202}
+  - component: {fileID: 1010713006274671892}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -1947,7 +1948,7 @@ MonoBehaviour:
   m_text: 'There are no items in this category.
 
     If you want you can find the
-    ideal one for you in the <color=#FF2D55><link="marketplace">Marketplace</link></color>.'
+    ideal one for you in the <color=#FF2D55><link="https://decentraland.org/marketplace">Marketplace</link></color>.'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
@@ -2018,6 +2019,18 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &1010713006274671892
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2833562870660444991}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa79a46ad7d14748b3e248214931267e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2954157724309682084
 GameObject:
   m_ObjectHideFlags: 0
@@ -2167,6 +2180,7 @@ GameObject:
   - component: {fileID: 5729606332592299148}
   - component: {fileID: 6656045789409414248}
   - component: {fileID: 296753013852746040}
+  - component: {fileID: 9100726896621302767}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -2224,7 +2238,7 @@ MonoBehaviour:
   m_text: 'There are no items in this category.
 
     If you want you can find the
-    ideal one for you in the <color=#FF2D55><link="marketplace">Marketplace</link></color>.'
+    ideal one for you in the <color=#FF2D55><link="https://decentraland.org/marketplace">Marketplace</link></color>.'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
@@ -2295,6 +2309,18 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &9100726896621302767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001405956435724077}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa79a46ad7d14748b3e248214931267e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3129263849770448644
 GameObject:
   m_ObjectHideFlags: 0
@@ -2544,8 +2570,9 @@ MonoBehaviour:
   <PageSelectorView>k__BackingField: {fileID: 3712294798457460945}
   <RegularResults>k__BackingField: {fileID: 4286908778797955625}
   <NoSearchResults>k__BackingField: {fileID: 2670128207509277336}
-  <MarketplaceTextLink>k__BackingField: {fileID: 8916202270401981245}
+  <NoSearchResultsMarketplaceTextLink>k__BackingField: {fileID: 8916202270401981245}
   <NoCategoryResults>k__BackingField: {fileID: 4883820917948329291}
+  <NoCategoryResultsMarketplaceTextLink>k__BackingField: {fileID: 1010713006274671892}
   <BreadCrumbView>k__BackingField: {fileID: 6956049020834478445}
 --- !u!1 &3190748306234886068
 GameObject:
@@ -5264,8 +5291,9 @@ MonoBehaviour:
   <PageSelectorView>k__BackingField: {fileID: 9151801607187252162}
   <RegularResults>k__BackingField: {fileID: 2293997709252917235}
   <NoSearchResults>k__BackingField: {fileID: 6292301406972969359}
-  <MarketplaceTextLink>k__BackingField: {fileID: 6148931348814617546}
+  <NoSearchResultsMarketplaceTextLink>k__BackingField: {fileID: 6148931348814617546}
   <NoCategoryResults>k__BackingField: {fileID: 4373380581338508548}
+  <NoCategoryResultsMarketplaceTextLink>k__BackingField: {fileID: 9100726896621302767}
   <BreadCrumbView>k__BackingField: {fileID: 0}
 --- !u!1 &7825276156756374324
 GameObject:

--- a/Explorer/Assets/DCL/Backpack/Assets/Backpack.prefab
+++ b/Explorer/Assets/DCL/Backpack/Assets/Backpack.prefab
@@ -2544,6 +2544,7 @@ MonoBehaviour:
   <PageSelectorView>k__BackingField: {fileID: 3712294798457460945}
   <RegularResults>k__BackingField: {fileID: 4286908778797955625}
   <NoSearchResults>k__BackingField: {fileID: 2670128207509277336}
+  <MarketplaceTextLink>k__BackingField: {fileID: 8916202270401981245}
   <NoCategoryResults>k__BackingField: {fileID: 4883820917948329291}
   <BreadCrumbView>k__BackingField: {fileID: 6956049020834478445}
 --- !u!1 &3190748306234886068
@@ -4651,6 +4652,7 @@ GameObject:
   - component: {fileID: 4984711898986185379}
   - component: {fileID: 3851007865483918846}
   - component: {fileID: 2768975878690625424}
+  - component: {fileID: 6148931348814617546}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -4706,7 +4708,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_text: You do not have any wearable that meets this category or search criteria.
-    If you want you can find the ideal one for you in the <color=#FF2D55><link="marketplace">Marketplace</link></color>.
+    If you want you can find the ideal one for you in the <color=#FF2D55><link="https://decentraland.org/marketplace">Marketplace</link></color>.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
@@ -4777,6 +4779,18 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &6148931348814617546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6441933127628158550}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa79a46ad7d14748b3e248214931267e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6473974854937344738
 GameObject:
   m_ObjectHideFlags: 0
@@ -4864,6 +4878,7 @@ GameObject:
   - component: {fileID: 1756632032611501278}
   - component: {fileID: 5293173539392528250}
   - component: {fileID: 4323447657527004265}
+  - component: {fileID: 8916202270401981245}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -4919,7 +4934,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_text: You do not have any wearable that meets this category or search criteria.
-    If you want you can find the ideal one for you in the <color=#FF2D55><link="marketplace">Marketplace</link></color>.
+    If you want you can find the ideal one for you in the <color=#FF2D55><link="https://decentraland.org/marketplace">Marketplace</link></color>.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
@@ -4990,6 +5005,18 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &8916202270401981245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6816447324940577629}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa79a46ad7d14748b3e248214931267e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7162625725267460611
 GameObject:
   m_ObjectHideFlags: 0
@@ -5237,6 +5264,7 @@ MonoBehaviour:
   <PageSelectorView>k__BackingField: {fileID: 9151801607187252162}
   <RegularResults>k__BackingField: {fileID: 2293997709252917235}
   <NoSearchResults>k__BackingField: {fileID: 6292301406972969359}
+  <MarketplaceTextLink>k__BackingField: {fileID: 6148931348814617546}
   <NoCategoryResults>k__BackingField: {fileID: 4373380581338508548}
   <BreadCrumbView>k__BackingField: {fileID: 0}
 --- !u!1 &7825276156756374324

--- a/Explorer/Assets/DCL/Backpack/Backpack.asmdef
+++ b/Explorer/Assets/DCL/Backpack/Backpack.asmdef
@@ -30,7 +30,8 @@
         "GUID:e5a23cdae0ef4d86aafc237a73280975",
         "GUID:f95dba842fdbb470fb6d1dced822ba04",
         "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b",
-        "GUID:8baf705856414dad9a73b3f382f1bc8b"
+        "GUID:8baf705856414dad9a73b3f382f1bc8b",
+        "GUID:91cf8206af184dac8e30eb46747e9939"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -91,7 +91,8 @@ namespace DCL.Backpack
             breadcrumbController = new BackpackBreadCrumbController(view.BreadCrumbView, eventBus, commandBus, categoryIcons, colorToggle, hairColors, eyesColors, bodyshapeColors);
             eventBus.EquipWearableEvent += OnEquip;
             eventBus.UnEquipWearableEvent += OnUnequip;
-            view.MarketplaceTextLink.OnLinkClicked += OpenMarketplaceLink;
+            view.NoSearchResultsMarketplaceTextLink.OnLinkClicked += OpenMarketplaceLink;
+            view.NoCategoryResultsMarketplaceTextLink.OnLinkClicked += OpenMarketplaceLink;
         }
 
         public void Dispose()
@@ -100,7 +101,8 @@ namespace DCL.Backpack
 
             eventBus.EquipWearableEvent -= OnEquip;
             eventBus.UnEquipWearableEvent -= OnUnequip;
-            view.MarketplaceTextLink.OnLinkClicked -= OpenMarketplaceLink;
+            view.NoSearchResultsMarketplaceTextLink.OnLinkClicked -= OpenMarketplaceLink;
+            view.NoCategoryResultsMarketplaceTextLink.OnLinkClicked -= OpenMarketplaceLink;
         }
 
         public void Activate()

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -8,6 +8,7 @@ using DCL.AvatarRendering.Wearables.Equipped;
 using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Backpack.BackpackBus;
 using DCL.Backpack.Breadcrumb;
+using DCL.Browser;
 using DCL.Diagnostics;
 using DCL.UI;
 using System;
@@ -40,6 +41,7 @@ namespace DCL.Backpack
         private readonly IObjectPool<BackpackItemView> gridItemsPool;
         private readonly IThumbnailProvider thumbnailProvider;
         private readonly IWearablesProvider wearablesProvider;
+        private readonly IWebBrowser webBrowser;
 
         private CancellationTokenSource? pageFetchCancellationToken;
         private bool currentCollectiblesOnly;
@@ -67,7 +69,8 @@ namespace DCL.Backpack
             ColorPresetsSO hairColors,
             ColorPresetsSO eyesColors,
             ColorPresetsSO bodyshapeColors,
-            IWearablesProvider wearablesProvider)
+            IWearablesProvider wearablesProvider,
+            IWebBrowser webBrowser)
         {
             this.view = view;
             this.commandBus = commandBus;
@@ -80,6 +83,7 @@ namespace DCL.Backpack
             this.thumbnailProvider = thumbnailProvider;
             this.wearablesProvider = wearablesProvider;
             this.gridItemsPool = gridItemsPool;
+            this.webBrowser = webBrowser;
             pageSelectorController = new PageSelectorController(view.PageSelectorView, pageButtonView);
 
             usedPoolItems = new Dictionary<URN, BackpackItemView>();
@@ -87,6 +91,7 @@ namespace DCL.Backpack
             breadcrumbController = new BackpackBreadCrumbController(view.BreadCrumbView, eventBus, commandBus, categoryIcons, colorToggle, hairColors, eyesColors, bodyshapeColors);
             eventBus.EquipWearableEvent += OnEquip;
             eventBus.UnEquipWearableEvent += OnUnequip;
+            view.MarketplaceTextLink.OnLinkClicked += OpenMarketplaceLink;
         }
 
         public void Dispose()
@@ -95,6 +100,7 @@ namespace DCL.Backpack
 
             eventBus.EquipWearableEvent -= OnEquip;
             eventBus.UnEquipWearableEvent -= OnUnequip;
+            view.MarketplaceTextLink.OnLinkClicked -= OpenMarketplaceLink;
         }
 
         public void Activate()
@@ -350,5 +356,8 @@ namespace DCL.Backpack
                 itemView.SetEquipButtonsState();
             }
         }
+
+        private void OpenMarketplaceLink(string url) =>
+            webBrowser.OpenUrl(url);
     }
 }

--- a/Explorer/Assets/DCL/Backpack/BackpackGridView.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridView.cs
@@ -3,7 +3,6 @@ using DCL.Backpack.Breadcrumb;
 using DCL.Backpack.EmotesSection;
 using DCL.UI;
 using System;
-using TMPro;
 using UnityEngine;
 
 namespace DCL.Backpack
@@ -26,10 +25,13 @@ namespace DCL.Backpack
         public GameObject NoSearchResults { get; private set; }
 
         [field: SerializeField]
-        public TMP_Text_ClickeableLink MarketplaceTextLink { get; private set; }
+        public TMP_Text_ClickeableLink NoSearchResultsMarketplaceTextLink { get; private set; }
 
         [field: SerializeField]
         public GameObject NoCategoryResults { get; private set; }
+
+        [field: SerializeField]
+        public TMP_Text_ClickeableLink NoCategoryResultsMarketplaceTextLink { get; private set; }
 
         [field: SerializeField]
         public BackpackBreadCrumbView BreadCrumbView { get; private set; }

--- a/Explorer/Assets/DCL/Backpack/BackpackGridView.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridView.cs
@@ -26,6 +26,9 @@ namespace DCL.Backpack
         public GameObject NoSearchResults { get; private set; }
 
         [field: SerializeField]
+        public TMP_Text_ClickeableLink MarketplaceTextLink { get; private set; }
+
+        [field: SerializeField]
         public GameObject NoCategoryResults { get; private set; }
 
         [field: SerializeField]

--- a/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
@@ -8,6 +8,7 @@ using DCL.AvatarRendering.Wearables;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Backpack.BackpackBus;
+using DCL.Browser;
 using DCL.UI;
 using DCL.Utilities.Extensions;
 using DCL.Web3.Identities;
@@ -44,6 +45,7 @@ namespace DCL.Backpack.EmotesSection
         private readonly IEmoteProvider emoteProvider;
         private readonly IReadOnlyCollection<URN> embeddedEmoteIds;
         private readonly IThumbnailProvider thumbnailProvider;
+        private readonly IWebBrowser webBrowser;
 
         private CancellationTokenSource? loadElementsCancellationToken;
         private string? currentCategory;
@@ -66,7 +68,8 @@ namespace DCL.Backpack.EmotesSection
             IObjectPool<BackpackEmoteGridItemView> gridItemsPool,
             IEmoteProvider emoteProvider,
             IReadOnlyCollection<URN> embeddedEmoteIds,
-            IThumbnailProvider thumbnailProvider)
+            IThumbnailProvider thumbnailProvider,
+            IWebBrowser webBrowser)
         {
             this.view = view;
             this.commandBus = commandBus;
@@ -81,6 +84,7 @@ namespace DCL.Backpack.EmotesSection
             this.emoteProvider = emoteProvider;
             this.embeddedEmoteIds = embeddedEmoteIds;
             this.thumbnailProvider = thumbnailProvider;
+            this.webBrowser = webBrowser;
             pageSelectorController = new PageSelectorController(view.PageSelectorView, pageButtonView);
 
             usedPoolItems = new Dictionary<URN, BackpackEmoteGridItemView>();
@@ -88,6 +92,7 @@ namespace DCL.Backpack.EmotesSection
             eventBus.EquipEmoteEvent += OnEquip;
             eventBus.EquipWearableEvent += OnWearableEquipped;
             eventBus.UnEquipEmoteEvent += OnUnequip;
+            view.MarketplaceTextLink.OnLinkClicked += OpenMarketplaceLink;
         }
 
         public void Activate()
@@ -109,6 +114,7 @@ namespace DCL.Backpack.EmotesSection
         public void Dispose()
         {
             loadElementsCancellationToken.SafeCancelAndDispose();
+            view.MarketplaceTextLink.OnLinkClicked -= OpenMarketplaceLink;
         }
 
         public static async UniTask<ObjectPool<BackpackEmoteGridItemView>> InitializeAssetsAsync(IAssetsProvisioner assetsProvisioner,
@@ -373,5 +379,8 @@ namespace DCL.Backpack.EmotesSection
                 return;
             }
         }
+
+        private void OpenMarketplaceLink(string url) =>
+            webBrowser.OpenUrl(url);
     }
 }

--- a/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
@@ -92,7 +92,8 @@ namespace DCL.Backpack.EmotesSection
             eventBus.EquipEmoteEvent += OnEquip;
             eventBus.EquipWearableEvent += OnWearableEquipped;
             eventBus.UnEquipEmoteEvent += OnUnequip;
-            view.MarketplaceTextLink.OnLinkClicked += OpenMarketplaceLink;
+            view.NoSearchResultsMarketplaceTextLink.OnLinkClicked += OpenMarketplaceLink;
+            view.NoCategoryResultsMarketplaceTextLink.OnLinkClicked += OpenMarketplaceLink;
         }
 
         public void Activate()
@@ -114,7 +115,8 @@ namespace DCL.Backpack.EmotesSection
         public void Dispose()
         {
             loadElementsCancellationToken.SafeCancelAndDispose();
-            view.MarketplaceTextLink.OnLinkClicked -= OpenMarketplaceLink;
+            view.NoSearchResultsMarketplaceTextLink.OnLinkClicked -= OpenMarketplaceLink;
+            view.NoCategoryResultsMarketplaceTextLink.OnLinkClicked -= OpenMarketplaceLink;
         }
 
         public static async UniTask<ObjectPool<BackpackEmoteGridItemView>> InitializeAssetsAsync(IAssetsProvisioner assetsProvisioner,

--- a/Explorer/Assets/DCL/PluginSystem/Global/BackpackSubPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/BackpackSubPlugin.cs
@@ -12,6 +12,7 @@ using DCL.Backpack;
 using DCL.Backpack.BackpackBus;
 using DCL.Backpack.CharacterPreview;
 using DCL.Backpack.EmotesSection;
+using DCL.Browser;
 using DCL.CharacterPreview;
 using DCL.Input;
 using DCL.Utilities.Extensions;
@@ -54,6 +55,7 @@ namespace DCL.PluginSystem.Global
         private readonly CharacterPreviewEventBus characterPreviewEventBus;
         private readonly IInputBlock inputBlock;
         private readonly IAppArgs appArgs;
+        private readonly IWebBrowser webBrowser;
         private BackpackBusController? busController;
         private BackpackEquipStatusController? backpackEquipStatusController;
 
@@ -82,7 +84,8 @@ namespace DCL.PluginSystem.Global
             IEmoteProvider emoteProvider,
             Arch.Core.World world,
             Entity playerEntity,
-            IAppArgs appArgs)
+            IAppArgs appArgs,
+            IWebBrowser webBrowser)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.web3Identity = web3Identity;
@@ -107,6 +110,7 @@ namespace DCL.PluginSystem.Global
             this.world = world;
             this.playerEntity = playerEntity;
             this.appArgs = appArgs;
+            this.webBrowser = webBrowser;
 
             backpackCommandBus = new BackpackCommandBus();
         }
@@ -177,12 +181,12 @@ namespace DCL.PluginSystem.Global
                 rarityBackgroundsMapping, rarityColorMappings, categoryIconsMapping,
                 equippedWearables, sortController, pageButtonView, gridPool,
                 thumbnailProvider, colorToggle, hairColors, eyesColors, bodyshapeColors,
-                wearablesProvider
+                wearablesProvider, webBrowser
             );
 
             var emoteGridController = new BackpackEmoteGridController(emoteView.GridView, backpackCommandBus, backpackEventBus,
                 web3Identity, rarityBackgroundsMapping, rarityColorMappings, categoryIconsMapping, equippedEmotes,
-                sortController, pageButtonView, emoteGridPool, emoteProvider, embeddedEmotes, thumbnailProvider);
+                sortController, pageButtonView, emoteGridPool, emoteProvider, embeddedEmotes, thumbnailProvider, webBrowser);
 
             var emotesController = new EmotesController(emoteView,
                 new BackpackEmoteSlotsController(emoteView.Slots, backpackEventBus, backpackCommandBus, rarityBackgroundsMapping), emoteGridController);

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -268,7 +268,8 @@ namespace DCL.PluginSystem.Global
                 emoteProvider,
                 world,
                 playerEntity,
-                appArgs
+                appArgs,
+                webBrowser
             );
 
             ExplorePanelView panelViewAsset = (await assetsProvisioner.ProvideMainAssetValueAsync(settings.ExplorePanelPrefab, ct: ct)).GetComponent<ExplorePanelView>();


### PR DESCRIPTION
# Pull Request Description

Fix #3362 

## What does this PR change?

When we did a search without matches or clicking an empty category in the backpack, the link to market place didn't exist to redirect the user to the marketplace webpage. Now it redirects to the marketplace.

<img width="507" alt="Image" src="https://github.com/user-attachments/assets/b75e9a06-e9fa-4190-8ea7-8170d417c6ea" />
<img width="585" alt="Image" src="https://github.com/user-attachments/assets/1d032a1e-9de3-45dc-9d9b-16c2d8cd3bb7" />

## Test Instructions
1. Launch the client
2. Open the backpack and click an empty category. Then try to click the marketplace link.
3. Try to look for an item you don't have in your backpack. Try to click the marketplace link from the empty state message.
4. Check that the marketplace website opens.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
