### PR TITLE
fix: Avoid badge and avatar overlap on passport

### DIFF
--- a/Explorer/Assets/DCL/Passport/Modules/Badges/BadgesDetails_PassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/Badges/BadgesDetails_PassportModuleController.cs
@@ -136,7 +136,7 @@ namespace DCL.Passport.Modules.Badges
                 badgeDetailsCardsController.CreateEmptyDetailCards();
                 ShowBadgesInGridByCategory(ALL_FILTER);
                 view.LoadingSpinner.SetActive(false);
-                badgeInfoController.SetAsEmpty(badges.achieved.Count == 0 && badges.notAchieved.Count == 0);
+
                 view.NoBadgesLabel.SetActive(badges.achieved.Count == 0 && badges.notAchieved.Count == 0);
             }
             catch (OperationCanceledException) { }

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -319,9 +319,14 @@ namespace DCL.Passport
             passportProfileInfoController.OnProfilePublished += OnProfilePublished;
             badgesDetailsPassportModuleController.OnBadgeSelected += OnBadgeSelected;
 
-            viewInstance.OverviewSectionButton.Button.onClick.AddListener(OpenOverviewSection);
-            viewInstance.BadgesSectionButton.Button.onClick.AddListener(() => OpenBadgesSection());
-            viewInstance.PhotosSectionButton.Button.onClick.AddListener(OpenPhotosSection);
+            foreach (PassportView.SectionData section in viewInstance.Sections)
+            {
+                PassportSection selectedSection = section.PassportSection;
+                section.Button.Button.onClick.AddListener(() => OpenSection(selectedSection));
+            }
+            // viewInstance.OverviewSectionButton.Button.onClick.AddListener(OpenOverviewSection);
+            // viewInstance.BadgesSectionButton.Button.onClick.AddListener(() => OpenBadgesSection());
+            // viewInstance.PhotosSectionButton.Button.onClick.AddListener(OpenPhotosSection);
             viewInstance.AcceptFriendButton.onClick.AddListener(AcceptFriendship);
             viewInstance.AddFriendButton.onClick.AddListener(SendFriendRequest);
             viewInstance.CancelFriendButton.onClick.AddListener(CancelFriendRequest);

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -336,9 +336,6 @@ namespace DCL.Passport
                     section.ButtonWithState.Button.gameObject.SetActive(enableCameraReel);
             }
 
-            // viewInstance.OverviewSectionButton.Button.onClick.AddListener(OpenOverviewSection);
-            // viewInstance.BadgesSectionButton.Button.onClick.AddListener(() => OpenBadgesSection());
-            // viewInstance.PhotosSectionButton.Button.onClick.AddListener(OpenPhotosSection);
             viewInstance.AcceptFriendButton.onClick.AddListener(AcceptFriendship);
             viewInstance.AddFriendButton.onClick.AddListener(SendFriendRequest);
             viewInstance.CancelFriendButton.onClick.AddListener(CancelFriendRequest);
@@ -353,7 +350,6 @@ namespace DCL.Passport
             if (isCallEnabled)
                 viewInstance.CallButton.onClick.AddListener(OnStartCallButtonClicked);
 
-            // viewInstance.PhotosSectionButton.gameObject.SetActive(enableCameraReel);
             viewInstance.FriendInteractionContainer.SetActive(enableFriendshipInteractions);
             viewInstance.MutualFriends.Root.SetActive(enableFriendshipInteractions);
 

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -560,11 +560,10 @@ namespace DCL.Passport
 
             photoLoadingCts = photoLoadingCts.SafeRestart();
 
-            viewInstance!.OpenPhotosSection();
-
             cameraReelGalleryController!.ShowWalletGalleryAsync(currentUserId!, photoLoadingCts.Token).Forget();
 
             currentSection = PassportSection.PHOTOS;
