### PR TITLE
fix: Set the correct icon for favorites pins in the navmap

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/Addressables/MapLayerCategoryIconMapping.asset
+++ b/Explorer/Assets/DCL/MapRenderer/Addressables/MapLayerCategoryIconMapping.asset
@@ -36,5 +36,5 @@ MonoBehaviour:
   - key: 10
     value: {fileID: 21300000, guid: d3bdc91d4c12b4849a2aa6fa73d846b2, type: 3}
   - key: 12
-    value: {fileID: 21300000, guid: 44239da255e2f43a5a6b7098772e6ff1, type: 3}
+    value: {fileID: 21300000, guid: 832e2146c0b634ff78a73d0557cbd54a, type: 3}
   defaultIcon: {fileID: 21300000, guid: e177591664b9842f98c79c9dc3665311, type: 3}

--- a/Explorer/Assets/DCL/MapRenderer/Addressables/MapLayerCategoryIconMapping.asset
+++ b/Explorer/Assets/DCL/MapRenderer/Addressables/MapLayerCategoryIconMapping.asset
@@ -35,4 +35,6 @@ MonoBehaviour:
     value: {fileID: 21300000, guid: 85f66ad95d7474cfd9f3e72db4d8e6ca, type: 3}
   - key: 10
     value: {fileID: 21300000, guid: d3bdc91d4c12b4849a2aa6fa73d846b2, type: 3}
+  - key: 12
+    value: {fileID: 21300000, guid: 44239da255e2f43a5a6b7098772e6ff1, type: 3}
   defaultIcon: {fileID: 21300000, guid: e177591664b9842f98c79c9dc3665311, type: 3}


### PR DESCRIPTION
# Pull Request Description
Fix #3124 

## What does this PR change?
When we selected the 'Favorites' category in the map, the pins were displayed as the default location pins:

![image](https://github.com/user-attachments/assets/9e62532b-16b7-409f-97fb-183e00363d6b)

Now, with this fix we are showing the expected heart design:

![image](https://github.com/user-attachments/assets/fc82494a-c9af-445d-8905-fe5011546897)

### Test Steps
1. Open the map.
2. Select the 'Favorites' category from the filters.
3. Check that the pin's icon showed for this category is correct (a heart instead of the generic place one).

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
