### PR TITLE
hotfix: Open Marketplace Credits panel by default for users that didn't start the program

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -933,7 +933,8 @@ namespace Global.Dynamic
                     mvcManager,
                     notificationsBusController,
                     staticContainer.RealmData,
-                    sharedSpaceManager));
+                    sharedSpaceManager,
+                    identityCache));
             }
 
             if (dynamicWorldParams.EnableAnalytics)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -934,7 +934,8 @@ namespace Global.Dynamic
                     notificationsBusController,
                     staticContainer.RealmData,
                     sharedSpaceManager,
-                    identityCache));
+                    identityCache,
+                    staticContainer.LoadingStatus));
             }
 
             if (dynamicWorldParams.EnableAnalytics)

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCredits.asmdef
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCredits.asmdef
@@ -24,7 +24,9 @@
         "GUID:ace653ac543d483ba8abee112a3ba2a6",
         "GUID:5ab29fa8ae5769b49ab29e390caca7a4",
         "GUID:28964ef7dc9441b6b8671b61a8106690",
-        "GUID:0401f68d61b24c63a3abf51e27bb46f1"
+        "GUID:0401f68d61b24c63a3abf51e27bb46f1",
+        "GUID:f3634757d00dab2429c6c11e69404e97",
+        "GUID:166b65e6dfc848bb9fb075f53c293a38"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCredits.asmdef
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCredits.asmdef
@@ -21,7 +21,10 @@
         "GUID:26b8f796ecc6b4a2ab621c9a7e70fd11",
         "GUID:e0eedfa2deb9406daf86fd8368728e39",
         "GUID:bd6eca6559a7438f86a272185d5bc54b",
-        "GUID:ace653ac543d483ba8abee112a3ba2a6"
+        "GUID:ace653ac543d483ba8abee112a3ba2a6",
+        "GUID:5ab29fa8ae5769b49ab29e390caca7a4",
+        "GUID:28964ef7dc9441b6b8671b61a8106690",
+        "GUID:0401f68d61b24c63a3abf51e27bb46f1"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
@@ -324,9 +324,12 @@ namespace DCL.MarketplaceCredits
                 var creditsProgramProgressResponse = await marketplaceCreditsAPIClient.GetProgramProgressAsync(ownProfile.UserId, ct);
                 SetSidebarButtonState(creditsProgramProgressResponse);
 
