### PR TITLE
fix: cancel notification polling on changing identity

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -583,8 +583,7 @@ namespace Global.Dynamic
             var clipboardManager = new ClipboardManager(clipboard);
             ITextFormatter hyperlinkTextFormatter = new HyperlinkTextFormatter(profileCache, selfProfile);
 
-            var notificationsRequestController = new NotificationsRequestController(staticContainer.WebRequestsContainer.WebRequestController, notificationsBusController, bootstrapContainer.DecentralandUrlsSource, identityCache, includeFriends);
-            notificationsRequestController.StartGettingNewNotificationsOverTimeAsync(ct).SuppressCancellationThrow().Forget();
+            NotificationsRequestController notificationsRequestController = new (staticContainer.WebRequestsContainer.WebRequestController, notificationsBusController, bootstrapContainer.DecentralandUrlsSource, identityCache, includeFriends);
 
             // Local scene development scenes are excluded from deeplink runtime handling logic
             if (appArgs.HasFlag(AppArgsFlags.LOCAL_SCENE) == false)
@@ -834,7 +833,8 @@ namespace Global.Dynamic
                     mvcManager,
                     staticContainer.WebRequestsContainer.WebRequestController,
                     notificationsBusController,
-                    sharedSpaceManager),
+                    notificationsRequestController,
+                    identityCache),
                 new RewardPanelPlugin(mvcManager, assetsProvisioner, notificationsBusController, staticContainer.WebRequestsContainer.WebRequestController),
                 new PassportPlugin(
                     assetsProvisioner,

--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuController.cs
@@ -10,7 +10,6 @@ using DCL.UI.Profiles.Helpers;
 using DCL.UI.SharedSpaceManager;
 using DCL.UI.Utilities;
 using DCL.Utilities;
-using DCL.Web3;
 using DCL.Web3.Identities;
 using DCL.WebRequests;
 using MVC;
@@ -27,7 +26,6 @@ namespace DCL.Notifications.NotificationsMenu
     public class NotificationsMenuController : IDisposable, IPanelInSharedSpace<ControllerNoData>
     {
         private const int PIXELS_PER_UNIT = 50;
-        private const int IDENTITY_CHANGE_POLLING_INTERVAL = 5000;
         private const int DEFAULT_NOTIFICATION_INDEX = 0;
         private const int FRIENDS_NOTIFICATION_INDEX = 1;
 
@@ -42,16 +40,15 @@ namespace DCL.Notifications.NotificationsMenu
         private readonly NotificationIconTypes notificationIconTypes;
         private readonly IWebRequestController webRequestController;
         private readonly NftTypeIconSO rarityBackgroundMapping;
+        private readonly IWeb3IdentityCache web3IdentityCache;
         private readonly Dictionary<string, Sprite> notificationThumbnailCache = new ();
         private readonly List<INotification> notifications = new ();
         private readonly CancellationTokenSource lifeCycleCts = new ();
-        private readonly IWeb3IdentityCache web3IdentityCache;
         private readonly ProfileRepositoryWrapper profileRepository;
         private readonly CancellationTokenSource notificationThumbnailCts;
 
         private CancellationTokenSource? notificationPanelCts = new ();
         private int unreadNotifications;
-        private Web3Address? previousWeb3Identity;
 
         public bool IsVisibleInSharedSpace => view.gameObject.activeSelf;
 
@@ -80,10 +77,12 @@ namespace DCL.Notifications.NotificationsMenu
             this.view.OnViewShown += OnViewShown;
             this.view.LoopList.InitListView(0, OnGetItemByIndex);
             this.view.CloseButton.onClick.AddListener(ClosePanel);
-            this.previousWeb3Identity = web3IdentityCache.Identity?.Address;
-            CheckIdentityChangeAsync(lifeCycleCts.Token).Forget();
+            web3IdentityCache.OnIdentityChanged += OnIdentityChanged;
             notificationsBusController.SubscribeToAllNotificationTypesReceived(OnNotificationReceived);
             this.view.LoopList.gameObject.GetComponent<ScrollRect>()?.SetScrollSensitivityBasedOnPlatform();
+
+            if (web3IdentityCache.Identity is { IsExpired: false })
+                InitialNotificationRequestAsync(lifeCycleCts.Token).SuppressCancellationThrow().Forget();
         }
 
         public void Dispose()
@@ -92,6 +91,7 @@ namespace DCL.Notifications.NotificationsMenu
             notificationPanelCts.SafeCancelAndDispose();
             lifeCycleCts.SafeCancelAndDispose();
             this.view.OnViewShown -= OnViewShown;
+            web3IdentityCache.OnIdentityChanged -= OnIdentityChanged;
             this.view.CloseButton.onClick.RemoveListener(ClosePanel);
         }
 
@@ -134,22 +134,8 @@ namespace DCL.Notifications.NotificationsMenu
             }
         }
 
