### PR TITLE
fix: Passport doesn't display all equipped items

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/Wearable.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/Wearable.cs
@@ -214,7 +214,7 @@ namespace DCL.AvatarRendering.Wearables.Components
             return representation.Value.overrideReplaces;
         }
 
-        public static HashSet<string> ComposeHiddenCategories(string bodyShapeId, List<IWearable> wearables)
+        public static HashSet<string> ComposeHiddenCategories(string bodyShapeId, List<IWearable> wearables, IReadOnlyCollection<string> forceRender)
         {
             HashSet<string> result = new HashSet<string>();
 
@@ -231,6 +231,10 @@ namespace DCL.AvatarRendering.Wearables.Components
 
                 result.UnionWith(wearableHidesList);
             }
+
+            // Remove the categories that are forced to be rendered
+            foreach (string forceRenderCategory in forceRender)
+                result.Remove(forceRenderCategory);
 
             return result;
         }

--- a/Explorer/Assets/DCL/Passport/Modules/EquippedItems_PassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/EquippedItems_PassportModuleController.cs
@@ -172,6 +172,7 @@ namespace DCL.Passport.Modules
             ClearLoadingItems();
 
             HashSet<string> hidesList = Wearable.ComposeHiddenCategories(currentProfile.Avatar.BodyShape, gridWearables);
+            HashSet<string> forceRenderList = new HashSet<string>(currentProfile.Avatar.ForceRender);
             var elementsAddedInTheGird = 0;
 
             foreach (IWearable wearable in gridWearables)
@@ -179,7 +180,7 @@ namespace DCL.Passport.Modules
                 if (wearable.GetCategory() == WearablesConstants.Categories.BODY_SHAPE)
                     continue;
 
-                if (hidesList.Contains(wearable.GetCategory()))
+                if (hidesList.Contains(wearable.GetCategory()) && !forceRenderList.Contains(wearable.GetCategory()))
                     continue;
 
                 string rarityName = wearable.GetRarity();

--- a/Explorer/Assets/DCL/Passport/Modules/EquippedItems_PassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/EquippedItems_PassportModuleController.cs
@@ -180,7 +180,8 @@ namespace DCL.Passport.Modules
                 if (wearable.GetCategory() == WearablesConstants.Categories.BODY_SHAPE)
                     continue;
 
-                if (hidesList.Contains(wearable.GetCategory()) && !forceRenderList.Contains(wearable.GetCategory()))
+                string wearableCategory = wearable.GetCategory();
+                if (hidesList.Contains(wearableCategory) && !forceRenderList.Contains(wearableCategory))
                     continue;
 
                 string rarityName = wearable.GetRarity();

--- a/Explorer/Assets/DCL/Passport/Modules/EquippedItems_PassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/EquippedItems_PassportModuleController.cs
@@ -171,8 +171,7 @@ namespace DCL.Passport.Modules
         {
             ClearLoadingItems();
 
-            HashSet<string> hidesList = Wearable.ComposeHiddenCategories(currentProfile.Avatar.BodyShape, gridWearables);
-            HashSet<string> forceRenderList = new HashSet<string>(currentProfile.Avatar.ForceRender);
+            HashSet<string> hidesList = Wearable.ComposeHiddenCategories(currentProfile.Avatar.BodyShape, gridWearables, currentProfile.Avatar.ForceRender);
             var elementsAddedInTheGird = 0;
 
             foreach (IWearable wearable in gridWearables)
@@ -181,7 +180,7 @@ namespace DCL.Passport.Modules
                     continue;
 
                 string wearableCategory = wearable.GetCategory();
-                if (hidesList.Contains(wearableCategory) && !forceRenderList.Contains(wearableCategory))
+                if (hidesList.Contains(wearableCategory))
                     continue;
 
                 string rarityName = wearable.GetRarity();


### PR DESCRIPTION
# Pull Request Description
Fix #2619 

## What does this PR change?
The profile card was not displaying all items that the avatar had equipped. Hidden categories by another wearable that were proactively turned on were not visible.

### Test Steps
1. Open your backpack and equip any wearable that hides another one.
2. Make sure the hidden wearable is not marked as "forced to render" (bottom right icon in the wearable slot), I mean it should be set as hidden.

![image](https://github.com/user-attachments/assets/b10e7fb6-1df6-446d-8679-c3998199d708)

3. Close the backpack and wait for the new set of wearables are applied to your avatar.
4. Open you passport and check that all your visible wearables are included in the "EQUIPPED ITEMS" section. The wearable(s) that were hidden by another wearable(s) shouldn't appear.

![image](https://github.com/user-attachments/assets/951992b5-951c-44b4-87c2-722a876440fe)

5. Open your backpack again and set any of the hidden wearables as "dorced to render" (bottom right icon in the wearable slot), I mean it should be set as visible.

![image](https://github.com/user-attachments/assets/4b148908-b98f-48bb-b253-069ee047e1d0)

6. Close the backpack and wait for the new set of wearables are applied to your avatar.
7. Open you passport and check that all your visible wearables are included in the "EQUIPPED ITEMS" section. The wearable(s) that were hidden by another wearable(s) but were set as visible manually should appear.

![image](https://github.com/user-attachments/assets/e795c80c-68c4-49a3-9e42-f92696bec97e)

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
