### PR TITLE
chore: removed object proxy for social service rpc

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -526,7 +526,7 @@ namespace Global.Dynamic
             var coreBackpackEventBus = new BackpackEventBus();
 
             ISocialServiceEventBus socialServiceEventBus = new SocialServiceEventBus();
-            IRPCSocialServices rpcSocialServices = new RPCSocialServices(GetApiUrl(bootstrapContainer.DecentralandUrlsSource, appArgs), identityCache, socialServiceEventBus);
+            IRPCSocialServices rpcSocialServices = new RPCSocialServices(GetFriendsApiUrl(bootstrapContainer.DecentralandUrlsSource, appArgs), identityCache, socialServiceEventBus);
 
             IBackpackEventBus backpackEventBus = dynamicWorldParams.EnableAnalytics
                 ? new BackpackEventBusAnalyticsDecorator(coreBackpackEventBus, bootstrapContainer.Analytics!)
@@ -997,7 +997,7 @@ namespace Global.Dynamic
             return (container, true);
         }
 
-        private static URLAddress GetApiUrl(IDecentralandUrlsSource dclUrlSource, IAppArgs appArgs)
+        private static URLAddress GetFriendsApiUrl(IDecentralandUrlsSource dclUrlSource, IAppArgs appArgs)
         {
             string url = dclUrlSource.Url(DecentralandUrl.ApiFriends);
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
@@ -57,7 +57,7 @@ namespace DCL.PluginSystem.Global
         private ChatHistoryStorage? chatStorage;
         private readonly ObjectProxy<IUserBlockingCache> userBlockingCacheProxy;
         private readonly ObjectProxy<FriendsCache> friendsCacheProxy;
-        private readonly ObjectProxy<IRPCSocialServices> socialServiceProxy;
+        private readonly IRPCSocialServices rpcSocialService;
         private readonly IFriendsEventBus friendsEventBus;
         private readonly ObjectProxy<IFriendsService> friendsServiceProxy;
 
@@ -84,7 +84,7 @@ namespace DCL.PluginSystem.Global
             ILoadingStatus loadingStatus,
             ISharedSpaceManager sharedSpaceManager,
             ObjectProxy<IUserBlockingCache> userBlockingCacheProxy,
-            ObjectProxy<IRPCSocialServices> socialServiceProxy,
+            IRPCSocialServices rpcSocialService,
             IFriendsEventBus friendsEventBus,
             ChatMessageFactory chatMessageFactory,
             FeatureFlagsCache featureFlagsCache,
@@ -114,7 +114,7 @@ namespace DCL.PluginSystem.Global
             this.featureFlagsCache = featureFlagsCache;
             this.friendsServiceProxy = friendsServiceProxy;
             this.userBlockingCacheProxy = userBlockingCacheProxy;
-            this.socialServiceProxy = socialServiceProxy;
+            this.rpcSocialService = rpcSocialService;
             this.friendsEventBus = friendsEventBus;
         }
 
