### PR TITLE
fix: outdated avatar in-world

### DIFF
--- a/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
@@ -161,12 +161,17 @@ namespace DCL.Backpack
             }
 
             Profile newProfile = oldProfile.CreateNewProfileForUpdate(equippedEmotes, equippedWearables,
-                forceRender, emoteStorage, wearableStorage);
+                forceRender, emoteStorage, wearableStorage,
+                // Don't increment the version as it will be incremented later on selfProfile.UpdateProfileAsync
+                !publishProfileChange);
 
             // Skip publishing the same profile
             if (newProfile.Avatar.IsSameAvatar(oldProfile.Avatar))
                 return;
 
+            // Update profile immediately to prevent UI inconsistencies
+            // Without this immediate update, temporary desync can occur between backpack closure and catalyst validation
+            // Example: Opening the emote wheel before catalyst validation would show outdated emote selections
             profileCache.Set(newProfile.UserId, newProfile);
             UpdateAvatarInWorld(newProfile);
 

--- a/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
@@ -187,9 +187,9 @@ namespace DCL.Backpack
 
             try
             {
-                var updatedProfile = await selfProfile.UpdateProfileAsync(newProfile, ct);
+                await selfProfile.UpdateProfileAsync(newProfile, ct);
                 MultithreadingUtility.AssertMainThread(nameof(UpdateProfileAsync), true);
-                UpdateAvatarInWorld(updatedProfile!);
+                oldProfile.Dispose();
             }
             catch (OperationCanceledException) { }
             catch (Exception e)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -750,7 +750,8 @@ namespace Global.Dynamic
                     userBlockingCacheProxy,
                     sharedSpaceManager,
                     profileChangesBus,
-                    staticContainer.SceneLoadingLimit
+                    staticContainer.SceneLoadingLimit,
+                    mainUIView.WarningNotification
                 ),
                 new CharacterPreviewPlugin(staticContainer.ComponentsContainer.ComponentPoolsRegistry, assetsProvisioner, staticContainer.CacheCleaner),
                 new WebRequestsPlugin(staticContainer.WebRequestsContainer.AnalyticsContainer, debugBuilder),

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/BroadcastProfiles/EnsureSelfPublishedProfileBroadcast.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/BroadcastProfiles/EnsureSelfPublishedProfileBroadcast.cs
@@ -37,7 +37,7 @@ namespace DCL.Multiplayer.Profiles.BroadcastProfiles
                 bool published = await selfProfile.IsProfilePublishedAsync(ct);
 
                 if (published == false)
-                    await selfProfile.UpdateProfileAsync(publish: true, ct);
+                    await selfProfile.UpdateProfileAsync(ct);
 
                 origin.NotifyRemotes();
             }

--- a/Explorer/Assets/DCL/PluginSystem/Global/BackpackSubPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/BackpackSubPlugin.cs
@@ -16,16 +16,16 @@ using DCL.Browser;
 using DCL.CharacterPreview;
 using DCL.Input;
 using DCL.Profiles;
-using DCL.Utilities.Extensions;
 using DCL.Profiles.Self;
 using DCL.UI;
+using DCL.Utilities.Extensions;
 using DCL.Web3.Identities;
+using DCL.WebRequests;
 using ECS;
+using Global.AppArgs;
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using DCL.WebRequests;
-using Global.AppArgs;
 using UnityEngine.Pool;
 
 namespace DCL.PluginSystem.Global
@@ -58,6 +58,7 @@ namespace DCL.PluginSystem.Global
         private readonly IInputBlock inputBlock;
         private readonly IAppArgs appArgs;
         private readonly IWebBrowser webBrowser;
+        private readonly WarningNotificationView inWorldWarningNotificationView;
         private BackpackBusController? busController;
         private BackpackEquipStatusController? backpackEquipStatusController;
 
@@ -88,7 +89,8 @@ namespace DCL.PluginSystem.Global
             Arch.Core.World world,
             Entity playerEntity,
             IAppArgs appArgs,
-            IWebBrowser webBrowser)
+            IWebBrowser webBrowser,
+            WarningNotificationView inWorldWarningNotificationView)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.web3Identity = web3Identity;
@@ -115,6 +117,7 @@ namespace DCL.PluginSystem.Global
             this.playerEntity = playerEntity;
             this.appArgs = appArgs;
             this.webBrowser = webBrowser;
+            this.inWorldWarningNotificationView = inWorldWarningNotificationView;
 
             backpackCommandBus = new BackpackCommandBus();
         }
@@ -210,7 +213,8 @@ namespace DCL.PluginSystem.Global
                 web3Identity,
                 world,
                 playerEntity,
