### PR TITLE
[SHAPE-UP] Communities Fix (Pictures with transparent background can overlap the load image icon in community creation)

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
@@ -45,6 +45,7 @@ namespace DCL.Communities.CommunityCreation
         [SerializeField] private TMP_Text creationPanelTitleText;
         [SerializeField] private ScrollRect creationPanelScrollRect;
         [SerializeField] private Button creationPanelEditProfilePictureButton;
+        [SerializeField] private GameObject creationPanelProfilePictureIcon;
         [SerializeField] private ImageView creationPanelProfileSelectedImage;
         [SerializeField] private Sprite creationPanelProfileDefaultSelectedImage;
         [SerializeField] private TMP_InputField creationPanelCommunityNameInputField;
@@ -176,6 +177,7 @@ namespace DCL.Communities.CommunityCreation
         {
             isDefaultImageSelected = false;
             creationPanelProfileSelectedImage.gameObject.SetActive(true);
+            creationPanelProfilePictureIcon.SetActive(false);
 
             if (!string.IsNullOrEmpty(imageUrl))
                 imageController?.RequestImage(imageUrl, hideImageWhileLoading: true);
@@ -190,6 +192,7 @@ namespace DCL.Communities.CommunityCreation
         {
             isDefaultImageSelected = false;
             creationPanelProfileSelectedImage.gameObject.SetActive(sprite is not null);
+            creationPanelProfilePictureIcon.SetActive(!creationPanelProfileSelectedImage.gameObject.activeSelf);
             imageController.SetImage(sprite);
         }
 

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/CommunityCreationWizard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/CommunityCreationWizard.prefab
@@ -251,6 +251,7 @@ MonoBehaviour:
   creationPanelTitleText: {fileID: 8589843375831761775}
   creationPanelScrollRect: {fileID: 6953688788700206590}
   creationPanelEditProfilePictureButton: {fileID: 8294393226662565609}
+  creationPanelProfilePictureIcon: {fileID: 7466861170140788330}
   creationPanelProfileSelectedImage: {fileID: 5895951136704436539}
   creationPanelProfileDefaultSelectedImage: {fileID: 21300000, guid: 3b627b525f70e419bb278c5d44830db2, type: 3}
   creationPanelCommunityNameInputField: {fileID: 1356991511893353481}
@@ -874,7 +875,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7891702222690418044, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
       propertyPath: m_Value
-      value: 1.0000002
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1011,6 +1012,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &7466861170140788330 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3563396630889176293, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &7556609997558448888 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4481745970114865271, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}


### PR DESCRIPTION
# Pull Request Description
Fix #4655 

## What does this PR change?
Pictures with transparent background can overlap the load image icon in community creation.

### Test Steps
Follow the steps described here: https://github.com/decentraland/unity-explorer/issues/4655

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.