### PR TITLE
Feat/add set public button to photo view

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelController.cs
@@ -57,8 +57,10 @@ namespace DCL.InWorldCamera.CameraReelGallery
             //TODO (Lorenzo): Close gallery and open camera
         }
 
-        private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index, Action<CameraReelResponseCompact> reelDeleteIntention) =>
-            mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index, true, reelDeleteIntention)));
+        private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index, 
+            Action<CameraReelResponseCompact> reelDeleteIntention, Action<CameraReelResponseCompact> reelListRefreshIntention) =>
+            mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index, 
+                false, reelDeleteIntention, reelListRefreshIntention)));
 
         private void StorageFullIconEnter() =>
             view.storageFullToast.DOFade(1f, view.storageFullToastFadeTime);

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
@@ -177,10 +177,12 @@ namespace DCL.PluginSystem.Global
                     profileRepositoryWrapper
                     ),
                 cameraReelScreenshotsStorage,
+                cameraReelStorageService,
                 systemClipboard,
                 decentralandUrlsSource,
                 webBrowser,
-                new PhotoDetailStringMessages(settings.ShareToXMessage, settings.PhotoSuccessfullyDownloadedMessage, settings.LinkCopiedMessage)));
+                new PhotoDetailStringMessages(settings.ShareToXMessage, settings.PhotoSuccessfullyDownloadedMessage,
+                    settings.PhotoSuccessfullySetAsPublicMessage, settings.LinkCopiedMessage)));
 
 
             inWorldCameraController = new InWorldCameraController(() => hud.GetComponent<InWorldCameraView>(), sidebarButton, globalWorld, mvcManager, cameraReelStorageService, sharedSpaceManager);
@@ -220,6 +222,7 @@ namespace DCL.PluginSystem.Global
             [field: SerializeField] internal AssetReferenceGameObject PhotoDetailPrefab { get; private set; }
             [field: SerializeField, Tooltip("Spaces will be HTTP sanitized, care for special characters")] internal string ShareToXMessage { get; private set; }
             [field: SerializeField] internal string PhotoSuccessfullyDownloadedMessage { get; private set; }
+            [field: SerializeField] internal string PhotoSuccessfullySetAsPublicMessage { get; private set; }
             [field: SerializeField] internal string LinkCopiedMessage { get; private set; }
             [field: SerializeField] internal AssetReferenceT<NftTypeIconSO> CategoryIconsMapping { get; private set; }
 

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
@@ -171,6 +171,7 @@ namespace DCL.PluginSystem.Global
                     decentralandUrlsSource,
                     new ECSThumbnailProvider(realmData, globalWorld, assetBundleURL, webRequestController),
                     new PassportBridgeOpener(),
+                    web3IdentityCache,
                     rarityBackgroundsMapping,
                     rarityColorMappings,
                     categoryIconsMapping,

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetail.asmdef
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetail.asmdef
@@ -27,7 +27,9 @@
         "GUID:ff38b7506167d314d987b4b8e8406988",
         "GUID:52421c42d33594c47a6fbd48b45b1259",
         "GUID:9cce9838ccdc58d46b673e02f1058718",
-        "GUID:d5368878df29ff849933a7d3586d18c6"
+        "GUID:d5368878df29ff849933a7d3586d18c6",
+        "GUID:ca4e81cdd6a34d1aa54c32ad41fc5b3b",
+        "GUID:5ab29fa8ae5769b49ab29e390caca7a4"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailController.cs
@@ -270,6 +270,7 @@ namespace DCL.InWorldCamera.PhotoDetail
             viewInstance!.mainImageCanvasGroup.alpha = 0;
             viewInstance.mainImageLoadingSpinner.gameObject.SetActive(true);
             viewInstance!.setAsPublicToggle.gameObject.SetActive(false);
+            viewInstance!.leftSeparator.gameObject.SetActive(false);
             viewInstance!.deleteButton.gameObject.SetActive(false);
 
             if (viewInstance.mainImage.texture != null)
@@ -287,12 +288,14 @@ namespace DCL.InWorldCamera.PhotoDetail
             viewInstance.mainImageCanvasGroup.DOFade(1, viewInstance.imageFadeInDuration);
 
             await detailInfoTask;
