### PR TITLE
Add a new field to track who receives a private message

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
@@ -41,16 +41,21 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
         {
             core.Send(channel, message, origin);
 
-            analytics.Track(AnalyticsEvents.UI.MESSAGE_SENT, new JsonObject
-            {
-                { "is_command", message[0] == '/' },
-                { "origin", origin },
-                { "is_mention", CheckIfIsMention(message)},
-                { "is_private", channel.ChannelType == ChatChannel.ChatChannelType.USER},
+            JsonObject jsonObject = new JsonObject
+                {
+                    { "is_command", message[0] == '/' },
+                    { "origin", origin },
+                    { "is_mention", CheckIfIsMention(message)},
+                    { "is_private", channel.ChannelType == ChatChannel.ChatChannelType.USER},
 
-                //TODO FRAN: Add here array of mentioned players.
-                // { "emoji_count", emoji_count },
-            });
+                    //TODO FRAN: Add here array of mentioned players.
+                    // { "emoji_count", emoji_count },
+                };
+
+            if (channel.ChannelType == ChatChannel.ChatChannelType.USER)
+                jsonObject.Add("receiver_id", channel.Id.Id);
+
+            analytics.Track(AnalyticsEvents.UI.MESSAGE_SENT, jsonObject);
         }
 
         private bool  CheckIfIsMention(string message)


### PR DESCRIPTION
# Pull Request Description

It's necessary to add extra data to the analytics trace that is sent when a message is sent, in order to know who received it.

## What does this PR change?

Just added the field "receiver_id" to the "chat_message_sent" trace with the wallet id of the receiver, only when the message belongs to a private conversation.

