### PR TITLE
fix: fetch only events directly tied to communities

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
@@ -321,7 +321,7 @@ namespace DCL.Communities.CommunitiesCard
 
                 viewInstance.ResetToggle(true);
 
-                eventListController?.ShowEvents(communityData, communityPlaceIds, ct);
+                eventListController?.ShowEvents(communityData, ct);
             }
         }
 

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
@@ -13,7 +13,6 @@ using DCL.UI;
 using DCL.Utilities.Extensions;
 using ECS.SceneLifeCycle.Realm;
 using MVC;
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using Utility;
@@ -49,7 +48,6 @@ namespace DCL.Communities.CommunitiesCard.Events
         private readonly string createEventFormat;
 
         private CommunityData? communityData = null;
-        private string[] communityPlaceIds = Array.Empty<string>();
         private CancellationTokenSource eventCardOperationsCts = new ();
 
         protected override SectionFetchData<PlaceAndEventDTO> currentSectionFetchData => eventsFetchData;
@@ -185,7 +183,7 @@ namespace DCL.Communities.CommunitiesCard.Events
 
         protected override async UniTask<int> FetchDataAsync(CancellationToken ct)
         {
-            Result<EventWithPlaceIdDTOListResponse> eventResponse = await eventsApiService.GetCommunityEventsByPlaceIdsAsync(communityData!.Value.id, communityPlaceIds, eventsFetchData.PageNumber, PAGE_SIZE, ct)
+            Result<EventWithPlaceIdDTOListResponse> eventResponse = await eventsApiService.GetCommunityEventsAsync(communityData!.Value.id, eventsFetchData.PageNumber, PAGE_SIZE, ct)
                                                                                                  .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
             if (ct.IsCancellationRequested)
@@ -238,11 +236,10 @@ namespace DCL.Communities.CommunitiesCard.Events
             return eventResponse.Value.data.total;
         }
 
-        public void ShowEvents(CommunityData community, string[] placeIds, CancellationToken token)
+        public void ShowEvents(CommunityData community, CancellationToken token)
         {
             cancellationToken = token;
             communityData = community;
-            communityPlaceIds = placeIds;
             view.SetCanModify(community.role is CommunityMemberRole.owner or CommunityMemberRole.moderator);
             FetchNewDataAsync(token).Forget();
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR switches the mode community events are fetched:
- before
   - endpoint with community id and place id array which returns both community events and events tied to community places
- after
   - endpoint with only community id which returns only events directly tied to the community

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- launch the client in zone with arg `--dclenv zone`

### Test Steps
1. Verify that only events directly tied to the community are shown in the community profile passport events section

### Additional Testing Notes
- You can compare the fetched events with a dev build and verify the place of the event by using the event info panel (opened when you click a community event)

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
