### PR TITLE
Feat/3242 respect fixed time in worlds

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -715,7 +715,7 @@ namespace Global.Dynamic
                 new CharacterPreviewPlugin(staticContainer.ComponentsContainer.ComponentPoolsRegistry, assetsProvisioner, staticContainer.CacheCleaner),
                 new WebRequestsPlugin(staticContainer.WebRequestsContainer.AnalyticsContainer, debugBuilder),
                 new Web3AuthenticationPlugin(assetsProvisioner, dynamicWorldDependencies.Web3Authenticator, debugBuilder, mvcManager, selfProfile, webBrowser, staticContainer.RealmData, identityCache, characterPreviewFactory, dynamicWorldDependencies.SplashScreen, audioMixerVolumesController, staticContainer.FeatureFlagsCache, characterPreviewEventBus, globalWorld),
-                new StylizedSkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, debugBuilder, staticContainer.FeatureFlagsCache),
+                new StylizedSkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, debugBuilder, staticContainer.FeatureFlagsCache,staticContainer.ScenesCache,staticContainer.RealmData),
                 new LoadingScreenPlugin(assetsProvisioner, mvcManager, audioMixerVolumesController,
                     staticContainer.InputBlock, debugBuilder, staticContainer.LoadingStatus),
                 new ExternalUrlPromptPlugin(assetsProvisioner, webBrowser, mvcManager, dclCursor),

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -715,7 +715,7 @@ namespace Global.Dynamic
                 new CharacterPreviewPlugin(staticContainer.ComponentsContainer.ComponentPoolsRegistry, assetsProvisioner, staticContainer.CacheCleaner),
                 new WebRequestsPlugin(staticContainer.WebRequestsContainer.AnalyticsContainer, debugBuilder),
                 new Web3AuthenticationPlugin(assetsProvisioner, dynamicWorldDependencies.Web3Authenticator, debugBuilder, mvcManager, selfProfile, webBrowser, staticContainer.RealmData, identityCache, characterPreviewFactory, dynamicWorldDependencies.SplashScreen, audioMixerVolumesController, staticContainer.FeatureFlagsCache, characterPreviewEventBus, globalWorld),
-                new StylizedSkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, debugBuilder, staticContainer.FeatureFlagsCache,staticContainer.ScenesCache,staticContainer.RealmData),
+                new StylizedSkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, debugBuilder, staticContainer.FeatureFlagsCache,staticContainer.ScenesCache),
                 new LoadingScreenPlugin(assetsProvisioner, mvcManager, audioMixerVolumesController,
                     staticContainer.InputBlock, debugBuilder, staticContainer.LoadingStatus),
                 new ExternalUrlPromptPlugin(assetsProvisioner, webBrowser, mvcManager, dclCursor),

--- a/Explorer/Assets/DCL/Ipfs/SceneMetadata.cs
+++ b/Explorer/Assets/DCL/Ipfs/SceneMetadata.cs
@@ -15,7 +15,8 @@ namespace DCL.Ipfs
         public List<string> requiredPermissions;
         public List<SpawnPoint>? spawnPoints;
         public bool isPortableExperience;
-
+        public WorldConfiguration? worldConfiguration;
+        
         [JsonIgnore]
         public string OriginalJson { get; set; }
 
@@ -49,6 +50,58 @@ namespace DCL.Ipfs
                 public float? SingleValue { get; internal set; }
                 public float[]? MultiValue { get; internal set; }
             }
