### PR TITLE
fix: check if tag exists before adding a new one on create a release page workflow

### DIFF
--- a/.github/workflows/build-release-main-page.yml
+++ b/.github/workflows/build-release-main-page.yml
@@ -43,8 +43,12 @@ jobs:
       - name: Apply tag to branch
         run: |
           TAG=${{ needs.get-info.outputs.tag_version }}
-          git tag $TAG
-          git push origin $TAG
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists. Skipping tag creation."
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
 
       - name: Download artifacts
         uses: dawidd6/action-download-artifact@v6


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
When build-release-main-page.yml workflow fails, rerunning it creates a new tag, which  breaks the release process. To prevent this, we now check if the tag already exists before creating and pushing it.
