### PR TITLE
fix: [Marketplace Credits] Last minute security measures

### DIFF
--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrl.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrl.cs
@@ -10,6 +10,7 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
         ArchipelagoHotScenes,
 
         DiscordLink,
+        DiscordDirectLink,
         TwitterLink,
         NewsletterSubscriptionLink,
         MarketplaceLink,

--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
@@ -73,6 +73,7 @@ namespace DCL.Browser.DecentralandUrls
             decentralandUrl switch
             {
                 DecentralandUrl.DiscordLink => $"https://decentraland.{ENV}/discord/",
+                DecentralandUrl.DiscordDirectLink => "https://discord.gg/decentraland",
                 DecentralandUrl.TwitterLink => "https://x.com/decentraland",
                 DecentralandUrl.NewsletterSubscriptionLink => "https://decentraland.beehiiv.com/?utm_org=dcl&utm_source=client&utm_medium=organic&utm_campaign=marketplacecredits&utm_term=trialend",
                 DecentralandUrl.MarketplaceLink => $"https://decentraland.{ENV}/marketplace",

--- a/Explorer/Assets/DCL/MarketplaceCredits/Assets/Fields/MarketplaceCreditsCaptcha.prefab
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Assets/Fields/MarketplaceCreditsCaptcha.prefab
@@ -586,7 +586,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Captcha challenge failed. Please reload and try again.
+  m_text: CAPTCHA challenge failed. Please reload and try again.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
@@ -738,7 +738,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -180}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -380, y: 0}
+  m_AnchoredPosition: {x: -389, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8231790982609885590

--- a/Explorer/Assets/DCL/MarketplaceCredits/Assets/Fields/MarketplaceCreditsTotalCreditsWidget.prefab
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Assets/Fields/MarketplaceCreditsTotalCreditsWidget.prefab
@@ -74,7 +74,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 3.5
+  m_PixelsPerUnitMultiplier: 3
 --- !u!1 &607884544357094887
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/MarketplaceCredits/Assets/MarketplaceCreditsUnlockedPanel.prefab
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Assets/MarketplaceCreditsUnlockedPanel.prefab
@@ -2587,7 +2587,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.9386792, g: 0.94029534, b: 1, a: 0.5019608}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.2}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Explorer/Assets/DCL/MarketplaceCredits/Assets/MarketplaceCreditsUnlockedPanel.prefab
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Assets/MarketplaceCreditsUnlockedPanel.prefab
@@ -205,7 +205,7 @@ MonoBehaviour:
       m_Calls: []
 --- !u!95 &1697367873285006921
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -219,6 +219,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -740,9 +741,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 4798403153753999039}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -239}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 301}
   m_SizeDelta: {x: 700, y: 51}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &2128563223269557618
@@ -1326,9 +1327,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 4798403153753999039}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0.5, y: -685}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.5, y: -145}
   m_SizeDelta: {x: 689.5, y: 36}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &322913384139061927
@@ -3060,9 +3061,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 4798403153753999039}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -196}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 344}
   m_SizeDelta: {x: 700, y: 20}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &542766201962481323

--- a/Explorer/Assets/DCL/MarketplaceCredits/Assets/Sections/MarketplaceCredits_GoalsOfTheWeekSection.prefab
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Assets/Sections/MarketplaceCredits_GoalsOfTheWeekSection.prefab
@@ -170,10 +170,10 @@ RectTransform:
   - {fileID: 7747470596857984721}
   m_Father: {fileID: 6404477174971950554}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 36}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 221.59, y: -11}
+  m_SizeDelta: {x: 226, y: 36}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6642163309283903699
 CanvasRenderer:
@@ -304,6 +304,139 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2098799715496721547}
   m_CullTransparentMesh: 1
