### PR TITLE
fix: camera overlap with walls

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Character Camera.prefab
@@ -332,13 +332,13 @@ MonoBehaviour:
     <Camera>k__BackingField: {fileID: 4115714836209283951}
   thirdPersonCameraData:
     <Camera>k__BackingField: {fileID: 1829658356799049534}
-    <CameraOffset>k__BackingField: {fileID: 5294527864094199746}
+    <CameraOffset>k__BackingField: {fileID: 7531990628935797749}
     <OffsetBottom>k__BackingField: {x: 0.3, y: 0.2, z: 0}
     <OffsetMid>k__BackingField: {x: 0.6, y: 0, z: 0}
     <OffsetTop>k__BackingField: {x: 0.3, y: 0.7, z: 0}
   droneViewCameraData:
     <Camera>k__BackingField: {fileID: 3873798736405262014}
-    <CameraOffset>k__BackingField: {fileID: 8869747115766645440}
+    <CameraOffset>k__BackingField: {fileID: 7236558867446750272}
     <OffsetBottom>k__BackingField: {x: 0, y: 0, z: 0}
     <OffsetMid>k__BackingField: {x: 0, y: 0, z: 0}
     <OffsetTop>k__BackingField: {x: 0, y: 2, z: 0}
@@ -1140,7 +1140,7 @@ GameObject:
   - component: {fileID: 1725871008748331031}
   - component: {fileID: 1829658356799049534}
   - component: {fileID: 769675175854280020}
-  - component: {fileID: 5294527864094199746}
+  - component: {fileID: 7531990628935797749}
   m_Layer: 0
   m_Name: ThirdPersonCameraSettings
   m_TagString: Untagged
@@ -1301,7 +1301,7 @@ MonoBehaviour:
   m_Damping: 0.5
   m_DampingWhenOccluded: 0.2
   m_OptimalTargetDistance: 0.5
