### PR TITLE
fix: back button in the search bar

### DIFF
--- a/Explorer/Assets/DCL/Navmap/PlacesAndEventsPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlacesAndEventsPanelController.cs
@@ -115,7 +115,7 @@ namespace DCL.Navmap
             isExpanded = false;
             view.CollapseButton.gameObject.SetActive(false);
             view.ExpandButton.gameObject.SetActive(true);
-
+            searchBarController.DisableBack();
             RectTransform transform = (RectTransform)view.CollapseSection;
 
             collapseExpandCancellationToken = collapseExpandCancellationToken.SafeRestart();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
The original bug can’t be reproduced anymore, now, when you exit the map, the search bar hides and fully resets (so it’s likely been fixed in the meantime). The only issue I still spotted was that the search icon wasn’t resetting properly, so it wouldn’t appear when opening the search panel and that’s been addressed.

NOTE: in the issue https://github.com/decentraland/unity-explorer/issues/3264 video shows something that is likely change in the meanwhile and that is that when you close the map search panel hides (in the video it doesn't hide when you exit the map)

### Test Steps
1. Open the map.
2. Select an item on the map to open the search panel.
3. Close the map (observe that the search bar disappears).
4. Reopen the map.
5. Note that the search panel stays hidden and the search icon appears inside the input field.

## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