-                // Open the Marketplace Credits panel by default when the user has completed the tutorial stage
-                await UniTask.WaitUntil(() => ownProfile.TutorialStep == TUTORIAL_STEP_DONE_MARK, cancellationToken: ct);
-                await sharedSpaceManager.ShowAsync(PanelsSharingSpace.MarketplaceCredits, new Params(isOpenedFromNotification: false));
+                if (!creditsProgramProgressResponse.HasUserStartedProgram())
+                {
+                    // Open the Marketplace Credits panel by default when the user didn't start the program. It will await for the new users to complete the tutorial stage.
+                    await UniTask.WaitUntil(() => ownProfile.TutorialStep == TUTORIAL_STEP_DONE_MARK, cancellationToken: ct);
+                    await sharedSpaceManager.ShowAsync(PanelsSharingSpace.MarketplaceCredits, new Params(isOpenedFromNotification: false));
+                }
             }
             catch (OperationCanceledException) { }
             catch (Exception e)

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
@@ -26,6 +26,7 @@ namespace DCL.MarketplaceCredits
     {
         public const string WEEKLY_REWARDS_INFO_LINK = "https://decentraland.org/blog/announcements/marketplace-credits-earn-weekly-rewards-to-power-up-your-look?utm_org=dcl&utm_source=explorer&utm_medium=organic&utm_campaign=marketplacecredits";
         private const int ERROR_NOTIFICATION_DURATION_MS = 3000;
+        private const int TUTORIAL_STEP_DONE_MARK = 256;
 
         public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Popup;
 
@@ -184,6 +185,7 @@ namespace DCL.MarketplaceCredits
                 case MarketplaceCreditsSection.WELCOME:
                     viewInstance.SetInfoLinkButtonActive(false);
                     marketplaceCreditsWelcomeSubController?.OpenSection();
+                    viewInstance.TotalCreditsWidget.gameObject.SetActive(false);
                     break;
                 case MarketplaceCreditsSection.VERIFY_EMAIL:
                     haveJustClaimedCredits = false;
@@ -321,6 +323,10 @@ namespace DCL.MarketplaceCredits
 
                 var creditsProgramProgressResponse = await marketplaceCreditsAPIClient.GetProgramProgressAsync(ownProfile.UserId, ct);
                 SetSidebarButtonState(creditsProgramProgressResponse);
+
+                // Open the Marketplace Credits panel by default when the user has completed the tutorial stage
+                await UniTask.WaitUntil(() => ownProfile.TutorialStep == TUTORIAL_STEP_DONE_MARK, cancellationToken: ct);
+                await sharedSpaceManager.ShowAsync(PanelsSharingSpace.MarketplaceCredits, new Params(isOpenedFromNotification: false));
             }
             catch (OperationCanceledException) { }
             catch (Exception e)

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
@@ -26,7 +26,6 @@ namespace DCL.MarketplaceCredits
     {
         public const string WEEKLY_REWARDS_INFO_LINK = "https://decentraland.org/blog/announcements/marketplace-credits-earn-weekly-rewards-to-power-up-your-look?utm_org=dcl&utm_source=explorer&utm_medium=organic&utm_campaign=marketplacecredits";
         private const int ERROR_NOTIFICATION_DURATION_MS = 3000;
-        private const int TUTORIAL_STEP_DONE_MARK = 256;
 
         public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Popup;
 
@@ -326,8 +325,8 @@ namespace DCL.MarketplaceCredits
 
                 if (!creditsProgramProgressResponse.HasUserStartedProgram())
                 {
-                    // Open the Marketplace Credits panel by default when the user didn't start the program. It will await for the new users to complete the tutorial stage.
-                    await UniTask.WaitUntil(() => ownProfile.TutorialStep == TUTORIAL_STEP_DONE_MARK, cancellationToken: ct);
+                    // Open the Marketplace Credits panel by default when the user didn't start the program and has landed in Genesis City.
+                    await UniTask.WaitUntil(() => realmData.IsGenesis(), cancellationToken: ct);
                     await sharedSpaceManager.ShowAsync(PanelsSharingSpace.MarketplaceCredits, new Params(isOpenedFromNotification: false));
                 }
             }

--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsWelcomeSubController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsWelcomeSubController.cs
@@ -207,6 +207,7 @@ namespace DCL.MarketplaceCredits.Sections
             {
                 subView.IsEmailLoginActive = true;
                 inputBlock.Disable(InputMapComponent.BLOCK_USER_INPUT);
+                totalCreditsWidgetView.gameObject.SetActive(false);
                 return;
             }
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/MarketplaceCreditsPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/MarketplaceCreditsPlugin.cs
@@ -2,7 +2,6 @@ using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
 using DCL.Browser;
-using DCL.FeatureFlags;
 using DCL.Input;
 using DCL.MarketplaceCredits;
 using DCL.MarketplaceCreditsAPIService;
@@ -11,6 +10,7 @@ using DCL.NotificationsBusController.NotificationsBus;
 using DCL.Profiles.Self;
 using DCL.UI.MainUI;
 using DCL.UI.SharedSpaceManager;
+using DCL.Web3.Identities;
 using DCL.WebRequests;
 using ECS;
 using MVC;
@@ -33,6 +33,7 @@ namespace DCL.PluginSystem.Global
         private readonly INotificationsBusController notificationBusController;
         private readonly IRealmData realmData;
         private readonly ISharedSpaceManager sharedSpaceManager;
+        private readonly IWeb3IdentityCache web3IdentityCache;
 
         private MarketplaceCreditsMenuController? marketplaceCreditsMenuController;
         private CreditsUnlockedController? creditsUnlockedController;
@@ -48,7 +49,8 @@ namespace DCL.PluginSystem.Global
             IMVCManager mvcManager,
             INotificationsBusController notificationBusController,
             IRealmData realmData,
-            ISharedSpaceManager sharedSpaceManager)
+            ISharedSpaceManager sharedSpaceManager,
+            IWeb3IdentityCache web3IdentityCache)
         {
             this.mainUIView = mainUIView;
             this.assetsProvisioner = assetsProvisioner;
@@ -60,6 +62,7 @@ namespace DCL.PluginSystem.Global
             this.notificationBusController = notificationBusController;
             this.realmData = realmData;
             this.sharedSpaceManager = sharedSpaceManager;
+            this.web3IdentityCache = web3IdentityCache;
 
             marketplaceCreditsAPIClient = new MarketplaceCreditsAPIClient(webRequestController, decentralandUrlsSource);
         }
