### PR TITLE
fix: lock concurrent prefs writing

### DIFF
--- a/Explorer/Assets/DCL/Prefs/FileDCLPlayerPrefs.cs
+++ b/Explorer/Assets/DCL/Prefs/FileDCLPlayerPrefs.cs
@@ -53,32 +53,44 @@ namespace DCL.Prefs
         {
             if (userData.Strings.TryGetValue(key, out string existing) && existing == value) return;
 
-            userData.Strings[key] = value;
-            dataChanged = true;
+            lock (userData)
+            {
+                userData.Strings[key] = value;
+                dataChanged = true;
+            }
         }
 
         public void SetInt(string key, int value)
         {
             if (userData.Ints.TryGetValue(key, out int existing) && existing == value) return;
 
-            userData.Ints[key] = value;
-            dataChanged = true;
+            lock (userData)
+            {
+                userData.Ints[key] = value;
+                dataChanged = true;
+            }
         }
 
         public void SetFloat(string key, float value)
         {
             if (userData.Floats.TryGetValue(key, out float existing) && Mathf.Approximately(existing, value)) return;
 
-            userData.Floats[key] = value;
-            dataChanged = true;
+            lock (userData)
+            {
+                userData.Floats[key] = value;
+                dataChanged = true;
+            }
         }
 
         public void SetBool(string key, bool value)
         {
             if (userData.Bools.TryGetValue(key, out bool existing) && existing == value) return;
 
-            userData.Bools[key] = value;
-            dataChanged = true;
+            lock (userData)
+            {
+                userData.Bools[key] = value;
+                dataChanged = true;
+            }
         }
 
         public string GetString(string key, string defaultValue)
@@ -105,15 +117,6 @@ namespace DCL.Prefs
             return userData.Bools.GetValueOrDefault(key, defaultValue);
         }
 
-        private void MigrateBool(string key)
-        {
-            if (unityPrefs == null || !unityPrefs.HasKey(key)) return;
-
-            userData.Bools.TryAdd(key, unityPrefs!.GetBool(key, false));
-            unityPrefs.DeleteKey(key);
-            unityPrefs.Save();
-        }
-
         public bool HasKey(string key) =>
             (unityPrefs != null && unityPrefs.HasKey(key)) || userData.Strings.ContainsKey(key) || userData.Ints.ContainsKey(key) || userData.Floats.ContainsKey(key);
 
@@ -121,20 +124,26 @@ namespace DCL.Prefs
         {
             if (!HasKey(key)) return;
 
-            userData.Strings.Remove(key);
-            userData.Ints.Remove(key);
-            userData.Floats.Remove(key);
-            PlayerPrefs.DeleteKey(key);
-            dataChanged = true;
+            lock (userData)
+            {
+                userData.Strings.Remove(key);
+                userData.Ints.Remove(key);
+                userData.Floats.Remove(key);
+                PlayerPrefs.DeleteKey(key);
+                dataChanged = true;
+            }
         }
 
         public void DeleteAll()
         {
-            userData.Strings.Clear();
-            userData.Ints.Clear();
-            userData.Floats.Clear();
-            PlayerPrefs.DeleteAll();
-            dataChanged = true;
+            lock (userData)
+            {
+                userData.Strings.Clear();
+                userData.Ints.Clear();
+                userData.Floats.Clear();
+                PlayerPrefs.DeleteAll();
+                dataChanged = true;
+            }
         }
 
         public void Save()
@@ -147,6 +156,7 @@ namespace DCL.Prefs
             Task.Run(() =>
             {
                 lock (fileStream)
+                lock (userData)
                 {
                     fileStream.Seek(0, SeekOrigin.Begin);
                     fileStream.SetLength(0);
@@ -163,7 +173,12 @@ namespace DCL.Prefs
         {
             if (unityPrefs == null || !unityPrefs.HasKey(key)) return;
 
-            userData.Strings.TryAdd(key, unityPrefs!.GetString(key, null));
+            lock (userData)
+            {
+                userData.Strings.TryAdd(key, unityPrefs!.GetString(key, null));
+                dataChanged = true;
+            }
+
             unityPrefs.DeleteKey(key);
             unityPrefs.Save();
         }
@@ -172,7 +187,12 @@ namespace DCL.Prefs
         {
             if (unityPrefs == null || !unityPrefs.HasKey(key)) return;
 
-            userData.Ints.TryAdd(key, unityPrefs!.GetInt(key, 0));
+            lock (userData)
+            {
+                userData.Ints.TryAdd(key, unityPrefs!.GetInt(key, 0));
+                dataChanged = true;
+            }
+
             unityPrefs.DeleteKey(key);
             unityPrefs.Save();
         }
@@ -181,7 +201,26 @@ namespace DCL.Prefs
         {
             if (unityPrefs == null || !unityPrefs.HasKey(key)) return;
 
-            userData.Floats.TryAdd(key, unityPrefs!.GetFloat(key, 0f));
+            lock (userData)
+            {
+                userData.Floats.TryAdd(key, unityPrefs!.GetFloat(key, 0f));
+                dataChanged = true;
+            }
+
+            unityPrefs.DeleteKey(key);
+            unityPrefs.Save();
+        }
+
+        private void MigrateBool(string key)
+        {
+            if (unityPrefs == null || !unityPrefs.HasKey(key)) return;
+
+            lock (userData)
+            {
+                userData.Bools.TryAdd(key, unityPrefs!.GetBool(key, false));
+                dataChanged = true;
+            }
+
             unityPrefs.DeleteKey(key);
             unityPrefs.Save();
         }


### PR DESCRIPTION
# Pull Request Description

This fixes #4841, caused by saving the prefs at the same time that something was written to them, without locking.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

All writes to userData are now locked, including the read while Saving, so we avoid changing the prefs while they are being serialized.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

Verify that the game does not block / lag when the user changes their preferences / settings, and that everything is persisted as expected.

### Test Steps
1. Login with a new account and verify it persists after relaunching explorer
2. Change settings (e.g. audio levels) and ensure they correctly persist.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
