### PR TITLE
fix: [Communities] Scrolling while places selector is open in the Creation Wizard can cause misplacing of UI

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
@@ -110,6 +110,8 @@ namespace DCL.Communities.CommunityCreation
                         worlds);
             });
             creationPanelPlacesDropdown.OptionClicked += OnPlacesDropdownOptionSelected;
+            creationPanelPlacesDropdown.OptionsPanelOpened += OnPlacesPanelOpened;
+            creationPanelPlacesDropdown.OptionsPanelClosed += OnPlacesPanelClosed;
         }
 
         private void OnDestroy()
@@ -125,6 +127,8 @@ namespace DCL.Communities.CommunityCreation
             creationPanelCommunityDescriptionInputField.onSelect.RemoveAllListeners();
             creationPanelCommunityDescriptionInputField.onDeselect.RemoveAllListeners();
             creationPanelPlacesDropdown.OptionClicked -= OnPlacesDropdownOptionSelected;
+            creationPanelPlacesDropdown.OptionsPanelOpened -= OnPlacesPanelOpened;
+            creationPanelPlacesDropdown.OptionsPanelClosed -= OnPlacesPanelClosed;
 
             updateScrollPositionCts.SafeCancelAndDispose();
             thumbnailLoadingCts.SafeCancelAndDispose();
@@ -217,6 +221,12 @@ namespace DCL.Communities.CommunityCreation
         private void OnPlacesDropdownOptionSelected(int index) =>
             AddPlaceButtonClicked?.Invoke(index);
 
+        private void OnPlacesPanelOpened() =>
+            creationPanelScrollRect.vertical = false;
+
+        private void OnPlacesPanelClosed() =>
+            creationPanelScrollRect.vertical = true;
+
         public void AddPlaceTag(string id, bool isWorld, string placeName, string ownerName, bool isRemovalAllowed, bool updateScrollPosition = true)
         {
             CommunityPlaceTag placeTag = Instantiate(placeTagPrefab, placeTagsContainer);
@@ -277,6 +287,7 @@ namespace DCL.Communities.CommunityCreation
             foreach (CommunityPlaceTag placeTag in currentPlaceTags)
                 Destroy(placeTag.gameObject);
             currentPlaceTags.Clear();
+            creationPanelScrollRect.vertical = true;
         }
 
         private async UniTaskVoid SetScrollPositionToBottomAsync(CancellationToken ct)

--- a/Explorer/Assets/DCL/UI/SelectorButton/SelectorButtonView.cs
+++ b/Explorer/Assets/DCL/UI/SelectorButton/SelectorButtonView.cs
@@ -10,6 +10,8 @@ namespace DCL.UI.SelectorButton
 {
     public class SelectorButtonView : MonoBehaviour
     {
+        public event Action? OptionsPanelOpened;
+        public event Action? OptionsPanelClosed;
         public event Action<int>? OptionClicked;
 
         [SerializeField] private Button selectorButton;
@@ -148,10 +150,15 @@ namespace DCL.UI.SelectorButton
                 selectorPanel.localPosition = originalLocalPosition;
                 selectorPanel.parent = selectorPanelParent;
             }
+
+            OptionsPanelOpened?.Invoke();
         }
 
-        private void OnCloseOptionsPanel() =>
+        private void OnCloseOptionsPanel()
+        {
             selectorPanel.gameObject.SetActive(false);
+            OptionsPanelClosed?.Invoke();
+        }
 
         private void RefreshSelectorPanelSize()
         {


### PR DESCRIPTION
# Pull Request Description
Fix #4987 

## What does this PR change?
In the Community Creation/Edition Wizard, if we opened the places selector and applied scrolling while the places panel was open, the panel was scrolled in the scrolling direction.

Now, while the places panel is open, we block the vertical scrolling to avoid this UI misplacing.

### Test Steps
1. Open the Creation Wizard.
2. Open the places selector.
3. Try to scroll up or down and check that you cannot.
4. Close the places selector.
5. Try to scroll up or down and check that you can.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.