### PR TITLE
fix: scene avatars initial relative positioning

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
@@ -30,7 +30,7 @@ namespace DCL.PluginSystem.World
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in ECSWorldInstanceSharedDependencies sharedDependencies, in PersistentEntities persistentEntities, List<IFinalizeWorldSystem> finalizeWorldSystems, List<ISceneIsCurrentListener> sceneIsCurrentListeners)
         {
             ResetDirtyFlagSystem<PBAvatarShape>.InjectToWorld(ref builder);
-            var avatarShapeHandlerSystem = AvatarShapeHandlerSystem.InjectToWorld(ref builder, globalWorld, globalTransformPool);
+            var avatarShapeHandlerSystem = AvatarShapeHandlerSystem.InjectToWorld(ref builder, globalWorld, globalTransformPool, sharedDependencies.SceneData);
             finalizeWorldSystems.Add(avatarShapeHandlerSystem);
             UpdateAvatarShapeInterpolateMovementSystem.InjectToWorld(ref builder, globalWorld, sharedDependencies.SceneData.SceneShortInfo.BaseParcel);
         }

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
@@ -60,6 +60,10 @@ namespace ECS.Unity.AvatarShape.Systems
             // may lead to unexpected consequences, since that one is disposed by the scene, while the avatar lives in the global world
             Transform globalTransform = globalTransformPool.Get();
             globalTransform.SetParent(transformComponent.Transform);
+            // We ensure that the avatar's transform initializes on the sdk location if the scene applies any offset
+            globalTransform.localPosition = Vector3.zero;
+            globalTransform.localRotation = Quaternion.identity;
+            globalTransform.localScale = Vector3.one;
 
             var globalWorldEntity = globalWorld.Create(
                 pbAvatarShape, partitionComponent,

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
@@ -77,7 +77,7 @@ namespace ECS.Unity.AvatarShape.Systems
         }
 
         [Query]
-        [All(typeof(SDKAvatarShapeComponent), typeof(PBAvatarShape))]
+        [All(typeof(PBAvatarShape))]
         [None(typeof(DeleteEntityIntention))]
         private void LoadCharacterInterpolation(ref SDKAvatarShapeComponent sdkAvatarShapeComponent,
             ref TransformComponent transformComponent)

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
@@ -52,11 +52,20 @@ namespace ECS.Unity.AvatarShape.Systems
             // may lead to unexpected consequences, since that one is disposed by the scene, while the avatar lives in the global world
             Transform globalTransform = globalTransformPool.Get();
             globalTransform.SetParent(transformComponent.Transform);
+            // During scene loading, the scene is positioned at MordorConstants.SCENE_MORDOR_POSITION.
+            // We need to reset the local transform values to maintain correct avatar positioning:
+            // 1. CharacterInterpolationMovementComponent works in global space and updates the position on every frame
+            // 2. When the scene root moves from Mordor to its final position, we want the avatar to move with it
+            // 3. By setting local values to identity/zero/one, we ensure proper relative positioning
+            globalTransform.localPosition = Vector3.zero;
+            globalTransform.localRotation = Quaternion.identity;
+            globalTransform.localScale = Vector3.one;
 
             var globalWorldEntity = globalWorld.Create(
                 pbAvatarShape, partitionComponent,
                 new CharacterTransform(globalTransform),
-                new CharacterInterpolationMovementComponent(transformComponent.Transform.position, transformComponent.Transform.position, transformComponent.Transform.rotation),
+                // Disabled so we keep the relative position to the scene transform
+                // new CharacterInterpolationMovementComponent(transformComponent.Transform.position, transformComponent.Transform.position, transformComponent.Transform.rotation),
                 new CharacterAnimationComponent(),
                 new CharacterEmoteComponent());
             World.Add(entity, new SDKAvatarShapeComponent(globalWorldEntity));

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Tests/AvatarShapeHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Tests/AvatarShapeHandlerSystemShould.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using DCL.Character.Components;
 using DCL.Optimization.Pools;
 using NSubstitute;
+using SceneRunner.Scene;
 using UnityEngine;
 
 namespace ECS.Unity.AvatarShape.Tests
@@ -22,7 +23,9 @@ namespace ECS.Unity.AvatarShape.Tests
             globalWorld = World.Create();
             IComponentPool<Transform> pool = Substitute.For<IComponentPool<Transform>>();
             pool.Get().Returns(new GameObject().transform);
-            system = new AvatarShapeHandlerSystem(world, globalWorld, pool);
+            ISceneData sceneData = Substitute.For<ISceneData>();
+            sceneData.SceneLoadingConcluded.Returns(true);
+            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, sceneData);
 
             entity = world.Create(PartitionComponent.TOP_PRIORITY);
             AddTransformToEntity(entity);


### PR DESCRIPTION
## What does this PR change?

Fixes #4050 

During scene loading, the scene is positioned at `MordorConstants.SCENE_MORDOR_POSITION`.

The solution consists in resetting the avatar’s local transform values to maintain correct avatar positioning, even considering the current scene’s offset. In addition, `CharacterInterpolationMovementComponent` is removed, because it updates the wrongly calculated global position on every frame.

This ensures the avatar no longer wanders into Mordor unexpectedly — because, as we all know, one does not simply interpolate into Mordor.

## Test Instructions

You need a scene that creates an `AvatarShape` on the startup. For example:
```
import { AvatarShape, Entity, Transform, engine } from "@dcl/sdk/ecs";

export function main() {
    const npc = engine.addEntity();

    Transform.create(npc, {
        position: { x: 7.82, y: 0, z: 8.6 },
        rotation: { x: 0, y: 1.3, z: 0, w: 1 },
    });

    AvatarShape.create(npc, {
        id: 'father',
        bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',
        wearables: [
            "urn:decentraland:off-chain:base-avatars:elegant_sweater",
            "urn:decentraland:off-chain:base-avatars:brown_pants",
            "urn:decentraland:off-chain:base-avatars:hair_bun",
            "urn:decentraland:off-chain:base-avatars:m_mountainshoes.glb"
        ],
        emotes: [
            'clap',
            'wave',
            'raiseHand',
            'cry',
            'shrug'
        ],
    });
}
```

Observe that the avatar should be located at the expected position.

You can test the following scenes:
- Rapture Gallery (-88,-66; there are avatars shapes dancing on the top floor)
- MVFW scene that duplicated the avatars (145,-81)
- `dalkia.dcl.eth` the scene has the fix for this [issue](https://github.com/decentraland/unity-explorer/pull/3705). You can check that one as well, the solution from that PR should still be valid

### Additional Testing Notes

You need to run a scene locally: https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
