### PR TITLE
fix: participants collection modified while iterating

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/Players/PlayersWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/Players/PlayersWrap.cs
@@ -62,10 +62,14 @@ namespace SceneRuntime.Apis.Modules.Players
 
                 using PooledObject<List<Player>> pooledObj = ListPool<Player>.Get(out List<Player>? players);
 
-                foreach (string identity in identities)
+                // See: https://github.com/decentraland/unity-explorer/issues/3796
+                lock (identities)
                 {
-                    Participant remote = participantsHub.RemoteParticipant(identity)!;
-                    players!.Add(new Player(remote));
+                    foreach (string identity in identities)
+                    {
+                        Participant remote = participantsHub.RemoteParticipant(identity)!;
+                        players!.Add(new Player(remote));
+                    }
                 }
 
                 playersJson = JsonConvert.SerializeObject(players);

--- a/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/RoomHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/RoomHub.cs
@@ -79,11 +79,19 @@ namespace DCL.Multiplayer.Connections.RoomHubs
 
             identityHashCache.EnsureCapacity(islandIdentities.Count + sceneIdentities.Count);
 
-            foreach (string? id in islandIdentities)
-                identityHashCache.Add(id);
+            // See: https://github.com/decentraland/unity-explorer/issues/3796
+            lock (islandIdentities)
+            {
+                foreach (string? id in islandIdentities)
+                    identityHashCache.Add(id);
+            }
 
-            foreach (string? id in sceneIdentities)
-                identityHashCache.Add(id);
+            // See: https://github.com/decentraland/unity-explorer/issues/3796
+            lock (sceneIdentities)
+            {
+                foreach (string? id in sceneIdentities)
+                    identityHashCache.Add(id);
+            }
 
             participantsUpdateLastFrame = MultithreadingUtility.FrameCount;
 

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/RemoveIntentions/RemoveIntention.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/RemoveIntentions/RemoveIntention.cs
@@ -1,9 +1,10 @@
 using DCL.Multiplayer.Connections.Rooms;
 using DCL.Multiplayer.Profiles.Entities;
+using System;
 
 namespace DCL.Multiplayer.Profiles.RemoveIntentions
 {
-    public readonly struct RemoveIntention
+    public readonly struct RemoveIntention : IEquatable<RemoveIntention>
     {
         public readonly string WalletId;
         public readonly RoomSource FromRoom;
@@ -16,5 +17,14 @@ namespace DCL.Multiplayer.Profiles.RemoveIntentions
 
         public override string ToString() =>
             $"(RemoveIntention: (WalletId: {WalletId}, From Room: {FromRoom}))";
+
+        public bool Equals(RemoveIntention other) =>
+            WalletId == other.WalletId && FromRoom == other.FromRoom;
+
+        public override bool Equals(object? obj) =>
+            obj is RemoveIntention other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(WalletId, (int) FromRoom);
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/RemoveIntentions/ThreadSafeRemoveIntentions.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/RemoveIntentions/ThreadSafeRemoveIntentions.cs
@@ -53,6 +53,7 @@ namespace DCL.Multiplayer.Profiles.RemoveIntentions
             {
                 using var _ = multithreadSync.GetScope();
 
+                // See: https://github.com/decentraland/unity-explorer/issues/3796
                 lock (room.Participants)
                 {
                     foreach (string identity in room.Participants.RemoteParticipantIdentities())

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/RemoveIntentions/ThreadSafeRemoveIntentions.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/RemoveIntentions/ThreadSafeRemoveIntentions.cs
@@ -53,10 +53,13 @@ namespace DCL.Multiplayer.Profiles.RemoveIntentions
             {
                 using var _ = multithreadSync.GetScope();
 
-                foreach (string identity in room.Participants.RemoteParticipantIdentities())
+                lock (room.Participants)
                 {
-                    Participant participant = room.Participants.RemoteParticipant(identity).EnsureNotNull();
-                    list.Add(new RemoveIntention(participant.Identity, roomSource));
+                    foreach (string identity in room.Participants.RemoteParticipantIdentities())
+                    {
+                        Participant participant = room.Participants.RemoteParticipant(identity).EnsureNotNull();
+                        list.Add(new RemoveIntention(participant.Identity, roomSource));
+                    }
                 }
             }
         }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
@@ -94,16 +94,20 @@ namespace DCL.SDKComponents.MediaStream
 
         private (string identity, string sid)? FirstAvailableTrackSid(TrackKind kind)
         {
-            foreach (string remoteParticipantIdentity in room.Participants.RemoteParticipantIdentities())
+            // See: https://github.com/decentraland/unity-explorer/issues/3796
+            lock (room.Participants)
             {
-                var participant = room.Participants.RemoteParticipant(remoteParticipantIdentity);
+                foreach (string remoteParticipantIdentity in room.Participants.RemoteParticipantIdentities())
+                {
+                    var participant = room.Participants.RemoteParticipant(remoteParticipantIdentity);
 
-                if (participant == null)
-                    continue;
+                    if (participant == null)
+                        continue;
 
-                foreach ((string sid, TrackPublication value) in participant.Tracks)
-                    if (value.Kind == kind)
-                        return (remoteParticipantIdentity, sid);
+                    foreach ((string sid, TrackPublication value) in participant.Tracks)
+                        if (value.Kind == kind)
+                            return (remoteParticipantIdentity, sid);
+                }
             }
 
             return null;


### PR DESCRIPTION
## What does this PR change?

Fixes #3796 

The root of the problem seems to be the threading concurrency. The participant list gets modified by another thread while its being iterated, even tho we do have a mutex.
The changes introduces a thread lock on `root.Participants` during the iteration process. Does it fix the issue? Cant tell 100%, since i was not able to reproduce it. As an alternative solution i though about making a copy of the participant list, but we could also have the same issue while its being copied through every element.
Additionally a minor performance improvement has been made so the `RemoveIntention` can be properly compared in the `HashSet`.

## Test Instructions

Jump in world into crowded places. Check in the logs you don't have the exception. Check that players are disconnected properly.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