@@ -128,7 +128,7 @@ namespace DCL.PluginSystem.Global
         public async UniTask InitializeAsync(ChatPluginSettings settings, CancellationToken ct)
         {
             ProvidedAsset<ChatSettingsAsset> chatSettingsAsset = await assetsProvisioner.ProvideMainAssetAsync(settings.ChatSettingsAsset, ct);
-            var privacySettings = new RPCChatPrivacyService(socialServiceProxy, chatSettingsAsset.Value);
+            var privacySettings = new RPCChatPrivacyService(rpcSocialService, chatSettingsAsset.Value);
             if (featureFlagsCache.Configuration.IsEnabled(FeatureFlagsStrings.CHAT_HISTORY_LOCAL_STORAGE))
             {
                 string walletAddress = web3IdentityCache.Identity != null ? web3IdentityCache.Identity.Address : string.Empty;

--- a/Explorer/Assets/DCL/PluginSystem/Global/FriendsPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/FriendsPlugin.cs
@@ -59,7 +59,7 @@ namespace DCL.PluginSystem.Global
         private readonly bool useAnalytics;
         private readonly IChatEventBus chatEventBus;
         private readonly ISharedSpaceManager sharedSpaceManager;
-        private readonly ObjectProxy<IRPCSocialServices> socialServicesRPCProxy;
+        private readonly IRPCSocialServices rpcSocialServices;
         private readonly ISocialServiceEventBus socialServiceEventBus;
         private readonly IFriendsEventBus friendsEventBus;
 
@@ -97,7 +97,7 @@ namespace DCL.PluginSystem.Global
             ViewDependencies viewDependencies,
             ISharedSpaceManager sharedSpaceManager,
             ISocialServiceEventBus socialServiceEventBus,
-            ObjectProxy<IRPCSocialServices> socialServicesRPCProxy,
+            IRPCSocialServices rpcSocialServices,
             ObjectProxy<FriendsCache> friendCacheProxy, IFriendsEventBus friendsEventBus)
         {
             this.mainUIView = mainUIView;
@@ -125,7 +125,7 @@ namespace DCL.PluginSystem.Global
             this.chatEventBus = chatEventBus;
             this.sharedSpaceManager = sharedSpaceManager;
             this.socialServiceEventBus = socialServiceEventBus;
-            this.socialServicesRPCProxy = socialServicesRPCProxy;
+            this.rpcSocialServices = rpcSocialServices;
             this.friendCacheProxy = friendCacheProxy;
             this.friendsEventBus = friendsEventBus;
         }
@@ -146,7 +146,7 @@ namespace DCL.PluginSystem.Global
             var friendsCache = new FriendsCache();
             friendCacheProxy.SetObject(friendsCache);
 
-            friendsService = new RPCFriendsService(friendsEventBus, friendsCache, selfProfile, socialServicesRPCProxy, socialServiceEventBus);
+            friendsService = new RPCFriendsService(friendsEventBus, friendsCache, selfProfile, rpcSocialServices, socialServiceEventBus);
 
             IFriendsService injectableFriendService = useAnalytics ? new FriendServiceAnalyticsDecorator(friendsService, analyticsController!) : friendsService;
 
@@ -295,7 +295,7 @@ namespace DCL.PluginSystem.Global
 
             void ReconnectFriendServiceAsync(CancellationToken ct)
             {
-                if (!socialServicesRPCProxy.Configured || friendsService == null) return;
+                if (friendsService == null) return;
 
                 friendsService.SubscribeToIncomingFriendshipEventsAsync(ct).Forget();
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/SocialServicesPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SocialServicesPlugin.cs
@@ -14,23 +14,22 @@ namespace DCL.PluginSystem.Global
 {
     public class SocialServicesPlugin : IDCLGlobalPluginWithoutSettings
     {
-        private readonly ObjectProxy<IRPCSocialServices> socialServicesRPCProxy;
+        private readonly RPCSocialServices rpcSocialServices;
         private readonly IDecentralandUrlsSource dclUrlSource;
         private readonly IWeb3IdentityCache web3IdentityCache;
         private readonly ISocialServiceEventBus socialServiceEventBus;
         private readonly IAppArgs appArgs;
 
-        private RPCSocialServices? socialServicesRPC;
         private CancellationTokenSource cts = new ();
 
         public SocialServicesPlugin(
-            ObjectProxy<IRPCSocialServices> socialServicesRPCProxy,
+            RPCSocialServices rpcSocialServices,
             IDecentralandUrlsSource dclUrlSource,
             IWeb3IdentityCache web3IdentityCache,
             ISocialServiceEventBus socialServiceEventBus,
             IAppArgs appArgs)
         {
-            this.socialServicesRPCProxy = socialServicesRPCProxy;
+            this.rpcSocialServices = rpcSocialServices;
             this.dclUrlSource = dclUrlSource;
             this.web3IdentityCache = web3IdentityCache;
             this.socialServiceEventBus = socialServiceEventBus;
@@ -45,14 +44,11 @@ namespace DCL.PluginSystem.Global
             // since that affects which friends the user can access
             web3IdentityCache.OnIdentityCleared += DisconnectRpcClient;
             web3IdentityCache.OnIdentityChanged += ReInitializeRpcClient;
-
-            socialServicesRPC = new RPCSocialServices(GetApiUrl(), web3IdentityCache, socialServiceEventBus);
-            socialServicesRPCProxy.SetObject(socialServicesRPC);
         }
 
         public void Dispose()
         {
-            socialServicesRPC?.Dispose();
+            rpcSocialServices?.Dispose();
             web3IdentityCache.OnIdentityCleared -= DisconnectRpcClient;
             web3IdentityCache.OnIdentityChanged -= ReInitializeRpcClient;
         }
@@ -65,12 +61,12 @@ namespace DCL.PluginSystem.Global
 
             async UniTaskVoid ReconnectRpcClientAsync(CancellationToken ct)
             {
-                if (socialServicesRPC == null) return;
+                if (rpcSocialServices == null) return;
 
                 try
                 {
-                    await socialServicesRPC.DisconnectAsync(ct);
-                    await socialServicesRPC.EnsureRpcConnectionAsync(ct);
+                    await rpcSocialServices.DisconnectAsync(ct);
+                    await rpcSocialServices.EnsureRpcConnectionAsync(ct);
                 }
                 catch (Exception e) when (e is not OperationCanceledException) { }
 
@@ -87,9 +83,9 @@ namespace DCL.PluginSystem.Global
 
             async UniTaskVoid DisconnectRpcClientAsync(CancellationToken ct)
             {
-                if (socialServicesRPC == null) return;
+                if (rpcSocialServices == null) return;
 
-                try { await socialServicesRPC.DisconnectAsync(ct); }
+                try { await rpcSocialServices.DisconnectAsync(ct); }
                 catch (Exception e) when (e is not OperationCanceledException) { }
             }
         }

--- a/Explorer/Assets/DCL/PluginSystem/Global/SocialServicesPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SocialServicesPlugin.cs
@@ -14,7 +14,7 @@ namespace DCL.PluginSystem.Global
 {
     public class SocialServicesPlugin : IDCLGlobalPluginWithoutSettings
     {
-        private readonly RPCSocialServices rpcSocialServices;
+        private readonly IRPCSocialServices rpcSocialServices;
         private readonly IDecentralandUrlsSource dclUrlSource;
         private readonly IWeb3IdentityCache web3IdentityCache;
         private readonly ISocialServiceEventBus socialServiceEventBus;
@@ -23,7 +23,7 @@ namespace DCL.PluginSystem.Global
         private CancellationTokenSource cts = new ();
 
         public SocialServicesPlugin(
-            RPCSocialServices rpcSocialServices,
+            IRPCSocialServices rpcSocialServices,
             IDecentralandUrlsSource dclUrlSource,
             IWeb3IdentityCache web3IdentityCache,
             ISocialServiceEventBus socialServiceEventBus,

--- a/Explorer/Assets/DCL/SocialServices/RPCSocialServices.cs
+++ b/Explorer/Assets/DCL/SocialServices/RPCSocialServices.cs
@@ -15,9 +15,11 @@ namespace DCL.SocialService
 {
     public interface IRPCSocialServices : IDisposable
     {
-        public RpcClientModule Module();
+        RpcClientModule Module();
 
-        public UniTask EnsureRpcConnectionAsync(CancellationToken ct);
+        UniTask DisconnectAsync(CancellationToken ct);
+
+        UniTask EnsureRpcConnectionAsync(CancellationToken ct);
     }
 
     public class RPCSocialServices : IRPCSocialServices


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR moves the initialization of the social service RPC in the dynamic world container and remove the object proxy that was previously used to pass it around.
This was a needed change to avoid the object proxy misuse and proper handling for the voice chat shape

## Test Instructions

### Test Steps
1. Do a quick smoke test of friends functionality, it should all work as it used to before

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