@@ -91,7 +94,8 @@ namespace DCL.PluginSystem.Global
                 mainUIView.SidebarView.marketplaceCreditsButtonAnimator,
                 mainUIView.SidebarView.marketplaceCreditsButtonAlertMark,
                 realmData,
-                sharedSpaceManager);
+                sharedSpaceManager,
+                web3IdentityCache);
 
             sharedSpaceManager.RegisterPanel(PanelsSharingSpace.MarketplaceCredits, marketplaceCreditsMenuController);
             mvcManager.RegisterController(marketplaceCreditsMenuController);

--- a/Explorer/Assets/DCL/PluginSystem/Global/MarketplaceCreditsPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/MarketplaceCreditsPlugin.cs
@@ -8,6 +8,7 @@ using DCL.MarketplaceCreditsAPIService;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.NotificationsBusController.NotificationsBus;
 using DCL.Profiles.Self;
+using DCL.RealmNavigation;
 using DCL.UI.MainUI;
 using DCL.UI.SharedSpaceManager;
 using DCL.Web3.Identities;
@@ -34,6 +35,7 @@ namespace DCL.PluginSystem.Global
         private readonly IRealmData realmData;
         private readonly ISharedSpaceManager sharedSpaceManager;
         private readonly IWeb3IdentityCache web3IdentityCache;
+        private readonly ILoadingStatus loadingStatus;
 
         private MarketplaceCreditsMenuController? marketplaceCreditsMenuController;
         private CreditsUnlockedController? creditsUnlockedController;
@@ -50,7 +52,8 @@ namespace DCL.PluginSystem.Global
             INotificationsBusController notificationBusController,
             IRealmData realmData,
             ISharedSpaceManager sharedSpaceManager,
-            IWeb3IdentityCache web3IdentityCache)
+            IWeb3IdentityCache web3IdentityCache,
+            ILoadingStatus loadingStatus)
         {
             this.mainUIView = mainUIView;
             this.assetsProvisioner = assetsProvisioner;
@@ -63,6 +66,7 @@ namespace DCL.PluginSystem.Global
             this.realmData = realmData;
             this.sharedSpaceManager = sharedSpaceManager;
             this.web3IdentityCache = web3IdentityCache;
+            this.loadingStatus = loadingStatus;
 
             marketplaceCreditsAPIClient = new MarketplaceCreditsAPIClient(webRequestController, decentralandUrlsSource);
         }
@@ -95,7 +99,8 @@ namespace DCL.PluginSystem.Global
                 mainUIView.SidebarView.marketplaceCreditsButtonAlertMark,
                 realmData,
                 sharedSpaceManager,
-                web3IdentityCache);
+                web3IdentityCache,
+                loadingStatus);
 
             sharedSpaceManager.RegisterPanel(PanelsSharingSpace.MarketplaceCredits, marketplaceCreditsMenuController);
             mvcManager.RegisterController(marketplaceCreditsMenuController);


### PR DESCRIPTION
# Pull Request Description
Fix #4540 

## What does this PR change?
In order to boost the users participation in the **Marketplace Credits** program and give it more visibility, this PR makes the main panel to be opened by default when the users that didn't start the program enter the world (without counting the tutorial stage).

### Test Steps
## Scenario 1: Existing users that didn't start the program
1. Enter Decentraland with an already existing user (a wallet that already did the onboarding tutorial in the past) that never started the Marketplace Program.
2. Wait for the loading screen finishes.
3. Once your avatar appears in the world, check that the Marketplace Credits panel is opened automatically.

## Scenario 2: Existing users that started the program
1. Enter Decentraland with an already existing user (a wallet that already did the onboarding tutorial in the past) that already started the Marketplace Program.
2. Wait for the loading screen finishes.
3. Once your avatar appears in the world, check that the Marketplace Credits panel is NOT opened automatically.

## Scenario 3: New users
1. Enter Decentraland with a new user (a wallet that never did the onboarding tutorial in the past).
2. Wait for the loading screen finishes.
3. Once your avatar appears in the onboarding tutorial scene, check that the Marketplace Credits panel is NOT opened automatically.
5. Complete the tutorial (or skip it).
6. Wait for the loading screen finishes.
7. Once your avatar appears in the world, check that the Marketplace Credits panel is opened automatically.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.