### PR TITLE
Decreased skybox's tooltip width

### DIFF
--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarUI.BottomLayout.prefab
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarUI.BottomLayout.prefab
@@ -1476,7 +1476,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 556587912230755051, guid: 571c63ddcf1523b45a64fabd71cb6dd5, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 90
+      value: 65
       objectReference: {fileID: 0}
     - target: {fileID: 791050805523401173, guid: 571c63ddcf1523b45a64fabd71cb6dd5, type: 3}
       propertyPath: m_SizeDelta.x


### PR DESCRIPTION
# Pull Request Description
Fixed skybox tooltip by decreasing its width

## What does this PR change?
Fix for [#4395](https://github.com/decentraland/unity-explorer/issues/4395)

## Test Instructions
Check if tooltip size looks alright
![image](https://github.com/user-attachments/assets/a20d3cec-59bc-4d08-8af2-0078154d52c2)

### Test Steps
1. Hover mouse over skybox button 
2. Confirm tooltip size looking good

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