+            viewInstance!.OpenSection(currentSection);
 
             if (!viewInstance.CharacterPreviewView.gameObject.activeSelf)
             {
@@ -578,12 +577,12 @@ namespace DCL.Passport
             if (currentSection == PassportSection.OVERVIEW)
                 return;
 
-            viewInstance!.OpenOverviewSection();
-
             characterPreviewLoadingCts = characterPreviewLoadingCts.SafeRestart();
             LoadPassportSectionAsync(currentUserId!, PassportSection.OVERVIEW, characterPreviewLoadingCts.Token).Forget();
+
             currentSection = PassportSection.OVERVIEW;
-            viewInstance.BadgeInfoModuleView.gameObject.SetActive(false);
+            viewInstance!.OpenSection(currentSection);
+
             characterPreviewController?.OnShow();
         }
 
@@ -592,12 +591,12 @@ namespace DCL.Passport
             if (currentSection == PassportSection.BADGES)
                 return;
 
-            viewInstance!.OpenBadgesSection();
-
             characterPreviewLoadingCts = characterPreviewLoadingCts.SafeRestart();
             LoadPassportSectionAsync(currentUserId!, PassportSection.BADGES, characterPreviewLoadingCts.Token, badgeIdSelected).Forget();
+
             currentSection = PassportSection.BADGES;
-            viewInstance.BadgeInfoModuleView.gameObject.SetActive(true);
+            viewInstance!.OpenSection(currentSection);
+
             characterPreviewController?.OnHide(false);
             bool isOwnPassport = ownProfile?.UserId == currentUserId;
             BadgesSectionOpened?.Invoke(currentUserId!, isOwnPassport, OpenBadgeSectionOrigin.BUTTON.ToString());

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -254,11 +254,13 @@ namespace DCL.Passport
 
             passportErrorsController = new PassportErrorsController(viewInstance!.ErrorNotification);
             characterPreviewController = new PassportCharacterPreviewController(viewInstance.CharacterPreviewView, characterPreviewFactory, world, characterPreviewEventBus);
+
             characterPreviewController = new PassportCharacterPreviewController(
                 viewInstance.CharacterPreviewView,
                 characterPreviewFactory,
                 world,
                 characterPreviewEventBus);
+
             var userBasicInfoPassportModuleController = new UserBasicInfo_PassportModuleController(
                 viewInstance.UserBasicInfoModuleView,
                 selfProfile,
@@ -267,8 +269,10 @@ namespace DCL.Passport
                 nftNamesProvider,
                 decentralandUrlsSource,
                 isNameEditorEnabled);
+
             userBasicInfoPassportModuleController.NameClaimRequested += OnNameClaimRequested;
             commonPassportModules.Add(userBasicInfoPassportModuleController);
+
             overviewPassportModules.Add(new UserDetailedInfo_PassportModuleController(
                 viewInstance.UserDetailedInfoModuleView,
                 mvcManager,
@@ -276,6 +280,7 @@ namespace DCL.Passport
                 viewInstance.AddLinkModal,
                 passportErrorsController,
                 passportProfileInfoController));
+
             overviewPassportModules.Add(new EquippedItems_PassportModuleController(
                 viewInstance.EquippedItemsModuleView,
                 world,
@@ -286,6 +291,7 @@ namespace DCL.Passport
                 webBrowser,
                 decentralandUrlsSource,
                 passportErrorsController));
+
             overviewPassportModules.Add(new BadgesOverview_PassportModuleController(
                 viewInstance.BadgesOverviewModuleView,
                 badgesAPIClient,
@@ -300,6 +306,7 @@ namespace DCL.Passport
                 webRequestController,
                 selfProfile,
                 badge3DPreviewCamera);
+
             cameraReelGalleryController = new CameraReelGalleryController(
                 viewInstance.CameraReelGalleryModuleView,
                 cameraReelStorageService,
@@ -312,6 +319,7 @@ namespace DCL.Passport
                     false),
                 false,
                 galleryEventBus);
+
             cameraReelGalleryController.ThumbnailClicked += ThumbnailClicked;
             badgesPassportModules.Add(badgesDetailsPassportModuleController);
 
