### PR TITLE
chore: remove additional scene origin

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
@@ -169,17 +169,10 @@ namespace DCL.Diagnostics.Sentry
                 // Add local scope
 
                 AddCategoryTag(scope, reportData);
-                AddSceneInfo(scope, reportData);
             }
 
             private static void AddCategoryTag(Scope scope, ReportData data) =>
                 scope.SetTag("category", data.Category);
-
-            private static void AddSceneInfo(Scope scope, ReportData data)
-            {
-                scope.SetTag("scene.base_parcel", data.SceneShortInfo.BaseParcel.ToString());
-                scope.SetTag("scene.name", data.SceneShortInfo.Name);
-            }
 
             internal class Pool : ThreadSafeObjectPool<PerReportScope>
             {


### PR DESCRIPTION
# Pull Request Description
Sentry was displaying two scene origins, one was wrong. I removed the invalid one.