### PR TITLE
feat: community notifications toggle

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardContextMenuConfiguration.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardContextMenuConfiguration.cs
@@ -10,6 +10,10 @@ namespace DCL.Communities.CommunitiesCard
         [field: SerializeField] public Vector2 OffsetFromTarget { get; private set; }
         [field: SerializeField] public RectOffset VerticalPadding { get; private set; } = null!;
 
+
+        [field: SerializeField] public Sprite ToggleNotificationsSprite { get; private set; } = null!;
+        [field: SerializeField] public string ToggleNotificationsText { get; private set; } = "Notifications";
+
         [field: SerializeField] public Sprite LeaveCommunitySprite { get; private set; } = null!;
         [field: SerializeField] public string LeaveCommunityText { get; private set; } = "Leave Community";
 

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardContextMenuSettings.asset
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardContextMenuSettings.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2b68e7f2294347b4a4320799a41d0abf, type: 3}
   m_Name: CommunityCardContextMenuSettings
   m_EditorClassIdentifier: 
-  <ContextMenuWidth>k__BackingField: 218
+  <ContextMenuWidth>k__BackingField: 262
   <ElementsSpacing>k__BackingField: 5
   <OffsetFromTarget>k__BackingField: {x: -20, y: -30}
   <VerticalPadding>k__BackingField:
@@ -20,6 +20,8 @@ MonoBehaviour:
     m_Right: 15
     m_Top: 20
     m_Bottom: 25
+  <ToggleNotificationsSprite>k__BackingField: {fileID: 21300000, guid: b68a1845513e146bbbbb9b209ce4120d, type: 3}
+  <ToggleNotificationsText>k__BackingField: Notifications
   <LeaveCommunitySprite>k__BackingField: {fileID: 21300000, guid: 5f39f01f09cd04a7c9a041960e0e0484, type: 3}
   <LeaveCommunityText>k__BackingField: Leave Community
   <DeleteCommunitySprite>k__BackingField: {fileID: 21300000, guid: ac4ebefc5fac7475ba19ac778feacfa8, type: 3}

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCardHeader.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCardHeader.prefab
@@ -565,8 +565,8 @@ RectTransform:
   m_Children:
   - {fileID: 1355487916901650505}
   - {fileID: 1572714093034108347}
-  - {fileID: 298761833657374106}
   - {fileID: 996816119135186131}
+  - {fileID: 298761833657374106}
   - {fileID: 860685452429630900}
   m_Father: {fileID: 7935310760175425802}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/CommunitiesDataProvider.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/CommunitiesDataProvider.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using UnityEngine.Networking;
+using Random = UnityEngine.Random;
 
 namespace DCL.Communities
 {
@@ -228,6 +229,12 @@ namespace DCL.Communities
                 CommunityDeleted?.Invoke(communityId);
 
             return result.Success;
+        }
+
+        public async UniTask<bool> UpdateCommunityNotificationsAsync(string communityId, bool value, CancellationToken ct)
+        {
+            //TODO: implement request
+            return Random.Range(0, 100) > 50;
         }
 
         public async UniTask<bool> SetMemberRoleAsync(string userId, string communityId, CommunityMemberRole newRole, CancellationToken ct)

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/GetCommunityResponse.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/GetCommunityResponse.cs
@@ -17,6 +17,7 @@ namespace DCL.Communities
             public CommunityPrivacy privacy;
             public CommunityMemberRole role;
             public int membersCount;
+            public bool notifications;
         }
 
         public CommunityData data;


### PR DESCRIPTION
# Pull Request Description
Fixes #4695 

Figma: https://www.figma.com/design/6Uuk4rAL10uFKNE3UxL171/%F0%9F%97%BA%EF%B8%8F-Communities-%7C-Explorer-2.0-%7C-07-25?node-id=1708-61916&t=43cF9PiVDw0SOeoJ-4

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR introduces the possibility of toggling on/off the notifications tied to a specific community.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- launch the explorer alpha in zone using the arg `--dlcenv zone`

### Test Steps
1. Open a community card and verify that, depending on your role:
   - none: you cannot interact with the toggle, only the `join` button is shown
   - member, moderator and owner: the context menu can be opened and it contains the notification toggle
2. After interacting with the toggle, a little banner is shown indicating the success/failure of the operation
3. Notification should be received according to the value you set


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