@@ -321,9 +329,13 @@ namespace DCL.Passport
 
             foreach (PassportView.SectionData section in viewInstance.Sections)
             {
-                PassportSection selectedSection = section.PassportSection;
-                section.Button.Button.onClick.AddListener(() => OpenSection(selectedSection));
+                PassportSection passportSection = section.PassportSection;
+                section.ButtonWithState.Button.onClick.AddListener(() => OpenSection(passportSection));
+
+                if (passportSection == PassportSection.PHOTOS)
+                    section.ButtonWithState.Button.gameObject.SetActive(enableCameraReel);
             }
+
             // viewInstance.OverviewSectionButton.Button.onClick.AddListener(OpenOverviewSection);
             // viewInstance.BadgesSectionButton.Button.onClick.AddListener(() => OpenBadgesSection());
             // viewInstance.PhotosSectionButton.Button.onClick.AddListener(OpenPhotosSection);
@@ -337,10 +349,11 @@ namespace DCL.Passport
             viewInstance.ChatButton.onClick.AddListener(OnChatButtonClicked);
 
             viewInstance.CallButton.gameObject.SetActive(isCallEnabled);
+
             if (isCallEnabled)
                 viewInstance.CallButton.onClick.AddListener(OnStartCallButtonClicked);
 
-            viewInstance.PhotosSectionButton.gameObject.SetActive(enableCameraReel);
+            // viewInstance.PhotosSectionButton.gameObject.SetActive(enableCameraReel);
             viewInstance.FriendInteractionContainer.SetActive(enableFriendshipInteractions);
             viewInstance.MutualFriends.Root.SetActive(enableFriendshipInteractions);
 
@@ -369,10 +382,7 @@ namespace DCL.Passport
                 chatEventBus.StartCallInCurrentConversation();
             }
             catch (OperationCanceledException) { }
-            catch (Exception ex)
-            {
-                ReportHub.LogError(new ReportData(ReportCategory.VOICE_CHAT), $"Error starting call from passport {ex.Message}");
-            }
+            catch (Exception ex) { ReportHub.LogError(new ReportData(ReportCategory.VOICE_CHAT), $"Error starting call from passport {ex.Message}"); }
         }
 
         private void OnChatButtonClicked()
@@ -437,6 +447,7 @@ namespace DCL.Passport
                 ShowFriendshipInteraction();
                 ShowMutualFriends();
             }
+
             PassportOpened?.Invoke(currentUserId, isOwnProfile);
             badge3DPreviewCamera.gameObject.SetActive(true);
         }
@@ -486,7 +497,6 @@ namespace DCL.Passport
             jumpToFriendLocationCts.SafeCancelAndDispose();
             passportProfileInfoController.OnProfilePublished -= OnProfilePublished;
             passportProfileInfoController.PublishError -= OnPublishError;
-
 
             foreach (IPassportModuleController module in commonPassportModules)
                 module.Dispose();
@@ -558,6 +568,22 @@ namespace DCL.Passport
         private void OnProfilePublished(Profile profile) =>
             SetupPassportModules(profile, PassportSection.OVERVIEW);
 
