### PR TITLE
fix: User cannot interact with communities after TAB is pressed

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
@@ -167,9 +167,8 @@ namespace MVC
             try
             {
                 // Hide all popups in the stack and clear it
-
-                foreach ((IController controller, int orderInLayer) popupController in fullscreenPushInfo.PopupControllers)
-                    popupController.controller.HideViewAsync(ct).Forget();
+                for (int i = fullscreenPushInfo.PopupControllers.Count - 1; i >= 0; i--)
+                    fullscreenPushInfo.PopupControllers[i].Item1.HideViewAsync(ct).Forget();
 
                 fullscreenPushInfo.PopupControllers.Clear();
 


### PR DESCRIPTION
# Pull Request Description
Fix #4997 

## What does this PR change?
Replaced foreach loop with inverse for loop, this ensures the correct order is followed when hiding popup views and prevents InvalidOperationException when iterating and a (parent) view asynchronously closes another (child) view.

Before, when opening a FullScreen window we iterated over the popup controllers hiding their views asynchronously.
This could lead to a InvalidOperationException during the loop because a view might close another view asynchronously when closing itself.

Also, this now works as intended, if a new fullscreen window is opened (i.e. Communities) all popups get closed correctly.

## Test Instructions
- Verify that pressing TAB when a community panel and/or context menu is open correctly closes the underlying UI but interaction with the panel / context menu is still possible.
- Verify that pressing TAB again closes all popups before opening the fullscreen window.

### Test Steps
1. Open Communities
2. Open a community
3. In the MEMBERS section click on the kebab button next to one of the members to open the context menu
4. Press the "TAB" key to close the Communities UI
5. Make sure you can still interact with the context menu or the community panel
6. Press again the "TAB" key to open Communities UI
7. Make sure the community panel and context menu have been closed correctly

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
