### PR TITLE
Fix: Chat | Disappears completely after using Jump In from Online Friends panel (#3843)

### DIFF
--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/FriendsPanelController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/FriendsPanelController.cs
@@ -139,8 +139,12 @@ namespace DCL.Friends.UI.FriendPanel
         private void OnlineFriendClick(string targetAddress) =>
             OnlineFriendClicked?.Invoke(targetAddress);
 
-        private void JumpToFriendClick(string targetAddress, Vector2Int parcel) =>
+        private void JumpToFriendClick(string targetAddress, Vector2Int parcel)
+        {
+            closeTaskCompletionSource.TrySetResult();
             JumpToFriendClicked?.Invoke(targetAddress, parcel);
+        }
+
 
         public UniTask InitAsync(CancellationToken ct) =>
             requestsSectionController.InitAsync(ct);


### PR DESCRIPTION
The friends panel wasn't being closed appropriately to let the shared space manager know.

# Pull Request Description

## What does this PR change?

The panel is now forced to close when the jump in button is pressed.

## Test Instructions

### Test Steps
1. Open the Friends panel. Chat hides.
2. Look for a friend that is online and click on the Jump In button for that user. Your avatar teleports.
3. After teleporting, the Friends panel should be hidden and the chat should be visible.