### PR TITLE
Fix: The input mask appears in Nearby when other user disconnects (#4917)

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -860,11 +860,10 @@ namespace DCL.Chat
         /// <param name="userId"></param>
         private void OnUserDisconnected(string userId)
         {
-            // Update the state of the user
-            // in the current conversation
-            // NOTE: if it's in the unfolded state (prevent setting the state of the
-            // NOTE: chat input box if user is offline)
-            if (!viewInstance!.IsUnfolded) return;
+            // Update the state of the user in the current conversation
+            // NOTE: if it's in the unfolded state (prevent setting the state of the chat input box if user is offline)
+            if (!viewInstance!.IsUnfolded || chatHistory.Channels[viewInstance.CurrentChannelId].ChannelType != ChatChannel.ChatChannelType.USER)
+                return;
 
             var state = chatUserStateUpdater.GetDisconnectedUserState(userId);
             SetupViewWithUserStateOnMainThreadAsync(state).Forget();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Now it checks if the current channel is a private conversation, otherwise the input mask is not evaluated.

It fixes this bug: https://github.com/decentraland/unity-explorer/issues/4917#issue-3280603671

## Test Instructions

### Test Steps
1. Open Nearby.
2. User X connects.
3. Open a private conversation with user X.
4. Go back to Nearby.
5. User X disconnects.
6. The input box mask does not appear in Nearby.
