### PR TITLE
Fix: Ensure Chat Messages are added in the order they were received

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Deduplication/MessageDeduplication.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Deduplication/MessageDeduplication.cs
@@ -35,7 +35,7 @@ namespace DCL.Multiplayer.Deduplication
         }
 
         [Serializable]
-        internal struct RegisteredStamp : IEquatable<RegisteredStamp>
+        public struct RegisteredStamp : IEquatable<RegisteredStamp>
         {
             public string walletId;
             public T timestamp;


### PR DESCRIPTION

## How to QA

The subject itself is an edge case, it will be really hard to test explicitly. I'd propose to validate delivery of chat messages that there is no regression