### PR TITLE
fix: teleporting to friend

### DIFF
--- a/Explorer/Assets/DCL/Chat/Commands/ChatTeleporter.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ChatTeleporter.cs
@@ -6,7 +6,10 @@ using ECS.SceneLifeCycle.Realm;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Arch.Core;
+using DCL.Character.Components;
 using UnityEngine;
+using Utility;
 using Utility.Types;
 
 namespace DCL.Chat.Commands
@@ -22,9 +25,17 @@ namespace DCL.Chat.Commands
         private readonly Dictionary<string, string> paramUrls;
         private readonly ChatEnvironmentValidator environmentValidator;
         private readonly URLDomain worldDomain;
+        private readonly Entity playerEntity;
+        private readonly World world;
 
-        public ChatTeleporter(IRealmNavigator realmNavigator, ChatEnvironmentValidator environmentValidator, IDecentralandUrlsSource decentralandUrlsSource)
+        public ChatTeleporter(World world,
+            Entity playerEntity,
+            IRealmNavigator realmNavigator,
+            ChatEnvironmentValidator environmentValidator,
+            IDecentralandUrlsSource decentralandUrlsSource)
         {
+            this.world = world;
+            this.playerEntity = playerEntity;
             this.realmNavigator = realmNavigator;
             this.environmentValidator = environmentValidator;
             worldDomain = URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.WorldContentServer));
