### PR TITLE
fix: texture wrap mode

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Textures/Components/Extensions/TextureDefaultsExtension.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Textures/Components/Extensions/TextureDefaultsExtension.cs
@@ -17,7 +17,8 @@ namespace ECS.Unity.Textures.Components.Extensions
 
             if (self.IsVideoTexture())
             {
-                var textureComponent = new TextureComponent(URLAddress.EMPTY, string.Empty, self.GetWrapMode(), self.GetFilterMode(), isVideoTexture: true, videoPlayerEntity: self.GetVideoTextureId());
+                var textureComponent = new TextureComponent(URLAddress.EMPTY, string.Empty, self.GetWrapMode(), 
+                    self.GetFilterMode(), isVideoTexture: true, videoPlayerEntity: self.GetVideoTextureId());
                 return textureComponent;
             }
 


### PR DESCRIPTION
# Pull Request Description
Fix for [#250](https://github.com/decentraland/creator-hub/issues/250)

## What does this PR change?
For context, LoadSystemBase.cs while loading game assets, its caching already loaded ones, to return them immediately if they are requested again.

Whenever we had same texture used on two, or more objects, with different settings (WrapMode,  FilterMode, IsVideoTexture, VideoPlayerEntity), cache would return the same texture for all of these occurrences. While it should return new texture (since eg. wrap mode is set in texture export settings).

This PR changes default hashes used as cache keys to already implemented Intention specific hashes.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. 

### Additional Testing Notes
- 

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
