### PR TITLE
Fixed: User needs to close and re-open the app to see their new community (#4642)

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -489,6 +489,29 @@ namespace DCL.Chat
             viewInstance.Focus();
         }
 
+        private void OnCommunitiesDataProviderCommunityCreated(CreateOrUpdateCommunityResponse.CommunityData newCommunity)
+        {
+            ChatChannel.ChannelId channelId = ChatChannel.NewCommunityChannelId(newCommunity.id);
+            userCommunities[channelId] = new GetUserCommunitiesData.CommunityData()
+                {
+                    id = newCommunity.id,
+                    thumbnails = newCommunity.thumbnails,
+                    description = newCommunity.description,
+                    ownerAddress = newCommunity.ownerAddress,
+                    name = newCommunity.name,
+                    privacy = newCommunity.privacy,
+                    role = CommunityMemberRole.owner,
+                    membersCount = 1
+                };
+            chatHistory.AddOrGetChannel(channelId, ChatChannel.ChatChannelType.COMMUNITY);
+        }
+
+        private void OnCommunitiesDataProviderCommunityDeleted(string communityId)
+        {
+            ChatChannel.ChannelId channelId = ChatChannel.NewCommunityChannelId(communityId);
+            chatHistory.RemoveChannel(channelId);
+        }
+
         private void OnSelectConversation(ChatChannel.ChannelId channelId)
         {
             if(!IsViewReady)
@@ -985,6 +1008,9 @@ namespace DCL.Chat
             DCLInput.Instance.Shortcuts.ToggleNametags.performed += OnToggleNametagsShortcutPerformed;
             DCLInput.Instance.Shortcuts.OpenChatCommandLine.performed += OnOpenChatCommandLineShortcutPerformed;
 
+            communitiesDataProvider.CommunityCreated += OnCommunitiesDataProviderCommunityCreated;
+            communitiesDataProvider.CommunityDeleted += OnCommunitiesDataProviderCommunityDeleted;
+
             SubscribeToCommunitiesBusEventsAsync().Forget();
         }
 
@@ -1070,6 +1096,9 @@ namespace DCL.Chat
 
             communitiesEventBus.UserConnectedToCommunity -= OnCommunitiesEventBusUserConnectedToCommunity;
             communitiesEventBus.UserDisconnectedFromCommunity -= OnCommunitiesEventBusUserDisconnectedToCommunity;
+
+            communitiesDataProvider.CommunityCreated -= OnCommunitiesDataProviderCommunityCreated;
+            communitiesDataProvider.CommunityDeleted -= OnCommunitiesDataProviderCommunityDeleted;
         }
 
         private async UniTaskVoid ShowErrorNotificationAsync(string errorMessage, CancellationToken ct)

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/CommunitiesDataProvider.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/CommunitiesDataProvider.cs
@@ -14,9 +14,9 @@ namespace DCL.Communities
 {
     public class CommunitiesDataProvider : ICommunitiesDataProvider
     {
-        public event Action CommunityCreated;
+        public event Action<CreateOrUpdateCommunityResponse.CommunityData> CommunityCreated;
         public event Action<string> CommunityUpdated;
-        public event Action CommunityDeleted;
+        public event Action<string> CommunityDeleted;
         public event Action<string, bool> CommunityJoined;
         public event Action<string, bool> CommunityLeft;
 
@@ -101,7 +101,7 @@ namespace DCL.Communities
                 response = await webRequestController.SignedFetchPostAsync(communitiesBaseUrl, GenericPostArguments.CreateMultipartForm(formData), string.Empty, ct)
                                                      .CreateFromJson<CreateOrUpdateCommunityResponse>(WRJsonParser.Newtonsoft);
 
-                CommunityCreated?.Invoke();
+                CommunityCreated?.Invoke(response.data);
             }
             else
             {
@@ -237,7 +237,7 @@ namespace DCL.Communities
                                       .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
             if (result.Success)
-                CommunityDeleted?.Invoke();
+                CommunityDeleted?.Invoke(communityId);
 
             return result.Success;
         }

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/FakeCommunitiesDataProvider.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/FakeCommunitiesDataProvider.cs
@@ -12,9 +12,9 @@ namespace DCL.Communities
 {
     public class FakeCommunitiesDataProvider : ICommunitiesDataProvider
     {
-        public event Action CommunityCreated;
+        public event Action<CreateOrUpdateCommunityResponse.CommunityData> CommunityCreated;
         public event Action<string> CommunityUpdated;
-        public event Action CommunityDeleted;
+        public event Action<string> CommunityDeleted;
         public event Action<string, bool> CommunityJoined;
         public event Action<string, bool> CommunityLeft;
 

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/ICommunitiesDataProvider.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/ICommunitiesDataProvider.cs
@@ -7,9 +7,9 @@ namespace DCL.Communities
 {
     public interface ICommunitiesDataProvider
     {
-        public event Action CommunityCreated;
+        public event Action<CreateOrUpdateCommunityResponse.CommunityData> CommunityCreated;
         public event Action<string> CommunityUpdated;
-        public event Action CommunityDeleted;
+        public event Action<string> CommunityDeleted;
         public event Action<string, bool> CommunityJoined;
         public event Action<string, bool> CommunityLeft;
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Now when the community is created, the chat conversation is created too. When the community deleted, the conversation is removed for the owner only.

## Test Instructions

### Prerequisites
Requires to be connected to Zone environment.

### The conversation appears when the community is created
1. Open the chat and see the conversations currently available in the toolbar.
2. Open the Community browser and create a new community.
3. Close the explore panel and open the chat. A new conversation for the new community should be there.


### The conversation disappears when the community is deleted
1. Open the chat and see the conversations currently available in the toolbar.
2. Open the communty card of one of the communities you own.
3. Delete the community.
4. Close the explore panel and open the chat. The conversation of the deleted community should NOT be there.