@@ -91,6 +102,10 @@ namespace DCL.Chat.Commands
         /// </summary>
         public async UniTask<string> TeleportToParcelAsync(Vector2Int targetPosition, bool local, CancellationToken ct)
         {
+            // var currentPosition = world.Get<CharacterTransform>(playerEntity).Transform.position.ToParcel();
+            // if (targetPosition == currentPosition)
+            //     return $"🔴 You are already at {targetPosition.x},{targetPosition.y}.";
+
             var result = await realmNavigator.TeleportToParcelAsync(targetPosition, ct, local);
 
             if (result.Success)

--- a/Explorer/Assets/DCL/Chat/Commands/ChatTeleporter.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ChatTeleporter.cs
@@ -102,9 +102,9 @@ namespace DCL.Chat.Commands
         /// </summary>
         public async UniTask<string> TeleportToParcelAsync(Vector2Int targetPosition, bool local, CancellationToken ct)
         {
-            // var currentPosition = world.Get<CharacterTransform>(playerEntity).Transform.position.ToParcel();
-            // if (targetPosition == currentPosition)
-            //     return $"🔴 You are already at {targetPosition.x},{targetPosition.y}.";
+            var currentPosition = world.Get<CharacterTransform>(playerEntity).Transform.position.ToParcel();
+            if (targetPosition == currentPosition)
+                return $"🔴 You are already at {targetPosition.x},{targetPosition.y}.";
 
             var result = await realmNavigator.TeleportToParcelAsync(targetPosition, ct, local);
 

--- a/Explorer/Assets/DCL/Chat/Commands/DCL.Chat.Commands.asmdef
+++ b/Explorer/Assets/DCL/Chat/Commands/DCL.Chat.Commands.asmdef
@@ -21,7 +21,8 @@
         "GUID:04e9a70e2a3843908ecb2c5135189184",
         "GUID:7175400a68914a45acecc9fb068de3b8",
         "GUID:286980af24684da6acc1caa413039811",
-        "GUID:d832748739a186646b8656bdbd447ad0"
+        "GUID:d832748739a186646b8656bdbd447ad0",
+        "GUID:c80c82a8f4e04453b85fbab973d6774a"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Friends/DCL.Friends.asmdef
+++ b/Explorer/Assets/DCL/Friends/DCL.Friends.asmdef
@@ -39,7 +39,9 @@
         "GUID:06ff434504c6ea64a97be2812894f353",
         "GUID:d5368878df29ff849933a7d3586d18c6",
         "GUID:3db07cecf8bc76f49bd3ffb446a18d11",
-        "GUID:bd6eca6559a7438f86a272185d5bc54b"
+        "GUID:bd6eca6559a7438f86a272185d5bc54b",
+        "GUID:809870cbfd80a7b46bcf72b178ab210b",
+        "GUID:6a48072a2835e984c81f98936d9133db"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/FriendsPanelController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/FriendsPanelController.cs
@@ -13,6 +13,7 @@ using ECS.SceneLifeCycle.Realm;
 using MVC;
 using System;
 using System.Threading;
+using DCL.Chat.MessageBus;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using Utility;
@@ -66,6 +67,7 @@ namespace DCL.Friends.UI.FriendPanel
             IRealmNavigator realmNavigator,
             IFriendsConnectivityStatusTracker friendsConnectivityStatusTracker,
             IChatEventBus chatEventBus,
+            IChatMessagesBus chatMessageBus,
             ViewDependencies viewDependencies,
             bool includeUserBlocking,
             bool isConnectivityStatusEnabled,
@@ -90,6 +92,7 @@ namespace DCL.Friends.UI.FriendPanel
                     realmNavigator,
                     friendsConnectivityStatusTracker,
                     chatEventBus,
+                    chatMessageBus,
                     sharedSpaceManager,
                     viewDependencies);
 
@@ -105,6 +108,7 @@ namespace DCL.Friends.UI.FriendPanel
                     realmNavigator,
                     viewDependencies,
                     chatEventBus,
+                    chatMessageBus,
                     sharedSpaceManager);
 
             requestsSectionController = new RequestsSectionController(instantiatedView.RequestsSection,

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListSectionUtilities.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListSectionUtilities.cs
@@ -28,7 +28,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
         /// Public entry:
         /// restarts the CTS and fires off the teleport lookup & send.
         /// </summary>
-        public static void PrepareTeleportTargetAsync2(
+        public static void TeleportToTargetAsync(
             string userId,
             IOnlineUsersProvider onlineUsersProvider,
             IChatMessagesBus chatMessageBus,
@@ -36,7 +36,6 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
         {
             cts = cts.SafeRestart();
             
-            // fire‐and‐forget the async work
             ExecuteTeleportLookupAndSendAsync(userId, onlineUsersProvider, chatMessageBus, cts.Token).Forget();
         }
 
@@ -68,39 +67,6 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             );
         }
         
-        /// <summary>
-        /// Fetches the OnlineUserData for `userId`, restarts the CTS, 
-        /// and returns (success, isInWorld, parameters, parcel).
-        /// </summary>
-        public static async UniTask<(bool success, bool isInWorld, string parameters, Vector2Int? parcel)> 
-            PrepareTeleportTargetAsync(string userId,
-                IOnlineUsersProvider onlineUsersProvider,
-                CancellationTokenSource? cts)
-        {
-            cts = cts.SafeRestart();
-            var onlineData = await onlineUsersProvider.GetAsync(new [] { userId }, cts.Token);
-            if (onlineData.Count == 0)
-                return (false, false, null!, null);
-
-            var userData = onlineData.First();
-
-            if (userData.IsInWorld)
-            {
-                // NOTE: Realm
-                return (true, true,
-                    userData.worldName!,
-                    null);
-            }
-            else
-            {
-                // NOTE: Parcel
-                var p = userData.position.ToParcel();
-                return (true, false,
-                    $"{p.x},{p.y}",
-                    p);
-            }
-        }
-        
         public static void BlockUserClicked(IMVCManager mvcManager, Web3Address targetUserAddress, string targetUserName) =>
             mvcManager.ShowAsync(BlockUserPromptController.IssueCommand(new BlockUserPromptParams(targetUserAddress, targetUserName, BlockUserPromptParams.UserBlockAction.BLOCK))).Forget();
 
@@ -117,8 +83,5 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
 
             return buffer.ToString();
         }
-
-
-
     }
 }

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListSectionUtilities.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListSectionUtilities.cs
@@ -1,14 +1,10 @@
-using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
-using DCL.CommunicationData.URLHelpers;
 using DCL.Friends.UI.BlockUserPrompt;
 using DCL.Multiplayer.Connectivity;
 using DCL.UI.GenericContextMenu.Controls.Configs;
 using DCL.Web3;