---- !u!114 &5294527864094199746
+--- !u!114 &7531990628935797749
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1310,12 +1310,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 4708074778744885137}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 44d70cc20219cd84593f67d248eafe36, type: 3}
+  m_Script: {fileID: 11500000, guid: 8529cabda5b14c7a8bf220c90074d7cd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Offset: {x: 1, y: 0, z: 0}
-  m_ApplyAfter: 1
-  m_PreserveComposition: 0
+  offset: {x: 1, y: 0, z: 0}
+  applyAfter: 1
+  preserveComposition: 0
+  minimumDistanceFromObstacle: 0.5
+  collider: {fileID: 769675175854280020}
 --- !u!1 &5872671959436779839
 GameObject:
   m_ObjectHideFlags: 3
@@ -1533,7 +1535,7 @@ GameObject:
   - component: {fileID: 994044998479405614}
   - component: {fileID: 3873798736405262014}
   - component: {fileID: 9197928246288095689}
-  - component: {fileID: 8869747115766645440}
+  - component: {fileID: 7236558867446750272}
   m_Layer: 0
   m_Name: DroneViewCameraSettings
   m_TagString: Untagged
@@ -1694,7 +1696,7 @@ MonoBehaviour:
   m_Damping: 0.5
   m_DampingWhenOccluded: 0.2
   m_OptimalTargetDistance: 0.5
---- !u!114 &8869747115766645440
+--- !u!114 &7236558867446750272
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1703,12 +1705,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 6234749757729860735}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 44d70cc20219cd84593f67d248eafe36, type: 3}
+  m_Script: {fileID: 11500000, guid: 8529cabda5b14c7a8bf220c90074d7cd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Offset: {x: 0, y: 0, z: 0}
-  m_ApplyAfter: 1
-  m_PreserveComposition: 0
+  offset: {x: 0, y: 0, z: 0}
+  applyAfter: 1
+  preserveComposition: 0
+  minimumDistanceFromObstacle: 0.5
+  collider: {fileID: 9197928246288095689}
 --- !u!1 &6786270023864290576
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Character/CharacterCamera/DCLCinemachineCameraOffset.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/DCLCinemachineCameraOffset.cs
@@ -1,0 +1,65 @@
+using Cinemachine;
+using Cinemachine.Utility;
+using UnityEngine;
+
+namespace DCL.CharacterCamera
+{
+    [AddComponentMenu("")] // Hide in menu
+    [ExecuteAlways]
+    [SaveDuringPlay]
+    public class DCLCinemachineCameraOffset : CinemachineExtension
+    {
+        [Tooltip("Offset the camera's position by this much (camera space)")]
+        public Vector3 offset = Vector3.zero;
+
+        [Tooltip("When to apply the offset")]
+        public CinemachineCore.Stage applyAfter = CinemachineCore.Stage.Aim;
+
+        [Tooltip("If applying offset after aim, re-adjust the aim to preserve the screen position of the LookAt target as much as possible")]
+        public bool preserveComposition;
+
+        [Tooltip("Minimum distance to keep from obstacles")]
+        public float minimumDistanceFromObstacle = 0.1f;
+
+        public CinemachineCollider collider;
+
+        protected override void PostPipelineStageCallback(
+            CinemachineVirtualCameraBase vcam,
+            CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
+        {
+            if (stage == applyAfter)
+            {
+                bool preserveAim = preserveComposition
+                                   && state.HasLookAt && stage > CinemachineCore.Stage.Body;
+
+                Vector3 screenOffset = Vector2.zero;
+
+                if (preserveAim)
+                {
+                    screenOffset = state.RawOrientation.GetCameraRotationToTarget(
+                        state.ReferenceLookAt - state.CorrectedPosition, state.ReferenceUp);
+                }
+
+                Vector3 desiredPosition = state.RawOrientation * this.offset;
+                float distance = desiredPosition.magnitude;
+
+                if (Physics.Raycast(new Ray(state.CorrectedPosition, desiredPosition.normalized),
+                        out RaycastHit hit, distance, collider.m_CollideAgainst))
+                    desiredPosition = desiredPosition.normalized * (hit.distance - minimumDistanceFromObstacle);
+
+                state.PositionCorrection += desiredPosition;
+
+                if (!preserveAim)
+                    state.ReferenceLookAt += desiredPosition;
+                else
+                {
+                    var q = Quaternion.LookRotation(
+                        state.ReferenceLookAt - state.CorrectedPosition, state.ReferenceUp);
+
+                    q = q.ApplyCameraRotation(-screenOffset, state.ReferenceUp);
+                    state.RawOrientation = q;
+                }
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Character/CharacterCamera/DCLCinemachineCameraOffset.cs.meta
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/DCLCinemachineCameraOffset.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8529cabda5b14c7a8bf220c90074d7cd
+timeCreated: 1749492832

--- a/Explorer/Assets/DCL/Character/CharacterCamera/Settings/CinemachineThirdPersonCameraData.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Settings/CinemachineThirdPersonCameraData.cs
@@ -9,7 +9,7 @@ namespace DCL.CharacterCamera.Settings
     public class CinemachineThirdPersonCameraData : ICinemachineThirdPersonCameraData
     {
         [field: SerializeField] public CinemachineFreeLook Camera { get; private set; }
-        [field: SerializeField] public CinemachineCameraOffset CameraOffset { get; private set; }
+        [field: SerializeField] public DCLCinemachineCameraOffset CameraOffset { get; private set; }
 
         [field: SerializeField] public Vector3 OffsetBottom { get; private set; }
         [field: SerializeField] public Vector3 OffsetMid { get; private set; }

--- a/Explorer/Assets/DCL/Character/CharacterCamera/Settings/ICinemachineThirdPersonCameraData.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Settings/ICinemachineThirdPersonCameraData.cs
@@ -6,7 +6,7 @@ namespace DCL.CharacterCamera.Settings
     internal interface ICinemachineThirdPersonCameraData
     {
         CinemachineFreeLook Camera { get; }
-        CinemachineCameraOffset CameraOffset { get; }
+        DCLCinemachineCameraOffset CameraOffset { get; }
         Vector3 OffsetBottom { get; }
         Vector3 OffsetMid { get; }
         Vector3 OffsetTop { get; }

--- a/Explorer/Assets/DCL/Character/CharacterCamera/Systems/ControlCinemachineVirtualCameraSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Systems/ControlCinemachineVirtualCameraSystem.cs
@@ -141,7 +141,7 @@ namespace DCL.Character.CharacterCamera.Systems
                             ThirdPersonCameraShoulder.Center => 0,
                         };
 
-            cameraData.CameraOffset.m_Offset = Vector3.MoveTowards(cameraData.CameraOffset.m_Offset, offset, cinemachinePreset.ShoulderChangeSpeed * dt);
+            cameraData.CameraOffset.offset = Vector3.MoveTowards(cameraData.CameraOffset.offset, offset, cinemachinePreset.ShoulderChangeSpeed * dt);
         }
 
         [Query]

--- a/Explorer/Assets/DCL/Character/CharacterCamera/Tests/ApplyCinemachineCameraInputSystemShould.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Tests/ApplyCinemachineCameraInputSystemShould.cs
@@ -49,14 +49,14 @@ namespace DCL.CharacterCamera.Tests
             thirdPersonCamera.transform.SetParent(cinemachineObj.transform);
             thirdPersonCameraData = Substitute.For<ICinemachineThirdPersonCameraData>();
             thirdPersonCameraData.Camera.Returns(thirdPersonCamera);
-            thirdPersonCameraData.CameraOffset.Returns(thirdPersonCamera.gameObject.AddComponent<CinemachineCameraOffset>());
+            thirdPersonCameraData.CameraOffset.Returns(thirdPersonCamera.gameObject.AddComponent<DCLCinemachineCameraOffset>());
 
             // Setup Drone View Camera
             CinemachineFreeLook droneView = new GameObject("Third Person Camera Drone").AddComponent<CinemachineFreeLook>();
             droneView.transform.SetParent(cinemachineObj.transform);
             droneViewData = Substitute.For<ICinemachineThirdPersonCameraData>();
             droneViewData.Camera.Returns(droneView);
-            droneViewData.CameraOffset.Returns(droneView.gameObject.AddComponent<CinemachineCameraOffset>());
+            droneViewData.CameraOffset.Returns(droneView.gameObject.AddComponent<DCLCinemachineCameraOffset>());
 
             // Setup Free Camera
             CinemachineVirtualCamera freeCamera = new GameObject("Free Camera").AddComponent<CinemachineVirtualCamera>();

--- a/Explorer/Assets/DCL/Character/CharacterCamera/Tests/CinemachineVirtualCameraSystemShould.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Tests/CinemachineVirtualCameraSystemShould.cs
@@ -49,13 +49,13 @@ namespace DCL.CharacterCamera.Tests
             thirdPersonCamera.transform.SetParent(cinemachineObj.transform);
             thirdPersonCameraData = Substitute.For<ICinemachineThirdPersonCameraData>();
             thirdPersonCameraData.Camera.Returns(thirdPersonCamera);
-            thirdPersonCameraData.CameraOffset.Returns(thirdPersonCamera.gameObject.AddComponent<CinemachineCameraOffset>());
+            thirdPersonCameraData.CameraOffset.Returns(thirdPersonCamera.gameObject.AddComponent<DCLCinemachineCameraOffset>());
 
             CinemachineFreeLook droneView = new GameObject("Third Person Camera Drone").AddComponent<CinemachineFreeLook>();
             droneView.transform.SetParent(cinemachineObj.transform);
             droneViewData = Substitute.For<ICinemachineThirdPersonCameraData>();
             droneViewData.Camera.Returns(droneView);
-            droneViewData.CameraOffset.Returns(droneView.gameObject.AddComponent<CinemachineCameraOffset>());
+            droneViewData.CameraOffset.Returns(droneView.gameObject.AddComponent<DCLCinemachineCameraOffset>());
 
             CinemachineVirtualCamera freeCamera = new GameObject("Free Camera").AddComponent<CinemachineVirtualCamera>();
             freeCamera.transform.SetParent(cinemachineObj.transform);


### PR DESCRIPTION
## What does this PR change?

Fixes #3666 

Related to https://github.com/decentraland/unity-explorer/pull/4356 & https://github.com/decentraland/unity-explorer/pull/4351

Hopefully this is the final solution that prevents the camera to overlap with walls on certain angles, since the previous approach was having issues in different scenes.

A new camera offset has been implemented so it considers the camera collider configuration. A new raycast is needed to make the proper calculations.

## Test Instructions

Test the main scenes in world and check the camera behaves normally. Some of the scenes that had problems:
- onboarding
- genesis plaza while falling through the tube

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
