### PR TITLE
fix: profile menu nre

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/MVC/ControllerBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/ControllerBase.cs
@@ -103,7 +103,8 @@ namespace MVC
 
             OnViewClose();
 
-            await viewInstance.HideAsync(ct);
+            if (viewInstance != null)
+                await viewInstance.HideAsync(ct);
 
             State = ControllerState.ViewHidden;
         }


### PR DESCRIPTION
## What does this PR change?

Fixes #4122 
Fixes an NRE on trying to hide the profile menu when closing the explore menu. This only happened if you didnt open the profile menu at any time.
We were missing a null check on the hide operation in the `ControllerBase`

## Test Instructions

Simply open the explore menu and close it. Everything should work as expected.
Do a smoke test on other UIs too.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
