### PR TITLE
fix: camera overlap walls on certain angles

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
@@ -1294,12 +1294,12 @@ MonoBehaviour:
   m_AvoidObstacles: 1
   m_DistanceLimit: 0
   m_MinimumOcclusionTime: 0
-  m_CameraRadius: 0.2
-  m_Strategy: 0
-  m_MaximumEffort: 4
-  m_SmoothingTime: 0.3
-  m_Damping: 0.5
-  m_DampingWhenOccluded: 0.2
+  m_CameraRadius: 1
+  m_Strategy: 2
+  m_MaximumEffort: 10
+  m_SmoothingTime: 0
+  m_Damping: 0
+  m_DampingWhenOccluded: 0
   m_OptimalTargetDistance: 0.5
 --- !u!114 &5294527864094199746
 MonoBehaviour:


### PR DESCRIPTION
## What does this PR change?

Fixes #3666 

The camera collider has been increased. Also the correction strategy has been modified so it keeps the distance to the target. The correction damping values has been modified so its immediate.

## Test Instructions

An intensive test is required. Go to the main scenes of the world and check that you dont have camera issues, specially near the walls.
Go to -12,-10. Play with the camera near the wall. Check that the camera does not overlap with the wall.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
