### PR TITLE
Chat messages not received

### DIFF
--- a/Explorer/Assets/DCL/Chat/MessageBus/MultiplayerChatMessagesBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/MultiplayerChatMessagesBus.cs
@@ -56,12 +56,10 @@ namespace DCL.Chat.MessageBus
         private async UniTaskVoid ConfigureMessagePipesHubAsync(CancellationToken ct)
         {
             isCommunitiesIncluded = await CommunitiesFeatureAccess.Instance.IsUserAllowedToUseTheFeatureAsync(ct);
-            if (isCommunitiesIncluded)
-            {
-                messagePipesHub.IslandPipe().Subscribe<Decentraland.Kernel.Comms.Rfc4.Chat>(Decentraland.Kernel.Comms.Rfc4.Packet.MessageOneofCase.Chat, OnMessageReceived);
-                messagePipesHub.ScenePipe().Subscribe<Decentraland.Kernel.Comms.Rfc4.Chat>(Decentraland.Kernel.Comms.Rfc4.Packet.MessageOneofCase.Chat, OnMessageReceived);
-                messagePipesHub.ChatPipe().Subscribe<Decentraland.Kernel.Comms.Rfc4.Chat>(Decentraland.Kernel.Comms.Rfc4.Packet.MessageOneofCase.Chat, OnChatPipeMessageReceived);
-            }
+
+            messagePipesHub.IslandPipe().Subscribe<Decentraland.Kernel.Comms.Rfc4.Chat>(Decentraland.Kernel.Comms.Rfc4.Packet.MessageOneofCase.Chat, OnMessageReceived);
+            messagePipesHub.ScenePipe().Subscribe<Decentraland.Kernel.Comms.Rfc4.Chat>(Decentraland.Kernel.Comms.Rfc4.Packet.MessageOneofCase.Chat, OnMessageReceived);
+            messagePipesHub.ChatPipe().Subscribe<Decentraland.Kernel.Comms.Rfc4.Chat>(Decentraland.Kernel.Comms.Rfc4.Packet.MessageOneofCase.Chat, OnChatPipeMessageReceived);
         }
 
         public void Dispose()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

It was not subscribing to multiplayer message pipes when the Communities feature flag was not enabled.
It solves this: https://github.com/decentraland/unity-explorer/issues/4726

## Test Instructions

You need 2 users.

### Messages arrive when the Feature flag is disabled
1. Open the chat with user A.
2. Send a message in Nearby.
3. Send a message in a private channel with user B.
4. Send a message in a community to which both users belong.
5. The 3 messages should have reached the chat of user B.