-            
+
+            bool isUserOwned = PhotoDetailInfoController.IsReelUserOwned;
             viewInstance!.setAsPublicToggle.Toggle.onValueChanged.RemoveListener(SetPublicFlag);
             viewInstance!.setAsPublicToggle.SetToggle(inputData.AllReels[currentReelIndex].isPublic);
             viewInstance!.setAsPublicToggle.Toggle.onValueChanged.AddListener(SetPublicFlag);
-            viewInstance!.setAsPublicToggle.gameObject.SetActive(PhotoDetailInfoController.IsReelUserOwned);
-            viewInstance!.deleteButton.gameObject.SetActive(PhotoDetailInfoController.IsReelUserOwned);
+            viewInstance!.setAsPublicToggle.gameObject.SetActive(isUserOwned);
+            viewInstance!.leftSeparator.gameObject.SetActive(isUserOwned);
+            viewInstance!.deleteButton.gameObject.SetActive(isUserOwned);
         }
 
         private void CheckNavigationButtonVisibility(List<CameraReelResponseCompact> allReels, int index)

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailInfoController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailInfoController.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
+using DCL.Web3.Identities;
 using UnityEngine;
 using Utility;
 
@@ -39,8 +40,11 @@ namespace DCL.InWorldCamera.PhotoDetail
         private readonly IRealmNavigator realmNavigator;
         private readonly IMVCManager mvcManager;
         private readonly IPassportBridge passportBridge;
+        private readonly IWeb3IdentityCache web3IdentityCache;
         private readonly PhotoDetailPoolManager photoDetailPoolManager;
         private readonly List<VisiblePersonController> visiblePersonControllers = new ();
+
+        public bool IsReelUserOwned => reelOwnerAddress == web3IdentityCache.Identity?.Address;
 
         private Vector2Int screenshotParcel = Vector2Int.zero;
         private string reelOwnerAddress;
@@ -59,6 +63,7 @@ namespace DCL.InWorldCamera.PhotoDetail
             IDecentralandUrlsSource decentralandUrlsSource,
             IThumbnailProvider thumbnailProvider,
             IPassportBridge passportBridge,
+            IWeb3IdentityCache web3IdentityCache,
             NftTypeIconSO rarityBackgrounds,
             NFTColorsSO rarityColors,
             NftTypeIconSO categoryIcons,
@@ -69,6 +74,7 @@ namespace DCL.InWorldCamera.PhotoDetail
             this.realmNavigator = realmNavigator;
             this.mvcManager = mvcManager;
             this.passportBridge = passportBridge;
+            this.web3IdentityCache = web3IdentityCache;
 
             this.photoDetailPoolManager = new PhotoDetailPoolManager(view.visiblePersonViewPrefab,
                 view.equippedWearablePrefab,

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailParameter.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailParameter.cs
@@ -13,20 +13,28 @@ namespace DCL.InWorldCamera.PhotoDetail
         public readonly List<CameraReelResponseCompact> AllReels;
         //Index of the current reel
         public readonly int CurrentReelIndex;
-        //If the reels are owned by the user (e.g. they are not if you are seeing a reel from another user's passport)
-        public readonly bool UserOwnedReels;
+        //If the PhotoDetailUI was opened from a panel, that contains reels from other users. (Used to hide functionality)
+        public readonly bool OpenedFromPublicBoard;
         //Action to execute when the user wants to delete a reel (only if UserOwnedReels is true, otherwise an error will be returned by the backend)
         public event Action<CameraReelResponseCompact> ReelDeleteIntention;
+        //Hides reel from list, used when reel is displayed from passport view, and user sets reel to private, which
+        //is not displayed in passport gallery.
+        public event Action<CameraReelResponseCompact> HideReelFromListIntention;
 
-        public PhotoDetailParameter(List<CameraReelResponseCompact> allReels, int currentReelIndex, bool userOwnedReels, Action<CameraReelResponseCompact> reelDeleteAction)
+        public PhotoDetailParameter(List<CameraReelResponseCompact> allReels, int currentReelIndex, bool openedFromPublicBoard, 
+            Action<CameraReelResponseCompact> reelDeleteAction, Action<CameraReelResponseCompact> hideReelFromListIntention)
         {
             this.AllReels = allReels;
             this.CurrentReelIndex = currentReelIndex;
-            this.UserOwnedReels = userOwnedReels;
+            this.OpenedFromPublicBoard = openedFromPublicBoard;
             ReelDeleteIntention = reelDeleteAction;
+            HideReelFromListIntention = hideReelFromListIntention;
         }
 
         public void ExecuteDeleteAction(int index) =>
             ReelDeleteIntention?.Invoke(AllReels[index]);
+        
+        public void ExecuteHideReelFromListAction(int index) =>
+            HideReelFromListIntention?.Invoke(AllReels[index]);
     }
 }

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailView.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailView.cs
@@ -1,4 +1,5 @@
 using DCL.InWorldCamera.CameraReelToast;
