### PR TITLE
fix: Make the max range of the skybox time slider is 23:59 instead of 24:00

### DIFF
--- a/Explorer/Assets/DCL/UI/Skybox/SkyboxMenuController.cs
+++ b/Explorer/Assets/DCL/UI/Skybox/SkyboxMenuController.cs
@@ -90,7 +90,8 @@ namespace DCL.UI.Skybox
 
         private string GetFormatedTime(float time)
         {
-            var totalSec = (int)(time * SECONDS_IN_DAY);
+            // We need to subtract 1 second to SECONDS_IN_DAY to make the slider range is between 00:00 and 23:59, instead of 00:00 and 24:00
+            var totalSec = (int)(time * (SECONDS_IN_DAY - 1));
 
             int hours = totalSec / 3600;
             int minutes = totalSec % 3600 / 60;


### PR DESCRIPTION
# Pull Request Description
Fix #3193 

## What does this PR change?
When we moved the skybox bar to its max range we saw `24:00`, when the correct thing would be to see `23:59`.

![image](https://github.com/user-attachments/assets/070f468a-03ee-4a64-8278-af27e2895101)

This PR fix it and now the range is from `00:00` to `23:59`.

### Test Steps
1. Open the Explorer.
2. Open the skybox panel from the sidebar.
3. Move the bar to the end of the range (right side of the bar).
4. Check that it says 23:59 instead of 00:00.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.