### PR TITLE
fix: handle socket errors & discriminate exception types during signature process

### DIFF
--- a/Explorer/Assets/DCL/Web3/Authenticators/CodeVerificationException.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/CodeVerificationException.cs
@@ -6,5 +6,8 @@ namespace DCL.Web3.Authenticators
     {
         public CodeVerificationException(string message)
             : base(message) { }
+
+        public CodeVerificationException(string message, Exception innerException)
+            : base(message, innerException) { }
     }
 }

--- a/Explorer/Assets/DCL/Web3/Authenticators/Web3SignatureException.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Web3SignatureException.cs
@@ -4,6 +4,6 @@ namespace DCL.Web3.Authenticators
 {
     public class Web3SignatureException : Exception
     {
-        public Web3SignatureException(string message) : base(message) { }
+        public Web3SignatureException(string message, Exception innerException) : base(message, innerException) { }
     }
 }

--- a/Explorer/Assets/DCL/Web3/Authenticators/WebSocketDisconnectedException.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/WebSocketDisconnectedException.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace DCL.Web3.Authenticators
-{
-    public class WebSocketDisconnectedException : Exception
-    {
-
-    }
-}

--- a/Explorer/Assets/DCL/Web3/Authenticators/WebSocketDisconnectedException.cs.meta
+++ b/Explorer/Assets/DCL/Web3/Authenticators/WebSocketDisconnectedException.cs.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: 837ef07981194cae83f8f90f828f6bf2
-timeCreated: 1755006107

--- a/Explorer/Assets/DCL/Web3/Authenticators/WebSocketErrorException.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/WebSocketErrorException.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace DCL.Web3.Authenticators
-{
-    public class WebSocketErrorException : Exception
-    {
-        public WebSocketErrorException(string message) : base(message) { }
-    }
-}

--- a/Explorer/Assets/DCL/Web3/Authenticators/WebSocketErrorException.cs.meta
+++ b/Explorer/Assets/DCL/Web3/Authenticators/WebSocketErrorException.cs.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: 0789f9b138e647b4a06d422585ee3984
-timeCreated: 1755006157


### PR DESCRIPTION
## What does this PR change?

Fixes #4904

We were not properly handling possible errors in the web socket during the signature process, either on login or ethereum message. If the web socket disconnected or failed by any reason, the task was continued until it failed due to timeout.

Errors are now handled and should properly cancel pending tasks with the correct exception type, so we properly manage each error accordingly if needed.

## Test Instructions

Check that the login flow works correctly. Either new account or switch accounts.
Also try to test any scene that uses signed fetch.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