+using DCL.UI;
 using MVC;
 using UnityEngine;
 using UnityEngine.UI;
@@ -21,6 +22,8 @@ namespace DCL.InWorldCamera.PhotoDetail
         [field: SerializeField] internal Button nextScreenshotButton { get; private set; }
 
         [field: Header("Actions panel")]
+        [field: SerializeField] internal Toggle publicToggle { get; private set; }
+        [field: SerializeField] internal ToggleView publicToggleView { get; private set; }
         [field: SerializeField] internal Button downloadButton { get; private set; }
         [field: SerializeField] internal Button deleteButton { get; private set; }
         [field: SerializeField] internal Button linkButton { get; private set; }

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailView.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailView.cs
@@ -22,8 +22,7 @@ namespace DCL.InWorldCamera.PhotoDetail
         [field: SerializeField] internal Button nextScreenshotButton { get; private set; }
 
         [field: Header("Actions panel")]
-        [field: SerializeField] internal Toggle publicToggle { get; private set; }
-        [field: SerializeField] internal ToggleView publicToggleView { get; private set; }
+        [field: SerializeField] internal ToggleWithTextView setAsPublicToggle { get; private set; }
         [field: SerializeField] internal Button downloadButton { get; private set; }
         [field: SerializeField] internal Button deleteButton { get; private set; }
         [field: SerializeField] internal Button linkButton { get; private set; }

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailView.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailView.cs
@@ -23,6 +23,7 @@ namespace DCL.InWorldCamera.PhotoDetail
 
         [field: Header("Actions panel")]
         [field: SerializeField] internal ToggleWithTextView setAsPublicToggle { get; private set; }
+        [field: SerializeField] internal RectTransform leftSeparator { get; private set; }
         [field: SerializeField] internal Button downloadButton { get; private set; }
         [field: SerializeField] internal Button deleteButton { get; private set; }
         [field: SerializeField] internal Button linkButton { get; private set; }

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/PhotoDetailUI.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/PhotoDetailUI.prefab
@@ -1,5 +1,71 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &464714534217328724
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 146340637411226168}
+  - component: {fileID: 6665781873777815552}
+  - component: {fileID: 2141843944113283653}
+  m_Layer: 5
+  m_Name: Separator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &146340637411226168
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464714534217328724}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2830297337055973705}
+  m_Father: {fileID: 5967177127723827522}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 30, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &6665781873777815552
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464714534217328724}
+  m_CullTransparentMesh: 1
+--- !u!114 &2141843944113283653
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464714534217328724}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: 30
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &1035579902756151757
 GameObject:
   m_ObjectHideFlags: 0
@@ -1229,6 +1295,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1797150160234841855}
+  - {fileID: 146340637411226168}
   - {fileID: 9152000481032343973}
   - {fileID: 2676025058752407588}
   - {fileID: 8909279516271577528}
@@ -1726,6 +1794,81 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &5587339117075946835
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2830297337055973705}
+  - component: {fileID: 3123264219333545535}
+  - component: {fileID: 7181739195491615322}
+  m_Layer: 5
+  m_Name: Graphics
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2830297337055973705
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5587339117075946835}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 146340637411226168}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.0000009536743, y: 0}
+  m_SizeDelta: {x: 1, y: 24}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3123264219333545535
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5587339117075946835}
+  m_CullTransparentMesh: 1
+--- !u!114 &7181739195491615322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5587339117075946835}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.101960786}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6253107035242712773
 GameObject:
   m_ObjectHideFlags: 0
