### PR TITLE
fix: Camera locked after going to an SDK scene

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Systems/MainCameraSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/CameraControl/MainCamera/Systems/MainCameraSystem.cs
@@ -199,7 +199,6 @@ namespace DCL.SDKComponents.CameraControl.MainCamera.Systems
         private void DisableActiveVirtualCamera(in MainCameraComponent mainCameraComponent)
         {
             if (mainCameraComponent.virtualCameraInstance == null
-                || !mainCameraComponent.virtualCameraInstance.enabled
                 || !VirtualCameraUtils.VirtualCameraExistsInEntitiesMap(entitiesMap, mainCameraComponent.virtualCameraCRDTEntity))
                 return;
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

After leaving a scene with a camera lock, the camera remained in CameraSDK state. This PR fixes that by disabling the camera on the exit state correctly

## Test Instructions


### Prerequisites


### Test Steps
1. Go to `olavra.dcl.eth`. The camera should be lcoked
2. Go back to Genesis. The camera should be in a normal state, you should be able to use it regularly




## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