+        private void OpenSection(PassportSection selectedSection)
+        {
+            switch (selectedSection)
+            {
+                case PassportSection.OVERVIEW:
+                    OpenOverviewSection();
+                    break;
+                case PassportSection.BADGES:
+                    OpenBadgesSection();
+                    break;
+                case PassportSection.PHOTOS:
+                    OpenPhotosSection();
+                    break;
+            }
+        }
+
         private void OpenPhotosSection()
         {
             if (currentSection == PassportSection.PHOTOS)
@@ -624,7 +650,7 @@ namespace DCL.Passport
         private void OnReferralUserAcceptedNotificationClicked(object[] parameters)
         {
             if (parameters.Length <= 0) return;
-            ReferralNotification notification = (ReferralNotification) parameters[0];
+            ReferralNotification notification = (ReferralNotification)parameters[0];
             openPassportFromNotificationCts = openPassportFromNotificationCts.SafeRestart();
             OpenPassportAsync(openPassportFromNotificationCts.Token).Forget();
             return;

--- a/Explorer/Assets/DCL/Passport/PassportView.cs
+++ b/Explorer/Assets/DCL/Passport/PassportView.cs
@@ -63,28 +63,8 @@ namespace DCL.Passport
         [field: SerializeField]
         public WarningNotificationView ErrorNotification { get; private set; }
 
-        // TODO insert here new list
-
         [field: SerializeField]
         public List<SectionData> Sections;
-
-        // [field: SerializeField]
-        // public ButtonWithSelectableStateView OverviewSectionButton { get; private set; }
-        //
-        // [field: SerializeField]
-        // public ButtonWithSelectableStateView BadgesSectionButton { get; private set; }
-        //
-        // [field: SerializeField]
-        // public ButtonWithSelectableStateView PhotosSectionButton { get; private set; }
-        //
-        // [field: SerializeField]
-        // public GameObject OverviewSectionPanel { get; private set; }
-        //
-        // [field: SerializeField]
-        // public GameObject BadgesSectionPanel { get; private set; }
-        //
-        // [field: SerializeField]
-        // public GameObject PhotosSectionPanel { get; private set; }
 
         [field: SerializeField]
         public SoftMask ViewportSoftMask { get; private set; }
@@ -178,30 +158,10 @@ namespace DCL.Passport
                     MainScroll.content = section.Panel.transform as RectTransform;
             }
 
-            // OverviewSectionButton.SetSelected(passportSection == PassportSection.OVERVIEW);
-            // BadgesSectionButton.SetSelected(passportSection == PassportSection.BADGES);
-            // PhotosSectionButton.SetSelected(passportSection == PassportSection.PHOTOS);
-
-            // OverviewSectionPanel.SetActive(passportSection == PassportSection.OVERVIEW);
-            // BadgesSectionPanel.SetActive(passportSection == PassportSection.BADGES);
-            // PhotosSectionPanel.SetActive(passportSection == PassportSection.PHOTOS);
-
             BadgeInfoModuleView.gameObject.SetActive(passportSection == PassportSection.BADGES);
 
             ViewportSoftMask.enabled = passportSection != PassportSection.PHOTOS;
 
-            // switch (passportSection)
-            // {
-            //     case PassportSection.OVERVIEW:
-            //         MainScroll.content = OverviewSectionPanel.transform as RectTransform;
-            //         break;
-            //     case PassportSection.BADGES:
-            //         MainScroll.content = BadgesSectionPanel.transform as RectTransform;
-            //         break;
-            //     case PassportSection.PHOTOS:
-            //         MainScroll.content = PhotosSectionPanel.transform as RectTransform;
-            //         break;
-            // }
             MainScroll.verticalNormalizedPosition = 1;
 
             CharacterPreviewView.gameObject.SetActive(passportSection != PassportSection.BADGES);

--- a/Explorer/Assets/DCL/Passport/PassportView.cs
+++ b/Explorer/Assets/DCL/Passport/PassportView.cs
@@ -8,6 +8,7 @@ using DCL.UI.ProfileElements;
 using MVC;
 using SoftMasking;
 using System;
+using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -61,23 +62,28 @@ namespace DCL.Passport
         [field: SerializeField]
         public WarningNotificationView ErrorNotification { get; private set; }
 
-        [field: SerializeField]
-        public ButtonWithSelectableStateView OverviewSectionButton { get; private set; }
+        // TODO insert here new list
 
         [field: SerializeField]
-        public ButtonWithSelectableStateView BadgesSectionButton { get; private set; }
+        public List<SectionData> Sections;
 
-        [field: SerializeField]
-        public ButtonWithSelectableStateView PhotosSectionButton { get; private set; }
-
-        [field: SerializeField]
-        public GameObject OverviewSectionPanel { get; private set; }
-
-        [field: SerializeField]
-        public GameObject BadgesSectionPanel { get; private set; }
-
-        [field: SerializeField]
-        public GameObject PhotosSectionPanel { get; private set; }
+        // [field: SerializeField]
+        // public ButtonWithSelectableStateView OverviewSectionButton { get; private set; }
+        //
+        // [field: SerializeField]
+        // public ButtonWithSelectableStateView BadgesSectionButton { get; private set; }
+        //
+        // [field: SerializeField]
+        // public ButtonWithSelectableStateView PhotosSectionButton { get; private set; }
+        //
+        // [field: SerializeField]
+        // public GameObject OverviewSectionPanel { get; private set; }
+        //
+        // [field: SerializeField]
+        // public GameObject BadgesSectionPanel { get; private set; }
+        //
+        // [field: SerializeField]
+        // public GameObject PhotosSectionPanel { get; private set; }
 
         [field: SerializeField]
         public SoftMask ViewportSoftMask { get; private set; }
@@ -143,6 +149,14 @@ namespace DCL.Passport
             }
         }
 
