### PR TITLE
fix: input missing after jump to player

### DIFF
--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/IDecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/IDecentralandUrlsSource.cs
@@ -3,8 +3,8 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
     public interface IDecentralandUrlsSource
     {
         const string EXPLORER_LATEST_RELEASE_URL = "https://api.github.com/repos/decentraland/unity-explorer/releases/latest";
-        const string LAUNCHER_LATEST_RELEASE_URL = "https://api.github.com/repos/decentraland/launcher/releases/latest";
-        const string LAUNCHER_DOWNLOAD_URL = "https://github.com/decentraland/launcher/releases/download";
+        const string LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher-rust";
+        const string LEGACY_LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher/dcl";
 
         string DecentralandDomain { get; }
         DecentralandEnvironment Environment { get; }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -701,8 +701,10 @@ namespace Global.Dynamic
                     friendsEventBus,
                     chatMessageFactory,
                     staticContainer.FeatureFlagsCache,
+                    profileRepositoryWrapper,
                     friendServiceProxy,
-                    profileRepositoryWrapper),
+                    staticContainer.RealmData,
+                    realmNavigator),
                 new ExplorePanelPlugin(
                     assetsProvisioner,
                     mvcManager,

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsConfiguration.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsConfiguration.asset
@@ -135,6 +135,18 @@ MonoBehaviour:
       isEnabled: 1
     - eventName: unblock_user
       isEnabled: 1
+  - groupName: MarketplaceCredits
+    events:
+    - eventName: marketplace_credits_opened
+      isEnabled: 1
+  - groupName: Settings
+    events:
+    - eventName: chat-bubbles-visibility-changed
+      isEnabled: 1
+  - groupName: FeatureFlags
+    events:
+    - eventName: feature_flags
+      isEnabled: 1
   useLocalEnvVariableFallback: 0
   flushSize: 20
   flushInterval: 60

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Playgrounds/AnalyticsConfiguration Playground.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Playgrounds/AnalyticsConfiguration Playground.asset
@@ -131,6 +131,18 @@ MonoBehaviour:
       isEnabled: 1
     - eventName: unblock_user
       isEnabled: 1
+  - groupName: MarketplaceCredits
+    events:
+    - eventName: marketplace_credits_opened
+      isEnabled: 1
+  - groupName: Settings
+    events:
+    - eventName: chat-bubbles-visibility-changed
+      isEnabled: 1
+  - groupName: FeatureFlags
+    events:
+    - eventName: feature_flags
+      isEnabled: 1
   useLocalEnvVariableFallback: 0
   flushSize: 20
   flushInterval: 30

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
@@ -94,7 +94,6 @@ namespace DCL.PluginSystem.Global
             IFriendsEventBus friendsEventBus,
             ChatMessageFactory chatMessageFactory,
             FeatureFlagsCache featureFlagsCache,
-            ObjectProxy<IFriendsService> friendsServiceProxy,
             ProfileRepositoryWrapper profileDataProvider,
             ObjectProxy<IFriendsService> friendsServiceProxy,
             IRealmData realmData,

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
@@ -189,11 +189,23 @@ namespace DCL.PluginSystem.Global
             realmNavigator.NavigationExecuted += OnNavigationExecuted;
         }
 
+        /// <summary>
+        /// TODO: This is a temporary solution to show the chat when the user navigates to a parcel.
+        /// NOTE: check this PR for more details:
+        /// https://github.com/decentraland/unity-explorer/issues/4324
+        /// </summary>
+        /// <param name="parcel"></param>
         private void OnNavigationExecuted(Vector2Int parcel)
         {
             sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat, new ChatControllerShowParams(true,false)).Forget();
         }
 
