### PR TITLE
hotfix: name tag layer

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
@@ -2096,7 +2096,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 1141047927
+    m_Bits: 1677918839
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Brings back the nametags, since the camera layer was modified incorrectly

## Test Instructions




### Test Steps
1. Check that the nametags are visible before and after pressing N
2. Walk around with other players and verify nametags
3. To confirm, check changing wearables (and maybe ask your friends the same) to see that you dont have the name udpate problem currently on dev


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