-                appArgs
+                appArgs,
+                inWorldWarningNotificationView
             );
 
             backpackController = new BackpackController(

--- a/Explorer/Assets/DCL/PluginSystem/Global/BackpackSubPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/BackpackSubPlugin.cs
@@ -15,6 +15,7 @@ using DCL.Backpack.EmotesSection;
 using DCL.Browser;
 using DCL.CharacterPreview;
 using DCL.Input;
+using DCL.Profiles;
 using DCL.Utilities.Extensions;
 using DCL.Profiles.Self;
 using DCL.UI;
@@ -34,11 +35,12 @@ namespace DCL.PluginSystem.Global
         private readonly IAssetsProvisioner assetsProvisioner;
         private readonly IWearableStorage wearableStorage;
         private readonly ISelfProfile selfProfile;
+        private readonly IProfileCache profileCache;
         private readonly IEquippedWearables equippedWearables;
         private readonly IEquippedEmotes equippedEmotes;
         private readonly IEmoteStorage emoteStorage;
         private readonly IReadOnlyCollection<URN> embeddedEmotes;
-        private readonly ICollection<string> forceRender;
+        private readonly List<string> forceRender;
         private readonly IRealmData realmData;
         private readonly IWeb3IdentityCache web3Identity;
         private readonly BackpackCommandBus backpackCommandBus;
@@ -67,11 +69,12 @@ namespace DCL.PluginSystem.Global
             ICharacterPreviewFactory characterPreviewFactory,
             IWearableStorage wearableStorage,
             ISelfProfile selfProfile,
+            IProfileCache profileCache,
             IEquippedWearables equippedWearables,
             IEquippedEmotes equippedEmotes,
             IEmoteStorage emoteStorage,
             IReadOnlyCollection<URN> embeddedEmotes,
-            ICollection<string> forceRender,
+            List<string> forceRender,
             IRealmData realmData,
             URLDomain assetBundleURL,
             IWebRequestController webRequestController,
@@ -92,6 +95,7 @@ namespace DCL.PluginSystem.Global
             this.characterPreviewFactory = characterPreviewFactory;
             this.wearableStorage = wearableStorage;
             this.selfProfile = selfProfile;
+            this.profileCache = profileCache;
             this.equippedWearables = equippedWearables;
             this.equippedEmotes = equippedEmotes;
             this.emoteStorage = emoteStorage;
@@ -199,7 +203,10 @@ namespace DCL.PluginSystem.Global
                 equippedEmotes,
                 equippedWearables,
                 selfProfile,
+                profileCache,
                 forceRender,
+                emoteStorage,
+                wearableStorage,
                 web3Identity,
                 world,
                 playerEntity,

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -95,8 +95,7 @@ namespace DCL.PluginSystem.Global
         private readonly Arch.Core.World world;
         private readonly Entity playerEntity;
         private readonly IMapPathEventBus mapPathEventBus;
-        private readonly ICollection<string> forceRender;
-        private ExplorePanelInputHandler? inputHandler;
+        private readonly List<string> forceRender;
         private readonly IRealmData realmData;
         private readonly IProfileCache profileCache;
         private readonly URLDomain assetBundleURL;
@@ -114,9 +113,9 @@ namespace DCL.PluginSystem.Global
         private readonly ISharedSpaceManager sharedSpaceManager;
         private readonly SceneLoadingLimit sceneLoadingLimit;
         private readonly IProfileChangesBus profileChangesBus;
-
         private readonly bool includeCameraReel;
 
+        private ExplorePanelInputHandler? inputHandler;
         private NavmapController? navmapController;
         private SettingsController? settingsController;
         private BackpackSubPlugin? backpackSubPlugin;
@@ -149,7 +148,7 @@ namespace DCL.PluginSystem.Global
             IEquippedEmotes equippedEmotes,
             IWebBrowser webBrowser,
             IEmoteStorage emoteStorage,
-            ICollection<string> forceRender,
+            List<string> forceRender,
             DCLInput dclInput,
             IRealmData realmData,
             IProfileCache profileCache,
@@ -255,6 +254,7 @@ namespace DCL.PluginSystem.Global
                 characterPreviewFactory,
                 wearableStorage,
                 selfProfile,
+                profileCache,
                 equippedWearables,
                 equippedEmotes,
                 emoteStorage,

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -49,6 +49,7 @@ using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.SDKComponents.MediaStream.Settings;
 using DCL.Settings.Settings;
+using DCL.UI;
 using DCL.UI.Profiles;
 using DCL.UI.SharedSpaceManager;
 using DCL.Utilities;
@@ -112,6 +113,7 @@ namespace DCL.PluginSystem.Global
         private readonly ObjectProxy<IUserBlockingCache> userBlockingCacheProxy;
         private readonly ISharedSpaceManager sharedSpaceManager;
         private readonly SceneLoadingLimit sceneLoadingLimit;
+        private readonly WarningNotificationView inWorldWarningNotificationView;
         private readonly IProfileChangesBus profileChangesBus;
         private readonly bool includeCameraReel;
 
@@ -176,7 +178,8 @@ namespace DCL.PluginSystem.Global
             ObjectProxy<IUserBlockingCache> userBlockingCacheProxy,
             ISharedSpaceManager sharedSpaceManager,
             IProfileChangesBus profileChangesBus,
-            SceneLoadingLimit sceneLoadingLimit)
+            SceneLoadingLimit sceneLoadingLimit,
+            WarningNotificationView inWorldWarningNotificationView)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.mvcManager = mvcManager;
@@ -228,6 +231,7 @@ namespace DCL.PluginSystem.Global
             this.sharedSpaceManager = sharedSpaceManager;
             this.profileChangesBus = profileChangesBus;
             this.sceneLoadingLimit = sceneLoadingLimit;
