### PR TITLE
chore: move warnings ignore to prebuild step

### DIFF
--- a/Explorer/Assets/Editor/CloudBuild.cs
+++ b/Explorer/Assets/Editor/CloudBuild.cs
@@ -31,8 +31,6 @@ namespace Editor
             // Debug.Log(Parameters["TEST_VALUE"] as string);
             //
 
-            GenerateIgnoreWarningsFile();
-
             //Unity suggestion: 1793168
             //This should ensure that the roslyn compiler has been run and everything is generated as needed.
             EditorApplication.ExecuteMenuItem("File/Save Project");
@@ -70,56 +68,6 @@ namespace Editor
         public static void PostExport()
         {
             Debug.Log($"~~ {nameof(CloudBuild)} PostExport ~~");
-        }
-
-        /// <summary>
-        /// Remove warnings from the build that are just clutter
-        /// We still want to maintain them outside of the build process
-        /// </summary>
-        private static void GenerateIgnoreWarningsFile()
-        {
-            // List of warning codes to ignore
-            string[] warningsToIgnore = {
-                "8618", // Nullable reference types
-                "8625", // Cannot convert null literal to non-nullable reference type
-                "8602", // Dereference of a possibly null reference
-                "8604", // Possible null reference argument
-                "8619", // Nullable value types
-                "8620", // Argument cannot be used for parameter due to differences in the nullability of reference types
-                "8603", // Possible null reference return
-                "8600", // Converting null literal or possible null value to non-nullable type
-                "8601", // Possible null reference assignment
-                "0649", // Field is never assigned to, and will always have its default value
-                "0414", // Field is assigned but its value is never used
-                "0168", // Variable is declared but never used
-                "0219", // Variable is assigned but its value is never used
-                "8632"  // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
-            };
-
-            // Path to the Assets folder
-            string assetsPath = Application.dataPath;
-            string filePath = Path.Combine(assetsPath, "csc.rsp");
-
-            try
-            {
-                using (StreamWriter writer = new StreamWriter(filePath))
-                {
-                    foreach (string warning in warningsToIgnore)
-                    {
-                        writer.WriteLine($"-nowarn:{warning}");
-                    }
-                }
-
-                Debug.Log($"Successfully generated csc.rsp file at: {filePath}");
-                Debug.Log($"Added {warningsToIgnore.Length} warning suppressions to the file.");
-
-                // Force a refresh
-                AssetDatabase.Refresh();
-            }
-            catch (System.Exception ex)
-            {
-                Debug.LogError($"Failed to generate csc.rsp file: {ex.Message}");
-            }
         }
 
         private static void WriteReleaseStoreToBuildData(string installSource)

--- a/scripts/generate-ignore-warnings.sh
+++ b/scripts/generate-ignore-warnings.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# List of warning codes to ignore
+warnings_to_ignore=(
+    8618 8625 8602 8604 8619 8620 8603 8600 8601
+    0649 0414 0168 0219 8632
+)
+
+# Determine path to the Unity Assets directory
+# Assumes this script is run from the project root
+assets_path="./Explorer/Assets"
+file_path="$assets_path/csc.rsp"
+
+# Make sure the Assets directory exists
+if [[ ! -d "$assets_path" ]]; then
+    echo "Assets directory not found at $assets_path"
+    exit 1
+fi
+
+# Write the suppressions to csc.rsp
+{
+    for warning in "${warnings_to_ignore[@]}"; do
+        echo "-nowarn:$warning"
+    done
+} > "$file_path"
+
+# Feedback
+if [[ $? -eq 0 ]]; then
+    echo "Successfully generated csc.rsp file at: $file_path"
+    echo "Added ${#warnings_to_ignore[@]} warning suppressions to the file."
+else
+    echo "Failed to generate csc.rsp file"
+    exit 1
+fi


### PR DESCRIPTION
# Pull Request Description

The generate csc.rsp was happening after the import, which is where all the spam is happening in the logs. 

This moves it to a pre-build step which should happen before the import.