+        [Serializable]
+        public class SectionData
+        {
+            public PassportSection PassportSection;
+            public ButtonWithSelectableStateView Button;
+            public GameObject Panel;
+        }
+
 #if UNITY_EDITOR
         private void Awake()
         {
@@ -153,30 +167,40 @@ namespace DCL.Passport
 
         public void OpenSection(PassportSection passportSection)
         {
-            OverviewSectionButton.SetSelected(passportSection == PassportSection.OVERVIEW);
-            BadgesSectionButton.SetSelected(passportSection == PassportSection.BADGES);
-            PhotosSectionButton.SetSelected(passportSection == PassportSection.PHOTOS);
+            foreach (var section in Sections)
+            {
+                bool isActive = passportSection == section.PassportSection;
+                section.Button.SetSelected(isActive);
+                section.Panel.SetActive(isActive);
 
-            OverviewSectionPanel.SetActive(passportSection == PassportSection.OVERVIEW);
-            BadgesSectionPanel.SetActive(passportSection == PassportSection.BADGES);
-            PhotosSectionPanel.SetActive(passportSection == PassportSection.PHOTOS);
+                if (isActive)
+                    MainScroll.content = section.Panel.transform as RectTransform;
+            }
+
+            // OverviewSectionButton.SetSelected(passportSection == PassportSection.OVERVIEW);
+            // BadgesSectionButton.SetSelected(passportSection == PassportSection.BADGES);
+            // PhotosSectionButton.SetSelected(passportSection == PassportSection.PHOTOS);
+
+            // OverviewSectionPanel.SetActive(passportSection == PassportSection.OVERVIEW);
+            // BadgesSectionPanel.SetActive(passportSection == PassportSection.BADGES);
+            // PhotosSectionPanel.SetActive(passportSection == PassportSection.PHOTOS);
 
             BadgeInfoModuleView.gameObject.SetActive(passportSection == PassportSection.BADGES);
 
             ViewportSoftMask.enabled = passportSection != PassportSection.PHOTOS;
 
-            switch (passportSection)
-            {
-                case PassportSection.OVERVIEW:
-                    MainScroll.content = OverviewSectionPanel.transform as RectTransform;
-                    break;
-                case PassportSection.BADGES:
-                    MainScroll.content = BadgesSectionPanel.transform as RectTransform;
-                    break;
-                case PassportSection.PHOTOS:
-                    MainScroll.content = PhotosSectionPanel.transform as RectTransform;
-                    break;
-            }
+            // switch (passportSection)
+            // {
+            //     case PassportSection.OVERVIEW:
+            //         MainScroll.content = OverviewSectionPanel.transform as RectTransform;
+            //         break;
+            //     case PassportSection.BADGES:
+            //         MainScroll.content = BadgesSectionPanel.transform as RectTransform;
+            //         break;
+            //     case PassportSection.PHOTOS:
+            //         MainScroll.content = PhotosSectionPanel.transform as RectTransform;
+            //         break;
+            // }
             MainScroll.verticalNormalizedPosition = 1;
 
             CharacterPreviewView.gameObject.SetActive(passportSection != PassportSection.BADGES);

--- a/Explorer/Assets/DCL/Passport/PassportView.cs
+++ b/Explorer/Assets/DCL/Passport/PassportView.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 namespace DCL.Passport
@@ -153,7 +154,7 @@ namespace DCL.Passport
         public class SectionData
         {
             public PassportSection PassportSection;
-            public ButtonWithSelectableStateView Button;
+            public ButtonWithSelectableStateView ButtonWithState;
             public GameObject Panel;
         }
 
@@ -170,7 +171,7 @@ namespace DCL.Passport
             foreach (var section in Sections)
             {
                 bool isActive = passportSection == section.PassportSection;
-                section.Button.SetSelected(isActive);
+                section.ButtonWithState.SetSelected(isActive);
                 section.Panel.SetActive(isActive);
 
                 if (isActive)

--- a/Explorer/Assets/DCL/Passport/PassportView.cs
+++ b/Explorer/Assets/DCL/Passport/PassportView.cs
@@ -151,47 +151,35 @@ namespace DCL.Passport
         }
 #endif
 
-        public void OpenPhotosSection()
+        public void OpenSection(PassportSection passportSection)
         {
-            OverviewSectionButton.SetSelected(false);
-            BadgesSectionButton.SetSelected(false);
-            PhotosSectionButton.SetSelected(true);
+            OverviewSectionButton.SetSelected(passportSection == PassportSection.OVERVIEW);
+            BadgesSectionButton.SetSelected(passportSection == PassportSection.BADGES);
+            PhotosSectionButton.SetSelected(passportSection == PassportSection.PHOTOS);
 
-            OverviewSectionPanel.SetActive(false);
-            PhotosSectionPanel.SetActive(true);
-            BadgesSectionPanel.SetActive(false);
-            BadgeInfoModuleView.gameObject.SetActive(false);
-            ViewportSoftMask.enabled = false;
-            MainScroll.content = PhotosSectionPanel.transform as RectTransform;
-            MainScroll.verticalNormalizedPosition = 1;
-        }
+            OverviewSectionPanel.SetActive(passportSection == PassportSection.OVERVIEW);
+            BadgesSectionPanel.SetActive(passportSection == PassportSection.BADGES);
+            PhotosSectionPanel.SetActive(passportSection == PassportSection.PHOTOS);
 
-        public void OpenBadgesSection()
-        {
-            OverviewSectionButton.SetSelected(false);
-            BadgesSectionButton.SetSelected(true);
-            PhotosSectionButton.SetSelected(false);
-            OverviewSectionPanel.SetActive(false);
-            BadgesSectionPanel.SetActive(true);
-            PhotosSectionPanel.SetActive(false);
-            ViewportSoftMask.enabled = true;
-            MainScroll.content = BadgesSectionPanel.transform as RectTransform;
-            MainScroll.verticalNormalizedPosition = 1;
-            CharacterPreviewView.gameObject.SetActive(false);
-        }
+            BadgeInfoModuleView.gameObject.SetActive(passportSection == PassportSection.BADGES);
 
-        public void OpenOverviewSection()
-        {
-            OverviewSectionButton.SetSelected(true);
-            BadgesSectionButton.SetSelected(false);
-            PhotosSectionButton.SetSelected(false);
-            OverviewSectionPanel.SetActive(true);
-            BadgesSectionPanel.SetActive(false);
-            PhotosSectionPanel.SetActive(false);
-            ViewportSoftMask.enabled = true;
-            MainScroll.content = OverviewSectionPanel.transform as RectTransform;
+            ViewportSoftMask.enabled = passportSection != PassportSection.PHOTOS;
+
+            switch (passportSection)
+            {
+                case PassportSection.OVERVIEW:
+                    MainScroll.content = OverviewSectionPanel.transform as RectTransform;
+                    break;
+                case PassportSection.BADGES:
+                    MainScroll.content = BadgesSectionPanel.transform as RectTransform;
+                    break;
+                case PassportSection.PHOTOS:
+                    MainScroll.content = PhotosSectionPanel.transform as RectTransform;
+                    break;
+            }
             MainScroll.verticalNormalizedPosition = 1;
-            CharacterPreviewView.gameObject.SetActive(true);
+
+            CharacterPreviewView.gameObject.SetActive(passportSection != PassportSection.BADGES);
         }
     }
 }