+--- !u!1 &2260767507251123619
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2321396250192465250}
+  - component: {fileID: 8861858470659336290}
+  m_Layer: 5
+  m_Name: CaptchaBlockedContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2321396250192465250
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2260767507251123619}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4415503798427420221}
+  - {fileID: 1938126194253041332}
+  m_Father: {fileID: 8135205393400111029}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 400, y: -483}
+  m_SizeDelta: {x: 800, y: 96}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8861858470659336290
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2260767507251123619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: 96
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &3120568075585452663
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4415503798427420221}
+  - component: {fileID: 3012999808478045779}
+  - component: {fileID: 4129627090172812943}
+  m_Layer: 5
+  m_Name: WarningIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4415503798427420221
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3120568075585452663}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2321396250192465250}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 52, y: -6}
+  m_SizeDelta: {x: 35, y: 35}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &3012999808478045779
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3120568075585452663}
+  m_CullTransparentMesh: 1
+--- !u!114 &4129627090172812943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3120568075585452663}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 11e50157680834b92b7f75220b425747, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3145763916966192315
 GameObject:
   m_ObjectHideFlags: 0
@@ -670,10 +803,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 6404477174971950554}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 16}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 86.59, y: -3}
+  m_SizeDelta: {x: 16, y: 16}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &9179357530723907215
 CanvasRenderer:
@@ -907,6 +1040,7 @@ RectTransform:
   - {fileID: 199656201185403613}
   - {fileID: 5699006330021557838}
   - {fileID: 8546342324709943202}
+  - {fileID: 2321396250192465250}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -965,6 +1099,7 @@ MonoBehaviour:
   <TimeLeftLinkTooltip>k__BackingField: {fileID: 1655922908401834200}
   <GoalsContainer>k__BackingField: {fileID: 5699006330021557838}
   <CaptchaContainer>k__BackingField: {fileID: 4803315691261139444}
+  <CaptchaBlockedContainer>k__BackingField: {fileID: 2260767507251123619}
   <CaptchaControl>k__BackingField: {fileID: 7279172496388326305}
   <GoalRowPrefab>k__BackingField: {fileID: 789829308341211883, guid: 09d58514bbbc1824cab2f4d741a03dc3, type: 3}
 --- !u!1 &5904915451802793637
@@ -999,10 +1134,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 6404477174971950554}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 22}
+  m_SizeDelta: {x: 68.14, y: 22}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &7671453241232074598
 CanvasRenderer:
@@ -1194,10 +1329,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 6404477174971950554}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 22}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 74.14, y: 0}
+  m_SizeDelta: {x: 6.45, y: 22}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &5548725507550244010
 CanvasRenderer:
@@ -1324,6 +1459,143 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &6914549294639286689
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1938126194253041332}
+  - component: {fileID: 4475246475362826390}
+  - component: {fileID: 7556575416486251087}
+  m_Layer: 5
+  m_Name: CaptchaBlockedError
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1938126194253041332
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6914549294639286689}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2321396250192465250}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 100, y: 0}
+  m_SizeDelta: {x: 635, y: 44}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &4475246475362826390
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6914549294639286689}
+  m_CullTransparentMesh: 1
+--- !u!114 &7556575416486251087
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6914549294639286689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Captcha challenge failed too many times. You will need to wait 24 hours
+    before you can retry.
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294769916
+  m_fontColor: {r: 0.9882353, g: 0.9882353, b: 0.9882353, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1001 &754302004683462035
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/MarketplaceCredits/Assets/Sections/MarketplaceCredits_GoalsOfTheWeekSection.prefab
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Assets/Sections/MarketplaceCredits_GoalsOfTheWeekSection.prefab
@@ -333,6 +333,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1807844525308389587}
   - {fileID: 4415503798427420221}
   - {fileID: 1938126194253041332}
   m_Father: {fileID: 8135205393400111029}
@@ -396,8 +397,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 52, y: -6}
-  m_SizeDelta: {x: 35, y: 35}
+  m_AnchoredPosition: {x: 135, y: -10}
+  m_SizeDelta: {x: 24, y: 24}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &3012999808478045779
 CanvasRenderer:
@@ -427,7 +428,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 11e50157680834b92b7f75220b425747, type: 3}
+  m_Sprite: {fileID: 21300000, guid: b4bc39df09b8ec24eb8dedf59c9d93f4, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -573,6 +574,81 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3457586901030255898
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1807844525308389587}
+  - component: {fileID: 371884279867130906}
+  - component: {fileID: 1205201215647808618}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1807844525308389587
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3457586901030255898}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2321396250192465250}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 26}
+  m_SizeDelta: {x: 700, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &371884279867130906
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3457586901030255898}
+  m_CullTransparentMesh: 1
+--- !u!114 &1205201215647808618
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3457586901030255898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.101960786}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 12dd1efc4e826764f9b02be515a9a033, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 2
 --- !u!1 &4401541610890069877
 GameObject:
   m_ObjectHideFlags: 0
@@ -1493,8 +1569,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 100, y: 0}
-  m_SizeDelta: {x: 635, y: 44}
+  m_AnchoredPosition: {x: 169, y: 0}
+  m_SizeDelta: {x: 502.5704, y: 44}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &4475246475362826390
 CanvasRenderer:
@@ -1524,8 +1600,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Captcha challenge failed too many times. You will need to wait 24 hours
-    before you can retry.
+  m_text: Too many failed CAPTCHA attempts. Please try again in 24 hours.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
   m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}

--- a/Explorer/Assets/DCL/MarketplaceCredits/Assets/Sections/MarketplaceCredits_ProgramEndedSection.prefab
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Assets/Sections/MarketplaceCredits_ProgramEndedSection.prefab
@@ -176,7 +176,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -247,8 +247,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 80, y: -90}
-  m_SizeDelta: {x: 500, y: 50}
+  m_AnchoredPosition: {x: 80, y: -80}
+  m_SizeDelta: {x: 500, y: 60}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &2789085573632065399
 CanvasRenderer:
@@ -314,7 +314,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
@@ -150,7 +150,7 @@ namespace DCL.MarketplaceCredits
             closeTaskCompletionSource = new UniTaskCompletionSource();
             OpenSection(MarketplaceCreditsSection.WELCOME);
             SetSidebarButtonAnimationAsPaused(true);
-            MarketplaceCreditsOpened?.Invoke(inputData.IsOpenedFromNotification);
+            MarketplaceCreditsOpened.Invoke(inputData.IsOpenedFromNotification);
         }
 
         protected override void OnViewClose()
@@ -164,7 +164,7 @@ namespace DCL.MarketplaceCredits
 
         protected override async UniTask WaitForCloseIntentAsync(CancellationToken ct)
         {
-            ViewShowingComplete?.Invoke(this);
+            ViewShowingComplete.Invoke(this);
             await UniTask.WhenAny(viewInstance!.CloseButton.OnClickAsync(ct), closeTaskCompletionSource.Task);
         }
 
@@ -191,6 +191,7 @@ namespace DCL.MarketplaceCredits
                 case MarketplaceCreditsSection.VERIFY_EMAIL:
                     haveJustClaimedCredits = false;
                     marketplaceCreditsVerifyEmailSubController?.OpenSection();
+                    viewInstance.TotalCreditsWidget.gameObject.SetActive(false);
                     break;
                 case MarketplaceCreditsSection.GOALS_OF_THE_WEEK:
                     if (marketplaceCreditsGoalsOfTheWeekSubController != null)
@@ -198,20 +199,20 @@ namespace DCL.MarketplaceCredits
                         marketplaceCreditsGoalsOfTheWeekSubController.HasToPlayClaimCreditsAnimation = haveJustClaimedCredits;
                         marketplaceCreditsGoalsOfTheWeekSubController.OpenSection();
                     }
-
+                    viewInstance.TotalCreditsWidget.gameObject.SetActive(true);
                     break;
                 case MarketplaceCreditsSection.WEEK_GOALS_COMPLETED:
                     haveJustClaimedCredits = false;
                     marketplaceCreditsWeekGoalsCompletedSubController?.OpenSection();
+                    viewInstance.TotalCreditsWidget.gameObject.SetActive(true);
                     break;
                 case MarketplaceCreditsSection.PROGRAM_ENDED:
                     haveJustClaimedCredits = false;
                     viewInstance.TotalCreditsWidget.SetAsProgramEndVersion(isProgramEndVersion: true);
                     marketplaceCreditsProgramEndedSubController?.OpenSection();
