### PR TITLE
Fix: community place thumbnails and loading animation

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunitiesBrowser.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunitiesBrowser.prefab
@@ -254,6 +254,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5898131792183240962, guid: 54b92d24b95063946930ed10047df8ef, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898131792183240962, guid: 54b92d24b95063946930ed10047df8ef, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6722829874285979988, guid: 54b92d24b95063946930ed10047df8ef, type: 3}
       propertyPath: m_Pivot.x
       value: 0

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunitiesBrowser_RightSection.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunitiesBrowser_RightSection.prefab
@@ -6168,7 +6168,7 @@ MonoBehaviour:
   - {fileID: 130928485671573892}
   - {fileID: 5229879686127759125}
   - {fileID: 2088843554703796664}
-  tweenDuration: 5
+  tweenDuration: 1
   fadeDuration: 0.3
 --- !u!1 &8188520677342984740
 GameObject:

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
@@ -15,6 +15,7 @@ using DCL.InWorldCamera.CameraReelStorageService;
 using DCL.InWorldCamera.CameraReelStorageService.Schemas;
 using DCL.InWorldCamera.PhotoDetail;
 using DCL.PlacesAPIService;
+using DCL.Profiles;
 using DCL.UI;
 using DCL.UI.Profiles.Helpers;
 using DCL.UI.SharedSpaceManager;
@@ -59,6 +60,7 @@ namespace DCL.Communities.CommunitiesCard
         private readonly ISharedSpaceManager sharedSpaceManager;
         private readonly IChatEventBus chatEventBus;
         private readonly IWeb3IdentityCache web3IdentityCache;
+        private readonly LambdasProfilesProvider lambdasProfilesProvider;
 
         private CameraReelGalleryController? cameraReelGalleryController;
         private MembersListController? membersListController;
@@ -90,7 +92,8 @@ namespace DCL.Communities.CommunitiesCard
             IEventsApiService eventsApiService,
             ISharedSpaceManager sharedSpaceManager,
             IChatEventBus chatEventBus,
