### PR TITLE
fix: profile update fails on identity change

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
@@ -114,6 +114,14 @@ namespace DCL.AvatarRendering.Emotes
             }
         }
 
+        public void ClearOwnedNftRegistry()
+        {
+            lock (lockObject)
+            {
+                ownedNftsRegistry.Clear();
+            }
+        }
+
         private IEmote AddEmote(URN urn, IEmote wearable, bool qualifiedForUnloading)
         {
             emotes.Add(urn, wearable);

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/FinalizeEmoteLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/FinalizeEmoteLoadingSystemShould.cs
@@ -555,7 +555,6 @@ namespace DCL.AvatarRendering.Emotes.Tests
         public class MockStreamableDataWithURN : IStreamableRefCountData
         {
             public URN Urn { get; }
-            public int ReferenceCount => 0;
 
             public MockStreamableDataWithURN(URN urn)
             {
@@ -563,8 +562,6 @@ namespace DCL.AvatarRendering.Emotes.Tests
             }
 
             public void Dispose() { }
-
-            public void Reference() { }
 
             public void Dereference() { }
         }
@@ -576,9 +573,6 @@ namespace DCL.AvatarRendering.Emotes.Tests
             public readonly List<URN> TryGetElementCalls = new ();
             public Action<MockEmote, bool> OnUpdateLoadingStatusCalled;
             public List<URN> EmbededURNs => throw new NotImplementedException();
-
-            public IEmote GetOrAddByDTO(EmoteDTO dto) =>
-                GetOrAddByDTO(dto, false);
 
             public IEmote GetOrAddByDTO(EmoteDTO dto, bool isDefault)
             {
@@ -602,21 +596,6 @@ namespace DCL.AvatarRendering.Emotes.Tests
             public void Set(URN urn, IEmote emote) =>
                 Emotes[urn] = emote;
 
-            public IEmote GetOrAdd(URN urn) =>
-                Emotes.TryGetValue(urn, out IEmote? e) ? e : Emotes[urn] = new MockEmote(urn, this);
-
-            public void Add(URN urn, IEmote emote) =>
-                Emotes[urn] = emote;
-
-            public bool TryGetMainAsset(URN urn, BodyShape bodyShape, out StreamableLoadingResult<AttachmentRegularAsset> asset) =>
-                throw new NotImplementedException();
-
-            public bool TryGetAudioClip(URN urn, BodyShape bodyShape, out StreamableLoadingResult<AudioClipData> audioClip) =>
-                throw new NotImplementedException();
-
-            public bool IsLoading(URN urn) =>
-                throw new NotImplementedException();
-
             public void AddEmbeded(URN urn, IEmote emote) =>
                 throw new NotImplementedException();
 
@@ -628,6 +607,11 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
             public bool TryGetOwnedNftRegistry(URN urn, out IReadOnlyDictionary<URN, NftBlockchainOperationEntry> registry) =>
                 throw new NotImplementedException();
+
+            public void ClearOwnedNftRegistry()
+            {
+                throw new NotImplementedException();
+            }
         }
 
         public class MockEmote : IEmote
@@ -673,9 +657,6 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 LastAppliedDTO = dto;
                 ApplyAndMarkAsLoadedCallCount++;
             }
-
-            public bool IsUnisex() =>
-                MockIsUnisexValue;
 
             public bool HasSameClipForAllGenders() =>
                 MockHasSameClipForAllGendersValue;

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/IAvatarElementStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/IAvatarElementStorage.cs
@@ -40,6 +40,8 @@ namespace DCL.AvatarRendering.Loading
         void SetOwnedNft(URN urn, NftBlockchainOperationEntry operation);
 
         bool TryGetOwnedNftRegistry(URN nftUrn, out IReadOnlyDictionary<URN, NftBlockchainOperationEntry> registry);
+
+        void ClearOwnedNftRegistry();
     }
 
     public static class AvatarElementCache

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableStorage.cs
@@ -115,6 +115,14 @@ namespace DCL.AvatarRendering.Wearables.Helpers
             }
         }
 