+                    viewInstance.TotalCreditsWidget.gameObject.SetActive(true);
                     break;
             }
-
-            viewInstance.TotalCreditsWidget.gameObject.SetActive(section != MarketplaceCreditsSection.WELCOME && section != MarketplaceCreditsSection.VERIFY_EMAIL);
         }
 
         public async UniTaskVoid ShowCreditsUnlockedPanelAsync(float claimedCredits)
@@ -264,7 +265,7 @@ namespace DCL.MarketplaceCredits
         }
 
         private void OnAnyPlaceClicked() =>
-            OnAnyPlaceClick?.Invoke();
+            OnAnyPlaceClick.Invoke();
 
         private void OpenInfoLink() =>
             webBrowser.OpenUrl(WEEKLY_REWARDS_INFO_LINK);
@@ -343,7 +344,8 @@ namespace DCL.MarketplaceCredits
 
         private void SetSidebarButtonState(CreditsProgramProgressResponse creditsProgramProgressResponse)
         {
-            if (creditsProgramProgressResponse.season.timeLeft <= 0f || creditsProgramProgressResponse.season.isOutOfFunds)
+            if (creditsProgramProgressResponse.IsProgramEnded())
+
             {
                 SetSidebarButtonAnimationAsAlert(false);
                 SetSidebarButtonAsClaimIndicator(false);
@@ -351,8 +353,8 @@ namespace DCL.MarketplaceCredits
             }
 
             bool thereIsSomethingToClaim = creditsProgramProgressResponse.SomethingToClaim();
-            SetSidebarButtonAnimationAsAlert(!creditsProgramProgressResponse.HasUserStartedProgram() || !creditsProgramProgressResponse.IsUserEmailVerified() || thereIsSomethingToClaim);
-            SetSidebarButtonAsClaimIndicator(creditsProgramProgressResponse.HasUserStartedProgram() && creditsProgramProgressResponse.IsUserEmailVerified() && thereIsSomethingToClaim);
+            SetSidebarButtonAnimationAsAlert(!creditsProgramProgressResponse.HasUserStartedProgram() || !creditsProgramProgressResponse.IsUserEmailVerified() || (thereIsSomethingToClaim && !creditsProgramProgressResponse.credits.isBlockedForClaiming));
+            SetSidebarButtonAsClaimIndicator(creditsProgramProgressResponse.HasUserStartedProgram() && creditsProgramProgressResponse.IsUserEmailVerified() && thereIsSomethingToClaim && !creditsProgramProgressResponse.credits.isBlockedForClaiming);
         }
     }
 }

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsUtils.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsUtils.cs
@@ -8,6 +8,15 @@ namespace DCL.MarketplaceCredits
 {
     public static class MarketplaceCreditsUtils
     {
+        public enum SeasonState
+        {
+            RUNNING,
+            ENDED,
+            ERR_SEASON_RUN_OUT_OF_FUNDS,
+            ERR_WEEK_RUN_OUT_OF_FUNDS,
+            ERR_PROGRAM_PAUSED,
+        }
+
         /// <summary>
         /// Formats the time left until the end of the week in a human-readable format.
         /// </summary>
@@ -65,8 +74,8 @@ namespace DCL.MarketplaceCredits
         /// <returns>>A string representing the season date range in a human-readable format.</returns>
         public static string FormatSeasonDateRange(string startDate, string endDate)
         {
-            DateTime startDateDT = DateTime.ParseExact(startDate, "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
-            DateTime endDateDT = DateTime.ParseExact(endDate, "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+            DateTime startDateDT = DateTime.Parse(startDate, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+            DateTime endDateDT = DateTime.Parse(endDate, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
             return $"{startDateDT.ToString("MMMM dd", CultureInfo.InvariantCulture)}-{endDateDT.ToString("MMMM dd", CultureInfo.InvariantCulture)}";
         }
 
@@ -104,7 +113,11 @@ namespace DCL.MarketplaceCredits
         /// </summary>
         /// <returns>True if the program has ended, false otherwise.</returns>
         public static bool IsProgramEnded(this CreditsProgramProgressResponse creditsProgramProgressResponse) =>
-            creditsProgramProgressResponse.season.timeLeft <= 0f || creditsProgramProgressResponse.season.isOutOfFunds;
+            creditsProgramProgressResponse.season.timeLeft <= 0f ||
+            creditsProgramProgressResponse.season.seasonState == nameof(SeasonState.ENDED) ||
+            creditsProgramProgressResponse.season.seasonState == nameof(SeasonState.ERR_SEASON_RUN_OUT_OF_FUNDS) ||
+            creditsProgramProgressResponse.season.seasonState == nameof(SeasonState.ERR_WEEK_RUN_OUT_OF_FUNDS) ||
+            creditsProgramProgressResponse.season.seasonState == nameof(SeasonState.ERR_PROGRAM_PAUSED);
 
         /// <summary>
         /// Checks if the user has completed all the weekly goals.

--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsGoalsOfTheWeekSubController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsGoalsOfTheWeekSubController.cs
@@ -195,7 +195,7 @@ namespace DCL.MarketplaceCredits.Sections
                 }
                 else
                 {
-                    if (!claimCreditsResponse.is_locked)
+                    if (!claimCreditsResponse.isBlockedForClaiming)
                         subView.SetCaptchaAsErrorState(true, isNonSolvedError: true);
                     else
                         subView.ShowCaptcha(true, true);

--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsGoalsOfTheWeekSubController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsGoalsOfTheWeekSubController.cs
@@ -93,9 +93,9 @@ namespace DCL.MarketplaceCredits.Sections
                 instantiatedGoalRows.Add(goalRow);
             }
 
-            subView.ShowCaptcha(creditsProgramProgressResponse.SomethingToClaim());
+            subView.ShowCaptcha(creditsProgramProgressResponse.SomethingToClaim(), creditsProgramProgressResponse.credits.isBlockedForClaiming);
 
-            if (creditsProgramProgressResponse.SomethingToClaim())
+            if (creditsProgramProgressResponse.SomethingToClaim() && !creditsProgramProgressResponse.credits.isBlockedForClaiming)
                 ReloadCaptcha();
         }
 
@@ -194,7 +194,12 @@ namespace DCL.MarketplaceCredits.Sections
                     marketplaceCreditsMenuController.SetSidebarButtonAsClaimIndicator(false);
                 }
                 else
-                    subView.SetCaptchaAsErrorState(true, isNonSolvedError: true);
+                {
+                    if (!claimCreditsResponse.is_locked)
+                        subView.SetCaptchaAsErrorState(true, isNonSolvedError: true);
+                    else
+                        subView.ShowCaptcha(true, true);
+                }
             }
             catch (OperationCanceledException) { }
             catch (Exception e)