+        }
+
+        /// <summary>
+        /// Configuration specific to Decentraland Worlds (Realms).
+        /// {
+        ///     "worldConfiguration": {
+        ///     "name": "my-name.dcl.eth",
+        ///     "skyboxConfig": {
+        ///         "fixedTime": 36000
+        ///     },
+        ///     "fixedAdapter": "offline:offline"
+        /// }
+        /// 
+        /// skyboxConfig.fixedTime: This property indicates how many
+        /// seconds have passed (in Decentraland time) since the start of the day,
+        /// assuming the full cycle lasts 24 hours. Divide the seconds value by 60 to obtain minutes,
+        /// and by 60 again to obtain the hours since the start of the day.
+        /// For example, if the seconds value is 36000, it corresponds to 10:00 am.
+        /// If no value is set for this field, the world will follow the same day/night cycle as Genesis City.
+        /// 
+        /// NOTE: more about the setup: https://docs.decentraland.org/creator/worlds/about/
+        /// </summary>
+        [Serializable]
+        public class WorldConfiguration
+        {
+            /// <summary>
+            /// The unique name of the world (e.g., an ENS name).
+            /// </summary>
+            public string? Name { get; set; }
+
+            /// <summary>
+            /// Configuration for the world's skybox.
+            /// </summary>
+            public SkyboxConfig? SkyboxConfig { get; set; }
+            
+            /// <summary>
+            /// Specifies the adapter used for scene deployment or loading (e.g., "offline:offline").
+            /// </summary>
+            public string? FixedAdapter { get; set; }
+        }
+
+        /// <summary>
+        /// Defines settings for the world's skybox.
+        /// </summary>
+        [Serializable]
+        public class SkyboxConfig
+        {
+            /// <summary>
+            /// A fixed time value (potentially in seconds or another unit) for the skybox visuals.
+            /// Null if not fixed.
+            /// </summary>
+            public float? FixedTime { get; set; }
         }
     }
 }

--- a/Explorer/Assets/DCL/Ipfs/SceneMetadata.cs
+++ b/Explorer/Assets/DCL/Ipfs/SceneMetadata.cs
@@ -17,6 +17,13 @@ namespace DCL.Ipfs
         public bool isPortableExperience;
         public WorldConfiguration? worldConfiguration;
         
+        /// <summary>
+        /// Is time set to be fixed in this scene?
+        /// </summary>
+        [JsonIgnore]
+        public bool IsTimeFixed
+            => worldConfiguration?.SkyboxConfig?.FixedTime.HasValue == true;
+        
         [JsonIgnore]
         public string OriginalJson { get; set; }
 

--- a/Explorer/Assets/DCL/StylizedSkybox/Scripts/Plugin/StylizedSkyboxPlugin.cs
+++ b/Explorer/Assets/DCL/StylizedSkybox/Scripts/Plugin/StylizedSkyboxPlugin.cs
@@ -9,6 +9,10 @@ using DCL.PluginSystem;
 using DCL.PluginSystem.Global;
 using System;
 using System.Threading;
+using DCL.Utilities;
+using ECS;
+using ECS.SceneLifeCycle;
+using SceneRunner.Scene;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -22,41 +26,94 @@ namespace DCL.StylizedSkybox.Scripts.Plugin
         private SkyboxController? skyboxController;
         private readonly ElementBinding<float> timeOfDay;
         private readonly FeatureFlagsCache featureFlagsCache;
-
+        private readonly IScenesCache scenesCache;
         private StylizedSkyboxSettingsAsset? settingsAsset;
+        private IRealmData? realmData;
 
+        private IDisposable onRealmTypeUpdateSubscription;
+        
         public StylizedSkyboxPlugin(
             IAssetsProvisioner assetsProvisioner,
             Light directionalLight,
             IDebugContainerBuilder debugContainerBuilder,
-            FeatureFlagsCache featureFlagsCache
-        )
+            FeatureFlagsCache featureFlagsCache,
+            IScenesCache scenesCache,
+            IRealmData? realmData)
         {
             timeOfDay = new ElementBinding<float>(0);
             this.assetsProvisioner = assetsProvisioner;
             this.directionalLight = directionalLight;
             this.debugContainerBuilder = debugContainerBuilder;
             this.featureFlagsCache = featureFlagsCache;
+            this.scenesCache = scenesCache;
+            this.realmData = realmData;
         }
-
-        public void Dispose() { }
-
+        
         public void InjectToWorld(ref ArchSystemsWorldBuilder<World> builder, in GlobalPluginArguments arguments) { }
