### PR TITLE
fix: don't use github release page to check latest version

### DIFF
--- a/Explorer/Assets/DCL/ApplicationsGuards/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationsGuards/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -48,8 +48,8 @@ namespace DCL.ApplicationVersionGuard
                 ReportCategory.VERSION_CONTROL,
                 new WebRequestHeadersInfo());
 
-            GitHubRelease latestRelease = JsonUtility.FromJson<GitHubRelease>(response.body);
-            string latestVersion = latestRelease.tag_name.TrimStart('v');
+            ClientVersionInfo versionInfo = JsonUtility.FromJson<ClientVersionInfo>(response.body);
+            string latestVersion = versionInfo.version.TrimStart('v');
 
             return latestVersion;
         }
@@ -159,9 +159,10 @@ namespace DCL.ApplicationVersionGuard
             SystemInfo.processorType.Contains("apple", StringComparison.OrdinalIgnoreCase);
 
         [Serializable]
-        private struct GitHubRelease
+        private struct ClientVersionInfo
         {
-            public string tag_name;
+            public string version;
+            public string timestamp;
         }
     }
 }

--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/IDecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/IDecentralandUrlsSource.cs
@@ -2,7 +2,7 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
 {
     public interface IDecentralandUrlsSource
     {
-        const string EXPLORER_LATEST_RELEASE_URL = "https://api.github.com/repos/decentraland/unity-explorer/releases/latest";
+        const string EXPLORER_LATEST_RELEASE_URL = "https://explorer-artifacts.decentraland.org/@dcl/unity-explorer/releases/latest.json";
         const string LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher-rust";
         const string LEGACY_LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher/dcl";
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR updates the ApplicationVersionGuard to fetch the latest launcher version from the same source as launcher does instead of relying on the GitHub Releases API. This ensures consistency between the launcher and the client by using the same version source. 

## Test Instructions
To trigger the popup us this command ".\Decentraland.exe" --simulateVersion 0.71.0-alpha
There should not be any changes in the popup and it should show properly the version number.


## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
