### PR TITLE
fix: retry fetch the stream

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
@@ -8,6 +8,7 @@ using LiveKit.Rooms.TrackPublications;
 using LiveKit.Rooms.VideoStreaming;
 using System;
 using UnityEngine;
+using UnityEngine.Assertions.Must;
 using UnityEngine.Pool;
 
 namespace DCL.SDKComponents.MediaStream
@@ -125,6 +126,10 @@ namespace DCL.SDKComponents.MediaStream
         {
             if (playerState is not PlayerState.PLAYING)
                 return null;
+
+            // retry to fetch the stream if it's not presented yet
+            if (playingAddress != null && currentStream?.video == null)
+                OpenMedia(playingAddress.Value);
 
             return currentStream?.video?.TryGetTarget(out var videoStream) ?? false
                 ? videoStream.DecodeLastFrame()

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
@@ -8,7 +8,6 @@ using LiveKit.Rooms.TrackPublications;
 using LiveKit.Rooms.VideoStreaming;
 using System;
 using UnityEngine;
-using UnityEngine.Assertions.Must;
 using UnityEngine.Pool;
 
 namespace DCL.SDKComponents.MediaStream


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Fix for the issue described in this ticket https://github.com/decentraland/unity-explorer/issues/4076

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Go to your streaming scene, I should not see any stream
2. Launch your stream from OBS after you reach the scene
3. The stream should appear on the screen normally

## Quality Checklist
- [+] Changes have been tested locally
- [+] Performance impact has been considered

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