-
+        
         public async UniTask InitializeAsync(StylizedSkyboxSettings settings, CancellationToken ct)
         {
             settingsAsset = settings.SettingsAsset;
+            
+            skyboxController = Object.Instantiate((await assetsProvisioner
+                .ProvideMainAssetAsync(settingsAsset.StylizedSkyboxPrefab, ct: ct))
+                .Value
+                .GetComponent<SkyboxController>());
+            
+            AnimationClip skyboxAnimation = (await assetsProvisioner
+                .ProvideMainAssetAsync(settingsAsset.SkyboxAnimationCycle, ct: ct))
+                .Value;
 
-            skyboxController = Object.Instantiate((await assetsProvisioner.ProvideMainAssetAsync(settingsAsset.StylizedSkyboxPrefab, ct: ct)).Value.GetComponent<SkyboxController>());
-            AnimationClip skyboxAnimation = (await assetsProvisioner.ProvideMainAssetAsync(settingsAsset.SkyboxAnimationCycle, ct: ct)).Value;
+            skyboxController.Initialize(
+                settingsAsset.SkyboxMaterial,
+                directionalLight,
+                skyboxAnimation,
+                featureFlagsCache,
+                settingsAsset);
 
-            skyboxController.Initialize(settingsAsset.SkyboxMaterial, directionalLight, skyboxAnimation, featureFlagsCache, settingsAsset);
-
+            if (realmData != null)
+                onRealmTypeUpdateSubscription = realmData.RealmType.Subscribe(OnRealmUpdate);
+            
+            
             debugContainerBuilder.TryAddWidget("Skybox")
                                 ?.AddSingleButton("Play", () => skyboxController.UseDynamicTime = true)
                                  .AddSingleButton("Pause", () => skyboxController.UseDynamicTime = false)
                                  .AddFloatSliderField("Time", timeOfDay, 0, 1)
                                  .AddSingleButton("SetTime", () => skyboxController.SetTimeOverride(timeOfDay.Value)); //TODO: replace this by a system to update the value
+        }
+
+        private void OnRealmUpdate(RealmKind kind)
+        {
+            Debug.Log("Realm updated to " + kind);
+            // NOTE: only use fixedTime if the realm is world
+            // NOTE or a local scene it can be world and local scene at the same time?
+            if (realmData?.RealmType.Value is 
+                RealmKind.World or
+                RealmKind.LocalScene)
+                
+                scenesCache.OnCurrentSceneChanged += HandleSceneChanged;
+        }
+        
+        private void HandleSceneChanged(ISceneFacade? scene)
+        {
+            if (scene == null) return;
+            
+            var meta = scene.SceneData.SceneEntityDefinition.metadata;
+            if (meta.IsTimeFixed)
+            {
+                float secs = meta.worldConfiguration!.SkyboxConfig!.FixedTime!.Value;
+                if (settingsAsset != null)
+                {
+                    settingsAsset.FixedTime = secs;
+                    settingsAsset.UseDynamicTime = false;
+                }
+            }
+        }
+        
+        public void Dispose()
+        {
+            scenesCache.OnCurrentSceneChanged -= HandleSceneChanged;
+            onRealmTypeUpdateSubscription?.Dispose();
         }
 
         [Serializable]

--- a/Explorer/Assets/DCL/StylizedSkybox/Scripts/SkyboxController.cs
+++ b/Explorer/Assets/DCL/StylizedSkybox/Scripts/SkyboxController.cs
@@ -1,7 +1,6 @@
 using DCL.Diagnostics;
 using DCL.FeatureFlags;
 using DCL.StylizedSkybox.Scripts;
-using System;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -98,9 +97,17 @@ public class SkyboxController : MonoBehaviour
                 sinceLastRefresh = 0;
             }
         }
+        else
+        {
+            UpdateSkybox();
+        }
     }
 
-    public void Initialize(Material skyboxMat, Light dirLight, AnimationClip skyboxAnimationClip, FeatureFlagsCache featureFlagsCache, StylizedSkyboxSettingsAsset settingsAsset)
+    public void Initialize(Material skyboxMat, 
+        Light dirLight, 
+        AnimationClip skyboxAnimationClip, 
+        FeatureFlagsCache featureFlagsCache, 
+        StylizedSkyboxSettingsAsset settingsAsset)
     {
         this.settingsAsset = settingsAsset;
 
@@ -160,14 +167,33 @@ public class SkyboxController : MonoBehaviour
         }
         else { DynamicTimeNormalized = DEFAULT_TIME; }
 
