### PR TITLE
fix: remove manual curl install

### DIFF
--- a/.github/workflows/on-delete-release.yml
+++ b/.github/workflows/on-delete-release.yml
@@ -11,10 +11,10 @@ jobs:
     container:
       image: amazon/aws-cli:latest
     steps:
-      - name: Install jq and curl
+      - name: Install jq
         run: |
           yum update -y
-          yum install -y jq curl
+          yum install -y jq
 
       - name: Check Deleted and Update Latest
         env:

--- a/.github/workflows/s3-latest-release.yml
+++ b/.github/workflows/s3-latest-release.yml
@@ -12,10 +12,11 @@ jobs:
     container:
       image: amazon/aws-cli:latest
     steps:
-      - name: Install jq and curl
+      - name: Install jq
         run: |
           yum update -y
-          yum install -y jq curl
+          yum install -y jq
+
       - name: Check if current release is the latest release
         id: check_latest
         run: |


### PR DESCRIPTION
- used image amazon/aws-cli:latest was updated from Amazon Linux 2 to Amazon Linux 2023 , conflicting when trying to install curl
- curl install is not required anymore, so it was removed from all workflow steps