### PR TITLE
fix: chat messages out of order

### DIFF
--- a/Explorer/Assets/DCL/Chat/History/ChatHistorySerializer.cs
+++ b/Explorer/Assets/DCL/Chat/History/ChatHistorySerializer.cs
@@ -81,7 +81,7 @@ namespace DCL.Chat.History
                     ParseEntryValues(currentLine, entryValues);
                     bool sentByLocalUser = entryValues[ENTRY_SENT_BY_LOCAL_USER] == LOCAL_USER_TRUE_VALUE;
                     string walletAddress = sentByLocalUser ? localUserWalletAddress : remoteUserWalletAddress;
-                    ChatMessage newMessage = await messageFactory.CreateChatMessageAsync(walletAddress, sentByLocalUser, entryValues[ENTRY_MESSAGE], entryValues[ENTRY_USERNAME], ct);
+                    ChatMessage newMessage = messageFactory.CreateChatMessage(walletAddress, sentByLocalUser, entryValues[ENTRY_MESSAGE], entryValues[ENTRY_USERNAME]);
 
                     obtainedMessages.Add(newMessage);
                     currentLine = await reader2.ReadLineAsync();

--- a/Explorer/Assets/DCL/Chat/History/ChatMessageFactory.cs
+++ b/Explorer/Assets/DCL/Chat/History/ChatMessageFactory.cs
@@ -24,6 +24,7 @@ namespace DCL.Chat.History
 
         /// <summary>
         /// Generates a new chat message filled with the data provided in the parameters and also by the profile cache.
+        /// Additional note: we need this function to be immediate (not async) to ensure chat messages are propagated in the correct chronological order.
         /// </summary>
         /// <param name="senderWalletAddress">The wallet address of the user that sent the message.</param>
         /// <param name="isSentByLocalUser">Whether the user that sent the message corresponds to the local user.</param>

--- a/Explorer/Assets/DCL/Chat/History/ChatMessageFactory.cs
+++ b/Explorer/Assets/DCL/Chat/History/ChatMessageFactory.cs
@@ -1,8 +1,6 @@
-using Cysharp.Threading.Tasks;
 using DCL.Profiles;
-using DCL.Profiles.Self;
+using DCL.Web3.Identities;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 namespace DCL.Chat.History
 {
@@ -13,65 +11,68 @@ namespace DCL.Chat.History
     {
         private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{3,15}(?:#[A-Za-z0-9]{4})?)(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
 
-        private readonly ISelfProfile selfProfile;
-        private readonly IProfileRepository profileRepository;
+        private readonly IProfileCache profileCache;
+        private readonly IWeb3IdentityCache web3IdentityCache;
 
-        public ChatMessageFactory(ISelfProfile selfProfile, IProfileRepository profileRepository)
+        public ChatMessageFactory(
+            IProfileCache profileCache,
+            IWeb3IdentityCache web3IdentityCache)
         {
-            this.selfProfile = selfProfile;
-            this.profileRepository = profileRepository;
+            this.profileCache = profileCache;
+            this.web3IdentityCache = web3IdentityCache;
         }
 
         /// <summary>
-        /// Generates a new chat message filled with the data provided in the parameters and also by the profile repository.
+        /// Generates a new chat message filled with the data provided in the parameters and also by the profile cache.
         /// </summary>
         /// <param name="senderWalletAddress">The wallet address of the user that sent the message.</param>
         /// <param name="isSentByLocalUser">Whether the user that sent the message corresponds to the local user.</param>
         /// <param name="message">The formatted text message.</param>
         /// <param name="usernameOverride">Optional. A sender's username to use instead of the one stored in the profile currently.
         /// Leave it null to use the one provided by the profile.</param>
-        /// <param name="ct">A cancellation token.</param>
-        /// <returns>The task of the asynchronous operation.</returns>
-        public async UniTask<ChatMessage> CreateChatMessageAsync(string senderWalletAddress, bool isSentByLocalUser, string message, string usernameOverride, CancellationToken ct)
+        public ChatMessage CreateChatMessage(string senderWalletAddress, bool isSentByLocalUser, string message, string? usernameOverride)
         {
-            Profile ownProfile = await selfProfile.ProfileAsync(ct);
+            Profile? ownProfile = null;
+
+            if (web3IdentityCache.Identity != null)
+                ownProfile = profileCache.Get(web3IdentityCache.Identity.Address);
 
             if (isSentByLocalUser)
             {
-                if(string.IsNullOrEmpty(usernameOverride))
-                    usernameOverride = ownProfile?.ValidatedName ?? string.Empty;
+                if (string.IsNullOrEmpty(usernameOverride))
+                    usernameOverride = ownProfile?.ValidatedName ?? $"#{senderWalletAddress[^4..]}";
 
                 return new ChatMessage(
                     message,
                     usernameOverride,
                     senderWalletAddress,
                     true,
-                    ownProfile?.WalletId,
+                    ownProfile?.WalletId ?? string.Empty,
                     isMention: false
                 );
             }
-            else
-            {
-                Profile profile = await profileRepository.GetAsync(senderWalletAddress, ct);
 
-                if(string.IsNullOrEmpty(usernameOverride))
-                    usernameOverride = profile?.ValidatedName ?? string.Empty;
+            // Using profileCache for immediate access ensures chat messages maintain the correct chronological order
+            // since async profile fetching times are unpredictable.
+            Profile? profile = profileCache.Get(senderWalletAddress);
 
-                bool isMention = false;
+            if (string.IsNullOrEmpty(usernameOverride))
+                usernameOverride = profile?.ValidatedName ?? $"#{senderWalletAddress[^4..]}";
 
-                if (ownProfile != null)
-                    isMention = IsMention(message, ownProfile.MentionName);
+            bool isMention = false;
 
-                return new ChatMessage(
-                    message,
-                    usernameOverride,
-                    senderWalletAddress,
-                    false,
-                    profile?.WalletId,
-                    isMention,
-                    false
-                );
-            }
+            if (ownProfile != null)
+                isMention = IsMention(message, ownProfile.MentionName);
+
+            return new ChatMessage(
+                message,
+                usernameOverride,
+                senderWalletAddress,
+                false,
+                profile?.WalletId ?? string.Empty,
+                isMention,
+                false
+            );
         }
 
         private bool IsMention(string chatMessage, string userName)
@@ -81,6 +82,7 @@ namespace DCL.Chat.History
                 if (match.Value == userName)
                     return true;
             }
+
             return false;
         }
     }

