### PR TITLE
[Communities Polishing] Show/Hide members counter in the Community Result Card (under new Feature Flag)

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunityResultCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunityResultCardView.cs
@@ -36,6 +36,7 @@ namespace DCL.Communities.CommunitiesBrowser
         [SerializeField] private Sprite publicPrivacySprite = null!;
         [SerializeField] private Sprite privatePrivacySprite = null!;
         [SerializeField] private TMP_Text communityPrivacyText = null!;
+        [SerializeField] private GameObject communityMembersSeparator = null!;
         [SerializeField] private TMP_Text communityMembersCountText = null!;
         [SerializeField] private GameObject communityLiveMark = null!;
         [SerializeField] private Button mainButton = null!;
@@ -115,7 +116,11 @@ namespace DCL.Communities.CommunitiesBrowser
 
         public void SetMembersCount(int memberCount)
         {
-            communityMembersCountText.text = string.Format(MEMBERS_COUNTER_FORMAT, CommunitiesUtility.NumberToCompactString(memberCount));
+            bool showMembers = CommunitiesFeatureAccess.Instance.CanMembersCounterBeDisplayer();
+            communityMembersSeparator.SetActive(showMembers);
+            communityMembersCountText.gameObject.SetActive(showMembers);
+            if (showMembers)
+                communityMembersCountText.text = string.Format(MEMBERS_COUNTER_FORMAT, CommunitiesUtility.NumberToCompactString(memberCount));
         }
 
         public void SetOwnership(bool isMember)

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunityResultCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunityResultCard.prefab
@@ -1415,6 +1415,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <LoadingObject>k__BackingField: {fileID: 2987537105166981742}
   <Image>k__BackingField: {fileID: 9127482766625081763}
+  <imageLoadingFadeDuration>k__BackingField: 0.3
 --- !u!114 &9212648285223425415
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1771,6 +1772,7 @@ MonoBehaviour:
   publicPrivacySprite: {fileID: 21300000, guid: ce952777a378746d48f3cb3b51815ed9, type: 3}
   privatePrivacySprite: {fileID: 21300000, guid: cee9a3dbf9f6544da96abe48bb2550af, type: 3}
   communityPrivacyText: {fileID: 1598583829820689214}
+  communityMembersSeparator: {fileID: 5717000641063294861}
   communityMembersCountText: {fileID: 5759947373287357163}
   communityLiveMark: {fileID: 7783451404242258191}
   mainButton: {fileID: 7446897494615956440}
@@ -1786,7 +1788,6 @@ MonoBehaviour:
       picture: {fileID: 2573895094594536804}
     - root: {fileID: 4816826890462254729}
       picture: {fileID: 873994822332494481}
-  defaultThumbnailSprite: {fileID: 21300000, guid: 3b627b525f70e419bb278c5d44830db2, type: 3}
 --- !u!1 &8345438408242346082
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Communities/CommunitiesFeatureAccess.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesFeatureAccess.cs
@@ -13,6 +13,7 @@ namespace DCL.Communities
         private readonly IWeb3IdentityCache web3IdentityCache;
 
         private bool? storedResult;
+        private bool? storedMembersCounterResult;
 
         public CommunitiesFeatureAccess(IWeb3IdentityCache web3IdentityCache)
         {
@@ -50,6 +51,16 @@ namespace DCL.Communities
             }
 
             storedResult = cacheResult ? result : null;
+            return result;
+        }
+
+        public bool CanMembersCounterBeDisplayer()
+        {
+            if (storedMembersCounterResult != null)
+                return storedMembersCounterResult.Value;
+
+            bool result = FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.COMMUNITIES_MEMBERS_COUNTER);
+            storedMembersCounterResult = result;
             return result;
         }
 

--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -36,6 +36,7 @@
         public const string MARKETPLACE_CREDITS_WALLETS_VARIANT = "wallets";
         public const string COMMUNITIES = "alfa-communities";
         public const string COMMUNITIES_WALLETS_VARIANT = "wallets";
+        public const string COMMUNITIES_MEMBERS_COUNTER = "alfa-communities-members-counter";
 
         public const string AUTH_CODE_VALIDATION = "number-validation";
 


### PR DESCRIPTION
# Pull Request Description
Fix #4716 

## What does this PR change?
We have added a new Feature Flag (`alfa-communities-members-counter`) to show / hide the number of members of a community in the community browser.

![image](https://github.com/user-attachments/assets/55308ee2-a1f7-4b73-9f17-1043310b0f5f)

### Test Steps
1. Make sure the feature flag `alfa-communities-members-counter` is currently deactivated.
2. Open the build (in zone).
3. Open the Communities Browser.
4. Check that there is no members counter in any card.
5. Close the build.
6. Make sure the feature flag `alfa-communities-members-counter` is currently activated.
7. Open the build (in zone).
8. Open the Communities Browser.
9. Check that there is a members counter in each card.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.