### PR TITLE
fix: ignore warnings in build only

### DIFF
--- a/Explorer/Assets/Editor/CloudBuild.cs
+++ b/Explorer/Assets/Editor/CloudBuild.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using DCL.Rendering.Menus;
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -17,6 +17,7 @@ namespace Editor
 
         private static string SEGMENT_WRITE_KEY = "SEGMENT_WRITE_KEY";
 
+        // Defined in the @T_MacOS/@T_Windows64 configurations in Unity Cloud
         [UsedImplicitly]
         public static void PreExport()
         {
@@ -33,6 +34,8 @@ namespace Editor
             //Unity suggestion: 1793168
             //This should ensure that the roslyn compiler has been run and everything is generated as needed.
             EditorApplication.ExecuteMenuItem("File/Save Project");
+
+            GenerateIgnoreWarningsFile();
 
             // Set version for this build
             var buildVersion = Parameters["BUILD_VERSION"] as string;
@@ -62,10 +65,57 @@ namespace Editor
 
         }
 
+        // Defined in the @T_MacOS/@T_Windows64 configurations in Unity Cloud
         [UsedImplicitly]
         public static void PostExport()
         {
             Debug.Log($"~~ {nameof(CloudBuild)} PostExport ~~");
+        }
+
+        /// <summary>
+        /// Remove warnings from the build that are just clutter
+        /// We still want to maintain them outside of the build process
+        /// </summary>
+        private static void GenerateIgnoreWarningsFile()
+        {
+            // List of warning codes to ignore
+            string[] warningsToIgnore = {
+                "8618", // Nullable reference types
+                "8625", // Cannot convert null literal to non-nullable reference type
+                "8602", // Dereference of a possibly null reference
+                "8604", // Possible null reference argument
+                "8619", // Nullable value types
+                "8620", // Argument cannot be used for parameter due to differences in the nullability of reference types
+                "8603", // Possible null reference return
+                "8600", // Converting null literal or possible null value to non-nullable type
+                "8601", // Possible null reference assignment
+                "0649", // Field is never assigned to, and will always have its default value
+                "0414", // Field is assigned but its value is never used
+                "0168", // Variable is declared but never used
+                "0219"  // Variable is assigned but its value is never used
+            };
+
+            // Path to the Assets folder
+            string assetsPath = Application.dataPath;
+            string filePath = Path.Combine(assetsPath, "csc.rsp");
+
+            try
+            {
+                using (StreamWriter writer = new StreamWriter(filePath))
+                {
+                    foreach (string warning in warningsToIgnore)
+                    {
+                        writer.WriteLine($"-nowarn:{warning}");
+                    }
+                }
+
+                Debug.Log($"Successfully generated csc.rsp file at: {filePath}");
+                Debug.Log($"Added {warningsToIgnore.Length} warning suppressions to the file.");
+            }
+            catch (System.Exception ex)
+            {
+                Debug.LogError($"Failed to generate csc.rsp file: {ex.Message}");
+            }
         }
 
         private static void WriteReleaseStoreToBuildData(string installSource)

--- a/Explorer/Assets/Editor/CloudBuild.cs
+++ b/Explorer/Assets/Editor/CloudBuild.cs
@@ -31,11 +31,11 @@ namespace Editor
             // Debug.Log(Parameters["TEST_VALUE"] as string);
             //
 
+            GenerateIgnoreWarningsFile();
+
             //Unity suggestion: 1793168
             //This should ensure that the roslyn compiler has been run and everything is generated as needed.
             EditorApplication.ExecuteMenuItem("File/Save Project");
-
-            GenerateIgnoreWarningsFile();
 
             // Set version for this build
             var buildVersion = Parameters["BUILD_VERSION"] as string;
@@ -111,6 +111,9 @@ namespace Editor
 
                 Debug.Log($"Successfully generated csc.rsp file at: {filePath}");
                 Debug.Log($"Added {warningsToIgnore.Length} warning suppressions to the file.");
+
+                // Force a refresh
+                AssetDatabase.Refresh();
             }
             catch (System.Exception ex)
             {

--- a/Explorer/Assets/Editor/CloudBuild.cs
+++ b/Explorer/Assets/Editor/CloudBuild.cs
@@ -92,7 +92,8 @@ namespace Editor
                 "0649", // Field is never assigned to, and will always have its default value
                 "0414", // Field is assigned but its value is never used
                 "0168", // Variable is declared but never used
-                "0219"  // Variable is assigned but its value is never used
+                "0219", // Variable is assigned but its value is never used
+                "8632"  // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
             };
 
             // Path to the Assets folder


### PR DESCRIPTION
# Pull Request Description
Add csc.rsp generation for Unity Cloud Build warning suppression

## Overview
This PR introduces a function to generate a `csc.rsp` file that suppresses specific compiler warnings during Unity Cloud Build processes. The file is only generated and used in cloud build environments to prevent build failures from non-critical warnings.

## Changes
- Added `GenerateIgnoreWarningsFile()` function to create `csc.rsp` in Assets root
- Configured suppression for common nullable reference type warnings (8618, 8625, 8602, etc.)
- Included suppression for unused variable/field warnings (0649, 0414, 0168, 0219)
- Added error handling and logging for successful/failed file generation

## Why This Change?
Too many unnessecary Unity Cloud Build warnings can clutter our ability to diagnose any failures quickly, this was mainly introduced after we enabled nullables. By generating a `csc.rsp` file, we can suppress these warnings specifically in the cloud build environment while keeping local development builds clean and warning-free.

## Target Environment
- **Unity Cloud Build ONLY** - this suppression is not intended for local development
- Local developers should continue to see and address warnings during development