### PR TITLE
fix: address concurrent retry case for enforce-approvals workflow

### DIFF
--- a/.github/workflows/enforce-group-approvals.yml
+++ b/.github/workflows/enforce-group-approvals.yml
@@ -133,14 +133,26 @@ jobs:
         if: env.APPROVAL_CHECK == 'passed' && github.event_name == 'pull_request_review'
         run: |
           echo "📦 Searching 'Enforce QA and DEV Approvals' workflow run for SHA $HEAD_SHA..."
-          gh run list \
+          RUNS_JSON=$(gh run list \
             --workflow="Enforce QA and DEV Approvals" \
             --limit 1000 \
             --repo "$REPO_OWNER/$REPO_NAME" \
-            --json databaseId,headSha,event,conclusion,status,createdAt \
-            | jq --arg HEAD_SHA "$HEAD_SHA" '
-                .[] | select(.headSha == $HEAD_SHA)
-              '
+            --json databaseId,headSha,event,conclusion,status,createdAt)
+
+          echo "$RUNS_JSON" | jq --arg HEAD_SHA "$HEAD_SHA" '
+            .[] | select(.headSha == $HEAD_SHA)
+          '
+
+          # Count in-progress runs for this SHA
+          IN_PROGRESS_COUNT=$(echo "$RUNS_JSON" | jq --arg HEAD_SHA "$HEAD_SHA" -r '
+            map(select(.headSha == $HEAD_SHA and .status == "in_progress")) | length
+          ')
+
+          echo "🔸 Number of in-progress runs for SHA $HEAD_SHA: $IN_PROGRESS_COUNT"
+          if [ "$IN_PROGRESS_COUNT" -gt 1 ]; then
+            echo "⚠️ More than 1 in-progress run detected for this SHA, skipping rerun."
+            exit 0
+          fi
 
           echo "🔎 Searching failed 'Enforce QA and DEV Approvals' workflow run for SHA $HEAD_SHA..."
           WORKFLOW_RUN_ID=$(gh run list \


### PR DESCRIPTION
- Updated the "Enforce QA and DEV Approvals" workflow to better handle cases where multiple runs overlap
- The job now displays all runs for the current commit and checks how many are still in progress before retrying
- If it finds more than one run in progress for the same SHA, it skips triggering a rerun to avoid GitHub CLI errors