### PR TITLE
fix: handle local scene development websocket errors

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/Bootstraper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/Bootstraper.cs
@@ -196,6 +196,7 @@ namespace Global.Dynamic
                 appArgs,
                 coroutineRunner,
                 dclVersion,
+                realmUrls,
                 ct);
 
             if (tuple.container != null)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -14,8 +14,8 @@ using DCL.BadgesAPIService;
 using DCL.Browser;
 using DCL.CharacterPreview;
 using DCL.Chat.Commands;
-using DCL.Chat.History;
 using DCL.Chat.EventBus;
+using DCL.Chat.History;
 using DCL.Chat.MessageBus;
 using DCL.Clipboard;
 using DCL.DebugUtilities;
@@ -86,11 +86,10 @@ using DCL.WebRequests.Analytics;
 using ECS.Prioritization.Components;
 using ECS.SceneLifeCycle;
 using ECS.SceneLifeCycle.CurrentScene;
-using ECS.SceneLifeCycle.IncreasingRadius;
-using ECS.SceneLifeCycle.LocalSceneDevelopment;
 using ECS.SceneLifeCycle.Realm;
 using Global.AppArgs;
 using Global.Dynamic.ChatCommands;
+using Global.Dynamic.RealmUrl;
 using Global.Versioning;
 using LiveKit.Internal.FFIClients.Pools;
 using LiveKit.Internal.FFIClients.Pools.Memory;