-using ECS.SceneLifeCycle.Realm;
 using MVC;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -24,62 +20,39 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
         private const int CONTEXT_MENU_SEPARATOR_HEIGHT = 20;
         private const int CONTEXT_MENU_ELEMENTS_SPACING = 5;
 
-        public static void JumpToFriendLocation(string targetUserAddress,
-            CancellationTokenSource? jumpToFriendLocationCts,
-            string[] getUserPositionBuffer,
-            IOnlineUsersProvider onlineUsersProvider,
-            IRealmNavigator realmNavigator,
-            Action<Vector2Int>? parcelCalculatedCallback = null)
+        /// <summary>
+        /// Fetches the OnlineUserData for `userId`, restarts the CTS, 
+        /// and returns (success, isInWorld, parameters, parcel).
+        /// </summary>
+        public static async UniTask<(bool success, bool isInWorld, string parameters, Vector2Int? parcel)> 
+            PrepareTeleportTargetAsync(string userId,
+                IOnlineUsersProvider onlineUsersProvider,
+                CancellationTokenSource? ct)
         {
-            jumpToFriendLocationCts = jumpToFriendLocationCts.SafeRestart();
-            JumpToFriendLocationAsync(jumpToFriendLocationCts.Token).Forget();
-            return;
+            ct = ct.SafeRestart();
+            var onlineData = await onlineUsersProvider.GetAsync(new [] { userId }, ct.Token);
+            if (onlineData.Count == 0)
+                return (false, false, null!, null);
 
-            async UniTaskVoid JumpToFriendLocationAsync(CancellationToken ct = default)
+            var userData = onlineData.First();
+
+            if (userData.IsInWorld)
             {
-                getUserPositionBuffer[0] = targetUserAddress;
-
-                IReadOnlyCollection<OnlineUserData> onlineData = await onlineUsersProvider.GetAsync(getUserPositionBuffer, ct);
-
-                if (onlineData.Count == 0)
-                    return;
-
-                OnlineUserData userData = onlineData.First();
-
-                if (userData.IsInWorld)
-                {
-                    realmNavigator.TryChangeRealmAsync(URLDomain.FromString(new ENS(userData.worldName).ConvertEnsToWorldUrl()), ct).Forget();
-                }
-                else
-                {
-                    Vector2Int parcel = userData.position.ToParcel();
-                    realmNavigator.TeleportToParcelAsync(parcel, ct, false).Forget();
-                    parcelCalculatedCallback?.Invoke(parcel);
-                }
+                // NOTE: Realm
+                return (true, true,
+                    userData.worldName!,
+                    null);
+            }
+            else
+            {
+                // NOTE: Parcel
+                var p = userData.position.ToParcel();
+                return (true, false,
+                    $"{p.x},{p.y}",
+                    p);
             }
         }