+        public void ClearOwnedNftRegistry()
+        {
+            lock (lockObject)
+            {
+                ownedNftsRegistry.Clear();
+            }
+        }
+
         internal IWearable AddWearable(URN urn, IWearable wearable, bool qualifiedForUnloading)
         {
             lock (lockObject)

--- a/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackEquipStatusController.cs
@@ -71,6 +71,11 @@ namespace DCL.Backpack
             backpackEventBus.ChangeColorEvent += ChangeColor;
             backpackEventBus.ForceRenderEvent += SetForceRender;
             backpackEventBus.UnEquipAllEvent += UnEquipAll;
+            // Avoid publishing an invalid profile
+            // For example: logout while the update operation is being processed
+            // See: https://github.com/decentraland/unity-explorer/issues/4413
+            web3IdentityCache.OnIdentityCleared += CancelUpdateOperation;
+            web3IdentityCache.OnIdentityChanged += CancelUpdateOperation;
 
             this.world = world;
             this.playerEntity = playerEntity;
@@ -88,6 +93,8 @@ namespace DCL.Backpack
             backpackEventBus.ChangeColorEvent -= ChangeColor;
             backpackEventBus.ForceRenderEvent -= SetForceRender;
             backpackEventBus.UnEquipAllEvent -= UnEquipAll;
+            web3IdentityCache.OnIdentityCleared -= CancelUpdateOperation;
+            web3IdentityCache.OnIdentityChanged -= CancelUpdateOperation;
             publishProfileCts?.SafeCancelAndDispose();
         }
 
@@ -220,5 +227,8 @@ namespace DCL.Backpack
 
             inWorldWarningNotificationView.Hide(ct: ct);
         }
+
+        private void CancelUpdateOperation() =>
+            publishProfileCts?.SafeCancelAndDispose();
     }
 }

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Playground/ScreenRecorderTester.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Playground/ScreenRecorderTester.cs
@@ -53,7 +53,6 @@ namespace DCL.InWorldCamera.Playground
             hud.Screenshot = Texture;
         }
 
-
         [ContextMenu(nameof(CaptureMetadata))]
         public async UniTask CaptureMetadata()
         {
@@ -87,9 +86,7 @@ namespace DCL.InWorldCamera.Playground
             Entity playerEntity = world.Create();
 
             return new SelfProfile(
-                new LogProfileRepository(
-                    new RealmProfileRepository(IWebRequestController.DEFAULT, realmData, new DefaultProfileCache())
-                ),
+                new RealmProfileRepository(IWebRequestController.DEFAULT, realmData, new DefaultProfileCache()),
                 web3IdentityCache,
                 new EquippedWearables(),
                 new WearableStorage(),

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -119,6 +119,7 @@ namespace Global.Dynamic
         private readonly IChatMessagesBus chatMessagesBus;
         private readonly IProfileBroadcast profileBroadcast;
         private readonly SocialServicesContainer socialServicesContainer;
+        private readonly ISelfProfile selfProfile;
 
         public IMVCManager MvcManager { get; }
 
@@ -150,7 +151,8 @@ namespace Global.Dynamic
             IRemoteMetadata remoteMetadata,
             IProfileBroadcast profileBroadcast,
             IRoomHub roomHub,
-            SocialServicesContainer socialServicesContainer)
+            SocialServicesContainer socialServicesContainer,
+            ISelfProfile selfProfile)
         {
             MvcManager = mvcManager;
             RealmController = realmController;
@@ -164,6 +166,7 @@ namespace Global.Dynamic
             this.chatMessagesBus = chatMessagesBus;
             this.profileBroadcast = profileBroadcast;
             this.socialServicesContainer = socialServicesContainer;
+            this.selfProfile = selfProfile;
         }
 
         public override void Dispose()
@@ -172,6 +175,7 @@ namespace Global.Dynamic
             profileBroadcast.Dispose();
             MessagePipesHub.Dispose();
             socialServicesContainer.Dispose();
+            selfProfile.Dispose();
         }
 
         public static async UniTask<(DynamicWorldContainer? container, bool success)> CreateAsync(
@@ -996,7 +1000,8 @@ namespace Global.Dynamic
                 remoteMetadata,
                 profileBroadcast,
                 roomHub,
-                socialServiceContainer
+                socialServiceContainer,
+                selfProfile
             );
 
             // Init itself

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -289,9 +289,7 @@ namespace Global.Dynamic
 
             IProfileCache profileCache = new DefaultProfileCache();
 
