### PR TITLE
[Communities Polishing] Add creator name into place tags in the Creation Wizard

### DIFF
--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrl.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrl.cs
@@ -88,5 +88,7 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
 
         DecentralandContentOverride,
         DecentralandLambdasOverride,
+
+        LambdasProfiles,
     }
 }

--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
@@ -127,6 +127,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.DecentralandWorlds => "https://decentraland.org/blog/about-decentraland/decentraland-worlds-your-own-virtual-space?utm_org=dcl&utm_source=explorer&utm_medium=organic",
                 DecentralandUrl.DecentralandLambdasOverride => LAMBDAS_URL_OVERRIDE,
                 DecentralandUrl.DecentralandContentOverride => CONTENT_URL_OVERRIDE,
+                DecentralandUrl.LambdasProfiles =>$"https://peer.decentraland.{ENV}/lambdas/profiles",
                 _ => throw new ArgumentOutOfRangeException(nameof(decentralandUrl), decentralandUrl, null!)
             };
     }

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
@@ -217,10 +217,10 @@ namespace DCL.Communities.CommunityCreation
         private void OnPlacesDropdownOptionSelected(int index) =>
             AddPlaceButtonClicked?.Invoke(index);
 
-        public void AddPlaceTag(string id, bool isWorld, string placeName, bool isRemovalAllowed, bool updateScrollPosition = true)
+        public void AddPlaceTag(string id, bool isWorld, string placeName, string ownerName, bool isRemovalAllowed, bool updateScrollPosition = true)
         {
             CommunityPlaceTag placeTag = Instantiate(placeTagPrefab, placeTagsContainer);
-            placeTag.Setup(id, isWorld, placeName, isRemovalAllowed);
+            placeTag.Setup(id, isWorld, placeName, ownerName, isRemovalAllowed);
 
             void OnPlaceTagRemovedClicked()
             {

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityPlaceTag.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityPlaceTag.cs
@@ -10,12 +10,11 @@ namespace DCL.Communities.CommunityCreation
         public Action? RemoveButtonClicked;
 
         [SerializeField] private TMP_Text tagText = null!;
+        [SerializeField] private TMP_Text ownerNameText = null!;
         [SerializeField] private Button removeButton = null!;
 
         public string Id { get; private set; } = null!;
         public bool IsWorld { get; private set; }
-
-        public string Text { set => tagText.text = value; }
 
         private void Awake() =>
             removeButton.onClick.AddListener(() => RemoveButtonClicked?.Invoke());
@@ -23,11 +22,12 @@ namespace DCL.Communities.CommunityCreation
         private void OnDestroy() =>
             removeButton.onClick.RemoveAllListeners();
 
-        public void Setup(string id, bool isWorld, string text, bool allowRemove)
+        public void Setup(string id, bool isWorld, string text, string ownerName, bool allowRemove)
         {
             Id = id;
             IsWorld = isWorld;
-            Text = text;
+            tagText.text = text;
+            ownerNameText.text = ownerName;
             removeButton.gameObject.SetActive(allowRemove);
         }
     }

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/PlaceTag.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/PlaceTag.prefab
@@ -198,7 +198,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.2}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -385,26 +385,26 @@ PrefabInstance:
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_TargetGraphic
       value: 
-      objectReference: {fileID: 5902376632327636488}
+      objectReference: {fileID: 43650694656926278}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_FadeDuration
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_NormalColor.a
-      value: 0.4
+      value: 0.011764706
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_NormalColor.b
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_NormalColor.g
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_NormalColor.r
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Colors.m_PressedColor.a
@@ -492,7 +492,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3783773368439746124, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_Color.a
-      value: 0.019607844
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3783773368439746124, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3783773368439746124, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3783773368439746124, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
+      propertyPath: m_Color.r
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3783773368439746124, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
       propertyPath: m_PixelsPerUnitMultiplier
@@ -587,6 +599,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
+--- !u!114 &43650694656926278 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3783773368439746124, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}
+  m_PrefabInstance: {fileID: 3754240429023202314}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &4547437306164256742 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 793200768551293932, guid: 7842eaf6eb5af984291ecacc1280f742, type: 3}

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/PlaceTag.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/PlaceTag.prefab
@@ -34,8 +34,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -9.5, y: 0}
-  m_SizeDelta: {x: -51, y: -20}
+  m_AnchoredPosition: {x: -144.5, y: 0}
+  m_SizeDelta: {x: -321, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5240012874911417880
 CanvasRenderer:
@@ -168,13 +168,14 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7037453062087020733}
+  - {fileID: 3371228998868271303}
   - {fileID: 8494510836744117012}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 295, y: 40}
