### PR TITLE
feat: integration of new career quest loading screen

### DIFF
--- a/Explorer/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-English (en).asset
+++ b/Explorer/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-English (en).asset
@@ -21,6 +21,12 @@ MonoBehaviour:
     m_SerializedLabels:
     - Locale-en
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: d5a5afcb41e894aef83f169d6b2bc67c
+    m_Address: Smaller_Career_Quest_White
+    m_ReadOnly: 1
+    m_SerializedLabels:
+    - Locale-en
+    FlaggedDuringContentUpdateRestriction: 0
   m_ReadOnly: 1
   m_Settings: {fileID: 11400000, guid: fc8a9d2b539788c47a5b305639fa8b34, type: 2}
   m_SchemaSet:

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Textures/Smaller_Career_Quest_White.png
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Textures/Smaller_Career_Quest_White.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e22655a947720d403c7c81e713992751211a2eba6ac987272769fcaa802d74b
+size 222426

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Textures/Smaller_Career_Quest_White.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Textures/Smaller_Career_Quest_White.png.meta
@@ -1,0 +1,117 @@
+fileFormatVersion: 2
+guid: d5a5afcb41e894aef83f169d6b2bc67c
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 0
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages Shared Data.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages Shared Data.asset
@@ -47,6 +47,10 @@ MonoBehaviour:
     m_Key: IMAGE-7
     m_Metadata:
       m_Items: []
+  - m_Id: 185833164146466816
+    m_Key: IMAGE-8
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items:
     - rid: 4107643858754469895
@@ -101,6 +105,9 @@ MonoBehaviour:
           m_TableCodes:
           - en
         - m_KeyId: 175390780715859968
+          m_TableCodes:
+          - en
+        - m_KeyId: 185833164146466816
           m_TableCodes:
           - en
         m_TypeString: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages_en.asset
@@ -50,6 +50,10 @@ MonoBehaviour:
     m_Localized: 88fa6c198b6da4e3680d88682eaad9d0
     m_Metadata:
       m_Items: []
+  - m_Id: 185833164146466816
+    m_Localized: d5a5afcb41e894aef83f169d6b2bc67c
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips Shared Data.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips Shared Data.asset
@@ -79,6 +79,14 @@ MonoBehaviour:
     m_Key: BODY-7
     m_Metadata:
       m_Items: []
+  - m_Id: 186916418471583744
+    m_Key: TITLE-8
+    m_Metadata:
+      m_Items: []
+  - m_Id: 186916549694578688
+    m_Key: BODY-8
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
@@ -101,6 +101,16 @@ MonoBehaviour:
       high-speed races to logic puzzles."
     m_Metadata:
       m_Items: []
+  - m_Id: 186916549694578688
+    m_Localized: "Decentraland Career Quest is your springboard into Web3 careers\u2014a
+      two-day event (July 16\u201317) designed to help you explore job paths, grow
+      your confidence, and meet the people shaping what\u2019s next in Web3."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 186916418471583744
+    m_Localized: Build Your Future
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
## What does this PR change?

Integrates the new loading screen for the Career Quest as designed here: https://www.figma.com/design/V9el6eF6PpxGrEAbO8Xgy4/Marketing-Brand-Images-DCL-2.0?node-id=2613-11&p=f

## Test Instructions

Start the app. Check that the loading screen images includes the new one, with title: Build your Future.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