-
-        internal static (GenericContextMenu, GenericContextMenuElement) BuildContextMenu(
-            FriendListContextMenuConfiguration contextMenuSettings,
-            UserProfileContextMenuControlSettings userProfileContextMenuControlSettings,
-            bool includeUserBlocking,
-            Action openProfilePassportCallback,
-            Action jumpToFriendCallback,
-            Action blockUserCallback)
-        {
-            GenericContextMenuElement jumpInElement;
-
-            GenericContextMenu contextMenu = new GenericContextMenu(contextMenuSettings.ContextMenuWidth, verticalLayoutPadding: CONTEXT_MENU_VERTICAL_LAYOUT_PADDING, elementsSpacing: CONTEXT_MENU_ELEMENTS_SPACING)
-                                            .AddControl(userProfileContextMenuControlSettings)
-                                            .AddControl(new SeparatorContextMenuControlSettings(CONTEXT_MENU_SEPARATOR_HEIGHT, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.left, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.right))
-                                            .AddControl(new ButtonContextMenuControlSettings(contextMenuSettings.ViewProfileText, contextMenuSettings.ViewProfileSprite, openProfilePassportCallback))
-                                            .AddControl(jumpInElement = new GenericContextMenuElement(new ButtonContextMenuControlSettings(contextMenuSettings.JumpToLocationText,
-                                                 contextMenuSettings.JumpToLocationSprite, jumpToFriendCallback), false))
-                                            .AddControl(new GenericContextMenuElement(new ButtonContextMenuControlSettings(contextMenuSettings.BlockText, contextMenuSettings.BlockSprite, blockUserCallback), includeUserBlocking));
-
-            return (contextMenu, jumpInElement);
-        }
-
+        
         public static void BlockUserClicked(IMVCManager mvcManager, Web3Address targetUserAddress, string targetUserName) =>
             mvcManager.ShowAsync(BlockUserPromptController.IssueCommand(new BlockUserPromptParams(targetUserAddress, targetUserName, BlockUserPromptParams.UserBlockAction.BLOCK))).Forget();
 

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendSectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendSectionController.cs
@@ -75,35 +75,19 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             viewDependencies.GlobalUIViews.ShowUserProfileContextMenuFromWalletIdAsync(new Web3Address(friendProfile.Address), buttonPosition, default(Vector2),
                 popupCts.Token, menuTask, onHide: () => elementView.CanUnHover = true, anchorPoint: MenuAnchorPoint.TOP_RIGHT).Forget();
         }
-        
-        private async UniTaskVoid HandleJump(FriendProfile profile)
+
+        private void HandleJump(FriendProfile profile)
         {
-            chatMessageBus.Send(ChatChannel.NEARBY_CHANNEL,
-                $"/{ChatCommandsUtils.COMMAND_GOTO} 100,10",
-                "passport-jump"
-            );
-            
-            
-            // (bool success, bool isInWorld, string parameters, var parcel) =
-            //     await FriendListSectionUtilities
-            //         .PrepareTeleportTargetAsync(profile.Address,
-            //             onlineUsersProvider,
-            //             jumpToFriendLocationCts);
-            //
-            // if(!success) return;
-            //
-            // chatMessageBus.Send(ChatChannel.NEARBY_CHANNEL,
-            //     $"/{ChatCommandsUtils.COMMAND_GOTO} {parameters}",
-            //     "passport-jump"
-            // );
-            //
-            // sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat,
-            //     new ChatControllerShowParams(true, true)).Forget();
+            FriendListSectionUtilities
+                .PrepareTeleportTargetAsync2(profile.Address,
+                    onlineUsersProvider,
+                    chatMessageBus,
+                    jumpToFriendLocationCts);
         }
 
         private void JumpInClicked(FriendProfile profile)
         {
-            HandleJump(profile).Forget();
+            HandleJump(profile);
         }
 
         protected override void ElementClicked(FriendProfile profile) =>

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendSectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendSectionController.cs
@@ -85,7 +85,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
                     jumpToFriendLocationCts);
             
             sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat,
-                new ChatControllerShowParams(true, true)).Forget();
+                new ChatControllerShowParams(true, false)).Forget();
         }
 
         private void JumpInClicked(FriendProfile profile)

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendSectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendSectionController.cs
@@ -79,10 +79,13 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
         private void HandleJump(FriendProfile profile)
         {
             FriendListSectionUtilities
-                .PrepareTeleportTargetAsync2(profile.Address,
+                .TeleportToTargetAsync(profile.Address,
                     onlineUsersProvider,
                     chatMessageBus,
                     jumpToFriendLocationCts);
+            
+            sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat,
+                new ChatControllerShowParams(true, true)).Forget();
         }
 
         private void JumpInClicked(FriendProfile profile)

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
@@ -144,12 +144,18 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
                 ,anchorPoint: MenuAnchorPoint.TOP_RIGHT).Forget();
         }
 
