### PR TITLE
feat: open user profile on community member entry click

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListController.cs
@@ -445,11 +445,8 @@ namespace DCL.Communities.CommunitiesCard.Members
             FetchNewDataAsync(ct).Forget();
         }
 
-        private void OnMainButtonClicked(MemberData profile)
-        {
-            // Handle main button click
-            // Debug.Log("MainButtonClicked: " + profile.id);
-        }
+        private void OnMainButtonClicked(MemberData profile) =>
+            OpenProfilePassport(profile);
 
         private void OnFriendButtonClicked(MemberData profile) =>
             HandleContextMenuUserProfileButtonAsync(profile.ToUserData(), profile.friendshipStatus.Convert());


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes the clicking of a community member found in the member list, open the relative user passport.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- launch the explorer in zone using the arg `--dclenv zone`

### Test Steps
1. Verify that clicking on a community member, opens their passport

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
