### PR TITLE
fix: crash when taking screenshots on low resolutions

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Playground/ScreenRecorderTester.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Playground/ScreenRecorderTester.cs
@@ -43,9 +43,9 @@ namespace DCL.InWorldCamera.Playground
         [ContextMenu(nameof(Screenshot))]
         private IEnumerator Screenshot()
         {
-            recorder ??= new ScreenRecorder(canvasRectTransform, new GPUInstancingService(null));
+            recorder ??= new ScreenRecorder(canvasRectTransform);
 
-            StartCoroutine(recorder.CaptureScreenshot(Camera.main));
+            StartCoroutine(recorder.CaptureScreenshot());
             yield return GameObjectExtensions.WAIT_FOR_END_OF_FRAME;
 
             Texture = recorder.GetScreenshotAndReset();

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/ScreenRecorder.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/ScreenRecorder.cs
@@ -65,24 +65,46 @@ namespace DCL.InWorldCamera
             int roundedUpscale = Mathf.CeilToInt(targetRescale);
             ScreenFrameData rescaledScreenFrame = CalculateRoundRescaledScreenFrame(currentScreenFrame, roundedUpscale);
 
-            // Workaround to fix roads appearance on the screenshot (since they are rendered indirectly).
-            // TODO (Vit): Remove this workaround when GPU Instancing is moved to the RenderFeature approach.
-            RenderTexture rt = RenderTexture.GetTemporary((int)rescaledScreenFrame.ScreenWidth, (int)currentScreenFrame.ScreenHeight, 24, RenderTextureFormat.ARGB32);
-            RenderTexture previousCamRT = camera.targetTexture;
-            camera.targetTexture = rt;
+            Texture2D screenshotTexture = ScreenCapture.CaptureScreenshotAsTexture(1); // upscaled Screen Frame resolution
 
-            gpuInstancingService.RenderIndirect();
-            camera.Render();
-
-            Texture2D screenshotTexture = ScreenCapture.CaptureScreenshotAsTexture(roundedUpscale); // upscaled Screen Frame resolution
+            screenshotTexture = UpscaleTexture2D(screenshotTexture, roundedUpscale);
             screenshotTexture = CropTexture2D(screenshotTexture, rescaledScreenFrame.CalculateFrameCorners(), rescaledScreenFrame.FrameWidthInt, rescaledScreenFrame.FrameHeightInt);
             ResizeTexture2D(screenshotTexture);
 
             Object.Destroy(screenshotTexture);
-            RenderTexture.ReleaseTemporary(rt);
-            camera.targetTexture = previousCamRT;
+
 
             State = RecordingState.SCREENSHOT_READY;
+        }
+
+        private Texture2D UpscaleTexture2D(Texture2D sourceTexture, int upscaleFactor)
+        {
+            if (upscaleFactor <= 1)
+                return sourceTexture;
+
+            int targetWidth = sourceTexture.width * upscaleFactor;
+            int targetHeight = sourceTexture.height * upscaleFactor;
+
+            var rt = RenderTexture.GetTemporary(targetWidth, targetHeight, 0, RenderTextureFormat.Default, RenderTextureReadWrite.sRGB);
+            RenderTexture.active = rt;
+
+            // Graphics.Blit uses the source texture's filterMode. Ensure it's Bilinear for smooth scaling (default for Texture2D).
+            Graphics.Blit(sourceTexture, rt);
+
+            // Create the result texture: no mipmaps, and ensure it's sRGB (linear=false).
+            // Use the source format for consistency.
+            var result = new Texture2D(targetWidth, targetHeight, sourceTexture.format, /*mipChain:*/ false, /*linear:*/ false);
+            result.ReadPixels(new Rect(0, 0, targetWidth, targetHeight), 0, 0);
+            result.Apply( /*updateMipmaps:*/ false);
+
+            // Cleanup
+            RenderTexture.active = null;
+            RenderTexture.ReleaseTemporary(rt);
+
+            // Destroy the original source texture as we are returning a new one
+            Object.Destroy(sourceTexture);
+
+            return result;
         }
 
         public Texture2D GetScreenshotAndReset()
