### PR TITLE
Feat: sdk scene video and streams fade in/out

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/MediaPlayerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MediaPlayerPlugin.cs
@@ -80,6 +80,7 @@ namespace DCL.PluginSystem.World
                 mediaPlayerPrefab,
                 worldVolumeMacBus,
                 exposedCameraData,
+                settings.FadeSpeed,
                 videoPrioritizationSettings,
                 roomHub
             );
@@ -90,6 +91,8 @@ namespace DCL.PluginSystem.World
         {
             [field: SerializeField]
             public AssetReferenceGameObject MediaPlayerPrefab;
+
+            [field: SerializeField] public float FadeSpeed { get; private set; } = 1f;
 
             public StaticSettings.VideoPrioritizationSettingsRef VideoPrioritizationSettings;
         }

--- a/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
+++ b/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
@@ -215,6 +215,7 @@ MonoBehaviour:
           m_SubObjectType: 
           m_SubObjectGUID: 
           m_EditorAssetChanged: 0
+        <FadeSpeed>k__BackingField: 1
         VideoPrioritizationSettings:
           m_AssetGUID: 12f48d0297bd3f746b92a97878478086
           m_SubObjectName: 

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
@@ -107,15 +107,15 @@ namespace DCL.SDKComponents.AudioSources
 
         private void FadeVolumeOnSceneChange(PBAudioSource sdkComponent, AudioSource audio, float dt)
         {
+            float sdkVolume = sdkComponent.GetVolume();
+
             switch (sceneStateProvider.IsCurrent)
             {
-                case true when audio.volume < sdkComponent.GetVolume():
-                    audio.volume += dt * settings.FadeSpeed * sdkComponent.GetVolume();
-                    audio.volume = Mathf.Min(audio.volume, sdkComponent.GetVolume());
+                case true when audio.volume < sdkVolume:
+                    audio.volume = Mathf.Min(sdkVolume, audio.volume + (dt * settings.FadeSpeed * sdkVolume));
                     return;
                 case false when audio.volume > 0:
-                    audio.volume -= dt * settings.FadeSpeed * sdkComponent.GetVolume();
-                    audio.volume = Mathf.Max(audio.volume, 0);
+                    audio.volume = Mathf.Max(0, audio.volume - (dt * settings.FadeSpeed * sdkVolume));
                     break;
             }
         }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
@@ -33,6 +33,7 @@ namespace DCL.SDKComponents.MediaStream
         private bool disposed;
 
         public bool MediaOpened => currentStream != null;
+        public float Volume { get; private set; }
 
         public PlayerState State => playerState;
 
@@ -167,7 +168,21 @@ namespace DCL.SDKComponents.MediaStream
 
         public void SetVolume(float target)
         {
+            Volume = target;
             audioSource.SetVolume(target);
+        }
+
+        public void SetVolumeFaded(bool isCurrentScene, float targetVolume, float volumeDelta)
+        {
+            switch (isCurrentScene)
+            {
+                case true when Volume < targetVolume:
+                    SetVolume(Mathf.Min(targetVolume, Volume + volumeDelta));
+                    break;
+                case false when Volume > 0:
+                    SetVolume(Mathf.Max(0, targetVolume - volumeDelta));
+                    break;
+            }
         }
 
         public void PlaceAudioAt(Vector3 position)

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerExtensions.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerExtensions.cs
@@ -17,28 +17,15 @@ namespace DCL.SDKComponents.MediaStream
                 mediaPlayer.Events.RemoveAllListeners();
         }
 
-        public static void UpdateVolume(this MediaPlayer mediaPlayer, float delta, bool isCurrentScene, bool hasVolume, float volume)
+        public static void UpdateVolume(this MediaPlayer mediaPlayer, bool isCurrentScene, float targetVolume, float volumeDelta)
         {
-            float targetVolume = hasVolume ? volume
-                :
-                //This following part is a workaround applied for the MacOS platform, the reason
-                //is related to the video and audio streams, the MacOS environment does not support
-                //the volume control for the video and audio streams, as it doesn’t allow to route audio
-                //from HLS through to Unity. This is a limitation of Apple’s AVFoundation framework
-                //Similar issue reported here https://github.com/RenderHeads/UnityPlugin-AVProVideo/issues/1086
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-                   MediaPlayerComponent.DEFAULT_VOLUME * volume;
-#else
-                MediaPlayerComponent.DEFAULT_VOLUME;
-#endif
-
             switch (isCurrentScene)
             {
                 case true when mediaPlayer.AudioVolume < targetVolume:
-                    mediaPlayer.AudioVolume = Mathf.Min(targetVolume, mediaPlayer.AudioVolume + (delta * targetVolume));
+                    mediaPlayer.AudioVolume = Mathf.Min(targetVolume, mediaPlayer.AudioVolume + volumeDelta);
                     break;
                 case false when mediaPlayer.AudioVolume > 0:
-                    mediaPlayer.AudioVolume = Mathf.Max(0, mediaPlayer.AudioVolume - (delta * targetVolume));
+                    mediaPlayer.AudioVolume = Mathf.Max(0, mediaPlayer.AudioVolume - volumeDelta);
                     break;
             }
         }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MultiMediaPlayer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MultiMediaPlayer.cs
