### PR TITLE
feat: add context menu container rim option

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListView.cs
@@ -93,7 +93,7 @@ namespace DCL.Communities.CommunitiesCard.Members
             foreach (var sectionMapping in memberListSectionsElements)
                 sectionMapping.Button.onClick.AddListener(() => ToggleSection(sectionMapping.Section));
 
-            contextMenu = new GenericContextMenu(contextMenuSettings.ContextMenuWidth, verticalLayoutPadding: contextMenuSettings.VerticalPadding, elementsSpacing: contextMenuSettings.ElementsSpacing)
+            contextMenu = new GenericContextMenu(contextMenuSettings.ContextMenuWidth, verticalLayoutPadding: contextMenuSettings.VerticalPadding, elementsSpacing: contextMenuSettings.ElementsSpacing, showRim: true)
                          .AddControl(userProfileContextMenuControlSettings = new UserProfileContextMenuControlSettings((user, friendshipStatus) => ContextMenuUserProfileButtonClicked?.Invoke(user, friendshipStatus), showProfilePicture: false))
                          .AddControl(new SeparatorContextMenuControlSettings(contextMenuSettings.SeparatorHeight, -contextMenuSettings.VerticalPadding.left, -contextMenuSettings.VerticalPadding.right))
                          .AddControl(new ButtonContextMenuControlSettings(contextMenuSettings.ViewProfileText, contextMenuSettings.ViewProfileSprite, () => OpenProfilePassportRequested?.Invoke(lastClickedProfileCtx!)))

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controls/ControlsContainerView.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controls/ControlsContainerView.cs
@@ -7,5 +7,6 @@ namespace DCL.UI.GenericContextMenu.Controls
     {
         [SerializeField] internal RectTransform controlsContainer;
         [SerializeField] internal VerticalLayoutGroup controlsLayoutGroup;
+        [SerializeField] internal GameObject containerRim;
     }
 }

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
@@ -129,6 +129,7 @@ namespace DCL.UI.GenericContextMenu
 
             container.controlsLayoutGroup.spacing = contextMenuConfig.elementsSpacing;
             container.controlsLayoutGroup.padding = contextMenuConfig.verticalLayoutPadding;
+            container.containerRim.SetActive(contextMenuConfig.showRim);
 
             container.controlsContainer.sizeDelta = new Vector2(contextMenuConfig.width,
                 totalHeight

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Prefabs/ControlsContainer.prefab
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Prefabs/ControlsContainer.prefab
@@ -1,5 +1,130 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2138740960330858265
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 504687111200171935}
+  - component: {fileID: 2170804228160695259}
+  - component: {fileID: 4572047061433505274}
+  - component: {fileID: 2990912939596259358}
+  - component: {fileID: 5102680255756732099}
+  m_Layer: 5
+  m_Name: Rim
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &504687111200171935
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2138740960330858265}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8137949506953210344}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 3.365}
+  m_SizeDelta: {x: 0, y: -6.1699996}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2170804228160695259
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2138740960330858265}
+  m_CullTransparentMesh: 1
+--- !u!114 &4572047061433505274
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2138740960330858265}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1882353, g: 0.1764706, b: 0.21176471, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 37894a231569347e8b89612f29611b85, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 2
+--- !u!114 &2990912939596259358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2138740960330858265}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &5102680255756732099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2138740960330858265}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0bac33ade27cf4542bd53b1b13d90941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _source: 0
+  _separateMask: {fileID: 0}
+  _sprite: {fileID: 0}
+  _spriteBorderMode: 0
+  _spritePixelsPerUnitMultiplier: 1
+  _texture: {fileID: 0}
+  _textureUVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  _channelWeights: {r: 0, g: 0, b: 0, a: 1}
+  _raycastThreshold: 0
+  _invertMask: 0
+  _invertOutsides: 0
 --- !u!1 &4314237914999204937
 GameObject:
   m_ObjectHideFlags: 0
@@ -33,7 +158,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 504687111200171935}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -133,6 +259,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   controlsContainer: {fileID: 8137949506953210344}
   controlsLayoutGroup: {fileID: 1362902911226604175}
+  containerRim: {fileID: 2138740960330858265}
 --- !u!114 &2711059917953831877
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/UI/GenericContextMenuParameter/GenericContextMenu.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenuParameter/GenericContextMenu.cs
@@ -24,6 +24,7 @@ namespace DCL.UI.GenericContextMenuParameter
         public readonly float width;
         public readonly RectOffset verticalLayoutPadding;
         public readonly int elementsSpacing;
+        public readonly bool showRim;
         public ContextMenuOpenDirection anchorPoint;
         public Vector2 offsetFromTarget;
 
@@ -32,13 +33,15 @@ namespace DCL.UI.GenericContextMenuParameter
         ///     offsetFromTarget has the default value of (11, 18).
         ///     horizontalLayoutPadding has the default value of (8, 8, 4, 12).
         /// </summary>
-        public GenericContextMenu(float width = 186, Vector2? offsetFromTarget = null, RectOffset verticalLayoutPadding = null, int elementsSpacing = 1, ContextMenuOpenDirection anchorPoint = ContextMenuOpenDirection.BOTTOM_RIGHT)
+        public GenericContextMenu(float width = 186, Vector2? offsetFromTarget = null, RectOffset verticalLayoutPadding = null, int elementsSpacing = 1, ContextMenuOpenDirection anchorPoint = ContextMenuOpenDirection.BOTTOM_RIGHT,
+            bool showRim = false)
         {
             this.width = width;
             this.offsetFromTarget = offsetFromTarget ?? DEFAULT_OFFSET_FROM_TARGET;
             this.verticalLayoutPadding = verticalLayoutPadding ?? DEFAULT_VERTICAL_LAYOUT_PADDING;
             this.elementsSpacing = elementsSpacing;
             this.anchorPoint = anchorPoint;
+            this.showRim = showRim;
         }
 
         public GenericContextMenu AddControl(IContextMenuControlSettings settings)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR adds the support to show a border on the edge of the context menu container 

With the border:
<img width="385" height="423" alt="image" src="https://github.com/user-attachments/assets/f30c0447-df20-48ef-9b11-46eece5acaad" />

Without the border:
<img width="303" height="374" alt="image" src="https://github.com/user-attachments/assets/43b7fa41-9d61-474b-8ea3-d5167420e051" />


## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- launch the client in zone with the arg `--dclenv zone`

### Test Steps
1. Verify that context menus in general appear and work as before
2. Verify that the context menu on the member list of a community has the rim enabled and works as before


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