-            var profileRepository = new LogProfileRepository(
-                new RealmProfileRepository(staticContainer.WebRequestsContainer.WebRequestController, staticContainer.RealmData, profileCache)
-            );
+            var profileRepository = new RealmProfileRepository(staticContainer.WebRequestsContainer.WebRequestController, staticContainer.RealmData, profileCache);
 
             static IMultiPool MultiPoolFactory() =>
                 new DCLMultiPool();

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Demo/ArchipelagoFakeIdentityCache.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Demo/ArchipelagoFakeIdentityCache.cs
@@ -32,7 +32,6 @@ namespace DCL.Multiplayer.Connections.Demo
                 identityCache.Identity = identity;
             }
 
-            identityCache.Identity = new LogWeb3Identity(identityCache.Identity);
             return identityCache;
         }
     }

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Tests/AvatarEmoteCommandPropagationSystemShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Tests/AvatarEmoteCommandPropagationSystemShould.cs
@@ -148,6 +148,11 @@ namespace DCL.Multiplayer.SDK.Tests
             public bool TryGetOwnedNftRegistry(URN nftUrn, out IReadOnlyDictionary<URN, NftBlockchainOperationEntry> registry) =>
                 throw new NotImplementedException();
 
+            public void ClearOwnedNftRegistry()
+            {
+                throw new NotImplementedException();
+            }
+
             public void AddEmbeded(URN urn, IEmote emote)
             {
                 throw new NotImplementedException();

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsDevelopment.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsDevelopment.asset
@@ -512,6 +512,8 @@ MonoBehaviour:
       Severity: 4
     - Category: MARKETPLACE_CREDITS
       Severity: 1
+    - Category: PROFILE
+      Severity: 3
   sentryMatrix:
     entries: []
   debounceEnabled: 1

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
@@ -338,6 +338,8 @@ MonoBehaviour:
       Severity: 4
     - Category: CHAT_HISTORY
       Severity: 0
+    - Category: PROFILE
+      Severity: 3
   sentryMatrix:
     entries:
     - Category: AUDIO_SOURCES

--- a/Explorer/Assets/DCL/Profiles/DataModels/ProfileJsonDto.cs
+++ b/Explorer/Assets/DCL/Profiles/DataModels/ProfileJsonDto.cs
@@ -387,7 +387,7 @@ namespace DCL.Profiles
 
         public List<ProfileJsonDto>? avatars;
 
-        private GetProfileJsonRootDto() { }
+        public GetProfileJsonRootDto() { }
 
         public void Dispose()
         {
@@ -405,13 +405,14 @@ namespace DCL.Profiles
             return root;
         }
 
-        public void CopyFrom(Profile profile)
+        public GetProfileJsonRootDto CopyFrom(Profile profile)
         {
             avatars ??= new List<ProfileJsonDto>();
             avatars.Clear();
             var profileDto = new ProfileJsonDto();
             profileDto.CopyFrom(profile);
             avatars.Add(profileDto);
+            return this;
         }
 
         private bool AnyAvatarInList()

--- a/Explorer/Assets/DCL/Profiles/Self/ISelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/ISelfProfile.cs
@@ -1,10 +1,11 @@
 using Cysharp.Threading.Tasks;
 using DCL.Utilities.Extensions;
+using System;
 using System.Threading;
 
 namespace DCL.Profiles.Self
 {
-    public interface ISelfProfile
+    public interface ISelfProfile : IDisposable
     {
         UniTask<Profile?> ProfileAsync(CancellationToken ct);
         UniTask<Profile?> UpdateProfileAsync(CancellationToken ct, bool updateAvatarInWorld = true);

--- a/Explorer/Assets/DCL/Profiles/Self/Playground/SelfProfilePlayground.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/Playground/SelfProfilePlayground.cs
@@ -34,24 +34,22 @@ namespace DCL.Profiles.Self.Playground
             var playerEntity = world.Create();
 
             SelfProfile selfProfile = new SelfProfile(
-                new LogProfileRepository(
-                    new RealmProfileRepository(
-                        IWebRequestController.DEFAULT,
-                        new RealmData(
-                            new LogIpfsRealm(
-                                new IpfsRealm(
-                                    web3IdentityCache,
-                                    IWebRequestController.DEFAULT,
-                                    URLDomain.FromString(url),
-                                    URLDomain.EMPTY,
-                                    new ServerAbout(
-                                        lambdas: new ContentEndpoint(url)
-                                    )
+                new RealmProfileRepository(
+                    IWebRequestController.DEFAULT,
+                    new RealmData(
+                        new LogIpfsRealm(
+                            new IpfsRealm(
+                                web3IdentityCache,
+                                IWebRequestController.DEFAULT,
+                                URLDomain.FromString(url),
+                                URLDomain.EMPTY,
+                                new ServerAbout(
+                                    lambdas: new ContentEndpoint(url)
                                 )
                             )
-                        ),
-                        new DefaultProfileCache())
-                ),
+                        )
+                    ),
+                    new DefaultProfileCache()),
                 web3IdentityCache,
                 new EquippedWearables(),
                 new WearableStorage(),

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -199,6 +199,9 @@ namespace DCL.Profiles.Self
         {
             copyOfOwnProfile = null;
             OwnProfile = null;
+            // We also need to clear the owned nfts since they need to be re-initialized, otherwise we might end up with wrong nftIds (last part of the urn chunks)
+            wearableStorage.ClearOwnedNftRegistry();
+            emoteStorage.ClearOwnedNftRegistry();
         }
     }
 }

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -112,6 +112,8 @@ namespace DCL.Profiles.Self
 
         public async UniTask<Profile?> UpdateProfileAsync(Profile newProfile, CancellationToken ct, bool updateAvatarInWorld = true)
         {
+            ct.ThrowIfCancellationRequested();
+
             if (web3IdentityCache.Identity == null)
                 throw new Web3IdentityMissingException("Web3 Identity is not initialized");
 

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -166,12 +166,14 @@ namespace DCL.Profiles.Self
             }
             catch (Exception e) when (e is not OperationCanceledException)
             {
+                ReportHub.Log(ReportCategory.PROFILE, $"UpdateProfileAsync.Failed.Reverted: {e}");
                 // Revert to the old profile so we are aligned to the catalyst's version
                 // copyOfOwnProfile should never be null at this point
                 Profile oldProfile = profileBuilder.From(copyOfOwnProfile!).Build();
                 profileCache.Set(oldProfile.UserId, oldProfile);
                 UpdateAvatarInWorld(oldProfile);
                 OwnProfile = oldProfile;
+                ReportHub.Log(ReportCategory.PROFILE, $"UpdateProfileAsync.Failed.Reverted: {JsonConvert.SerializeObject(new GetProfileJsonRootDto().CopyFrom(oldProfile))}");
                 throw;
             }
         }

--- a/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
@@ -54,7 +54,7 @@ namespace DCL.Web3.Identities
 
             public Default(IWeb3AccountFactory? web3AccountFactory = null)
             {
-                origin = new LogWeb3IdentityCache(
+                origin =
                     new ProxyIdentityCache(
                         new MemoryWeb3IdentityCache(),
                         new PlayerPrefsIdentityProvider(
@@ -67,8 +67,7 @@ namespace DCL.Web3.Identities
                             new MemoryMappedFilePlayerPrefsIdentityProviderKeyStrategy()
 #endif
                         )
-                    )
-                );
+                    );
             }
 
             public event Action? OnIdentityCleared

--- a/Explorer/Assets/DCL/Web3/Identities/LogWeb3IdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/LogWeb3IdentityCache.cs
@@ -40,9 +40,7 @@ namespace DCL.Web3.Identities
                    .WithReport(ReportCategory.PROFILE)
                    .Log("Web3IdentityCache Identity value get requested");
                 var value = origin.Identity;
-                return value == null
-                    ? null
-                    : new LogWeb3Identity(value);
+                return value;
             }
 
             set


### PR DESCRIPTION
## What does this PR change?

Fixes #4413 

Three different problems were found in the process:
- If you rapidly logout after you update the profile from the backpack, you got an inconsistent profile state because it was invalid/cleared from the pool while the operation was being processed, provoking an internal exception.
- The `OwnProfile` of the `SelfProfile` needed to be invalidated on account switch, otherwise we might end up caching the profile from the previous account.
- The owned nft registry at the `WearableStorage` & `EmoteStorage` needed to be invalidated on account switch. We were trying to publish the owned `itemId` (last part of the urn chunks) of the wearable from the previous account if your new account had the same wearables.

## Test Instructions

Save the profile through the backpack. Change accounts. The avatar should always represent your latest changes.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