@@ -111,11 +111,11 @@ namespace DCL.SDKComponents.MediaStream
             );
         }
 
-        public void UpdateVolume(bool isCurrentScene, bool hasVolume, float volume)
+        public void UpdateVolume(float delta, bool isCurrentScene, bool hasVolume, float volume)
         {
             Match(
-                (isCurrentScene, hasVolume, volume),
-                static (ctx, avPro) => avPro.AvProMediaPlayer.UpdateVolume(ctx.isCurrentScene, ctx.hasVolume, ctx.volume),
+                (delta, isCurrentScene, hasVolume, volume),
+                static (ctx, avPro) => avPro.AvProMediaPlayer.UpdateVolume(ctx.delta, ctx.isCurrentScene, ctx.hasVolume, ctx.volume),
                 static (ctx, livekitPlayer) =>
                 {
                     float target = ctx.hasVolume ? ctx.volume : MediaPlayerComponent.DEFAULT_VOLUME;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs
@@ -9,17 +9,16 @@ using DCL.ECSComponents;
 using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Multiplayer.Connections.Rooms;
 using DCL.Optimization.PerformanceBudgeting;
-using DCL.Optimization.Pools;
 using DCL.Utilities;
 using DCL.Utilities.Extensions;
 using DCL.WebRequests;
 using ECS.Abstract;
 using ECS.Unity.Groups;
 using ECS.Unity.Textures.Components;
-using ECS.Unity.Transforms.Components;
+#if UNITY_EDITOR
 using RenderHeads.Media.AVProVideo;
+#endif
 using SceneRunner.Scene;
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using UnityEngine;
@@ -83,7 +82,7 @@ namespace DCL.SDKComponents.MediaStream
         {
             if (!frameTimeBudget.TrySpendBudget()) return;
 
-            MediaPlayerComponent component = CreateMediaPlayerComponent(dt, entity, url, hasVolume, volume);
+            MediaPlayerComponent component = CreateMediaPlayerComponent(entity, url, hasVolume, volume);
 
             if (component.State != VideoState.VsError)
                 component.OpenMediaPromise.UrlReachabilityResolveAsync(webRequestController, component.MediaAddress, GetReportData(), component.Cts.Token).SuppressCancellationThrow().Forget();
@@ -98,7 +97,7 @@ namespace DCL.SDKComponents.MediaStream
         }
 
         [SuppressMessage("ReSharper", "RedundantAssignment")]
-        private MediaPlayerComponent CreateMediaPlayerComponent(float dt, Entity entity, string url, bool hasVolume, float volume)
+        private MediaPlayerComponent CreateMediaPlayerComponent(Entity entity, string url, bool hasVolume, float volume)
         {
             var isValidLocalPath = false;
             var isValidStreamUrl = false;
@@ -152,7 +151,7 @@ namespace DCL.SDKComponents.MediaStream
 #endif
 
             // speed
-            component.MediaPlayer.UpdateVolume(dt, sceneStateProvider.IsCurrent, hasVolume, volume);
+            component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, hasVolume, volume);
 
             return component;
         }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs
@@ -150,7 +150,6 @@ namespace DCL.SDKComponents.MediaStream
                 avPro!.gameObject.name = $"MediaPlayer_Entity_{entity}";
 #endif
 
-            // speed
             component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, hasVolume, volume);
 
             return component;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -103,7 +103,7 @@ namespace DCL.SDKComponents.MediaStream
             if (component.State != VideoState.VsError)
             {
                 float actualVolume = (sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME) * worldVolumePercentage * masterVolumePercentage;
-                component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume, dt * audioFadeSpeed);
+                component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume, dt * audioFadeSpeed * actualVolume);
             }
 
             var address = MediaAddress.New(sdkComponent.Url!);
