### PR TITLE
chore: Emote flow cleanup

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/IEmote.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/IEmote.cs
@@ -13,5 +13,8 @@ namespace DCL.AvatarRendering.Emotes
         bool IsLooping();
 
         bool HasSameClipForAllGenders();
+
+        public static IEmote NewEmpty() =>
+            new Emote();
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetEmotesByPointersIntention.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetEmotesByPointersIntention.cs
@@ -19,8 +19,6 @@ namespace DCL.AvatarRendering.Emotes
 
         public IReadOnlyCollection<URN> Pointers => pointers;
 
-        // TODO why so many allocations?
-        public HashSet<URN> RequestedPointers { get; }
         public HashSet<URN> SuccessfulPointers { get; }
         public AssetSource PermittedSources { get; }
         public BodyShape BodyShape { get; }
@@ -34,7 +32,6 @@ namespace DCL.AvatarRendering.Emotes
         {
             this.pointers = pointers;
             CancellationTokenSource = new CancellationTokenSource();
-            RequestedPointers = POINTERS_HASHSET_POOL.Get();
             SuccessfulPointers = POINTERS_HASHSET_POOL.Get();
             PermittedSources = permittedSources;
             BodyShape = bodyShape;
@@ -54,7 +51,6 @@ namespace DCL.AvatarRendering.Emotes
         {
             if (isDisposed) return;
             POINTERS_POOL.Release(pointers);
-            POINTERS_HASHSET_POOL.Release(RequestedPointers);
             POINTERS_HASHSET_POOL.Release(SuccessfulPointers);
             CancellationTokenSource.Cancel();
             isDisposed = true;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Emote.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Emote.cs
@@ -22,6 +22,9 @@ namespace DCL.AvatarRendering.Emotes
 
         public bool IsLoading { get; private set; }
 
+        public Emote() { }
+
+
         public Emote(StreamableLoadingResult<EmoteDTO> model, bool isLoading = true)
         {
             Model = model;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -190,12 +190,16 @@ namespace DCL.AvatarRendering.Emotes.Load
 
                 if (!emoteStorage.TryGetElement(shortenedPointer, out IEmote emote))
                 {
+                    IEmote newEmote = IEmote.NewEmpty();
+                    newEmote.UpdateLoadingStatus(true);
+                    emoteStorage.Set(shortenedPointer, newEmote);
+                    //TODO (JUANI) : The same emote can be twice in the requested pointer?
                     if (!intention.RequestedPointers.Contains(loadingIntentionPointer))
                     {
+                        Debug.Log($"JUANI ADDING SHORTENED POINTER TO MISSING EMOTES {shortenedPointer}");
                         missingPointers.Add(shortenedPointer);
                         intention.RequestedPointers.Add(loadingIntentionPointer);
                     }
-
                     continue;
                 }
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -194,7 +194,6 @@ namespace DCL.AvatarRendering.Emotes.Load
                     newEmote.UpdateLoadingStatus(true);
                     emoteStorage.Set(shortenedPointer, newEmote);
 
-                    Debug.Log($"JUANI ADDING MISSING POINTER {shortenedPointer}");
                     missingPointers.Add(shortenedPointer);
                     continue;
                 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -193,13 +193,9 @@ namespace DCL.AvatarRendering.Emotes.Load
                     IEmote newEmote = IEmote.NewEmpty();
                     newEmote.UpdateLoadingStatus(true);
                     emoteStorage.Set(shortenedPointer, newEmote);
-                    //TODO (JUANI) : The same emote can be twice in the requested pointer?
-                    if (!intention.RequestedPointers.Contains(loadingIntentionPointer))
-                    {
-                        Debug.Log($"JUANI ADDING SHORTENED POINTER TO MISSING EMOTES {shortenedPointer}");
-                        missingPointers.Add(shortenedPointer);
-                        intention.RequestedPointers.Add(loadingIntentionPointer);
-                    }
+
+                    Debug.Log($"JUANI ADDING MISSING POINTER {shortenedPointer}");
+                    missingPointers.Add(shortenedPointer);
                     continue;
                 }
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -221,8 +221,6 @@ namespace DCL.AvatarRendering.Emotes.Play
                 }
                 else
                 {
-                    if (string.IsNullOrEmpty(emoteId))
-                        Debug.Log("JUANI WE SHOULD NOT BE REQUESTING AN EMPTY EMOTE");
                     // Request the emote when not it cache. It will eventually endup in the emoteStorage so it can be played by this query
                     World.Create(CreateEmotePromise(emoteId, avatarShapeComponent.BodyShape));
                 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -219,8 +219,13 @@ namespace DCL.AvatarRendering.Emotes.Play
                     World.Remove<CharacterEmoteIntent>(entity);
                 }
                 else
+                {
+                    if (string.IsNullOrEmpty(emoteId))
+                        Debug.Log("JUANI WE SHOULD NOT BE REQUESTING AN EMPTY EMOTE");
                     // Request the emote when not it cache. It will eventually endup in the emoteStorage so it can be played by this query
                     LoadEmote(emoteId, avatarShapeComponent.BodyShape);
+                }
+
             }
             catch (Exception e) { ReportHub.LogException(e, GetReportData()); }
         }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
