### PR TITLE
Revert "fix: 3rd person camera collider re-configuration (#4356)"

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
@@ -1294,12 +1294,12 @@ MonoBehaviour:
   m_AvoidObstacles: 1
   m_DistanceLimit: 0
   m_MinimumOcclusionTime: 0
-  m_CameraRadius: 1
-  m_Strategy: 2
-  m_MaximumEffort: 10
-  m_SmoothingTime: 0
-  m_Damping: 0
-  m_DampingWhenOccluded: 0
+  m_CameraRadius: 0.2
+  m_Strategy: 0
+  m_MaximumEffort: 4
+  m_SmoothingTime: 0.3
+  m_Damping: 0.5
+  m_DampingWhenOccluded: 0.2
   m_OptimalTargetDistance: 0.5
 --- !u!114 &5294527864094199746
 MonoBehaviour:


### PR DESCRIPTION
This reverts commit cbd34c960fbda9a2e72b279439798a5c240d4f36.

## What does this PR change?

There has been reports of camera glitches around different areas of the world, specially on the onboarding scene and the falling tube at genesis plaza.

## Test Instructions

Test main scenes, camera should not move akwardly.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