+            this.inWorldWarningNotificationView = inWorldWarningNotificationView;
         }
 
         public void Dispose()
@@ -273,7 +277,8 @@ namespace DCL.PluginSystem.Global
                 world,
                 playerEntity,
                 appArgs,
-                webBrowser
+                webBrowser,
+                inWorldWarningNotificationView
             );
 
             ExplorePanelView panelViewAsset = (await assetsProvisioner.ProvideMainAssetValueAsync(settings.ExplorePanelPrefab, ct: ct)).GetComponent<ExplorePanelView>();

--- a/Explorer/Assets/DCL/Profiles/Components/ProfileExtensions.cs
+++ b/Explorer/Assets/DCL/Profiles/Components/ProfileExtensions.cs
@@ -22,7 +22,8 @@ namespace DCL.Profiles
             IEquippedWearables equippedWearables,
             IReadOnlyList<string> forceRender,
             IEmoteStorage emoteStorage,
-            IWearableStorage wearableStorage)
+            IWearableStorage wearableStorage,
+            bool incrementVersion = true)
         {
             using PooledObject<HashSet<URN>> _ = HashSetPool<URN>.Get(out HashSet<URN> uniqueWearables);
 
@@ -34,14 +35,17 @@ namespace DCL.Profiles
 
             var bodyShape = BodyShape.FromStringSafe(equippedWearables.Wearable(WearablesConstants.Categories.BODY_SHAPE)!.GetUrn());
 
-            Profile newProfile = PROFILE_BUILDER.From(profile)
-                                               .WithBodyShape(bodyShape)
-                                               .WithWearables(uniqueWearables)
-                                               .WithColors(equippedWearables.GetColors())
-                                               .WithEmotes(uniqueEmotes)
-                                               .WithForceRender(forceRender)
-                                               .WithVersion(profile.Version + 1)
-                                               .Build();
+            ProfileBuilder builder = PROFILE_BUILDER.From(profile)
+                                                           .WithBodyShape(bodyShape)
+                                                           .WithWearables(uniqueWearables)
+                                                           .WithColors(equippedWearables.GetColors())
+                                                           .WithEmotes(uniqueEmotes)
+                                                           .WithForceRender(forceRender);
+
+            if (incrementVersion)
+                builder = builder.WithVersion(profile.Version + 1);
+
+            Profile newProfile = builder.Build();
 
             return newProfile;
 

--- a/Explorer/Assets/DCL/Profiles/Components/ProfileExtensions.cs
+++ b/Explorer/Assets/DCL/Profiles/Components/ProfileExtensions.cs
@@ -1,0 +1,94 @@
+using CommunicationData.URLHelpers;
+using DCL.AvatarRendering.Emotes;
+using DCL.AvatarRendering.Emotes.Equipped;
+using DCL.AvatarRendering.Loading.Components;
+using DCL.AvatarRendering.Wearables.Components;
+using DCL.AvatarRendering.Wearables.Equipped;
+using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Utilities.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine.Pool;
+
+namespace DCL.Profiles
+{
+    public static class ProfileExtensions
+    {
+        private static readonly ProfileBuilder PROFILE_BUILDER = new ();
+
+        public static Profile CreateNewProfileForUpdate(this Profile profile,
+            IEquippedEmotes equippedEmotes,
+            IEquippedWearables equippedWearables,
+            IReadOnlyList<string> forceRender,
+            IEmoteStorage emoteStorage,
+            IWearableStorage wearableStorage)
+        {
+            using PooledObject<HashSet<URN>> _ = HashSetPool<URN>.Get(out HashSet<URN> uniqueWearables);
+
+            uniqueWearables = uniqueWearables.EnsureNotNull();
+            ConvertEquippedWearablesIntoUniqueUrns();
+
+            var uniqueEmotes = new URN[profile.Avatar.Emotes.Count];
+            ConvertEquippedEmotesIntoUniqueUrns();
+
+            var bodyShape = BodyShape.FromStringSafe(equippedWearables.Wearable(WearablesConstants.Categories.BODY_SHAPE)!.GetUrn());
+
+            Profile newProfile = PROFILE_BUILDER.From(profile)
+                                               .WithBodyShape(bodyShape)
+                                               .WithWearables(uniqueWearables)
+                                               .WithColors(equippedWearables.GetColors())
+                                               .WithEmotes(uniqueEmotes)
+                                               .WithForceRender(forceRender)
+                                               .WithVersion(profile.Version + 1)
+                                               .Build();
+
+            return newProfile;
+
+            void ConvertEquippedWearablesIntoUniqueUrns()
+            {
+                foreach ((string category, IWearable? w) in equippedWearables.Items())
+                {
+                    if (w == null) continue;
+                    if (category == WearablesConstants.Categories.BODY_SHAPE) continue;
+
+                    URN uniqueUrn = w.GetUrn();
+
+                    if (wearableStorage.TryGetOwnedNftRegistry(uniqueUrn, out IReadOnlyDictionary<URN, NftBlockchainOperationEntry>? registry))
+                        uniqueUrn = registry.First().Value.Urn;
+                    else
+                    {
+                        foreach (URN profileWearable in profile?.Avatar?.Wearables ?? Array.Empty<URN>())
+                            if (profileWearable.Shorten() == uniqueUrn)
+                                uniqueUrn = profileWearable;
+                    }
+
+                    uniqueWearables.Add(uniqueUrn);
+                }
+            }
+
+            void ConvertEquippedEmotesIntoUniqueUrns()
+            {
+                for (var i = 0; i < equippedEmotes.SlotCount; i++)
+                {
+                    IEmote? w = equippedEmotes.EmoteInSlot(i);
+
+                    if (w == null) continue;
+
+                    URN uniqueUrn = w.GetUrn();
+
+                    if (emoteStorage.TryGetOwnedNftRegistry(uniqueUrn, out IReadOnlyDictionary<URN, NftBlockchainOperationEntry>? registry))
+                        uniqueUrn = registry.First().Value.Urn;
+                    else
+                    {
+                        foreach (URN urn in profile?.Avatar?.Emotes ?? Array.Empty<URN>())
+                            if (urn.Shorten() == uniqueUrn)
+                                uniqueUrn = urn;
+                    }
+
+                    uniqueEmotes[i] = uniqueUrn;
+                }
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Profiles/Components/ProfileExtensions.cs.meta
+++ b/Explorer/Assets/DCL/Profiles/Components/ProfileExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4a9befc17d974c0b894b726134966c71
+timeCreated: 1748267648

--- a/Explorer/Assets/DCL/Profiles/MemoryProfileRepository.cs
+++ b/Explorer/Assets/DCL/Profiles/MemoryProfileRepository.cs
@@ -13,7 +13,7 @@ namespace DCL.Profiles
             this.profileCache = profileCache;
         }
 
-        public async UniTask SetAsync(Profile profile, bool publish, CancellationToken ct) =>
+        public async UniTask SetAsync(Profile profile, CancellationToken ct) =>
             profileCache.Set(profile.UserId, profile);
 
         public async UniTask<Profile?> GetAsync(string id, int version, URLDomain? fromCatalyst, CancellationToken ct) =>

--- a/Explorer/Assets/DCL/Profiles/Repository/IProfileRepository.cs
+++ b/Explorer/Assets/DCL/Profiles/Repository/IProfileRepository.cs
@@ -14,7 +14,7 @@ namespace DCL.Profiles
         public const string GUEST_RANDOM_ID = "fakeUserId";
         public const string PLAYER_RANDOM_ID = "Player";
 
-        UniTask SetAsync(Profile profile, bool publish, CancellationToken ct);
+        UniTask SetAsync(Profile profile, CancellationToken ct);
 
         UniTask<Profile?> GetAsync(string id, int version, URLDomain? fromCatalyst, CancellationToken ct);
 
@@ -22,7 +22,7 @@ namespace DCL.Profiles
         {
             private readonly Dictionary<Key, Profile> profiles = new ();
 
-            public UniTask SetAsync(Profile profile, bool publish, CancellationToken ct)
+            public UniTask SetAsync(Profile profile, CancellationToken ct)
             {
                 var key = new Key(profile);
 

--- a/Explorer/Assets/DCL/Profiles/Repository/LogProfileRepository.cs
+++ b/Explorer/Assets/DCL/Profiles/Repository/LogProfileRepository.cs
@@ -1,7 +1,6 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
-using System;
 using System.Threading;
 
 namespace DCL.Profiles
@@ -15,12 +14,12 @@ namespace DCL.Profiles
             this.origin = origin;
         }
 
-        public async UniTask SetAsync(Profile profile, bool publish, CancellationToken ct)
+        public async UniTask SetAsync(Profile profile, CancellationToken ct)
         {
             ReportHub
                .WithReport(ReportCategory.PROFILE)
                .Log($"ProfileRepository: set requested for profile: {profile}");
-            await origin.SetAsync(profile, publish: publish, ct);
+            await origin.SetAsync(profile, ct);
             ReportHub
                .WithReport(ReportCategory.PROFILE)
                .Log($"ProfileRepository: set finished for profile: {profile}");

--- a/Explorer/Assets/DCL/Profiles/Repository/RealmProfileRepository.cs
+++ b/Explorer/Assets/DCL/Profiles/Repository/RealmProfileRepository.cs
@@ -38,7 +38,7 @@ namespace DCL.Profiles
             this.profileCache = profileCache;
         }
 
-        public async UniTask SetAsync(Profile profile, bool publish, CancellationToken ct)
+        public async UniTask SetAsync(Profile profile, CancellationToken ct)
         {
             if (string.IsNullOrEmpty(profile.UserId))
                 throw new ArgumentException("Can't set a profile with an empty UserId");
@@ -61,8 +61,7 @@ namespace DCL.Profiles
 
             try
             {
-                if (publish)
-                    await ipfs.PublishAsync(entity, ct, files);
+                await ipfs.PublishAsync(entity, ct, files);
                 profileCache.Set(profile.UserId, profile);
             }
             finally { files.Clear(); }

--- a/Explorer/Assets/DCL/Profiles/Self/ISelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/ISelfProfile.cs
@@ -8,7 +8,7 @@ namespace DCL.Profiles.Self
     {
         UniTask<Profile?> ProfileAsync(CancellationToken ct);
 
-        UniTask<Profile?> UpdateProfileAsync(bool publish, CancellationToken ct);
+        UniTask<Profile?> UpdateProfileAsync(CancellationToken ct);
         UniTask<Profile?> UpdateProfileAsync(Profile profile, CancellationToken ct);
 
         /// <summary>
@@ -16,6 +16,7 @@ namespace DCL.Profiles.Self
         /// </summary>
         /// <param name="ct">Cancellation token.</param>
         /// <returns>The published profile.</returns>
+        /// TODO: it is odd in the interface design. Why would you want to publish the profile without modifications? Consider redesign..
         UniTask<Profile?> ForcePublishWithoutModificationsAsync(CancellationToken ct);
     }
 
@@ -32,7 +33,7 @@ namespace DCL.Profiles.Self
             bool isPublished = await selfProfile.IsProfilePublishedAsync(ct);
 
             if (isPublished == false)
-                await selfProfile.UpdateProfileAsync(true, ct);
+                await selfProfile.UpdateProfileAsync(ct);
 
             return (await selfProfile.ProfileAsync(ct)).EnsureNotNull();
         }

--- a/Explorer/Assets/DCL/Profiles/Self/Playground/SelfProfilePlayground.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/Playground/SelfProfilePlayground.cs
@@ -59,7 +59,7 @@ namespace DCL.Profiles.Self.Playground
 
             var profile = await selfProfile.ProfileAsync(ct);
             ReportHub.Log(ReportData.UNSPECIFIED, $"Profile is found {profile != null}");
-            await selfProfile.UpdateProfileAsync(publish: true, ct);
+            await selfProfile.UpdateProfileAsync(ct);
             ReportHub.Log(ReportData.UNSPECIFIED, $"Profile is published successfully");
         }
     }

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -2,18 +2,13 @@ using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.AvatarRendering.Emotes;
 using DCL.AvatarRendering.Emotes.Equipped;
-using DCL.AvatarRendering.Loading.Components;
-using DCL.AvatarRendering.Wearables.Components;
 using DCL.AvatarRendering.Wearables.Equipped;
 using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.UI.Profiles.Helpers;
-using DCL.Utilities.Extensions;
 using DCL.Web3.Identities;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
-using UnityEngine.Pool;
 
 namespace DCL.Profiles.Self
 {
@@ -21,13 +16,13 @@ namespace DCL.Profiles.Self
     {
         private readonly IProfileRepository profileRepository;
         private readonly IWeb3IdentityCache web3IdentityCache;
-        private readonly IEquippedWearables equippedWearables;
         private readonly IWearableStorage wearableStorage;
-        private readonly IEquippedEmotes equippedEmotes;
         private readonly IEmoteStorage emoteStorage;
-        private readonly IReadOnlyList<string> forceRender;
         private readonly IReadOnlyList<URN>? forcedEmotes;
         private readonly ProfileBuilder profileBuilder = new ();
+        private readonly IEquippedWearables equippedWearables;
+        private readonly IEquippedEmotes equippedEmotes;
+        private readonly IReadOnlyList<string> forceRender;
 
         public SelfProfile(
             IProfileRepository profileRepository,
@@ -77,7 +72,7 @@ namespace DCL.Profiles.Self
             return profile;
         }
 
-        public async UniTask<Profile?> UpdateProfileAsync(bool publish, CancellationToken ct)
+        public async UniTask<Profile?> UpdateProfileAsync(CancellationToken ct)
         {
             Profile? profile = await ProfileAsync(ct);
 
@@ -87,24 +82,7 @@ namespace DCL.Profiles.Self
             if (profile == null)
                 throw new Exception("Self profile not found");
 
-            using PooledObject<HashSet<URN>> _ = HashSetPool<URN>.Get(out HashSet<URN> uniqueWearables);
-
-            uniqueWearables = uniqueWearables.EnsureNotNull();
-            ConvertEquippedWearablesIntoUniqueUrns(profile, uniqueWearables);
-
-            var uniqueEmotes = new URN[profile.Avatar?.Emotes?.Count ?? 0];
-            ConvertEquippedEmotesIntoUniqueUrns(profile, uniqueEmotes);
-
-            var bodyShape = BodyShape.FromStringSafe(equippedWearables.Wearable(WearablesConstants.Categories.BODY_SHAPE)!.GetUrn());
-
-            Profile newProfile = profileBuilder.From(profile)
-                                               .WithBodyShape(bodyShape)
-                                               .WithWearables(uniqueWearables)
-                                               .WithColors(equippedWearables.GetColors())
-                                               .WithEmotes(uniqueEmotes)
-                                               .WithForceRender(forceRender)
-                                               .WithVersion(profile!.Version + 1)
-                                               .Build();
+            Profile newProfile = profile.CreateNewProfileForUpdate(equippedEmotes, equippedWearables, forceRender, emoteStorage, wearableStorage);
 
             newProfile.UserId = web3IdentityCache.Identity.Address;
 
@@ -115,7 +93,7 @@ namespace DCL.Profiles.Self
             newProfile.UserNameColor = ProfileNameColorHelper.GetNameColor(profile.DisplayName);
             OwnProfile = newProfile;
 
-            await profileRepository.SetAsync(newProfile, publish, ct);
+            await profileRepository.SetAsync(newProfile, ct);
             return await profileRepository.GetAsync(newProfile.UserId, newProfile.Version, ct);
         }
 
@@ -125,14 +103,14 @@ namespace DCL.Profiles.Self
                 throw new Web3IdentityMissingException("Web3 Identity is not initialized");
 
             Profile newProfile = profileBuilder.From(profile)
-                                               .WithVersion(profile!.Version + 1)
+                                               .WithVersion(profile.Version + 1)
                                                .Build();
 
             newProfile.UserId = web3IdentityCache.Identity.Address;
             newProfile.UserNameColor = ProfileNameColorHelper.GetNameColor(profile.DisplayName);
             OwnProfile = newProfile;
 
-            await profileRepository.SetAsync(newProfile, true, ct);
+            await profileRepository.SetAsync(newProfile, ct);
             return await profileRepository.GetAsync(newProfile.UserId, newProfile.Version, ct);
         }
 
@@ -154,53 +132,8 @@ namespace DCL.Profiles.Self
             newProfile.UserNameColor = ProfileNameColorHelper.GetNameColor(profile.DisplayName);
             OwnProfile = newProfile;
 
-            await profileRepository.SetAsync(newProfile, publish: true, ct);
+            await profileRepository.SetAsync(newProfile, ct);
             return await profileRepository.GetAsync(newProfile.UserId, newProfile.Version, ct);
-        }
-
-        private void ConvertEquippedWearablesIntoUniqueUrns(Profile? profile, ISet<URN> uniqueWearables)
-        {
-            foreach ((string category, IWearable? w) in equippedWearables.Items())
-            {
-                if (w == null) continue;
-                if (category == WearablesConstants.Categories.BODY_SHAPE) continue;
-
-                URN uniqueUrn = w.GetUrn();
-
-                if (wearableStorage.TryGetOwnedNftRegistry(uniqueUrn, out IReadOnlyDictionary<URN, NftBlockchainOperationEntry>? registry))
-                    uniqueUrn = registry.First().Value.Urn;
-                else
-                {
-                    foreach (URN profileWearable in profile?.Avatar?.Wearables ?? Array.Empty<URN>())
-                        if (profileWearable.Shorten() == uniqueUrn)
-                            uniqueUrn = profileWearable;
-                }
-
-                uniqueWearables.Add(uniqueUrn);
-            }
-        }
-
-        private void ConvertEquippedEmotesIntoUniqueUrns(Profile? profile, IList<URN> uniqueEmotes)
-        {
-            for (var i = 0; i < equippedEmotes.SlotCount; i++)
-            {
-                IEmote? w = equippedEmotes.EmoteInSlot(i);
-
-                if (w == null) continue;
-
-                URN uniqueUrn = w.GetUrn();
-
-                if (emoteStorage.TryGetOwnedNftRegistry(uniqueUrn, out IReadOnlyDictionary<URN, NftBlockchainOperationEntry>? registry))
-                    uniqueUrn = registry.First().Value.Urn;
-                else
-                {
-                    foreach (URN urn in profile?.Avatar.Emotes ?? Array.Empty<URN>())
-                        if (urn.Shorten() == uniqueUrn)
-                            uniqueUrn = urn;
-                }
-
-                uniqueEmotes[i] = uniqueUrn;
-            }
         }
     }
 }

--- a/Explorer/Assets/DCL/UI/MainUIContainer/MainUIContainer.prefab
+++ b/Explorer/Assets/DCL/UI/MainUIContainer/MainUIContainer.prefab
@@ -434,6 +434,7 @@ RectTransform:
   - {fileID: 8350103084299140157}
   - {fileID: 4576630911448043548}
   - {fileID: 6687142488575908541}
+  - {fileID: 3339784900465726867}
   m_Father: {fileID: 5183775639776229429}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -586,6 +587,7 @@ MonoBehaviour:
   <ConnectionStatusPanelView>k__BackingField: {fileID: 7739535119352627263}
   <SidebarView>k__BackingField: {fileID: 152339575270123223}
   <ControlsPanelView>k__BackingField: {fileID: 2155008871701633240, guid: 542424588a68b46f688ef5c667aa0c68, type: 3}
+  <WarningNotification>k__BackingField: {fileID: 6667610896396879065}
   <pointerDetectionArea>k__BackingField: {fileID: 2527603276159390384}
   <sidebarLayoutElement>k__BackingField: {fileID: 3900643109725378707}
   <sidebarDetectionArea>k__BackingField: {fileID: 5658050912149109760}
@@ -1041,35 +1043,35 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 62449564340620185, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 62449564340620185, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 62449564340620185, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 62449564340620185, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -213
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 239284970452477663, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 239284970452477663, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 239284970452477663, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 239284970452477663, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -194.24841
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 260298768150988075, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1153,19 +1155,19 @@ PrefabInstance:
       objectReference: {fileID: 2958791553259585229}
     - target: {fileID: 835415575200949320, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 835415575200949320, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 835415575200949320, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 835415575200949320, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -12
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1012159428012599717, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1237,19 +1239,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1642678963826568086, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1642678963826568086, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1642678963826568086, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1642678963826568086, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -302
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1658352131639769245, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1309,19 +1311,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1959621558750892143, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1959621558750892143, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1959621558750892143, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1959621558750892143, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -342
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2127497387316116056, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_SizeDelta.x
@@ -1353,35 +1355,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2345943681759489479, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2345943681759489479, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2345943681759489479, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2345943681759489479, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -277
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2352952653014969869, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2352952653014969869, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2352952653014969869, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2352952653014969869, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -108
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2449254615540203552, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_IsActive
@@ -1529,19 +1531,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3059858376115429252, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3059858376115429252, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3059858376115429252, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3059858376115429252, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -219.24841
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3475354120315141622, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1679,6 +1681,22 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4496169757731986300, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4496169757731986300, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4496169757731986300, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4496169757731986300, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4496926898282664668, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1769,19 +1787,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4818886527868760749, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4818886527868760749, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4818886527868760749, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4818886527868760749, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -133
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4819338268005737125, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1829,35 +1847,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5589918054500395128, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5589918054500395128, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5589918054500395128, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5589918054500395128, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -253
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5629447080230894465, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5629447080230894465, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5629447080230894465, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5629447080230894465, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -283.2484
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5690124512576908724, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1917,19 +1935,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6187374922625486835, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6187374922625486835, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6187374922625486835, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6187374922625486835, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -84
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6223025834660201070, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1949,35 +1967,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6275068675692716138, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6275068675692716138, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6275068675692716138, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6275068675692716138, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -173
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6552569803138220511, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6552569803138220511, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6552569803138220511, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6552569803138220511, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -308.2484
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6855022383667530539, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_IsActive
@@ -2041,19 +2059,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7025013892562922834, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7025013892562922834, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7025013892562922834, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7025013892562922834, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -44
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7164879677755628076, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_IsActive
@@ -2109,19 +2127,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7356816839523289458, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7356816839523289458, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7356816839523289458, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7356816839523289458, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -348.2484
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7370586444465567073, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_AnchorMax.y
@@ -2350,6 +2368,22 @@ PrefabInstance:
     - target: {fileID: 8583266494908829812, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_SizeDelta.y
       value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 8625882705585754948, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8625882705585754948, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8625882705585754948, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8625882705585754948, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8639185943282826979, guid: e495fc295bd1f3e44aeda4cbccc5f767, type: 3}
       propertyPath: m_IsActive
@@ -2866,6 +2900,131 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5647564073185826373, guid: f2ef3a867ab2840cb9bc73b4762922fd, type: 3}
   m_PrefabInstance: {fileID: 3443520972679509683}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3721135072543636036
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4950822455619195612}
+    m_Modifications:
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 433.769
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -56
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4292958671161261228, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_Alpha
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4292958671161261228, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_Interactable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4292958671161261228, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_BlocksRaycasts
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4397080764487562581, guid: aae56f4776100974ba051333a3974811, type: 3}
+      propertyPath: m_Name
+      value: WarningNotification
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aae56f4776100974ba051333a3974811, type: 3}
+--- !u!224 &3339784900465726867 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2161002204034297815, guid: aae56f4776100974ba051333a3974811, type: 3}
+  m_PrefabInstance: {fileID: 3721135072543636036}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6667610896396879065 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8010844266177199773, guid: aae56f4776100974ba051333a3974811, type: 3}
+  m_PrefabInstance: {fileID: 3721135072543636036}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad5746687007427186ea77e4568f01cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &6078156994302795662
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3135,6 +3294,22 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 563733743856818651, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 563733743856818651, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 563733743856818651, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 563733743856818651, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 566381147654157823, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -3145,6 +3320,22 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 566381147654157823, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
       propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665457535653319764, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665457535653319764, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665457535653319764, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665457535653319764, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 834245118592697365, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
