### PR TITLE
fix: desync emotes with props on preview

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenCharacterPreviewController.cs
@@ -36,7 +36,7 @@ namespace DCL.AuthenticationScreenFlow
             previewAvatarModel.Emotes = ShortenEmotes(avatar);
 
             base.Initialize(avatar, position);
-            previewController!.Value.AddHeadIK();
+            previewController!.Value.EnableHeadIK();
             PlayEmote(settings.IntroEmoteURN);
         }
 

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Components/HeadIKComponent.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Components/HeadIKComponent.cs
@@ -2,6 +2,6 @@
 {
     public struct HeadIKComponent
     {
-        public bool IsDisabled;
+        public bool IsEnabled;
     }
 }

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/HeadIKSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/HeadIKSystem.cs
@@ -83,10 +83,10 @@ namespace DCL.CharacterMotion.Systems
         private void UpdatePreviewAvatarIK([Data] float dt, in CharacterPreviewComponent previewComponent, ref HeadIKComponent headIK,
             ref AvatarBase avatarBase, in CharacterEmoteComponent emoteComponent)
         {
-            headIK.IsDisabled = emoteComponent.CurrentEmoteReference != null || !this.headIKIsEnabled;
-            avatarBase.HeadIKRig.weight = Mathf.MoveTowards(avatarBase.HeadIKRig.weight, headIK.IsDisabled ? 0 : 1, settings.HeadIKWeightChangeSpeed * dt);
+            bool isEnabled = emoteComponent.CurrentEmoteReference == null && headIKIsEnabled && headIK.IsEnabled;
+            avatarBase.HeadIKRig.weight = Mathf.MoveTowards(avatarBase.HeadIKRig.weight, isEnabled ? 1 : 0, settings.HeadIKWeightChangeSpeed * dt);
 
-            if (headIK.IsDisabled) return;
+            if (!isEnabled) return;
 
             (Vector3 bottomLeft, Vector3 topRight) = GetImageScreenCorners(previewComponent.RenderImageRect);
             Vector3 viewportPos = previewComponent.Camera.WorldToViewportPoint(avatarBase.HeadPositionConstraint.position);
@@ -161,12 +161,10 @@ namespace DCL.CharacterMotion.Systems
             in CharacterPlatformComponent platformComponent
         )
         {
-            headIK.IsDisabled = !this.headIKIsEnabled;
-
             bool isEnabled = !stunComponent.IsStunned
                              && rigidTransform.IsGrounded
                              && !rigidTransform.IsOnASteepSlope
-                             && !headIK.IsDisabled
+                             && headIKIsEnabled && headIK.IsEnabled
                              && !(rigidTransform.MoveVelocity.Velocity.sqrMagnitude > 0.5f)
                              && !emoteComponent.IsPlayingEmote
                              && !platformComponent.IsMovingPlatform;
@@ -174,7 +172,7 @@ namespace DCL.CharacterMotion.Systems
             avatarBase.HeadIKRig.weight = Mathf.MoveTowards(avatarBase.HeadIKRig.weight, isEnabled ? 1 : 0, settings.HeadIKWeightChangeSpeed * dt);
 
             // TODO: When enabling and disabling we should reset the reference position
-            if (headIK.IsDisabled || inWorldCameraActive) return;
+            if (!isEnabled || inWorldCameraActive) return;
 
             // TODO: Tie this to a proper look-at system to decide what to look at
             Vector3 targetDirection = cameraComponent.Camera.transform.forward;

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/HeadIKSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/HeadIKSystem.cs
@@ -161,10 +161,12 @@ namespace DCL.CharacterMotion.Systems
             in CharacterPlatformComponent platformComponent
         )
         {
+            bool isFeatureAndComponentEnabled = headIKIsEnabled && headIK.IsEnabled;
+
             bool isEnabled = !stunComponent.IsStunned
                              && rigidTransform.IsGrounded
                              && !rigidTransform.IsOnASteepSlope
-                             && headIKIsEnabled && headIK.IsEnabled
+                             && isFeatureAndComponentEnabled
                              && !(rigidTransform.MoveVelocity.Velocity.sqrMagnitude > 0.5f)
                              && !emoteComponent.IsPlayingEmote
                              && !platformComponent.IsMovingPlatform;

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
@@ -61,7 +61,7 @@ namespace DCL.CharacterPreview
                 new HeadIKComponent { IsEnabled = false });
         }
 
