### PR TITLE
fix: raycast result returning wrong initial values furing scene mordor time

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Utility/ParcelMathHelper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ParcelMathHelper.cs
@@ -30,6 +30,10 @@ namespace Utility
             globalPosition - sceneGlobalPosition;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3 FromGlobalToSceneRelativePosition(this Vector3 globalPosition, Transform sceneRoot) =>
+            globalPosition - sceneRoot.position;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 FromGlobalToSceneRelativePosition(this Vector3 globalPosition, Vector2Int sceneBaseParcelCoords) =>
             globalPosition - sceneBaseParcelCoords.ParcelToPositionFlat();
 

--- a/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/WritePointerEventResultsSystemShould.cs
+++ b/Explorer/Assets/DCL/Interaction/PlayerOriginated/Tests/WritePointerEventResultsSystemShould.cs
@@ -11,8 +11,10 @@ using SceneRunner.Scene;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Arch.Core;
+using ECS.Unity.Transforms.Components;
 using UnityEngine;
-using Utility;
+using Object = UnityEngine.Object;
 using RaycastHit = DCL.ECSComponents.RaycastHit;
 
 namespace DCL.Interaction.PlayerOriginated.Tests
@@ -23,13 +25,11 @@ namespace DCL.Interaction.PlayerOriginated.Tests
         private IECSToCRDTWriter writer;
         private IGlobalInputEvents globalInputEvents;
         private ISceneStateProvider sceneStateProvider;
