### PR TITLE
fix: finalize area camera mode only if it was active before

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/CameraModeArea/Systems/CameraModeAreaHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/CameraModeArea/Systems/CameraModeAreaHandlerSystem.cs
@@ -142,8 +142,9 @@ namespace DCL.SDKComponents.CameraModeArea.Systems
         [All(typeof(CameraModeAreaComponent))]
         private void FinalizeComponents(Entity entity)
         {
-            OnExitedCameraModeArea();
-            activeAreas.Remove(entity);
+            if (activeAreas.Remove(entity))
+                OnExitedCameraModeArea();
+
             World.Remove<CameraModeAreaComponent>(entity);
         }
 


### PR DESCRIPTION
## What does this PR change?

Fixes #4346 

When the camera mode area was destroyed, it was considered as the played exited the area, but the player didn't enter in the first place.
The solution consists to only consider the player exit the area when it was active before.

## Test Instructions

Follow issue steps. Check the camera mode is not changed automatically while walking around the place.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