-        public void AddHeadIK()
+        public void EnableHeadIK()
         {
             ref HeadIKComponent headIK = ref globalWorld.TryGetRef<HeadIKComponent>(characterPreviewEntity, out bool exists);
 

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewController.cs
@@ -57,11 +57,17 @@ namespace DCL.CharacterPreview
                 new CharacterTransform(parent),
                 new AvatarShapeComponent(CHARACTER_PREVIEW_NAME, CHARACTER_PREVIEW_NAME) { IsPreview = true },
                 new CharacterPreviewComponent { Camera = avatarContainer.camera, RenderImageRect = renderImage, Settings = avatarContainer.headIKSettings },
-                new CharacterEmoteComponent());
+                new CharacterEmoteComponent(),
+                new HeadIKComponent { IsEnabled = false });
         }
 
-        public void AddHeadIK() =>
-            globalWorld.Add(characterPreviewEntity, new HeadIKComponent());
+        public void AddHeadIK()
+        {
+            ref HeadIKComponent headIK = ref globalWorld.TryGetRef<HeadIKComponent>(characterPreviewEntity, out bool exists);
+
+            if (exists)
+                headIK.IsEnabled = true;
+        }
 
         public void Dispose()
         {
@@ -102,11 +108,12 @@ namespace DCL.CharacterPreview
                 PartitionComponent.TOP_PRIORITY
             );
 
-            Entity emotePromiseEntity = builderEmotesPreview ? Entity.Null
+            Entity emotePromiseEntity = builderEmotesPreview
+                ? Entity.Null
                 : globalWorld.Create(EmotePromise.Create(globalWorld,
-                EmoteComponentsUtils.CreateGetEmotesByPointersIntention(avatarShape.BodyShape,
-                    avatarModel.Emotes ?? (IReadOnlyCollection<URN>)Array.Empty<URN>()),
-                PartitionComponent.TOP_PRIORITY));
+                    EmoteComponentsUtils.CreateGetEmotesByPointersIntention(avatarShape.BodyShape,
+                        avatarModel.Emotes ?? (IReadOnlyCollection<URN>)Array.Empty<URN>()),
+                    PartitionComponent.TOP_PRIORITY));
 
             avatarShape.IsDirty = true;
 
@@ -123,11 +130,12 @@ namespace DCL.CharacterPreview
 
             ct.ThrowIfCancellationRequested();
 
-            if (world.TryGet(avatarEntity, out AvatarBase avatarBase) && avatarBase != null  && !avatarBase.RigBuilder.enabled)
+            if (world.TryGet(avatarEntity, out AvatarBase avatarBase) && avatarBase != null && !avatarBase.RigBuilder.enabled)
             {
                 avatarBase.RigBuilder.enabled = true;
                 avatarBase.HeadIKRig.weight = 1f;
             }
+
             return;
 
             bool IsEmoteLoaded() =>

--- a/Explorer/Assets/DCL/PluginSystem/Global/CharacterMotionPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/CharacterMotionPlugin.cs
@@ -69,7 +69,7 @@ namespace DCL.PluginSystem.Global
                 new StunComponent(),
                 new FeetIKComponent(),
                 new HandsIKComponent(),
-                new HeadIKComponent());
+                new HeadIKComponent { IsEnabled = true });
 
             InterpolateCharacterSystem.InjectToWorld(ref builder);
             TeleportPositionCalculationSystem.InjectToWorld(ref builder);


### PR DESCRIPTION
## What does this PR change?

Fixes #4831 

The problem was the head IK. In the backpack, the avatar preview didnt have any head ik component and it was never initialized nor updated. By default has `weight:1`. This provoked a small offset in the avatar, which was noticeable on emotes with props.

The solution consists on adding the head IK component but only on backpack with `isEnabled:false`. This forces the ik to be updated with `weight:0`.

## Test Instructions

Check that the head IK works as expected:
- on authentication screen, check that the avatar's head follows the pointer.
- lock the mouse in-world and check that the avatar's head follows the target.
- open the backpack and check that the avatar's head does not follow the pointer. Also check that the emotes with props works correctly.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
