### PR TITLE
fix: bring back verified icon

### DIFF
--- a/Explorer/Assets/DCL/NameTags/NametagView.cs
+++ b/Explorer/Assets/DCL/NameTags/NametagView.cs
@@ -194,7 +194,7 @@ namespace DCL.Nametags
             return currentText.StartsWith(username, StringComparison.Ordinal);
         }
 
-        public void SetUsername(string username, string? walletId, bool hasClaimedName, Color usernameColor)
+        public void SetUsername(string username, string? walletId, bool hasClaimedName, bool userVerfiedIcon, Color usernameColor)
         {
             ResetElement();
 
@@ -202,7 +202,7 @@ namespace DCL.Nametags
             cts = new CancellationTokenSource();
 
             isClaimedName = hasClaimedName;
-            verifiedIcon.gameObject.SetActive(hasClaimedName);
+            verifiedIcon.gameObject.SetActive(hasClaimedName && userVerfiedIcon);
 
             privateMessageIcon.gameObject.SetActive(false);
             privateMessageText.gameObject.SetActive(false);

--- a/Explorer/Assets/DCL/NameTags/NametagView.cs
+++ b/Explorer/Assets/DCL/NameTags/NametagView.cs
@@ -194,7 +194,7 @@ namespace DCL.Nametags
             return currentText.StartsWith(username, StringComparison.Ordinal);
         }
 
-        public void SetUsername(string username, string? walletId, bool hasClaimedName, bool userVerfiedIcon, Color usernameColor)
+        public void SetUsername(string username, string? walletId, bool hasClaimedName, bool useVerifiedIcon, Color usernameColor)
         {
             ResetElement();
 
@@ -202,7 +202,7 @@ namespace DCL.Nametags
             cts = new CancellationTokenSource();
 
             isClaimedName = hasClaimedName;
-            verifiedIcon.gameObject.SetActive(hasClaimedName && userVerfiedIcon);
+            verifiedIcon.gameObject.SetActive(useVerifiedIcon);
 
             privateMessageIcon.gameObject.SetActive(false);
             privateMessageText.gameObject.SetActive(false);

--- a/Explorer/Assets/DCL/NameTags/NametagView.cs
+++ b/Explorer/Assets/DCL/NameTags/NametagView.cs
@@ -214,7 +214,7 @@ namespace DCL.Nametags
             cachedUsernameWidth = usernameText.preferredWidth;
             messageContent.color = NametagViewConstants.DEFAULT_TRANSPARENT_COLOR;
 
-            if (hasClaimedName)
+            if (hasClaimedName && useVerifiedIcon)
             {
                 usernamePos.x = usernameText.rectTransform.anchoredPosition.x;
                 verifiedIconInitialPosition = CalculateVerifiedIconPosition(usernamePos.x, cachedUsernameWidth, verifiedIconWidth, nametagMarginOffsetHeight);

--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -141,7 +141,7 @@ namespace DCL.Nametags
             if (nametagView.IsSameName(profile.ValidatedName, profile.HasClaimedName)) return;
 
             nametagView.Id = avatarShape.ID;
-            nametagView.SetUsername(profile.ValidatedName, profile.WalletId, profile.HasClaimedName, true, profile.UserNameColor);
+            nametagView.SetUsername(profile.ValidatedName, profile.WalletId, profile.HasClaimedName, profile.HasClaimedName, profile.UserNameColor);
             nametagView.gameObject.name = avatarShape.ID;
 
             UpdateTagTransparencyAndScale(nametagView, camera.Camera.transform.position, characterTransform.Position, fovScaleFactor);

--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -141,7 +141,7 @@ namespace DCL.Nametags
             if (nametagView.IsSameName(profile.ValidatedName, profile.HasClaimedName)) return;
 
             nametagView.Id = avatarShape.ID;
-            nametagView.SetUsername(profile.ValidatedName, profile.WalletId, profile.HasClaimedName, profile.UserNameColor);
+            nametagView.SetUsername(profile.ValidatedName, profile.WalletId, profile.HasClaimedName, true, profile.UserNameColor);
             nametagView.gameObject.name = avatarShape.ID;
 
             UpdateTagTransparencyAndScale(nametagView, camera.Camera.transform.position, characterTransform.Position, fovScaleFactor);
@@ -225,7 +225,7 @@ namespace DCL.Nametags
                 : NAMETAG_DEFAULT_WALLET_ID);
 
             nametagView.InjectConfiguration(chatBubbleConfigurationSo);
-            nametagView.SetUsername(avatarShape.Name, walletId, hasClaimedName, usernameColor);
+            nametagView.SetUsername(avatarShape.Name, walletId, hasClaimedName, useVerifiedIcon, usernameColor);
 
             return nametagView;
         }

--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -96,7 +96,7 @@ namespace DCL.Nametags
                 NametagMathHelper.IsOutOfRenderRange(camera.Camera.transform.position, characterTransform.Position, maxDistanceSqr))
                 return;
 
-            var nametagView = CreateNameTagView(in avatarShape, profile.HasClaimedName, true, profile);
+            NametagView nametagView = CreateNameTagView(in avatarShape, profile.HasClaimedName, profile.HasClaimedName, profile);
             UpdateTagPosition(nametagView, characterTransform.Position, cameraForward, cameraUp);
             World.Add(e, nametagView);
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Brings back the correct usage of the verified icon

## Test Instructions


### Test Steps
1. Get together some real users. Check that the verified icon is there for people with claimed names, and that it isnt for people without claimed names.
2. Instantiate some avatars from the debug panel. None of them should have a claimed named
3. Go to this location. Check that Skeeter does not have a verified icon

![image](https://github.com/user-attachments/assets/0a88d314-23c3-42d1-9894-4a502e7702ea)


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
