### PR TITLE
[SHAPE-UP] Communities (Manage cancellations properly)

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -347,6 +347,9 @@ namespace DCL.Chat
             communitiesServiceCts = communitiesServiceCts.SafeRestart();
             Result<GetUserCommunitiesResponse> result = await communitiesDataProvider.GetUserCommunitiesAsync(string.Empty, true, 0, ALL_COMMUNITIES_OF_USER, communitiesServiceCts.Token).SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+            if (communitiesServiceCts.IsCancellationRequested)
+                return;
+
             if (result.Success)
             {
                 await UniTask.SwitchToMainThread();
@@ -378,6 +381,9 @@ namespace DCL.Chat
         {
             communitiesServiceCts = communitiesServiceCts.SafeRestart();
             Result<GetCommunityResponse> result = await communitiesDataProvider.GetCommunityAsync(communityId, communitiesServiceCts.Token).SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+            if (communitiesServiceCts.IsCancellationRequested)
+                return;
 
             if (result.Success)
             {
@@ -511,6 +517,10 @@ namespace DCL.Chat
                 return;
 
             Result<ChatUserStateUpdater.ChatUserState> result = await chatUserStateUpdater.GetChatUserStateAsync(userId, ct).SuppressToResultAsync(ReportCategory.CHAT_MESSAGES);
+
+            if (ct.IsCancellationRequested)
+                return;
+
             if (result.Success == false)
                 return;
 
@@ -878,6 +888,9 @@ namespace DCL.Chat
             else if (chatHistory.Channels[viewInstance!.CurrentChannelId].ChannelType == ChatChannel.ChatChannelType.COMMUNITY)
             {
                 Result<GetCommunityMembersResponse> result = await communitiesDataProvider.GetOnlineCommunityMembersAsync(userCommunities[viewInstance!.CurrentChannelId].id, ct).SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+                if (ct.IsCancellationRequested)
+                    return;
 
                 if (result.Success)
                 {

--- a/Explorer/Assets/DCL/Chat/ChatControllerMemberListHelper.cs
+++ b/Explorer/Assets/DCL/Chat/ChatControllerMemberListHelper.cs
@@ -134,6 +134,9 @@ namespace DCL.Chat
         {
              Result<int> result = await dataProvider.GetOnlineMemberCountAsync(communityId, ct).SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+             if (ct.IsCancellationRequested)
+                 return;
+
              if (result.Success)
              {
                  viewInstance.MemberCount = result.Value - 1;

--- a/Explorer/Assets/DCL/Chat/ChatUserStateUpdater.cs
+++ b/Explorer/Assets/DCL/Chat/ChatUserStateUpdater.cs
@@ -256,6 +256,10 @@ namespace DCL.Chat
         private async UniTaskVoid CheckFriendStatusAsync(string userId)
         {
             Result<FriendshipStatus> result = await friendsService.StrictObject.GetFriendshipStatusAsync(userId, cts.Token).SuppressToResultAsync(ReportCategory.CHAT_MESSAGES);
+
+            if (cts.IsCancellationRequested)
+                return;
+
             if (!result.Success) return;
 
             if (result.Value == FriendshipStatus.FRIEND)
@@ -277,6 +281,10 @@ namespace DCL.Chat
             }
 
             Result<FriendshipStatus> status = await friendsService.StrictObject.GetFriendshipStatusAsync(userId, cts.Token).SuppressToResultAsync(ReportCategory.CHAT_MESSAGES);
+
+            if (cts.IsCancellationRequested)
+                return;
+
             if (status is { Success: true, Value: FriendshipStatus.FRIEND }) return;
 
             chatUserStateEventBus.OnCurrentConversationUserUnavailable();

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserController.cs
@@ -193,6 +193,9 @@ namespace DCL.Communities.CommunitiesBrowser
                                                 elementsPerPage: 1000,
                                                 ct: ct).SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+            if (ct.IsCancellationRequested)
+                return;
+
             if (!result.Success)
             {
                 showErrorCts = showErrorCts.SafeRestart();
@@ -270,6 +273,9 @@ namespace DCL.Communities.CommunitiesBrowser
                 pageNumber,
                 elementsPerPage,
                 ct).SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+            if (ct.IsCancellationRequested)
+                return;
 
             if (!result.Success)
             {
@@ -361,6 +367,9 @@ namespace DCL.Communities.CommunitiesBrowser
         private async UniTaskVoid JoinCommunityAsync(string communityId, CancellationToken ct)
         {
             var result = await dataProvider.JoinCommunityAsync(communityId, ct).SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+            if (ct.IsCancellationRequested)
+                return;
 
             if (!result.Success || !result.Value)
             {

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
@@ -161,6 +161,9 @@ namespace DCL.Communities.CommunitiesCard
                 Result<bool> result = await communitiesDataProvider.DeleteCommunityAsync(communityData.id, ct)
                                                                    .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+                if (ct.IsCancellationRequested)
+                    return;
+
                 if (!result.Success || !result.Value)
                 {
                     await viewInstance!.warningNotificationView.AnimatedShowAsync(DELETE_COMMUNITY_ERROR_TEXT, WARNING_NOTIFICATION_DURATION_MS, ct)
@@ -346,6 +349,9 @@ namespace DCL.Communities.CommunitiesCard
                 Result<bool> result = await communitiesDataProvider.JoinCommunityAsync(communityData.id, ct)
                                                                    .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+                if (ct.IsCancellationRequested)
+                    return;
+
                 if (!result.Success || !result.Value)
                 {
                     await viewInstance!.warningNotificationView.AnimatedShowAsync(JOIN_COMMUNITY_ERROR_TEXT, WARNING_NOTIFICATION_DURATION_MS, ct)
@@ -367,6 +373,9 @@ namespace DCL.Communities.CommunitiesCard
             {
                 Result<bool> result = await communitiesDataProvider.LeaveCommunityAsync(communityData.id, ct)
                                                            .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+                if (ct.IsCancellationRequested)
+                    return;
 
                 if (!result.Success || !result.Value)
                 {

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardView.cs
@@ -159,7 +159,7 @@ namespace DCL.Communities.CommunitiesCard
                                                                                                                   ct)
                                                                                                              .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
-                if (!dialogResult.Success || dialogResult.Value == ConfirmationDialogView.ConfirmationResult.CANCEL) return;
+                if (ct.IsCancellationRequested || !dialogResult.Success || dialogResult.Value == ConfirmationDialogView.ConfirmationResult.CANCEL) return;
 
                 DeleteCommunityRequested?.Invoke();
             }
@@ -200,7 +200,7 @@ namespace DCL.Communities.CommunitiesCard
                                                                                                         ct)
                                                                                                      .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
-                if (!dialogResult.Success || dialogResult.Value == ConfirmationDialogView.ConfirmationResult.CANCEL) return;
+                if (ct.IsCancellationRequested || !dialogResult.Success || dialogResult.Value == ConfirmationDialogView.ConfirmationResult.CANCEL) return;
 
                 LeaveCommunityRequested?.Invoke();
             }

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
@@ -125,6 +125,9 @@ namespace DCL.Communities.CommunitiesCard.Events
                     : await eventsApiService.MarkAsInterestedAsync(eventData.Event.id, ct)
                                             .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+                if (ct.IsCancellationRequested)
+                    return;
+
                 if (!result.Success)
                 {
                     eventItemView.UpdateInterestedButtonState();
@@ -174,7 +177,10 @@ namespace DCL.Communities.CommunitiesCard.Events
         protected override async UniTask<int> FetchDataAsync(CancellationToken ct)
         {
             Result<EventWithPlaceIdDTOListResponse> eventResponse = await eventsApiService.GetEventsByPlaceIdsAsync(communityPlaceIds, eventsFetchData.pageNumber, PAGE_SIZE, ct)
-                                                                                                 .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+                                                                                          .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+            if (ct.IsCancellationRequested)
+                return 0;
 
             if (!eventResponse.Success)
             {
@@ -195,6 +201,9 @@ namespace DCL.Communities.CommunitiesCard.Events
 
             Result<PlacesData.PlacesAPIResponse> placesResponse = await placesAPIService.GetPlacesByIdsAsync(eventPlaceIds, ct)
                                                                                 .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+            if (ct.IsCancellationRequested)
+                return 0;
 
             if (!placesResponse.Success)
             {

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListController.cs
@@ -168,6 +168,9 @@ namespace DCL.Communities.CommunitiesCard.Members
                 Result<bool> result = await communitiesDataProvider.BanUserFromCommunityAsync(profile.memberAddress, communityData?.id, token)
                                                            .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+                if (token.IsCancellationRequested)
+                    return;
+
                 if (!result.Success || !result.Value)
                 {
                     await inWorldWarningNotificationView.AnimatedShowAsync(BAN_USER_ERROR_TEXT, WARNING_NOTIFICATION_DURATION_MS, token)
@@ -198,6 +201,9 @@ namespace DCL.Communities.CommunitiesCard.Members
                 Result<bool> result = await communitiesDataProvider.KickUserFromCommunityAsync(profile.memberAddress, communityData?.id, token)
                                                            .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+                if (token.IsCancellationRequested)
+                    return;
+
                 if (!result.Success || !result.Value)
                 {
                     await inWorldWarningNotificationView.AnimatedShowAsync(KICK_USER_ERROR_TEXT, WARNING_NOTIFICATION_DURATION_MS, token)
@@ -220,6 +226,9 @@ namespace DCL.Communities.CommunitiesCard.Members
             {
                 Result<bool> result = await communitiesDataProvider.SetMemberRoleAsync(profile.memberAddress, communityData?.id, CommunityMemberRole.moderator, token)
                                                            .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+                if (token.IsCancellationRequested)
+                    return;
 
                 if (!result.Success || !result.Value)
                 {
@@ -254,6 +263,9 @@ namespace DCL.Communities.CommunitiesCard.Members
 
                 Result<bool> result = await communitiesDataProvider.SetMemberRoleAsync(profile.memberAddress, communityData?.id, CommunityMemberRole.member, token)
                                                            .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+                if (token.IsCancellationRequested)
+                    return;
 
                 if (!result.Success || !result.Value)
                 {
@@ -353,6 +365,9 @@ namespace DCL.Communities.CommunitiesCard.Members
                         break;
                 }
 
+                if (ct.IsCancellationRequested)
+                    return;
+
                 await FetchFriendshipStatusAndRefreshAsync(userData.userAddress, ct);
             }
             catch (OperationCanceledException) { }
@@ -381,6 +396,9 @@ namespace DCL.Communities.CommunitiesCard.Members
                                                .SuppressToResultAsync(ReportCategory.COMMUNITIES)
                 : await communitiesDataProvider.GetBannedCommunityMembersAsync(communityData?.id, membersData.pageNumber, PAGE_SIZE, ct)
                                                .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+            if (ct.IsCancellationRequested)
+                return 0;
 
             if (!response.Success)
             {
@@ -432,6 +450,9 @@ namespace DCL.Communities.CommunitiesCard.Members
 
                 Result<bool> result = await communitiesDataProvider.UnBanUserFromCommunityAsync(profile.memberAddress, communityData?.id, ct)
                                                            .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+                if (ct.IsCancellationRequested)
+                    return;
 
                 if (!result.Success || !result.Value)
                 {

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListView.cs
@@ -152,7 +152,7 @@ namespace DCL.Communities.CommunitiesCard.Members
                                                                                                                   ct)
                                                                                                              .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
-                if (!dialogResult.Success || dialogResult.Value == ConfirmationDialogView.ConfirmationResult.CANCEL) return;
+                if (ct.IsCancellationRequested || !dialogResult.Success || dialogResult.Value == ConfirmationDialogView.ConfirmationResult.CANCEL) return;
 
                 KickUserRequested?.Invoke(profile);
             }
@@ -176,7 +176,7 @@ namespace DCL.Communities.CommunitiesCard.Members
                                                                                                         ct)
                                                                                                      .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
-                if (!dialogResult.Success || dialogResult.Value == ConfirmationDialogView.ConfirmationResult.CANCEL) return;
+                if (ct.IsCancellationRequested || !dialogResult.Success || dialogResult.Value == ConfirmationDialogView.ConfirmationResult.CANCEL) return;
 
                 BanUserRequested?.Invoke(profile);
             }

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlacesSectionController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlacesSectionController.cs
@@ -135,6 +135,9 @@ namespace DCL.Communities.CommunitiesCard.Places
                 var result = await communitiesDataProvider.RemovePlaceFromCommunityAsync(communityData!.Value.id, placeInfo.id, ct)
                                                           .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+                if (ct.IsCancellationRequested)
+                    return;
+
                 if (!result.Success)
                 {
                     await inWorldWarningNotificationView.AnimatedShowAsync(COMMUNITY_PLACES_DELETE_ERROR_MESSAGE, WARNING_NOTIFICATION_DURATION_MS, ct)
@@ -199,6 +202,9 @@ namespace DCL.Communities.CommunitiesCard.Places
                 var result = await placesAPIService.SetPlaceFavoriteAsync(placeInfo.id, favoriteValue, ct)
                                                    .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+                if (ct.IsCancellationRequested)
+                    return;
+
                 if (!result.Success)
                 {
                     placeCardView.SilentlySetFavoriteToggle(!favoriteValue);
@@ -220,6 +226,9 @@ namespace DCL.Communities.CommunitiesCard.Places
             {
                 var result = await placesAPIService.RatePlaceAsync(dislikeValue ? false : null, placeInfo.id, ct)
                                                    .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+                if (ct.IsCancellationRequested)
+                    return;
 
                 if (!result.Success)
                 {
@@ -249,6 +258,9 @@ namespace DCL.Communities.CommunitiesCard.Places
             {
                 var result = await placesAPIService.RatePlaceAsync(likeValue ? true : null, placeInfo.id, ct)
                                       .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+                if (ct.IsCancellationRequested)
+                    return;
 
                 if (!result.Success)
                 {
@@ -288,6 +300,9 @@ namespace DCL.Communities.CommunitiesCard.Places
 
             Result<PlacesData.PlacesAPIResponse> response = await placesAPIService.GetPlacesByIdsAsync(slice, ct)
                                                                                   .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+            if (ct.IsCancellationRequested)
+                return 0;
 
             if (!response.Success || !response.Value.ok)
             {

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlacesSectionView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlacesSectionView.cs
@@ -159,7 +159,7 @@ namespace DCL.Communities.CommunitiesCard.Places
                                                                                                                   ct)
                                                                                                              .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
-                if (!dialogResult.Success || dialogResult.Value == ConfirmationDialogView.ConfirmationResult.CANCEL) return;
+                if (ct.IsCancellationRequested || !dialogResult.Success || dialogResult.Value == ConfirmationDialogView.ConfirmationResult.CANCEL) return;
 
                 ElementDeleteButtonClicked?.Invoke(placeInfo);
             }

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionController.cs
@@ -299,6 +299,9 @@ namespace DCL.Communities.CommunityCreation
             var getCommunityResult = await dataProvider.GetCommunityAsync(inputData.CommunityId, ct)
                                                        .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+            if (ct.IsCancellationRequested)
+                return;
+
             if (!getCommunityResult.Success)
             {
                 showErrorCts = showErrorCts.SafeRestart();
@@ -316,6 +319,9 @@ namespace DCL.Communities.CommunityCreation
             var getCommunityPlacesResult = await dataProvider.GetCommunityPlacesAsync(inputData.CommunityId, ct)
                                                              .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+            if (ct.IsCancellationRequested)
+                return;
+
             if (!getCommunityPlacesResult.Success)
             {
                 showErrorCts = showErrorCts.SafeRestart();
@@ -329,6 +335,9 @@ namespace DCL.Communities.CommunityCreation
                 // Load places details
                 var getPlacesDetailsResult = await  placesAPIService.GetPlacesByIdsAsync(getCommunityPlacesResult.Value, ct)
                                                                     .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+                if (ct.IsCancellationRequested)
+                    return;
 
                 if (!getPlacesDetailsResult.Success)
                 {
@@ -381,6 +390,9 @@ namespace DCL.Communities.CommunityCreation
             var result = await dataProvider.CreateOrUpdateCommunityAsync(null, name, description, lastSelectedImageData, lands, worlds, ct)
                                            .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
+            if (ct.IsCancellationRequested)
+                return;
+
             if (!result.Success)
             {
                 showErrorCts = showErrorCts.SafeRestart();
@@ -406,6 +418,9 @@ namespace DCL.Communities.CommunityCreation
 
             var result = await dataProvider.CreateOrUpdateCommunityAsync(id, name, description, lastSelectedImageData, lands, worlds, ct)
                                            .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+            if (ct.IsCancellationRequested)
+                return;
 
             if (!result.Success)
             {


### PR DESCRIPTION
# Pull Request Description
Fix #4643 

## What does this PR change?
It manages, after each call to `SuppressToResultAsync`, the corresponding cancellation correctly.

### Test Steps
- Check the Communities feature works as before.
- Specific test: Try to switch between the "Communities" tab and the "Map" one (like it's desceribed in https://github.com/decentraland/unity-explorer/issues/4643) and check that the communities load correctly and you don't see any error message.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.