### PR TITLE
fix: additional validation to avoid community places nullref

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlacesSectionController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlacesSectionController.cs
@@ -303,41 +303,23 @@ namespace DCL.Communities.CommunitiesCard.Places
 
         protected override async UniTask<int> FetchDataAsync(CancellationToken ct)
         {
+            if(communityPlaceIds.Length <= 0)
+                return 0;
+
             int offset = (placesFetchData.PageNumber - 1) * PAGE_SIZE;
             int total = communityPlaceIds.Length;
 
-            Result<PlacesData.PlacesAPIResponse> response;
+            // Ensure offset doesn't exceed the array bounds
+            if (offset >= total)
+                return 0;
 
-            if (offset < 0 || offset >= total)
-            {
-                response = Result<PlacesData.PlacesAPIResponse>.SuccessResult(new PlacesData.PlacesAPIResponse
-                {
-                    ok = true,
-                    data = new List<PlaceInfo>(),
-                    total = 0
-                });
-            }
-            else
-            {
-                int remaining = total - offset;
-                int count = Math.Min(PAGE_SIZE, remaining);
+            int remaining = total - offset;
+            int count = Math.Max(0, Math.Min(PAGE_SIZE, remaining));
 
-                if (count <= 0)
-                {
-                    response = Result<PlacesData.PlacesAPIResponse>.SuccessResult(new PlacesData.PlacesAPIResponse
-                    {
-                        ok = true,
-                        data = new List<PlaceInfo>(),
-                        total = 0
-                    });
-                }
-                else
-                {
-                    ArraySegment<string> slice = new ArraySegment<string>(communityPlaceIds, offset, count);
-                    response = await placesAPIService.GetPlacesByIdsAsync(slice, ct)
-                                                      .SuppressToResultAsync(ReportCategory.COMMUNITIES);
-                }
-            }
+            ArraySegment<string> slice = new ArraySegment<string>(communityPlaceIds, offset, count);
+
+            Result<PlacesData.PlacesAPIResponse> response = await placesAPIService.GetPlacesByIdsAsync(slice, ct)
+                                                                                  .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
             if (ct.IsCancellationRequested)
                 return 0;

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlacesSectionController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Places/PlacesSectionController.cs
@@ -309,7 +309,6 @@ namespace DCL.Communities.CommunitiesCard.Places
             int offset = (placesFetchData.PageNumber - 1) * PAGE_SIZE;
             int total = communityPlaceIds.Length;
 
-            // Ensure offset doesn't exceed the array bounds
             if (offset >= total)
                 return 0;
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix https://decentraland.sentry.io/issues/6798279571/events/a6f8ddfbd1494338bbd1e57e4ee7f4b3/?project=4506075736047616
Avoids array segment creation with a negative count when something wrong happened

## Test Instructions
Smoke test of communities and their assigned places.
Verify that community panel is working fine and that the places assigned to a community are correctly shown

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
