### PR TITLE
fix: allow space after a comma in the chat commands

### DIFF
--- a/Explorer/Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs
@@ -51,7 +51,7 @@ namespace DCL.Chat.MessageBus
 
         private async UniTaskVoid HandleChatCommandAsync(ChatChannel.ChannelId channelId, string message)
         {
-            string[] split = message.Split(' ');
+            string[] split = message.Replace(", ", ",").Split(' '); // Split by space but keep commas
             string userCommand = split[0][1..];
             string[] parameters = new ArraySegment<string>(split, 1, split.Length - 1).ToArray()!;
 


### PR DESCRIPTION
# Pull Request Description
Fix #3159 

## What does this PR change?
It allows to put an space after a comma in a chat command. For example: `/goto 10, 10`.

Before this change, if we did put the coordinates with a space after the comma, we received the next error:

![image](https://github.com/user-attachments/assets/e82a6f6c-435c-44e3-a8a3-eaf7f626272d)

## Test Instructions
1. Type `/goto 10, 10` on the chat field (make sure you introduce a space after the comma)
2. Check that the teleport is done correctly.
3. Check that the rest of chat commands work correctly as before.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