@@ -3020,9 +3163,12 @@ MonoBehaviour:
   <mainImageCanvasGroup>k__BackingField: {fileID: 1334348678107638751}
   <mainImageLoadingSpinner>k__BackingField: {fileID: 2635738037032744515}
   <cameraReelToastMessage>k__BackingField: {fileID: 5397767913691116859}
+  <publicToggle>k__BackingField: {fileID: 5918471616511514239}
+  <publicToggleView>k__BackingField: {fileID: 3925348598504204046}
   <closeButton>k__BackingField: {fileID: 8272827282084343181}
   <previousScreenshotButton>k__BackingField: {fileID: 4174928257314461076}
   <nextScreenshotButton>k__BackingField: {fileID: 7911290084806989879}
+  <publicToggleText>k__BackingField: 
   <downloadButton>k__BackingField: {fileID: 3557052328246332746}
   <deleteButton>k__BackingField: {fileID: 3843227689883949517}
   <linkButton>k__BackingField: {fileID: 8059763448884128982}
@@ -3229,7 +3375,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7153544815187403164}
   m_HandleRect: {fileID: 1973156823025283239}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -3625,6 +3771,186 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 8797775191845768574, guid: 6a180d50880b443b4b6239fdc4eb88c5, type: 3}
   m_PrefabInstance: {fileID: 1118576381656504551}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1129243475615584718
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5967177127723827522}
+    m_Modifications:
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2938718002221827054, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_text
+      value: Set as Public
+      objectReference: {fileID: 0}
+    - target: {fileID: 2965888496743192953, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_Spacing
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2965888496743192953, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_Padding.m_Left
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7989221792673684171, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7989221792673684171, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7989221792673684171, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7989221792673684171, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7989221792673684171, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8057678888699711851, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_Name
+      value: ToggleWithText
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683627804299419299, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683627804299419299, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683627804299419299, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683627804299419299, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 26
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683627804299419299, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8683627804299419299, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+--- !u!224 &1797150160234841855 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+  m_PrefabInstance: {fileID: 1129243475615584718}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3925348598504204046 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4166466502424606400, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+  m_PrefabInstance: {fileID: 1129243475615584718}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 822ef88491b0c4b3982153e7574be1fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5918471616511514239 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6739991326136731569, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+  m_PrefabInstance: {fileID: 1129243475615584718}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1235438315300981597
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3633,6 +3959,82 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 167780619579560475}
     m_Modifications:
