### PR TITLE
fix: streaming volume change through settings on mac

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
@@ -180,10 +180,10 @@ namespace DCL.SDKComponents.MediaStream
         {
             switch (isCurrentScene)
             {
-                case true when Volume < targetVolume:
+                case true:
                     SetVolume(Mathf.Min(targetVolume, Volume + volumeDelta));
                     break;
-                case false when Volume > 0:
+                case false:
                     SetVolume(Mathf.Max(0, targetVolume - volumeDelta));
                     break;
             }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerExtensions.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerExtensions.cs
@@ -21,10 +21,10 @@ namespace DCL.SDKComponents.MediaStream
         {
             switch (isCurrentScene)
             {
-                case true when mediaPlayer.AudioVolume < targetVolume:
+                case true:
                     mediaPlayer.AudioVolume = Mathf.Min(targetVolume, mediaPlayer.AudioVolume + volumeDelta);
                     break;
-                case false when mediaPlayer.AudioVolume > 0:
+                case false:
                     mediaPlayer.AudioVolume = Mathf.Max(0, mediaPlayer.AudioVolume - volumeDelta);
                     break;
             }


### PR DESCRIPTION
## What does this PR change?

Fixes #2294  #4759 

The volume was only changing on current scene if it was higher than the current set in the media player, but it was not considering if you lowered the volume through the settings.
The solution consists on removing the volume change conditions so it always applies to the given target volume.

## Test Instructions

Test the streaming volumes on mac and check that the settings applies.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
