### PR TITLE
fix: added support for new launcher in application version guard

### DIFF
--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -27,7 +27,7 @@ namespace DCL.ApplicationVersionGuard
         private const string DECENTRALAND_LAUNCHER_WIN_X64_EXE = "Decentraland_x64-setup.exe";
         private const string DECENTRALAND_LAUNCHER_MAC_ARM_64DMG = "Decentraland_aarch64.dmg";
         //Aga: Rust version of launcher does not support intel macs, until fully deprecating it, we need to keep the old launcher for intel based macs
-        private const string DECENTRALAND_LEGACY_LAUNCHER_MAC_X_64DMG = "Decentraland%20Launcher-mac-x64.dmg";
+        private const string DECENTRALAND_LEGACY_LAUNCHER_MAC_X_64DMG = "Decentraland Launcher-mac-x64.dmg";
 
         private readonly IWebRequestController webRequestController;
         private readonly IWebBrowser webBrowser;

--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -118,7 +118,7 @@ namespace DCL.ApplicationVersionGuard
             return Application.platform switch
                    {
                        RuntimePlatform.WindowsEditor or RuntimePlatform.WindowsPlayer => IDecentralandUrlsSource.LAUNCHER_DOWNLOAD_URL,
-                       RuntimePlatform.OSXEditor or RuntimePlatform.OSXPlayer => SystemInfo.processorType.ToLower().Contains("arm") ? IDecentralandUrlsSource.LAUNCHER_DOWNLOAD_URL : IDecentralandUrlsSource.LEGACY_LAUNCHER_DOWNLOAD_URL,
+                       RuntimePlatform.OSXEditor or RuntimePlatform.OSXPlayer => SystemInfo.processorType.Contains("arm", StringComparison.OrdinalIgnoreCase) ? IDecentralandUrlsSource.LAUNCHER_DOWNLOAD_URL : IDecentralandUrlsSource.LEGACY_LAUNCHER_DOWNLOAD_URL,
                        _ => throw new NotSupportedException("Unsupported platform for launcher download."),
                    };
         }
@@ -139,7 +139,7 @@ namespace DCL.ApplicationVersionGuard
 
                 case RuntimePlatform.OSXEditor:
                 case RuntimePlatform.OSXPlayer:
-                    possiblePaths = SystemInfo.processorType.ToLower().Contains("arm")
+                    possiblePaths = SystemInfo.processorType.Contains("arm", StringComparison.OrdinalIgnoreCase)
                         ? new[]
                         {
                             LAUNCHER_PATH_MAC,

--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -19,14 +19,15 @@ namespace DCL.ApplicationVersionGuard
 {
     public class ApplicationVersionGuard
     {
-        private const string LAUNCHER_EXECUTABLE_NAME = "Decentraland Launcher";
+        private const string LAUNCHER_EXECUTABLE_NAME = "Decentraland";
+        private const string LEGACY_LAUNCHER_EXECUTABLE_NAME = "Decentraland Launcher";
+        private const string LAUNCHER_EXECUTABLE_FILENAME = "dcl_launcher.exe";
         private const string LAUNCHER_PATH_MAC = "/Applications/" + LAUNCHER_EXECUTABLE_NAME + ".app";
-        private const string LAUNCHER_PATH_WIN_MAIN = @"C:\Program Files\Decentraland Launcher\" + LAUNCHER_EXECUTABLE_NAME + ".exe";
-        private const string LAUNCHER_PATH_WIN_86 = @"C:\Program Files (x86)\Decentraland Launcher\" + LAUNCHER_EXECUTABLE_NAME + ".exe";
-        private const string LAUNCHER_PATH_WIN_COMBINED = @"Programs\Decentraland Launcher\" + LAUNCHER_EXECUTABLE_NAME + ".exe";
-        private const string DECENTRALAND_LAUNCHER_WIN_X64_EXE = "Decentraland-Launcher-win-x64.exe";
-        private const string DECENTRALAND_LAUNCHER_MAC_ARM_64DMG = "Decentraland-Launcher-mac-arm64.dmg";
-        private const string DECENTRALAND_LAUNCHER_MAC_X_64DMG = "Decentraland-Launcher-mac-x64.dmg";
+        private const string LEGACY_LAUNCHER_PATH_MAC = "/Applications/" + LEGACY_LAUNCHER_EXECUTABLE_NAME + ".app";
+        private const string DECENTRALAND_LAUNCHER_WIN_X64_EXE = "Decentraland_x64-setup.exe";
+        private const string DECENTRALAND_LAUNCHER_MAC_ARM_64DMG = "Decentraland_aarch64.dmg";
+        //Aga: Rust version of launcher does not support intel macs, until fully deprecating it, we need to keep the old launcher for intel based macs
+        private const string DECENTRALAND_LEGACY_LAUNCHER_MAC_X_64DMG = "Decentraland-Launcher-mac-x64.dmg";
 
         private readonly IWebRequestController webRequestController;
         private readonly IWebBrowser webBrowser;
@@ -92,38 +93,32 @@ namespace DCL.ApplicationVersionGuard
 
         private async UniTask DownloadLauncherAsync(CancellationToken ct)
         {
-            string downloadUrl = await GetLauncherDownloadUrlAsync(ct);
+            string assetName = GetLauncherAssetName();
+            string downloadUrl = $"{GetLauncherDownloadPath()}/{assetName}";
 
             if (!string.IsNullOrEmpty(downloadUrl))
                 webBrowser.OpenUrl(downloadUrl);
             else
                 ReportHub.LogError(ReportCategory.VERSION_CONTROL, "Failed to get launcher download URL.");
-
-            return;
-
-            async UniTask<string> GetLauncherDownloadUrlAsync(CancellationToken cancellationToken)
-            {
-                FlatFetchResponse response = await webRequestController.GetAsync<FlatFetchResponse<GenericGetRequest>, FlatFetchResponse>(
-                    IDecentralandUrlsSource.LAUNCHER_LATEST_RELEASE_URL,
-                    new FlatFetchResponse<GenericGetRequest>(),
-                    cancellationToken,
-                    ReportCategory.VERSION_CONTROL,
-                    new WebRequestHeadersInfo());
-
-                GitHubRelease latestRelease = JsonUtility.FromJson<GitHubRelease>(response.body);
-                string version = latestRelease.tag_name.TrimStart('v');
-
-                string assetName = GetLauncherAssetName();
-                return $"{IDecentralandUrlsSource.LAUNCHER_DOWNLOAD_URL}/{version}/{assetName}";
-            }
         }
 
         private static string GetLauncherAssetName()
         {
             return Application.platform switch
+            {
+                RuntimePlatform.WindowsEditor or RuntimePlatform.WindowsPlayer => DECENTRALAND_LAUNCHER_WIN_X64_EXE,
+                RuntimePlatform.OSXEditor or RuntimePlatform.OSXPlayer => SystemInfo.processorType.ToLower().Contains("arm") ? DECENTRALAND_LAUNCHER_MAC_ARM_64DMG : DECENTRALAND_LEGACY_LAUNCHER_MAC_X_64DMG,
+                _ => throw new NotSupportedException("Unsupported platform for launcher download."),
+            };
+        }
+
+
+        private static string GetLauncherDownloadPath()
+        {
+            return Application.platform switch
                    {
-                       RuntimePlatform.WindowsEditor or RuntimePlatform.WindowsPlayer => DECENTRALAND_LAUNCHER_WIN_X64_EXE,
-                       RuntimePlatform.OSXEditor or RuntimePlatform.OSXPlayer => SystemInfo.processorType.ToLower().Contains("arm") ? DECENTRALAND_LAUNCHER_MAC_ARM_64DMG : DECENTRALAND_LAUNCHER_MAC_X_64DMG,
+                       RuntimePlatform.WindowsEditor or RuntimePlatform.WindowsPlayer => IDecentralandUrlsSource.LAUNCHER_DOWNLOAD_URL,
+                       RuntimePlatform.OSXEditor or RuntimePlatform.OSXPlayer => SystemInfo.processorType.ToLower().Contains("arm") ? IDecentralandUrlsSource.LAUNCHER_DOWNLOAD_URL : IDecentralandUrlsSource.LEGACY_LAUNCHER_DOWNLOAD_URL,
                        _ => throw new NotSupportedException("Unsupported platform for launcher download."),
                    };
         }
@@ -138,28 +133,33 @@ namespace DCL.ApplicationVersionGuard
                 case RuntimePlatform.WindowsPlayer:
                     possiblePaths = new[]
                     {
-                        LAUNCHER_PATH_WIN_MAIN,
-                        LAUNCHER_PATH_WIN_86,
-                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), LAUNCHER_PATH_WIN_COMBINED),
+                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), LAUNCHER_EXECUTABLE_FILENAME, LAUNCHER_EXECUTABLE_FILENAME),
                     };