--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsGoalsOfTheWeekSubView.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsGoalsOfTheWeekSubView.cs
@@ -23,6 +23,9 @@ namespace DCL.MarketplaceCredits.Sections
         public GameObject CaptchaContainer { get; private set; }
 
         [field: SerializeField]
+        public GameObject CaptchaBlockedContainer { get; private set; }
+
+        [field: SerializeField]
         public MarketplaceCreditsCaptchaView CaptchaControl { get; private set; }
 
         [field: SerializeField]
@@ -37,8 +40,11 @@ namespace DCL.MarketplaceCredits.Sections
         public void ShowTimeLeftTooltip(bool show) =>
             TimeLeftLinkTooltip.SetActive(show);
 
-        public void ShowCaptcha(bool show) =>
-            CaptchaContainer.SetActive(show);
+        public void ShowCaptcha(bool show, bool isBlocked)
+        {
+            CaptchaContainer.SetActive(show && !isBlocked);
+            CaptchaBlockedContainer.SetActive(show && isBlocked);
+        }
 
         public void SetCaptchaAsLoading(bool isLoading) =>
             CaptchaControl.SetAsLoading(isLoading);

--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsProgramEndedSubController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsProgramEndedSubController.cs
@@ -39,9 +39,9 @@ namespace DCL.MarketplaceCredits.Sections
             switch (creditsProgramProgressResponse.season.seasonState)
             {
                 case nameof(MarketplaceCreditsUtils.SeasonState.ERR_SEASON_RUN_OUT_OF_FUNDS):
-                case nameof(MarketplaceCreditsUtils.SeasonState.ERR_WEEK_RUN_OUT_OF_FUNDS):
                     title = "All Available Credits Claimed: The beta run of the Weekly Rewards program is now closed";
                     break;
+                case nameof(MarketplaceCreditsUtils.SeasonState.ERR_WEEK_RUN_OUT_OF_FUNDS):
                 case nameof(MarketplaceCreditsUtils.SeasonState.ERR_PROGRAM_PAUSED):
                     title = "Marketplace Credits are Temporarily Offline";
                     subTitle = $"Please check the #product-status channel in <color=#FF2D55><b><u><link={DISCORD_LINK_ID}>Decentraland's Discord server</link></u></b></color> for updates if service does not resume shortly.";

--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsProgramEndedSubController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsProgramEndedSubController.cs
@@ -10,6 +10,7 @@ namespace DCL.MarketplaceCredits.Sections
     {
         private const string SUBSCRIBE_LINK_ID = "SUBSCRIBE_LINK_ID";
         private const string X_LINK_ID = "X_LINK_ID";
+        private const string DISCORD_LINK_ID = "DISCORD_LINK_ID";
 
         private readonly MarketplaceCreditsProgramEndedSubView subView;
         private readonly IWebBrowser webBrowser;
@@ -32,18 +33,23 @@ namespace DCL.MarketplaceCredits.Sections
 
         public void Setup(CreditsProgramProgressResponse creditsProgramProgressResponse)
         {
-            string title = creditsProgramProgressResponse.season.seasonState switch
-                           {
-                               nameof(MarketplaceCreditsUtils.SeasonState.ENDED) => $"The current run of Marketplace Credits Weekly Rewards ({MarketplaceCreditsUtils.FormatSeasonDateRange(creditsProgramProgressResponse.season.startDate, creditsProgramProgressResponse.season.endDate)}) has closed",
-                               nameof(MarketplaceCreditsUtils.SeasonState.ERR_SEASON_RUN_OUT_OF_FUNDS) => "All Available Credits Claimed: The beta run of the Weekly Rewards program is now closed",
-                               nameof(MarketplaceCreditsUtils.SeasonState.ERR_WEEK_RUN_OUT_OF_FUNDS) => "All credits has been emitted for this week. Lets try next week",
-                               nameof(MarketplaceCreditsUtils.SeasonState.ERR_PROGRAM_PAUSED) => "The Weekly Rewards program has been paused. Please come back later",
-                               _ => string.Empty,
-                           };
+            var title = $"The current run of Marketplace Credits Weekly Rewards ({MarketplaceCreditsUtils.FormatSeasonDateRange(creditsProgramProgressResponse.season.startDate, creditsProgramProgressResponse.season.endDate)}) has closed";
+            var subTitle = $"Make sure to <color=#FF2D55><b><u><link={SUBSCRIBE_LINK_ID}>subscribe</link></u></b></color> to Decentraland's newsletter or follow on <color=#FF2D55><b><u><link={X_LINK_ID}>X</link></u></b></color> to find out when the next run goes live!";
+
+            switch (creditsProgramProgressResponse.season.seasonState)
+            {
+                case nameof(MarketplaceCreditsUtils.SeasonState.ERR_SEASON_RUN_OUT_OF_FUNDS):
+                case nameof(MarketplaceCreditsUtils.SeasonState.ERR_WEEK_RUN_OUT_OF_FUNDS):
+                    title = "All Available Credits Claimed: The beta run of the Weekly Rewards program is now closed";
+                    break;
+                case nameof(MarketplaceCreditsUtils.SeasonState.ERR_PROGRAM_PAUSED):
+                    title = "Marketplace Credits are Temporarily Offline";
+                    subTitle = $"Please check the #product-status channel in <color=#FF2D55><b><u><link={DISCORD_LINK_ID}>Decentraland's Discord server</link></u></b></color> for updates if service does not resume shortly.";
+                    break;
+            }
 
             subView.SetTitle(title);
-
-            subView.SetSubtitle($"Make sure to <color=#FF2D55><b><u><link={SUBSCRIBE_LINK_ID}>subscribe</link></u></b></color> to Decentraland's newsletter or follow on <color=#FF2D55><b><u><link={X_LINK_ID}>X</link></u></b></color> to find out when the next run goes live!");
+            subView.SetSubtitle(subTitle);
         }
 
         public void Dispose() { }
@@ -57,6 +63,9 @@ namespace DCL.MarketplaceCredits.Sections
                     break;
                 case X_LINK_ID:
                     webBrowser.OpenUrl(DecentralandUrl.TwitterLink);
+                    break;
+                case DISCORD_LINK_ID:
+                    webBrowser.OpenUrl(DecentralandUrl.DiscordDirectLink);
                     break;
             }
 

--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsProgramEndedSubController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsProgramEndedSubController.cs
@@ -32,9 +32,16 @@ namespace DCL.MarketplaceCredits.Sections
 
         public void Setup(CreditsProgramProgressResponse creditsProgramProgressResponse)
         {
-            subView.SetTitle(!creditsProgramProgressResponse.season.isOutOfFunds ?
-                $"The current run of Marketplace Credits Weekly Rewards ({MarketplaceCreditsUtils.FormatSeasonDateRange(creditsProgramProgressResponse.season.startDate, creditsProgramProgressResponse.season.endDate)}) has closed" :
-                "All Available Credits Claimed: The beta run of the Weekly Rewards program is now closed");
+            string title = creditsProgramProgressResponse.season.seasonState switch
+                           {
+                               nameof(MarketplaceCreditsUtils.SeasonState.ENDED) => $"The current run of Marketplace Credits Weekly Rewards ({MarketplaceCreditsUtils.FormatSeasonDateRange(creditsProgramProgressResponse.season.startDate, creditsProgramProgressResponse.season.endDate)}) has closed",
+                               nameof(MarketplaceCreditsUtils.SeasonState.ERR_SEASON_RUN_OUT_OF_FUNDS) => "All Available Credits Claimed: The beta run of the Weekly Rewards program is now closed",
+                               nameof(MarketplaceCreditsUtils.SeasonState.ERR_WEEK_RUN_OUT_OF_FUNDS) => "All credits has been emitted for this week. Lets try next week",
+                               nameof(MarketplaceCreditsUtils.SeasonState.ERR_PROGRAM_PAUSED) => "The Weekly Rewards program has been paused. Please come back later",
+                               _ => string.Empty,
+                           };
+
+            subView.SetTitle(title);
 
             subView.SetSubtitle($"Make sure to <color=#FF2D55><b><u><link={SUBSCRIBE_LINK_ID}>subscribe</link></u></b></color> to Decentraland's newsletter or follow on <color=#FF2D55><b><u><link={X_LINK_ID}>X</link></u></b></color> to find out when the next run goes live!");
         }

--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsWelcomeSubController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsWelcomeSubController.cs
@@ -67,6 +67,7 @@ namespace DCL.MarketplaceCredits.Sections
         public void OpenSection()
         {
             subView.gameObject.SetActive(true);
+            totalCreditsWidgetView.gameObject.SetActive(false);
 
             fetchProgramRegistrationInfoCts = fetchProgramRegistrationInfoCts.SafeRestart();
             LoadProgramRegistrationInfoAsync(fetchProgramRegistrationInfoCts.Token).Forget();
@@ -193,8 +194,11 @@ namespace DCL.MarketplaceCredits.Sections
             {
                 marketplaceCreditsProgramEndedSubController.Setup(currentCreditsProgramProgress);
                 marketplaceCreditsMenuController.OpenSection(MarketplaceCreditsSection.PROGRAM_ENDED);
+                totalCreditsWidgetView.gameObject.SetActive(currentCreditsProgramProgress.season.seasonState != nameof(MarketplaceCreditsUtils.SeasonState.ERR_PROGRAM_PAUSED));
                 return;
             }
+
+            totalCreditsWidgetView.gameObject.SetActive(true);
 
             // NON-REGISTERED USER FLOW
             if (!currentCreditsProgramProgress.IsUserEmailRegistered())

--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsWelcomeSubController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsWelcomeSubController.cs
@@ -194,7 +194,9 @@ namespace DCL.MarketplaceCredits.Sections
             {
                 marketplaceCreditsProgramEndedSubController.Setup(currentCreditsProgramProgress);
                 marketplaceCreditsMenuController.OpenSection(MarketplaceCreditsSection.PROGRAM_ENDED);
-                totalCreditsWidgetView.gameObject.SetActive(currentCreditsProgramProgress.season.seasonState != nameof(MarketplaceCreditsUtils.SeasonState.ERR_PROGRAM_PAUSED));
+                totalCreditsWidgetView.gameObject.SetActive(
+                    currentCreditsProgramProgress.season.seasonState != nameof(MarketplaceCreditsUtils.SeasonState.ERR_WEEK_RUN_OUT_OF_FUNDS) &&
+                    currentCreditsProgramProgress.season.seasonState != nameof(MarketplaceCreditsUtils.SeasonState.ERR_PROGRAM_PAUSED));
                 return;
             }
 

--- a/Explorer/Assets/DCL/MarketplaceCreditsAPIService/ClaimCreditsResponse.cs
+++ b/Explorer/Assets/DCL/MarketplaceCreditsAPIService/ClaimCreditsResponse.cs
@@ -7,6 +7,6 @@ namespace DCL.MarketplaceCreditsAPIService
     {
         public bool ok;
         public float credits_granted;
-        public bool is_locked;
+        public bool isBlockedForClaiming;
     }
 }

--- a/Explorer/Assets/DCL/MarketplaceCreditsAPIService/ClaimCreditsResponse.cs
+++ b/Explorer/Assets/DCL/MarketplaceCreditsAPIService/ClaimCreditsResponse.cs
@@ -7,5 +7,6 @@ namespace DCL.MarketplaceCreditsAPIService
     {
         public bool ok;
         public float credits_granted;
+        public bool is_locked;
     }
 }

