### PR TITLE
Fix: texture wrap mode

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Systems/Abstract/LoadElementsByIntentionSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Systems/Abstract/LoadElementsByIntentionSystem.cs
@@ -18,7 +18,7 @@ namespace DCL.AvatarRendering.Loading.Systems.Abstract
 {
     public abstract class LoadElementsByIntentionSystem<TAsset, TIntention, TAvatarElement, TAvatarElementDTO> :
         LoadSystemBase<TAsset, TIntention>
-        where TIntention: struct, IAttachmentsLoadingIntention<TAvatarElement>
+        where TIntention: struct, IAttachmentsLoadingIntention<TAvatarElement>, IEquatable<TIntention>
         where TAvatarElementDTO: AvatarAttachmentDTO where TAvatarElement : IAvatarAttachment<TAvatarElementDTO>
     {
         private readonly IAvatarElementStorage<TAvatarElement, TAvatarElementDTO> avatarElementStorage;

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Systems/Abstract/LoadElementsByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Systems/Abstract/LoadElementsByPointersSystem.cs
@@ -10,6 +10,7 @@ using ECS.Prioritization.Components;
 using ECS.StreamableLoading.Cache;
 using ECS.StreamableLoading.Common.Components;
 using ECS.StreamableLoading.Common.Systems;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -17,7 +18,8 @@ using UnityEngine;
 
 namespace DCL.AvatarRendering.Loading.Systems.Abstract
 {
-    public abstract class LoadElementsByPointersSystem<TAsset, TIntention, TDTO> : LoadSystemBase<TAsset, TIntention> where TIntention: struct, IPointersLoadingIntention
+    public abstract class LoadElementsByPointersSystem<TAsset, TIntention, TDTO> : LoadSystemBase<TAsset, TIntention> 
+        where TIntention: struct, IPointersLoadingIntention, IEquatable<TIntention>
     {
         // When the number of wearables to request is greater than MAX_WEARABLES_PER_REQUEST, we split the request into several smaller ones.
         // In this way we avoid to send a very long url string that would fail due to the web request size limitations.

--- a/Explorer/Assets/DCL/DemoWorlds/SystemExtensions.cs
+++ b/Explorer/Assets/DCL/DemoWorlds/SystemExtensions.cs
@@ -1,5 +1,6 @@
 using ECS.StreamableLoading.Common.Components;
 using ECS.StreamableLoading.Common.Systems;
+using System;
 
 namespace DCL.DemoWorlds
 {
@@ -7,7 +8,7 @@ namespace DCL.DemoWorlds
     {
         public static LoadSystemBase<TAsset, TIntention> InitializeAndReturnSelf<TAsset, TIntention>(
             this LoadSystemBase<TAsset, TIntention> system
-        ) where TIntention: struct, ILoadingIntention
+        ) where TIntention: struct, ILoadingIntention, IEquatable<TIntention>
         {
             system.Initialize();
             return system;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetBundleCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetBundleCache.cs
@@ -12,11 +12,5 @@ namespace ECS.StreamableLoading.AssetBundles
     public class AssetBundleCache : RefCountStreamableCacheBase<AssetBundleData, AssetBundle, GetAssetBundleIntention>
     {
         protected override ref ProfilerCounterValue<int> inCacheCount => ref ProfilingCounters.AssetBundlesInCache;
-
-        public override bool Equals(GetAssetBundleIntention x, GetAssetBundleIntention y) =>
-            StringComparer.OrdinalIgnoreCase.Equals(x.Hash, y.Hash);
-
-        public override int GetHashCode(GetAssetBundleIntention obj) =>
-            StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Hash!); // at this point hash can't be null
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AudioClips/AudioClipsCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AudioClips/AudioClipsCache.cs
@@ -8,11 +8,5 @@ namespace ECS.StreamableLoading.AudioClips
     public class AudioClipsCache : RefCountStreamableCacheBase<AudioClipData, AudioClip, GetAudioClipIntention>
     {
         protected override ref ProfilerCounterValue<int> inCacheCount => ref ProfilingCounters.AudioClipsInCache;
-
-        public override bool Equals(GetAudioClipIntention x, GetAudioClipIntention y) =>
-            x.Equals(y);
-
-        public override int GetHashCode(GetAudioClipIntention obj) =>
-            obj.GetHashCode();
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/FakeDictionaryCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/FakeDictionaryCache.cs
@@ -4,51 +4,51 @@ using System.Collections.Generic;
 
 namespace ECS.StreamableLoading.Cache
 {
-    public class FakeDictionaryCache<TAsset> : IDictionary<string, TAsset>
+    public class FakeDictionaryCache<TKey, TAsset> : IDictionary<TKey, TAsset>
     {
-        public TAsset this[string key]
+        public TAsset this[TKey key]
         {
             get => throw new NotImplementedException();
 
             set => throw new NotImplementedException();
         }
 
-        public ICollection<string> Keys { get; }
+        public ICollection<TKey> Keys { get; }
         public ICollection<TAsset> Values { get; }
 
         public int Count { get; }
         public bool IsReadOnly { get; }
 
-        public void Add(string key, TAsset value) { }
+        public void Add(TKey key, TAsset value) { }
 
-        public bool ContainsKey(string key) =>
+        public bool ContainsKey(TKey key) =>
             false;
 
-        public bool Remove(string key) =>
+        public bool Remove(TKey key) =>
             false;
 
-        public bool TryGetValue(string key, out TAsset value)
+        public bool TryGetValue(TKey key, out TAsset value)
         {
             value = default(TAsset);
             return false;
         }
 
-        public IEnumerator<KeyValuePair<string, TAsset>> GetEnumerator() =>
+        public IEnumerator<KeyValuePair<TKey, TAsset>> GetEnumerator() =>
             throw new NotImplementedException();
 
         IEnumerator IEnumerable.GetEnumerator() =>
             GetEnumerator();
 
-        public void Add(KeyValuePair<string, TAsset> item) { }
+        public void Add(KeyValuePair<TKey, TAsset> item) { }
 
         public void Clear() { }
 
-        public bool Contains(KeyValuePair<string, TAsset> item) =>
+        public bool Contains(KeyValuePair<TKey, TAsset> item) =>
             false;
 
-        public void CopyTo(KeyValuePair<string, TAsset>[] array, int arrayIndex) { }
+        public void CopyTo(KeyValuePair<TKey, TAsset>[] array, int arrayIndex) { }
 
-        public bool Remove(KeyValuePair<string, TAsset> item) =>
+        public bool Remove(KeyValuePair<TKey, TAsset> item) =>
             false;
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/ISizedStreamableCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/ISizedStreamableCache.cs
@@ -1,6 +1,9 @@
+using System;
+
 namespace ECS.StreamableLoading.Cache
 {
-    public interface ISizedStreamableCache<TAsset, TLoadingIntention> : IStreamableCache<TAsset, TLoadingIntention>, ISizedContent
+    public interface ISizedStreamableCache<TAsset, TLoadingIntention> : IStreamableCache<TAsset, TLoadingIntention>, 
+        ISizedContent where TLoadingIntention: IEquatable<TLoadingIntention>
     {
         int ItemCount { get; }
     }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/IStreamableCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/IStreamableCache.cs
@@ -13,10 +13,10 @@ namespace ECS.StreamableLoading.Cache
     /// </summary>
     /// <typeparam name="TAsset"></typeparam>
     /// <typeparam name="TLoadingIntention"></typeparam>
-    public interface IStreamableCache<TAsset, TLoadingIntention> : IEqualityComparer<TLoadingIntention>, IDisposable
+    public interface IStreamableCache<TAsset, TLoadingIntention> : IDisposable where TLoadingIntention: IEquatable<TLoadingIntention>
     {
-        IDictionary<string, UniTaskCompletionSource<OngoingRequestResult<TAsset>>> OngoingRequests { get; }
-        IDictionary<string, StreamableLoadingResult<TAsset>> IrrecoverableFailures { get; }
+	    IDictionary<IntentionsComparer<TLoadingIntention>.SourcedIntentionId, UniTaskCompletionSource<OngoingRequestResult<TAsset>>> OngoingRequests { get; }
+	    IDictionary<IntentionsComparer<TLoadingIntention>.SourcedIntentionId, StreamableLoadingResult<TAsset>?> IrrecoverableFailures { get; }
 
         /// <summary>
         ///     Get the asset for referencing, it should be called one time and saved in the component,

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/InMemory/StreamableWrapMemoryCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/InMemory/StreamableWrapMemoryCache.cs
@@ -1,8 +1,9 @@
 using DCL.Optimization.PerformanceBudgeting;
+using System;
 
 namespace ECS.StreamableLoading.Cache.InMemory
 {
-    public class StreamableWrapMemoryCache<T, TKey> : IMemoryCache<T, TKey>
+    public class StreamableWrapMemoryCache<T, TKey> : IMemoryCache<T, TKey> where TKey: IEquatable<TKey>
     {
         private const int UNLOAD_CHUNK = int.MaxValue;
         private readonly IStreamableCache<T, TKey> streamableCache;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/IntentionsComparer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/IntentionsComparer.cs
@@ -1,0 +1,45 @@
+using AssetManagement;
+using System;
+using System.Collections.Generic;
+
+namespace ECS.StreamableLoading.Cache
+{
+	public class IntentionsComparer<TLoadingIntention> : IEqualityComparer<TLoadingIntention>
+		where TLoadingIntention: IEquatable<TLoadingIntention>
+	{
+		public static readonly IntentionsComparer<TLoadingIntention> INSTANCE = new ();
+
+		public bool Equals(TLoadingIntention x, TLoadingIntention y) =>
+			x.Equals(y);
+
+		public int GetHashCode(TLoadingIntention obj) =>
+			obj.GetHashCode();
+
+		public readonly struct SourcedIntentionId : IEquatable<SourcedIntentionId>
+		{
+			private readonly TLoadingIntention intention;
+			private readonly AssetSource source;
+
+			public SourcedIntentionId(TLoadingIntention intention, AssetSource source)
+			{
+				this.intention = intention;
+				this.source = source;
+			}
+
+			public bool Equals(SourcedIntentionId other) =>
+				INSTANCE.Equals(intention, other.intention) && source == other.source;
+
+			public override bool Equals(object? obj) =>
+				obj is SourcedIntentionId other && Equals(other);
+
+			public override int GetHashCode() =>
+				HashCode.Combine(intention, (int)source);
+
+			public static bool operator ==(SourcedIntentionId left, SourcedIntentionId right) =>
+				left.Equals(right);
+
+			public static bool operator !=(SourcedIntentionId left, SourcedIntentionId right) =>
+				!left.Equals(right);
+		}
+	}
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/IntentionsComparer.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/IntentionsComparer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3ee89b8f1b4c4afcb5b01e2b0867bce1
+timeCreated: 1752837784

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/RefCountStreamableCacheBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/RefCountStreamableCacheBase.cs
@@ -1,38 +1,31 @@
-﻿using Cysharp.Threading.Tasks;
+﻿﻿using Cysharp.Threading.Tasks;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.StreamableLoading.Common.Components;
 using System;
 using System.Collections.Generic;
-using ECS.StreamableLoading.AssetBundles;
 using Unity.Profiling;
-using UnityEngine;
 
 namespace ECS.StreamableLoading.Cache
 {
     public abstract class RefCountStreamableCacheBase<TAssetData, TAsset, TLoadingIntention> : IStreamableCache<TAssetData, TLoadingIntention>
-        where TAssetData: StreamableRefCountData<TAsset> where TAsset: class
+        where TAssetData: StreamableRefCountData<TAsset> where TAsset: class where TLoadingIntention: IEquatable<TLoadingIntention>
     {
         private static readonly Comparison<(TLoadingIntention intention, TAssetData asset)> COMPARE_BY_LAST_USED_FRAME_REVERSED =
             (d1, d2) => d2.asset.LastUsedFrame.CompareTo(d1.asset.LastUsedFrame);
 
-        internal readonly Dictionary<TLoadingIntention, TAssetData> cache;
+        internal readonly Dictionary<TLoadingIntention, TAssetData> cache = new (IntentionsComparer<TLoadingIntention>.INSTANCE);
 
         internal readonly List<(TLoadingIntention intention, TAssetData asset)> listedCache = new ();
 
         private bool disposed;
 
-        public IDictionary<string, UniTaskCompletionSource<OngoingRequestResult<TAssetData>>> OngoingRequests { get; }
-            = new Dictionary<string, UniTaskCompletionSource<OngoingRequestResult<TAssetData>>>();
+        public IDictionary<IntentionsComparer<TLoadingIntention>.SourcedIntentionId, UniTaskCompletionSource<OngoingRequestResult<TAssetData>>> OngoingRequests { get; }
+            = new Dictionary<IntentionsComparer<TLoadingIntention>.SourcedIntentionId, UniTaskCompletionSource<OngoingRequestResult<TAssetData>>>();
 
-        public IDictionary<string, StreamableLoadingResult<TAssetData>> IrrecoverableFailures { get; }
-            = new Dictionary<string, StreamableLoadingResult<TAssetData>>();
+        public IDictionary<IntentionsComparer<TLoadingIntention>.SourcedIntentionId, StreamableLoadingResult<TAssetData>?> IrrecoverableFailures { get; }
+            = new Dictionary<IntentionsComparer<TLoadingIntention>.SourcedIntentionId, StreamableLoadingResult<TAssetData>?>();
 
         protected abstract ref ProfilerCounterValue<int> inCacheCount { get; }
-
-        protected RefCountStreamableCacheBase()
-        {
-            cache = new Dictionary<TLoadingIntention, TAssetData>(this);
-        }
 
         public void Dispose()
         {
@@ -84,9 +77,5 @@ namespace ECS.StreamableLoading.Cache
 
             inCacheCount.Value = cache.Count;
         }
-
-        public abstract bool Equals(TLoadingIntention x, TLoadingIntention y);
-
-        public abstract int GetHashCode(TLoadingIntention obj);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/Tests/RefCountingCacheShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Cache/Tests/RefCountingCacheShould.cs
@@ -1,8 +1,9 @@
-﻿using DCL.Diagnostics;
+﻿﻿using DCL.Diagnostics;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.StreamableLoading.Common.Components;
 using NSubstitute;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Unity.Profiling;
@@ -139,7 +140,7 @@ namespace ECS.StreamableLoading.Cache.Tests
             CollectionAssert.AreEqual(new[] { (intent1, data1) }, cache.listedCache);
         }
 
-        public class TestLoadingIntent : ILoadingIntention
+        public class TestLoadingIntent : ILoadingIntention, IEquatable<TestLoadingIntent>
         {
             public readonly int Value;
 
@@ -151,6 +152,30 @@ namespace ECS.StreamableLoading.Cache.Tests
             {
                 Value = value;
             }
+
+            public bool Equals(TestLoadingIntent? other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Value == other.Value;
+            }
+
+            public override bool Equals(object? obj)
+            {
+                if (obj is null) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != GetType()) return false;
+                return Equals((TestLoadingIntent)obj);
+            }
+
+            public override int GetHashCode() =>
+                Value;
+
+            public static bool operator ==(TestLoadingIntent? left, TestLoadingIntent? right) =>
+                Equals(left, right);
+
+            public static bool operator !=(TestLoadingIntent? left, TestLoadingIntent? right) =>
+                !Equals(left, right);
         }
 
         public class TestAsset
@@ -182,12 +207,6 @@ namespace ECS.StreamableLoading.Cache.Tests
             public ProfilerCounterValue<int> InCacheCount = new (ProfilerCategory.Memory, "TEST IN CACHE COUNT", ProfilerMarkerDataUnit.Count);
 
             protected override ref ProfilerCounterValue<int> inCacheCount => ref InCacheCount;
-
-            public override bool Equals(TestLoadingIntent x, TestLoadingIntent y) =>
-                x.Value == y.Value;
-
-            public override int GetHashCode(TestLoadingIntent obj) =>
-                obj.Value.GetHashCode();
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Common/Systems/LoadSystemBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Common/Systems/LoadSystemBase.cs
@@ -23,7 +23,7 @@ namespace ECS.StreamableLoading.Common.Systems
     /// </summary>
     /// <typeparam name="TAsset"></typeparam>
     /// <typeparam name="TIntention"></typeparam>
-    public abstract class LoadSystemBase<TAsset, TIntention> : BaseUnityLoopSystem where TIntention: struct, ILoadingIntention
+    public abstract class LoadSystemBase<TAsset, TIntention> : BaseUnityLoopSystem where TIntention: struct, ILoadingIntention, IEquatable<TIntention>
     {
         private static readonly QueryDescription CREATE_WEB_REQUEST = new QueryDescription()
                                                                      .WithAll<TIntention, IPartitionComponent, StreamableLoadingState>()
@@ -96,6 +96,8 @@ namespace ECS.StreamableLoading.Common.Systems
         {
             AssetSource currentSource = intention.CommonArguments.CurrentSource;
 
+            var intentionId = new IntentionsComparer<TIntention>.SourcedIntentionId(intention, currentSource);
+                
             //If a chunk is already loading, don't start another one, if it is a partial request it will resume from the point it was stopped
             if (state.Value != StreamableLoadingState.Status.Allowed)
             {
@@ -113,7 +115,7 @@ namespace ECS.StreamableLoading.Common.Systems
             // Indicate that loading has started
             state.StartProgress();
 
-            FlowAsync(entity, currentSource, intention, state, partitionComponent, cancellationTokenSource.Token).Forget();
+            FlowAsync(entity, currentSource, intention, state, partitionComponent, intentionId, cancellationTokenSource.Token).Forget();
         }
 
         private async UniTask FlowAsync(
@@ -122,6 +124,7 @@ namespace ECS.StreamableLoading.Common.Systems
             TIntention intention,
             StreamableLoadingState state,
             IPartitionComponent partition,
+            IntentionsComparer<TIntention>.SourcedIntentionId intentionId,
             CancellationToken disposalCt
         )
         {
@@ -130,11 +133,10 @@ namespace ECS.StreamableLoading.Common.Systems
             try
             {
                 var requestIsNotFulfilled = true;
-                string cacheKey = GetIntentionCacheKey(in intention);
 
                 // if the request is cached wait for it
                 // If there is an ongoing request it means that the result is neither cached, nor failed
-                if (cache.OngoingRequests.SyncTryGetValue(cacheKey, out UniTaskCompletionSource<OngoingRequestResult<TAsset>>? cachedSource))
+                if (cache.OngoingRequests.SyncTryGetValue(intentionId, out UniTaskCompletionSource<OngoingRequestResult<TAsset>>? cachedSource))
                 {
                     // Release budget immediately, if we don't do it and load a lot of bundles with dependencies sequentially, it will be a deadlock
                     state.AcquiredBudget?.Release();
@@ -151,13 +153,13 @@ namespace ECS.StreamableLoading.Common.Systems
 
                     if (requestIsNotFulfilled)
                     {
-                        await FlowAsync(entity, source, intention, state, partition, disposalCt);
+                        await FlowAsync(entity, source, intention, state, partition, intentionId, disposalCt);
                         return;
                     }
                 }
 
                 // If the given URL failed irrecoverably just return the failure
-                if (cache.IrrecoverableFailures.TryGetValue(cacheKey, out StreamableLoadingResult<TAsset> failure))
+                if (cache.IrrecoverableFailures.TryGetValue(intentionId, out StreamableLoadingResult<TAsset>? failure))
                 {
                     result = failure;
                     return;
@@ -165,7 +167,7 @@ namespace ECS.StreamableLoading.Common.Systems
 
                 // if this request must be cancelled by `intention.CommonArguments.CancellationToken` it will be cancelled after `if (!requestIsNotFulfilled)`
                 if (requestIsNotFulfilled)
-                    result = await CacheableFlowAsync(intention, state, partition, CancellationTokenSource.CreateLinkedTokenSource(intention.CommonArguments.CancellationToken, disposalCt).Token);
+                    result = await CacheableFlowAsync(intention, state, partition, intentionId, CancellationTokenSource.CreateLinkedTokenSource(intention.CommonArguments.CancellationToken, disposalCt).Token);
 
                 if (!result.HasValue)
 
@@ -271,17 +273,19 @@ namespace ECS.StreamableLoading.Common.Systems
         /// <summary>
         ///     All exceptions are handled by the upper functions, just do pure work
         /// </summary>
-        protected abstract UniTask<StreamableLoadingResult<TAsset>> FlowInternalAsync(TIntention intention, StreamableLoadingState state, IPartitionComponent partition, CancellationToken ct);
+        protected abstract UniTask<StreamableLoadingResult<TAsset>> FlowInternalAsync(TIntention intention, 
+            StreamableLoadingState state, IPartitionComponent partition, CancellationToken ct);
 
         /// <summary>
         ///     Part of the flow that can be reused by multiple intentions
         /// </summary>
-        private async UniTask<StreamableLoadingResult<TAsset>?> CacheableFlowAsync(TIntention intention, StreamableLoadingState state, IPartitionComponent partition, CancellationToken ct)
+        private async UniTask<StreamableLoadingResult<TAsset>?> CacheableFlowAsync(TIntention intention, 
+            StreamableLoadingState state, IPartitionComponent partition, 
+            IntentionsComparer<TIntention>.SourcedIntentionId intentionId, CancellationToken ct)
         {
             var source = new UniTaskCompletionSource<OngoingRequestResult<TAsset>>(); //AutoResetUniTaskCompletionSource<StreamableLoadingResult<TAsset>?>.Create();
-            string cacheKey = GetIntentionCacheKey(in intention);
             
-            cache.OngoingRequests.SyncTryAdd(cacheKey, source);
+            cache.OngoingRequests.SyncTryAdd(intentionId, source);
             var ongoingRequestRemoved = false;
 
             StreamableLoadingResult<TAsset>? result = null;
@@ -289,7 +293,7 @@ namespace ECS.StreamableLoading.Common.Systems
             try
             {
                 // Try load from cache first
-                result = await TryLoadFromCacheAsync(intention, ct) ?? await RepeatLoopAsync(intention, state, partition, ct);
+                result = await TryLoadFromCacheAsync(intention, ct) ?? await RepeatLoopAsync(intention, state, partition, intentionId, ct);
 
                 // Ensure that we returned to the main thread
                 await UniTask.SwitchToMainThread(ct);
@@ -340,7 +344,7 @@ namespace ECS.StreamableLoading.Common.Systems
                 if (!ongoingRequestRemoved)
                 {
                     // ReportHub.Log(GetReportCategory(), $"OngoingRequests.SyncRemove {intention.CommonArguments.URL}");
-                    cache.OngoingRequests.SyncRemove(cacheKey);
+                    cache.OngoingRequests.SyncRemove(intentionId);
                     ongoingRequestRemoved = true;
                 }
             }
@@ -361,24 +365,22 @@ namespace ECS.StreamableLoading.Common.Systems
             return null;
         }
 
-        private async UniTask<StreamableLoadingResult<TAsset>?> RepeatLoopAsync(TIntention intention, StreamableLoadingState state, IPartitionComponent partition, CancellationToken ct)
+        private async UniTask<StreamableLoadingResult<TAsset>?> RepeatLoopAsync(TIntention intention, 
+            StreamableLoadingState state, IPartitionComponent partition, 
+            IntentionsComparer<TIntention>.SourcedIntentionId intentionId, CancellationToken ct)
         {
-            StreamableLoadingResult<TAsset>? result = await intention.RepeatLoopAsync(state, partition, cachedInternalFlowDelegate, GetReportData(), ct);
-            return result is { Succeeded: false, IsInitialized: true } ? SetIrrecoverableFailure(intention, result.Value) : result;
+            StreamableLoadingResult<TAsset>? result = await intention.RepeatLoopAsync(state, partition, 
+                cachedInternalFlowDelegate, GetReportData(), ct);
+            return result is { Succeeded: false, IsInitialized: true } ? SetIrrecoverableFailure(intention, 
+                intentionId, result.Value) : result;
         }
 
-        private StreamableLoadingResult<TAsset> SetIrrecoverableFailure(TIntention intention, StreamableLoadingResult<TAsset> failure)
+        private StreamableLoadingResult<TAsset> SetIrrecoverableFailure(TIntention intention, 
+            IntentionsComparer<TIntention>.SourcedIntentionId intentionId, StreamableLoadingResult<TAsset> failure)
         {
-            string cacheKey = GetIntentionCacheKey(in intention);
-            bool result = cache.IrrecoverableFailures.SyncTryAdd(cacheKey, failure);
+            bool result = cache.IrrecoverableFailures.SyncTryAdd(intentionId, failure);
             if (result == false) ReportHub.LogError(GetReportData(), $"Irrecoverable failure for {intention} is already added");
             return failure;
-        }
-        
-        private string GetIntentionCacheKey(in TIntention intention)
-        {
-            // Use the intention's hash code which includes all relevant properties
-            return intention.GetHashCode().ToString();
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Common/Systems/PartialDownloadSystemBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Common/Systems/PartialDownloadSystemBase.cs
@@ -18,7 +18,7 @@ using Utility.Types;
 namespace ECS.StreamableLoading.Common.Systems
 {
     public abstract class PartialDownloadSystemBase<TData, TIntention> : LoadSystemBase<TData, TIntention>
-        where TIntention: struct, ILoadingIntention
+        where TIntention: struct, ILoadingIntention, IEquatable<TIntention>
     {
         private const string PARTIALS_FILES_EXTENSION = "part";
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/TexturesCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/TexturesCache.cs
@@ -1,20 +1,16 @@
 ﻿using DCL.Profiling;
 using ECS.StreamableLoading.Cache;
+using System;
 using System.Linq;
 using Unity.Profiling;
 using UnityEngine;
 
 namespace ECS.StreamableLoading.Textures
 {
-    public class TexturesCache<TIntention> : RefCountStreamableCacheBase<Texture2DData, Texture2D, TIntention>, ISizedStreamableCache<Texture2DData, TIntention>
+    public class TexturesCache<TIntention> : RefCountStreamableCacheBase<Texture2DData, Texture2D, TIntention>, 
+        ISizedStreamableCache<Texture2DData, TIntention> where TIntention: IEquatable<TIntention>
     {
         protected override ref ProfilerCounterValue<int> inCacheCount => ref ProfilingCounters.TexturesInCache;
-
-        public override bool Equals(TIntention x, TIntention y) =>
-            x.Equals(y);
-
-        public override int GetHashCode(TIntention obj) =>
-            obj.GetHashCode();
 
         public long ByteSize => cache.Sum(e => e.Value!.ByteSize);
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
@@ -37,7 +37,7 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
             parentContainer.gameObject.SetActive(false);
 
             cache = new Dictionary<string, List<GltfContainerAsset>>(this);
-            OngoingRequests = new FakeDictionaryCache<UniTaskCompletionSource<StreamableLoadingResult<GltfContainerAsset>?>>();
+            OngoingRequests = new FakeDictionaryCache<string, UniTaskCompletionSource<StreamableLoadingResult<GltfContainerAsset>?>>();
             IrrecoverableFailures = new Dictionary<string, StreamableLoadingResult<GltfContainerAsset>>();
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Textures/Components/Extensions/TextureDefaultsExtension.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Textures/Components/Extensions/TextureDefaultsExtension.cs
@@ -17,7 +17,8 @@ namespace ECS.Unity.Textures.Components.Extensions
 
             if (self.IsVideoTexture())
             {
-                var textureComponent = new TextureComponent(URLAddress.EMPTY, string.Empty, self.GetWrapMode(), self.GetFilterMode(), isVideoTexture: true, videoPlayerEntity: self.GetVideoTextureId());
+                var textureComponent = new TextureComponent(URLAddress.EMPTY, string.Empty, self.GetWrapMode(), 
+                    self.GetFilterMode(), isVideoTexture: true, videoPlayerEntity: self.GetVideoTextureId());
                 return textureComponent;
             }
 

--- a/Explorer/Assets/DCL/ResourcesUnloading/CacheCleaner.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/CacheCleaner.cs
@@ -156,7 +156,7 @@ namespace DCL.ResourcesUnloading
 #endif
         }
 
-        private void TryAppendToDebug<TA, TI>(ISizedStreamableCache<TA, TI> cache, string title)
+        private void TryAppendToDebug<TA, TI>(ISizedStreamableCache<TA, TI> cache, string title) where TI: IEquatable<TI>
         {
             if (widgetBuilder == null)
                 return;


### PR DESCRIPTION
# Pull Request Description
Fix [#250](https://github.com/decentraland/creator-hub/issues/250)

## What does this PR change?
Fixes bug which caused texture settings not being loaded properly. It happen because we were stashing texture in the cache at first request of it. And whenever same texture were used in different object, it was returning the same texture, no matter if that texture had different settings. That was because we were using base hash for caching. This PR makes cache read hash constructed by each intention separately. 

Example hash for texture (GetTextureIntention.cs)
```
public readonly override int GetHashCode() =>
            HashCode.Combine((int)WrapMode, (int)FilterMode, cacheKey, IsVideoTexture, VideoPlayerEntity);
```

## Test Instructions


### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
