### PR TITLE
fix: center notification icons

### DIFF
--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuController.cs
@@ -214,7 +214,7 @@ namespace DCL.Notifications.NotificationsMenu
             notificationView.NotificationImage.SetImage(null);
 
             if (notificationThumbnailCache.TryGetValue(notificationData.Id, out Sprite thumbnailSprite))
-                notificationView.NotificationImage.SetImage(thumbnailSprite);
+                notificationView.NotificationImage.SetImage(thumbnailSprite, true);
             else
                 LoadNotificationThumbnailAsync(notificationView, notificationData, notificationThumbnailCts!.Token).Forget();
 
@@ -285,7 +285,7 @@ namespace DCL.Notifications.NotificationsMenu
                 if (profileThumbnail != null)
                 {
                     notificationThumbnailCache.TryAdd(notificationData.Id, profileThumbnail);
-                    notificationImage.NotificationImage.SetImage(profileThumbnail);
+                    notificationImage.NotificationImage.SetImage(profileThumbnail, true);
                 }
 
                 return;
@@ -306,7 +306,7 @@ namespace DCL.Notifications.NotificationsMenu
             //Try add has been added in case it happens that BE returns duplicated notifications id
             //In that case we will just use the same thumbnail for each notification with the same id
             notificationThumbnailCache.TryAdd(notificationData.Id, thumbnailSprite);
-            notificationImage.NotificationImage.SetImage(thumbnailSprite);
+            notificationImage.NotificationImage.SetImage(thumbnailSprite, true);
 
             return;
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR enable the centering of the sprite inside the image view of the notification entry in the notifications panel/

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Launch the explorer and verify that the notifications thumbnails are  centered and visible


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