@@ -3179,6 +3370,38 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1300557755116459844, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1300557755116459844, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1300557755116459844, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1300557755116459844, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1300557755116459844, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1300557755116459844, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1356590976676138457, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1356590976676138457, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1402808790101428821, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -3189,6 +3412,42 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1402808790101428821, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
       propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1869143947337345009, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1869143947337345009, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1869143947337345009, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1869143947337345009, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2246107075082759032, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2246107075082759032, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2246107075082759032, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2246107075082759032, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2246107075082759032, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2279782679853722047, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
@@ -3206,6 +3465,26 @@ PrefabInstance:
     - target: {fileID: 2279782679853722047, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3010292462524168376, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3010292462524168376, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3010292462524168376, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 8.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 3010292462524168376, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 26
+      objectReference: {fileID: 0}
+    - target: {fileID: 3010292462524168376, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -7
       objectReference: {fileID: 0}
     - target: {fileID: 3194559171488964360, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
       propertyPath: m_AnchorMax.y
@@ -3343,6 +3622,50 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4818495058722043163, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4818495058722043163, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958350511691414847, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958350511691414847, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958350511691414847, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 134.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958350511691414847, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 36
+      objectReference: {fileID: 0}
+    - target: {fileID: 4958350511691414847, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -16
+      objectReference: {fileID: 0}
+    - target: {fileID: 5139224247957288545, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5139224247957288545, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5139224247957288545, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5139224247957288545, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5665430339207882965, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -3361,6 +3684,26 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6186551520230418445, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
       propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252910912605816960, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252910912605816960, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252910912605816960, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252910912605816960, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6252910912605816960, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6334738306198345799, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
@@ -3443,6 +3786,42 @@ PrefabInstance:
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7065330647346269168, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7065330647346269168, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7065330647346269168, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7065330647346269168, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7065330647346269168, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7314532220786135309, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7314532220786135309, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7314532220786135309, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7314532220786135309, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7426884741399343867, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -3455,8 +3834,120 @@ PrefabInstance:
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7595064321916154549, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595064321916154549, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595064321916154549, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595064321916154549, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595064321916154549, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595064321916154549, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7654340139690966630, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7654340139690966630, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7654340139690966630, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7654340139690966630, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7654340139690966630, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7821383068482764140, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8250917491738269919, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8250917491738269919, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8250917491738269919, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8250917491738269919, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8341601108133503693, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
       propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411302640272790022, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411302640272790022, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411302640272790022, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411302640272790022, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411302640272790022, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8411302640272790022, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9128897290791795990, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9128897290791795990, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9128897290791795990, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9128897290791795990, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9128897290791795990, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9128897290791795990, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9152785347356188261, guid: f3b1d401bc50845629a6b982f9793f16, type: 3}

--- a/Explorer/Assets/DCL/UI/MainUIContainer/MainUIView.cs
+++ b/Explorer/Assets/DCL/UI/MainUIContainer/MainUIView.cs
@@ -22,6 +22,7 @@ namespace DCL.UI.MainUI
         [field: SerializeField] public ConnectionStatusPanelView ConnectionStatusPanelView { get; private set; }
         [field: SerializeField] public SidebarView SidebarView { get; private set; }
         [field: SerializeField] public ControlsPanelView ControlsPanelView { get; private set; }
+        [field: SerializeField] public WarningNotificationView WarningNotification { get; private set; }
         [field: SerializeField] internal PointerDetectionArea pointerDetectionArea { get; private set; }
         [field: SerializeField] internal LayoutElement sidebarLayoutElement { get; private set; }
         [field: SerializeField] internal GameObject sidebarDetectionArea { get; private set; }

--- a/Explorer/Assets/DCL/UI/Profiles/Names/InWorldSelfProfileDecorator.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/InWorldSelfProfileDecorator.cs
@@ -27,9 +27,9 @@ namespace DCL.UI.ProfileNames
         public UniTask<Profile?> ProfileAsync(CancellationToken ct) =>
             origin.ProfileAsync(ct);
 
-        public async UniTask<Profile?> UpdateProfileAsync(bool publish, CancellationToken ct)
+        public async UniTask<Profile?> UpdateProfileAsync(CancellationToken ct)
         {
-            Profile? profile = await origin.UpdateProfileAsync(publish, ct);
+            Profile? profile = await origin.UpdateProfileAsync(ct);
 
             if (profile != null)
                 UpdateAvatarInWorld(profile);


### PR DESCRIPTION
## What does this PR change?

Fixes #3984 

The issue was caused by a delay in saving the profile between closing the backpack and opening the emote wheel. During this gap, the profile data was outdated, resulting in outdated emotes being shown.
The solution updates the avatar’s in-world immediately, and performs a rollback if an error occurs, ensuring consistency with the catalyst.

## Test Instructions

Save the profile and open the wheel emote. You should always have your emotes updated.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