+    - target: {fileID: 1613251353603609339, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1613251353603609339, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1613251353603609339, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1613251353603609339, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1613251353603609339, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1863089799025834328, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1863089799025834328, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1863089799025834328, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1863089799025834328, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967787221647975183, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967787221647975183, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967787221647975183, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967787221647975183, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967787221647975183, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2994809827674191325, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2994809827674191325, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2994809827674191325, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2994809827674191325, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2994809827674191325, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3818669314171149728, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -3654,6 +4056,50 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4298821328858515220, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4380587157812278686, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4380587157812278686, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4380587157812278686, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4380587157812278686, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4380587157812278686, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4644907115840231941, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4644907115840231941, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4644907115840231941, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4644907115840231941, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4644907115840231941, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5701802129777246385, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
@@ -3798,6 +4244,26 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7452968672632771285, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8620269320281344089, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8620269320281344089, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8620269320281344089, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8620269320281344089, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8620269320281344089, guid: d3c7651cfc8ca4aa5a94d5502e133d78, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/PhotoDetailUI.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/PhotoDetailUI.prefab
@@ -3167,6 +3167,7 @@ MonoBehaviour:
   <previousScreenshotButton>k__BackingField: {fileID: 4174928257314461076}
   <nextScreenshotButton>k__BackingField: {fileID: 7911290084806989879}
   <setAsPublicToggle>k__BackingField: {fileID: 3130503048021005829}
+  <leftSeparator>k__BackingField: {fileID: 146340637411226168}
   <downloadButton>k__BackingField: {fileID: 3557052328246332746}
   <deleteButton>k__BackingField: {fileID: 3843227689883949517}
   <linkButton>k__BackingField: {fileID: 8059763448884128982}

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/PhotoDetailUI.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/PhotoDetailUI.prefab
@@ -3163,12 +3163,10 @@ MonoBehaviour:
   <mainImageCanvasGroup>k__BackingField: {fileID: 1334348678107638751}
   <mainImageLoadingSpinner>k__BackingField: {fileID: 2635738037032744515}
   <cameraReelToastMessage>k__BackingField: {fileID: 5397767913691116859}
-  <publicToggle>k__BackingField: {fileID: 5918471616511514239}
-  <publicToggleView>k__BackingField: {fileID: 3925348598504204046}
   <closeButton>k__BackingField: {fileID: 8272827282084343181}
   <previousScreenshotButton>k__BackingField: {fileID: 4174928257314461076}
   <nextScreenshotButton>k__BackingField: {fileID: 7911290084806989879}
-  <publicToggleText>k__BackingField: 
+  <setAsPublicToggle>k__BackingField: {fileID: 3130503048021005829}
   <downloadButton>k__BackingField: {fileID: 3557052328246332746}
   <deleteButton>k__BackingField: {fileID: 3843227689883949517}
   <linkButton>k__BackingField: {fileID: 8059763448884128982}
@@ -3929,26 +3927,15 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 1682976792197666609, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
   m_PrefabInstance: {fileID: 1129243475615584718}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &3925348598504204046 stripped
+--- !u!114 &3130503048021005829 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4166466502424606400, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
+  m_CorrespondingSourceObject: {fileID: 2655477926760237003, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
   m_PrefabInstance: {fileID: 1129243475615584718}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 822ef88491b0c4b3982153e7574be1fa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &5918471616511514239 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6739991326136731569, guid: 42f993a26991889449d58dcf6a15c6f8, type: 3}
-  m_PrefabInstance: {fileID: 1129243475615584718}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Script: {fileID: 11500000, guid: 11cdf22c09c7e9848be751d287b3eb5d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1235438315300981597

--- a/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
@@ -130,8 +130,10 @@ namespace DCL.Navmap
             view.EventsTabContainer.GetComponent<ScrollRect>()?.SetScrollSensitivityBasedOnPlatform();
         }
 
-        private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index, Action<CameraReelResponseCompact> reelDeleteIntention) =>
-            mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index, false, reelDeleteIntention)));
+        private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index, 
+            Action<CameraReelResponseCompact> reelDeleteIntention,  Action<CameraReelResponseCompact> reelListRefreshIntention) =>
+            mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index,
+                true, reelDeleteIntention, reelListRefreshIntention)));
 
         private void UpdatePhotosTabText(int count) =>
             view.SetPhotoTabText(count);

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -224,8 +224,10 @@ namespace DCL.Passport
             userProfileContextMenuControlSettings = new UserProfileContextMenuControlSettings((_, _) => { });
         }
 
