### PR TITLE
fix: prevent chat from capturing Enter when another screen’s input is submitted.

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -254,6 +254,16 @@ namespace DCL.Chat
             viewInstance.Blur();
         }
 
+        protected override void OnBlur()
+        {
+            viewInstance?.UnsubscribeToSubmitEvent();
+        }
+
+        protected override void OnFocus()
+        {
+            viewInstance?.SubscribeToSubmitEvent();
+        }
+
         private void AddNearbyChannelAndSendWelcomeMessage()
         {
             chatHistory.AddOrGetChannel(ChatChannel.NEARBY_CHANNEL_ID, ChatChannel.ChatChannelType.NEARBY);
@@ -711,7 +721,6 @@ namespace DCL.Chat
 
             viewDependencies.DclInput.Shortcuts.ToggleNametags.performed += OnToggleNametagsShortcutPerformed;
             viewDependencies.DclInput.Shortcuts.OpenChatCommandLine.performed += OnOpenChatCommandLineShortcutPerformed;
-            viewDependencies.DclInput.UI.Submit.performed += OnSubmitUIInputPerformed;
         }
 
         private void OnViewDeleteChatHistoryRequested()
@@ -762,17 +771,6 @@ namespace DCL.Chat
 
             viewDependencies.DclInput.Shortcuts.ToggleNametags.performed -= OnToggleNametagsShortcutPerformed;
             viewDependencies.DclInput.Shortcuts.OpenChatCommandLine.performed -= OnOpenChatCommandLineShortcutPerformed;
-            viewDependencies.DclInput.UI.Submit.performed -= OnSubmitUIInputPerformed;
-        }
-
-        private void OnSubmitUIInputPerformed(InputAction.CallbackContext obj)
-        {
-            // check if we don't have other things opened
-            // like popup or something else?
-            if (TryGetView(out var view))
-            {
-                view.HandleUIInput();
-            }
         }
     }
 }

--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -692,6 +692,7 @@ namespace DCL.Chat
                 view.CurrentChannelChanged += OnViewCurrentChannelChangedAsync;
                 view.ConversationSelected += OnSelectConversation;
                 view.DeleteChatHistoryRequested += OnViewDeleteChatHistoryRequested;
+                
             }
 
             chatHistory.ChannelAdded += OnChatHistoryChannelAdded;
@@ -710,6 +711,7 @@ namespace DCL.Chat
 
             viewDependencies.DclInput.Shortcuts.ToggleNametags.performed += OnToggleNametagsShortcutPerformed;
             viewDependencies.DclInput.Shortcuts.OpenChatCommandLine.performed += OnOpenChatCommandLineShortcutPerformed;
+            viewDependencies.DclInput.UI.Submit.performed += OnSubmitUIInputPerformed;
         }
 
         private void OnViewDeleteChatHistoryRequested()
@@ -760,6 +762,17 @@ namespace DCL.Chat
 
             viewDependencies.DclInput.Shortcuts.ToggleNametags.performed -= OnToggleNametagsShortcutPerformed;
             viewDependencies.DclInput.Shortcuts.OpenChatCommandLine.performed -= OnOpenChatCommandLineShortcutPerformed;
+            viewDependencies.DclInput.UI.Submit.performed -= OnSubmitUIInputPerformed;
+        }
+
+        private void OnSubmitUIInputPerformed(InputAction.CallbackContext obj)
+        {
+            // check if we don't have other things opened
+            // like popup or something else?
+            if (TryGetView(out var view))
+            {
+                view.HandleUIInput();
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/Chat/ChatView.cs
+++ b/Explorer/Assets/DCL/Chat/ChatView.cs
@@ -445,7 +445,7 @@ namespace DCL.Chat
 
             viewDependencies.DclInput.UI.Click.performed -= OnClickUIInputPerformed;
             viewDependencies.DclInput.UI.Close.performed -= OnCloseUIInputPerformed;
-            viewDependencies.DclInput.UI.Submit.performed -= OnSubmitUIInputPerformed;
+            //viewDependencies.DclInput.UI.Submit.performed -= OnSubmitUIInputPerformed;
             return base.HideAsync(ct, isInstant);
         }
 
@@ -488,7 +488,7 @@ namespace DCL.Chat
             chatInputBox.InputChanged += OnInputChanged;
             chatInputBox.InputSubmitted += OnInputSubmitted;
 
-            viewDependencies.DclInput.UI.Submit.performed += OnSubmitUIInputPerformed;
+            //viewDependencies.DclInput.UI.Submit.performed += OnSubmitUIInputPerformed;
             viewDependencies.DclInput.UI.Close.performed += OnCloseUIInputPerformed;
             viewDependencies.DclInput.UI.Click.performed += OnClickUIInputPerformed;
 
@@ -786,7 +786,7 @@ namespace DCL.Chat
                 chatMessageViewer.StartChatEntriesFadeout();
         }
 