@@ -42,6 +42,15 @@ namespace DCL.AvatarRendering.Emotes.Play
         {
             EmoteReferences? emoteInUse = emoteComponent.CurrentEmoteReference;
 
+            // Early return if the same looping emote is already playing
+            if (emoteInUse != null &&
+                emotesInUse.ContainsKey(emoteInUse) &&
+                pools.ContainsKey(mainAsset) &&
+                emotesInUse[emoteInUse] == pools[mainAsset] &&
+                emoteComponent.EmoteLoop &&
+                isLooping)
+                return true;
+
             if (emoteInUse != null)
                 Stop(emoteInUse);
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/RemoteEmotesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/RemoteEmotesSystem.cs
@@ -45,13 +45,15 @@ namespace DCL.AvatarRendering.Emotes
                         continue;
                     }
 
-                    ref CharacterEmoteIntent intention = ref World!.AddOrGet<CharacterEmoteIntent>(entry.Entity);
                     ref RemotePlayerMovementComponent replicaMovement = ref World.TryGetRef<RemotePlayerMovementComponent>(entry.Entity, out bool _);
                     ref InterpolationComponent intComp = ref World.TryGetRef<InterpolationComponent>(entry.Entity, out bool interpolationExists);
 
                     // If interpolation passed the time of emote, then we can play it (otherwise emote is still in the interpolation future)
                     if (interpolationExists && EmoteIsInPresentOrPast(replicaMovement, remoteEmoteIntention, intComp))
+                    {
+                        ref CharacterEmoteIntent intention = ref World!.AddOrGet<CharacterEmoteIntent>(entry.Entity);
                         intention.UpdateRemoteId(remoteEmoteIntention.EmoteId);
+                    }
                     else
                         savedIntentions.Add(remoteEmoteIntention);
                 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes #4794, and does the following cleanup:

- Makes simetric the implementation with the wearables: When an emote DTO is requested for the first time, its added to the storage. This avoid duplication of DTOs requests, and allows to securely use the `isLoading` flag.
- Given the change mentioned above, is not necessary to check all the emotes intention to see if an emote is loading. The `LoadEmote` method and its query can be removed.
- After the emote resending change that was added recently, we introduced an overhead. We add an empty `CharacterEmoteIntent`, which is harmless; but triggers unnecessary ECS systems.
- Finally, after the emote resending, the looping emotes are resent; and stopped and restared. This PR adds an early return for looping emotes. (Maybe its better not to resend the looping emote? @lorux0 )

## Test Instructions


### Test Steps
1. Emotes as much as possible. Alone, with friends, in backpack, looping. Anything that comes to mind



## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
