### PR TITLE
fix: avatar freezes when switching tabs

### DIFF
--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -586,17 +586,14 @@ namespace DCL.Passport
                 return;
 
             photoLoadingCts = photoLoadingCts.SafeRestart();
+            characterPreviewLoadingCts = characterPreviewLoadingCts.SafeRestart();
 
             cameraReelGalleryController!.ShowWalletGalleryAsync(currentUserId!, photoLoadingCts.Token).Forget();
 
             currentSection = PassportSection.PHOTOS;
             viewInstance!.OpenSection(currentSection);
 
-            if (!viewInstance.CharacterPreviewView.gameObject.activeSelf)
-            {
-                viewInstance.CharacterPreviewView.gameObject.SetActive(true);
-                characterPreviewController?.OnShow();
-            }
+            SetCharacterPreviewVisible(true);
         }
 
         private void OpenOverviewSection()
@@ -610,7 +607,7 @@ namespace DCL.Passport
             currentSection = PassportSection.OVERVIEW;
             viewInstance!.OpenSection(currentSection);
 
-            characterPreviewController?.OnShow();
+            SetCharacterPreviewVisible(true);
         }
 
         private void OpenBadgesSection(string? badgeIdSelected = null)
@@ -624,9 +621,25 @@ namespace DCL.Passport
             currentSection = PassportSection.BADGES;
             viewInstance!.OpenSection(currentSection);
 
-            characterPreviewController?.OnHide(false);
+            SetCharacterPreviewVisible(false, false);
+
             bool isOwnPassport = ownProfile?.UserId == currentUserId;
             BadgesSectionOpened?.Invoke(currentUserId!, isOwnPassport, OpenBadgeSectionOrigin.BUTTON.ToString());
+        }
+
+        private void SetCharacterPreviewVisible(bool visible, bool triggerOnShowBusEvent = true)
+        {
+            GameObject previewGO = viewInstance.CharacterPreviewView.gameObject;
+
+            if (previewGO.activeSelf == visible)
+                return;
+
+            previewGO.SetActive(visible);
+
+            if (visible)
+                characterPreviewController?.OnShow(triggerOnShowBusEvent);
+            else
+                characterPreviewController?.OnHide(triggerOnShowBusEvent);
         }
 
         private void OnBadgeNotificationReceived(INotification notification) =>

--- a/Explorer/Assets/DCL/Passport/PassportView.cs
+++ b/Explorer/Assets/DCL/Passport/PassportView.cs
@@ -163,8 +163,6 @@ namespace DCL.Passport
             ViewportSoftMask.enabled = passportSection != PassportSection.PHOTOS;
 
             MainScroll.verticalNormalizedPosition = 1;
-
-            CharacterPreviewView.gameObject.SetActive(passportSection != PassportSection.BADGES);
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description
fix #4985 
## What does this PR change?
Moved logic to handle character preview in PassportController.SetCharacterPreviewVisible, getting rid of the freezing and preventing reloading the preview when switching from PHOTOS to OVERVIEW (this was happening before).

## Test Instructions
Open the Passport and quickly switch to Badges section and then to either Overview or Photos. 
The avatar should always be animated and interactable when shown.

### Test Steps
1. Open Passport
2. Switch to Badges section
3. Switch to Photos section
4. Make sure the avatar is animated and interactable
5. Repeat 1-2
6. Switch to Overview
7. Make sure the avatar is animated and interactable

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
