### PR TITLE
style: homogenise call to action label to open profile cards

### DIFF
--- a/Explorer/Assets/DCL/Interaction/Systems/ProcessOtherAvatarsInteractionSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Systems/ProcessOtherAvatarsInteractionSystem.cs
@@ -25,7 +25,7 @@ namespace DCL.Interaction.Systems
     [LogCategory(ReportCategory.INPUT)]
     public partial class ProcessOtherAvatarsInteractionSystem : BaseUnityLoopSystem
     {
-        private const string HOVER_TOOLTIP = "Open Passport";
+        private const string HOVER_TOOLTIP = "View Profile";
 
         private readonly IEventSystem eventSystem;
         private readonly DCLInput dclInput;

--- a/Explorer/Assets/DCL/UI/Sidebar/ProfileMenuView.prefab
+++ b/Explorer/Assets/DCL/UI/Sidebar/ProfileMenuView.prefab
@@ -1116,7 +1116,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: MY PROFILE
+  m_text: View PROFILE
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}


### PR DESCRIPTION
## What does this PR change?
This PR updates the call-to-action text for opening profile cards (both your own and others’).
The hover text when pointing at an avatar in-world has been changed from [Open Passport] to [View Profile].
In the profile menu, the [My Profile] label has also been updated to [View Profile].

BEFORE
<img width="186" alt="Screenshot 2025-06-16 at 11 27 44" src="https://github.com/user-attachments/assets/87bccae2-3d1e-4840-8dc2-c5648e9622e4" />
<img width="413" alt="Screenshot 2025-06-16 at 11 27 51" src="https://github.com/user-attachments/assets/9e90b148-de54-40a4-b073-dfabb5f33106" />

AFTER
<img width="305" alt="Screenshot 2025-06-16 at 11 15 20" src="https://github.com/user-attachments/assets/07fcd994-09c2-4965-98c1-eb0eee8370f2" />
<img width="718" alt="Screenshot 2025-06-16 at 11 16 05" src="https://github.com/user-attachments/assets/032bf6ac-c7dd-41e6-94f2-4b4806de3676" />

### Test Steps
1. Launch the client.
2. Once in Genesis Plaza, hover over any avatar and check that the text now says [View Profile].
3. Click your profile button, at the top of the sidebar, and confirm that the main button text has also been updated.