### PR TITLE
Fixed: When there is an online private conversation it stopped loading when entering DCL

### DIFF
--- a/Explorer/Assets/DCL/Chat/UserConnectivityInfoProvider.cs
+++ b/Explorer/Assets/DCL/Chat/UserConnectivityInfoProvider.cs
@@ -64,6 +64,8 @@ namespace DCL.Chat
             this.chatHistory = chatHistory;
             this.communitiesEventBus = communitiesEventBus;
             this.realmNavigator = realmNavigator;
+
+            participantsPerChannel.Add(privateConversationOnlineUserListId, new HashSet<string>());
         }
 
         public void Dispose()
@@ -262,9 +264,6 @@ namespace DCL.Chat
             if (connectionState == ConnectionState.ConnConnected)
             {
                 chatRoom.ConnectionStateChanged -= OnChatRoomConnectionStateChangedAsync;
-
-                if(!participantsPerChannel.ContainsKey(privateConversationOnlineUserListId))
-                   participantsPerChannel.Add(privateConversationOnlineUserListId, new HashSet<string>());
 
                 IReadOnlyCollection<string> roomParticipants = chatRoom.Participants.RemoteParticipantIdentities();
                 participantsPerChannel[privateConversationOnlineUserListId].Clear();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

When opening the chat, if there is one private conversation with a user that is online, the system stopped loading the rest of the stored private conversations.
The problem was that the special hashset of the participants per channel dictionary used to store the online private conversations was not ready when private conversations are loaded from disk.

## Test Instructions

Pre-condition: Your user should have several private conversations stored on disk.
You need 2 users.

### Test Steps
1. Enter DCL with user A (user B has an stored conversation with this user).
2. Enter DCL with user B (user B should have several private conversations).
3. You should be able to see all the expected conversations, offline, and one online in the middle of the list (with user A).

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
