### PR TITLE
fix: add multiple emojis

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatInputBoxElement.cs
+++ b/Explorer/Assets/DCL/Chat/ChatInputBoxElement.cs
@@ -347,7 +347,6 @@ namespace DCL.Chat
             IsEmojisEnabled = false;
             characterCounter.gameObject.SetActive(false);
             InputBoxFocusChanged?.Invoke(false);
-            inputField.text = string.Empty;
         }
 
         private void OnInputSelected(string _)


### PR DESCRIPTION
## What does this PR change?

Fixes #4183 

Previously, the input text was reset when the field was considered "deselected".
Clicking an emoji triggered this deselect event, causing the text to reset before the emoji was added.
This resulted in losing the previous input whenever an emoji was selected.
Now, the input text is preserved and no longer reset on deselection.

## Test Instructions
Add emojis in the chat. You should be able to add as many as you want, inside the character limit.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
