### PR TITLE
fix: recover character collisions on load failure

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/TeleportCharacterSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/TeleportCharacterSystem.cs
@@ -55,6 +55,8 @@ namespace DCL.CharacterMotion.Systems
                     case UniTaskStatus.Pending:
                         controller.transform.position = teleportIntent.Position;
                         // Disable collisions so the scene does not interact with the character, and we avoid possible issues at startup
+                        // For example: teleport to Genesis Plaza. The dialog with the barman should not show at the spawn point
+                        // See https://github.com/decentraland/unity-explorer/issues/3289 for more info
                         controller.detectCollisions = false;
                         return;
                     case UniTaskStatus.Succeeded:
@@ -62,9 +64,11 @@ namespace DCL.CharacterMotion.Systems
                         ResolveAsSuccess(entity, in teleportIntent, controller, platformComponent, rigidTransform);
                         return;
                     case UniTaskStatus.Canceled:
+                        controller.detectCollisions = true;
                         ResolveAsCancelled(entity, in teleportIntent);
                         return;
                     case UniTaskStatus.Faulted:
+                        controller.detectCollisions = true;
                         ResolveAsFailure(entity, in teleportIntent, status.Exception!);
                         return;
                 }


### PR DESCRIPTION
## What does this PR change?

This is related to https://github.com/decentraland/unity-explorer/pull/4419
In case of load failure/cancelled we also restore the character collisions so we go back to the original state.

## Test Instructions

Teleport to different scenes. The character should collide normally within the scene.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
