### PR TITLE
Fix: Emotes not looping in backpack

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -213,7 +213,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                     StreamableLoadingResult<AudioClipData>? audioAssetResult = emote.AudioAssetResults[bodyShape];
                     AudioClip? audioClip = audioAssetResult?.Asset;
 
-                    if (!emotePlayer.Play(mainAsset, audioClip, emoteIntent.TriggerSource != TriggerSource.PREVIEW && emote.IsLooping(), emoteIntent.Spatial, in avatarView, ref emoteComponent))
+                    if (!emotePlayer.Play(mainAsset, audioClip, emote.IsLooping(), emoteIntent.Spatial, in avatarView, ref emoteComponent))
                         ReportHub.LogWarning(GetReportData(), $"Emote {emote.Model.Asset?.metadata.name} cant be played, AB version: {emote.ManifestResult?.Asset?.GetVersion()} should be >= 16");
 
                     World.Remove<CharacterEmoteIntent>(entity);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
We had added an extra condition to avoid emotes looping during auth screen, but that also broke emotes looping in backpack.
Now that we removed looping emotes on auth screen, we can restore this logic.


## Test Instructions
Play any looping emote in the backpack. It should loop as expected.