-        private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index, Action<CameraReelResponseCompact> reelDeleteIntention) =>
-            mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index, false, reelDeleteIntention)));
+        private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index, 
+            Action<CameraReelResponseCompact> reelDeleteIntention, Action<CameraReelResponseCompact> reelListRefreshIntention) =>
+            mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index, 
+                true, reelDeleteIntention, reelListRefreshIntention)));
 
         protected override void OnViewInstantiated()
         {

--- a/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
@@ -818,6 +818,8 @@ MonoBehaviour:
         <ShareToXMessage>k__BackingField: Check out what I'm doing in @decentraland
           right now and join me!
         <PhotoSuccessfullyDownloadedMessage>k__BackingField: Photo successfully downloaded
+        <PhotoSuccessfullySetAsPublicMessage>k__BackingField: Photo successfully
+          updated
         <LinkCopiedMessage>k__BackingField: Link copied!
         <CategoryIconsMapping>k__BackingField:
           m_AssetGUID: 4a2a7b610414b45c1b576946ce094877

--- a/Explorer/Assets/DCL/UI/Assets/ToggleWithText.prefab
+++ b/Explorer/Assets/DCL/UI/Assets/ToggleWithText.prefab
@@ -1,0 +1,356 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7414244993536315417
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8683627804299419299}
+  - component: {fileID: 3779327471833531041}
+  - component: {fileID: 2938718002221827054}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8683627804299419299
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7414244993536315417}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1682976792197666609}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 16}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3779327471833531041
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7414244993536315417}
+  m_CullTransparentMesh: 1
+--- !u!114 &2938718002221827054
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7414244993536315417}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Your Cool Txt
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &8057678888699711851
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1682976792197666609}
+  - component: {fileID: 2965888496743192953}
+  m_Layer: 5
+  m_Name: ToggleWithText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1682976792197666609
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8057678888699711851}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8683627804299419299}
+  - {fileID: 7989221792673684171}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2965888496743192953
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8057678888699711851}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 7
+    m_Right: 7
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 5
+  m_Spacing: 8
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1001 &3773273977910126689
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1682976792197666609}
+    m_Modifications:
+    - target: {fileID: 977034302134673057, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: <autoToggleImagesOnToggle>k__BackingField
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975587278961672583, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_Color.b
+      value: 0.4862745
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975587278961672583, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_Color.g
+      value: 0.41960785
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975587278961672583, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_Color.r
+      value: 0.44313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 7225474628005434785, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_Name
+      value: Toggle
+      objectReference: {fileID: 0}
+    - target: {fileID: 8806659310530846726, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9008524825783389075, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7225474628005434785, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4643746892624216629}
+  m_SourcePrefab: {fileID: 100100000, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+--- !u!1 &5772302268905979328 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7225474628005434785, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+  m_PrefabInstance: {fileID: 3773273977910126689}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4643746892624216629
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5772302268905979328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: 32
+  m_PreferredHeight: 18
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!224 &7989221792673684171 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+  m_PrefabInstance: {fileID: 3773273977910126689}
+  m_PrefabAsset: {fileID: 0}

--- a/Explorer/Assets/DCL/UI/Assets/ToggleWithText.prefab
+++ b/Explorer/Assets/DCL/UI/Assets/ToggleWithText.prefab
@@ -146,6 +146,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1682976792197666609}
   - component: {fileID: 2965888496743192953}
+  - component: {fileID: 2655477926760237003}
   m_Layer: 5
   m_Name: ToggleWithText
   m_TagString: Untagged
@@ -200,6 +201,27 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &2655477926760237003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8057678888699711851}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11cdf22c09c7e9848be751d287b3eb5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <autoToggleImagesOnToggle>k__BackingField: 1
+  <Toggle>k__BackingField: {fileID: 6739991326136731569}
+  <OnImage>k__BackingField: {fileID: 5650563201723336807}
+  <OffImage>k__BackingField: {fileID: 5285512002055545842}
+  <OnBackgroundImage>k__BackingField: {fileID: 4187387521697926856}
+  <OffBackgroundImage>k__BackingField: {fileID: 6094248929970383334}
+  <ToggleOnAudio>k__BackingField: {fileID: 11400000, guid: bbf6fdc100a3def44853fe48acbf4fd5, type: 2}
+  <ToggleOffAudio>k__BackingField: {fileID: 11400000, guid: e95bf9b95c2484148a081ec1b18e3aa6, type: 2}
+  <toggleText>k__BackingField: {fileID: 2938718002221827054}
 --- !u!1001 &3773273977910126689
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -316,7 +338,8 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 977034302134673057, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
@@ -324,6 +347,27 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 4643746892624216629}
   m_SourcePrefab: {fileID: 100100000, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+--- !u!114 &4187387521697926856 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1027324785593132713, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+  m_PrefabInstance: {fileID: 3773273977910126689}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &5285512002055545842 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9008524825783389075, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+  m_PrefabInstance: {fileID: 3773273977910126689}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5650563201723336807 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8806659310530846726, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+  m_PrefabInstance: {fileID: 3773273977910126689}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &5772302268905979328 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7225474628005434785, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
@@ -349,6 +393,28 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &6094248929970383334 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6975587278961672583, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+  m_PrefabInstance: {fileID: 3773273977910126689}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6739991326136731569 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7625753975028379600, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}
+  m_PrefabInstance: {fileID: 3773273977910126689}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5772302268905979328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &7989221792673684171 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6521834947971461802, guid: 6a387e1548b1545319b57f5a417160aa, type: 3}