-            IWeb3IdentityCache web3IdentityCache)
+            IWeb3IdentityCache web3IdentityCache,
+            LambdasProfilesProvider lambdasProfilesProvider)
             : base(viewFactory)
         {
             this.mvcManager = mvcManager;
@@ -108,6 +111,7 @@ namespace DCL.Communities.CommunitiesCard
             this.sharedSpaceManager = sharedSpaceManager;
             this.chatEventBus = chatEventBus;
             this.web3IdentityCache = web3IdentityCache;
+            this.lambdasProfilesProvider = lambdasProfilesProvider;
             this.thumbnailLoader = new ThumbnailLoader(null);
 
             chatEventBus.OpenPrivateConversationRequested += CloseCardOnConversationRequested;
@@ -254,7 +258,8 @@ namespace DCL.Communities.CommunitiesCard
                 realmNavigator,
                 mvcManager,
                 clipboard,
-                webBrowser);
+                webBrowser,
+                lambdasProfilesProvider);
 
             eventListController = new EventListController(viewInstance.EventListView,
                 eventsApiService,

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlaceCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlaceCardView.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using PlaceInfo = DCL.PlacesAPIService.PlacesData.PlaceInfo;
+using PlaceData = DCL.Communities.CommunitiesCard.Places.PlacesSectionController.PlaceData;
 
 namespace DCL.Communities.CommunitiesCard.Places
 {
@@ -85,16 +86,16 @@ namespace DCL.Communities.CommunitiesCard.Places
         private void OnEnable() =>
             PlayHoverExitAnimation(instant: true);
 
-        public void Configure(PlaceInfo placeInfo, bool userOwnsPlace, ThumbnailLoader thumbnailLoader, CancellationToken ct)
+        public void Configure(PlaceData placeInfo, bool userOwnsPlace, ThumbnailLoader thumbnailLoader, CancellationToken ct)
         {
-            currentPlaceInfo = placeInfo;
+            currentPlaceInfo = placeInfo.PlaceInfo;
 
-            thumbnailLoader.LoadCommunityThumbnailAsync(placeInfo.image, placeThumbnailImage, defaultPlaceThumbnail, ct).Forget();
+            thumbnailLoader.LoadCommunityThumbnailAsync(placeInfo.PlaceInfo.image, placeThumbnailImage, defaultPlaceThumbnail, ct).Forget();
 
-            placeNameText.text = placeInfo.title;
-            placeDescriptionText.text = placeInfo.description;
-            onlineMembersText.text = $"{placeInfo.user_count}";
-            placeCoordsText.text = string.IsNullOrWhiteSpace(placeInfo.world_name) ? placeInfo.base_position : placeInfo.world_name;
+            placeNameText.text = placeInfo.PlaceInfo.title;
+            placeDescriptionText.text = placeInfo.OwnerName;
+            onlineMembersText.text = $"{placeInfo.PlaceInfo.user_count}";
+            placeCoordsText.text = string.IsNullOrWhiteSpace(placeInfo.PlaceInfo.world_name) ? placeInfo.PlaceInfo.base_position : placeInfo.PlaceInfo.world_name;
 
             deleteButton.gameObject.SetActive(userOwnsPlace);
 
@@ -103,9 +104,9 @@ namespace DCL.Communities.CommunitiesCard.Places
             DislikeToggleChanged = null;
             FavoriteToggleChanged = null;
 
-            likeToggle.Toggle.isOn = placeInfo.user_like;
-            dislikeToggle.Toggle.isOn = placeInfo.user_dislike;
-            favoriteToggle.Toggle.isOn = placeInfo.user_favorite;
+            likeToggle.Toggle.isOn = placeInfo.PlaceInfo.user_like;
+            dislikeToggle.Toggle.isOn = placeInfo.PlaceInfo.user_dislike;
+            favoriteToggle.Toggle.isOn = placeInfo.PlaceInfo.user_favorite;
         }
 
         public void SubscribeToInteractions(Action<PlaceInfo, bool, PlaceCardView> likeToggleChanged,

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlacesSectionView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlacesSectionView.cs
@@ -16,10 +16,11 @@ using UnityEngine.UI;
 using Utility.Types;
 using PlaceInfo = DCL.PlacesAPIService.PlacesData.PlaceInfo;
 using CommunityData = DCL.Communities.GetCommunityResponse.CommunityData;
+using PlaceData = DCL.Communities.CommunitiesCard.Places.PlacesSectionController.PlaceData;
 
 namespace DCL.Communities.CommunitiesCard.Places
 {
-    public class PlacesSectionView : MonoBehaviour, ICommunityFetchingView<PlaceInfo>
+    public class PlacesSectionView : MonoBehaviour, ICommunityFetchingView<PlaceData>
     {
         private const int ELEMENT_MISSING_THRESHOLD = 5;
         private const int ADD_PLACE_PREFAB_INDEX = 0;
@@ -49,7 +50,7 @@ namespace DCL.Communities.CommunitiesCard.Places
         public event Action<PlaceInfo>? ElementJumpInButtonClicked;
         public event Action<PlaceInfo>? ElementDeleteButtonClicked;
 
-        private SectionFetchData<PlaceInfo> placesInfo = null!;
+        private SectionFetchData<PlaceData> placesInfo = null!;
         private bool canModify;
         private CommunityData communityData;
         private ThumbnailLoader? thumbnailLoader;
@@ -112,11 +113,11 @@ namespace DCL.Communities.CommunitiesCard.Places
             LoopGridViewItem listItem = loopGridView.NewListViewItem(loopGridView.ItemPrefabDataList[PLACE_PREFAB_INDEX].mItemPrefab.name);
             PlaceCardView elementView = listItem.GetComponent<PlaceCardView>();
 
-            SectionFetchData<PlaceInfo> membersData = placesInfo;
+            SectionFetchData<PlaceData> membersData = placesInfo;
 
             int realIndex = canModify ? index - 1 : index;
-            PlaceInfo placeInfo = membersData.Items[realIndex];
-            elementView.Configure(placeInfo, placeInfo.owner.EqualsIgnoreCase(ViewDependencies.CurrentIdentity?.Address) && canModify, thumbnailLoader!, cancellationToken);
+            PlaceData placeInfo = membersData.Items[realIndex];
+            elementView.Configure(placeInfo, placeInfo.PlaceInfo.owner.EqualsIgnoreCase(ViewDependencies.CurrentIdentity?.Address) && canModify, thumbnailLoader!, cancellationToken);
 
             elementView.SubscribeToInteractions((placeInfo, value, cardView) => ElementLikeToggleChanged?.Invoke(placeInfo, value, cardView),
                 (placeInfo, value, cardView) => ElementDislikeToggleChanged?.Invoke(placeInfo, value, cardView),
@@ -163,7 +164,7 @@ namespace DCL.Communities.CommunitiesCard.Places
             }
         }
 
-        public void RefreshGrid(SectionFetchData<PlaceInfo> placesInfo, bool redraw)
+        public void RefreshGrid(SectionFetchData<PlaceData> placesInfo, bool redraw)
         {
             this.placesInfo = placesInfo;
             int count = placesInfo.Items.Count;

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCardEvents.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCardEvents.prefab
@@ -1651,7 +1651,7 @@ MonoBehaviour:
   - {fileID: 4418461772446874494}
   - {fileID: 4379479570568262795}
   - {fileID: 1931124675555126151}
-  tweenDuration: 7
+  tweenDuration: 1
   fadeDuration: 0.3
 --- !u!1 &4824639616395220465
 GameObject:
@@ -3226,6 +3226,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4536725697558613486, guid: d4226feb8cb684109bb7833b764418fa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641221226267985663, guid: d4226feb8cb684109bb7833b764418fa, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641221226267985663, guid: d4226feb8cb684109bb7833b764418fa, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641221226267985663, guid: d4226feb8cb684109bb7833b764418fa, type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6042187927880008599, guid: d4226feb8cb684109bb7833b764418fa, type: 3}

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCardPlaces.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCardPlaces.prefab
@@ -182,7 +182,6 @@ MonoBehaviour:
   <emptyState>k__BackingField: {fileID: 1720708892090664944}
   <loadingObject>k__BackingField: {fileID: 2063066630832939637}
   <contextMenuConfiguration>k__BackingField: {fileID: 11400000, guid: ca02eb1ec7d6947c1b6683ad3e847437, type: 2}
-  <confirmationDialogView>k__BackingField: {fileID: 0}
   <deleteSprite>k__BackingField: {fileID: 21300000, guid: 767d48f13763447a3b8bdc48c0a2efee, type: 3}
 --- !u!114 &2063066630832939637
 MonoBehaviour:
@@ -208,7 +207,7 @@ MonoBehaviour:
   - {fileID: 5514977292644474435}
   - {fileID: 8740097530220918798}
   - {fileID: 4314993956740610484}
-  tweenDuration: 7
+  tweenDuration: 1
   fadeDuration: 0.3
 --- !u!1 &1122154419499980750
 GameObject:
@@ -3027,11 +3026,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5870015658720737092, guid: 37d30f2f05a6f4606839b9f3045b0155, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 18.03
+      value: 18.11
       objectReference: {fileID: 0}
     - target: {fileID: 5870015658720737092, guid: 37d30f2f05a6f4606839b9f3045b0155, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 51.015
+      value: 51.055
       objectReference: {fileID: 0}
     - target: {fileID: 5870015658720737092, guid: 37d30f2f05a6f4606839b9f3045b0155, type: 3}
       propertyPath: m_AnchoredPosition.y

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/PlaceCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/PlaceCard.prefab
@@ -2001,7 +2001,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/PlaceCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/PlaceCard.prefab
@@ -419,7 +419,7 @@ MonoBehaviour:
   footerContainer: {fileID: 5951469731124757622}
   interactionButtonsCanvasGroup: {fileID: 4679103036289497690}
   defaultPlaceThumbnail: {fileID: 21300000, guid: 50c948c68942a4cf188b1f118ba70f8d, type: 3}
-  placeThumbnailImage: {fileID: 3951069872983715749}
+  placeThumbnailImage: {fileID: 1473715677279745013}
   onlineMembersText: {fileID: 6311681305906227349}
   placeNameText: {fileID: 5579438315706490994}
   placeDescriptionText: {fileID: 6987001651034814178}
@@ -572,7 +572,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6055750018662083017}
+  - {fileID: 1508454948285574238}
   - {fileID: 1658707101884923339}
   m_Father: {fileID: 4861997092845700045}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2387,129 +2387,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &7717559044640100053
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6055750018662083017}
-  - component: {fileID: 2265345955067352057}
-  - component: {fileID: 6296225220407222590}
-  - component: {fileID: 3951069872983715749}
-  - component: {fileID: 8626749671046439750}
-  - component: {fileID: 1338662176729295832}
-  m_Layer: 5
-  m_Name: Thumbnail
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6055750018662083017
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7717559044640100053}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 79485028649577918}
-  m_Father: {fileID: 5629250283557921473}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0.5}
---- !u!222 &2265345955067352057
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7717559044640100053}
-  m_CullTransparentMesh: 1
---- !u!114 &6296225220407222590
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7717559044640100053}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 50c948c68942a4cf188b1f118ba70f8d, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &3951069872983715749
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7717559044640100053}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e79e296834574c5d9138852d94c8998, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <LoadingObject>k__BackingField: {fileID: 3549040772072870632}
-  <skeletonLoadingView>k__BackingField: {fileID: 0}
-  <Image>k__BackingField: {fileID: 6296225220407222590}
-  <imageLoadingFadeDuration>k__BackingField: 0.3
-  aspectRatioFitter: {fileID: 1338662176729295832}
-  rectTransform: {fileID: 6055750018662083017}
---- !u!114 &8626749671046439750
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7717559044640100053}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1338662176729295832
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7717559044640100053}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AspectMode: 4
-  m_AspectRatio: 1
 --- !u!1 &7928868741710540312
 GameObject:
   m_ObjectHideFlags: 0
