### PR TITLE
fix: Update Marketplace Credits tip in the Loading Screen

### DIFF
--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
@@ -79,7 +79,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 161948706800656384
-    m_Localized: '<b><size=26><color #FF531A>LIVE NOW!</color></size></b>
+    m_Localized: '<b><size=26><color #FF531A>NOW LIVE!</color></size></b>
 
       <i>Connect
       in Decentraland, Earn Credits,

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
@@ -79,7 +79,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 161948706800656384
-    m_Localized: '<b><size=26><color #FF531A>COMING SOON</color></size></b>
+    m_Localized: '<b><size=26><color #FF531A>LIVE NOW!</color></size></b>
 
       <i>Connect
       in Decentraland, Earn Credits,


### PR DESCRIPTION
# Pull Request Description
Fix #4196 

## What does this PR change?
It updates the text "**COMING SOON**" by "**NOW LIVE!**" in the loading tip related to the Marketplace Credits feature.

### BEFORE
![image](https://github.com/user-attachments/assets/94970340-a838-455d-a018-61ecccba4054)

### NOW
![image](https://github.com/user-attachments/assets/6486f80a-1aa7-4dfd-9d86-e4ec0d14c0d3)

### Test Steps
1. Open the app.
2. Check that the tip "Marketplace Credits" in the loading screen's carrousel says "NOW LIVE!" instead of "COMING SOON".

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
