### PR TITLE
chore: updated sharing urls to new format

### DIFF
--- a/Explorer/Assets/DCL/Navmap/EventInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/EventInfoPanelController.cs
@@ -149,7 +149,7 @@ namespace DCL.Navmap
         private void AddRecurrentEventToCalendar(DateTime startAt)
         {
             // Same link as https://decentraland.org/events/event?id=... website
-            var description = $"jump in: https://play.decentraland.org/?position={@event?.x},{@event?.y}";
+            var description = $"jump in: https://decentraland.org/jump/?position={@event?.x},{@event?.y}";
 
             DateTime nextStartAt = DateTime.Parse(@event?.next_start_at, null, DateTimeStyles.RoundtripKind);
             DateTime nextFinishAt = DateTime.Parse(@event?.next_finish_at, null, DateTimeStyles.RoundtripKind);

--- a/Explorer/Assets/DCL/Navmap/SharePlacesAndEventsContextMenuController.cs
+++ b/Explorer/Assets/DCL/Navmap/SharePlacesAndEventsContextMenuController.cs
@@ -12,7 +12,7 @@ namespace DCL.Navmap
 {
     public class SharePlacesAndEventsContextMenuController
     {
-        private const string JUMP_IN_LINK = "https://play.decentraland.org/?position={0},{1}";
+        private const string JUMP_IN_LINK = " https://decentraland.org/jump/?position={0},{1}";
         private const string EVENT_WEBSITE_LINK = "https://decentraland.org/events/event/?id={0}";
         private const string TWITTER_NEW_POST_LINK = "https://twitter.com/intent/tweet?text={0}&hashtags={1}&url={2}";
         private const string TWITTER_PLACE_DESCRIPTION = "Check out {0}, a cool place I found in Decentraland!";


### PR DESCRIPTION
# Pull Request Description

This PR updates the format of shareable links generated by the client to align with the new standard.

Old format:
https://play.decentraland.org/?position=143%2C-77&realm=main

New format:
https://decentraland.org/jump/?position=-142%2C87

All shared links from the client should now:
Use the https://decentraland.org/jump/ base URL
Point to the new landing experience (see screenshot below)
![Screenshot 2025-05-09 144844](https://github.com/user-attachments/assets/f86ffc5a-11c2-4a4a-9011-6d7f0880b9e8)

Examples:
![Screenshot 2025-05-09 124236](https://github.com/user-attachments/assets/f38483b0-4f7e-40db-9217-bdff8d330c7b)
![Screenshot 2025-05-09 144834](https://github.com/user-attachments/assets/b749fbbb-0aa2-4012-9967-d792b286850a)


## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Open the client
2. Go to map
3. Click the share option

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