@@ -121,7 +121,7 @@ namespace DCL.SDKComponents.MediaStream
             if (component.State != VideoState.VsError)
             {
                 float actualVolume = (sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME) * worldVolumePercentage * masterVolumePercentage;
-                component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume, dt * audioFadeSpeed);
+                component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume, dt * audioFadeSpeed * actualVolume);
             }
 
             var address = MediaAddress.New(sdkComponent.Src!);

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -31,8 +31,11 @@ namespace DCL.SDKComponents.MediaStream
         private readonly ISceneData sceneData;
         private readonly ISceneStateProvider sceneStateProvider;
         private readonly IPerformanceBudget frameTimeBudget;
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         private readonly WorldVolumeMacBus worldVolumeMacBus;
-        private readonly MediaPlayerCustomPool mediaPlayerPool;
+#endif
+
+        private readonly float audioFadeSpeed;
 
         private float worldVolumePercentage = 1f;
         private float masterVolumePercentage = 1f;
@@ -44,15 +47,14 @@ namespace DCL.SDKComponents.MediaStream
             ISceneStateProvider sceneStateProvider,
             IPerformanceBudget frameTimeBudget,
             WorldVolumeMacBus worldVolumeMacBus,
-            MediaPlayerCustomPool mediaPlayerPool
+            float audioFadeSpeed
         ) : base(world)
         {
             this.webRequestController = webRequestController;
             this.sceneData = sceneData;
             this.sceneStateProvider = sceneStateProvider;
             this.frameTimeBudget = frameTimeBudget;
-            this.worldVolumeMacBus = worldVolumeMacBus;
-            this.mediaPlayerPool = mediaPlayerPool;
+            this.audioFadeSpeed = audioFadeSpeed;
 
             //This following part is a workaround applied for the MacOS platform, the reason
             //is related to the video and audio streams, the MacOS environment does not support
@@ -60,6 +62,7 @@ namespace DCL.SDKComponents.MediaStream
             //from HLS through to Unity. This is a limitation of Apple’s AVFoundation framework
             //Similar issue reported here https://github.com/RenderHeads/UnityPlugin-AVProVideo/issues/1086
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+            this.worldVolumeMacBus = worldVolumeMacBus;
             this.worldVolumeMacBus.OnWorldVolumeChanged += OnWorldVolumeChanged;
             this.worldVolumeMacBus.OnMasterVolumeChanged += OnMasterVolumeChanged;
             masterVolumePercentage = worldVolumeMacBus.GetMasterVolume();
@@ -100,7 +103,7 @@ namespace DCL.SDKComponents.MediaStream
             if (component.State != VideoState.VsError)
             {
                 float actualVolume = (sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME) * worldVolumePercentage * masterVolumePercentage;
-                component.MediaPlayer.UpdateVolume(dt, sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
+                component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume, dt * audioFadeSpeed);
             }
 
             var address = MediaAddress.New(sdkComponent.Url!);
@@ -118,7 +121,7 @@ namespace DCL.SDKComponents.MediaStream
             if (component.State != VideoState.VsError)
             {
                 float actualVolume = (sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME) * worldVolumePercentage * masterVolumePercentage;
-                component.MediaPlayer.UpdateVolume(dt, sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
+                component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume, dt * audioFadeSpeed);
             }
 
             var address = MediaAddress.New(sdkComponent.Src!);

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -80,8 +80,8 @@ namespace DCL.SDKComponents.MediaStream
         protected override void Update(float t)
         {
             UpdateMediaPlayerPositionQuery(World);
-            UpdateAudioStreamQuery(World);
-            UpdateVideoStreamQuery(World);
+            UpdateAudioStreamQuery(World, t);
+            UpdateVideoStreamQuery(World, t);
 
             UpdateVideoTextureQuery(World);
         }
@@ -93,14 +93,14 @@ namespace DCL.SDKComponents.MediaStream
         }
 
         [Query]