-
                     break;
+
                 case RuntimePlatform.OSXEditor:
                 case RuntimePlatform.OSXPlayer:
-                    possiblePaths = new[]
-                    {
-                        LAUNCHER_PATH_MAC,
-                        $"{Environment.GetFolderPath(Environment.SpecialFolder.Personal)}{LAUNCHER_PATH_MAC}",
-                    };
-
+                    possiblePaths = SystemInfo.processorType.ToLower().Contains("arm")
+                        ? new[]
+                        {
+                            LAUNCHER_PATH_MAC,
+                            $"{Environment.GetFolderPath(Environment.SpecialFolder.Personal)}{LAUNCHER_PATH_MAC}",
+                        }
+                        : new[]
+                        {
+                            LEGACY_LAUNCHER_PATH_MAC,
+                            $"{Environment.GetFolderPath(Environment.SpecialFolder.Personal)}{LEGACY_LAUNCHER_PATH_MAC}",
+                        };
                     break;
+
                 default:
                     ReportHub.LogError(ReportCategory.VERSION_CONTROL, "Unsupported platform for launching the application.");
                     return null;
             }
 
-            return possiblePaths.FirstOrDefault(path => File.Exists(path)
-                                                        || (Directory.Exists(path) && (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)));
+            return possiblePaths.FirstOrDefault(path =>
+                File.Exists(path) ||
+                (Directory.Exists(path) && (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)));
         }
 
         [Serializable]

--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -59,7 +59,7 @@ namespace DCL.ApplicationVersionGuard
 
             if (string.IsNullOrEmpty(launcherPath))
             {
-                await DownloadLauncherAsync(ct);
+                DownloadLauncher();
                 Quit();
             }
             else
@@ -91,7 +91,7 @@ namespace DCL.ApplicationVersionGuard
 #endif
         }
 
-        private async UniTask DownloadLauncherAsync(CancellationToken ct)
+        private void DownloadLauncher()
         {
             string assetName = GetLauncherAssetName();
             string downloadUrl = $"{GetLauncherDownloadPath()}/{assetName}";
@@ -133,7 +133,7 @@ namespace DCL.ApplicationVersionGuard
                 case RuntimePlatform.WindowsPlayer:
                     possiblePaths = new[]
                     {
-                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), LAUNCHER_EXECUTABLE_FILENAME, LAUNCHER_EXECUTABLE_FILENAME),
+                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), LAUNCHER_EXECUTABLE_NAME, LAUNCHER_EXECUTABLE_FILENAME),
                     };
                     break;
 

--- a/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -27,7 +27,7 @@ namespace DCL.ApplicationVersionGuard
         private const string DECENTRALAND_LAUNCHER_WIN_X64_EXE = "Decentraland_x64-setup.exe";
         private const string DECENTRALAND_LAUNCHER_MAC_ARM_64DMG = "Decentraland_aarch64.dmg";
         //Aga: Rust version of launcher does not support intel macs, until fully deprecating it, we need to keep the old launcher for intel based macs
-        private const string DECENTRALAND_LEGACY_LAUNCHER_MAC_X_64DMG = "Decentraland-Launcher-mac-x64.dmg";
+        private const string DECENTRALAND_LEGACY_LAUNCHER_MAC_X_64DMG = "Decentraland%20Launcher-mac-x64.dmg";
 
         private readonly IWebRequestController webRequestController;
         private readonly IWebBrowser webBrowser;
@@ -107,7 +107,7 @@ namespace DCL.ApplicationVersionGuard
             return Application.platform switch
             {
                 RuntimePlatform.WindowsEditor or RuntimePlatform.WindowsPlayer => DECENTRALAND_LAUNCHER_WIN_X64_EXE,
-                RuntimePlatform.OSXEditor or RuntimePlatform.OSXPlayer => SystemInfo.processorType.ToLower().Contains("arm") ? DECENTRALAND_LAUNCHER_MAC_ARM_64DMG : DECENTRALAND_LEGACY_LAUNCHER_MAC_X_64DMG,
+                RuntimePlatform.OSXEditor or RuntimePlatform.OSXPlayer => IsAppleSiliconMac ? DECENTRALAND_LAUNCHER_MAC_ARM_64DMG : DECENTRALAND_LEGACY_LAUNCHER_MAC_X_64DMG,
                 _ => throw new NotSupportedException("Unsupported platform for launcher download."),
             };
         }
