### PR TITLE
fix/skinned mesh renderer bounds

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetBundleData.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetBundleData.cs
@@ -94,6 +94,12 @@ namespace ECS.StreamableLoading.AssetBundles
             return (T)mainAsset!;
         }
 
+        public bool TryGetMainAsset<T>(out T? result) where T: Object
+        {
+            result = mainAsset as T;
+            return result;
+        }
+
         public string GetInstanceName() => description;
 
     }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetProcessingRequest.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetProcessingRequest.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace ECS.StreamableLoading.AssetBundles
+{
+    public struct AssetProcessingRequest<T> where T : Object
+    {
+        public T Asset;
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetProcessingRequest.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetProcessingRequest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ca8c1cff43474a319d389b9175021f03
+timeCreated: 1751362790

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/ProcessAssetSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/ProcessAssetSystem.cs
@@ -1,0 +1,29 @@
+﻿using Arch.Core;
+using Arch.System;
+using ECS.Abstract;
+using UnityEngine;
+
+namespace ECS.StreamableLoading.AssetBundles
+{
+    public abstract partial class ProcessAssetSystem<T> : BaseUnityLoopSystem where T : Object
+    {
+        protected ProcessAssetSystem(World world) : base(world)
+        {
+        }
+        
+        protected override void Update(float t)
+        {
+            ProcessAssetQuery(World);
+        }
+
+        [Query]
+        public void ProcessAsset(Entity entity, in AssetProcessingRequest<T> request)
+        {
+            ProcessAsset(request.Asset);
+
+            World.Destroy(entity);
+        }
+
+        protected abstract void ProcessAsset(T asset);
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/ProcessAssetSystem.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/ProcessAssetSystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 90c333fc1cf646eb8226796a2d94af7a
+timeCreated: 1751368278

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/ProcessGameObjectSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/ProcessGameObjectSystem.cs
@@ -1,0 +1,33 @@
+﻿using Arch.Core;
+using Arch.SystemGroups;
+using DCL.Diagnostics;
+using UnityEngine;
+using UnityEngine.Pool;
+
+namespace ECS.StreamableLoading.AssetBundles
+{
+    [UpdateInGroup(typeof(StreamableLoadingGroup))]
+    [LogCategory(ReportCategory.ASSET_BUNDLES)]
+    [UpdateAfter(typeof(LoadAssetBundleSystem))]
+    public partial class ProcessGameObjectSystem : ProcessAssetSystem<GameObject>
+    {
+        private const float SKINNED_MESH_RENDERER_MAX_BOUNDS = 100;
+
+        public ProcessGameObjectSystem(World world) : base(world)
+        {
+        }
+
+        protected override void ProcessAsset(GameObject asset)
+        {
+            _ = ListPool<SkinnedMeshRenderer>.Get(out var skinnedMeshRenderers);
+            asset.GetComponentsInChildren(true, skinnedMeshRenderers);
+
+            foreach (var skinnedMeshRenderer in skinnedMeshRenderers)
+            {
+                var bounds = skinnedMeshRenderer.localBounds;
+                bounds.extents = Vector3.Min(bounds.extents, SKINNED_MESH_RENDERER_MAX_BOUNDS * Vector3.one);
+                skinnedMeshRenderer.localBounds = bounds;
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/ProcessGameObjectSystem.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/ProcessGameObjectSystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 89ff20f015c74d869bccea16c22ec1ec
+timeCreated: 1751362610

--- a/Explorer/Assets/DCL/PluginSystem/World/AssetBundlesPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AssetBundlesPlugin.cs
@@ -56,6 +56,8 @@ namespace DCL.PluginSystem.World
 
             // TODO create a runtime ref-counting cache
             LoadAssetBundleSystem.InjectToWorld(ref builder, assetBundleCache, webRequestController, buffersPool, assetBundleLoadingMutex, partialsDiskCache);
+
+            ProcessGameObjectSystem.InjectToWorld(ref builder);
         }
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments)
@@ -65,6 +67,8 @@ namespace DCL.PluginSystem.World
 
             // TODO create a runtime ref-counting cache
             LoadGlobalAssetBundleSystem.InjectToWorld(ref builder, assetBundleCache, webRequestController, assetBundleLoadingMutex, buffersPool, partialsDiskCache);
+
+            ProcessGameObjectSystem.InjectToWorld(ref builder);
         }
 
         UniTask IDCLPlugin<NoExposedPluginSettings>.InitializeAsync(NoExposedPluginSettings settings, CancellationToken ct) =>


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR fixes the shadows flickering issue reported [here](https://github.com/decentraland/unity-explorer/issues/2825).

A simple asset processing pipeline has been added after the asset bundle loading. Every time we load an asset from an AB we can hook a processing system up to process it. A system for each type has to be created, similarly to how our loading systems work with generic intentions.

For this specific case a game object processor was added which clamps the bounds of skinned mesh renderers. A game object with huge bounds is what was causing the shadows flickering.

## Test Instructions
Go to `47,115`, shadows should look normal now.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included