--- a/Explorer/Assets/DCL/MarketplaceCreditsAPIService/CreditsProgramProgressResponse.cs
+++ b/Explorer/Assets/DCL/MarketplaceCreditsAPIService/CreditsProgramProgressResponse.cs
@@ -19,7 +19,7 @@ namespace DCL.MarketplaceCreditsAPIService
         public string startDate;
         public string endDate;
         public uint timeLeft;
-        public bool isOutOfFunds;
+        public string seasonState;
     }
 
     [Serializable]
@@ -41,6 +41,7 @@ namespace DCL.MarketplaceCreditsAPIService
     {
         public float available;
         public uint expiresIn;
+        public bool isBlockedForClaiming;
     }
 
     [Serializable]


### PR DESCRIPTION
# Pull Request Description
Fix #4157 

## What does this PR change?
### New scenarios added
- New UI screen for when all the credits have been emitted for the current week so the user will have to wait forn ext one.

![image](https://github.com/user-attachments/assets/c79cdf2b-ec6a-4119-b6a6-c1d0ab0bd394)

- For the cases when, for any reason, we decide to pause the rewards program... instead of directly hiding the feature through the feature flag, we show a new UI screen indicating the user that it is paused.

![image](https://github.com/user-attachments/assets/c79cdf2b-ec6a-4119-b6a6-c1d0ab0bd394)

- For the cases when the user has tried to solve the claiming credits captcha too many times, we will show a message indicating that the captcha is blocked so the user will need to wait 24h for trying again.

![image](https://github.com/user-attachments/assets/82b87e08-6fff-4836-9520-235494befc84)

### Fixes
- Fix anchors in the Credits Rewards UI.
- Fix the alpha transparency of the rays in the Credits Rewards UI.

![image](https://github.com/user-attachments/assets/f0aff540-a93e-4d40-9ae6-25278478e0e2)

**NOTE**: The idea is to add these changes in the next release after **Marketplace Credits** feature has been put into production.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.