+        /// <summary>
+        /// TODO: This is a temporary solution to show the chat when the user changes realm.
+        /// NOTE: check this PR for more details:
+        /// https://github.com/decentraland/unity-explorer/issues/4324
+        /// </summary>
+        /// <param name="realmKind"></param>
         private void OnRealmChange(RealmKind realmKind)
         {
             sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat, new ChatControllerShowParams(true,false)).Forget();

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
@@ -27,6 +27,8 @@ using DCL.UI.SharedSpaceManager;
 using DCL.Utilities;
 using MVC;
 using System.Threading;
+using ECS;
+using ECS.SceneLifeCycle.Realm;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 
@@ -64,7 +66,9 @@ namespace DCL.PluginSystem.Global
         private readonly ProfileRepositoryWrapper profileRepositoryWrapper;
 
         private ChatController chatController;
-
+        private IRealmData realmData;
+        private IRealmNavigator realmNavigator;
+        
         public ChatPlugin(
             IMVCManager mvcManager,
             IChatMessagesBus chatMessagesBus,
@@ -91,7 +95,10 @@ namespace DCL.PluginSystem.Global
             ChatMessageFactory chatMessageFactory,
             FeatureFlagsCache featureFlagsCache,
             ObjectProxy<IFriendsService> friendsServiceProxy,
-            ProfileRepositoryWrapper profileDataProvider)
+            ProfileRepositoryWrapper profileDataProvider,
+            ObjectProxy<IFriendsService> friendsServiceProxy,
+            IRealmData realmData,
+            IRealmNavigator realmNavigator)
         {
             this.mvcManager = mvcManager;
             this.chatHistory = chatHistory;
@@ -120,6 +127,8 @@ namespace DCL.PluginSystem.Global
             this.socialServiceProxy = socialServiceProxy;
             this.friendsEventBus = friendsEventBus;
             this.profileRepositoryWrapper = profileDataProvider;
+            this.realmData = realmData;
+            this.realmNavigator = realmNavigator;
         }
 
         public void Dispose()
@@ -176,6 +185,19 @@ namespace DCL.PluginSystem.Global
             // Log out / log in
             web3IdentityCache.OnIdentityCleared += OnIdentityCleared;
             web3IdentityCache.OnIdentityChanged += OnIdentityChanged;
+
+            realmData.RealmType.OnUpdate += OnRealmChange;
+            realmNavigator.NavigationExecuted += OnNavigationExecuted;
+        }
+
+        private void OnNavigationExecuted(Vector2Int parcel)
+        {
+            sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat, new ChatControllerShowParams(true,false)).Forget();
+        }
+
+        private void OnRealmChange(RealmKind realmKind)
+        {
+            sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat, new ChatControllerShowParams(true,false)).Forget();
         }
 
         private void OnIdentityCleared()

--- a/Explorer/Assets/DCL/UI/MainUIContainer/MainUIController.cs
+++ b/Explorer/Assets/DCL/UI/MainUIContainer/MainUIController.cs
@@ -56,7 +56,6 @@ namespace DCL.UI.MainUI
             viewInstance.pointerDetectionArea.OnExitArea += OnPointerExit;
             mvcManager.ShowAsync(SidebarController.IssueCommand()).Forget();
             mvcManager.ShowAsync(MinimapController.IssueCommand()).Forget();
-            sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat, new ChatControllerShowParams(true)).Forget();
             mvcManager.ShowAsync(ConnectionStatusPanelController.IssueCommand()).Forget();
 
             if (isFriendsEnabled)


### PR DESCRIPTION
# Pull Request Description
input missing after jump to player
When using the Jump In button from a friend's passport (accessed via the Friends tab), the chat panel disappears and the input box is not visible after teleporting.

NOTE: this is a workaround fix and here is the issue for the tech debt to be handled later:
https://github.com/decentraland/unity-explorer/pull/4317

## What does this PR change?
This PR fixes missing chat input box after teleporting to friend

### Test Steps
1. Play
2. Jump to friend through friend's passport
3. Observe that chat input box is there.

--

1. Play
2. Jump to friend through friend list
3. Observe that chat input box is there.

NOTE: this works for both teleport to parcel or load the world where friend is

## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