@@ -2777,176 +2654,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1001 &1237361652372722785
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 6055750018662083017}
-    m_Modifications:
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -336.96002
-      objectReference: {fileID: 0}
-    - target: {fileID: 2336035712942851721, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_Name
-      value: LoadingSpinner
-      objectReference: {fileID: 0}
-    - target: {fileID: 2336035712942851721, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3817016671180041992, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_Maskable
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2336035712942851721, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 812481570440461138}
-    - targetCorrespondingSourceObject: {fileID: 1478407899719663598, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8538315281923893664}
-    - targetCorrespondingSourceObject: {fileID: 1761498992749964840, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4379006121491227013}
-  m_SourcePrefab: {fileID: 100100000, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
---- !u!224 &79485028649577918 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1166888513132788191, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-  m_PrefabInstance: {fileID: 1237361652372722785}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &409724191256226703 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1478407899719663598, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-  m_PrefabInstance: {fileID: 1237361652372722785}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8538315281923893664
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 409724191256226703}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &673824558650505801 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1761498992749964840, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-  m_PrefabInstance: {fileID: 1237361652372722785}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &4379006121491227013
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 673824558650505801}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &3549040772072870632 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2336035712942851721, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-  m_PrefabInstance: {fileID: 1237361652372722785}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &812481570440461138
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3549040772072870632}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1709506758810688811
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3848,5 +3555,158 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 822ef88491b0c4b3982153e7574be1fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &8772553705313830265
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5629250283557921473}
+    m_Modifications:
+    - target: {fileID: 492899578579090772, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 50c948c68942a4cf188b1f118ba70f8d, type: 3}
+    - target: {fileID: 4906287755250558190, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4906287755250558190, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4906287755250558190, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4906287755250558190, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5130070239436171725, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_Name
+      value: ImageWithSkeletonAnimation
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5130070239436171725, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3486483284148339430}
+  m_SourcePrefab: {fileID: 100100000, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+--- !u!114 &1473715677279745013 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7912243470682191500, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+  m_PrefabInstance: {fileID: 8772553705313830265}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e79e296834574c5d9138852d94c8998, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &1508454948285574238 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7877152905847466279, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+  m_PrefabInstance: {fileID: 8772553705313830265}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4508090781862587572 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5130070239436171725, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
+  m_PrefabInstance: {fileID: 8772553705313830265}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3486483284148339430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4508090781862587572}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/PlaceCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/PlaceCard.prefab
@@ -801,8 +801,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 51.015, y: -14}
-  m_SizeDelta: {x: 18.03, y: 28}
+  m_AnchoredPosition: {x: 51.055, y: -14}
+  m_SizeDelta: {x: 18.11, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5791249021391754608
 CanvasRenderer:
@@ -2479,7 +2479,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <LoadingObject>k__BackingField: {fileID: 3549040772072870632}
+  <skeletonLoadingView>k__BackingField: {fileID: 0}
   <Image>k__BackingField: {fileID: 6296225220407222590}
+  <imageLoadingFadeDuration>k__BackingField: 0.3
+  aspectRatioFitter: {fileID: 1338662176729295832}
+  rectTransform: {fileID: 6055750018662083017}
 --- !u!114 &8626749671046439750
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
@@ -192,7 +192,7 @@ namespace DCL.Communities.CommunityCreation
         {
             creationPanelProfileSelectedImage.gameObject.SetActive(sprite is not null);
             creationPanelProfilePictureIcon.SetActive(!creationPanelProfileSelectedImage.gameObject.activeSelf);
-            creationPanelProfileSelectedImage.SetImage(sprite);
+            creationPanelProfileSelectedImage.SetImage(sprite, true);
         }
 
         public void SetCommunityName(string text, bool isInteractable)

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/CreateOrEditCommunityPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/CreateOrEditCommunityPanel.prefab
@@ -901,6 +901,7 @@ GameObject:
   - component: {fileID: 4307894797937581009}
   - component: {fileID: 522000452717065140}
   - component: {fileID: 8678047472896997349}
+  - component: {fileID: 3750359444821652255}
   m_Layer: 5
   m_Name: SelectedImage
   m_TagString: Untagged
@@ -979,8 +980,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <LoadingObject>k__BackingField: {fileID: 387604661219919414}
+  <skeletonLoadingView>k__BackingField: {fileID: 0}
   <Image>k__BackingField: {fileID: 4307894797937581009}
   <imageLoadingFadeDuration>k__BackingField: 0.3
+  aspectRatioFitter: {fileID: 3750359444821652255}
+  rectTransform: {fileID: 7709803362638602964}
 --- !u!114 &8678047472896997349
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -993,6 +997,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &3750359444821652255
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844705562271976723}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 0
+  m_AspectRatio: 1
 --- !u!1 &1902539947599714145
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/PluginSystem/Global/CommunitiesPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/CommunitiesPlugin.cs
@@ -133,7 +133,8 @@ namespace DCL.PluginSystem.Global
                 eventsApiService,
                 sharedSpaceManager,
                 chatEventBus,
