### PR TITLE
fix: scene emote props sometimes not disposing

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
@@ -13,7 +13,7 @@ namespace DCL.AvatarRendering.Emotes
         public void Reset()
         {
             EmoteLoop = false;
-            // CurrentEmoteReference = null;
+            CurrentEmoteReference = null;
             StopEmote = false;
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
@@ -13,7 +13,7 @@ namespace DCL.AvatarRendering.Emotes
         public void Reset()
         {
             EmoteLoop = false;
-            CurrentEmoteReference = null;
+            // CurrentEmoteReference = null;
             StopEmote = false;
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -150,11 +150,14 @@ namespace DCL.AvatarRendering.Emotes.Play
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void StopEmote(ref CharacterEmoteComponent emoteComponent, IAvatarView avatarView)
         {
-            if (emoteComponent.CurrentEmoteReference != null)
-            {
-                emotePlayer.Stop(emoteComponent.CurrentEmoteReference);
-                avatarView.SetAnimatorTrigger(AnimationHashes.EMOTE_STOP);
-            }
+            if (emoteComponent.CurrentEmoteReference == null) return;
+
+            emotePlayer.Stop(emoteComponent.CurrentEmoteReference);
+
+            // Create a clean slate for the animator before setting the stop trigger
+            avatarView.ResetTrigger(AnimationHashes.EMOTE);
+            avatarView.ResetTrigger(AnimationHashes.EMOTE_RESET);
+            avatarView.SetAnimatorTrigger(AnimationHashes.EMOTE_STOP);
 
             emoteComponent.Reset();
         }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
@@ -223,6 +223,11 @@ namespace DCL.AvatarRendering.Emotes.Play
                 emoteComponent.EmoteLoop = isLooping;
             }
 
+            // Create a clean slate for the animator before setting the play trigger
+            view.ResetTrigger(AnimationHashes.EMOTE_STOP);
+            view.ResetTrigger(AnimationHashes.EMOTE);
+            view.ResetTrigger(AnimationHashes.EMOTE_RESET);
+
             view.SetAnimatorTrigger(view.IsAnimatorInTag(AnimationHashes.EMOTE) || view.IsAnimatorInTag(AnimationHashes.EMOTE_LOOP) ? AnimationHashes.EMOTE_RESET : AnimationHashes.EMOTE);
             view.SetAnimatorBool(AnimationHashes.EMOTE_LOOP, emoteComponent.EmoteLoop);
 

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/RestrictedActions/GlobalWorldActions.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/RestrictedActions/GlobalWorldActions.cs
@@ -73,7 +73,8 @@ namespace CrdtEcsBridge.RestrictedActions
         {
             if (world.TryGet(playerEntity, out AvatarShapeComponent avatarShape) && !avatarShape.IsVisible) return;
 
-            world.Add(playerEntity, new CharacterEmoteIntent { EmoteId = urn, Spatial = true, TriggerSource = TriggerSource.SCENE });
+            // If it's just Add() there are inconsistencies when the intent is processed at CharacterEmoteSystem for rapidly triggered emotes...
+            world.AddOrSet(playerEntity, new CharacterEmoteIntent { EmoteId = urn, Spatial = true, TriggerSource = TriggerSource.SCENE });
             messageBus.Send(urn, isLooping);
         }
 


### PR DESCRIPTION
### WHY

Currently, sometimes when a scene emote that has props is played, the props may linger without being correctly disposed as displayed in https://github.com/decentraland/unity-explorer/issues/4405.

The bug is easily triggered by quickly triggering a scene emote with props while moving the avatar:

https://github.com/user-attachments/assets/ed49d76c-b35a-485c-a162-ee1e2e0a4253

Fixes Issue: https://github.com/decentraland/unity-explorer/issues/4405

### WHAT

* Corrected how `CharacterEmoteIntent` is updated in the entity when playing scene emotes
* Added a needed animator triggers cleanup when triggering play/stop of emotes to avoid observed conflicts of having both "EMOTE_STOP" and "EMOTE_RESET" triggers at the same time in the Animator...

### TEST INSTRUCTIONS

1. Download the build from this PR
2. Enter the world `nullrefxeption.dcl.eth`
3. Stand next to the clickable cube and click it, confirm that the scene emote is played and it loops
4. Then try to trigger the bug that makes the scene emote prop linger: constantly click on the cube while moving around it and confirm that the prop doesn't get stuck with the player when you get away from the cube as shown in the "Why" demo
5. Do a smoke test of general usage of Emotes with this PR build