-        private void UpdateAudioStream(in Entity entity, ref MediaPlayerComponent component, PBAudioStream sdkComponent)
+        private void UpdateAudioStream(in Entity entity, ref MediaPlayerComponent component, PBAudioStream sdkComponent, [Data] float dt)
         {
             if (!frameTimeBudget.TrySpendBudget()) return;
 
             if (component.State != VideoState.VsError)
             {
                 float actualVolume = (sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME) * worldVolumePercentage * masterVolumePercentage;
-                component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
+                component.MediaPlayer.UpdateVolume(dt, sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
             }
 
             var address = MediaAddress.New(sdkComponent.Url!);
@@ -111,14 +111,14 @@ namespace DCL.SDKComponents.MediaStream
         }
 
         [Query]
-        private void UpdateVideoStream(in Entity entity, ref MediaPlayerComponent component, PBVideoPlayer sdkComponent)
+        private void UpdateVideoStream(in Entity entity, ref MediaPlayerComponent component, PBVideoPlayer sdkComponent, [Data] float dt)
         {
             if (!frameTimeBudget.TrySpendBudget()) return;
 
             if (component.State != VideoState.VsError)
             {
                 float actualVolume = (sdkComponent.HasVolume ? sdkComponent.Volume : MediaPlayerComponent.DEFAULT_VOLUME) * worldVolumePercentage * masterVolumePercentage;
-                component.MediaPlayer.UpdateVolume(sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
+                component.MediaPlayer.UpdateVolume(dt, sceneStateProvider.IsCurrent, sdkComponent.HasVolume, actualVolume);
             }
 
             var address = MediaAddress.New(sdkComponent.Src!);

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/MediaPlayerPluginWrapper.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/MediaPlayerPluginWrapper.cs
@@ -25,22 +25,24 @@ namespace DCL.SDKComponents.MediaStream.Wrapper
         private readonly IPerformanceBudget frameTimeBudget;
         private readonly WorldVolumeMacBus worldVolumeMacBus;
         private readonly IExposedCameraData exposedCameraData;
+        private readonly float audioFadeSpeed;
         private readonly VideoPrioritizationSettings videoPrioritizationSettings;
         private readonly ObjectProxy<IRoomHub> roomHub;
         private readonly MediaPlayerCustomPool mediaPlayerCustomPool;
 
-        public MediaPlayerPluginWrapper(
-            IWebRequestController webRequestController,
+        public MediaPlayerPluginWrapper(IWebRequestController webRequestController,
             CacheCleaner cacheCleaner,
             IExtendedObjectPool<Texture2D> videoTexturePool,
             IPerformanceBudget frameTimeBudget,
             MediaPlayer mediaPlayerPrefab,
             WorldVolumeMacBus worldVolumeMacBus,
             IExposedCameraData exposedCameraData,
+            float audioFadeSpeed,
             VideoPrioritizationSettings videoPrioritizationSettings,
             ObjectProxy<IRoomHub> roomHub)
         {
             this.exposedCameraData = exposedCameraData;
+            this.audioFadeSpeed = audioFadeSpeed;
             this.videoPrioritizationSettings = videoPrioritizationSettings;
             this.roomHub = roomHub;
 
@@ -58,9 +60,8 @@ namespace DCL.SDKComponents.MediaStream.Wrapper
         public void InjectToWorld(ref ArchSystemsWorldBuilder<World> builder, ISceneData sceneData, ISceneStateProvider sceneStateProvider, IECSToCRDTWriter ecsToCrdtWriter, List<IFinalizeWorldSystem> finalizeWorldSystems, FeatureFlagsCache featureFlagsCache)
         {
 #if AV_PRO_PRESENT && !UNITY_EDITOR_LINUX && !UNITY_STANDALONE_LINUX
-
             CreateMediaPlayerSystem.InjectToWorld(ref builder, webRequestController, roomHub, sceneData, mediaPlayerCustomPool, sceneStateProvider, frameTimeBudget);
-            UpdateMediaPlayerSystem.InjectToWorld(ref builder, webRequestController, sceneData, sceneStateProvider, frameTimeBudget, worldVolumeMacBus, mediaPlayerCustomPool);
+            UpdateMediaPlayerSystem.InjectToWorld(ref builder, webRequestController, sceneData, sceneStateProvider, frameTimeBudget, worldVolumeMacBus, audioFadeSpeed);
 
             if(featureFlagsCache.Configuration.IsEnabled(FeatureFlagsStrings.VIDEO_PRIORITIZATION))
                 UpdateMediaPlayerPrioritizationSystem.InjectToWorld(ref builder, exposedCameraData, videoPrioritizationSettings);


### PR DESCRIPTION
# Pull Request Description
This PR implements audio fade in/out for audio from LiveKit streams and MediaPlayer video/audio.

- extended logic to fade instead to set volume directly to the final value

## Test Instructions
Test on scenes with Video streams (like Game Night or `/goto 1,93`).
If possible, try to test it with the Live Streaming.

### Test Steps 1
GIVEN player is on the SDK scene with Video stream or Live Stream
WHEN player step out of the scene by foot
THEN audio should slowly fade out (and not just be off/mute in one hit)

### Test Steps 2
GIVEN player is near to the SDK scene with Video stream or Live Stream
WHEN player step in to the scene by foot
THEN audio should slowly fade in (and not just be on on full volume)

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
