### PR TITLE
fix: nre on user name element disposal

### DIFF
--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/UserNameElementController.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/UserNameElementController.cs
@@ -41,7 +41,6 @@ namespace DCL.UI.ProfileElements
         public void Dispose()
         {
             Element.CopyUserNameButton.onClick.RemoveAllListeners();
-            Element.CopyNameWarningNotification.Hide(true);
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fixes #4161 

The exception occurs on the disposal of the main started from `MainSceneLoader`.
Removed the `warning.Hide` operation of the `UserNameElement` since seems to be unnecessary during application disposal.

## Test Instructions

Open the profile menu from the top left button of the side bar. Copy your wallet. Check that the toast shows as expected.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