-        private async UniTaskVoid HandleJump(FriendProfile profile)
+        private void HandleJump(FriendProfile profile)
         {
-            chatMessagesBus.Send(ChatChannel.NEARBY_CHANNEL,
-                $"/{ChatCommandsUtils.COMMAND_GOTO} 100,10",
-                "jump in"
-            );
+            Debug.Log(this.GetType().Name + ": HandleJump");
+            
+            FriendListSectionUtilities
+                .PrepareTeleportTargetAsync2(profile.Address,
+                    onlineUsersProvider,
+                    chatMessagesBus,
+                    jumpToFriendLocationCts);
+
+            sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat,
+                new ChatControllerShowParams(true, true)).Forget();
             
             // (bool success, bool isInWorld, string parameters, var parcel) =
             //     await FriendListSectionUtilities
@@ -170,7 +176,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
         
         private void OnJumpInClicked(FriendProfile profile)
         {
-            HandleJump(profile).Forget();
+            HandleJump(profile);
         }
 
         private void OnChatButtonClicked(FriendProfile elementViewUserProfile)

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
@@ -153,7 +153,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
                     jumpToFriendLocationCts);
 
             sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat,
-                new ChatControllerShowParams(true, true)).Forget();
+                new ChatControllerShowParams(false, false)).Forget();
         }
         
         private void OnJumpInClicked(FriendProfile profile)

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
@@ -146,32 +146,14 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
 
         private void HandleJump(FriendProfile profile)
         {
-            Debug.Log(this.GetType().Name + ": HandleJump");
-            
             FriendListSectionUtilities
-                .PrepareTeleportTargetAsync2(profile.Address,
+                .TeleportToTargetAsync(profile.Address,
                     onlineUsersProvider,
                     chatMessagesBus,
                     jumpToFriendLocationCts);
 
             sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat,
                 new ChatControllerShowParams(true, true)).Forget();
-            
-            // (bool success, bool isInWorld, string parameters, var parcel) =
-            //     await FriendListSectionUtilities
-            //         .PrepareTeleportTargetAsync(profile.Address,
-            //             onlineUsersProvider,
-            //             jumpToFriendLocationCts);
-            //
-            // if(!success) return;
-            //
-            // chatMessagesBus.Send(ChatChannel.NEARBY_CHANNEL,
-            //     $"/{ChatCommandsUtils.COMMAND_GOTO} {parameters}",
-            //     "passport-jump"
-            // );
-            //
-            // sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat,
-            //     new ChatControllerShowParams(true, true)).Forget();
         }
         
         private void OnJumpInClicked(FriendProfile profile)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -494,8 +494,10 @@ namespace Global.Dynamic
             var currentSceneInfo = new CurrentSceneInfo();
 
             var connectionStatusPanelPlugin = new ConnectionStatusPanelPlugin(initializationFlowContainer.InitializationFlow, mvcManager, mainUIView, roomsStatus, currentSceneInfo, reloadSceneController, globalWorld, playerEntity, debugBuilder, chatCommandsBus);
-
-            var chatTeleporter = new ChatTeleporter(realmNavigator, new ChatEnvironmentValidator(bootstrapContainer.Environment), bootstrapContainer.DecentralandUrlsSource);
+            
+            var chatTeleporter = new ChatTeleporter(globalWorld,playerEntity,realmNavigator,
+                new ChatEnvironmentValidator(bootstrapContainer.Environment), 
+                bootstrapContainer.DecentralandUrlsSource);
 
             var chatCommands = new List<IChatCommand>
             {
@@ -585,6 +587,7 @@ namespace Global.Dynamic
                 profileCache,
                 friendServiceProxy,
                 chatEventBus,
+                chatMessagesBus,
                 genericUserProfileContextMenuSettingsSo,
                 includeUserBlocking,
                 bootstrapContainer.Analytics,
@@ -832,6 +835,7 @@ namespace Global.Dynamic
                     includeUserBlocking,
                     isNameEditorEnabled,
                     chatEventBus,
+                    chatMessagesBus,
                     sharedSpaceManager,
                     profileRepositoryWrapper
                 ),
@@ -882,6 +886,7 @@ namespace Global.Dynamic
                     dynamicWorldParams.EnableAnalytics,
                     bootstrapContainer.Analytics,
                     chatEventBus,
