### PR TITLE
Fixed: Nearby chat appears with an offline warning (#4824)

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -237,9 +237,11 @@ namespace DCL.Chat
                         SetupViewWithUserStateOnMainThreadAsync(ChatUserStateUpdater.ChatUserState.CONNECTED).Forget();
                         return;
                     }
-
-                    chatUsersUpdateCts = chatUsersUpdateCts.SafeRestart();
-                    UpdateChatUserStateAsync(chatUserStateUpdater.CurrentConversation, true, chatUsersUpdateCts.Token).Forget();
+                    else if (chatHistory.Channels[viewInstance.CurrentChannelId].ChannelType == ChatChannel.ChatChannelType.USER)
+                    {
+                        chatUsersUpdateCts = chatUsersUpdateCts.SafeRestart();
+                        UpdateChatUserStateAsync(chatUserStateUpdater.CurrentConversation, true, chatUsersUpdateCts.Token).Forget();
+                    }
 
                     viewInstance.ShowNewMessages();
                 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

It now checks that the current channel of the chat is a private conversation, before checking if a remote user is offline.

The bug: https://github.com/decentraland/unity-explorer/issues/4824

## Test Instructions

### Test Steps
1. Enter DCL.
2. Click on the input box of the chat.
3. The input box must not show the mask that says that the user is offline.
4. Change to a conversation with a user that is offline. The mask shold appear.
5. Go to nearby again. The mask should disappear.