### PR TITLE
chore: skip enforce approval when no QA needed label present

### DIFF
--- a/.github/workflows/enforce-group-approvals.yml
+++ b/.github/workflows/enforce-group-approvals.yml
@@ -56,6 +56,14 @@ jobs:
             exit 0
           fi
 
+          REQUIRES_QA=true
+          if jq -r '.[].name' <<< "$LABELS_JSON" | grep -qi "^no QA needed$"; then
+            REQUIRES_QA=false
+            echo "ℹ️ 'no QA needed' label found — QA approval NOT required."
+          else
+            echo "ℹ️ 'no QA needed' label not found — QA approval required."
+          fi
+
           echo "🔍 Fetching team members..."
           QA_TEAM="qa"
           DEV_TEAM="explorer-devs"
@@ -106,9 +114,9 @@ jobs:
             fi
           done
 
-          if [ "$HAS_QA_APPROVAL" != true ] || [ "$HAS_DEV_APPROVAL" != true ]; then
+          if { [ "$REQUIRES_QA" == true ] && [ "$HAS_QA_APPROVAL" != true ]; } || [ "$HAS_DEV_APPROVAL" != true ]; then
             MISSING=()
-            [ "$HAS_QA_APPROVAL" != true ] && MISSING+=("QA approval")
+            [ "$REQUIRES_QA" == true ] && [ "$HAS_QA_APPROVAL" != true ] && MISSING+=("QA approval")
             [ "$HAS_DEV_APPROVAL" != true ] && MISSING+=("DEV approval")
             MISSING_MSG=$(IFS=", "; echo "${MISSING[*]}")
             echo "❌ PR must have at least 1: $MISSING_MSG."


### PR DESCRIPTION
This PR updates the `Enforce QA and DEV Approvals` workflow to allow skipping QA approval when the "no QA needed" label is applied to a pull request.

Changes:
- If the label "no QA needed" is present on the PR, QA approval is skipped.
- DEV approval is still always required.

This allows more flexibility for non-functional or low-risk PRs (e.g. documentation, CI changes) where QA review isn't necessary, reducing review overhead and allowing for faster merging.