### PR TITLE
fix: remove logs during save profile process

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Playground/ScreenRecorderTester.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Playground/ScreenRecorderTester.cs
@@ -53,6 +53,7 @@ namespace DCL.InWorldCamera.Playground
             hud.Screenshot = Texture;
         }
 
+
         [ContextMenu(nameof(CaptureMetadata))]
         public async UniTask CaptureMetadata()
         {
@@ -86,7 +87,9 @@ namespace DCL.InWorldCamera.Playground
             Entity playerEntity = world.Create();
 
             return new SelfProfile(
-                new RealmProfileRepository(IWebRequestController.DEFAULT, realmData, new DefaultProfileCache()),
+                new LogProfileRepository(
+                    new RealmProfileRepository(IWebRequestController.DEFAULT, realmData, new DefaultProfileCache())
+                ),
                 web3IdentityCache,
                 new EquippedWearables(),
                 new WearableStorage(),

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -293,7 +293,9 @@ namespace Global.Dynamic
 
             IProfileCache profileCache = new DefaultProfileCache();
 
-            var profileRepository = new RealmProfileRepository(staticContainer.WebRequestsContainer.WebRequestController, staticContainer.RealmData, profileCache);
+            var profileRepository = new LogProfileRepository(
+                new RealmProfileRepository(staticContainer.WebRequestsContainer.WebRequestController, staticContainer.RealmData, profileCache)
+            );
 
             static IMultiPool MultiPoolFactory() =>
                 new DCLMultiPool();

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Demo/ArchipelagoFakeIdentityCache.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Demo/ArchipelagoFakeIdentityCache.cs
@@ -32,6 +32,7 @@ namespace DCL.Multiplayer.Connections.Demo
                 identityCache.Identity = identity;
             }
 
+            identityCache.Identity = new LogWeb3Identity(identityCache.Identity);
             return identityCache;
         }
     }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsDevelopment.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsDevelopment.asset
@@ -512,8 +512,6 @@ MonoBehaviour:
       Severity: 4
     - Category: MARKETPLACE_CREDITS
       Severity: 1
-    - Category: PROFILE
-      Severity: 3
   sentryMatrix:
     entries: []
   debounceEnabled: 1

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
@@ -338,8 +338,6 @@ MonoBehaviour:
       Severity: 4
     - Category: CHAT_HISTORY
       Severity: 0
-    - Category: PROFILE
-      Severity: 3
   sentryMatrix:
     entries:
     - Category: AUDIO_SOURCES

--- a/Explorer/Assets/DCL/Profiles/DataModels/ProfileJsonDto.cs
+++ b/Explorer/Assets/DCL/Profiles/DataModels/ProfileJsonDto.cs
@@ -387,7 +387,7 @@ namespace DCL.Profiles
 
         public List<ProfileJsonDto>? avatars;
 
-        public GetProfileJsonRootDto() { }
+        private GetProfileJsonRootDto() { }
 
         public void Dispose()
         {
@@ -405,14 +405,13 @@ namespace DCL.Profiles
             return root;
         }
 
-        public GetProfileJsonRootDto CopyFrom(Profile profile)
+        public void CopyFrom(Profile profile)
         {
             avatars ??= new List<ProfileJsonDto>();
             avatars.Clear();
             var profileDto = new ProfileJsonDto();
             profileDto.CopyFrom(profile);
             avatars.Add(profileDto);
-            return this;
         }
 
         private bool AnyAvatarInList()

--- a/Explorer/Assets/DCL/Profiles/Self/Playground/SelfProfilePlayground.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/Playground/SelfProfilePlayground.cs
@@ -34,22 +34,24 @@ namespace DCL.Profiles.Self.Playground
             var playerEntity = world.Create();
 
             SelfProfile selfProfile = new SelfProfile(
-                new RealmProfileRepository(
-                    IWebRequestController.DEFAULT,
-                    new RealmData(
-                        new LogIpfsRealm(
-                            new IpfsRealm(
-                                web3IdentityCache,
-                                IWebRequestController.DEFAULT,
-                                URLDomain.FromString(url),
-                                URLDomain.EMPTY,
-                                new ServerAbout(
-                                    lambdas: new ContentEndpoint(url)
+                new LogProfileRepository(
+                    new RealmProfileRepository(
+                        IWebRequestController.DEFAULT,
+                        new RealmData(
+                            new LogIpfsRealm(
+                                new IpfsRealm(
+                                    web3IdentityCache,
+                                    IWebRequestController.DEFAULT,
+                                    URLDomain.FromString(url),
+                                    URLDomain.EMPTY,
+                                    new ServerAbout(
+                                        lambdas: new ContentEndpoint(url)
+                                    )
                                 )
                             )
-                        )
-                    ),
-                    new DefaultProfileCache()),
+                        ),
+                        new DefaultProfileCache())
+                ),
                 web3IdentityCache,
                 new EquippedWearables(),
                 new WearableStorage(),

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -176,14 +176,12 @@ namespace DCL.Profiles.Self
             }
             catch (Exception e) when (e is not OperationCanceledException)
             {
-                ReportHub.Log(ReportCategory.PROFILE, $"UpdateProfileAsync.Failed.Reverted: {e}");
                 // Revert to the old profile so we are aligned to the catalyst's version
                 // copyOfOwnProfile should never be null at this point
                 Profile oldProfile = profileBuilder.From(copyOfOwnProfile!).Build();
                 profileCache.Set(oldProfile.UserId, oldProfile);
                 UpdateAvatarInWorld(oldProfile);
                 OwnProfile = oldProfile;
-                ReportHub.Log(ReportCategory.PROFILE, $"UpdateProfileAsync.Failed.Reverted: {JsonConvert.SerializeObject(new GetProfileJsonRootDto().CopyFrom(oldProfile))}");
                 throw;
             }
         }

--- a/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
@@ -54,7 +54,7 @@ namespace DCL.Web3.Identities
 
             public Default(IWeb3AccountFactory? web3AccountFactory = null)
             {
-                origin =
+                origin = new LogWeb3IdentityCache(
                     new ProxyIdentityCache(
                         new MemoryWeb3IdentityCache(),
                         new PlayerPrefsIdentityProvider(
@@ -67,7 +67,8 @@ namespace DCL.Web3.Identities
                             new MemoryMappedFilePlayerPrefsIdentityProviderKeyStrategy()
 #endif
                         )
-                    );
+                    )
+                );
             }
 
             public event Action? OnIdentityCleared

--- a/Explorer/Assets/DCL/Web3/Identities/LogWeb3IdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/LogWeb3IdentityCache.cs
@@ -40,7 +40,9 @@ namespace DCL.Web3.Identities
                    .WithReport(ReportCategory.PROFILE)
                    .Log("Web3IdentityCache Identity value get requested");
                 var value = origin.Identity;
-                return value;
+                return value == null
+                    ? null
+                    : new LogWeb3Identity(value);
             }
 
             set


### PR DESCRIPTION
## What does this PR change?

Revert some changes introduced here: https://github.com/decentraland/unity-explorer/pull/4428
Logs were added for test purposes but we need to remove them.

## Test Instructions

Just do a smoke test, specially by saving the avatar. Nothing should be affected.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