-        private async UniTaskVoid CheckIdentityChangeAsync(CancellationToken token)
-        {
-            if (previousWeb3Identity != null)
-                await InitialNotificationRequestAsync(token);
-
-            while (token.IsCancellationRequested == false)
-            {
-                if (previousWeb3Identity != web3IdentityCache.Identity?.Address && web3IdentityCache.Identity?.Address != null)
-                {
-                    previousWeb3Identity = web3IdentityCache.Identity?.Address;
-                    await InitialNotificationRequestAsync(lifeCycleCts.Token);
-                }
-                else
-                    await UniTask.Delay(IDENTITY_CHANGE_POLLING_INTERVAL, cancellationToken: token);
-            }
-        }
+        private void OnIdentityChanged() =>
+            InitialNotificationRequestAsync(lifeCycleCts.Token).SuppressCancellationThrow().Forget();
 
         private async UniTask InitialNotificationRequestAsync(CancellationToken ct)
         {

--- a/Explorer/Assets/DCL/PluginSystem/Global/NotificationPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/NotificationPlugin.cs
@@ -5,13 +5,14 @@ using DCL.Backpack;
 using DCL.Notifications;
 using DCL.Notifications.NewNotification;
 using DCL.NotificationsBusController.NotificationsBus;
-using DCL.UI.SharedSpaceManager;
+using DCL.Web3.Identities;
 using DCL.WebRequests;
 using MVC;
 using System;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using Utility;
 
 namespace DCL.PluginSystem.Global
 {
@@ -21,24 +22,34 @@ namespace DCL.PluginSystem.Global
         private readonly IMVCManager mvcManager;
         private readonly IWebRequestController webRequestController;
         private readonly INotificationsBusController notificationsBusController;
-        private readonly ISharedSpaceManager sharedSpaceManager;
+        private readonly NotificationsRequestController notificationsRequestController;
+        private readonly IWeb3IdentityCache web3IdentityCache;
+
+        private CancellationTokenSource? notificationPollingCt;
 
         public NotificationPlugin(
             IAssetsProvisioner assetsProvisioner,
             IMVCManager mvcManager,
             IWebRequestController webRequestController,
             INotificationsBusController notificationsBusController,
-            ISharedSpaceManager sharedSpaceManager)
+            NotificationsRequestController notificationsRequestController,
+            IWeb3IdentityCache web3IdentityCache)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.mvcManager = mvcManager;
             this.webRequestController = webRequestController;
             this.notificationsBusController = notificationsBusController;
-            this.sharedSpaceManager = sharedSpaceManager;
+            this.notificationsRequestController = notificationsRequestController;
+            this.web3IdentityCache = web3IdentityCache;
         }
 
         public async UniTask InitializeAsync(NotificationSettings settings, CancellationToken ct)
         {
+            web3IdentityCache.OnIdentityCleared += OnIdentityCleared;
+            web3IdentityCache.OnIdentityChanged += OnIdentityChanged;
+
+            StartPollingNotifications();
+
             NewNotificationView newNotificationView = (await assetsProvisioner.ProvideMainAssetAsync(settings.NewNotificationView, ct: ct)).Value.GetComponent<NewNotificationView>();
             NotificationIconTypes notificationIconTypes = (await assetsProvisioner.ProvideMainAssetAsync(settings.NotificationIconTypesSO, ct: ct)).Value;
             NftTypeIconSO rarityBackgroundMapping = await assetsProvisioner.ProvideMainAssetValueAsync(settings.RarityColorMappings, ct);
@@ -58,6 +69,21 @@ namespace DCL.PluginSystem.Global
         public void Dispose() { }
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments) { }
+
+        private void OnIdentityChanged() =>
+            StartPollingNotifications();
+
+        private void OnIdentityCleared() =>
+            notificationPollingCt.SafeCancelAndDispose();
+
+        private void StartPollingNotifications()
+        {
+            notificationPollingCt = notificationPollingCt.SafeRestart();
+
+            notificationsRequestController.StartGettingNewNotificationsOverTimeAsync(notificationPollingCt.Token)
+                                          .SuppressCancellationThrow()
+                                          .Forget();
+        }
 
         public class NotificationSettings : IDCLPluginSettings
         {


### PR DESCRIPTION
## What does this PR change?

Fixes #4903 

We are polling notifications over time, but it was continued even if we changed identity. Since it is a signed fetch, it was provoking an unauthorized error, by trying to use the old identity.

These changes cancel the polling whenever we clear identity. When we change it, we restart the polling.
Additionally the request to get the most recent notifications has been improved. It is now subscribed to the identity change event making it more consistent.

## Test Instructions

Start normally, enter the world and check you can see notifications in the side bar.
Logout and change the account. Enter world and check that you can see notifications in the side bar.
Also check that you can keep receiving notifications normally.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
