### PR TITLE
[SHAPE-UP] Communities (Open community card after creation)

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionController.cs
@@ -50,6 +50,7 @@ namespace DCL.Communities.CommunityCreation
         private CancellationTokenSource? loadPanelCts;
         private CancellationTokenSource? showErrorCts;
         private CancellationTokenSource? openImageSelectionCts;
+        private CancellationTokenSource? openCommunityCardAfterCreationCts;
 
         private Sprite? lastSelectedProfileThumbnail;
         private bool isProfileThumbnailDirty;
@@ -143,6 +144,7 @@ namespace DCL.Communities.CommunityCreation
             loadPanelCts?.SafeCancelAndDispose();
             showErrorCts?.SafeCancelAndDispose();
             openImageSelectionCts?.SafeCancelAndDispose();
+            openCommunityCardAfterCreationCts?.SafeCancelAndDispose();
         }
 
         protected override UniTask WaitForCloseIntentAsync(CancellationToken ct) =>
@@ -438,7 +440,9 @@ namespace DCL.Communities.CommunityCreation
             }
 
             closeTaskCompletionSource.TrySetResult();
-            mvcManager.ShowAsync(CommunityCardController.IssueCommand(new CommunityCardParameter(result.Value.data.id, spriteCache.StrictObject))).Forget();
+
+            openCommunityCardAfterCreationCts = openCommunityCardAfterCreationCts.SafeRestart();
+            mvcManager.ShowAsync(CommunityCardController.IssueCommand(new CommunityCardParameter(result.Value.data.id, spriteCache.StrictObject)), openCommunityCardAfterCreationCts.Token).Forget();
         }
 
         private void UpdateCommunity(string name, string description, List<string> lands, List<string> worlds)

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionController.cs
@@ -2,6 +2,7 @@ using Crosstales;
 using Crosstales.FB;
 using Cysharp.Threading.Tasks;
 using DCL.Browser;
+using DCL.Communities.CommunitiesCard;
 using DCL.Diagnostics;
 using DCL.Input;
 using DCL.Input.Component;
@@ -41,6 +42,7 @@ namespace DCL.Communities.CommunityCreation
         private readonly ICommunitiesDataProvider dataProvider;
         private readonly IPlacesAPIService placesAPIService;
         private readonly ISelfProfile selfProfile;
+        private readonly IMVCManager mvcManager;
         private readonly string[] allowedImageExtensions = { "jpg", "png" };
 
         private UniTaskCompletionSource closeTaskCompletionSource = new ();
@@ -72,13 +74,15 @@ namespace DCL.Communities.CommunityCreation
             IInputBlock inputBlock,
             ICommunitiesDataProvider dataProvider,
             IPlacesAPIService placesAPIService,
-            ISelfProfile selfProfile) : base(viewFactory)
+            ISelfProfile selfProfile,
+            IMVCManager mvcManager) : base(viewFactory)
         {
             this.webBrowser = webBrowser;
             this.inputBlock = inputBlock;
             this.dataProvider = dataProvider;
             this.placesAPIService = placesAPIService;
             this.selfProfile = selfProfile;
+            this.mvcManager = mvcManager;
 
             FileBrowser.Instance.AllowSyncCalls = true;
         }
@@ -434,6 +438,7 @@ namespace DCL.Communities.CommunityCreation
             }
 
             closeTaskCompletionSource.TrySetResult();
+            mvcManager.ShowAsync(CommunityCardController.IssueCommand(new CommunityCardParameter(result.Value.data.id, spriteCache.StrictObject))).Forget();
         }
 
         private void UpdateCommunity(string name, string description, List<string> lands, List<string> worlds)

--- a/Explorer/Assets/DCL/PluginSystem/Global/CommunitiesPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/CommunitiesPlugin.cs
@@ -137,7 +137,8 @@ namespace DCL.PluginSystem.Global
                 inputBlock,
                 communitiesDataProvider,
                 placesAPIService,
-                selfProfile);
+                selfProfile,
+                mvcManager);
             mvcManager.RegisterController(communityCreationEditionController);
 
             EventInfoView eventInfoViewAsset = (await assetsProvisioner.ProvideMainAssetValueAsync(settings.EventInfoPrefab, ct: ct)).GetComponent<EventInfoView>();


### PR DESCRIPTION
# Pull Request Description
Fix #4587 

## What does this PR change?
It makes the Community Profile Card opens right after we create the new community.

### Test Steps
1. Create a new community.
2. Check that, right after the creation wizard closes, the community's profile card opens.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.