### PR TITLE
fix: handle of SignatureExpiredException

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -290,6 +290,7 @@ namespace DCL.AuthenticationScreenFlow
                     }
                 }
                 catch (OperationCanceledException) { SwitchState(ViewState.Login); }
+                catch (SignatureExpiredException) { SwitchState(ViewState.Login); }
                 catch (Exception e)
                 {
                     SwitchState(ViewState.Login);


### PR DESCRIPTION
## What does this PR change?

Fixes #4159 

Changes consists on handling the `SignatureExpiredException` provoked by the user not signing the login request after 5 minutes.

## Test Instructions

Start the authentication flow. When it asks for wallet confirmation, wait more than 5 minutes until the timer expires. You should be redirected to start the auth flow again.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
