### PR TITLE
fix: transform's pointer filter on pointer event changes

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIFixPbPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIFixPbPointerEventsSystem.cs
@@ -27,10 +27,12 @@ namespace DCL.SDKComponents.SceneUI.Systems
         [Query]
         private void FixPointerEvents(ref PBPointerEvents pbPointerEventsModel, ref PBUiTransform uiSdkTransformModel, ref CRDTEntity sdkEntity)
         {
-            if (pbPointerEventsModel.IsDirty || uiSdkTransformModel.IsDirty)
-            {
-                uiSdkTransformModel.PointerFilter = PointerFilterMode.PfmBlock;
-            }
+            if (!pbPointerEventsModel.IsDirty && !uiSdkTransformModel.IsDirty) return;
+
+            ReportHub.Log($"FixPointerEvents: {uiSdkTransformModel.HasPointerFilter}, {uiSdkTransformModel.PointerFilter}", ReportCategory.ALWAYS);
+
+            uiSdkTransformModel.PointerFilter = PointerFilterMode.PfmBlock;
+            uiSdkTransformModel.IsDirty = true;
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIFixPbPointerEventsSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIFixPbPointerEventsSystem.cs
@@ -29,8 +29,6 @@ namespace DCL.SDKComponents.SceneUI.Systems
         {
             if (!pbPointerEventsModel.IsDirty && !uiSdkTransformModel.IsDirty) return;
 
-            ReportHub.Log($"FixPointerEvents: {uiSdkTransformModel.HasPointerFilter}, {uiSdkTransformModel.PointerFilter}", ReportCategory.ALWAYS);
-
             uiSdkTransformModel.PointerFilter = PointerFilterMode.PfmBlock;
             uiSdkTransformModel.IsDirty = true;
         }


### PR DESCRIPTION
## What does this PR change?

Fixes #4496 

For a reason i don't understand the issue was happening on build only.
If the `PBPointerEvents` was changing in runtime we were forcing the `PBUiTransform` to set the `pointerFilter: PointerFilterMode.PfmBlock` but we were not forcing the transform to re-update. The solution consists on setting the transform into `dirty:true` so the component is updated internally, applying the `pointerFilter` accordingly.

## Test Instructions

1. Download and run this scene: [button-pointer-filter.zip](https://github.com/user-attachments/files/21263175/button-pointer-filter.zip)
2. Open the developer console with key ` (left to number 1 key).
3. Click the button.
4. "Claim" log should appear whenever the button is enabled. The button is enabled and disabled every 3 seconds.

Ideally you should be able to verify that you can claim the DAO HQ wearable (I cannot confirm myself since i dont have the progress done).

### Additional Testing Notes

If you cant confirm on DAO HQ don't worry, this should fix the problem anyway, since the test scene was not working for the creator in the first place, so hypothetically is the same problem that DAO HQ is having on prod.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
