### PR TITLE
Chore: added new seasons endpoint implementation

### DIFF
--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
@@ -68,6 +68,7 @@ namespace DCL.MarketplaceCredits
         private CancellationTokenSource sidebarButtonStateCts;
 
         private bool haveJustClaimedCredits;
+        private SeasonsData? seasonsData;
 
         public MarketplaceCreditsMenuController(
             ViewFactoryMethod viewFactory,
@@ -323,11 +324,14 @@ namespace DCL.MarketplaceCredits
                 if (ownProfile == null)
                     return;
 
-                isFeatureActivated = MarketplaceCreditsUtils.IsUserAllowedToUseTheFeatureAsync(true, ownProfile.UserId, ct);
+                isFeatureActivated = MarketplaceCreditsUtils.IsUserAllowedToUseTheFeatureAsync(true, 
+                    ownProfile.UserId, ct);
                 if (!isFeatureActivated)
                     return;
-
-                var creditsProgramProgressResponse = await marketplaceCreditsAPIClient.GetProgramProgressAsync(ownProfile.UserId, ct);
+                
+                var creditsProgramProgressResponse = 
+                    await marketplaceCreditsAPIClient.GetProgramProgressAsync(ownProfile.UserId, ct);
+                
                 SetSidebarButtonState(creditsProgramProgressResponse);
 
                 if (!creditsProgramProgressResponse.HasUserStartedProgram())
@@ -360,7 +364,6 @@ namespace DCL.MarketplaceCredits
         private void SetSidebarButtonState(CreditsProgramProgressResponse creditsProgramProgressResponse)
         {
             if (creditsProgramProgressResponse.IsProgramEnded())
-
             {
                 SetSidebarButtonAnimationAsAlert(false);
                 SetSidebarButtonAsClaimIndicator(false);
@@ -368,8 +371,14 @@ namespace DCL.MarketplaceCredits
             }
 
             bool thereIsSomethingToClaim = creditsProgramProgressResponse.SomethingToClaim();
-            SetSidebarButtonAnimationAsAlert(!creditsProgramProgressResponse.HasUserStartedProgram() || !creditsProgramProgressResponse.IsUserEmailVerified() || (thereIsSomethingToClaim && !creditsProgramProgressResponse.credits.isBlockedForClaiming));
-            SetSidebarButtonAsClaimIndicator(creditsProgramProgressResponse.HasUserStartedProgram() && creditsProgramProgressResponse.IsUserEmailVerified() && thereIsSomethingToClaim && !creditsProgramProgressResponse.credits.isBlockedForClaiming);
+            SetSidebarButtonAnimationAsAlert(!creditsProgramProgressResponse.HasUserStartedProgram() 
+                                             || !creditsProgramProgressResponse.IsUserEmailVerified() 
+                                             || (thereIsSomethingToClaim 
+                                                 && !creditsProgramProgressResponse.credits.isBlockedForClaiming));
+            SetSidebarButtonAsClaimIndicator(creditsProgramProgressResponse.HasUserStartedProgram() 
+                                             && creditsProgramProgressResponse.IsUserEmailVerified() 
+                                             && thereIsSomethingToClaim 
+                                             && !creditsProgramProgressResponse.credits.isBlockedForClaiming);
         }
     }
 }

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsUtils.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsUtils.cs
@@ -10,11 +10,32 @@ namespace DCL.MarketplaceCredits
     {
         public enum SeasonState
         {
+            NO_DATA,
+            NOT_STARTED,
             RUNNING,
             ENDED,
             ERR_SEASON_RUN_OUT_OF_FUNDS,
             ERR_WEEK_RUN_OUT_OF_FUNDS,
             ERR_PROGRAM_PAUSED,
+        }
+
+        /// <summary>
+        /// Parses string date to DateTime format
+        /// </summary>
+        public static DateTime ParseDate(this string dateString)
+        {
+            return DateTime.Parse(dateString, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+        }
+
+        /// <summary>
+        /// Get span from now to given date
+        /// </summary>
+        /// <param name="dateString">DateTime as string</param>
+        /// <returns>TimeSpan from now to given date</returns>
+        public static TimeSpan ToSpanFromNow(this string dateString)
+        {
+            var spanFromNow = dateString.ParseDate() - DateTime.Now;
+            return spanFromNow;
         }
 
         /// <summary>
@@ -83,9 +104,7 @@ namespace DCL.MarketplaceCredits
         /// <returns>>A string representing the season date range in a human-readable format.</returns>
         public static string FormatSeasonDateRange(string startDate, string endDate)
         {
-            DateTime startDateDT = DateTime.Parse(startDate, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
-            DateTime endDateDT = DateTime.Parse(endDate, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
-            return $"{startDateDT.ToString("MMMM dd", CultureInfo.InvariantCulture)}-{endDateDT.ToString("MMMM dd", CultureInfo.InvariantCulture)}";
+            return $"{startDate.ParseDate().ToString("MMMM dd", CultureInfo.InvariantCulture)}-{endDate.ParseDate().ToString("MMMM dd", CultureInfo.InvariantCulture)}";
         }
 
         /// <summary>
@@ -121,12 +140,12 @@ namespace DCL.MarketplaceCredits
         /// Checks if the program has ended.
         /// </summary>
         /// <returns>True if the program has ended, false otherwise.</returns>
-        public static bool IsProgramEnded(this CreditsProgramProgressResponse creditsProgramProgressResponse) =>
-            creditsProgramProgressResponse.season.timeLeft <= 0f ||
-            creditsProgramProgressResponse.season.seasonState == nameof(SeasonState.ENDED) ||
-            creditsProgramProgressResponse.season.seasonState == nameof(SeasonState.ERR_SEASON_RUN_OUT_OF_FUNDS) ||
-            creditsProgramProgressResponse.season.seasonState == nameof(SeasonState.ERR_WEEK_RUN_OUT_OF_FUNDS) ||
-            creditsProgramProgressResponse.season.seasonState == nameof(SeasonState.ERR_PROGRAM_PAUSED);
+        public static bool IsProgramEnded(this CreditsProgramProgressResponse seasonsData) =>
+            seasonsData.currentSeason.timeLeft <= 0f ||
+            seasonsData.currentSeason.state == nameof(SeasonState.ERR_SEASON_RUN_OUT_OF_FUNDS) ||
+            seasonsData.currentSeason.state == nameof(SeasonState.ERR_WEEK_RUN_OUT_OF_FUNDS) ||
+            seasonsData.currentSeason.state == nameof(SeasonState.ENDED) ||
+            seasonsData.currentSeason.state == nameof(SeasonState.ERR_PROGRAM_PAUSED);
 
         /// <summary>
         /// Checks if the user has completed all the weekly goals.

--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsWelcomeSubController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsWelcomeSubController.cs
@@ -195,7 +195,7 @@ namespace DCL.MarketplaceCredits.Sections
                 marketplaceCreditsProgramEndedSubController.Setup(currentCreditsProgramProgress);
                 marketplaceCreditsMenuController.OpenSection(MarketplaceCreditsSection.PROGRAM_ENDED);
                 totalCreditsWidgetView.gameObject.SetActive(
-                    currentCreditsProgramProgress.season.seasonState != nameof(MarketplaceCreditsUtils.SeasonState.ERR_PROGRAM_PAUSED));
+                    currentCreditsProgramProgress.currentSeason.state != nameof(MarketplaceCreditsUtils.SeasonState.ERR_PROGRAM_PAUSED));
                 return;
             }
 

--- a/Explorer/Assets/DCL/MarketplaceCreditsAPIService/CreditsProgramProgressResponse.cs
+++ b/Explorer/Assets/DCL/MarketplaceCreditsAPIService/CreditsProgramProgressResponse.cs
@@ -6,8 +6,10 @@ namespace DCL.MarketplaceCreditsAPIService
     [Serializable]
     public struct CreditsProgramProgressResponse
     {
-        public SeasonData season;
-        public CurrentWeekData currentWeek;
+	    public SeasonData lastSeason;
+	    public SeasonData currentSeason;
+	    public Week currentWeek;
+	    public SeasonData nextSeason;
         public UserData user;
         public CreditsData credits;
         public List<GoalData> goals;
@@ -16,16 +18,24 @@ namespace DCL.MarketplaceCreditsAPIService
     [Serializable]
     public struct SeasonData
     {
-        public string startDate;
-        public string endDate;
-        public uint timeLeft;
-        public string seasonState;
+    	public int id;
+    	public string name;
+    	public string startDate;
+    	public string endDate;
+    	public string maxMana;
+	    public int timeLeft;
+    	public int amountOfWeeks;
+    	public string state;
     }
 
     [Serializable]
-    public struct CurrentWeekData
+    public struct Week
     {
-        public uint timeLeft;
+    	public int weekNumber;
+    	public uint timeLeft;
+    	public string startDate;
+    	public string endDate;
+    	public uint secondsRemaining;
     }
 
     [Serializable]
@@ -60,4 +70,24 @@ namespace DCL.MarketplaceCreditsAPIService
         public uint totalSteps;
         public uint completedSteps;
     }
+	
+	/// <summary>
+	/// Struct used to deserialize backend json data.
+	/// </summary>
+	public struct SeasonsData
+	{
+		public SeasonData lastSeason;
+		public CurrentSeasonInfo currentSeason;
+		public SeasonData nextSeason;
+	}
+
+	/// <summary>
+	/// Struct used to deserialize backend json data.
+	/// </summary>
+	[Serializable]
+	public struct CurrentSeasonInfo
+	{
+		public SeasonData season;
+		public Week week;
+	}
 }


### PR DESCRIPTION
# Pull Request Description
Fix [#4814](https://github.com/decentraland/unity-explorer/issues/4814)

## What does this PR change?
Added new `GET /seasons` endpoint implementation, which allowed us to separate Marketplace credits event data, from user's progress.

Figma: https://www.figma.com/design/1jwBNekCsdDXfXROzmL6Hz/%F0%9F%97%BA%EF%B8%8F-Weekly-Rewards-%7C-Explorer-2.0-%7C-02%2F25?node-id=0-1&p=f&t=K1zAWEQqjVnRMGWo-0

New panel, when current season ended, credits expired, and new season date is known:
<img width="771" height="451" alt="image" src="https://github.com/user-attachments/assets/a0d8cb7f-b5d5-48fb-b94e-bde3c2dd1eec" />


### Test Steps
1. Open build in a Zone environment.
2. Open Marketplace credits panel from.
3. Check if every panel displays correctly. Contact @aleortega to set corresponding backend data for each panel. 



### Additional Testing Notes
- Backend changes are introduced only in `zone` environment.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