+  m_SizeDelta: {x: 600, y: 40}
   m_Pivot: {x: 0, y: 0}
 --- !u!222 &8832623039404450805
 CanvasRenderer:
@@ -227,7 +228,144 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   tagText: {fileID: 6555109184114173320}
+  ownerNameText: {fileID: 1977813702972849284}
   removeButton: {fileID: 4547437306164256742}
+--- !u!1 &4518099339926580335
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3371228998868271303}
+  - component: {fileID: 1477310029270487055}
+  - component: {fileID: 1977813702972849284}
+  m_Layer: 5
+  m_Name: OwnerNameText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3371228998868271303
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4518099339926580335}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 677302244347562019}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 125.5, y: 0}
+  m_SizeDelta: {x: -359, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1477310029270487055
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4518099339926580335}
+  m_CullTransparentMesh: 1
+--- !u!114 &1977813702972849284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4518099339926580335}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Creator Name
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 3003121663
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.69803923}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 10
+  m_fontSizeMax: 14
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1001 &3754240429023202314
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -628,6 +628,8 @@ namespace Global.Dynamic
             var realmNftNamesProvider = new RealmNftNamesProvider(staticContainer.WebRequestsContainer.WebRequestController,
                 staticContainer.RealmData);
 
+            var lambdasProfilesProvider = new LambdasProfilesProvider(staticContainer.WebRequestsContainer.WebRequestController, bootstrapContainer.DecentralandUrlsSource);
+
             var globalPlugins = new List<IDCLGlobalPlugin>
             {
                 new MultiplayerPlugin(
@@ -1002,7 +1004,8 @@ namespace Global.Dynamic
                     sharedSpaceManager,
                     chatEventBus,
                     communitiesEventBus,
-                    socialServiceContainer.socialServicesRPC));
+                    socialServiceContainer.socialServicesRPC,
+                    lambdasProfilesProvider));
 
             if (dynamicWorldParams.EnableAnalytics)
                 globalPlugins.Add(new AnalyticsPlugin(

--- a/Explorer/Assets/DCL/PluginSystem/Global/CommunitiesPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/CommunitiesPlugin.cs
@@ -13,6 +13,7 @@ using DCL.EventsApi;
 using DCL.Friends;
 using DCL.InWorldCamera.CameraReelStorageService;
 using DCL.PlacesAPIService;
+using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.SocialService;
 using DCL.UI.Profiles.Helpers;
@@ -48,6 +49,7 @@ namespace DCL.PluginSystem.Global
         private readonly IEventsApiService eventsApiService;
         private readonly ISharedSpaceManager sharedSpaceManager;
         private readonly IChatEventBus chatEventBus;
+        private readonly LambdasProfilesProvider lambdasProfilesProvider;
 
         private CommunityCardController? communityCardController;
         private CommunityCreationEditionController? communityCreationEditionController;
@@ -73,7 +75,8 @@ namespace DCL.PluginSystem.Global
             ISharedSpaceManager sharedSpaceManager,
             IChatEventBus chatEventBus,
             CommunitiesEventBus communitiesEventBus,
-            IRPCSocialServices rpcSocialServices)
+            IRPCSocialServices rpcSocialServices,
+            LambdasProfilesProvider lambdasProfilesProvider)
         {
             this.mvcManager = mvcManager;
             this.assetsProvisioner = assetsProvisioner;
@@ -92,6 +95,7 @@ namespace DCL.PluginSystem.Global
             this.eventsApiService = eventsApiService;
             this.sharedSpaceManager = sharedSpaceManager;
             this.chatEventBus = chatEventBus;
+            this.lambdasProfilesProvider = lambdasProfilesProvider;
             rpcCommunitiesService = new RPCCommunitiesService(rpcSocialServices, communitiesEventBus);
         }
 
@@ -138,7 +142,8 @@ namespace DCL.PluginSystem.Global
                 communitiesDataProvider,
                 placesAPIService,
                 selfProfile,
-                mvcManager);
+                mvcManager,
+                lambdasProfilesProvider);
             mvcManager.RegisterController(communityCreationEditionController);
 
             EventInfoView eventInfoViewAsset = (await assetsProvisioner.ProvideMainAssetValueAsync(settings.EventInfoPrefab, ct: ct)).GetComponent<EventInfoView>();

--- a/Explorer/Assets/DCL/Profiles/DataModels/ProfileJsonDto.cs
+++ b/Explorer/Assets/DCL/Profiles/DataModels/ProfileJsonDto.cs
@@ -425,4 +425,11 @@ namespace DCL.Profiles
         public ProfileJsonDto? FirstProfileDto() =>
             AnyAvatarInList() ? avatars[0] : null;
     }