-        settingsAsset.NormalizedTime =DynamicTimeNormalized;
+        settingsAsset.NormalizedTime = DynamicTimeNormalized;
         settingsAsset.NormalizedTimeChanged += OnNormalizedTimeChanged;
         settingsAsset.UseDynamicTime = UseDynamicTime;
         settingsAsset.UseDynamicTimeChanged += OnUseDynamicTimeChanged;
-
+        //settingsAsset.UseFixedTime = UseFixedTime;
         isInitialized = true;
     }
 
+    /// <summary>
+    /// Switches off dynamic cycling and jumps straight to the given fixed time (in seconds).
+    /// </summary>
+    public void SetFixedTimeSeconds(float seconds)
+    {
+        float normalized = seconds / SECONDS_IN_DAY;
+        SetTimeOverride(normalized);
+    }
+    
+    /// <summary>
+    /// Switches off dynamic cycling and jumps straight to the given normalized time (0–1).
+    /// </summary>
+    public void SetFixedTimeNormalized(float normalized)
+    {
+        UseDynamicTime = false;
+        SetTimeOverride(normalized);
+    }
+
+    
     private void OnSkyboxUpdated()
     {
         // When skybox gets dynamically updated we refresh the
@@ -185,6 +211,8 @@ public class SkyboxController : MonoBehaviour
 
         if (dynamic)
             settingsAsset!.NormalizedTime = DynamicTimeNormalized;
+        else
+            SetFixedTimeSeconds(settingsAsset.FixedTime);
     }
 
     private void OnNormalizedTimeChanged(float tod)

--- a/Explorer/Assets/DCL/StylizedSkybox/Scripts/StylizedSkyboxSettingsAsset.cs
+++ b/Explorer/Assets/DCL/StylizedSkybox/Scripts/StylizedSkyboxSettingsAsset.cs
@@ -8,14 +8,16 @@ namespace DCL.StylizedSkybox.Scripts
     [CreateAssetMenu(menuName = "DCL/SO/Stylized Skybox Settings", fileName = "StylizedSkyboxSettings")]
     public class StylizedSkyboxSettingsAsset : ScriptableObject
     {
+        public int SECONDS_IN_DAY = 86400;
+        
         public StylizedSkyboxControllerRef StylizedSkyboxPrefab = null!;
         public Material SkyboxMaterial = null!;
         public AssetReferenceT<AnimationClip> SkyboxAnimationCycle = null!;
-
         public event Action<float> NormalizedTimeChanged;
         public event Action<bool> UseDynamicTimeChanged;
-
-        public float FixedTime { get; set; }
+        public float FixedTime { get; private set; }
+        public bool IsFixedTime { get; private set; }
+        
         private float normalizedTime;
 
         public float NormalizedTime
@@ -32,7 +34,6 @@ namespace DCL.StylizedSkybox.Scripts
         }
 
         private bool useDynamicTime = true;
-
         public bool UseDynamicTime
         {
             get => useDynamicTime;
@@ -44,6 +45,25 @@ namespace DCL.StylizedSkybox.Scripts
                 useDynamicTime = value;
                 UseDynamicTimeChanged?.Invoke(value);
             }
+        }
+        
+        /// <summary>
+        /// Configures a fixed skybox time.
+        /// </summary>
+        public void ApplyFixedTime(float secondsOfDay)
+        {
+            FixedTime = secondsOfDay;
+            IsFixedTime = true;
+            UseDynamicTime = false;
+        }
+
+        /// <summary>
+        /// Switches back to dynamic (real-time) skybox cycling.
+        /// </summary>
+        public void ApplyDynamicTime()
+        {
+            IsFixedTime = false;
+            UseDynamicTime = true;
         }
 
         [Serializable]

