### PR TITLE
fix: [Communities Polishing] Rename "isVerified" by "hasClaimedName" in GetUserCommunitiesResponse DTO

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunityResultCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunityResultCardView.cs
@@ -154,7 +154,7 @@ namespace DCL.Communities.CommunitiesBrowser
                 if (!friendExists) continue;
                 GetUserCommunitiesData.FriendInCommunity mutualFriend = communityData.friends[i];
                 mutualFriends.thumbnails[i].picture.Setup(profileDataProvider, ProfileNameColorHelper.GetNameColor(mutualFriend.name), mutualFriend.profilePictureUrl);
-                mutualFriends.thumbnails[i].profileNameTooltip.Setup(mutualFriend.name, mutualFriend.isVerified);
+                mutualFriends.thumbnails[i].profileNameTooltip.Setup(mutualFriend.name, mutualFriend.hasClaimedName);
 
                 if (mutualFriends.thumbnails[i].isPointerEventsSubscribed)
                     continue;

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/GetUserCommunitiesResponse.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/GetUserCommunitiesResponse.cs
@@ -46,7 +46,7 @@ namespace DCL.Communities
             public string address;
             public string name;
             public string profilePictureUrl;
-            public bool isVerified;
+            public bool hasClaimedName;
         }
 
         public CommunityData[] results;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Rename "isVerified" by "hasClaimedName" in GetUserCommunitiesResponse DTO.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.