### PR TITLE
fix: Ignore the position feature flag when in editor

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
@@ -164,16 +164,14 @@ namespace Global.Dynamic
             if (appArgs.HasFlag(AppArgsFlags.POSITION))
                 return;
 
-            //If we are on editor, and we set a target scene, we dont want it to be overriden
-            if (Application.isEditor && targetScene.magnitude != 0)
-                return;
-
             //Note: If you dont want the feature flag for the localhost hostname, remember to remove ir from the feature flag configuration
             // (https://features.decentraland.systems/#/features/strategies/explorer-alfa-genesis-spawn-parcel)
             string? parcelToTeleportOverride = null;
 
             //If not, we check the feature flag usage
+            //If we are in editor, we ignore the feature flag override
             var featureFlagOverride =
+                !Application.isEditor &&
                 featureFlagsConfigurationCache.IsEnabled(FeatureFlagsStrings.GENESIS_STARTING_PARCEL) &&
                 featureFlagsConfigurationCache.TryGetTextPayload(FeatureFlagsStrings.GENESIS_STARTING_PARCEL,
                     FeatureFlagsStrings.STRING_VARIANT, out parcelToTeleportOverride) &&

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
@@ -164,6 +164,10 @@ namespace Global.Dynamic
             if (appArgs.HasFlag(AppArgsFlags.POSITION))
                 return;
 
+            //If we are on editor, and we set a target scene, we dont want it to be overriden
+            if (Application.isEditor && targetScene.magnitude != 0)
+                return;
+
             //Note: If you dont want the feature flag for the localhost hostname, remember to remove ir from the feature flag configuration
             // (https://features.decentraland.systems/#/features/strategies/explorer-alfa-genesis-spawn-parcel)
             string? parcelToTeleportOverride = null;

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
@@ -175,7 +175,6 @@ namespace Global.Dynamic
             string? parcelToTeleportOverride = null;
 
             //If not, we check the feature flag usage
-            //If we are in editor, we ignore the feature flag override
             var featureFlagOverride =
                 featureFlagsConfigurationCache.IsEnabled(FeatureFlagsStrings.GENESIS_STARTING_PARCEL) &&
                 featureFlagsConfigurationCache.TryGetTextPayload(FeatureFlagsStrings.GENESIS_STARTING_PARCEL,

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
@@ -26,6 +26,7 @@ namespace Global.Dynamic
 
         [SerializeField] internal InitialRealm initialRealm;
         [SerializeField] internal Vector2Int targetScene;
+        [SerializeField] internal bool overrideSceneStartPositionEditor = true;
         [SerializeField] internal PredefinedScenes predefinedScenes;
         [SerializeField] private string targetWorld = "MetadyneLabs.dcl.eth";
         [SerializeField] internal string customRealm = IRealmNavigator.GOERLI_URL;
@@ -164,6 +165,11 @@ namespace Global.Dynamic
             if (appArgs.HasFlag(AppArgsFlags.POSITION))
                 return;
 
+            //If this bool is true in editor, we want the position to be the one that has been serialized
+            //This avoid the feature flag from overriding the dev's start position
+            if (Application.isEditor && overrideSceneStartPositionEditor)
+                return;
+
             //Note: If you dont want the feature flag for the localhost hostname, remember to remove ir from the feature flag configuration
             // (https://features.decentraland.systems/#/features/strategies/explorer-alfa-genesis-spawn-parcel)
             string? parcelToTeleportOverride = null;
@@ -171,7 +177,6 @@ namespace Global.Dynamic
             //If not, we check the feature flag usage
             //If we are in editor, we ignore the feature flag override
             var featureFlagOverride =
-                !Application.isEditor &&
                 featureFlagsConfigurationCache.IsEnabled(FeatureFlagsStrings.GENESIS_STARTING_PARCEL) &&
                 featureFlagsConfigurationCache.TryGetTextPayload(FeatureFlagsStrings.GENESIS_STARTING_PARCEL,
                     FeatureFlagsStrings.STRING_VARIANT, out parcelToTeleportOverride) &&

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
@@ -26,7 +26,7 @@ namespace Global.Dynamic
 
         [SerializeField] internal InitialRealm initialRealm;
         [SerializeField] internal Vector2Int targetScene;
-        [SerializeField] internal bool overrideSceneStartPositionEditor = true;
+        [SerializeField] internal bool EditorSceneStartPosition = true;
         [SerializeField] internal PredefinedScenes predefinedScenes;
         [SerializeField] private string targetWorld = "MetadyneLabs.dcl.eth";
         [SerializeField] internal string customRealm = IRealmNavigator.GOERLI_URL;
@@ -167,7 +167,7 @@ namespace Global.Dynamic
 
             //If this bool is true in editor, we want the position to be the one that has been serialized
             //This avoid the feature flag from overriding the dev's start position
-            if (Application.isEditor && overrideSceneStartPositionEditor)
+            if (Application.isEditor && EditorSceneStartPosition)
                 return;
 
             //Note: If you dont want the feature flag for the localhost hostname, remember to remove ir from the feature flag configuration

--- a/Explorer/Assets/DCL/Infrastructure/Global/Editor/RealmLaunchSettingsDrawer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Editor/RealmLaunchSettingsDrawer.cs
@@ -48,9 +48,12 @@ namespace Global.Editor
 
         private static Rect DrawTargetScene(Rect propertyPosition, SerializedProperty parent, InitialRealm initialRealm)
         {
+            SerializedProperty overrideSceneStartPosition = parent.FindPropertyRelative(nameof(RealmLaunchSettings.overrideSceneStartPositionEditor));
+            EditorGUI.PropertyField(propertyPosition, overrideSceneStartPosition, new GUIContent("Editor Override Start Position", "If this is on, the feature flag position will not be set"), true);
+            propertyPosition.y += singleLineHeight;
+
             Rect fieldPosition = propertyPosition;
             SerializedProperty property = parent.FindPropertyRelative(nameof(RealmLaunchSettings.targetScene));
-
             const float BUTTON_WIDTH = 80f;
 
             if (TEST_REALMS.Contains(initialRealm))

--- a/Explorer/Assets/DCL/Infrastructure/Global/Editor/RealmLaunchSettingsDrawer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Editor/RealmLaunchSettingsDrawer.cs
@@ -48,8 +48,8 @@ namespace Global.Editor
 
         private static Rect DrawTargetScene(Rect propertyPosition, SerializedProperty parent, InitialRealm initialRealm)
         {
-            SerializedProperty overrideSceneStartPosition = parent.FindPropertyRelative(nameof(RealmLaunchSettings.overrideSceneStartPositionEditor));
-            EditorGUI.PropertyField(propertyPosition, overrideSceneStartPosition, new GUIContent("Editor Override Start Position", "If this is on, the feature flag position will not be set"), true);
+            SerializedProperty editorSceneStartPosition = parent.FindPropertyRelative(nameof(RealmLaunchSettings.EditorSceneStartPosition));
+            EditorGUI.PropertyField(propertyPosition, editorSceneStartPosition, new GUIContent("Editor Start Position", "If this is on, the feature flag position will not be set"), true);
             propertyPosition.y += singleLineHeight;
 
             Rect fieldPosition = propertyPosition;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Adds a bool to be able to ignore the set of the start position via the feature flag in editor.


## Test Instructions


### Test Steps
1. No QA required


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