+
+    [Serializable]
+    public class GetAvatarsDetailsDto
+    {
+        public long timestamp;
+        public List<ProfileJsonDto> avatars;
+    }
 }

--- a/Explorer/Assets/DCL/Profiles/LambdasProfilesProvider.cs
+++ b/Explorer/Assets/DCL/Profiles/LambdasProfilesProvider.cs
@@ -1,0 +1,60 @@
+using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.WebRequests;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace DCL.Profiles
+{
+    public class LambdasProfilesProvider
+    {
+        private readonly IWebRequestController webRequestController;
+        private readonly IDecentralandUrlsSource urlsSource;
+
+        private string lambdasProfilesBaseUrl => urlsSource.Url(DecentralandUrl.LambdasProfiles);
+
+        public LambdasProfilesProvider(
+            IWebRequestController webRequestController,
+            IDecentralandUrlsSource urlsSource)
+        {
+            this.webRequestController = webRequestController;
+            this.urlsSource = urlsSource;
+        }
+
+        public async UniTask<GetAvatarsDetailsDto?> GetAvatarsDetailsAsync(List<string> userIds, CancellationToken ct)
+        {
+            StringBuilder bodyBuilder = new ();
+            bodyBuilder.Clear();
+            bodyBuilder.Append("{\"ids\":[");
+
+            for (var i = 0; i < userIds.Count; ++i)
+            {
+                bodyBuilder.Append('\"');
+                bodyBuilder.Append(userIds[i]);
+                bodyBuilder.Append('\"');
+
+                if (i != userIds.Count - 1)
+                    bodyBuilder.Append(",");
+            }
+
+            bodyBuilder.Append("]}");
+
+            GenericDownloadHandlerUtils.Adapter<GenericPostRequest, GenericPostArguments> result = webRequestController.PostAsync(
+                lambdasProfilesBaseUrl,
+                GenericPostArguments.CreateJson(bodyBuilder.ToString()),
+                ct,
+                ReportCategory.PROFILE);
+
+            var response = await result.CreateFromJson<List<GetAvatarsDetailsDto>>(WRJsonParser.Newtonsoft,
+                createCustomExceptionOnFailure: static (_, text) => new Exception($"Error parsing Get Avatars details response: {text}"));
+
+            if (response == null)
+                throw new Exception("No Avatars details info retrieved");
+
+            return response.Count > 0 ? response[0] : null;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Profiles/LambdasProfilesProvider.cs
+++ b/Explorer/Assets/DCL/Profiles/LambdasProfilesProvider.cs
@@ -24,7 +24,7 @@ namespace DCL.Profiles
             this.urlsSource = urlsSource;
         }
 
-        public async UniTask<GetAvatarsDetailsDto?> GetAvatarsDetailsAsync(List<string> userIds, CancellationToken ct)
+        public async UniTask<List<GetAvatarsDetailsDto>> GetAvatarsDetailsAsync(List<string> userIds, CancellationToken ct)
         {
             StringBuilder bodyBuilder = new ();
             bodyBuilder.Clear();
@@ -54,7 +54,7 @@ namespace DCL.Profiles
             if (response == null)
                 throw new Exception("No Avatars details info retrieved");
 
-            return response.Count > 0 ? response[0] : null;
+            return response;
         }
     }
 }

--- a/Explorer/Assets/DCL/Profiles/LambdasProfilesProvider.cs.meta
+++ b/Explorer/Assets/DCL/Profiles/LambdasProfilesProvider.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 15d6bb27cdf3418e8a2b73af26afcdb4
+timeCreated: 1752491989


### PR DESCRIPTION
# Pull Request Description
Fix #4653 

## What does this PR change?
It adds the creator name for each place/world tag in the Creation/Edition Wizard.

### Test Steps
#### Scenario 1
1. Open the build (using `zone`).
2. Open the Communities Browser.
3. Click on [+ CREATE A COMMUNITY].
4. Add several places/worlds.
5. Check that the owner's name (in this case it should be yours) is showed in the right side of each place/word tag.

<img width="516" height="323" alt="image" src="https://github.com/user-attachments/assets/cfc2d1e7-b958-47ca-b37e-83e008010881" />

#### Scenario 2
1. Open the build (using `zone`).
2. Open the Communities Browser.
3. Open any existing community where you're the owner or a moderator.
4. Click on the edit button to open the Edition Wizard.
6. Scroll down to the PLACES section.
7. Check that the owner's name is showed in the right side of each place/word tag. If the place/world is yours you will see your name, but if the place/world is owned by another user you will see his name.

<img width="516" height="445" alt="image" src="https://github.com/user-attachments/assets/e6e16972-7a89-4ff9-856f-240722b32896" />

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.