@@ -118,7 +118,7 @@ namespace DCL.ApplicationVersionGuard
             return Application.platform switch
                    {
                        RuntimePlatform.WindowsEditor or RuntimePlatform.WindowsPlayer => IDecentralandUrlsSource.LAUNCHER_DOWNLOAD_URL,
-                       RuntimePlatform.OSXEditor or RuntimePlatform.OSXPlayer => SystemInfo.processorType.Contains("arm", StringComparison.OrdinalIgnoreCase) ? IDecentralandUrlsSource.LAUNCHER_DOWNLOAD_URL : IDecentralandUrlsSource.LEGACY_LAUNCHER_DOWNLOAD_URL,
+                       RuntimePlatform.OSXEditor or RuntimePlatform.OSXPlayer => IsAppleSiliconMac ? IDecentralandUrlsSource.LAUNCHER_DOWNLOAD_URL : IDecentralandUrlsSource.LEGACY_LAUNCHER_DOWNLOAD_URL,
                        _ => throw new NotSupportedException("Unsupported platform for launcher download."),
                    };
         }
@@ -139,7 +139,7 @@ namespace DCL.ApplicationVersionGuard
 
                 case RuntimePlatform.OSXEditor:
                 case RuntimePlatform.OSXPlayer:
-                    possiblePaths = SystemInfo.processorType.Contains("arm", StringComparison.OrdinalIgnoreCase)
+                    possiblePaths = IsAppleSiliconMac
                         ? new[]
                         {
                             LAUNCHER_PATH_MAC,
@@ -161,6 +161,10 @@ namespace DCL.ApplicationVersionGuard
                 File.Exists(path) ||
                 (Directory.Exists(path) && (Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer)));
         }
+
+        private static bool IsAppleSiliconMac =>
+            Application.platform is RuntimePlatform.OSXEditor or RuntimePlatform.OSXPlayer &&
+            SystemInfo.processorType.Contains("apple", StringComparison.OrdinalIgnoreCase);
 
         [Serializable]
         private struct GitHubRelease

--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/IDecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/IDecentralandUrlsSource.cs
@@ -3,8 +3,8 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
     public interface IDecentralandUrlsSource
     {
         const string EXPLORER_LATEST_RELEASE_URL = "https://api.github.com/repos/decentraland/unity-explorer/releases/latest";
-        const string LAUNCHER_LATEST_RELEASE_URL = "https://api.github.com/repos/decentraland/launcher/releases/latest";
-        const string LAUNCHER_DOWNLOAD_URL = "https://github.com/decentraland/launcher/releases/download";
+        const string LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher-rust/";
+        const string LEGACY_LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher/dcl/";
 
         string DecentralandDomain { get; }
         DecentralandEnvironment Environment { get; }

--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/IDecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/IDecentralandUrlsSource.cs
@@ -3,8 +3,8 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
     public interface IDecentralandUrlsSource
     {
         const string EXPLORER_LATEST_RELEASE_URL = "https://api.github.com/repos/decentraland/unity-explorer/releases/latest";
-        const string LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher-rust/";
-        const string LEGACY_LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher/dcl/";
+        const string LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher-rust";
+        const string LEGACY_LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher/dcl";
 
         string DecentralandDomain { get; }
         DecentralandEnvironment Environment { get; }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This PR updates all launcher URLs to align with the release of the new launcher:
Windows and Apple Silicon Macs now use updated paths pointing to the new launcher.
Intel-based Macs continue to use the old launcher, as the new version does not support them.

If the launcher is not installed, the client will now default to a direct S3 bucket URL instead of the GitHub release page. This change improves download speed and consistency.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->
![Screenshot 2025-05-29 170531](https://github.com/user-attachments/assets/f9a175c8-dae4-48f4-9978-39695bdfe7d4)

To trigger the popup us this command `".\Decentraland.exe" --simulateVersion 0.71.0-alpha`
- Launcher not installed → Clicking "Update now" should open a website with the correct download link for the user's platform.
- Launcher installed → Should open the launcher directly.
   - Intel Mac → Should open the old launcher.
   - Apple Silicon or Windows → Should open the new launcher.

### Prerequisites
- [x] List any required setup steps
- [x] Include environment/configuration requirements.

## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
