### PR TITLE
Fixed: Communities | Chat is not open automatically when joining a new community

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -397,6 +397,10 @@ namespace DCL.Chat
 
         private async UniTask AddCommunityConversationAsync(string communityId, bool setAsCurrentChannel = false)
         {
+            // Note: The conversation has to be added to the connectivity info provider in advance because if it is successful, the "user connected" message
+            //       will arrive to the provider while the conversation is not registered yet, causing an error
+            userConnectivityInfoProvider.AddConversation(ChatChannel.NewCommunityChannelId(communityId), ChatChannel.ChatChannelType.COMMUNITY);
+
             communitiesServiceCts = communitiesServiceCts.SafeRestart();
             Result<GetCommunityResponse> result = await communitiesDataProvider.GetCommunityAsync(communityId, communitiesServiceCts.Token).SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
@@ -429,6 +433,8 @@ namespace DCL.Chat
             }
             else
             {
+                // Note: In case the conversation could not be created, it has to be removed from the connectivity info provider. Read the note above
+                userConnectivityInfoProvider.RemoveConversation(ChatChannel.NewCommunityChannelId(communityId), ChatChannel.ChatChannelType.COMMUNITY);
                 ReportHub.LogError(ReportCategory.COMMUNITIES, GET_COMMUNITY_FAILED_MESSAGE + result.ErrorMessage ?? string.Empty);
                 ShowErrorNotificationAsync(GET_COMMUNITY_FAILED_MESSAGE, errorNotificationCts.Token).Forget();
             }
@@ -509,6 +515,14 @@ namespace DCL.Chat
             };
 
             chatHistory.AddOrGetChannel(channelId, ChatChannel.ChatChannelType.COMMUNITY);
+        }
+
+        private void OnCommunitiesDataProviderCommunityJoined(string joinedCommunityId, bool joinResult)
+        {
+            if(!joinResult)
+                return;
+
+            AddCommunityConversationAsync(joinedCommunityId, false).Forget();
         }
 
         private void OnCommunitiesDataProviderCommunityDeleted(string communityId)
@@ -836,7 +850,10 @@ namespace DCL.Chat
                     break;
             }
 
-            userConnectivityInfoProvider.AddConversation(addedChannel.Id, addedChannel.ChannelType);
+            // Registers the conversation in the connectivity info provider
+            // Note: There is an exceptional case for communities, when the user joins a community. The conversation may have been created before
+            if(addedChannel.ChannelType != ChatChannel.ChatChannelType.COMMUNITY || !userConnectivityInfoProvider.HasConversation(addedChannel.Id, addedChannel.ChannelType))
+                userConnectivityInfoProvider.AddConversation(addedChannel.Id, addedChannel.ChannelType);
         }
 #endregion
 
@@ -1057,6 +1074,7 @@ namespace DCL.Chat
             DCLInput.Instance.Shortcuts.OpenChatCommandLine.performed += OnOpenChatCommandLineShortcutPerformed;
 
             communitiesDataProvider.CommunityCreated += OnCommunitiesDataProviderCommunityCreated;
+            communitiesDataProvider.CommunityJoined += OnCommunitiesDataProviderCommunityJoined;
             communitiesDataProvider.CommunityDeleted += OnCommunitiesDataProviderCommunityDeleted;
 
             userConnectivityInfoProvider.UserConnected += OnUserConnectivityInfoProviderUserConnected;

--- a/Explorer/Assets/DCL/Chat/UserConnectivityInfoProvider.cs
+++ b/Explorer/Assets/DCL/Chat/UserConnectivityInfoProvider.cs
@@ -212,7 +212,8 @@ namespace DCL.Chat
             ReportHub.Log(ReportCategory.DEBUG, $"-PARTICIPANT: {userConnectivity.Member.Address}, {userConnectivity.CommunityId}, {userConnectivity.Status}");
             ChatChannel.ChannelId communityChannelId = ChatChannel.NewCommunityChannelId(userConnectivity.CommunityId);;
 
-            participantsPerChannel[communityChannelId].Remove(userConnectivity.Member.Address);
+            if(participantsPerChannel.TryGetValue(communityChannelId, out HashSet<string>? communityParticipants))
+                communityParticipants.Remove(userConnectivity.Member.Address);
 
             UserDisconnected?.Invoke(userConnectivity.Member.Address, communityChannelId, ChatChannel.ChatChannelType.COMMUNITY);
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

It fixes the bug described here: https://github.com/decentraland/unity-explorer/issues/5001
Additionally, it also makes the conversation disappear when the user leaves the community.

## Test Instructions

### Joining the community
1. Open the communities browser.
2. Join a community.
3. Close the browser.
4. There must be a conversation icon in the chat toolbar for the community you just joined to.

### Leaving the community
1. Open the communities browser.
2. Leave a community.
3. Close the browser.
4. The conversation icon in the chat toolbar for the community you just left should be gone.
