### PR TITLE
fix: no dm indicator before we open the chat for the first time.

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatConversationsToolbarView.cs
+++ b/Explorer/Assets/DCL/Chat/ChatConversationsToolbarView.cs
@@ -75,6 +75,7 @@ namespace DCL.Chat
             if (items.TryGetValue(channel.Id, out var item)) return;
 
             ChatConversationsToolbarViewItem newItem = Instantiate(itemPrefab, itemsContainer);
+            newItem.Initialize();
             newItem.OpenButtonClicked += OpenButtonClicked;
             newItem.RemoveButtonClicked += OnRemoveButtonClicked;
             newItem.TooltipShown += OnItemTooltipShown;
@@ -101,7 +102,6 @@ namespace DCL.Chat
             }
 
             newItem.SetConversationType(channel.ChannelType == ChatChannel.ChatChannelType.USER);
-            newItem.Initialize();
             
             items.Add(channel.Id, newItem);
 

--- a/Explorer/Assets/DCL/Chat/ChatConversationsToolbarView.cs
+++ b/Explorer/Assets/DCL/Chat/ChatConversationsToolbarView.cs
@@ -101,7 +101,8 @@ namespace DCL.Chat
             }
 
             newItem.SetConversationType(channel.ChannelType == ChatChannel.ChatChannelType.USER);
-
+            newItem.Initialize();
+            
             items.Add(channel.Id, newItem);
 
             if(items.Count == 1)

--- a/Explorer/Assets/DCL/Chat/ChatConversationsToolbarViewItem.cs
+++ b/Explorer/Assets/DCL/Chat/ChatConversationsToolbarViewItem.cs
@@ -217,11 +217,11 @@ namespace DCL.Chat
         private void Awake()
         {
             openButton.onClick.AddListener(() => { OpenButtonClicked?.Invoke(this); });
-            removeButton.onClick.AddListener(() => {
+            removeButton.onClick.AddListener(() =>
+            {
                 HideTooltip(true);
                 RemoveButtonClicked?.Invoke(this);
             });
-            SetUnreadMessages(0);
         }
 
         private void Start()

--- a/Explorer/Assets/DCL/Chat/ChatConversationsToolbarViewItem.cs
+++ b/Explorer/Assets/DCL/Chat/ChatConversationsToolbarViewItem.cs
@@ -214,7 +214,7 @@ namespace DCL.Chat
             }
         }
 
-        private void Awake()
+        public void Initialize()
         {
             openButton.onClick.AddListener(() => { OpenButtonClicked?.Invoke(this); });
             removeButton.onClick.AddListener(() =>
@@ -222,6 +222,7 @@ namespace DCL.Chat
                 HideTooltip(true);
                 RemoveButtonClicked?.Invoke(this);
             });
+            SetUnreadMessages(0);
         }
 
         private void Start()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR fixed the issue If we received messages before we opened the chat we would not get DM indicator

### Prerequisites
- [ ] Two clients with different players logged in
- [ ] Players are connected as friends to be able to send messages to each other

### Test Steps
1. Start Game 1 (Player 1) but don't open the chat, Start Game 2 (Player 2)
2. From Game 2 (Player 2) send direct message to Player 1
3. Notification is received in Game 1 in the chat panel that message is received
4. Open chat in Game 1
5. DM badge for Player 2 shows unread messages

## Quality Checklist
- [X] Changes have been tested locally

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
