### PR TITLE
fix: Modify the link for Marketplace Credits feature info

### DIFF
--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
@@ -24,7 +24,7 @@ namespace DCL.MarketplaceCredits
 {
     public partial class MarketplaceCreditsMenuController : ControllerBase<MarketplaceCreditsMenuView, MarketplaceCreditsMenuController.Params>, IControllerInSharedSpace<MarketplaceCreditsMenuView, MarketplaceCreditsMenuController.Params>
     {
-        public const string WEEKLY_REWARDS_INFO_LINK = "https://decentraland.org/blog/announcements/marketplace-credits-earn-weekly-rewards-to-power-up-your-look";
+        public const string WEEKLY_REWARDS_INFO_LINK = "https://decentraland.org/blog/announcements/marketplace-credits-earn-weekly-rewards-to-power-up-your-look?utm_org=dcl&utm_source=explorer&utm_medium=organic&utm_campaign=marketplacecredits";
         private const int ERROR_NOTIFICATION_DURATION_MS = 3000;
 
         public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Popup;


### PR DESCRIPTION
# Pull Request Description
Fix #4102 

## What does this PR change?
Modify the link for the info button in the Marketplace Credits panel.

**NEW LINK**: https://decentraland.org/blog/announcements/marketplace-credits-earn-weekly-rewards-to-power-up-your-look

### Test Steps
1. Open the MC panel.
2. Click on the info button by the main title.
3. Check that it redirects you to: https://decentraland.org/blog/announcements/marketplace-credits-earn-weekly-rewards-to-power-up-your-look
4. In the welcome screen (when you're not still registered in the Program), the LEARN MORE link must also redirects to the same link.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.