### PR TITLE
fix/4169 chat scroll not working

### DIFF
--- a/Explorer/Assets/DCL/Chat/Assets/Chat.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/Chat.prefab
@@ -2211,7 +2211,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1624684265765288882, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 134.91
       objectReference: {fileID: 0}
     - target: {fileID: 1624684265765288882, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -2407,7 +2407,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8900561152139656757, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 8.76
       objectReference: {fileID: 0}
     - target: {fileID: 8900561152139656757, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -2577,10 +2577,6 @@ PrefabInstance:
     - target: {fileID: 7301239302916120637, guid: ee73406bf16a6fe4b9d216a8a192a765, type: 3}
       propertyPath: m_Size
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8646576932515811346, guid: ee73406bf16a6fe4b9d216a8a192a765, type: 3}
-      propertyPath: m_Enabled
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Explorer/Assets/DCL/UI/Utilities/ScrollRectExtensions.cs
+++ b/Explorer/Assets/DCL/UI/Utilities/ScrollRectExtensions.cs
@@ -6,14 +6,14 @@ namespace DCL.UI.Utilities
     public static class ScrollRectExtensions
     {
         private const float MACOS_SCROLL_SENSITIVITY = 0.45f;
-        private const float WINDOWS_SCROLL_SENSITIVITY = 0.15f;
+        private const float WINDOWS_SCROLL_SENSITIVITY = 2f;
 
         public static void SetScrollSensitivityBasedOnPlatform(this ScrollRect scrollRect, float overrideWindows = WINDOWS_SCROLL_SENSITIVITY, float overrideMacOS = MACOS_SCROLL_SENSITIVITY)
         {
             if (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)
-                scrollRect.scrollSensitivity = overrideWindows;
-            else
                 scrollRect.scrollSensitivity = overrideMacOS;
+            else
+                scrollRect.scrollSensitivity = overrideWindows;
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description
## What does this PR change?
This PR restores scroll functionality for the chat and applies correct platform-specific sensitivity

## Test Instructions
### Test Steps
1. Open chat
2. Send enough message so the chat area is scrollable
3. Try to drag/scroll while mouse is over message and also when over the empty area
4. Observe that chat scroll is working

### Additional Testing Notes
- Sensitivity is increased for windows platform

## Quality Checklist
- [x ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