-        private void OnSubmitUIInputPerformed(InputAction.CallbackContext obj)
+        public void HandleUIInput()
         {
             if (isChatFocused)
             {
@@ -802,6 +802,23 @@ namespace DCL.Chat
                 Focus();
             }
         }
+        
+        // private void OnSubmitUIInputPerformed(InputAction.CallbackContext obj)
+        // {
+        //     if (isChatFocused)
+        //     {
+        //         chatInputBox.SubmitInputField();
+        //         chatInputBox.Focus(); // Necessary in order not to hide the caret
+        //     }
+        //     else
+        //     {
+        //         // If the Enter key is pressed while the member list is visible, it is hidden and the chat appears
+        //         if (memberListView.IsVisible)
+        //             memberListView.IsVisible = false;
+        //
+        //         Focus();
+        //     }
+        // }
 
         private void OnClickUIInputPerformed(InputAction.CallbackContext callbackContext)
         {

--- a/Explorer/Assets/DCL/Chat/ChatView.cs
+++ b/Explorer/Assets/DCL/Chat/ChatView.cs
@@ -12,6 +12,7 @@ using DG.Tweening;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using DCL.Diagnostics;
 using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -445,7 +446,6 @@ namespace DCL.Chat
 
             viewDependencies.DclInput.UI.Click.performed -= OnClickUIInputPerformed;
             viewDependencies.DclInput.UI.Close.performed -= OnCloseUIInputPerformed;
-            //viewDependencies.DclInput.UI.Submit.performed -= OnSubmitUIInputPerformed;
             return base.HideAsync(ct, isInstant);
         }
 
@@ -488,10 +488,10 @@ namespace DCL.Chat
             chatInputBox.InputChanged += OnInputChanged;
             chatInputBox.InputSubmitted += OnInputSubmitted;
 
-            //viewDependencies.DclInput.UI.Submit.performed += OnSubmitUIInputPerformed;
             viewDependencies.DclInput.UI.Close.performed += OnCloseUIInputPerformed;
             viewDependencies.DclInput.UI.Click.performed += OnClickUIInputPerformed;
-
+            SubscribeToSubmitEvent();
+            
             closePopupTask = new UniTaskCompletionSource();
 
             conversationsToolbar.ConversationSelected += OnConversationsToolbarConversationSelected;
@@ -785,8 +785,8 @@ namespace DCL.Chat
             else
                 chatMessageViewer.StartChatEntriesFadeout();
         }
-
-        public void HandleUIInput()
+        
+        private void OnSubmitUIInputPerformed(InputAction.CallbackContext obj)
         {
             if (isChatFocused)
             {
@@ -798,27 +798,10 @@ namespace DCL.Chat
                 // If the Enter key is pressed while the member list is visible, it is hidden and the chat appears
                 if (memberListView.IsVisible)
                     memberListView.IsVisible = false;
-
+        
                 Focus();
             }
         }
