### PR TITLE
fix: character stuck on scene hot-reload at LSD mode

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Components/StopCharacterMotion.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Components/StopCharacterMotion.cs
@@ -1,0 +1,6 @@
+namespace DCL.Character.CharacterMotion.Components
+{
+    public struct StopCharacterMotion
+    {
+    }
+}

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Components/StopCharacterMotion.cs.meta
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Components/StopCharacterMotion.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0d19d45889da443ea9f040a676296187
+timeCreated: 1747147996

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/InterpolateCharacterSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/InterpolateCharacterSystem.cs
@@ -5,7 +5,6 @@ using DCL.Character.CharacterMotion.Components;
 using DCL.CharacterMotion.Components;
 using DCL.CharacterMotion.Platforms;
 using DCL.CharacterMotion.Settings;
-using DCL.Chat.Commands;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
 using UnityEngine;
@@ -34,7 +33,7 @@ namespace DCL.CharacterMotion.Systems
         }
 
         [Query]
-        [None(typeof(ReloadSceneChatCommand.SceneReloadComponent), typeof(PlayerTeleportIntent), typeof(DeleteEntityIntention), typeof(PlayerTeleportIntent.JustTeleported))]
+        [None(typeof(StopCharacterMotion), typeof(PlayerTeleportIntent), typeof(DeleteEntityIntention), typeof(PlayerTeleportIntent.JustTeleported))]
         private void Interpolate(
             [Data] float dt,
             in ICharacterControllerSettings settings,

--- a/Explorer/Assets/DCL/Chat/Commands/DCL.Chat.Commands.asmdef
+++ b/Explorer/Assets/DCL/Chat/Commands/DCL.Chat.Commands.asmdef
@@ -20,7 +20,8 @@
         "GUID:1d2c76eb8b48e0b40940e8b31a679ce1",
         "GUID:04e9a70e2a3843908ecb2c5135189184",
         "GUID:7175400a68914a45acecc9fb068de3b8",
-        "GUID:286980af24684da6acc1caa413039811"
+        "GUID:286980af24684da6acc1caa413039811",
+        "GUID:d832748739a186646b8656bdbd447ad0"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Chat/Commands/ReloadSceneChatCommand.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ReloadSceneChatCommand.cs
@@ -1,6 +1,7 @@
 ﻿using Arch.Core;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using DCL.Character.CharacterMotion.Components;
 using ECS.SceneLifeCycle;
 using System;
 
@@ -34,7 +35,7 @@ namespace DCL.Chat.Commands
 
         public async UniTask<string> ExecuteCommandAsync(string[] parameters, CancellationToken ct)
         {
-            globalWorld.Add<SceneReloadComponent>(playerEntity);
+            globalWorld.Add<StopCharacterMotion>(playerEntity);
 
             try
             {
@@ -46,10 +47,8 @@ namespace DCL.Chat.Commands
             }
             finally
             {
-                globalWorld.Remove<SceneReloadComponent>(playerEntity);
+                globalWorld.Remove<StopCharacterMotion>(playerEntity);
             }
         }
-
-        public struct SceneReloadComponent {}
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
@@ -1,7 +1,8 @@
-﻿using Cysharp.Threading.Tasks;
+﻿using Arch.Core;
+using Cysharp.Threading.Tasks;
+using DCL.Character.CharacterMotion.Components;
 using DCL.Diagnostics;
 using Decentraland.Sdk.Development;
-using ECS.SceneLifeCycle.Systems;
 using Google.Protobuf;
 using System;
 using System.Net.WebSockets;
@@ -13,23 +14,39 @@ namespace ECS.SceneLifeCycle.LocalSceneDevelopment
     public class LocalSceneDevelopmentController
     {
         private readonly IReloadScene reloadScene;
+        private readonly Entity playerEntity;
+        private readonly World globalWorld;
         private readonly CancellationTokenSource connectToServerCancellationToken = new ();
         private ClientWebSocket? webSocket;
 
-        public LocalSceneDevelopmentController(IReloadScene reloadScene, string localSceneServer)
+        public LocalSceneDevelopmentController(IReloadScene reloadScene,
+            string localSceneServer,
+            Entity playerEntity,
+            World globalWorld)
         {
             this.reloadScene = reloadScene;
+            this.playerEntity = playerEntity;
+            this.globalWorld = globalWorld;
 
-            ConnectToServerAsync(
-                    localSceneServer.Contains("https") ? localSceneServer.Replace("https", "wss") : localSceneServer.Replace("http", "ws"),
-                    new WsSceneMessage(),
-                    new byte[1024],
-                    connectToServerCancellationToken.Token
-                )
-               .Forget();
+            ConnectToServerAsync(localSceneServer.Contains("https") ? localSceneServer.Replace("https", "wss") : localSceneServer.Replace("http", "ws"),
+                new WsSceneMessage(),
+                new byte[1024],
+                connectToServerCancellationToken.Token).Forget();
         }
 
-        private async UniTaskVoid ConnectToServerAsync(string localSceneWebsocketServer, WsSceneMessage wsSceneMessage, byte[] receiveBuffer, CancellationToken ct)
+        public void Dispose()
+        {
+            try
+            {
+                webSocket?.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+                webSocket?.Dispose();
+            }
+            catch (ObjectDisposedException) { }
+            connectToServerCancellationToken.SafeCancelAndDispose();
+        }
+
+        private async UniTaskVoid ConnectToServerAsync(string localSceneWebsocketServer,
+            WsSceneMessage wsSceneMessage, byte[] receiveBuffer,CancellationToken ct)
         {
             await UniTask.SwitchToThreadPool();
 
@@ -56,9 +73,19 @@ namespace ECS.SceneLifeCycle.LocalSceneDevelopment
 
                     // Switch to the main thread because `TryReloadSceneAsync` requires that
                     await UniTask.SwitchToMainThread(cancellationToken: ct);
-                    await reloadScene.TryReloadSceneAsync(ct,
-                        wsSceneMessage.MessageCase == WsSceneMessage.MessageOneofCase.UpdateScene ?
-                            wsSceneMessage.UpdateScene.SceneId : wsSceneMessage.UpdateModel.SceneId);
+
+                    try
+                    {
+                        // We need to freeze the character movement until the scene is reloaded
+                        globalWorld.AddOrGet(playerEntity, new StopCharacterMotion());
+
+                        await reloadScene.TryReloadSceneAsync(ct,
+                            wsSceneMessage.MessageCase == WsSceneMessage.MessageOneofCase.UpdateScene ? wsSceneMessage.UpdateScene.SceneId : wsSceneMessage.UpdateModel.SceneId);
+                    }
+                    finally
+                    {
+                        globalWorld.Remove<StopCharacterMotion>(playerEntity);
+                    }
                 }
                 else if (receiveResult.MessageType == WebSocketMessageType.Close)
                 {
@@ -66,17 +93,6 @@ namespace ECS.SceneLifeCycle.LocalSceneDevelopment
                     ReportHub.Log(ReportCategory.SDK_LOCAL_SCENE_DEVELOPMENT, $"Websocket connection closed.");
                 }
             }
-        }
-
-        public void Dispose()
-        {
-            try
-            {
-                webSocket?.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
-                webSocket?.Dispose();
-            }
-            catch (ObjectDisposedException) { }
-            connectToServerCancellationToken.SafeCancelAndDispose();
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/GatherGltfAssetsSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/GatherGltfAssetsSystem.cs
@@ -1,18 +1,17 @@
 ﻿using Arch.Core;
 using Arch.SystemGroups;
 using DCL.ECSComponents;
+using DCL.Optimization.PerformanceBudgeting;
+using DCL.RealmNavigation;
+using DCL.Utilities;
 using ECS.Abstract;
 using ECS.Groups;
 using ECS.SceneLifeCycle.Reporting;
 using ECS.Unity.GLTFContainer.Components;
-using SceneRunner.Scene;
-using System.Collections.Generic;
-using DCL.Optimization.PerformanceBudgeting;
-using DCL.RealmNavigation;
-using DCL.UserInAppInitializationFlow;
-using DCL.Utilities;
 using ECS.Unity.Transforms.Components;
+using SceneRunner.Scene;
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Pool;
 
@@ -163,6 +162,7 @@ namespace ECS.SceneLifeCycle.Systems
             {
                 concluded = true;
                 sceneData.SceneLoadingConcluded = true;
+
                 World.Get<TransformComponent>(sceneContainerEntity).Transform.position =
                     sceneData.Geometry.BaseParcelPosition;
             }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -362,7 +362,9 @@ namespace Global.Dynamic
 
             var reloadSceneController = new ECSReloadScene(staticContainer.ScenesCache, globalWorld, playerEntity, localSceneDevelopment);
 
-            LocalSceneDevelopmentController? localSceneDevelopmentController = localSceneDevelopment ? new LocalSceneDevelopmentController(reloadSceneController, dynamicWorldParams.LocalSceneDevelopmentRealm) : null;
+            LocalSceneDevelopmentController? localSceneDevelopmentController = localSceneDevelopment
+                ? new LocalSceneDevelopmentController(reloadSceneController, dynamicWorldParams.LocalSceneDevelopmentRealm, playerEntity, globalWorld)
+                : null;
 
             var chatRoom = new ChatConnectiveRoom(staticContainer.WebRequestsContainer.WebRequestController, URLAddress.FromString(bootstrapContainer.DecentralandUrlsSource.Url(DecentralandUrl.ChatAdapter)));
 


### PR DESCRIPTION
## What does this PR change?

Fixes #3972 

The client was not freezing the character movement while the scene is reloaded due to a change in the Creator Hub, provoking the character to fall and then get stuck through the colliders.

The changes consists in adding a new `StopCharacterMotion` component into the player's entity at `LocalSceneDevelopmentController` which triggers the moment on which the Creator Hub request a hot-reload of the scene.
This was not enough, since `IReloadScene.TryReloadSceneAsync` was not waiting until the new scene was loaded as a whole, but instead it was only waiting until the old scene was disposed. Now the scene is considered "reloaded" until its state is `Running` and all the GLTF are loaded.
This changes will introduce more waiting time on any change in the scene, until the user can start moving the character, but it is the only way to prevent from getting stuck.

## Test Instructions

In order to be able to test the scene from the Creator Hub with a custom build you can try:
1. Run the Creator Hub
2. Preview the scene
3. It will open a new client, close it
4. Run the custom build with the args provided here: https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene

### Test Steps
1. Make a scene through the creator's hub
5. Add models
6. Preview the scene in the build
7. Stand on top of any model
8. Make a change in the scene through the creator's hub
9. The scene should reload in the client
10. The character should remain on top of the model
11. It should work the same if you type `/reload` command in the chat

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
