### PR TITLE
Shape: destroy cached sprite on clear and remove previous image while loading

### DIFF
--- a/Explorer/Assets/DCL/UI/ImageController.cs
+++ b/Explorer/Assets/DCL/UI/ImageController.cs
@@ -3,6 +3,7 @@ using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Utilities;
 using DCL.WebRequests;
+using DG.Tweening;
 using System;
 using Utility;
 using System.Threading;
@@ -12,6 +13,8 @@ namespace DCL.UI
 {
     public class ImageController
     {
+        private static readonly Color LOADING_COLOR = new (0, 0, 0, 0);
+
         private const int PIXELS_PER_UNIT = 50;
         private readonly ImageView view;
         private readonly ObjectProxy<ISpriteCache>? spriteCache;
@@ -64,6 +67,8 @@ namespace DCL.UI
         {
             try
             {
+                view.Image.color = LOADING_COLOR;
+
                 view.LoadingObject.SetActive(true);
 
                 Sprite? sprite = null;
@@ -97,6 +102,7 @@ namespace DCL.UI
                     SetImage(sprite);
                     SpriteLoaded?.Invoke(sprite);
                     view.Image.enabled = true;
+                    view.Image.DOColor(Color.white, view.imageLoadingFadeDuration);
                 }
             }
             finally

--- a/Explorer/Assets/DCL/UI/ImageView.cs
+++ b/Explorer/Assets/DCL/UI/ImageView.cs
@@ -13,6 +13,9 @@ namespace DCL.UI
         [field: SerializeField]
         internal Image Image { get; private set; }
 
+        [field: SerializeField]
+        internal float imageLoadingFadeDuration { get; private set; } = 0.3f;
+
         public Sprite ImageSprite => Image.sprite;
 
         public bool IsLoading

--- a/Explorer/Assets/DCL/UI/SpriteCache.cs
+++ b/Explorer/Assets/DCL/UI/SpriteCache.cs
@@ -79,20 +79,19 @@ namespace DCL.UI
 
         public void AddOrReplaceCachedSprite(string imageUrl, Sprite imageContent)
         {
-            if(currentSpriteTasks.ContainsKey(imageUrl))
-                currentSpriteTasks[imageUrl].TrySetCanceled();
+            if(currentSpriteTasks.TryGetValue(imageUrl, out UniTaskCompletionSource<Sprite?>? task))
+                task.TrySetCanceled();
 
-            if(failedSprites.ContainsKey(imageUrl))
-                failedSprites.Remove(imageUrl);
+            failedSprites.Remove(imageUrl);
 
-            if(cachedSprites.ContainsKey(imageUrl))
-                cachedSprites[imageUrl] = imageContent;
-            else
-                cachedSprites.Add(imageUrl, imageContent);
+            cachedSprites[imageUrl] = imageContent;
         }
 
         public void Clear()
         {
+            foreach (KeyValuePair<string, Sprite> row in cachedSprites)
+                GameObject.Destroy(row.Value);
+
             cachedSprites.Clear();
             failedSprites.Clear();
 


### PR DESCRIPTION
# Pull Request Description

Fixes #4603 
Fixes #4604 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR destroys all cached sprites contained by `SpriteCache` when `Clear` method is invoked in order to really free the memory (the instances of the sprites could be referenced by pooled/inactive objects).

It also adds a fade in animation on the `ImageView`/`ImageController` so that the previous contained image is hidden, while also improving the UX.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- launch the explorer in `zone` with the args `--dclenv zone`

### Test Steps
1. Verify that all communities images are loading correctly
   - community profile image
   - events
   - places
   - event info panel

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
