### PR TITLE
feat: sdk avatar shapes scene emotes support (revisited)

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
@@ -259,7 +259,7 @@ namespace Global
                 new MaterialsPlugin(sharedDependencies, videoTexturePool),
                 textureResolvePlugin,
                 new AssetsCollidersPlugin(sharedDependencies),
-                new AvatarShapePlugin(globalWorld, componentsContainer.ComponentPoolsRegistry),
+                new AvatarShapePlugin(globalWorld, componentsContainer.ComponentPoolsRegistry, launchMode),
                 new AvatarAttachPlugin(globalWorld, container.MainPlayerAvatarBaseProxy, componentsContainer.ComponentPoolsRegistry, container.EntityParticipantTableProxy),
                 new PrimitivesRenderingPlugin(sharedDependencies),
                 new VisibilityPlugin(),

--- a/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
@@ -6,6 +6,7 @@ using DCL.SDKComponents.AvatarShape.Systems;
 using ECS.LifeCycle;
 using ECS.LifeCycle.Systems;
 using ECS.Unity.AvatarShape.Systems;
+using Global.Dynamic.LaunchModes;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -14,11 +15,13 @@ namespace DCL.PluginSystem.World
     public class AvatarShapePlugin : IDCLWorldPlugin
     {
         private readonly Arch.Core.World globalWorld;
-        public IComponentPool<Transform> globalTransformPool;
+        private readonly IComponentPool<Transform> globalTransformPool;
+        private readonly ILaunchMode launchMode;
 
-        public AvatarShapePlugin(Arch.Core.World globalWorld, IComponentPoolsRegistry poolRegistry)
+        public AvatarShapePlugin(Arch.Core.World globalWorld, IComponentPoolsRegistry poolRegistry, ILaunchMode launchMode)
         {
             this.globalWorld = globalWorld;
+            this.launchMode = launchMode;
             this.globalTransformPool = poolRegistry.GetReferenceTypePool<Transform>();
         }
 
@@ -30,8 +33,7 @@ namespace DCL.PluginSystem.World
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in ECSWorldInstanceSharedDependencies sharedDependencies, in PersistentEntities persistentEntities, List<IFinalizeWorldSystem> finalizeWorldSystems, List<ISceneIsCurrentListener> sceneIsCurrentListeners)
         {
             ResetDirtyFlagSystem<PBAvatarShape>.InjectToWorld(ref builder);
-            var avatarShapeHandlerSystem = AvatarShapeHandlerSystem.InjectToWorld(ref builder, globalWorld, globalTransformPool, sharedDependencies.SceneData);
-            finalizeWorldSystems.Add(avatarShapeHandlerSystem);
+            finalizeWorldSystems.Add(AvatarShapeHandlerSystem.InjectToWorld(ref builder, globalWorld, globalTransformPool, sharedDependencies.SceneData, launchMode.CurrentMode == LaunchMode.LocalSceneDevelopment));
             UpdateAvatarShapeInterpolateMovementSystem.InjectToWorld(ref builder, globalWorld, sharedDependencies.SceneData.SceneShortInfo.BaseParcel);
         }
     }

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Components/SDKAvatarShapeComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Components/SDKAvatarShapeComponent.cs
@@ -1,14 +1,22 @@
 using Arch.Core;
+using RealmSceneEmotePromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution,
+    DCL.AvatarRendering.Emotes.GetSceneEmoteFromRealmIntention>;
+using LocalSceneEmotePromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution,
+    DCL.AvatarRendering.Emotes.GetSceneEmoteFromLocalSceneIntention>;
 
 namespace ECS.Unity.AvatarShape.Components
 {
     public struct SDKAvatarShapeComponent
     {
-        public Entity globalWorldEntity;
+        public Entity GlobalWorldEntity;
+        public RealmSceneEmotePromise? RealmSceneEmotePromise;
+        public LocalSceneEmotePromise? LocalSceneEmotePromise;
 
         public SDKAvatarShapeComponent(Entity globalWorldEntity)
         {
-            this.globalWorldEntity = globalWorldEntity;
+            this.GlobalWorldEntity = globalWorldEntity;
+            RealmSceneEmotePromise = null;
+            LocalSceneEmotePromise = null;
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/UpdateAvatarShapeInterpolateMovementSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/UpdateAvatarShapeInterpolateMovementSystem.cs
@@ -69,7 +69,7 @@ namespace DCL.SDKComponents.AvatarShape.Systems
             bool isRotationManagedByTween)
         {
             ref CharacterInterpolationMovementComponent characterInterpolationMovementComponent = ref globalWorld.TryGetRef<CharacterInterpolationMovementComponent>(
-                sdkAvatarShapeComponent.globalWorldEntity,
+                sdkAvatarShapeComponent.GlobalWorldEntity,
                 out bool hasCharacterInterpolationMovement);
 
             if (!hasCharacterInterpolationMovement)

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Tests/AvatarShapeHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Tests/AvatarShapeHandlerSystemShould.cs
@@ -25,7 +25,7 @@ namespace ECS.Unity.AvatarShape.Tests
             pool.Get().Returns(new GameObject().transform);
             ISceneData sceneData = Substitute.For<ISceneData>();
             sceneData.SceneLoadingConcluded.Returns(true);
-            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, sceneData);
+            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, sceneData, false);
 
             entity = world.Create(PartitionComponent.TOP_PRIORITY);
             AddTransformToEntity(entity);

--- a/Explorer/Assets/DCL/SDKComponents/DCL.SDKComponents.asmdef
+++ b/Explorer/Assets/DCL/SDKComponents/DCL.SDKComponents.asmdef
@@ -31,7 +31,8 @@
         "GUID:0d87731a01a547bd97421cb01c596850",
         "GUID:d832748739a186646b8656bdbd447ad0",
         "GUID:f4a0f40a2545482b8929d4c3c642f50a",
-        "GUID:e37c129839591a044b0819431bee5cb5"
+        "GUID:e37c129839591a044b0819431bee5cb5",
+        "GUID:543b8f091a5947a3880b7f2bca2358bd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
### WHY

Currently SDK Avatar Shapes cannot play any scene-emote, only published "urn emotes".

### WHAT

Implemented support to load scene emotes through the `PBAvatarShape.expressionTriggerId`. (Loop is not supported right now as we would need either a new property in `PBAvatarShape` for that or a dedicated `triggerSceneEmote() for avatar shapes or for targetted avatars, containing the `loop` parameter)

"fire-and-forget" async usage made compliant with the recent new guidelines at https://github.com/decentraland/unity-explorer/wiki/How-To#how-to-handle-async-flows

Tackles: https://github.com/decentraland/creator-hub/issues/638

### TEST INSTRUCTIONS

1. Download the build from this PR and open it entering the `65, -125` scene.
2. Once the scene loads, click on the different cubes and confirm that all of them play an emote on the avatar shape that you see standing in the scene

https://github.com/user-attachments/assets/28bd285f-71b5-42cd-9d64-9ab6bb20b029
