### PR TITLE
fix: teleport position validation

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/TeleportPositionCalculationSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/TeleportPositionCalculationSystem.cs
@@ -39,17 +39,24 @@ namespace DCL.Character.CharacterMotion.Systems
         {
             if (teleportIntent.IsPositionSet) return;
 
-            if (teleportIntent.SceneDef == null)
+            SceneEntityDefinition? sceneDef = teleportIntent.SceneDef;
+            Vector2Int parcel = teleportIntent.Parcel;
+
+            if (sceneDef == null)
             {
-                teleportIntent.Position = ParcelMathHelper.GetPositionByParcelPosition(teleportIntent.Parcel).WithErrorCompensation().WithTerrainOffset();
+                teleportIntent.Position = ParcelMathHelper.GetPositionByParcelPosition(parcel).WithErrorCompensation().WithTerrainOffset();
             }
-            else if (TeleportUtils.IsTramLine(teleportIntent.SceneDef.metadata.OriginalJson.AsSpan()))
+            else if (TeleportUtils.IsTramLine(sceneDef.metadata.OriginalJson.AsSpan()))
             {
-                teleportIntent.Position = ParcelMathHelper.GetPositionByParcelPosition(teleportIntent.Parcel).WithErrorCompensation();
+                teleportIntent.Position = ParcelMathHelper.GetPositionByParcelPosition(parcel).WithErrorCompensation();
             }
             else
             {
-                (Vector3 targetWorldPosition, Vector3? cameraTarget) = PickTargetWithOffset(teleportIntent.SceneDef, teleportIntent.Parcel);
+                (Vector3 targetWorldPosition, Vector3? cameraTarget) = PickTargetWithOffset(sceneDef, parcel);
+
+                var originalTargetPosition = targetWorldPosition;
+                if (!ValidateTeleportPosition(ref targetWorldPosition, parcel, sceneDef))
+                    Debug.LogError($"Invalid teleport position: {originalTargetPosition}. Adjusted to: {targetWorldPosition}");
 
                 teleportIntent.Position = targetWorldPosition;
 
@@ -61,6 +68,19 @@ namespace DCL.Character.CharacterMotion.Systems
             }
 
             teleportIntent.IsPositionSet = true;
+        }
+
+        private bool ValidateTeleportPosition(ref Vector3 targetPosition, Vector2Int targetParcel, SceneEntityDefinition sceneDefinition)
+        {
+            IReadOnlyList<Vector2Int> sceneParcels = sceneDefinition.metadata.scene.DecodedParcels;
+
+            foreach (var sceneParcel in sceneParcels)
+                if (ParcelMathHelper.CalculateCorners(sceneParcel).Contains(targetPosition))
+                    return true;
+
+            // Invalid position, use the target parcel to compute a valid one
+            targetPosition = ParcelMathHelper.GetPositionByParcelPosition(targetParcel).WithErrorCompensation();
+            return false;
         }
 
         private static (Vector3 targetWorldPosition, Vector3? cameraTarget) PickTargetWithOffset(SceneEntityDefinition? sceneDef, Vector2Int parcel)

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ParcelMathHelper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ParcelMathHelper.cs
@@ -104,6 +104,11 @@ namespace Utility
             return new ParcelCorners(min, min + new Vector3(0, 0, PARCEL_SIZE), min + new Vector3(PARCEL_SIZE, 0, PARCEL_SIZE), min + new Vector3(PARCEL_SIZE, 0, 0));
         }
 
+        public static bool Contains(this ParcelCorners corners, Vector3 position)
+        {
+            return position.x >= corners.minXZ.x && position.x < corners.maxXZ.x &&
+                   position.z >= corners.minXZ.z && position.z < corners.maxXZ.z;
+        }
 
         public static void ParcelsInRange(Vector3 position, int loadRadius, HashSet<int2> results)
         {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix for [#4342](https://github.com/decentraland/unity-explorer/issues/4342).

The issue with that scene is that it has a spawn point that offsets the teleport target position to a place outside of the scene. This seems to break the loading process.

To fix such cases validation logic for the target position was added. Now the target position is adjusted to always be within the scene as expected.

## Test Instructions
Should verify that teleporting `/goto` to `-150,85` and `-150,86` works correctly.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included
