### PR TITLE
fix: duplicated avatar preview

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenCharacterPreviewController.cs
@@ -28,14 +28,14 @@ namespace DCL.AuthenticationScreenFlow
             this.settings = settings;
         }
 
-        public override void Initialize(Avatar avatar)
+        public override void Initialize(Avatar avatar, Vector3 position)
         {
             playEmotesCts = playEmotesCts.SafeRestart();
 
             previewAvatarModel.Wearables = ShortenWearables(avatar);
             previewAvatarModel.Emotes = ShortenEmotes(avatar);
 
-            base.Initialize(avatar);
+            base.Initialize(avatar, position);
             previewController!.Value.AddHeadIK();
             PlayEmote(settings.IntroEmoteURN);
         }

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -331,7 +331,7 @@ namespace DCL.AuthenticationScreenFlow
             profile.HasConnectedWeb3 = true;
 
             profileNameLabel!.Value = IsNewUser() ? profile.Name : "back " + profile.Name;
-            characterPreviewController?.Initialize(profile.Avatar);
+            characterPreviewController?.Initialize(profile.Avatar, CharacterPreviewUtils.AVATAR_POSITION_2);
 
             return;
 

--- a/Explorer/Assets/DCL/Backpack/BackpackController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackController.cs
@@ -7,6 +7,7 @@ using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Backpack.BackpackBus;
 using DCL.Backpack.CharacterPreview;
 using DCL.Backpack.EmotesSection;
+using DCL.CharacterPreview;
 using DCL.Input;
 using DCL.Profiles;
 using DCL.UI;
@@ -168,7 +169,7 @@ namespace DCL.Backpack
 
             avatarController.RequestInitialWearablesPage();
             backpackEmoteGridController.RequestAndFillEmotes(1, true);
-            backpackCharacterPreviewController.Initialize(avatar);
+            backpackCharacterPreviewController.Initialize(avatar, CharacterPreviewUtils.AVATAR_POSITION_1);
 
             if (!avatarShapeComponent.WearablePromise.IsConsumed)
                 await avatarShapeComponent.WearablePromise.ToUniTaskAsync(world, cancellationToken: ct);

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewAvatarContainer.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewAvatarContainer.cs
@@ -27,9 +27,9 @@ namespace DCL.CharacterPreview
             StopCameraTween();
         }
 
