### PR TITLE
fix: NRE on exit for toolbar view

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatConversationsToolbarView.cs
+++ b/Explorer/Assets/DCL/Chat/ChatConversationsToolbarView.cs
@@ -127,7 +127,7 @@ namespace DCL.Chat
         public void RemoveAllConversations()
         {
             foreach (var itemsValue in items.Values)
-                UnityObjectUtils.SafeDestroy(itemsValue.gameObject);
+                UnityObjectUtils.SafeDestroyGameObject(itemsValue);
             items.Clear();
             UpdateScrollButtonsVisibility();
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

We thought that we fixed it, but we actually didnt. The component was null, so asking for the gameobejct was still giving a NRE.

![image](https://github.com/user-attachments/assets/17e73647-4d06-49ed-8d0a-cf7ba390b36c)


## Test Instructions



### Test Steps
1. Run at least 5 times DCL
2. Check that you dont get an exit crash


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
