### PR TITLE
fix: onboarding soft lock

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/ToggleInWorldCameraActivitySystem.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/ToggleInWorldCameraActivitySystem.cs
@@ -91,7 +91,8 @@ namespace DCL.InWorldCamera.Systems
                     nametagsData.showNameTags = !nametagsData.showNameTags;
             }
 
-            if (World.TryGet(camera, out ToggleInWorldCameraRequest request))
+            CameraComponent cameraComponent = camera.GetCameraComponent(World);
+            if (cameraComponent.Mode != CameraMode.SDKCamera && World.TryGet(camera, out ToggleInWorldCameraRequest request))
                 ToggleCamera(request.IsEnable, request.TargetCameraMode);
         }
 
@@ -126,7 +127,7 @@ namespace DCL.InWorldCamera.Systems
         {
             if(hudController.State == ControllerState.ViewHiding || hudController.State == ControllerState.ViewHidden)
                 return;
-            
+
             if (debugContainerBuilder?.Container != null)
                 debugContainerBuilder.IsVisible = wasDebugVisible;
 


### PR DESCRIPTION
# Pull Request Description

Fixes https://github.com/decentraland/unity-explorer/issues/4930

## What does this PR change?
Prevents "camera mode" (in-world camera) activation while in SDK camera mode.

This is meant to fix the soft-lock that can happen during onboarding when camera mode is activated while the SDK has control over the camera.

## Test Instructions
- `/goto onboardingdcl` and confirm the C button does not enable the camera during "cutscenes"
- Generally speaking soft-locks shouldn't happen anymore

## Quality Checklist
- [x] Changes have been tested locally