### PR TITLE
Minimap: Black screen on first open

### DIFF
--- a/Explorer/Assets/DCL/ExplorePanel/ExplorePanelController.cs
+++ b/Explorer/Assets/DCL/ExplorePanel/ExplorePanelController.cs
@@ -124,11 +124,11 @@ namespace DCL.ExplorePanel
                 { ExploreSections.Communities, CommunitiesBrowserController },
             };
 
-            sectionSelectorController = new SectionSelectorController<ExploreSections>(exploreSections, ExploreSections.Navmap);
-
             includeCommunities = await CommunitiesFeatureAccess.Instance.IsUserAllowedToUseTheFeatureAsync(ct);
 
             lastShownSection = includeCommunities ? ExploreSections.Communities : ExploreSections.Navmap;
+
+            sectionSelectorController = new SectionSelectorController<ExploreSections>(exploreSections, lastShownSection);
 
             foreach (KeyValuePair<ExploreSections, ISection> keyValuePair in exploreSections)
                 keyValuePair.Value.Deactivate();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

It fixes this bug: https://github.com/decentraland/unity-explorer/issues/4733

The problem was that the default tab in the SectionSelectorController was not being set depending on the FF of Communities, however the last shown section variable was. Due to this inconsistency, the Activate method of the NavmapController was not being called when the minimap section was shown the first time the Explore panel is open (the "shownSection == lastShownSection" condition fails, the Activate method is not called there).

## Test Instructions

### Test Steps
1. With an account that has the Communities Feature flag enabled, entre DCL.
2. Click on the minimap.
3. The minimap shows properly and the tab of the Minimap is activated (the tab of Communities is not).