@@ -116,7 +115,6 @@ namespace Global.Dynamic
 {
     public class DynamicWorldContainer : DCLWorldContainer<DynamicWorldSettings>
     {
-        private readonly LocalSceneDevelopmentController? localSceneDevelopmentController;
         private readonly IChatMessagesBus chatMessagesBus;
         private readonly IProfileBroadcast profileBroadcast;
 
@@ -139,7 +137,6 @@ namespace Global.Dynamic
         public IRoomHub RoomHub { get; }
 
         private DynamicWorldContainer(
-            LocalSceneDevelopmentController? localSceneDevelopmentController,
             IMVCManager mvcManager,
             IGlobalRealmController realmController,
             GlobalWorldFactory globalWorldFactory,
@@ -161,7 +158,6 @@ namespace Global.Dynamic
             MessagePipesHub = messagePipesHub;
             RemoteMetadata = remoteMetadata;
             RoomHub = roomHub;
-            this.localSceneDevelopmentController = localSceneDevelopmentController;
             this.chatMessagesBus = chatMessagesBus;
             this.profileBroadcast = profileBroadcast;
         }
@@ -171,7 +167,6 @@ namespace Global.Dynamic
             chatMessagesBus.Dispose();
             profileBroadcast.Dispose();
             MessagePipesHub.Dispose();
-            localSceneDevelopmentController?.Dispose();
         }
 
         public static async UniTask<(DynamicWorldContainer? container, bool success)> CreateAsync(
@@ -184,6 +179,7 @@ namespace Global.Dynamic
             IAppArgs appArgs,
             ICoroutineRunner coroutineRunner,
             DCLVersion dclVersion,
+            IRealmUrls realmUrls,
             CancellationToken ct)
         {
             DynamicSettings dynamicSettings = dynamicWorldDependencies.DynamicSettings;
@@ -360,10 +356,6 @@ namespace Global.Dynamic
             );
 
             var reloadSceneController = new ECSReloadScene(staticContainer.ScenesCache, globalWorld, playerEntity, localSceneDevelopment);
-
-            LocalSceneDevelopmentController? localSceneDevelopmentController = localSceneDevelopment
-                ? new LocalSceneDevelopmentController(reloadSceneController, dynamicWorldParams.LocalSceneDevelopmentRealm, playerEntity, globalWorld)
-                : null;
 
             var chatRoom = new ChatConnectiveRoom(staticContainer.WebRequestsContainer.WebRequestController, URLAddress.FromString(bootstrapContainer.DecentralandUrlsSource.Url(DecentralandUrl.ChatAdapter)));
 
@@ -858,6 +850,9 @@ namespace Global.Dynamic
 
             globalPlugins.AddRange(staticContainer.SharedPlugins);
 
+            if (localSceneDevelopment)
+                globalPlugins.Add(new LocalSceneDevelopmentPlugin(reloadSceneController, realmUrls));
+
             if (includeCameraReel)
                 globalPlugins.Add(new InWorldCameraPlugin(
                     dclInput,
@@ -982,7 +977,6 @@ namespace Global.Dynamic
             staticContainer.RoomHubProxy.SetObject(roomHub);
 
             var container = new DynamicWorldContainer(
-                localSceneDevelopmentController,
                 mvcManager,
                 realmContainer.RealmController,
                 globalWorldFactory,

--- a/Explorer/Assets/DCL/PluginSystem/Global/LocalSceneDevelopmentPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/LocalSceneDevelopmentPlugin.cs
@@ -1,0 +1,63 @@
+using Arch.Core;
+using Arch.SystemGroups;
+using Cysharp.Threading.Tasks;
+using ECS.SceneLifeCycle;
+using ECS.SceneLifeCycle.LocalSceneDevelopment;
+using Global.Dynamic.RealmUrl;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Threading;
+using Utility;
+
+namespace DCL.PluginSystem.Global
+{
+    public class LocalSceneDevelopmentPlugin : IDCLGlobalPlugin
+    {
+        private const int RETRY_DELAY_MS = 5000;
+
+        private readonly IReloadScene reloadSceneController;
+        private readonly IRealmUrls realmUrls;
+        private LocalSceneDevelopmentController? localSceneDevelopmentController;
+        private CancellationTokenSource? lifeCycleCancellationTokenSource;
+
+        public LocalSceneDevelopmentPlugin(IReloadScene reloadSceneController,
+            IRealmUrls realmUrls)
+        {
+            this.reloadSceneController = reloadSceneController;
+            this.realmUrls = realmUrls;
+        }
+
+        public void Dispose()
+        {
+            localSceneDevelopmentController?.Dispose();
+            lifeCycleCancellationTokenSource.SafeCancelAndDispose();
+        }
+
+        public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments)
+        {
+            lifeCycleCancellationTokenSource = lifeCycleCancellationTokenSource.SafeRestart();
+            ConnectToServerAsync(arguments.PlayerEntity, builder.World, lifeCycleCancellationTokenSource.Token).Forget();
+        }
+
+        private async UniTaskVoid ConnectToServerAsync(Entity playerEntity, Arch.Core.World world, CancellationToken ct)
+        {
+            string realm = await realmUrls.LocalSceneDevelopmentRealmAsync(ct) ?? string.Empty;
+
+            localSceneDevelopmentController = new LocalSceneDevelopmentController(reloadSceneController,
+                playerEntity,
+                world);
+
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    await localSceneDevelopmentController.ConnectToServerAsync(
+                        realm.Contains("https") ? realm.Replace("https", "wss") : realm.Replace("http", "ws"),
+                        ct);
+                }
+                catch (WebSocketException) { await UniTask.Delay(RETRY_DELAY_MS, cancellationToken: ct); }
+                catch (SocketException) { await UniTask.Delay(RETRY_DELAY_MS, cancellationToken: ct); }
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/PluginSystem/Global/LocalSceneDevelopmentPlugin.cs.meta
+++ b/Explorer/Assets/DCL/PluginSystem/Global/LocalSceneDevelopmentPlugin.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 84bc574bfc144be783eb0aa37f06744d
+timeCreated: 1747421836


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Refactor of `LocalSceneDevelopmentController` creation into a plugin, so the web socket is opened during the plugin initialization. Additionally it handles web socket exceptions and implements a retry system.

## Test Instructions

In order to be able to test the scene from the Creator Hub with a custom build you can try:
1. Run the Creator Hub
2. Preview the scene
3. It will open a new client, close it
4. Run the custom build with the args provided here: https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene

### Test Steps
1. Make a scene through the creator's hub
2. Add models
3. Preview the scene in the build
4. Make a change in the scene through the creator's hub
5. The scene should reload in the client

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
