### PR TITLE
fix: [Communities] Missing comma concatenating places in the community creation

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/CommunitiesDataProvider.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/CommunitiesDataProvider.cs
@@ -81,6 +81,8 @@ namespace DCL.Communities
                 if (i < lands.Count - 1)
                     placeIdsJsonString.Append(", ");
             }
+            if (worlds.Count > 0)
+                placeIdsJsonString.Append(", ");
             for (var i = 0; i < worlds.Count; i++)
             {
                 placeIdsJsonString.Append($"\"{worlds[i]}\"");


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
We were missing a comma when we concatenated places and worlds in the community creation process. This was provoked an error in the creation.

### Test Steps
1. Open the creation community wizard.
2. Associate places and words in the places selector.
3. Create the community.
4. Check that the community is created successfully.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.