### PR TITLE
fix: gallery event bus null injection

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
@@ -244,7 +244,7 @@ namespace DCL.Communities.CommunitiesCard
 
             cameraReelGalleryController = new CameraReelGalleryController(viewInstance.CameraReelGalleryConfigs.PhotosView.GalleryView, cameraReelStorageService, cameraReelScreenshotsStorage,
                 new ReelGalleryConfigParams(viewInstance.CameraReelGalleryConfigs.GridLayoutFixedColumnCount, viewInstance.CameraReelGalleryConfigs.ThumbnailHeight,
-                    viewInstance.CameraReelGalleryConfigs.ThumbnailWidth, false, false), false);
+                    viewInstance.CameraReelGalleryConfigs.ThumbnailWidth, false, false), false, galleryEventBus);
             cameraReelGalleryController.ThumbnailClicked += OnThumbnailClicked;
 
             membersListController = new MembersListController(viewInstance.MembersListView,
@@ -343,9 +343,9 @@ namespace DCL.Communities.CommunitiesCard
             eventListController?.Reset();
         }
 
-        private void OnThumbnailClicked(List<CameraReelResponseCompact> reels, int index, 
+        private void OnThumbnailClicked(List<CameraReelResponseCompact> reels, int index,
             Action<CameraReelResponseCompact> reelDeleteIntention, Action<CameraReelResponseCompact> reelListRefreshIntention) =>
-            mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index, 
+            mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index,
                 true, PhotoDetailParameter.CallerContext.CommunityCard, reelDeleteIntention,
                 reelListRefreshIntention, galleryEventBus)));
 

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryController.cs
@@ -44,9 +44,9 @@ namespace DCL.InWorldCamera.CameraReelGallery
         }
 
         public delegate void ThumbnailClick(
-            List<CameraReelResponseCompact> reels, 
-            int index, 
-            Action<CameraReelResponseCompact> reelDeleteIntention, 
+            List<CameraReelResponseCompact> reels,
+            int index,
+            Action<CameraReelResponseCompact> reelDeleteIntention,
             Action<CameraReelResponseCompact> reelListRefreshIntention);
         public event ThumbnailClick? ThumbnailClicked;
         public event Action<CameraReelStorageStatus>? StorageUpdated;
@@ -97,13 +97,13 @@ namespace DCL.InWorldCamera.CameraReelGallery
             ICameraReelScreenshotsStorage cameraReelScreenshotsStorage,
             ReelGalleryConfigParams reelGalleryConfigParams,
             bool useSignedRequest,
+            GalleryEventBus galleryEventBus,
             CameraReelOptionButtonView? optionButtonView = null,
             IWebBrowser? webBrowser = null,
             IDecentralandUrlsSource? decentralandUrlsSource = null,
             ISystemClipboard? systemClipboard = null,
             ReelGalleryStringMessages? reelGalleryStringMessages = null,
-            IMVCManager? mvcManager = null,
-            GalleryEventBus galleryEventBus = null)
+            IMVCManager? mvcManager = null)
         {
             this.view = view;
             this.cameraReelStorageService = cameraReelStorageService;
@@ -272,7 +272,7 @@ namespace DCL.InWorldCamera.CameraReelGallery
             if (reelToHide != null)
                 RemoveThumbnailFromList(reelToHide.id, reelToHide.dateTime);
         }
-        
+
         private void RemoveThumbnailFromList(string reelId, string dateTime)
         {
             int indexToRemove = -1;
@@ -302,17 +302,17 @@ namespace DCL.InWorldCamera.CameraReelGallery
             }
 
             pagedCameraReelManager.RemoveReelId(reelId);
-            
+
             if(currentSize <= 0)
                 view.emptyState.SetActive(true);
         }
