### PR TITLE
fix: game night loading screen text

### DIFF
--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
@@ -96,9 +96,9 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 176474039361110016
-    m_Localized: "Decentraland Game Night kicks off June 19\u201424 hours of fast,
+    m_Localized: Decentraland Game Night kicks off June 19 with 24 hours of fast,
       social, chaotic fun. Squad up or go solo in micro-games made for mayhem, from
-      high-speed races to logic puzzles."
+      high-speed races to logic puzzles.
     m_Metadata:
       m_Items: []
   - m_Id: 186916549694578688


### PR DESCRIPTION
## What does this PR change?

Changes the game night loading screen text to:

```
Decentraland Game Night kicks off June 19 with 24 hours of fast, social, chaotic fun. Squad up or go solo in micro-games made for mayhem, from high-speed races to logic puzzles.
```

## Test Instructions

Check that the game night loading screen has the text fixed.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
