### PR TITLE
fix: [Communities] Scrolling makes the members duplicate

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityFetchingControllerBase.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityFetchingControllerBase.cs
@@ -65,7 +65,7 @@ namespace DCL.Communities.CommunitiesCard
 
                 view.SetEmptyStateActive(membersData.TotalToFetch == 0);
 
-                view.RefreshGrid(currentSectionFetchData, count == membersData.Items.Count);
+                view.RefreshGrid(currentSectionFetchData, true);
             }
             finally { isFetching = false; }
         }


### PR DESCRIPTION
# Pull Request Description
Fix #4996 

## What does this PR change?
It fixes the duplication of members that sometimes happened when we increased the members grid's pagination.

<img width="718" height="504" alt="image" src="https://github.com/user-attachments/assets/ca89c35c-a7d3-4b07-ab7e-a4a08edf9fd7" />

### Test Steps
1. Go to the Communities Browser.
2. Open the "Teemo Fans" community.
3. Go to the Members section and scroll down quickly.
4. Check that there is not any duplicated member.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.