-        
-        // private void OnSubmitUIInputPerformed(InputAction.CallbackContext obj)
-        // {
-        //     if (isChatFocused)
-        //     {
-        //         chatInputBox.SubmitInputField();
-        //         chatInputBox.Focus(); // Necessary in order not to hide the caret
-        //     }
-        //     else
-        //     {
-        //         // If the Enter key is pressed while the member list is visible, it is hidden and the chat appears
-        //         if (memberListView.IsVisible)
-        //             memberListView.IsVisible = false;
-        //
-        //         Focus();
-        //     }
-        // }
 
         private void OnClickUIInputPerformed(InputAction.CallbackContext callbackContext)
         {
@@ -1025,6 +1008,31 @@ namespace DCL.Chat
         private void OnConversationsToolbarConversationRemovalRequested(ChatChannel.ChannelId channelId)
         {
             ChannelRemovalRequested?.Invoke(channelId);
+        }
+
+        private bool isSubmitHooked;
+        public void SubscribeToSubmitEvent()
+        {
+            if (isSubmitHooked)
+            {
+                ReportHub.Log(ReportCategory.UNSPECIFIED, "Trying to subscribe to submit event when it was already hooked");
+                return;
+            }
+
+            viewDependencies.DclInput.UI.Submit.performed += OnSubmitUIInputPerformed;
+            isSubmitHooked = true;
+        }
+
+        public void UnsubscribeToSubmitEvent()
+        {
+            if (!isSubmitHooked)
+            {
+                ReportHub.Log(ReportCategory.UNSPECIFIED, "Trying to unsubscribe from submit event when it was not hooked");
+                return;
+            }
+
+            viewDependencies.DclInput.UI.Submit.performed -= OnSubmitUIInputPerformed;
+            isSubmitHooked = false;
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/WindowStackManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/WindowStackManager.cs
@@ -73,9 +73,13 @@ namespace MVC
         {
             popupStack.Remove(controller);
 
-            foreach (var persistant in persistentStack)
-                if (persistant.State == ControllerState.ViewBlurred)
-                    persistant.Focus();
+            if (popupStack.Count == 0)
+            {
+                foreach (var persistant in persistentStack)
+                    if (persistant.State == ControllerState.ViewBlurred)
+                        persistant.Focus();
+            }
+            
             
             return new PopupPopInfo(
                 new CanvasOrdering(CanvasOrdering.SortingLayer.Popup, ((popupStack.Count - 1) * 2) - 1),

--- a/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/WindowStackManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/WindowStackManager.cs
@@ -17,7 +17,11 @@ namespace MVC
         {
             int orderInLayer = popupStack.Count * 2;
             popupStack.Add(controller);
-
+            
+            foreach (var persistant in persistentStack)
+                if (persistant.State == ControllerState.ViewFocused)
+                    persistant.Blur();
+            
             return new PopupPushInfo(
                     new CanvasOrdering(CanvasOrdering.SortingLayer.Popup, orderInLayer),
                     new CanvasOrdering(CanvasOrdering.SortingLayer.Popup, orderInLayer - 1),
@@ -68,6 +72,11 @@ namespace MVC
         public PopupPopInfo PopPopup(IController controller)
         {
             popupStack.Remove(controller);
+
+            foreach (var persistant in persistentStack)
+                if (persistant.State == ControllerState.ViewBlurred)
+                    persistant.Focus();
+            
             return new PopupPopInfo(
                 new CanvasOrdering(CanvasOrdering.SortingLayer.Popup, ((popupStack.Count - 1) * 2) - 1),
                 TopMostPopup);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR refactors how the chat input’s Enter/Submit handler is registered and unregistered, ensuring that the chat only processes “Submit” events when it actually has focus. Previously, opening any other popup or screen could leave the chat’s handler active, causing unintended message submissions when players pressed Enter. Now, we explicitly unsubscribe before subscribing, and only attach the handler when the chat regains focus, preventing double registrations or stale subscriptions.

NOTE to developers:
- In WindowStackManager,  Blur() and Focus() are called inside PushPopup and PopPopup so that the chat can properly subscribe or unsubscribe from the OnSubmit event.
- To avoid redundant calls, we added guards around SubscribeToSubmitEvent() and UnsubscribeToSubmitEvent() so that each subscription or unsubscription happens only when necessary.

### Test Steps
1. Play
2. Open profile
3. Go to about me section and click edit icon
4. Type something and click enter
5. Observe that cursor is on the next line (focus not moved to the chat in the background)

Repeat same steps for other screens that have input box and observe that focus didn't change to chat in the background

## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
