### PR TITLE
fix: hot-reload exceptions + broken VCam apply retry

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/ECSReloadScene.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/ECSReloadScene.cs
@@ -75,7 +75,7 @@ namespace ECS.SceneLifeCycle
             ct.ThrowIfCancellationRequested();
 
             //There is a lingering promise we need to remove, and add the DeleteEntityIntention to make the standard unload flow.
-            world!.Remove<AssetPromise<ISceneFacade, GetSceneFacadeIntention>>(entity);
+            world.Remove<AssetPromise<ISceneFacade, GetSceneFacadeIntention>>(entity);
             world.Add<DeleteEntityIntention>(entity);
 
             //We wait until scene is fully disposed
@@ -93,9 +93,9 @@ namespace ECS.SceneLifeCycle
                 world.Query(in new QueryDescription().WithAll<RealmComponent>(),
                     (ref StaticScenePointers staticScenePointers) => { staticScenePointers.Promise = null; });
 
-                Resources.UnloadUnusedAssets();
-
                 await WaitUntilNewSceneIsFullyLoadedAsync();
+
+                Resources.UnloadUnusedAssets();
             }
 
             return;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Common/AssetPromise.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Common/AssetPromise.cs
@@ -130,7 +130,10 @@ namespace ECS.StreamableLoading.Common
         {
             if (Entity == Entity.Null || !world.IsAlive(Entity)) return;
 
-            LoadingIntention.CancellationTokenSource.Cancel();
+            // Avoids ObjectDisposedException on already-disposed TokenSources
+            if(LoadingIntention.CancellationTokenSource.Token.CanBeCanceled)
+                LoadingIntention.CancellationTokenSource.Cancel();
+
             DestroyEntity(world);
         }
 


### PR DESCRIPTION
### WHY

I encountered these 3 bugs that affect creators dev-exp + unity devs dev-exp:
1. Since recently, during the hot-reload of a local scene, Unity may crash randomly while the scene reloads.
2. Since recently, during hot-reload of a local scene, Unity may end up throwing `ObjectDisposedException` infinitely
3. I detected that if a scene uses a VCam from the beginning, it works OK the first load but after hot-reloading many many times the VCam is never re-assigned correctly at the beginning of the scene.

Editor log of the crash (1.):
![Screenshot 2025-05-31 at 10 09 34 PM](https://github.com/user-attachments/assets/b435ac5b-e93f-4a8a-b065-b58194daaa55)

### WHAT



### TEST INTSTRUCTIONS


