### PR TITLE
fix: pasting system message formatting fix

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/ChatHistoryService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/ChatHistoryService.cs
@@ -4,6 +4,7 @@ using DCL.Chat.MessageBus;
 using DCL.Settings.Settings;
 using DCL.UI.InputFieldFormatting;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace DCL.Chat.ChatServices
 {
@@ -41,7 +42,7 @@ namespace DCL.Chat.ChatServices
             if (type == ChatChannel.ChatChannelType.COMMUNITY && !chatHistory.Channels.ContainsKey(channel))
                 return;
 
-            if (!message.IsSystemMessage)
+            if (!message.IsSystemMessage && !IsCopyOfSystemMessage(message.Message))
             {
                 string formattedText = hyperlinkTextFormatter.FormatText(message.Message);
                 var newChatMessage = ChatMessage.CopyWithNewMessage(formattedText, message);
@@ -71,6 +72,21 @@ namespace DCL.Chat.ChatServices
                     UIAudioEventsBus.Instance.SendPlayAudioEvent(message.IsMention ? chatConfig.ChatReceiveMentionMessageAudio : chatConfig.ChatReceiveMessageAudio);
                     break;
             }
+        }
+
+        /// <summary>
+        ///     Determines if a message string is a copy of a system message by checking for status emojis.
+        /// </summary>
+        /// <param name="message">The message content to check.</param>
+        /// <returns>True if the message starts with a known system message emoji.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool IsCopyOfSystemMessage(string message)
+        {
+            // System messages are identified by starting with one of these status emojis.
+            // We check for these to avoid re-formatting a message that a user has copied and pasted.
+            return message.StartsWith("🟢") ||
+                   message.StartsWith("🔴") ||
+                   message.StartsWith("🟡");
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description
## What does this PR change?
If we copy a system message treat it as such and don't format url


### Test Steps
1. Start
2. Teleport somewhere
3. Copy message (it has to be system message, "You have teleported to...")
4. Past message
5. Observe there is no link in the copied message

## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
