### PR TITLE
fix: invalid profile after save through backpack

### DIFF
--- a/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
@@ -189,6 +189,8 @@ namespace DCL.Backpack
             {
                 Profile? savedProfile = await selfProfile.UpdateProfileAsync(newProfile, ct);
                 MultithreadingUtility.AssertMainThread(nameof(UpdateProfileAsync), true);
+                // We need to re-update the avatar in-world with the new profile because the save operation invalidates the previous profile
+                // breaking the avatar and the backpack
                 UpdateAvatarInWorld(savedProfile!);
                 oldProfile.Dispose();
             }


### PR DESCRIPTION
## What does this PR change?

Fixes #4284 

The root issue was that the catalyst confirmation replaced the saved profile in the cache, which invalidated the previous instance still set on the avatar entity. As a result, the avatar was referencing an invalid profile.

The fix ensures that once the profile is successfully saved through the backpack, the updated version from the catalyst confirmation is immediately applied to the in-world avatar.

## Test Instructions

Save the avatar at the backpack. Check that your avatar in-world is updated immediately and keeps all the saved changes. Logout or restart the client. Check that all changes are saved.
Open the backpack and keep changing wearables many times. Fast as possible. Check changes are applied. Also you should see name tags correctly.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