-                web3IdentityCache);
+                web3IdentityCache,
+                lambdasProfilesProvider);
 
             mvcManager.RegisterController(communityCardController);
 

--- a/Explorer/Assets/DCL/UI/SkeletonLoadingView.cs
+++ b/Explorer/Assets/DCL/UI/SkeletonLoadingView.cs
@@ -5,6 +5,8 @@ namespace DCL.UI
 {
     public class SkeletonLoadingView : MonoBehaviour
     {
+        private const float PULSE_BUFFER_SCALAR = 1.3f;
+
         [SerializeField] private CanvasGroup loadedCanvasGroup = null!;
         [SerializeField] private CanvasGroup loadingCanvasGroup = null!;
 
@@ -30,7 +32,7 @@ namespace DCL.UI
             {
                 bone.DOKill();
                 bone.anchoredPosition = new Vector2(0f, bone.anchoredPosition.y);
-                bone.DOAnchorPos3DX(bone.sizeDelta.x, tweenDuration)
+                bone.DOAnchorPosX(bone.sizeDelta.x * PULSE_BUFFER_SCALAR, tweenDuration)
                     .SetEase(Ease.Linear)
                     .SetLoops(-1, LoopType.Restart);
             }

--- a/Explorer/Assets/DCL/UI/SkeletonLoadingView.cs
+++ b/Explorer/Assets/DCL/UI/SkeletonLoadingView.cs
@@ -29,8 +29,9 @@ namespace DCL.UI
             foreach (var bone in bones)
             {
                 bone.DOKill();
-                bone.localPosition = new Vector3(0f, bone.localPosition.y, bone.localPosition.z);
-                bone.DOLocalMoveX(bone.position.x + (bone.sizeDelta.x / 2f), tweenDuration)
+                bone.anchoredPosition = new Vector2(0f, bone.anchoredPosition.y);
+                bone.DOAnchorPos3DX(bone.sizeDelta.x, tweenDuration)
+                    .SetEase(Ease.Linear)
                     .SetLoops(-1, LoopType.Restart);
             }
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR fixes the community place card:
- subtext now contains the owner of the place
- the coordinates text no longer wraps
- added loading skeleton animation
- place thumbnail now adapts to the card

It also fixes the skeleton loading animation script because previously it was moving the UI elements in world coordinate rather than anchored positions leading to weird behaviours.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- launch the client in zone with the arg `--dclenv zone`

### Test Steps
1. Open a community
2. Check that the place card thumbnail adapts to the card container
3. Check that it shows the scene owner
4. Check that the coordinates text never overflows/wraps
5. Verify that all skeleton animation behave as expected

WARNING: currently the events api have changed but the PR that addresses that is not yet merged: you will see errors about the client failing to fetch events

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
