### PR TITLE
fix: prevent javascript error propagation during teleport process

### DIFF
--- a/Explorer/Assets/DCL/RealmNavigation/DCL.RealmNavigation.asmdef
+++ b/Explorer/Assets/DCL/RealmNavigation/DCL.RealmNavigation.asmdef
@@ -26,7 +26,8 @@
         "GUID:9e314663ce958b746873cb22d57ede55",
         "GUID:d8b63aba1907145bea998dd612889d6b",
         "GUID:c80c82a8f4e04453b85fbab973d6774a",
-        "GUID:21c2e77c042a2d34d8cfbf58f8217053"
+        "GUID:21c2e77c042a2d34d8cfbf58f8217053",
+        "GUID:9659fcb6593e30b46909c1245ed056df"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/MoveToParcelInSameRealmTeleportOperation.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/MoveToParcelInSameRealmTeleportOperation.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.Utilities;
-using System;
+using Microsoft.ClearScript;
 using System.Threading;
 using Utility.Types;
 
@@ -21,6 +22,15 @@ namespace DCL.RealmNavigation.TeleportOperations
             AsyncLoadProcessReport teleportLoadReport = args.Report.CreateChildReport(finalizationProgress);
             EnumResult<TaskError> result = await teleportController.TryTeleportToSceneSpawnPointAsync(args.CurrentDestinationParcel, teleportLoadReport, ct);
             args.Report.SetProgress(finalizationProgress);
+
+            // See https://github.com/decentraland/unity-explorer/issues/4470: we should teleport the player even if the scene has javascript errors
+            // We need to prevent the error propagation, otherwise the load state remains invalid which provokes issues like the incapability of typing another command in the chat
+            if (result.Error is { Exception: ScriptEngineException })
+            {
+                ReportHub.LogError(ReportCategory.SCENE_LOADING, $"Error on teleport to parcel in same realm {args.CurrentDestinationRealm}, {args.CurrentDestinationParcel}: {result.Error.Value.Exception}");
+                return EnumResult<TaskError>.SuccessResult();
+            }
+
             return result;
         }
     }


### PR DESCRIPTION
## What does this PR change?

Fixes #4470 & #1825 

The issue #1825 is a consequence of the scene not compiling at javascript level. Nothing we can do from the client, the creator needs to fix it.

The solution consists on stopping the propagation of `ScriptEngineException` generated by the load of the scene during the teleportation process. Now we teleport the player normally, even if the scene has compilation issues.

## Test Instructions

Teleport to -35,128 by typing `/goto` or setting the start position as an app arg `--position 35,-128`. Check that you are teleported correctly, even if the scene doesn't load.
Teleport to a world and then perform a `/goto -35,128`. You should be teleported to the location.


## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
