### PR TITLE
fix: scenes ui rendering order breaks on scene reload

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Components/UITransformComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Components/UITransformComponent.cs
@@ -39,7 +39,7 @@ namespace DCL.SDKComponents.SceneUI.Components
             this.rootTransform ??= root;
             IsHidden = false;
             PointerEventTriggered = null;
-
+            ZIndex = null;
             RelationData.parent = Entity.Null;
             RelationData.rightOf = 0;
             IsRoot = true;
@@ -52,7 +52,7 @@ namespace DCL.SDKComponents.SceneUI.Components
             IsHidden = false;
             IsRoot = false;
             PointerEventTriggered = null;
-
+            ZIndex = null;
             RelationData.parent = Entity.Null;
             RelationData.rightOf = rightOf;
         }
@@ -69,7 +69,6 @@ namespace DCL.SDKComponents.SceneUI.Components
             int i = 0;
             for (UITransformRelationLinkedData.Node node = RelationData.head; node != null; node = node.Next)
             {
-                //Entity child = node.EntityId;
                 var childEntityId = node.EntityId;
 
                 if (entitiesMap.TryGetValue(childEntityId, out var child))


### PR DESCRIPTION
### WHY

With [the recent introduction](https://github.com/decentraland/unity-explorer/pull/4366) of `ZIndex` property in the `UiTransform` SDK component, when the property is set, it never gets cleaned up when the `UiTransform` gets re-used and re-initialized...

That makes scenes UI completely break their rendering order whne they get re-loaded (or walking away and returning, since that unloads and re-loads the scene) because the `ZIndex` property of different previously loaded `UiTransform` entities now gets assigned to the new entities...

Fixes: #4548

### WHAT

Added missing ZIndex property initialization.

### TEST INSTRUCTIONS