### PR TITLE
chore: updating auto assign action to latest version

### DIFF
--- a/.github/auto_assign_config_dev.yml
+++ b/.github/auto_assign_config_dev.yml
@@ -4,6 +4,7 @@ numberOfAssignees: 1
 addReviewers: true
 numberOfReviewers: 1
 useReviewGroups: true
+
 reviewGroups:
   techleads:
     - mikhail-dcl
@@ -19,12 +20,8 @@ reviewGroups:
     - lorenzo-ranciaffi
     - mihakrajnc
     - AnsisMalins
-  qa:
-    - Ludmilafantaniella
-    - anicalbano
-    - dafgreco
+    - daniele-dcl
 
 filterLabels:
   exclude:
     - "no review"
-    - "no QA needed"

--- a/.github/auto_assign_config_qa.yml
+++ b/.github/auto_assign_config_qa.yml
@@ -1,0 +1,14 @@
+addReviewers: true
+numberOfReviewers: 1
+useReviewGroups: true
+
+reviewGroups:
+  qa:
+    - Ludmilafantaniella
+    - anicalbano
+    - dafgreco
+
+filterLabels:
+  exclude:
+    - "no QA needed"
+    - "no review"

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,12 +1,20 @@
-name: 'Auto Assign'
+name: 'Auto Assign Reviewers'
+
 on:
   pull_request:
     types: [opened, ready_for_review]
 
 jobs:
-  add-reviews:
+  assign-devs:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.2.1
+      - uses: kentaro-m/auto-assign-action@v2.0.0
         with:
-          configuration-path: '.github/auto_assign_config.yml'
+          configuration-path: '.github/auto_assign_config_dev.yml'
+
+  assign-qa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: '.github/auto_assign_config_qa.yml'


### PR DESCRIPTION
This PR improves the auto-assign workflow by:
- Splitting reviewer assignment into two separate jobs:
  - One for developers
  - One for QA
  - Allowing the QA reviewers to be skipped when the no QA needed label is present
- Updated the list of reviewers
- Bumped the action version to the latest available