@@ -107,7 +129,7 @@ namespace DCL.InWorldCamera
 
         private void ResizeTexture2D(Texture originalTexture)
         {
-            var renderTexture = RenderTexture.GetTemporary(TARGET_FRAME_WIDTH, TARGET_FRAME_HEIGHT, 0);
+            var renderTexture = RenderTexture.GetTemporary(TARGET_FRAME_WIDTH, TARGET_FRAME_HEIGHT, 0, RenderTextureFormat.Default, RenderTextureReadWrite.sRGB);
             RenderTexture.active = renderTexture;
 
             // Copy and scale the original texture into the RenderTexture

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/ScreenRecorder.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/ScreenRecorder.cs
@@ -65,13 +65,17 @@ namespace DCL.InWorldCamera
             int roundedUpscale = Mathf.CeilToInt(targetRescale);
             ScreenFrameData rescaledScreenFrame = CalculateRoundRescaledScreenFrame(currentScreenFrame, roundedUpscale);
 
-            Texture2D screenshotTexture = ScreenCapture.CaptureScreenshotAsTexture(1); // upscaled Screen Frame resolution
+            Texture2D screenshotTexture = ScreenCapture.CaptureScreenshotAsTexture(); // upscaled Screen Frame resolution
 
-            screenshotTexture = UpscaleTexture2D(screenshotTexture, roundedUpscale);
-            screenshotTexture = CropTexture2D(screenshotTexture, rescaledScreenFrame.CalculateFrameCorners(), rescaledScreenFrame.FrameWidthInt, rescaledScreenFrame.FrameHeightInt);
-            ResizeTexture2D(screenshotTexture);
+            var newScreenShot = new Texture2D(Screen.width, Screen.height, TextureFormat.RGB24, false);
+            newScreenShot.SetPixels(screenshotTexture.GetPixels());
+            newScreenShot.Apply();
 
-            Object.Destroy(screenshotTexture);
+            newScreenShot = UpscaleTexture2D(newScreenShot, roundedUpscale);
+            newScreenShot = CropTexture2D(newScreenShot, rescaledScreenFrame.CalculateFrameCorners(), rescaledScreenFrame.FrameWidthInt, rescaledScreenFrame.FrameHeightInt);
+            ResizeTexture2D(newScreenShot);
+
+            Object.Destroy(newScreenShot);
 
 
             State = RecordingState.SCREENSHOT_READY;

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/ScreenRecorder.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/ScreenRecorder.cs
@@ -86,10 +86,12 @@ namespace DCL.InWorldCamera
             if (upscaleFactor <= 1)
                 return sourceTexture;
 
+            sourceTexture.filterMode = FilterMode.Bilinear;
             int targetWidth = sourceTexture.width * upscaleFactor;
             int targetHeight = sourceTexture.height * upscaleFactor;
 
             var rt = RenderTexture.GetTemporary(targetWidth, targetHeight, 0, RenderTextureFormat.Default, RenderTextureReadWrite.sRGB);
+            rt.filterMode = FilterMode.Bilinear;
             RenderTexture.active = rt;
 
             // Graphics.Blit uses the source texture's filterMode. Ensure it's Bilinear for smooth scaling (default for Texture2D).

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/ScreenRecorder.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/ScreenRecorder.cs
@@ -26,7 +26,6 @@ namespace DCL.InWorldCamera
 
         private readonly float targetAspectRatio;
         private readonly RectTransform canvasRectTransform;
-        private readonly GPUInstancingService gpuInstancingService;
 
         private readonly Texture2D screenshot = new (TARGET_FRAME_WIDTH, TARGET_FRAME_HEIGHT, TextureFormat.RGB24, false);
 
@@ -36,13 +35,12 @@ namespace DCL.InWorldCamera
 
         public RecordingState State { get; private set; } = RecordingState.IDLE;
 
-        public ScreenRecorder(RectTransform canvasRectTransform, GPUInstancingService gpuInstancingService)
+        public ScreenRecorder(RectTransform canvasRectTransform)
         {
             targetAspectRatio = (float)TARGET_FRAME_WIDTH / TARGET_FRAME_HEIGHT;
             Debug.Assert(targetAspectRatio != 0, "Target aspect ratio cannot be zero");
 
             this.canvasRectTransform = canvasRectTransform;
-            this.gpuInstancingService = gpuInstancingService;
         }
 
         public void Dispose()
@@ -54,7 +52,7 @@ namespace DCL.InWorldCamera
                 RenderTexture.ReleaseTemporary(originalBaseTargetTexture);
         }
 
-        public IEnumerator CaptureScreenshot(Camera camera)
+        public IEnumerator CaptureScreenshot()
         {
             State = RecordingState.CAPTURING;
 

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/CaptureScreenshotSystem.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/CaptureScreenshotSystem.cs
@@ -33,7 +33,6 @@ namespace DCL.InWorldCamera.Systems
         private readonly ICoroutineRunner coroutineRunner;
         private readonly ICameraReelStorageService cameraReelStorageService;
         private readonly InWorldCameraController hudController;
-        private readonly ExposedCameraData exposedCameraData;
         private readonly CancellationTokenSource ctx;
         private readonly Entity playerEntity;
 
@@ -49,8 +48,7 @@ namespace DCL.InWorldCamera.Systems
             ScreenshotMetadataBuilder metadataBuilder,
             ICoroutineRunner coroutineRunner,
             ICameraReelStorageService cameraReelStorageService,
-            InWorldCameraController hudController,
-            ExposedCameraData exposedCameraData)
+            InWorldCameraController hudController)
             : base(world)
         {
             this.recorder = recorder;
@@ -59,7 +57,6 @@ namespace DCL.InWorldCamera.Systems
             this.coroutineRunner = coroutineRunner;
             this.cameraReelStorageService = cameraReelStorageService;
             this.hudController = hudController;
-            this.exposedCameraData = exposedCameraData;
 
             ctx = new CancellationTokenSource();
         }
