### PR TITLE
fix: Redirect to Genesis City if the app is initialized with a wrong realm

### DIFF
--- a/Explorer/Assets/DCL/RealmNavigation/Container/RealmContainer.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/Container/RealmContainer.cs
@@ -67,7 +67,8 @@ namespace DCL.RealmNavigation
                 realmNavigatorDebugView,
                 localSceneDevelopment,
                 assetBundleRegistry,
-                appArgs
+                appArgs,
+                urlsSource
             );
 
             BuildDebugWidget(teleportController, debugContainerBuilder, loadingScreen, loadingScreenTimeout);


### PR DESCRIPTION
# Pull Request Description
Fix #2675 

## What does this PR change?
Before this change, if an invalid realm app parameter was used, the application remained in a pre-authentication screen state forever:

![image](https://github.com/user-attachments/assets/ca1804c4-e4cb-42ed-8a40-5caac2740be6)

Now, if this happens, we redirect the user to Genesis City.

## Test Instructions
1. Execute the build with a wrong `realm` parameter, for example: `decentraland://?realm=sadfsfds`.
2. Check that, instead of remaining in an infinite loading, the app redirects you to Genesis City (it's probably that it request you to authenticate your wallet before).

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
