### PR TITLE
fix: The scene card reamins visible after re-opening the navmap

### DIFF
--- a/Explorer/Assets/DCL/Navmap/NavmapController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapController.cs
@@ -222,6 +222,7 @@ namespace DCL.Navmap
             zoomController.Deactivate();
             cameraController?.Release(this);
             navmapBus.ClearHistory();
+            searchBarController.ClearInput();
         }
 
         public void Animate(int triggerId)


### PR DESCRIPTION
# Pull Request Description
Fix #3263 

## What does this PR change?
When we select any location in the map, an info card opens. If the map was closed and reopened, the card remained visible. This fix makes it to be closed the card when reopening the map.

![image](https://github.com/user-attachments/assets/da680036-15cc-4ba4-b348-9b321fbdb3a6)

### Test Steps
1. Open the Map.
2. Select any Scene on the map.
3. The card opens in the right side of the sscreen.
4. Close the Map with the card still open.
5. Reopen the Map.
6. Check that the card is closed.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