--- a/Explorer/Assets/DCL/Chat/History/ChatMessageFactory.cs
+++ b/Explorer/Assets/DCL/Chat/History/ChatMessageFactory.cs
@@ -41,14 +41,14 @@ namespace DCL.Chat.History
             if (isSentByLocalUser)
             {
                 if (string.IsNullOrEmpty(usernameOverride))
-                    usernameOverride = ownProfile?.ValidatedName ?? $"#{senderWalletAddress[^4..]}";
+                    usernameOverride = ownProfile?.ValidatedName ?? string.Empty;
 
                 return new ChatMessage(
                     message,
                     usernameOverride,
                     senderWalletAddress,
                     true,
-                    ownProfile?.WalletId ?? string.Empty,
+                    GetUserHash(ownProfile),
                     isMention: false
                 );
             }
@@ -58,7 +58,7 @@ namespace DCL.Chat.History
             Profile? profile = profileCache.Get(senderWalletAddress);
 
             if (string.IsNullOrEmpty(usernameOverride))
-                usernameOverride = profile?.ValidatedName ?? $"#{senderWalletAddress[^4..]}";
+                usernameOverride = profile?.ValidatedName ?? string.Empty;
 
             bool isMention = false;
 
@@ -70,10 +70,22 @@ namespace DCL.Chat.History
                 usernameOverride,
                 senderWalletAddress,
                 false,
-                profile?.WalletId ?? string.Empty,
+                GetUserHash(profile),
                 isMention,
                 false
             );
+
+            string GetUserHash(Profile? profile)
+            {
+                string userHash;
+
+                if (profile != null)
+                    userHash = profile.WalletId ?? string.Empty;
+                else
+                    userHash = $"#{senderWalletAddress[^4..]}";
+
+                return userHash;
+            }
         }
 
         private bool IsMention(string chatMessage, string userName)

--- a/Explorer/Assets/DCL/Chat/History/DCL.Chat.History.asmdef
+++ b/Explorer/Assets/DCL/Chat/History/DCL.Chat.History.asmdef
@@ -6,7 +6,9 @@
         "GUID:fa7b3fdbb04d67549916da7bd2af58ab",
         "GUID:3640f3c0b42946b0b8794a1ed8e06ca5",
         "GUID:e56a0d6a94c144c784012e63b6043100",
