### PR TITLE
fix: instant cancel of scene emote on PBAvatar instantiation during local scene development

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller
@@ -1038,7 +1038,7 @@ AnimatorController:
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
-    m_DefaultBool: 0
+    m_DefaultBool: 1
     m_Controller: {fileID: 9100000}
   - m_Name: EmoteLoop
     m_Type: 4


### PR DESCRIPTION
## What does this PR change?

Fixes #5047 

In the original issue, the test scene has the incorrect file naming for scene-emotes. They should end with `_emote.glb`.

Another problem: whenever a `PBAvatar` its instantiated with `expressionTriggerId: anims/scene_emote.glb` during local scene development mode, the emote was immediatelly cancelled because the updating of the animator state here: https://github.com/decentraland/unity-explorer/blob/b7246463cce5d9c4237937b944f4dc287e96474f/Explorer/Assets/DCL/Character/CharacterMotion/Systems/SDKAvatarShapesMotionSystem.cs#L137
`IsGrounded` param was initially `false` and then changed to `true` enabling the `Animator` again, and disabling the legacy `Animation` component on which the scene emote was running originally.

The solution consists on setting the `IsGrounded` param default as `true` in the character animator, so the state doesnt change initially and the `Animator` remains disabled allowing the `Animation` to run normally. Sadly not a robust solution, but this only affects the local scene development mode, since only there we execute the legacy animations due to the missing asset bundles.

## Test Instructions

Run this test scene:  [avatar.shape.tests.zip](https://github.com/user-attachments/files/21797108/avatar.shape.tests.zip)
Check that the wearables that are showcased over a "hidden" avatar shape are frozen in place.
Click the box that plays the emote. Check that your avatar gets frozen in place.
Check that two avatars are playing the emotes: one sitting in ground, the other frozen in place.

Also try `/reload` on the scene. Check that the wearables are not moving.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