--- a/Explorer/Assets/DCL/StylizedSkybox/Scripts/StylizedSkyboxSettingsAsset.cs
+++ b/Explorer/Assets/DCL/StylizedSkybox/Scripts/StylizedSkyboxSettingsAsset.cs
@@ -15,6 +15,7 @@ namespace DCL.StylizedSkybox.Scripts
         public event Action<float> NormalizedTimeChanged;
         public event Action<bool> UseDynamicTimeChanged;
 
+        public float FixedTime { get; set; }
         private float normalizedTime;
 
         public float NormalizedTime

--- a/Explorer/Assets/DCL/UI/Sidebar/SkyboxMenuView.prefab
+++ b/Explorer/Assets/DCL/UI/Sidebar/SkyboxMenuView.prefab
@@ -1130,6 +1130,7 @@ MonoBehaviour:
   <canvas>k__BackingField: {fileID: 1326869274718830892}
   <raycaster>k__BackingField: {fileID: 1000022871862360222}
   <viewAnimationElement>k__BackingField: {fileID: 2099558127564310200}
+  <ToggleView>k__BackingField: {fileID: 4371132422882648884}
   <DynamicToggle>k__BackingField: {fileID: 6409291411393466949}
   <TimeSlider>k__BackingField: {fileID: 7213994172632849929}
   <TimeText>k__BackingField: {fileID: 283481863282831205}
@@ -1454,6 +1455,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+--- !u!114 &4371132422882648884 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 977034302134673057, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+  m_PrefabInstance: {fileID: 3541656983000530325}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 822ef88491b0c4b3982153e7574be1fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &6409291411393466949 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7625753975028379600, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}

--- a/Explorer/Assets/DCL/UI/Skybox/SkyboxMenuView.cs
+++ b/Explorer/Assets/DCL/UI/Skybox/SkyboxMenuView.cs
@@ -7,7 +7,6 @@ namespace DCL.UI.Skybox
 {
     public class SkyboxMenuView: ViewBaseWithAnimationElement, IView
     {
-        [field: SerializeField] public ToggleView ToggleView { get; private set; } = null!;
         [field: SerializeField] public Toggle DynamicToggle { get; private set; } = null!;
         [field: SerializeField] public Slider TimeSlider { get; private set; } = null!;
         [field: SerializeField] public TMP_Text TimeText { get; private set; } = null!;

--- a/Explorer/Assets/DCL/UI/Skybox/SkyboxMenuView.cs
+++ b/Explorer/Assets/DCL/UI/Skybox/SkyboxMenuView.cs
@@ -7,6 +7,7 @@ namespace DCL.UI.Skybox
 {
     public class SkyboxMenuView: ViewBaseWithAnimationElement, IView
     {
+        [field: SerializeField] public ToggleView ToggleView { get; private set; } = null!;
         [field: SerializeField] public Toggle DynamicToggle { get; private set; } = null!;
         [field: SerializeField] public Slider TimeSlider { get; private set; } = null!;
         [field: SerializeField] public TMP_Text TimeText { get; private set; } = null!;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
- **Closes** #3242
- Adds support for honoring fixedTime in worldConfiguration.skyboxConfig when loading a world scene.
- Disables skybox controls in the UI whenever a fixed time is specified.

## Test Instructions

### Prerequisites
- [x] Edit scene.json to add fixedTime setting
```
"worldConfiguration": {
    "skyboxConfig": {
      "fixedTime": 82000
    }
  }
```

### Test Steps
1. Launch scene with your modified scene.json.
2. **Verify fixed time application**
    - On load, the skybox’s time is set to 82000 seconds (≈ 22:46) rather than real-time.
3. **Inspect  UI behaviour**
    - Open the Skybox menu — confirm that both the time slider and “Dynamic Time” toggle are disabled.
4. **Fallback to dynamic**
    - Load a scene without fixedTime (e.g., Genesis Plaza).
    - Verify the skybox cycles normally and the UI controls are enabled.

**NOTE**: this was tested on the local scene, switching back to Genesis City properly handles skybox
 
## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
