### PR TITLE
Chore: Enable IL2CPP stack trace information in builds

### DIFF
--- a/Explorer/ProjectSettings/ProjectSettings.asset
+++ b/Explorer/ProjectSettings/ProjectSettings.asset
@@ -904,7 +904,8 @@ PlayerSettings:
   il2cppCompilerConfiguration: {}
   il2cppCodeGeneration:
     Standalone: 1
-  il2cppStacktraceInformation: {}
+  il2cppStacktraceInformation:
+    Standalone: 1
   managedStrippingLevel:
     EmbeddedLinux: 1
     GameCoreScarlett: 1


### PR DESCRIPTION
Unity 6 brought support for line numbers in IL2CPP builds

https://docs.unity3d.com/6000.0/Documentation/Manual/il2cpp-managed-stack-traces.html