--- a/Explorer/Assets/DCL/UI/Assets/ToggleWithText.prefab.meta
+++ b/Explorer/Assets/DCL/UI/Assets/ToggleWithText.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 42f993a26991889449d58dcf6a15c6f8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/UI/ToggleView.cs
+++ b/Explorer/Assets/DCL/UI/ToggleView.cs
@@ -49,6 +49,12 @@ namespace DCL.UI
             Toggle.onValueChanged.RemoveListener(OnToggle);
         }
 
+        public void SetToggle(bool isOn)
+        {
+            Toggle.isOn = isOn;
+            OnToggle(isOn);
+        }
+
         public void SetToggleGraphics(bool toggle)
         {
             OnImage.SetActive(toggle);

--- a/Explorer/Assets/DCL/UI/ToggleWithTextView.cs
+++ b/Explorer/Assets/DCL/UI/ToggleWithTextView.cs
@@ -1,0 +1,16 @@
+using TMPro;
+using UnityEngine;
+
+namespace DCL.UI
+{
+    public class ToggleWithTextView : ToggleView
+    {
+        [field: SerializeField]
+        public TMP_Text toggleText { get; private set; }
+
+        public void SetToggleText(string text)
+        {
+            toggleText.text = text;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/UI/ToggleWithTextView.cs.meta
+++ b/Explorer/Assets/DCL/UI/ToggleWithTextView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 11cdf22c09c7e9848be751d287b3eb5d


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

- Introduced **Set as Public** toggle in _Photo Details_ panel #3206
- Added functionality to enable **Set as Public** and **Delete** Button only for reels owner by current user.
- Setting reel to private, from public panels (panels which can contain reels from other users alongside reels from current user), will switch to next reel, or close _Photo Details_ panel. Hiding reel in this way, reorganizes reels in panel bellow (passport, location photos).

![obraz](https://github.com/user-attachments/assets/88fd0d93-b14d-4506-b83b-e78c351a35b1)

## Test Instructions

- During tests, enter reel's _Photo Detail_ panel from different panels (from Passpost's gallery, Location gallery and Gallery from keyboard shortcut 'K')
- While in _Photo Details_ panel (![obraz](https://github.com/user-attachments/assets/43e5e04f-25f8-4d5a-9635-f5bf1f880b85)) switch to next/previous reels, set your reel to private, and observe if everything works like it should.

### Prerequisites
- [ ] Account with 2 reels shot (can be more, but for test setting every reel to private is required, so too many would introduce much more clicking)

### Test Steps
1. Enter reel shot functionality with 'C' shortcut and shot at least 2 reels
2. Enter your Gallery with 'K' shortcut, and set these reels as public by either clicking 3 dots in right corner of reel thumbnail, or by entering _Photo Details_ panel (try doing both during testing) 
![obraz](https://github.com/user-attachments/assets/38358795-cd24-4b71-ae19-9c8b3d40c552)
![obraz](https://github.com/user-attachments/assets/417b7785-7b5f-4af4-b91a-0dcd286384bc)
3. Open _Photo Details_ panel from different panels (passport, location gallery, gallery 'K' shortcut)
4. Set reel as private
5. Expected behavior: If reel was set as private from Gallery 'K', reel will be set at private, and user will get this notification
![obraz](https://github.com/user-attachments/assets/506823e0-10cd-4f9d-a444-992d9a20dd57)
If _Photo Details_ was opened from gallery, which can contain reels from other users, it additionally will switch to next reel, or if there's no reels in gallery left, it will close _Photo Details_ panel, and update gallery panel without recently set private reels.

https://github.com/user-attachments/assets/07aa0bda-8b84-4ccd-8f85-3b4e3805f7d1


### Additional Testing Notes
- To enable Set as Public toggle, and Delete button, web request is required, to ensure reel ownership, this web request is send at the very end of all the functionality, so it might take up to 5 seconds to load. I'm still figuring out what can be done with this. Right now the most probable scenario would be pushing it like it is, and request from Back end team to add owner information in first web request.
- In editor enlarging game window too much cause reels from disappearing, check if it's reproduceable in a build please (although its rather unrelated to this feature).

https://github.com/user-attachments/assets/947ab17b-59ad-4eb0-841a-47e90edd4291


## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