-        public void Initialize(RenderTexture targetTexture)
+        public void Initialize(RenderTexture targetTexture, Vector3 position)
         {
-            transform.position = new Vector3(0, 5000, 0);
+            transform.position = position;
             camera.targetTexture = targetTexture;
             rotationTarget.rotation = Quaternion.identity;
 

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
@@ -15,27 +15,28 @@ namespace DCL.CharacterPreview
 {
     public abstract class CharacterPreviewControllerBase : IDisposable
     {
-        private static readonly float AVATAR_FADE_ANIMATION = 0.5f;
+        private const float AVATAR_FADE_ANIMATION = 0.5f;
+
         protected readonly CharacterPreviewInputEventBus inputEventBus;
 
         private readonly CharacterPreviewView view;
         private readonly ICharacterPreviewFactory previewFactory;
         private readonly CharacterPreviewCursorController cursorController;
         private readonly CharacterPreviewEventBus characterPreviewEventBus;
-
         private readonly World world;
         private readonly bool isPreviewPlatformActive;
+        private readonly Func<bool> isPlayingEmoteDelegate;
 
         private bool initialized;
-        private CancellationTokenSource updateModelCancellationToken;
+        private CancellationTokenSource? updateModelCancellationToken;
         private Color profileColor;
+        private Vector3 avatarPosition;
 
         protected CharacterPreviewController? previewController;
         protected CharacterPreviewAvatarModel previewAvatarModel;
         protected bool zoomEnabled = true;
         protected bool panEnabled = true;
         protected bool rotateEnabled = true;
-        private readonly Func<bool> isPlayingEmoteDelegate;
 
         protected CharacterPreviewControllerBase(
             CharacterPreviewView view,
@@ -67,7 +68,7 @@ namespace DCL.CharacterPreview
             isPlayingEmoteDelegate = () => previewController!.Value.IsPlayingEmote();
         }
 
-        public virtual void Initialize(Avatar avatar)
+        public virtual void Initialize(Avatar avatar, Vector3 position)
         {
             previewAvatarModel.BodyShape = avatar.BodyShape;
             previewAvatarModel.HairColor = avatar.HairColor;
@@ -75,6 +76,8 @@ namespace DCL.CharacterPreview
             previewAvatarModel.EyesColor = avatar.EyesColor;
             previewAvatarModel.ForceRenderCategories = new HashSet<string>(avatar.ForceRender);
             previewAvatarModel.Initialized = true;
+
+            avatarPosition = position;
 
             Initialize();
         }
@@ -97,7 +100,8 @@ namespace DCL.CharacterPreview
 
             view.RawImage.texture = newTexture;
 
-            previewController = previewFactory.Create(world, view.RawImage.rectTransform, newTexture, inputEventBus, view.CharacterPreviewSettingsSo.cameraSettings);
+            previewController = previewFactory.Create(world, view.RawImage.rectTransform, newTexture,
+                inputEventBus, view.CharacterPreviewSettingsSo.cameraSettings, avatarPosition);
             initialized = true;
 
             OnModelUpdated();
@@ -177,7 +181,8 @@ namespace DCL.CharacterPreview
                 inputEventBus.OnChangePreviewFocus(AvatarWearableCategoryEnum.Body);
                 OnModelUpdated();
             }
-            else if (previewAvatarModel.Initialized) { Initialize(); }
+            else if (previewAvatarModel.Initialized)
+                Initialize();
 
             previewController?.SetPreviewPlatformActive(isPreviewPlatformActive);
 

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewUtils.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewUtils.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace DCL.CharacterPreview
+{
+    public class CharacterPreviewUtils
+    {
+        public static readonly Vector3 AVATAR_POSITION_1 = new (0, 5000, 0);
+        public static readonly Vector3 AVATAR_POSITION_2 = new (0, 6000, 0);
+        public static readonly Vector3 AVATAR_POSITION_3 = new (0, 7000, 0);
+    }
+}

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewUtils.cs.meta
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewUtils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a1fd59ab2dfe4374b7d0cfc03569a900
+timeCreated: 1754489807

--- a/Explorer/Assets/DCL/Character/CharacterPreview/ICharacterPreviewFactory.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/ICharacterPreviewFactory.cs
@@ -11,7 +11,12 @@ namespace DCL.CharacterPreview
     /// </summary>
     public interface ICharacterPreviewFactory
     {
-        CharacterPreviewController Create(World world, RectTransform renderImage, RenderTexture targetTexture, CharacterPreviewInputEventBus inputEventBus, CharacterPreviewCameraSettings cameraSettings);
+        CharacterPreviewController Create(World world,
+            RectTransform renderImage,
+            RenderTexture targetTexture,
+            CharacterPreviewInputEventBus inputEventBus,
+            CharacterPreviewCameraSettings cameraSettings,
+            Vector3 position);
     }
 
     public class CharacterPreviewFactory : ICharacterPreviewFactory
@@ -28,12 +33,17 @@ namespace DCL.CharacterPreview
             this.appArgs = appArgs;
         }
 
-        public CharacterPreviewController Create(World world, RectTransform renderImage, RenderTexture targetTexture, CharacterPreviewInputEventBus inputEventBus, CharacterPreviewCameraSettings cameraSettings)
+        public CharacterPreviewController Create(World world,
+            RectTransform renderImage,
+            RenderTexture targetTexture,
+            CharacterPreviewInputEventBus inputEventBus,
+            CharacterPreviewCameraSettings cameraSettings,
+            Vector3 position)
         {
             characterPreviewComponentPool ??= componentPoolsRegistry.GetReferenceTypePool<CharacterPreviewAvatarContainer>();
             transformPool ??= componentPoolsRegistry.GetReferenceTypePool<Transform>();
             CharacterPreviewAvatarContainer container = characterPreviewComponentPool.Get();
-            container.Initialize(targetTexture);
+            container.Initialize(targetTexture, position);
             return new CharacterPreviewController(world, renderImage, container, inputEventBus, characterPreviewComponentPool, cameraSettings, transformPool, appArgs);
         }
     }

--- a/Explorer/Assets/DCL/Passport/PassportCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportCharacterPreviewController.cs
@@ -1,8 +1,9 @@
 using Arch.Core;
 using CommunicationData.URLHelpers;
 using DCL.CharacterPreview;
-using DCL.Profiles;
 using System.Collections.Generic;
+using UnityEngine;
+using Avatar = DCL.Profiles.Avatar;
 
 namespace DCL.Passport
 {
@@ -13,7 +14,7 @@ namespace DCL.Passport
         public PassportCharacterPreviewController(CharacterPreviewView view, ICharacterPreviewFactory previewFactory, World world, CharacterPreviewEventBus characterPreviewEventBus)
             : base(view, previewFactory, world, false, characterPreviewEventBus) { }
 
-        public override void Initialize(Avatar avatar)
+        public override void Initialize(Avatar avatar, Vector3 position)
         {
             shortenedWearables.Clear();
 
@@ -22,7 +23,7 @@ namespace DCL.Passport
 
             previewAvatarModel.Wearables = shortenedWearables;
 
-            base.Initialize(avatar);
+            base.Initialize(avatar, position);
             PlayEmote("wave");
         }
     }

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -511,7 +511,7 @@ namespace DCL.Passport
                 if (sectionToLoad == PassportSection.OVERVIEW)
                 {
                     // Load avatar preview
-                    characterPreviewController!.Initialize(profile.Avatar);
+                    characterPreviewController!.Initialize(profile.Avatar, CharacterPreviewUtils.AVATAR_POSITION_3);
                     characterPreviewController.OnShow();
                 }
 


### PR DESCRIPTION
## What does this PR change?

Fixes #4858 

The problem was that we make an instance of a new character preview for each UI that wants to display it, so they were stacking in the same place, being duplicated in the rendering.
The solution consists on setting a different position offset depending on the ui that wants to render it.

## Test Instructions

You can check 3 different sources of avatar preview. Check that it displays correctly and you dont see it duplicated:
- Open the backpack and then your own profile from the system menu
- Other profiles in-world
- Your own avatar on the authentication screen

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
