### PR TITLE
Fixed: When clicking on private chat toolbar icons their colors turn wrong

### DIFF
--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfilePictureView.cs
@@ -28,18 +28,21 @@ namespace DCL.UI.ProfileElements
         private Color originalThumbnailBackgroundColor;
         private Color originalThumbnailFrameColor;
 
-        private bool initialized;
+        private bool isColorInitialized;
         private float greyOutOpacity;
 
         private void Awake()
         {
-            if(thumbnailImageView != null)
-                originalThumbnailImageColor = thumbnailImageView.ImageColor;
+            if (!isColorInitialized)
+            {
+                if (thumbnailImageView != null)
+                    originalThumbnailImageColor = thumbnailImageView.ImageColor;
 
-            if(thumbnailFrame != null)
-                originalThumbnailFrameColor = thumbnailFrame.color;
+                if(thumbnailFrame != null)
+                    originalThumbnailFrameColor = thumbnailFrame.color;
 
-            initialized = true;
+                isColorInitialized = true;
+            }
 
             GreyOut(greyOutOpacity);
         }
@@ -65,7 +68,19 @@ namespace DCL.UI.ProfileElements
 
         public void SetupOnlyColor(Color userColor)
         {
+            if (!isColorInitialized)
+            {
+                if (thumbnailImageView != null)
+                    originalThumbnailImageColor = thumbnailImageView.ImageColor;
+
+                if(thumbnailFrame != null)
+                    originalThumbnailFrameColor = thumbnailFrame.color;
+
+                isColorInitialized = true;
+            }
+
             originalThumbnailBackgroundColor = userColor;
+
             GreyOut(greyOutOpacity);
         }
 
@@ -140,7 +155,7 @@ namespace DCL.UI.ProfileElements
 
         public void GreyOut(float opacity)
         {
-            if (!initialized)
+            if (!isColorInitialized)
             {
                 // The method was called before Awake, it stores the value to be applied on Awake later
                 greyOutOpacity = opacity;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Due to a race condition when the chat toolbar icons are initialized, the original color of its parts (image, background, etc.) used later when they are greyed out, were stored while the values were not correct.

## Test Instructions

Note: The bug happens randomly so you need to test it several times.

### Test Steps
1. Open the chat (there should be several private conversations open, some of them offline).
2. Click on the icons of the toolbar. When clicking on each, the color of the background and the thumbnail should not change, and should be the expected one.
