### PR TITLE
Fix/3743 texture arrays optimization

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayConstants.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayConstants.cs
@@ -18,9 +18,12 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
         public const TextureFormat DEFAULT_EMISSIVEMAP_TEXTURE_FORMAT = TextureFormat.BC7;
         public const TextureFormat DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT = TextureFormat.RGBA32;
 
+        public const int HIGH_RES_THRESHOLD = 1024;
+        
         // Some textures are less probably contained in the original material
         // so we can use a smaller starting array size for them
         public const int MAIN_TEXTURE_ARRAY_SIZE = 80; //Before: 250
+        public const int MAIN_TEXTURE_ARRAY_SIZE_FOR_1024_AND_ABOVE = 32;
         public const int NORMAL_TEXTURE_ARRAY_SIZE = 32; //Before: 125
         public const int EMISSION_TEXTURE_ARRAY_SIZE = 32; //Before: 75
         public const int FACIAL_FEATURES_TEXTURE_ARRAY_SIZE = 32; //Before: 75

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayConstants.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayConstants.cs
@@ -20,10 +20,10 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
 
         // Some textures are less probably contained in the original material
         // so we can use a smaller starting array size for them
-        public const int MAIN_TEXTURE_ARRAY_SIZE = 250;
-        public const int NORMAL_TEXTURE_ARRAY_SIZE = 125;
-        public const int EMISSION_TEXTURE_ARRAY_SIZE = 75;
-        public const int FACIAL_FEATURES_TEXTURE_ARRAY_SIZE = 75;
+        public const int MAIN_TEXTURE_ARRAY_SIZE = 80; //Before: 250
+        public const int NORMAL_TEXTURE_ARRAY_SIZE = 32; //Before: 125
+        public const int EMISSION_TEXTURE_ARRAY_SIZE = 32; //Before: 75
+        public const int FACIAL_FEATURES_TEXTURE_ARRAY_SIZE = 32; //Before: 75
 
         public const int MAIN_TEXTURE_RESOLUTION = 512;
         public const int NORMAL_TEXTURE_RESOLUTION = 512;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayContainerFactory.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Rendering/TextureArray/TextureArrayContainerFactory.cs
@@ -40,11 +40,38 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
             var textureArrayMapping = new List<TextureArrayMapping>
             {
                 // Asset Bundle Wearables
-                new (new TextureArrayHandler("Avatar_Toon", MAIN_TEXTURE_ARRAY_SIZE, MAINTEX_ARR_SHADER_INDEX, MAINTEX_ARR_TEX_SHADER, defaultResolutions, DEFAULT_BASEMAP_TEXTURE_FORMAT, defaultTextures),
-                    MAINTEX_ORIGINAL_TEXTURE, MAIN_TEXTURE_RESOLUTION),
-                new (new TextureArrayHandler("Avatar_Toon", NORMAL_TEXTURE_ARRAY_SIZE, NORMAL_MAP_TEX_ARR_INDEX, NORMAL_MAP_TEX_ARR, defaultResolutions, DEFAULT_NORMALMAP_TEXTURE_FORMAT, defaultTextures),
-                    BUMP_MAP_ORIGINAL_TEXTURE_ID, NORMAL_TEXTURE_RESOLUTION),
-                new (new TextureArrayHandler("Avatar_Toon", EMISSION_TEXTURE_ARRAY_SIZE, EMISSIVE_MAP_TEX_ARR_INDEX, EMISSIVE_MAP_TEX_ARR, defaultResolutions, DEFAULT_EMISSIVEMAP_TEXTURE_FORMAT, defaultTextures),
+                new (new TextureArrayHandler("Avatar_Toon",
+                        MAIN_TEXTURE_ARRAY_SIZE,
+                        MAINTEX_ARR_SHADER_INDEX,
+                        MAINTEX_ARR_TEX_SHADER,
+                        defaultResolutions,
+                        DEFAULT_BASEMAP_TEXTURE_FORMAT,
+                        defaultTextures,
+                        // NOTE: using different texture array size for high res textures
+                        // NOTE: for main textures
+                        // NOTE: Normal and Emission handlers remain unchanged,
+                        // NOTE: using their single respective constants
+                        minArraySizeForHighRes:MAIN_TEXTURE_ARRAY_SIZE_FOR_1024_AND_ABOVE),
+                    MAINTEX_ORIGINAL_TEXTURE,
+                    MAIN_TEXTURE_RESOLUTION),
+                
+                new (new TextureArrayHandler("Avatar_Toon",
+                        NORMAL_TEXTURE_ARRAY_SIZE,
+                        NORMAL_MAP_TEX_ARR_INDEX,
+                        NORMAL_MAP_TEX_ARR,
+                        defaultResolutions,
+                        DEFAULT_NORMALMAP_TEXTURE_FORMAT,
+                        defaultTextures),
+                    BUMP_MAP_ORIGINAL_TEXTURE_ID,
+                    NORMAL_TEXTURE_RESOLUTION),
+                
+                new (new TextureArrayHandler("Avatar_Toon",
+                        EMISSION_TEXTURE_ARRAY_SIZE,
+                        EMISSIVE_MAP_TEX_ARR_INDEX,
+                        EMISSIVE_MAP_TEX_ARR,
+                        defaultResolutions,
+                        DEFAULT_EMISSIVEMAP_TEXTURE_FORMAT,
+                        defaultTextures),
                     EMISSION_MAP_ORIGINAL_TEXTURE_ID, EMISSION_TEXTURE_RESOLUTION),
             };
 
@@ -53,12 +80,37 @@ namespace DCL.AvatarRendering.AvatarShape.Rendering.TextureArray
                 // Raw GLTF Wearables
                 textureArrayMapping.AddRange(new[]
                 {
-                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Toon_Raw_GLTF", MAIN_TEXTURE_ARRAY_SIZE, MAINTEX_ARR_SHADER_INDEX, MAINTEX_ARR_TEX_SHADER, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
-                        MAINTEX_ORIGINAL_TEXTURE, MAIN_TEXTURE_RESOLUTION),
-                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Toon_Raw_GLTF", NORMAL_TEXTURE_ARRAY_SIZE, NORMAL_MAP_TEX_ARR_INDEX, NORMAL_MAP_TEX_ARR, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
-                        BUMP_MAP_ORIGINAL_TEXTURE_ID, NORMAL_TEXTURE_RESOLUTION),
-                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Toon_Raw_GLTF", EMISSION_TEXTURE_ARRAY_SIZE, EMISSIVE_MAP_TEX_ARR_INDEX, EMISSIVE_MAP_TEX_ARR, defaultResolutions, DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
-                        EMISSION_MAP_ORIGINAL_TEXTURE_ID, EMISSION_TEXTURE_RESOLUTION)
+                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Toon_Raw_GLTF",
+                            MAIN_TEXTURE_ARRAY_SIZE,
+                            MAINTEX_ARR_SHADER_INDEX,
+                            MAINTEX_ARR_TEX_SHADER,
+                            defaultResolutions,
+                            DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT,
+                            // NOTE: using different texture array size for high res textures
+                            // NOTE: for main textures
+                            // NOTE: Normal and Emission handlers remain unchanged,
+                            // NOTE: using their single respective constants
+                            minArraySizeForHighRes:MAIN_TEXTURE_ARRAY_SIZE_FOR_1024_AND_ABOVE),
+                        MAINTEX_ORIGINAL_TEXTURE,
+                        MAIN_TEXTURE_RESOLUTION),
+                    
+                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Toon_Raw_GLTF",
+                            NORMAL_TEXTURE_ARRAY_SIZE,
+                            NORMAL_MAP_TEX_ARR_INDEX,
+                            NORMAL_MAP_TEX_ARR,
+                            defaultResolutions,
+                            DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
+                        BUMP_MAP_ORIGINAL_TEXTURE_ID,
+                        NORMAL_TEXTURE_RESOLUTION),
+                    
+                    new TextureArrayMapping(new TextureArrayHandler("Avatar_Toon_Raw_GLTF",
+                            EMISSION_TEXTURE_ARRAY_SIZE,
+                            EMISSIVE_MAP_TEX_ARR_INDEX,
+                            EMISSIVE_MAP_TEX_ARR,
+                            defaultResolutions,
+                            DEFAULT_RAW_WEARABLE_TEXTURE_FORMAT),
+                        EMISSION_MAP_ORIGINAL_TEXTURE_ID,
+                        EMISSION_TEXTURE_RESOLUTION)
                 });
             }
 