@@ -85,10 +82,10 @@ namespace DCL.InWorldCamera.Systems
                 return;
             }
 
-            if (ScreenshotIsRequested() && exposedCameraData.CinemachineBrain.OutputCamera != null&& cameraReelStorageService.StorageStatus.HasFreeSpace)
+            if (ScreenshotIsRequested() && cameraReelStorageService.StorageStatus.HasFreeSpace)
             {
                 hudController.SetViewCanvasActive(false);
-                coroutineRunner.StartCoroutine(recorder.CaptureScreenshot(exposedCameraData.CinemachineBrain.OutputCamera));
+                coroutineRunner.StartCoroutine(recorder.CaptureScreenshot());
                 CollectMetadata();
             }
         }

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
@@ -76,8 +76,6 @@ namespace DCL.PluginSystem.Global
         private readonly IDebugContainerBuilder debugContainerBuilder;
         private readonly NametagsData nametagsData;
         private readonly ViewDependencies viewDependencies;
-        private readonly GPUInstancingService gpuInstancingBuffers;
-        private readonly ExposedCameraData exposedCameraData;
         private readonly ISharedSpaceManager sharedSpaceManager;
         private readonly IWeb3IdentityCache web3IdentityCache;
 
@@ -103,8 +101,6 @@ namespace DCL.PluginSystem.Global
             IDebugContainerBuilder debugContainerBuilder,
             NametagsData nametagsData,
             ViewDependencies viewDependencies,
-            GPUInstancingService gpuInstancingBuffers,
-            ExposedCameraData exposedCameraData,
             ISharedSpaceManager sharedSpaceManager,
             IWeb3IdentityCache web3IdentityCache)
         {
@@ -134,8 +130,6 @@ namespace DCL.PluginSystem.Global
             this.debugContainerBuilder = debugContainerBuilder;
             this.nametagsData = nametagsData;
             this.viewDependencies = viewDependencies;
-            this.gpuInstancingBuffers = gpuInstancingBuffers;
-            this.exposedCameraData = exposedCameraData;
             this.sharedSpaceManager = sharedSpaceManager;
             this.web3IdentityCache = web3IdentityCache;
 
@@ -155,7 +149,7 @@ namespace DCL.PluginSystem.Global
             hud = factory.CreateScreencaptureHud(settings.ScreencaptureHud);
             followTarget = factory.CreateFollowTarget(settings.FollowTarget);
 
-            recorder = new ScreenRecorder(hud.GetComponent<RectTransform>(), gpuInstancingBuffers);
+            recorder = new ScreenRecorder(hud.GetComponent<RectTransform>());
             metadataBuilder = new ScreenshotMetadataBuilder(selfProfile, characterObject.Controller, realmData, placesAPIService);
 
             PhotoDetailView photoDetailViewAsset = (await assetsProvisioner.ProvideMainAssetValueAsync(settings.PhotoDetailPrefab, ct: ct)).GetComponent<PhotoDetailView>();
@@ -199,7 +193,7 @@ namespace DCL.PluginSystem.Global
             ToggleInWorldCameraActivitySystem.InjectToWorld(ref builder, settings.TransitionSettings, inWorldCameraController, followTarget, debugContainerBuilder, cursor, input.InWorldCamera, nametagsData);
             EmitInWorldCameraInputSystem.InjectToWorld(ref builder, input.InWorldCamera);
             MoveInWorldCameraSystem.InjectToWorld(ref builder, settings.MovementSettings, characterObject.Controller.transform, cursor);
-            CaptureScreenshotSystem.InjectToWorld(ref builder, recorder, playerEntity, metadataBuilder, coroutineRunner, cameraReelStorageService, inWorldCameraController, exposedCameraData);
+            CaptureScreenshotSystem.InjectToWorld(ref builder, recorder, playerEntity, metadataBuilder, coroutineRunner, cameraReelStorageService, inWorldCameraController);
 
             CleanupScreencaptureCameraSystem.InjectToWorld(ref builder);
         }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -836,8 +836,6 @@ namespace Global.Dynamic
                     debugBuilder,
                     nametagsData,
                     viewDependencies,
-                    staticContainer.GPUInstancingService,
-                    exposedGlobalDataContainer.ExposedCameraData,
                     sharedSpaceManager,
                     identityCache));
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fixes #3715. 

The crash occured in Mac when using low resolutions. This resorts the code to avoid it, while keeping the roads visible

## Test Instructions


### Test Steps
1. Go to a scene with roads
2. Take screenshots on all avialable resolutions. You shouldnt get the crash
3. Download the screenshots. They should all be 1920x1080. Screenshots from higher resolutions should have crisper images



## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
