### PR TITLE
fix: sdk vcam panning pointer lock

### DIFF
--- a/Explorer/Assets/DCL/Input/Systems/UpdateCursorInputSystem.cs
+++ b/Explorer/Assets/DCL/Input/Systems/UpdateCursorInputSystem.cs
@@ -193,7 +193,7 @@ namespace DCL.Input.Systems
             if (!cursor.IsLocked() && cursorComponent is { CursorState: CursorState.Locked })
                 nextState = CursorState.Free;
 
-            if (!isMouseOutOfBounds && isTemporalLock && cursorComponent is { CursorState: CursorState.Free, PositionIsDirty: true, IsOverUI: false })
+            if (!isMouseOutOfBounds && isTemporalLock && cameraData.CameraMode != CameraMode.SDKCamera && cursorComponent is { CursorState: CursorState.Free, PositionIsDirty: true, IsOverUI: false })
                 nextState = CursorState.Panning;
 
             if (!isTemporalLock && cursorComponent is { CursorState: CursorState.Panning })


### PR DESCRIPTION
### WHY

Currently, while a scene uses the SDK Virtual Camera, the logic for locking the pointer cursor and have it in "panning mode" is still running, so the cursor cannot be freely used with the new `PrimaryPointerInfo` component.

Fixes: https://github.com/decentraland/unity-explorer/issues/4349

### WHAT

Added sdk camera mode check before allowing panning state of the pointer cursor.

### TEST INSTRUCTIONS

1. Download the build from this PR
2. Open it and go to the `pravus.dcl.eth` world
3. Once inside the scene, press the 'F' key and when the scene takes control of the camera and leaves you pointing to the wall, **confirm that you can release the pointer and drag it accross the wall to "draw" on it**
4. Press the 'E' key to release the SDK Virtual Camera and take control of the character camera, confirm that the normal camera panning works as expected.

**DEMO**

https://github.com/user-attachments/assets/b8163b7a-dd20-4a69-a206-ef7e43423ddb

