### PR TITLE
fix: prevent initializing the chat until loading is completed

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
@@ -183,46 +183,19 @@ namespace DCL.PluginSystem.Global
 
             // Log out / log in
             web3IdentityCache.OnIdentityCleared += OnIdentityCleared;
-            web3IdentityCache.OnIdentityChanged += OnIdentityChanged;
-
-            realmData.RealmType.OnUpdate += OnRealmChange;
-            realmNavigator.NavigationExecuted += OnNavigationExecuted;
+            loadingStatus.CurrentStage.OnUpdate += OnLoadingStatusUpdate;
         }
 
-        /// <summary>
-        /// TODO: This is a temporary solution to show the chat when the user navigates to a parcel.
-        /// NOTE: check this PR for more details:
-        /// https://github.com/decentraland/unity-explorer/issues/4324
-        /// </summary>
-        /// <param name="parcel"></param>
-        private void OnNavigationExecuted(Vector2Int parcel)
+        private void OnLoadingStatusUpdate(LoadingStatus.LoadingStage status)
         {
-            sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat, new ChatControllerShowParams(true,false)).Forget();
-        }
-
-        /// <summary>
-        /// TODO: This is a temporary solution to show the chat when the user changes realm.
-        /// NOTE: check this PR for more details:
-        /// https://github.com/decentraland/unity-explorer/issues/4324
-        /// </summary>
-        /// <param name="realmKind"></param>
-        private void OnRealmChange(RealmKind realmKind)
-        {
-            sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat, new ChatControllerShowParams(true,false)).Forget();
+            if (status == LoadingStatus.LoadingStage.Completed)
+                sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat, new ChatControllerShowParams(true, false)).Forget();
         }
 
         private void OnIdentityCleared()
         {
             if (chatController.IsVisibleInSharedSpace)
                 chatController.HideViewAsync(CancellationToken.None).Forget();
-        }
-
-        private void OnIdentityChanged()
-        {
-            //This might pose a problem if we havent logged in yet (so we change session before first login), it works, but we are trying to show the chat twice
-            //Once from here and once from the MainUIController. We need to account for this.
-
-            sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat, new ChatControllerShowParams(true, false)).Forget();
         }
     }
 


### PR DESCRIPTION
# Pull Request Description
## What does this PR change?

**Overview**

This pull request resolves a NullReferenceException in the chat subsystem when:
- The application is launched without an authenticated user
- A user logs out during an active session

**Changes**

- Use LoadingStatus.LoadingStage.Completed instead of realm change event to show chat

**Related**
- Sanity Check PR: https://github.com/decentraland/unity-explorer/pull/4317

### Test Steps

**Test I**
1. Start game
2. Play (if you are logged in)
3. Log out
4. Observe there is no errors ([Erros.txt](https://github.com/user-attachments/files/20691749/Erros.txt)) in the logs related to chat (inspect Player.log to verify chat remains error-free and compare with PRD logs)
---
**Test II**
1. Start game 
2. Log in (Observe there is no errors ([Erros.txt](https://github.com/user-attachments/files/20691749/Erros.txt)) in the logs related to chat during "Start" and "Log in" steps (inspect Player.log to verify chat remains error-free and compare with PRD logs.)

## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