-        "GUID:8322ea9340a544c59ddc56d4793eac74"
+        "GUID:8322ea9340a544c59ddc56d4793eac74",
+        "GUID:5ab29fa8ae5769b49ab29e390caca7a4",
+        "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Chat/History/csc.rsp
+++ b/Explorer/Assets/DCL/Chat/History/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:enable

--- a/Explorer/Assets/DCL/Chat/History/csc.rsp.meta
+++ b/Explorer/Assets/DCL/Chat/History/csc.rsp.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9faa49311b1844cc87a8e06ccb49d7c5
+timeCreated: 1747663016

--- a/Explorer/Assets/DCL/Chat/MessageBus/MultiplayerChatMessagesBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/MultiplayerChatMessagesBus.cs
@@ -65,7 +65,7 @@ namespace DCL.Chat.MessageBus
                     return;
 
                 ChatChannel.ChannelId parsedChannelId = isPrivate? new ChatChannel.ChannelId(receivedMessage.FromWalletId) : ChatChannel.NEARBY_CHANNEL_ID;
-                ChatMessage newMessage = await messageFactory.CreateChatMessageAsync(receivedMessage.FromWalletId, false, receivedMessage.Payload.Message, null, cancellationTokenSource.Token);
+                ChatMessage newMessage = messageFactory.CreateChatMessage(receivedMessage.FromWalletId, false, receivedMessage.Payload.Message, null);
 
                 MessageAdded?.Invoke(parsedChannelId, newMessage);
             }

--- a/Explorer/Assets/DCL/Chat/MessageBus/SelfResendChatMessageBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/SelfResendChatMessageBus.cs
@@ -1,9 +1,7 @@
-using Cysharp.Threading.Tasks;
 using DCL.Chat.History;
 using DCL.Diagnostics;
 using DCL.Web3.Identities;
 using System;
-using System.Threading;
 
 namespace DCL.Chat.MessageBus
 {
@@ -41,10 +39,10 @@ namespace DCL.Chat.MessageBus
         public void Send(ChatChannel channel, string message, string origin)
         {
             this.origin.Send(channel, message, origin);
-            SendSelfAsync(channel.Id, message).Forget();
+            SendSelf(channel.Id, message);
         }
 
-        private async UniTaskVoid SendSelfAsync(ChatChannel.ChannelId channelId, string chatMessage)
+        private void SendSelf(ChatChannel.ChannelId channelId, string chatMessage)
         {
             IWeb3Identity identity = web3IdentityCache.Identity;
 
@@ -54,7 +52,7 @@ namespace DCL.Chat.MessageBus
                 return;
             }
 
-            ChatMessage newMessage = await messageFactory.CreateChatMessageAsync(identity.Address, true, chatMessage, null, CancellationToken.None);
+            ChatMessage newMessage = messageFactory.CreateChatMessage(identity.Address, true, chatMessage, null);
 
             MessageAdded?.Invoke(channelId, newMessage);
         }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -518,7 +518,7 @@ namespace Global.Dynamic
 
             chatCommands.Add(new HelpChatCommand(chatCommands, appArgs));
 
-            var chatMessageFactory = new ChatMessageFactory(selfProfile, profileRepository);
+            var chatMessageFactory = new ChatMessageFactory(profileCache, identityCache);
             var userBlockingCacheProxy = new ObjectProxy<IUserBlockingCache>();
 
             IChatMessagesBus coreChatMessageBus = new MultiplayerChatMessagesBus(messagePipesHub, chatMessageFactory, new MessageDeduplication<double>(), userBlockingCacheProxy)


### PR DESCRIPTION
## What does this PR change?

Based on this pr: https://github.com/decentraland/unity-explorer/pull/4192

The approach has been updated to make chat message creation a synchronous function, ensuring immediate propagation and preserving the order of arrival.
In cases the profile is not in the cache, then the user name will be replaced by the `#userHash` being the last 4 numbers of the address.

## Test Instructions
You need to test chat messages in general. Either private conversations of nearby channel. Send and receive messages from different users. Check that you receive messages in the correct order. Also check that the username is always displayed correctly, and if by any case you receive just the #userHash, the next message should be fixed.

### Additional Testing Notes
To check correct order of arrival, you can try spamming numbers: 1,2,3,4,5,...

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
