### PR TITLE
fix: global audio streams

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs
@@ -91,7 +91,8 @@ namespace DCL.SDKComponents.MediaStream
             // There is no way to set this from the scene code, at the moment
             // If the player has no transform, it will appear at 0,0,0 and nobody will hear it if it is in 3D
             if (component.MediaPlayer.TryGetAvProPlayer(out var player) && player!.TryGetComponent(out AudioSource mediaPlayerAudio))
-                mediaPlayerAudio!.spatialBlend = World!.Has<TransformComponent>(entity) ? 1.0f : 0.0f;
+                // At the moment we consider streams as global audio always, until there is a way to change it from the scene
+                mediaPlayerAudio!.spatialBlend = 0.0f;
 
             World.Add(entity, component);
         }


### PR DESCRIPTION
## What does this PR change?

Fixes #4181 

The client was considering the audio stream as global or spatial depending if the entity had a transform. Now that changed so we force all audio streams to be global.

We have an open discussion about how we can make audio streams configurable so they support both global and spatial. In the meantime we keep the behaviour as it was in the old client.

## Test Instructions
Download and run the scene attached into the issue. The audio stream should not change the volume depending on the distance to the player.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