+                    chatMessagesBus,
                     viewDependencies,
                     sharedSpaceManager,
                     socialServiceEventBus,

--- a/Explorer/Assets/DCL/Infrastructure/MVC/MVCFacade/MVC.MVCManagerMenusAccessFacade.asmdef
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/MVCFacade/MVC.MVCManagerMenusAccessFacade.asmdef
@@ -21,7 +21,8 @@
         "GUID:5462d37de7d4344df8aade58a45b403e",
         "GUID:d28a7e4beeca475418c15757abf1b6f1",
         "GUID:e9db755bba99425db4ca5d30e48b7429",
-        "GUID:e0eedfa2deb9406daf86fd8368728e39"
+        "GUID:e0eedfa2deb9406daf86fd8368728e39",
+        "GUID:6a48072a2835e984c81f98936d9133db"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Infrastructure/MVC/MVCFacade/MVCManagerMenusAccessFacade.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/MVCFacade/MVCManagerMenusAccessFacade.cs
@@ -17,6 +17,7 @@ using DCL.Web3;
 using ECS.SceneLifeCycle.Realm;
 using System;
 using System.Threading;
+using DCL.Chat.MessageBus;
 using UnityEngine;
 
 namespace MVC
@@ -30,6 +31,7 @@ namespace MVC
         private readonly IProfileCache profileCache;
         private readonly ObjectProxy<IFriendsService> friendServiceProxy;
         private readonly IChatEventBus chatEventBus;
+        private readonly IChatMessagesBus chatMessageBus;
         private readonly GenericUserProfileContextMenuSettings contextMenuSettings;
         private readonly bool includeUserBlocking;
         private readonly IAnalyticsController analytics;
@@ -48,6 +50,7 @@ namespace MVC
             IProfileCache profileCache,
             ObjectProxy<IFriendsService> friendServiceProxy,
             IChatEventBus chatEventBus,
+            IChatMessagesBus chatMessageBus,
             GenericUserProfileContextMenuSettings contextMenuSettings,
             bool includeUserBlocking,
             IAnalyticsController analytics,
@@ -60,6 +63,7 @@ namespace MVC
             this.profileCache = profileCache;
             this.friendServiceProxy = friendServiceProxy;
             this.chatEventBus = chatEventBus;
+            this.chatMessageBus = chatMessageBus;
             this.contextMenuSettings = contextMenuSettings;
             this.includeUserBlocking = includeUserBlocking;
             this.analytics = analytics;
@@ -113,7 +117,7 @@ namespace MVC
         private async UniTask ShowUserProfileContextMenuAsync(Profile profile, Vector3 position, Vector2 offset, CancellationToken ct, Action onContextMenuHide,
             UniTask closeMenuTask, MenuAnchorPoint anchorPoint = MenuAnchorPoint.DEFAULT)
         {
-            genericUserProfileContextMenuController ??= new GenericUserProfileContextMenuController(friendServiceProxy, chatEventBus, mvcManager, contextMenuSettings, analytics, includeUserBlocking, onlineUsersProvider, realmNavigator, friendOnlineStatusCacheProxy, sharedSpaceManager);
+            genericUserProfileContextMenuController ??= new GenericUserProfileContextMenuController(friendServiceProxy, chatEventBus,chatMessageBus, mvcManager, contextMenuSettings, analytics, includeUserBlocking, onlineUsersProvider, realmNavigator, friendOnlineStatusCacheProxy, sharedSpaceManager);
             await genericUserProfileContextMenuController.ShowUserProfileContextMenuAsync(profile, position, offset, ct, closeMenuTask, onContextMenuHide, ConvertMenuAnchorPoint(anchorPoint));
         }
 

--- a/Explorer/Assets/DCL/Passport/Passport.asmdef
+++ b/Explorer/Assets/DCL/Passport/Passport.asmdef
@@ -48,7 +48,10 @@
         "GUID:9cce9838ccdc58d46b673e02f1058718",
         "GUID:d8acebc6c6214cf1a782f4e743e7699c",
         "GUID:7cfe53a67dd47414fbe97d2e908fe310",