-        
+
         private void OnReelPublicStateChange(string reelId, bool isPublic)
         {
             foreach (var thumbnail in pagedCameraReelManager.AllOrderedResponses)
             {
                 if(thumbnail.id != reelId) continue;
-                
+
                 thumbnail.isPublic = isPublic;
                 return;
             }
@@ -422,7 +422,7 @@ namespace DCL.InWorldCamera.CameraReelGallery
                 IReadOnlyList<ReelThumbnailController> thumbnailViews = monthGridView.Setup(bucket.Key, bucket.Value, optionButtonController,
                     (cameraReelResponse, sprite) => reelThumbnailCache.Add(cameraReelResponse, sprite),
                     cameraReelResponse =>
-                        ThumbnailClicked?.Invoke(pagedCameraReelManager.AllOrderedResponses, pagedCameraReelManager.AllOrderedResponses.IndexOf(cameraReelResponse), 
+                        ThumbnailClicked?.Invoke(pagedCameraReelManager.AllOrderedResponses, pagedCameraReelManager.AllOrderedResponses.IndexOf(cameraReelResponse),
                             reelToDelete =>
                             {
                                 this.reelToDelete = reelToDelete;
@@ -593,7 +593,7 @@ namespace DCL.InWorldCamera.CameraReelGallery
 
             HideDeleteModal();
             optionButtonController?.HideControl();
-            
+
             galleryEventBus.ReelPublicStateChangeEvent -= OnReelPublicStateChange;
         }
 

--- a/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
@@ -93,12 +93,12 @@ namespace DCL.Navmap
             if (view.CameraReelGalleryView != null)
             {
                 this.cameraReelGalleryController = new CameraReelGalleryController(
-                    view.CameraReelGalleryView, 
-                    cameraReelStorageService!, 
-                    cameraReelScreenshotsStorage!, 
-                    reelGalleryConfigParams!.Value, 
-                    reelUseSignedRequest!.Value, 
-                    galleryEventBus: galleryEventBus);
+                    view.CameraReelGalleryView,
+                    cameraReelStorageService!,
+                    cameraReelScreenshotsStorage!,
+                    reelGalleryConfigParams!.Value,
+                    reelUseSignedRequest!.Value,
+                    galleryEventBus);
                 this.cameraReelGalleryController.ThumbnailClicked += ThumbnailClicked;
                 this.cameraReelGalleryController.MaxThumbnailsUpdated += UpdatePhotosTabText;
             }
@@ -140,10 +140,10 @@ namespace DCL.Navmap
             view.EventsTabContainer.GetComponent<ScrollRect>()?.SetScrollSensitivityBasedOnPlatform();
         }
 
-        private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index, 
+        private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index,
             Action<CameraReelResponseCompact> reelDeleteIntention,  Action<CameraReelResponseCompact> reelListRefreshIntention) =>
             mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index,
-                true, PhotoDetailParameter.CallerContext.PlaceInfoPanel, reelDeleteIntention, 
+                true, PhotoDetailParameter.CallerContext.PlaceInfoPanel, reelDeleteIntention,
                 reelListRefreshIntention, galleryEventBus)));
 
         private void UpdatePhotosTabText(int count) =>

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -242,10 +242,10 @@ namespace DCL.Passport
             badge3DPreviewCamera.gameObject.SetActive(false);
         }
 
-        private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index, 
+        private void ThumbnailClicked(List<CameraReelResponseCompact> reels, int index,
             Action<CameraReelResponseCompact> reelDeleteIntention, Action<CameraReelResponseCompact> reelListRefreshIntention) =>
-            mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index, 
-                !isOwnProfile, PhotoDetailParameter.CallerContext.Passport, reelDeleteIntention, 
+            mvcManager.ShowAsync(PhotoDetailController.IssueCommand(new PhotoDetailParameter(reels, index,
+                !isOwnProfile, PhotoDetailParameter.CallerContext.Passport, reelDeleteIntention,
                 reelListRefreshIntention, galleryEventBus)));
 
         protected override void OnViewInstantiated()
@@ -255,63 +255,63 @@ namespace DCL.Passport
             passportErrorsController = new PassportErrorsController(viewInstance!.ErrorNotification);
             characterPreviewController = new PassportCharacterPreviewController(viewInstance.CharacterPreviewView, characterPreviewFactory, world, characterPreviewEventBus);
             characterPreviewController = new PassportCharacterPreviewController(
-                viewInstance.CharacterPreviewView, 
-                characterPreviewFactory, 
-                world, 
+                viewInstance.CharacterPreviewView,
+                characterPreviewFactory,
+                world,
                 characterPreviewEventBus);
             var userBasicInfoPassportModuleController = new UserBasicInfo_PassportModuleController(
-                viewInstance.UserBasicInfoModuleView, 
-                selfProfile, 
-                webBrowser, 
-                mvcManager, 
-                nftNamesProvider, 
+                viewInstance.UserBasicInfoModuleView,
+                selfProfile,
+                webBrowser,
+                mvcManager,
+                nftNamesProvider,
                 decentralandUrlsSource,
                 isNameEditorEnabled);
             userBasicInfoPassportModuleController.NameClaimRequested += OnNameClaimRequested;
             commonPassportModules.Add(userBasicInfoPassportModuleController);
             overviewPassportModules.Add(new UserDetailedInfo_PassportModuleController(
-                viewInstance.UserDetailedInfoModuleView, 
-                mvcManager, 
-                selfProfile, 
-                viewInstance.AddLinkModal, 
-                passportErrorsController, 
+                viewInstance.UserDetailedInfoModuleView,
+                mvcManager,
+                selfProfile,
+                viewInstance.AddLinkModal,
+                passportErrorsController,
                 passportProfileInfoController));
             overviewPassportModules.Add(new EquippedItems_PassportModuleController(
-                viewInstance.EquippedItemsModuleView, 
-                world, 
-                rarityBackgrounds, 
-                rarityColors, 
-                categoryIcons, 
-                thumbnailProvider, 
-                webBrowser, 
-                decentralandUrlsSource, 
+                viewInstance.EquippedItemsModuleView,
+                world,
+                rarityBackgrounds,
+                rarityColors,
+                categoryIcons,
+                thumbnailProvider,
+                webBrowser,
+                decentralandUrlsSource,
                 passportErrorsController));
             overviewPassportModules.Add(new BadgesOverview_PassportModuleController(
-                viewInstance.BadgesOverviewModuleView, 
-                badgesAPIClient, 
-                passportErrorsController, 
+                viewInstance.BadgesOverviewModuleView,
+                badgesAPIClient,
+                passportErrorsController,
                 webRequestController));
 
             badgesDetailsPassportModuleController = new BadgesDetails_PassportModuleController(
-                viewInstance.BadgesDetailsModuleView, 
-                viewInstance.BadgeInfoModuleView, 
-                badgesAPIClient, 
-                passportErrorsController, 
-                webRequestController, 
+                viewInstance.BadgesDetailsModuleView,
+                viewInstance.BadgeInfoModuleView,
+                badgesAPIClient,
+                passportErrorsController,
+                webRequestController,
                 selfProfile,
                 badge3DPreviewCamera);
             cameraReelGalleryController = new CameraReelGalleryController(
-                viewInstance.CameraReelGalleryModuleView, 
-                cameraReelStorageService, 
-                cameraReelScreenshotsStorage, 
+                viewInstance.CameraReelGalleryModuleView,
+                cameraReelStorageService,
+                cameraReelScreenshotsStorage,
                 new ReelGalleryConfigParams(
-                    gridLayoutFixedColumnCount, 
-                    thumbnailHeight, 
-                    thumbnailWidth, 
-                    false, 
-                    false), 
-                false, 
-                galleryEventBus: galleryEventBus);
+                    gridLayoutFixedColumnCount,
+                    thumbnailHeight,
+                    thumbnailWidth,
+                    false,
+                    false),
+                false,
+                galleryEventBus);
             cameraReelGalleryController.ThumbnailClicked += ThumbnailClicked;
             badgesPassportModules.Add(badgesDetailsPassportModuleController);
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -193,7 +193,7 @@ namespace DCL.PluginSystem.Global
             ProfileRepositoryWrapper profileDataProvider,
             UpscalingController upscalingController,
             CommunitiesDataProvider communitiesDataProvider,