--- a/Explorer/Assets/DCL/Passport/Prefabs/Passport.prefab
+++ b/Explorer/Assets/DCL/Passport/Prefabs/Passport.prefab
@@ -4370,6 +4370,9 @@ MonoBehaviour:
   <Button>k__BackingField: {fileID: 3818101583891139926}
   <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: 9c57af4963cf9cf4194435271beb8b73, type: 2}
   <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
+  <images>k__BackingField: []
+  interactableColor: {r: 1, g: 1, b: 1, a: 1}
+  hoverColor: {r: 0.54, g: 0.54, b: 0.54, a: 1}
 --- !u!1 &7146219950259528395
 GameObject:
   m_ObjectHideFlags: 0
@@ -4514,12 +4517,16 @@ MonoBehaviour:
   <MainContainer>k__BackingField: {fileID: 2324426899192856976}
   <AddLinkModal>k__BackingField: {fileID: 9054811651154528581}
   <ErrorNotification>k__BackingField: {fileID: 3800359461374942149}
-  <OverviewSectionButton>k__BackingField: {fileID: 7865167134026999089}
-  <BadgesSectionButton>k__BackingField: {fileID: 4917579215862328500}
-  <PhotosSectionButton>k__BackingField: {fileID: 5178114501700794038}
-  <OverviewSectionPanel>k__BackingField: {fileID: 1151176965044491678}
-  <BadgesSectionPanel>k__BackingField: {fileID: 4271026606323506798}
-  <PhotosSectionPanel>k__BackingField: {fileID: 3391748916552129337}
+  Sections:
+  - PassportSection: 1
+    ButtonWithState: {fileID: 7865167134026999089}
+    Panel: {fileID: 1151176965044491678}
+  - PassportSection: 2
+    ButtonWithState: {fileID: 4917579215862328500}
+    Panel: {fileID: 4271026606323506798}
+  - PassportSection: 4
+    ButtonWithState: {fileID: 5178114501700794038}
+    Panel: {fileID: 3391748916552129337}
   <ViewportSoftMask>k__BackingField: {fileID: 8361280252339374889}
   <FriendInteractionContainer>k__BackingField: {fileID: 3312541760748288554}
   <AddFriendButton>k__BackingField: {fileID: 2991507475140542023}
