### PR TITLE
Hotfix: Nearby chat appears with an offline warning

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -228,9 +228,11 @@ namespace DCL.Chat
                         SetupViewWithUserStateOnMainThreadAsync(ChatUserStateUpdater.ChatUserState.CONNECTED).Forget();
                         return;
                     }
-
-                    chatUsersUpdateCts = chatUsersUpdateCts.SafeRestart();
-                    UpdateChatUserStateAsync(chatUserStateUpdater.CurrentConversation, true, chatUsersUpdateCts.Token).Forget();
+                    else if (chatHistory.Channels[viewInstance.CurrentChannelId].ChannelType == ChatChannel.ChatChannelType.USER)
+                    {
+                        chatUsersUpdateCts = chatUsersUpdateCts.SafeRestart();
+                        UpdateChatUserStateAsync(chatUserStateUpdater.CurrentConversation, true, chatUsersUpdateCts.Token).Forget();
+                    }
 
                     viewInstance.ShowNewMessages();
                 }


### PR DESCRIPTION
It was trying to process an empty user while the current type of channel was not private.

# Pull Request Description

## What does this PR change?

It includes a commit cherry-picked from dev: https://github.com/decentraland/unity-explorer/pull/4907
The bug: https://github.com/decentraland/unity-explorer/issues/4824

## Test Instructions

### Test Steps
1. Enter DCL.
2. Click on the input box of the chat.
3. The input box must not show the mask that says that the user is offline.
4. Change to a conversation with a user that is offline. The mask should appear.
5. Go to nearby again. The mask should disappear.
