### PR TITLE
chore: adjust retry logic for unity build workflow

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -242,8 +242,8 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 180  # matches your GLOBAL_TIMEOUT = 10800s
-          max_attempts: 3
-          retry_on: any
+          max_attempts: 2
+          retry_on_exit_code: 99
           retry_wait_seconds: 30
           on_retry_command: |
             echo "::warning::🔁 Unity Cloud Build retry triggered at $(date '+%Y-%m-%d %H:%M:%S')"

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -62,7 +62,7 @@ def get_target(target):
     else:
         print("Failed to get target data with status code:", response.status_code)
         print("Response body:", response.text)
-        sys.exit(1)
+        sys.exit(99)
 
 def clone_current_target(use_cache):
     def generate_body(template_target, name, branch, options, remoteCacheStrategy):
@@ -164,7 +164,7 @@ def clone_current_target(use_cache):
     else:
         print('Target failed to clone/update with status code:', response.status_code)
         print('Response body:', response.text)
-        sys.exit(1)
+        sys.exit(99)
 
 def get_param_env_variables():
     param_variables = {}
@@ -189,7 +189,7 @@ def set_parameters(params):
     else:
         print("Parameters failed with status code:", response.status_code)
         print("Response body:", response.text)
-        sys.exit(1)
+        sys.exit(99)
 
 def get_latest_build(target):
     response = requests.get(f'{URL}/buildtargets/{target}/builds', headers=HEADERS, params={'per_page': 1, 'page': 1})


### PR DESCRIPTION
- Lowered the number of retry attempts in the workflow from three to two.
- Adjusted the retry logic so it now only kicks in when the script specifically exits with code 99, rather than retrying on any type of failure.
- Updated the Python script to use exit code 99 for certain HTTP-related errors, so those cases are the only ones that get retried automatically.