### PR TITLE
fix: disable skeleton loading in system chat messages

### DIFF
--- a/Explorer/Assets/DCL/Chat/Assets/Chat.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/Chat.prefab
@@ -2897,6 +2897,34 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6422561004597701791, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6422561004597701791, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6422561004597701791, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6422561004597701791, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512833171316400601, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512833171316400601, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512833171316400601, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6593197441684345561, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2947,7 +2975,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8900561152139656757, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 8.76
+      value: 8.67
       objectReference: {fileID: 0}
     - target: {fileID: 8900561152139656757, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -2955,7 +2983,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8900561152139656757, guid: 59623bf8df2e8c147b5b255b7256f444, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -7
+      value: -6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Explorer/Assets/DCL/Chat/Assets/ChatEntry_System.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/ChatEntry_System.prefab
@@ -24,6 +24,18 @@ PrefabInstance:
       propertyPath: <verifiedIcon>k__BackingField
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 2520904133966978804, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+      propertyPath: m_Alpha
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2520904133966978804, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+      propertyPath: m_Interactable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2520904133966978804, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+      propertyPath: m_BlocksRaycasts
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2986110115110872576, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -100,9 +112,25 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5569678122417686519, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+      propertyPath: m_Alpha
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569678122417686519, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+      propertyPath: m_Interactable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569678122417686519, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+      propertyPath: m_BlocksRaycasts
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5730766251205960226, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6332478220486376778, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+      propertyPath: thumbnailFrame
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 6332478220486376778, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
       propertyPath: thumbnailBackground
@@ -111,6 +139,10 @@ PrefabInstance:
     - target: {fileID: 6979630135461700999, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7088210785754902257, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+      propertyPath: <skeletonLoadingView>k__BackingField
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 7253102694193305417, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
       propertyPath: m_Pivot.x
@@ -263,6 +295,13 @@ PrefabInstance:
     - {fileID: 5298955457008553957, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
     - {fileID: 7406274172203655002, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
     - {fileID: 5337272724111525965, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+    - {fileID: 679667521870969891, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+    - {fileID: 7950505578789126724, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+    - {fileID: 2568169814313379662, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+    - {fileID: 591695399663106317, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+    - {fileID: 6078326758100426593, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+    - {fileID: 669214756966493442, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
+    - {fileID: 3504873494045477904, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
     m_RemovedGameObjects:
     - {fileID: 660116915281079526, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}
     - {fileID: 4097828356427392652, guid: f1fd648453d9bf442949ea1b0d1844c7, type: 3}


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR disables the skeleton loading animation in the system chat message as there is no avatar thumbnail to fetch/render.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Verify that system chat messages are rendered as normal, even after teleporting multiple times


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