### PR DESCRIPTION
# Pull Request Description
This adjust texture array depth based on resolution for VRAM efficiency

## What does this PR change?

Previously, a single large "**minArraySize**" (depth) was used for texture types like Main Avatar Textures, regardless of resolution, leading to VRAM over-allocation (e.g., ~250 MiB for 1024x textures even with low slot usage).

Changes:
- Introduced separate "**minArraySize**" configurations for Main Avatar Textures:
    - A smaller depth (e.g., 32 slices) is now used for high resolutions (>=1024x).
    - A moderately reduced depth (e.g., 80 slices) is used for common lower resolutions (<1024x).
- Globally reduced default "**minArraySize**" for other avatar texture types (Normal, Emission, Facial Features) based on profiling data indicating low utilization.

The system's ability to create new "**Texture2DArray**" instances if a smaller "**minArraySize**" is exceeded has been confirmed, ensuring functionality. This change aims to balance VRAM savings with the overhead of managing array objects.

Expected to reduce VRAM footprint. Further monitoring of slot usage and array object counts is required to fine-tune these new sizes.

## Test Instructions
**Test Focus**: Verify VRAM reduction and correct behavior of Texture Array sizing, especially for textures >= 1024x resolution, after **minArraySize** optimizations.

### Prerequisites
- Previous Build: A build of the application from the main/develop branch (or before the changes in this PR) to establish a baseline.
- Current Build: A build of the application that includes the changes from this Pull Request (with adjusted minArraySize values).
- Access to info about memory consumption

### Test Steps
Part 1.
- Launch the build with **no texture array optimizations** (previous)
- Navigate to a scene known to load a moderate to high number of diverse avatars (e.g., Genesis Plaza during a populated time, or a specific test scene with some number of unique avatars). Ensure some avatars are likely to have wearables with textures >= 1024x resolution if such assets exist.
- Observe memory consumption

Part 2.
- Launch the build **with texture array optimizations** (current)
- Navigate to the exact same scene and attempt to replicate similar avatar load conditions as in Part 1, Step 2.
- Observe memory consumption

Expected Result (Visuals & Stability):
- All avatar wearables and facial features should render correctly with their textures.
- The application should remain stable with no new crashes, freezes, or significant performance degradation.
- Memory consumption is lower for build with texture array optimizations

## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [X] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