@@ -6249,6 +6256,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1447895524821148947, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447895524821148947, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447895524821148947, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7319283368522151503, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
       propertyPath: m_Name
       value: ProfilePictureView
@@ -6266,36 +6285,7 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 4561718667523275783, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1217546410904618140}
-    - targetCorrespondingSourceObject: {fileID: 2651887179082774473, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8083411619533070129}
-    - targetCorrespondingSourceObject: {fileID: 3783720378857169263, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8579704505432269008}
-    - targetCorrespondingSourceObject: {fileID: 30788109269342216, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6653497825775293609}
-    - targetCorrespondingSourceObject: {fileID: 908363428936288718, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3286003120865559150}
   m_SourcePrefab: {fileID: 100100000, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
---- !u!1 &55061495882131491 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 30788109269342216, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 49257832265363499}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6653497825775293609
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 55061495882131491}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!224 &266671097160325396 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 224503025678412095, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
@@ -6310,57 +6300,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 946db314bdcc52a41a226ff3aa3acbbd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &879846818712730085 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 908363428936288718, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 49257832265363499}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &3286003120865559150
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 879846818712730085}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &2622109737993439202 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2651887179082774473, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 49257832265363499}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8083411619533070129
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2622109737993439202}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &3759527260905083204 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3783720378857169263, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 49257832265363499}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8579704505432269008
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3759527260905083204}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &4602825369033837612 stripped
@@ -12021,7 +11960,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 533235076076506494, guid: b705caef58a2b9941b467418b0b7abad, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 100
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 533235076076506494, guid: b705caef58a2b9941b467418b0b7abad, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -12037,7 +11976,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 942316798144216209, guid: b705caef58a2b9941b467418b0b7abad, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 342.58002
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 986899414889775072, guid: b705caef58a2b9941b467418b0b7abad, type: 3}
       propertyPath: m_SizeDelta.x
