### PR TITLE
fix: clouds reposition abruptly after exiting camera

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/Systems/CinemachineFarClipPlaneSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Systems/CinemachineFarClipPlaneSystem.cs
@@ -50,7 +50,8 @@ namespace DCL.CharacterCamera.Systems
                     break;
 
                 case CameraMode.InWorld:
-                    cinemachinePreset.InWorldCameraData.Camera.m_Lens.FarClipPlane = settings.MaxFarClipPlane;
+                    ICinemachineFreeCameraData inWorldCamera = cinemachinePreset.InWorldCameraData;
+                    UpdateFarClipPlane(inWorldCamera.Camera.Follow, settings, ref inWorldCamera.Camera.m_Lens);
                     break;
             }
 


### PR DESCRIPTION
- Adapting far clip plane dynamically for InWorld camera as we do for 1st / 3rd person camera.

# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
