### PR TITLE
fix: invalid userId on getFriendshipStatus

### DIFF
--- a/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
+++ b/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace DCL.Friends
 {
@@ -352,6 +353,9 @@ namespace DCL.Friends
 
         public async UniTask<FriendshipStatus> GetFriendshipStatusAsync(string userId, CancellationToken ct)
         {
+            if (string.IsNullOrEmpty(userId))
+                throw new ArgumentException("GetFriendshipStatus called with empty userId", nameof(userId));
+
             await socialServiceRPC.EnsureRpcConnectionAsync(ct);
 
             var payload = new GetFriendshipStatusPayload


### PR DESCRIPTION
## What does this PR change?

Fixes #4906 

An assert has been implemented so we ensure to send a valid userId to the friends service when requesting the friendship status. Additionally the exception handling has been improved on these calls.

I could not detect which specific flow is passing an invalid id. We should be able to see it in the analytics now.

## Test Instructions

Check flows whenever we need to request the friendship status. Everything should work normally:
- check player passports
- chat interactions: context menu, private messages
- friend interactions: send/receive/accept/cancel requests. Interaction on friends notifications

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