@@ -12389,7 +12328,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5534099374014550473, guid: b705caef58a2b9941b467418b0b7abad, type: 3}
       propertyPath: m_fontSize
-      value: 13.45
+      value: 13.65
       objectReference: {fileID: 0}
     - target: {fileID: 5748734980224432887, guid: b705caef58a2b9941b467418b0b7abad, type: 3}
       propertyPath: m_SizeDelta.x
@@ -13240,6 +13179,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1447895524821148947, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447895524821148947, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447895524821148947, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7319283368522151503, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
       propertyPath: m_Name
       value: ProfilePictureView
@@ -13257,18 +13208,6 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 4561718667523275783, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
       insertIndex: -1
       addedObject: {fileID: 3420798094509323425}
-    - targetCorrespondingSourceObject: {fileID: 2651887179082774473, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8868471413573756973}
-    - targetCorrespondingSourceObject: {fileID: 3783720378857169263, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1564542540857138061}
-    - targetCorrespondingSourceObject: {fileID: 30788109269342216, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3254401094175307077}
-    - targetCorrespondingSourceObject: {fileID: 908363428936288718, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 5881168754976340191}
   m_SourcePrefab: {fileID: 100100000, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
 --- !u!1 &946876458560234301 stripped
 GameObject:
@@ -13304,23 +13243,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &5511789359539577531 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2651887179082774473, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 7543716767575987570}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8868471413573756973
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5511789359539577531}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &6340734689782294901 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4561718667523275783, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
@@ -13338,23 +13260,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &6643605280946287645 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3783720378857169263, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 7543716767575987570}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1564542540857138061
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6643605280946287645}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &6972429121075474872 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 609007630589666506, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
@@ -13364,40 +13269,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 946db314bdcc52a41a226ff3aa3acbbd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &7218018783912418492 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 908363428936288718, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 7543716767575987570}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &5881168754976340191
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7218018783912418492}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &7556419989063355770 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 30788109269342216, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 7543716767575987570}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &3254401094175307077
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7556419989063355770}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!224 &7758912852241005645 stripped
@@ -14152,6 +14023,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1447895524821148947, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447895524821148947, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447895524821148947, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7319283368522151503, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
       propertyPath: m_Name
       value: ProfilePictureView
@@ -14169,18 +14052,6 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 4561718667523275783, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
       insertIndex: -1
       addedObject: {fileID: 3908312379650250966}
-    - targetCorrespondingSourceObject: {fileID: 2651887179082774473, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1811759700764325252}
-    - targetCorrespondingSourceObject: {fileID: 3783720378857169263, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1793565159005010912}
-    - targetCorrespondingSourceObject: {fileID: 30788109269342216, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6076689984859251331}
-    - targetCorrespondingSourceObject: {fileID: 908363428936288718, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 5573607102682300881}
   m_SourcePrefab: {fileID: 100100000, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
 --- !u!1 &1995474588577467689 stripped
 GameObject:
@@ -14233,57 +14104,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &5377422484073437705 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3783720378857169263, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 9088836760939887462}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1793565159005010912
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5377422484073437705}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &6552576619099278511 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2651887179082774473, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 9088836760939887462}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1811759700764325252
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6552576619099278511}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &8266690649405878952 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 908363428936288718, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 9088836760939887462}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &5573607102682300881
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8266690649405878952}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &8525782312680021932 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 609007630589666506, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
@@ -14300,20 +14120,3 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 224503025678412095, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
   m_PrefabInstance: {fileID: 9088836760939887462}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &9101609363186606958 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 30788109269342216, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 9088836760939887462}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6076689984859251331
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9101609363186606958}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #3082 
Removed asynchronous code that was handling badge preview GameObject visibility causing the overlap of badges on top of avatar.
Cleaned up code in PassportView.cs that was handling passport sections visibility to prevent configuration problems.

## Test Instructions
Open passport and quickly switch between Badges tab and other tabs.
You should not see any overlapping betweeen the badge preview and avatar preview.

### Test Steps
1. Open any passport
2. Switch to badges section and immediately switch to either overview or photos section
3. Verify that the badge preview and avatar preview do not appear together.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