-        "GUID:3db07cecf8bc76f49bd3ffb446a18d11"
+        "GUID:3db07cecf8bc76f49bd3ffb446a18d11",
+        "GUID:6a48072a2835e984c81f98936d9133db",
+        "GUID:809870cbfd80a7b46bcf72b178ab210b",
+        "GUID:c80c82a8f4e04453b85fbab973d6774a"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -294,7 +294,7 @@ namespace DCL.Passport
                     jumpToFriendLocationCts);
 
             sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat,
-                new ChatControllerShowParams(true, true)).Forget();
+                new ChatControllerShowParams(false, false)).Forget();
         }
 
         private void OnJumpToFriendButtonClicked()

--- a/Explorer/Assets/DCL/PluginSystem/Global/FriendsContainer.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/FriendsContainer.cs
@@ -30,6 +30,7 @@ using Global.AppArgs;
 using MVC;
 using System;
 using System.Threading;
+using DCL.Chat.MessageBus;
 using UnityEngine;
 using Utility;
 using Utility.Types;
@@ -89,6 +90,7 @@ namespace DCL.PluginSystem.Global
             bool useAnalytics,
             IAnalyticsController? analyticsController,
             IChatEventBus chatEventBus,
+            IChatMessagesBus chatMessageBus,
             ViewDependencies viewDependencies,
             ISharedSpaceManager sharedSpaceManager,
             ISocialServiceEventBus socialServiceEventBus,
@@ -145,6 +147,7 @@ namespace DCL.PluginSystem.Global
                 realmNavigator,
                 friendsConnectivityStatusTracker,
                 chatEventBus,
+                chatMessageBus,
                 viewDependencies,
                 includeUserBlocking,
                 isConnectivityStatusEnabled,

--- a/Explorer/Assets/DCL/PluginSystem/Global/PassportPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/PassportPlugin.cs
@@ -29,6 +29,7 @@ using ECS;
 using ECS.SceneLifeCycle.Realm;
 using MVC;
 using System.Threading;
+using DCL.Chat.MessageBus;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 
@@ -69,6 +70,7 @@ namespace DCL.PluginSystem.Global
         private readonly bool includeUserBlocking;
         private readonly bool isNameEditorEnabled;
         private readonly IChatEventBus chatEventBus;
+        private readonly IChatMessagesBus chatMessageBus;
         private readonly ISharedSpaceManager sharedSpaceManager;
         private readonly ProfileRepositoryWrapper profileRepositoryWrapper;
 
@@ -106,7 +108,11 @@ namespace DCL.PluginSystem.Global
             IProfileChangesBus profileChangesBus,
             bool enableFriends,
             bool includeUserBlocking,
-            bool isNameEditorEnabled, IChatEventBus chatEventBus, ISharedSpaceManager sharedSpaceManager, ProfileRepositoryWrapper profileDataProvider)
+            bool isNameEditorEnabled,
+            IChatEventBus chatEventBus,
+            IChatMessagesBus chatMessageBus,
+            ISharedSpaceManager sharedSpaceManager,
+            ProfileRepositoryWrapper profileDataProvider)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.mvcManager = mvcManager;
@@ -141,6 +147,7 @@ namespace DCL.PluginSystem.Global
             this.includeUserBlocking = includeUserBlocking;
             this.isNameEditorEnabled = isNameEditorEnabled;
             this.chatEventBus = chatEventBus;
+            this.chatMessageBus = chatMessageBus;
             this.sharedSpaceManager = sharedSpaceManager;
             this.profileRepositoryWrapper = profileDataProvider;
         }
@@ -202,6 +209,7 @@ namespace DCL.PluginSystem.Global
                 includeUserBlocking,
                 isNameEditorEnabled,
                 chatEventBus,
+                chatMessageBus,
                 sharedSpaceManager,
                 profileRepositoryWrapper
             );

--- a/Explorer/Assets/DCL/RealmNavigation/RealmNavigator.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/RealmNavigator.cs
@@ -76,6 +76,13 @@ namespace DCL.RealmNavigation
 
             return true;
         }
