### PR TITLE
Fixed: Logging in and out makes the community chats disappear (#4990)

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatController.cs
+++ b/Explorer/Assets/DCL/Chat/ChatController.cs
@@ -472,6 +472,7 @@ namespace DCL.Chat
             memberListCts.SafeCancelAndDispose();
             isUserAllowedInInitializationCts.SafeCancelAndDispose();
             isUserAllowedInCommunitiesBusSubscriptionCts.SafeCancelAndDispose();
+            userConnectivityInfoProvider.Dispose();
         }
 #endregion
 

--- a/Explorer/Assets/DCL/Chat/ChatView.cs
+++ b/Explorer/Assets/DCL/Chat/ChatView.cs
@@ -214,8 +214,8 @@ namespace DCL.Chat
         private bool isChatUnfolded;
         private bool isPointerOverChat;
         private bool isSubmitHooked;
-        private CancellationTokenSource privateConversationItemCts = new CancellationTokenSource();
-        private CancellationTokenSource communityConversationItemCts = new CancellationTokenSource();
+        private CancellationTokenSource privateConversationItemCts;
+        private CancellationTokenSource communityConversationItemCts;
         private CancellationTokenSource communityTitleCts;
 
         private ISpriteCache thumbnailCache;
@@ -523,6 +523,9 @@ namespace DCL.Chat
             chatTitleBar.ContextMenuVisibilityChanged += OnChatContextMenuVisibilityChanged;
             chatTitleBar.DeleteChatHistoryRequested += OnDeleteChatHistoryRequested;
             chatTitleBar.ViewCommunityRequested += OnTitleBarViewCommunityRequested;
+
+            privateConversationItemCts = new CancellationTokenSource();
+            communityConversationItemCts = new CancellationTokenSource();
 
             this.loadingStatus = loadingStatus;
             loadingStatus.CurrentStage.OnUpdate += SetInputFieldInteractable;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

It fixes this bug: https://github.com/decentraland/unity-explorer/issues/4990

The feature was not prepared for logging in an out, so several things were not being re-initialized when logging in again.

Additionally, another bug has been fixed: when a community conversation was hidden, incoming messages for that conversation were causing errors.

## Test Instructions

### Works as expected when logging out and in
1. Log into DCL.
2. Check that you have some conversations in the toolbar (private and community's).
3. Log out.
4. Log in (with the same account).
5. Check that all conversations are there again.