### PR TITLE
fix: audio stream being created and disposed every frame

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/MediaPlayerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MediaPlayerPlugin.cs
@@ -81,8 +81,7 @@ namespace DCL.PluginSystem.World
                 worldVolumeMacBus,
                 exposedCameraData,
                 videoPrioritizationSettings,
-                roomHub,
-                featureFlagsCache
+                roomHub
             );
         }
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CleanUpMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CleanUpMediaPlayerSystem.cs
@@ -40,6 +40,7 @@ namespace DCL.SDKComponents.MediaStream
         }
 
         [Query]
+        [All(typeof(VideoTextureConsumer))]
         [None(typeof(PBVideoPlayer), typeof(DeleteEntityIntention))]
         private void HandleSdkVideoPlayerComponentRemoval(Entity entity, ref MediaPlayerComponent mediaPlayer)
         {

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/MediaPlayerPluginWrapper.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/MediaPlayerPluginWrapper.cs
@@ -38,8 +38,7 @@ namespace DCL.SDKComponents.MediaStream.Wrapper
             WorldVolumeMacBus worldVolumeMacBus,
             IExposedCameraData exposedCameraData,
             VideoPrioritizationSettings videoPrioritizationSettings,
-            ObjectProxy<IRoomHub> roomHub,
-            FeatureFlagsCache featureFlagsCache)
+            ObjectProxy<IRoomHub> roomHub)
         {
             this.exposedCameraData = exposedCameraData;
             this.videoPrioritizationSettings = videoPrioritizationSettings;


### PR DESCRIPTION
# Pull Request Description

Fixes #4062 
Fixes #3981

The audio stream component was being disposed every frame after its creation because the cleanup system `CleanUpMediaPlayerSystem.HandleSdkVideoPlayerComponentRemoval` was removing the component indistinctly, even if it wasn't used for a video.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR adds a filter for `VideoTextureConsumer` on the query so that it's executed only for `MediaPlayerComponent` with videos.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Check that AudioStream works as normal
2. There is a scene at `-35,111` with 3 different cubes. By clicking one an audio stream is created. Every cube has a different URL

### Additional Testing Notes
- The scene code for `-35,111` is 
[index.ts.zip](https://github.com/user-attachments/files/20055866/index.ts.zip)


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