-            INftNamesProvider nftNamesProvider, 
+            INftNamesProvider nftNamesProvider,
             bool isVoiceChatEnabled,
             GalleryEventBus galleryEventBus)
         {
@@ -341,12 +341,12 @@ namespace DCL.PluginSystem.Global
                 webRequestController, placesAPIService, mapPathEventBus, navmapBus, chatMessagesBus, eventsApiService,
                 eventElementsPool, shareContextMenu, webBrowser, mvcManager, cameraReelStorageService, cameraReelScreenshotsStorage,
                 new ReelGalleryConfigParams(
-                    settings.PlaceGridLayoutFixedColumnCount, 
-                    settings.PlaceThumbnailHeight, 
-                    settings.PlaceThumbnailWidth, 
-                    false, 
-                    false), 
-                false, 
+                    settings.PlaceGridLayoutFixedColumnCount,
+                    settings.PlaceThumbnailHeight,
+                    settings.PlaceThumbnailWidth,
+                    false,
+                    false),
+                false,
                 galleryEventBus: galleryEventBus);
 
             eventInfoPanelController = new EventInfoPanelController(navmapView.PlacesAndEventsPanelView.EventInfoPanelView,
@@ -407,15 +407,15 @@ namespace DCL.PluginSystem.Global
             CameraReelView cameraReelView = explorePanelView.GetComponentInChildren<CameraReelView>();
             var cameraReelController = new CameraReelController(cameraReelView,
                 new CameraReelGalleryController(
-                    cameraReelView.CameraReelGalleryView, 
+                    cameraReelView.CameraReelGalleryView,
                     this.cameraReelStorageService,
                     cameraReelScreenshotsStorage,
                     new ReelGalleryConfigParams(settings.GridLayoutFixedColumnCount, settings.ThumbnailHeight, settings.ThumbnailWidth, true, true), true,
+                    galleryEventBus,
                     cameraReelView.CameraReelOptionsButton,
                     webBrowser, decentralandUrlsSource, systemClipboard,
                     new ReelGalleryStringMessages(settings.CameraReelGalleryShareToXMessage, settings.PhotoSuccessfullyDeletedMessage, settings.PhotoSuccessfullyUpdatedMessage, settings.PhotoSuccessfullyDownloadedMessage, settings.LinkCopiedMessage),
-                    mvcManager, 
-                    galleryEventBus: galleryEventBus),
+                    mvcManager),
                 cameraReelStorageService,
                 web3IdentityCache,
                 mvcManager,


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR fixes a NRE in the community card controller caused by the fact that `GalleryEventBus` was injected as null while being mandatory.
Refactored `CameraReelGalleryController` constructor so the bus is effectively mandatory and cannot be injected as null.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- launch the client in zone with the arg `--dclenv zone` in order to test the integration with the community profile card photos

### Test Steps
1. Verify that the photo detail panel of a reel works as before
2. Verify that opening the photos section of a community profile card doesn't trigger any error


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
