### PR TITLE
style: increase 'NametagObject' fonts size

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Assets/NametagObject.prefab
+++ b/Explorer/Assets/DCL/NameTags/Assets/NametagObject.prefab
@@ -129,8 +129,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 0.8
-  m_fontSizeBase: 0.8
+  m_fontSize: 1.2
+  m_fontSizeBase: 1.2
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -305,8 +305,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 1.3
-  m_fontSizeBase: 1.3
+  m_fontSize: 1.4
+  m_fontSizeBase: 1.4
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -592,7 +592,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.03, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0.16, y: 0.3}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!212 &4273700018563800502
@@ -684,7 +684,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 1.589, y: -0.004}
+  m_AnchoredPosition: {x: 1.639, y: -0.004}
   m_SizeDelta: {x: 0.12, y: 0.3}
   m_Pivot: {x: 0, y: 0}
 --- !u!1 &4540754272894297556
@@ -989,8 +989,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.419, y: 0}
-  m_SizeDelta: {x: 0.2, y: 0.3}
+  m_AnchoredPosition: {x: 0.3961, y: 0}
+  m_SizeDelta: {x: 0.1541, y: 0.3}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!1 &6424952767005950802
 GameObject:
@@ -1472,7 +1472,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 12dd1efc4e826764f9b02be515a9a033, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 99428d9ed6da74af2966fb29d960e48f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 0.02745098}
   m_FlipX: 0
   m_FlipY: 0
@@ -1612,8 +1612,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 1.3
-  m_fontSizeBase: 1.3
+  m_fontSize: 1.5
+  m_fontSizeBase: 1.5
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18


### PR DESCRIPTION
## What does this PR change?
Chat bubbles font size is not aligned with the design: they are smaller and sometimes, as happens with the community name, hard to read.

https://github.com/user-attachments/assets/05f84e06-564f-4b67-8db3-0d1f41983b18


### Test Steps
1. Launch the explorer.
2. Check you have the chat bubbles visibility toggled on in the settings panel.
3. Check your name tag font size is bigger than in prod (might be subtle).
4. Send a message to the nearby channel. Check everything in the chat bubble looks normal. 
5. Then send a private message. Check the recipient's name is almost as big as yours (might be subtle).
6. Send a message in a community chat. Check the community name readability had been enhanced in the chat bubble.