+        
+        private bool CheckIfItsSameParcel()
+        {
+            
+
+            return true;
+        }
 
         public async UniTask<EnumResult<ChangeRealmError>> TryChangeRealmAsync(
             URLDomain realm,

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/DCL.UI.GenericContextMenu.Controllers.asmdef
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/DCL.UI.GenericContextMenu.Controllers.asmdef
@@ -19,7 +19,9 @@
         "GUID:3640f3c0b42946b0b8794a1ed8e06ca5",
         "GUID:e169fa6683c924c7e99a85981a91d953",
         "GUID:9cce9838ccdc58d46b673e02f1058718",
-        "GUID:3db07cecf8bc76f49bd3ffb446a18d11"
+        "GUID:3db07cecf8bc76f49bd3ffb446a18d11",
+        "GUID:809870cbfd80a7b46bcf72b178ab210b",
+        "GUID:6a48072a2835e984c81f98936d9133db"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/GenericUserProfileContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/GenericUserProfileContextMenuController.cs
@@ -290,7 +290,7 @@ namespace DCL.UI.GenericContextMenu.Controllers
                     cancellationTokenSource);
 
             sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat,
-                new ChatControllerShowParams(true, true)).Forget();
+                new ChatControllerShowParams(false, true)).Forget();
         }
         
         private void OnJumpInClicked(string userId)

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/GenericUserProfileContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/GenericUserProfileContextMenuController.cs
@@ -281,28 +281,21 @@ namespace DCL.UI.GenericContextMenu.Controllers
             await mvcManager.ShowAsync(BlockUserPromptController.IssueCommand(new BlockUserPromptParams(new Web3Address(profile.UserId), profile.Name, BlockUserPromptParams.UserBlockAction.BLOCK)));
         }
 
-        private async UniTaskVoid HandleJump(string userId)
+        private void HandleJump(string userId)
         {
-            (bool success, bool isInWorld, string parameters, var parcel) =
-                await FriendListSectionUtilities
-                    .PrepareTeleportTargetAsync(userId,
-                        onlineUsersProvider,
-                        cancellationTokenSource);
-            
-            if(!success) return;
-            
-            chatMessageBus.Send(ChatChannel.NEARBY_CHANNEL,
-                $"/{ChatCommandsUtils.COMMAND_GOTO} {parameters}",
-                "passport-jump"
-            );
-            
+            FriendListSectionUtilities
+                .TeleportToTargetAsync(userId,
+                    onlineUsersProvider,
+                    chatMessageBus,
+                    cancellationTokenSource);
+
             sharedSpaceManager.ShowAsync(PanelsSharingSpace.Chat,
                 new ChatControllerShowParams(true, true)).Forget();
         }
         
         private void OnJumpInClicked(string userId)
         {
-            HandleJump(userId).Forget();
+            HandleJump(userId);
         }
 
         private UniTask ShowPassport(string userId, CancellationToken ct) =>


### PR DESCRIPTION
# Pull Request Description
## What does this PR change?
Prevent redundant teleports and show status message

- Skip teleport if user is already at the requested location
- Display a system message indicating teleport success or failure

### Test Steps
1. Teleport through friends list (directly or through context menu)
2. Observe teleport is successful (chat message with teleport status is present in the chat) 

============

1. Teleport through passport (directly or through context menu)
2. Observe teleport is successful (chat message with teleport status is present in the chat)


NOTE: 
- If player is in the same location, system message is received that user is already in requested location
- Test with realms and parcels 

![teleport_1](https://github.com/user-attachments/assets/890ddee7-95fd-4003-bfbb-e1f52b8a9364)
![teleport_2](https://github.com/user-attachments/assets/5129e45d-ad4d-4566-aa6f-0e9717d2e6f0)
![teleport_3](https://github.com/user-attachments/assets/ebd55f2e-a049-4c6c-8ba4-b6920271d0a4)
![teleport_4](https://github.com/user-attachments/assets/ee4766ad-ac06-4f42-bc9c-d18c1cf174a4)

## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
