### PR TITLE
fix: Uninitialized tilling for video textures

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Textures/Components/Extensions/TextureDefaultsExtension.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Textures/Components/Extensions/TextureDefaultsExtension.cs
@@ -17,7 +17,12 @@ namespace ECS.Unity.Textures.Components.Extensions
 
             if (self.IsVideoTexture())
             {
-                var textureComponent = new TextureComponent(URLAddress.EMPTY, string.Empty, self.GetWrapMode(), self.GetFilterMode(), isVideoTexture: true, videoPlayerEntity: self.GetVideoTextureId());
+                var textureComponent = new TextureComponent(URLAddress.EMPTY, string.Empty, self.GetWrapMode(), self.GetFilterMode(),
+                    textureOffset: self.GetOffset(),
+                    textureTiling: self.GetTiling(),
+                    isVideoTexture: true, videoPlayerEntity: self.GetVideoTextureId());
+
+
                 return textureComponent;
             }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes this issue

<img width="733" height="358" alt="image" src="https://github.com/user-attachments/assets/90ea2534-6a28-4533-b915-87e4a78baba3" />

Before the changes in the AVPro upgrade, the tilling was always set in `CreateMaterialSystemBase` if the texture was a video texture.

After the upgrade, we stopped doing that, but the tilling and offset were never initialized, therefore putting a tilling of `0,0`; showing nothing in the video.

This PR set the default values for tilling and offset


## Test Instructions


### Test Steps
1. Go to the screens in MVFW and Career Quests. Videos should be fine
2. Confirm that the steps in this [PR](https://github.com/decentraland/unity-explorer/pull/4513) are still fine
3. Confirm that videos in Goerli Plaza at `85,-8` are fine

### Additional Testing Notes




## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
