### PR TITLE
fix: 937,937 character coords on teleport

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/TeleportCharacterSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/TeleportCharacterSystem.cs
@@ -41,7 +41,6 @@ namespace DCL.CharacterMotion.Systems
         private void TeleportPlayer(Entity entity, in PlayerTeleportIntent teleportIntent, CharacterController controller,
             CharacterPlatformComponent platformComponent, CharacterRigidTransform rigidTransform)
         {
-
             AsyncLoadProcessReport? loadReport = teleportIntent.AssetsResolution;
 
             if (loadReport == null)
@@ -54,10 +53,12 @@ namespace DCL.CharacterMotion.Systems
                 switch (status.TaskStatus)
                 {
                     case UniTaskStatus.Pending:
-                        // Teleport the character to a far away place while the teleport is executed
-                        controller.transform.position = MordorConstants.PLAYER_MORDOR_POSITION;
+                        controller.transform.position = teleportIntent.Position;
+                        // Disable collisions so the scene does not interact with the character, and we avoid possible issues at startup
+                        controller.detectCollisions = false;
                         return;
                     case UniTaskStatus.Succeeded:
+                        controller.detectCollisions = true;
                         ResolveAsSuccess(entity, in teleportIntent, controller, platformComponent, rigidTransform);
                         return;
                     case UniTaskStatus.Canceled:

--- a/Explorer/Assets/DCL/Utilities/MordorConstants.cs
+++ b/Explorer/Assets/DCL/Utilities/MordorConstants.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 
 public static class MordorConstants
 {
-    public static readonly Vector3 PLAYER_MORDOR_POSITION = new(15000, 0, 15000);
     public static readonly Vector3 SCENE_MORDOR_POSITION = new(0, -10000, 0);
     public static readonly Vector3 AVATAR_ATTACH_MORDOR_POSITION = new(8000,0,0);
 }


### PR DESCRIPTION
## What does this PR change?

Fixes #3289

The solution consists on prevent changing the coords to Mordor but instead move the character immediately to the desired coords and disable collisions while the scene is loading so we prevent undesired scene interactions.

## Test Instructions

Teleport to the main scenes of decentraland. Wait for the loading to finish. Check that the scene starts up normally. Additionally test worlds too, ie: metadyne and check it starts normally.

You can check on https://greeter.decentraland.systems/
Look for your address. Observe that the coordinates are always representing your current location, and not 937,937.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
