### PR TITLE
[Communities Polishing] Several visual polishments in the Creation Wizard

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/CreateOrEditCommunityPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/CreateOrEditCommunityPanel.prefab
@@ -2112,8 +2112,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 3003121663
-  m_fontColor: {r: 1, g: 1, b: 1, a: 0.69803923}
+    rgba: 2164063484
+  m_fontColor: {r: 0.9882353, g: 0.9882353, b: 0.9882353, a: 0.5019608}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/PlaceTag.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/PlaceTag.prefab
@@ -197,7 +197,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -245,36 +245,44 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
+      propertyPath: m_TargetGraphic
+      value: 
+      objectReference: {fileID: 5902376632327636488}
+    - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
+      propertyPath: m_Colors.m_FadeDuration
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_NormalColor.a
-      value: 0.03137255
+      value: 0.4
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_NormalColor.b
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_NormalColor.g
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_NormalColor.r
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_PressedColor.a
-      value: 0.050980393
+      value: 0.4
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_PressedColor.b
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_PressedColor.g
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_PressedColor.r
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_DisabledColor.a
@@ -294,23 +302,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_SelectedColor.a
-      value: 0.03137255
+      value: 0.4
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_SelectedColor.b
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_SelectedColor.g
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_SelectedColor.r
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_HighlightedColor.a
-      value: 0.101960786
+      value: 0.03137255
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_HighlightedColor.b
@@ -338,11 +346,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2988973775201219658, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 8
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 2988973775201219658, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 8
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3783773368439746124, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
+      propertyPath: m_Color.a
+      value: 0.011764706
       objectReference: {fileID: 0}
     - target: {fileID: 3783773368439746124, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_PixelsPerUnitMultiplier
@@ -374,11 +386,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4754443713931925278, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 20
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 4754443713931925278, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 20
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 4754443713931925278, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_LocalPosition.x
@@ -410,7 +422,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4754443713931925278, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -10
+      value: -8
       objectReference: {fileID: 0}
     - target: {fileID: 4754443713931925278, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_AnchoredPosition.y

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/PlaceTag.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/PlaceTag.prefab
@@ -34,8 +34,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -12.5, y: 0}
-  m_SizeDelta: {x: -45, y: -20}
+  m_AnchoredPosition: {x: -9.5, y: 0}
+  m_SizeDelta: {x: -51, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5240012874911417880
 CanvasRenderer:

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/PlaceTag.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/PlaceTag.prefab
@@ -354,7 +354,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3783773368439746124, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Color.a
-      value: 0.011764706
+      value: 0.019607844
       objectReference: {fileID: 0}
     - target: {fileID: 3783773368439746124, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_PixelsPerUnitMultiplier

--- a/Explorer/Assets/DCL/UI/Assets/SelectorButton.prefab
+++ b/Explorer/Assets/DCL/UI/Assets/SelectorButton.prefab
@@ -262,11 +262,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   selectorButton: {fileID: 6430276237837877534}
   selectorButtonText: {fileID: 2191246548326702995}
-  selectorPanel: {fileID: 1494069765180602260}
+  selectorPanel: {fileID: 5196600299966827827}
+  selectorPanelContentContainer: {fileID: 4529298168230838044}
+  selectorPanelMaxHeight: 150
   selectorPanelScrollRect: {fileID: 8987135111240112651}
   selectorPanelParent: {fileID: 0}
   optionItemGameObject: {fileID: 1261629992894967956}
   backgroundCloseButton: {fileID: 7424665203201326611}
+  defaultPoolCapacity: 10
 --- !u!1 &568733401536827907
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/UI/SelectorButton/SelectorButtonView.cs
+++ b/Explorer/Assets/DCL/UI/SelectorButton/SelectorButtonView.cs
@@ -14,7 +14,9 @@ namespace DCL.UI.SelectorButton
 
         [SerializeField] private Button selectorButton;
         [SerializeField] private TMP_Text selectorButtonText;
-        [SerializeField] private GameObject selectorPanel;
+        [SerializeField] private RectTransform selectorPanel;
+        [SerializeField] private RectTransform selectorPanelContentContainer;
+        [SerializeField] private float selectorPanelMaxHeight = 150f;
         [SerializeField] private ScrollRect selectorPanelScrollRect;
         [SerializeField] private Transform selectorPanelParent;
         [SerializeField] private SelectorButtonOptionItemView optionItemGameObject;
@@ -29,8 +31,8 @@ namespace DCL.UI.SelectorButton
 
         private void Awake()
         {
-            originalParent = selectorPanel.transform.parent;
-            originalLocalPosition = selectorPanel.transform.localPosition;
+            originalParent = selectorPanel.parent;
+            originalLocalPosition = selectorPanel.localPosition;
             selectorPanelScrollRect.SetScrollSensitivityBasedOnPlatform();
 
             optionsPool = new ObjectPool<SelectorButtonOptionItemView>(
@@ -136,18 +138,26 @@ namespace DCL.UI.SelectorButton
 
         private void OnOpenOptionsPanel()
         {
-            selectorPanel.SetActive(true);
+            selectorPanel.gameObject.SetActive(true);
             selectorPanelScrollRect.verticalNormalizedPosition = 1f;
+            RefreshSelectorPanelSize();
 
             if (selectorPanelParent != null)
             {
-                selectorPanel.transform.parent = originalParent;
-                selectorPanel.transform.localPosition = originalLocalPosition;
-                selectorPanel.transform.parent = selectorPanelParent;
+                selectorPanel.parent = originalParent;
+                selectorPanel.localPosition = originalLocalPosition;
+                selectorPanel.parent = selectorPanelParent;
             }
         }
 
         private void OnCloseOptionsPanel() =>
-            selectorPanel.SetActive(false);
+            selectorPanel.gameObject.SetActive(false);
+
+        private void RefreshSelectorPanelSize()
+        {
+            float contentHeight = selectorPanelContentContainer.rect.height;
+            float maxHeight = Mathf.Min(contentHeight, selectorPanelMaxHeight);
+            selectorPanel.sizeDelta = new Vector2(selectorPanel.sizeDelta.x, maxHeight);
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Description
Fix #4652 

## What does this PR change?
- The color of the texts marked with yellow didn't seem to match.
- Increased place's name left margin.
- Place row width is the same than the dropdown now.
- The cancel button is now correctly aligned to the left with the rest of the components.
- The height of the dropdown list is responsive now: It has a max height but when there are few items inside, the size is decreased.

<img width="1366" height="1474" alt="Image" src="https://github.com/user-attachments/assets/c85dfff4-caf6-43c9-bd9b-b86b5fdf8b29" />

<img width="1082" height="1158" alt="Image" src="https://github.com/user-attachments/assets/4ee53b31-1c47-4208-aeb0-85195513cace" />

### Test Steps
1. Open the communities Creation/Wdition wizard.
2. Check all the points described above.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.