### PR TITLE
fix: photo detail wearable list loading spinner not spinning

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/VisiblePersonEntry.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/VisiblePersonEntry.prefab
@@ -1111,6 +1111,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: LoadingSpinner
       objectReference: {fileID: 0}
+    - target: {fileID: 3817016671180041992, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []


### PR DESCRIPTION
# Pull Request Description

Fixes #4104

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Deactivates the `maskable` option from the spinner image so that the right shader is applied in order to show the animation.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Open the photo details of a reel
2. Open the wearable list of a person
3. Verify that the loading spinner is spinning

### Additional Testing Notes
- In current version the spinner is not spinning

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
