### PR TITLE
fix: Keep active map layers when the map is closed and re-opened again

### DIFF
--- a/Explorer/Assets/DCL/Navmap/FilterPanel/NavmapFilterPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/FilterPanel/NavmapFilterPanelController.cs
@@ -1,6 +1,7 @@
 using DCL.MapRenderer;
 using DCL.MapRenderer.MapLayers;
 using DG.Tweening;
+using System.Collections.Generic;
 
 namespace DCL.Navmap.FilterPanel
 {
@@ -9,7 +10,8 @@ namespace DCL.Navmap.FilterPanel
         private const float ANIMATION_DURATION = 0.2f;
         private readonly IMapRenderer mapRenderer;
         private readonly NavmapFilterPanelView view;
-        private bool isToggled = false;
+        private bool isToggled;
+        private readonly HashSet<MapLayer> currentActiveLayers;
 
         public NavmapFilterPanelController(IMapRenderer mapRenderer, NavmapFilterPanelView view)
         {
@@ -19,10 +21,27 @@ namespace DCL.Navmap.FilterPanel
             view.canvasGroup.alpha = 0;
             view.canvasGroup.blocksRaycasts = false;
             view.canvasGroup.interactable = false;
+
+            // Set the default active layers
+            currentActiveLayers = new HashSet<MapLayer>
+            {
+                MapLayer.LiveEvents,
+                MapLayer.ScenesOfInterest,
+                MapLayer.Pins,
+                MapLayer.HotUsersMarkers,
+                MapLayer.SatelliteAtlas,
+            };
         }
 
-        private void OnFilterChanged(MapLayer layer, bool isActive) =>
+        private void OnFilterChanged(MapLayer layer, bool isActive)
+        {
             mapRenderer.SetSharedLayer(layer, isActive);
+
+            if (isActive)
+                currentActiveLayers.Add(layer);
+            else
+                currentActiveLayers.Remove(layer);
+        }
 
         public void ToggleFilterPanel()
         {
@@ -30,5 +49,8 @@ namespace DCL.Navmap.FilterPanel
             view.ToggleFilterPanel(isToggled);
             view.canvasGroup.DOFade(isToggled ? 1 : 0, ANIMATION_DURATION).SetEase(Ease.Linear);
         }
+
+        public bool IsFilterActivated(MapLayer layer) =>
+            currentActiveLayers.Contains(layer);
     }
 }

--- a/Explorer/Assets/DCL/Navmap/FilterPanel/NavmapFilterPanelView.cs
+++ b/Explorer/Assets/DCL/Navmap/FilterPanel/NavmapFilterPanelView.cs
@@ -63,11 +63,6 @@ namespace DCL.Navmap.FilterPanel
             parcelButton.onValueChanged.AddListener(ToggleParcelMap);
         }
 
-        private void OnEnable()
-        {
-            ToggleSatelliteMap(true);
-        }
-
         public void ToggleFilterPanel(bool isOn)
         {
             canvasGroup.alpha = isOn ? 1 : 0;

--- a/Explorer/Assets/DCL/Navmap/NavmapController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapController.cs
@@ -52,6 +52,7 @@ namespace DCL.Navmap
         private Vector2 lastParcelHovered;
         private NavmapSections lastShownSection;
         private MapRenderImage.ParcelClickData lastParcelClicked;
+        private NavmapFilterPanelController navmapFilterPanelController;
 
         public IReadOnlyDictionary<MapLayer, IMapLayerParameter> LayersParameters { get; } = new Dictionary<MapLayer, IMapLayerParameter>
             { { MapLayer.PlayerMarker, new PlayerMarkerParameter { BackgroundIsActive = true } } };
@@ -101,7 +102,7 @@ namespace DCL.Navmap
 
             navmapView.WorldsWarningNotificationView.Text.text = WORLDS_WARNING_MESSAGE;
             navmapView.WorldsWarningNotificationView.Hide();
-            NavmapFilterPanelController navmapFilterPanelController = new (mapRenderer, navmapView.LocationView.FiltersPanel);
+            navmapFilterPanelController = new (mapRenderer, navmapView.LocationView.FiltersPanel);
             navmapLocationController = new NavmapLocationController(navmapView.LocationView, world, playerEntity, navmapFilterPanelController, navmapBus);
         }
 
@@ -188,8 +189,13 @@ namespace DCL.Navmap
                     navmapView.zoomView.zoomVerticalRange
                 ));
 
-            mapRenderer.SetSharedLayer(MapLayer.ScenesOfInterest, true);
-            mapRenderer.SetSharedLayer(MapLayer.LiveEvents, true);
+            mapRenderer.SetSharedLayer(MapLayer.LiveEvents, navmapFilterPanelController.IsFilterActivated(MapLayer.LiveEvents));
+            mapRenderer.SetSharedLayer(MapLayer.ScenesOfInterest, navmapFilterPanelController.IsFilterActivated(MapLayer.ScenesOfInterest));
+            mapRenderer.SetSharedLayer(MapLayer.Pins, navmapFilterPanelController.IsFilterActivated(MapLayer.Pins));
+            mapRenderer.SetSharedLayer(MapLayer.HotUsersMarkers, navmapFilterPanelController.IsFilterActivated(MapLayer.HotUsersMarkers));
+            mapRenderer.SetSharedLayer(MapLayer.SatelliteAtlas, navmapFilterPanelController.IsFilterActivated(MapLayer.SatelliteAtlas));
+            mapRenderer.SetSharedLayer(MapLayer.ParcelsAtlas, navmapFilterPanelController.IsFilterActivated(MapLayer.ParcelsAtlas));
+
             satelliteController.InjectCameraController(cameraController);
             navmapLocationController.InjectCameraController(cameraController);
             satelliteController.Activate();

--- a/Explorer/Assets/DCL/Navmap/SatelliteController.cs
+++ b/Explorer/Assets/DCL/Navmap/SatelliteController.cs
@@ -48,8 +48,6 @@ namespace DCL.Navmap
 
         public void Activate()
         {
-            mapRenderer.SetSharedLayer(MapLayer.SatelliteAtlas, true);
-            mapRenderer.SetSharedLayer(MapLayer.ParcelsAtlas, false);
             view.SatelliteRenderImage.texture = cameraController.GetRenderTexture();
             view.SatellitePixelPerfectMapRendererTextureProvider.Activate(cameraController);
             view.SatelliteRenderImage.Activate(null, cameraController.GetRenderTexture(), cameraController);


### PR DESCRIPTION
# Pull Request Description
Fix #3262 

## What does this PR change?
It makes the navmap keeps the last filters' selection (live events, POIs, Quests Mini Games, People, Sat/Parcel View) when we open it after being closed, instead of resetting them and leave the filter's controls un-synched.

## Test Instructions
1. Open the map.
2. Observe that it's showing all the layers that are activated in the LAYERS filter.
3. Change the filter deactivating some layers.
4. Close the map and re-open it.
5. Check that it's showing only the layers that are activated and not showing the deactivated ones.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