+        private GameObject sceneRootGO;
 
         [SetUp]
         public void SetUp()
         {
-            ISceneData sceneData = Substitute.For<ISceneData>();
-            sceneData.Geometry.Returns(new ParcelMathHelper.SceneGeometry(Vector3.zero, new ParcelMathHelper.SceneCircumscribedPlanes(), 0.0f));
-
             sceneStateProvider = Substitute.For<ISceneStateProvider>();
             sceneStateProvider.TickNumber.Returns(123u);
             sceneStateProvider.IsCurrent.Returns(true);
@@ -37,7 +37,11 @@ namespace DCL.Interaction.PlayerOriginated.Tests
             IComponentPool<RaycastHit> pool = Substitute.For<IComponentPool<RaycastHit>>();
             pool.Get().Returns(new RaycastHit().Reset());
 
-            system = new WritePointerEventResultsSystem(world, sceneData,
+            sceneRootGO = new GameObject();
+            Entity sceneRoot = world.Create(new TransformComponent(sceneRootGO.transform));
+
+            system = new WritePointerEventResultsSystem(world,
+                sceneRoot,
                 writer = Substitute.For<IECSToCRDTWriter>(),
                 sceneStateProvider,
                 globalInputEvents = Substitute.For<IGlobalInputEvents>(),
@@ -48,6 +52,7 @@ namespace DCL.Interaction.PlayerOriginated.Tests
         public void ClearResults()
         {
             results.Clear();
+            Object.DestroyImmediate(sceneRootGO);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
@@ -42,14 +42,14 @@ namespace DCL.Interaction.Raycast.Systems
         private readonly IComponentPool<PBRaycastResult> raycastComponentPool;
         private readonly IComponentPool<ECSComponents.RaycastHit> raycastHitPool;
         private readonly ISceneStateProvider sceneStateProvider;
+        private readonly Entity sceneRoot;
 
-        private readonly ISceneData sceneData;
         private List<RaycastData>? orderedRaycastData;
 
         private readonly PBRaycastResult emptyRaycastResult;
 
         internal ExecuteRaycastSystem(World world,
-            ISceneData sceneData,
+            Entity sceneRoot,
             IReleasablePerformanceBudget budget,
             byte raycastBucketThreshold,
             IComponentPool<ECSComponents.RaycastHit> raycastHitPool,
@@ -59,7 +59,7 @@ namespace DCL.Interaction.Raycast.Systems
             IECSToCRDTWriter ecsToCRDTWriter,
             ISceneStateProvider sceneStateProvider) : base(world)
         {
-            this.sceneData = sceneData;
+            this.sceneRoot = sceneRoot;
             this.budget = budget;
             this.raycastBucketThreshold = raycastBucketThreshold;
             this.raycastHitPool = raycastHitPool;
@@ -87,14 +87,15 @@ namespace DCL.Interaction.Raycast.Systems
         protected override void Update(float t)
         {
             if (!sceneStateProvider.IsCurrent) return;
+            if (!World.IsAlive(sceneRoot) || !World.Has<TransformComponent>(sceneRoot)) return;
 
-            BudgetAndExecute(sceneData.Geometry.BaseParcelPosition);
+            BudgetAndExecute(World.Get<TransformComponent>(sceneRoot).Transform);
         }
 
         /// <summary>
         ///     Executes raycast if there is enough budget available.
         /// </summary>
-        private void BudgetAndExecute(Vector3 scenePosition)
+        private void BudgetAndExecute(Transform sceneRootTransform)
         {
             // Process only not executed raycasts which bucket is not farther than the max allowed distance
             orderedRaycastData.Clear();
@@ -120,7 +121,7 @@ namespace DCL.Interaction.Raycast.Systems
                 RaycastData data = orderedRaycastData[i];
 
                 if (budget.TrySpendBudget())
-                    Raycast(scenePosition, data.CRDTEntity, ref data.Component.Value, data.SDKComponent, in data.TransformComponent);
+                    Raycast(sceneRootTransform, data.CRDTEntity, ref data.Component.Value, data.SDKComponent, in data.TransformComponent);
                 else break;
             }
         }
@@ -162,9 +163,9 @@ namespace DCL.Interaction.Raycast.Systems
             });
         }
 
-        private void Raycast(Vector3 scenePos, CRDTEntity crdtEntity, ref RaycastComponent raycastComponent, PBRaycast sdkComponent, in TransformComponent transformComponent)
+        private void Raycast(Transform sceneRootTransform, CRDTEntity crdtEntity, ref RaycastComponent raycastComponent, PBRaycast sdkComponent, in TransformComponent transformComponent)
         {
-            if (!sdkComponent.TryCreateRay(World, entitiesMap, scenePos, in transformComponent, out Ray ray))
+            if (!sdkComponent.TryCreateRay(World, entitiesMap, sceneRootTransform.position, in transformComponent, out Ray ray))
             {
                 ReportHub.LogWarning(GetReportData(), "Raycast error: Raycast data is malformed.");
                 return;
@@ -180,15 +181,15 @@ namespace DCL.Interaction.Raycast.Systems
             // The range of Unity Layers is narrower than the range of SDK Layers
             // so we need to raycast against all (even if the query type is hit first) and then filter our each individual raycast hit
             int hitsCount = Physics.RaycastNonAlloc(ray, SHARED_RAYCAST_HIT_ARRAY, sdkComponent.MaxDistance, collisionMask);
-            Vector3 rayOriginPosition = ray.origin.FromGlobalToSceneRelativePosition(scenePos);
+            Vector3 rayOriginPosition = ray.origin.FromGlobalToSceneRelativePosition(sceneRootTransform);
 
             switch (sdkComponent.QueryType)
             {
                 case RaycastQueryType.RqtHitFirst:
-                    SetClosestQualifiedHit(raycastResult, SHARED_RAYCAST_HIT_ARRAY.AsSpan(0, hitsCount), sdkCollisionMask, scenePos, rayOriginPosition, ray.direction);
+                    SetClosestQualifiedHit(raycastResult, SHARED_RAYCAST_HIT_ARRAY.AsSpan(0, hitsCount), sdkCollisionMask, sceneRootTransform, rayOriginPosition, ray.direction);
                     break;
                 case RaycastQueryType.RqtQueryAll:
-                    SetAllQualifiedHits(raycastResult, SHARED_RAYCAST_HIT_ARRAY.AsSpan(0, hitsCount), sdkCollisionMask, scenePos, rayOriginPosition, ray.direction);
+                    SetAllQualifiedHits(raycastResult, SHARED_RAYCAST_HIT_ARRAY.AsSpan(0, hitsCount), sdkCollisionMask, sceneRootTransform, rayOriginPosition, ray.direction);
                     break;
             }
 
@@ -202,7 +203,7 @@ namespace DCL.Interaction.Raycast.Systems
             ecsToCRDTWriter.PutMessage(raycastResult, crdtEntity);
         }
 
-        private void SetClosestQualifiedHit(PBRaycastResult raycastResult, Span<RaycastHit> hits, ColliderLayer collisionMask, Vector3 scenePos, Vector3 globalOrigin,
+        private void SetClosestQualifiedHit(PBRaycastResult raycastResult, Span<RaycastHit> hits, ColliderLayer collisionMask, Transform sceneRootTransform, Vector3 globalOrigin,
             Vector3 rayDirection)
         {
             RaycastHit? closestQualifiedHit = null;
@@ -228,12 +229,12 @@ namespace DCL.Interaction.Raycast.Systems
             {
                 ECSComponents.RaycastHit sdkHit = raycastHitPool.Get();
                 RaycastHit qualifiedHit = closestQualifiedHit.Value;
-                sdkHit.FillSDKRaycastHit(scenePos, qualifiedHit, qualifiedHit.collider.name, foundEntity, globalOrigin, rayDirection);
+                sdkHit.FillSDKRaycastHit(sceneRootTransform, qualifiedHit, qualifiedHit.collider.name, foundEntity, globalOrigin, rayDirection);
                 raycastResult.Hits.Add(sdkHit);
             }
         }
 
-        private void SetAllQualifiedHits(PBRaycastResult raycastResult, Span<RaycastHit> hits, ColliderLayer collisionMask, Vector3 scenePos, Vector3 globalOrigin,
+        private void SetAllQualifiedHits(PBRaycastResult raycastResult, Span<RaycastHit> hits, ColliderLayer collisionMask, Transform sceneRootTransform, Vector3 globalOrigin,
             Vector3 rayDirection)
         {
             for (var i = 0; i < hits.Length; i++)
@@ -245,7 +246,7 @@ namespace DCL.Interaction.Raycast.Systems
                 if (!TryGetQualifiedEntity(collider, collisionMask, out CRDTEntity foundEntity)) continue;
 
                 ECSComponents.RaycastHit sdkHit = raycastHitPool.Get();
-                sdkHit.FillSDKRaycastHit(scenePos, hit, hit.collider.name, foundEntity, globalOrigin, rayDirection);
+                sdkHit.FillSDKRaycastHit(sceneRootTransform, hit, hit.collider.name, foundEntity, globalOrigin, rayDirection);
                 raycastResult.Hits.Add(sdkHit);
             }
         }

--- a/Explorer/Assets/DCL/Interaction/Raycast/Tests/RaycastUtilsShould.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Tests/RaycastUtilsShould.cs
@@ -113,7 +113,11 @@ namespace DCL.Interaction.Raycast.Tests
             Physics.Raycast(ray, out RaycastHit hit, 100, ~0, QueryTriggerInteraction.Collide);
 
             var sdkHit = new ECSComponents.RaycastHit { Direction = new Decentraland.Common.Vector3(), GlobalOrigin = new Decentraland.Common.Vector3(), Position = new Decentraland.Common.Vector3(), NormalHit = new Decentraland.Common.Vector3() };
-            sdkHit.FillSDKRaycastHit(new Vector3(1, 0, 1), hit, collider.name, 100, Vector3.zero, Vector3.forward);
+
+            var sceneRoot = new GameObject("SceneRoot");
+            sceneRoot.transform.position = new Vector3(1, 0, 1);
+
+            sdkHit.FillSDKRaycastHit(sceneRoot.transform, hit, collider.name, 100, Vector3.zero, Vector3.forward);
 
             Assert.That(sdkHit.EntityId, Is.EqualTo(100u));
             Assert.That(sdkHit.MeshName, Is.EqualTo("custom"));
@@ -122,6 +126,8 @@ namespace DCL.Interaction.Raycast.Tests
             Assert.That((Vector3)sdkHit.Position, Is.EqualTo(hit.point - new Vector3(1, 0, 1)));
             Assert.That((Vector3)sdkHit.GlobalOrigin, Is.EqualTo(Vector3.zero));
             Assert.That((Vector3)sdkHit.Direction, Is.EqualTo(Vector3.forward));
+
+            UnityObjectUtils.SafeDestroyGameObject(sceneRoot.transform);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Interaction/Utility/RaycastUtils.cs
+++ b/Explorer/Assets/DCL/Interaction/Utility/RaycastUtils.cs
@@ -70,12 +70,12 @@ namespace DCL.Interaction.Utility
             return true;
         }
 
-        public static void FillSDKRaycastHit(this RaycastHit target, Vector3 sceneRootPosition, AppendPointerEventResultsIntent intent, CRDTEntity crdtEntity)
+        public static void FillSDKRaycastHit(this RaycastHit target, Transform sceneRoot, AppendPointerEventResultsIntent intent, CRDTEntity crdtEntity)
         {
-            target.FillSDKRaycastHit(sceneRootPosition, intent.RaycastHit, string.Empty, crdtEntity, intent.Ray.origin, intent.Ray.direction);
+            target.FillSDKRaycastHit(sceneRoot, intent.RaycastHit, string.Empty, crdtEntity, intent.Ray.origin, intent.Ray.direction);
         }
 
-        public static void FillSDKRaycastHit(this RaycastHit target, Vector3 sceneRootPosition, in UnityEngine.RaycastHit unityHit, string colliderName, CRDTEntity crdtEntity,
+        public static void FillSDKRaycastHit(this RaycastHit target, Transform sceneRoot, in UnityEngine.RaycastHit unityHit, string colliderName, CRDTEntity crdtEntity,
             Vector3 globalOrigin,
             Vector3 direction)
         {
@@ -84,8 +84,8 @@ namespace DCL.Interaction.Utility
             // There is no real value in passing MeshName
             target.MeshName = colliderName;
             target.Length = unityHit.distance;
-            target.GlobalOrigin.Set(globalOrigin);
-            target.Position.Set(unityHit.point.FromGlobalToSceneRelativePosition(sceneRootPosition));
+            target.GlobalOrigin.Set(globalOrigin); // already scene relative position
+            target.Position.Set(unityHit.point.FromGlobalToSceneRelativePosition(sceneRoot));
             target.NormalHit.Set(unityHit.normal);
             target.Direction.Set(direction);
         }

--- a/Explorer/Assets/DCL/PluginSystem/World/InteractionPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/InteractionPlugin.cs
@@ -65,7 +65,7 @@ namespace DCL.PluginSystem.World
             sceneIsCurrentListeners.Add(
                 ExecuteRaycastSystem.InjectToWorld(
                     ref builder,
-                    sceneDeps.SceneData,
+                    persistentEntities.SceneRoot,
                     raycastBudget,
                     settings.RaycastBucketThreshold,
                     sharedDependencies.ComponentPoolsRegistry.GetReferenceTypePool<RaycastHit>(),
@@ -79,7 +79,7 @@ namespace DCL.PluginSystem.World
 
             WritePointerEventResultsSystem.InjectToWorld(
                 ref builder,
-                sceneDeps.SceneData,
+                persistentEntities.SceneRoot,
                 sceneDeps.EcsToCRDTWriter,
                 sceneDeps.SceneStateProvider,
                 globalInputEvents,


### PR DESCRIPTION
### WHY

Currently, we have the following order when a scene is loaded:
1. A new scene spawns at ["Mordor" position](https://github.com/decentraland/unity-explorer/blob/52d657bf2ab651d3ab483ff54f594e1898385e9a/Explorer/Assets/DCL/Utilities/MordorConstants.cs#L5)
2. We start the scene code execution (and main.crdt loading)
3. Soon we detect GLTFContainer entities that have to be loaded
4. We wait until the first GLTFContainer entities finish loading BEFORE moving the scene root GameObject to its righful global position based on its scene coordinates

Scene code is running BEFORE the scene is actually moved away from Mordor, so Raycasts that run during that time, end up updating the `RaycastResult` component with very large and "wrong" values, since the calculations to make those global Vector3 values scene-relative are done based on the Scene Coords, not on its real root GameObject position.

Fixes https://github.com/decentraland/unity-explorer/issues/4527

### WHAT

In `Raycast` and `PointerEvent` systems, replaced scene coord usage for scene root transform to have maximum reliability on raycast and pointer event result component update (even in mordor).

### TEST INSTRUCTIONS

(...)

