### PR TITLE
Fix: Remove `Name` from the Asset Bundle Intention Comparison

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/GetAssetBundleIntention.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/GetAssetBundleIntention.cs
@@ -72,6 +72,8 @@ namespace ECS.StreamableLoading.AssetBundles
         }
 
         public bool Equals(GetAssetBundleIntention other) =>
+
+            // It doesn't take into consideration the asset bundle version, so whatever is retrieved and cached first will be served for all versions
             StringComparer.OrdinalIgnoreCase.Equals(Hash, other.Hash);
 
         public CommonLoadingArguments CommonArguments { get; set; }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/PrepareAssetBundleLoadingParametersSystemBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/PrepareAssetBundleLoadingParametersSystemBase.cs
@@ -68,7 +68,6 @@ namespace ECS.StreamableLoading.AssetBundles
                 ca.Timeout = StreamableLoadingDefaults.TIMEOUT;
                 ca.CurrentSource = AssetSource.WEB;
                 ca.URL = assetBundleIntention.Manifest.GetAssetBundleURL(assetBundleIntention.Hash);
-                ca.CacheableURL = assetBundleIntention.Manifest.GetCacheableURL(assetBundleIntention.Hash);
                 assetBundleIntention.CommonArguments = ca;
                 assetBundleIntention.cacheHash = assetBundleIntention.Manifest.ComputeHash(assetBundleIntention.Hash);
             }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/Tests/PrepareAssetBundleLoadingParametersSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/Tests/PrepareAssetBundleLoadingParametersSystemShould.cs
@@ -132,21 +132,19 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
             system.Update(0);
             intent = world.Get<GetAssetBundleIntention>(entity1);
             string firstStandardURL = intent.CommonArguments.URL;
-            string firstCacheableHash = intent.CommonArguments.GetCacheableURL();
             world.Destroy(entity1);
 
             //Now, we simulate another scene, that has a different asset bundle version
             version = "v" + (SceneAssetBundleManifest.ASSET_BUNDLE_VERSION_REQUIRES_HASH + 1);
             sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, version, new[] { "abcd" }, "scene_hash_1", "04_10_2024"));
-            intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
-            Entity entity2 = world.Create(intent, new StreamableLoadingState());
+            var intent2 = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
+            Entity entity2 = world.Create(intent2, new StreamableLoadingState());
             system.Update(0);
-            intent = world.Get<GetAssetBundleIntention>(entity2);
-            string secondStandardURL = intent.CommonArguments.URL;
-            string secondCacheableHash = intent.CommonArguments.GetCacheableURL();
+            intent2 = world.Get<GetAssetBundleIntention>(entity2);
+            string secondStandardURL = intent2.CommonArguments.URL;
 
             Assert.AreNotEqual(firstStandardURL, secondStandardURL);
-            Assert.AreEqual(firstCacheableHash, secondCacheableHash);
+            Assert.AreEqual(intent, intent2);
         }
 
         [Test]
@@ -160,20 +158,18 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
             system.Update(0);
             intent = world.Get<GetAssetBundleIntention>(entity1);
             string firstStandardURL = intent.CommonArguments.URL;
-            string firstCacheableHash = intent.CommonArguments.GetCacheableURL();
             world.Destroy(entity1);
 
             //Now, we simulate another scene, that has a differente scene hash but same version
             sceneData.AssetBundleManifest.Returns(new SceneAssetBundleManifest(FAKE_AB_PATH, version, new[] { "abcd" }, "scene_hash_2", "04_10_2024"));
-            intent = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
-            Entity entity2 = world.Create(intent, new StreamableLoadingState());
+            var intent2 = GetAssetBundleIntention.FromHash(typeof(GameObject), "abcd", permittedSources: AssetSource.WEB);
+            Entity entity2 = world.Create(intent2, new StreamableLoadingState());
             system.Update(0);
-            intent = world.Get<GetAssetBundleIntention>(entity2);
-            string secondStandardURL = intent.CommonArguments.URL;
-            string secondCacheableHash = intent.CommonArguments.GetCacheableURL();
+            intent2 = world.Get<GetAssetBundleIntention>(entity2);
+            string secondStandardURL = intent2.CommonArguments.URL;
 
             Assert.AreNotEqual(firstStandardURL, secondStandardURL);
-            Assert.AreEqual(firstCacheableHash, secondCacheableHash);
+            Assert.AreEqual(intent, intent2);
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Common/Components/CommonLoadingArguments.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Common/Components/CommonLoadingArguments.cs
@@ -8,7 +8,6 @@ namespace ECS.StreamableLoading.Common.Components
     public struct CommonLoadingArguments
     {
         public URLAddress URL;
-        public URLAddress? CacheableURL;
         public int Attempts;
         public int Timeout;
 
@@ -43,7 +42,6 @@ namespace ECS.StreamableLoading.Common.Components
             Attempts = attempts;
             PermittedSources = permittedSources;
             CurrentSource = currentSource;
-            CacheableURL = null;
             CancellationTokenSource = cancellationTokenSource ?? new CancellationTokenSource();
         }
 
@@ -61,13 +59,5 @@ namespace ECS.StreamableLoading.Common.Components
         // Always override attempts count for streamable assets as repetitions are handled in LoadSystemBase
         public static implicit operator CommonArguments(in CommonLoadingArguments commonLoadingArguments) =>
             new (commonLoadingArguments.URL, RetryPolicy.WithRetries(1), timeout: commonLoadingArguments.Timeout);
-
-        public string GetCacheableURL()
-        {
-            //Needed to handle the different versioning and entityIDs of the ABs
-            if(CacheableURL.HasValue)
-                return CacheableURL.Value.Value;
-            return URL;
-        }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/SceneAssetBundleManifest.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/SceneAssetBundleManifest.cs
@@ -78,10 +78,5 @@ namespace SceneRunner.Scene
 
         public string GetSceneID() =>
             sceneID;
-
-        //Used for the OngoingRequests cache. We need to avoid version and sceneID in this URL to be able to reuse assets.
-        //The first loaded hash will be the one used for all the other requests
-        public URLAddress GetCacheableURL(string hash) =>
-            assetBundlesBaseUrl.Append(new URLPath(hash));
     }
 }


### PR DESCRIPTION
It was breaking the loading of the same/shared asset bundles as `Name` can be different but it doesn't participate in the URL resolution

How to QA:

1. Go to `65, 63`
2. There should be no exceptions like

<img width="2572" height="176" alt="image" src="https://github.com/user-attachments/assets/6ef5a0ef-118c-41af-ad2f-2158b537830b" />


