### PR TITLE
fix: private messages not loading in PL and DE region settings

### DIFF
--- a/Explorer/Assets/DCL/Chat/History/ChatHistorySerializer.cs
+++ b/Explorer/Assets/DCL/Chat/History/ChatHistorySerializer.cs
@@ -85,7 +85,7 @@ namespace DCL.Chat.History
                     ParseEntryValues(currentLine, entryValues);
                     bool sentByLocalUser = entryValues[ENTRY_SENT_BY_LOCAL_USER] == LOCAL_USER_TRUE_VALUE;
                     string walletAddress = sentByLocalUser ? localUserWalletAddress : remoteUserWalletAddress;
-                    ChatMessage newMessage = messageFactory.CreateChatMessage(walletAddress, sentByLocalUser, entryValues[ENTRY_MESSAGE], entryValues[ENTRY_USERNAME], double.Parse(entryValues[ENTRY_TIMESTAMP]));
+                    ChatMessage newMessage = messageFactory.CreateChatMessage(walletAddress, sentByLocalUser, entryValues[ENTRY_MESSAGE], entryValues[ENTRY_USERNAME], double.Parse(entryValues[ENTRY_TIMESTAMP], CultureInfo.InvariantCulture));
 
                     obtainedMessages.Add(newMessage);
                     currentLine = await reader2.ReadLineAsync();


### PR DESCRIPTION
# Pull Request Description
Fix [#5123](https://github.com/decentraland/unity-explorer/issues/5123)

## What does this PR change?
In Polish and German language while parsing a string 21233.421234 to a double, dot `.` was replaced with a comma `,` throwing an error while creating message. Which resulted in messages not loading at all. I have fixed that by parsing that string to a double with `CultureInfo.InvariantCulture` argument.



### Test Steps
1. Run the game.
2. Write few private messages and dont close the chat.
3. Exit the game.
4. Run the game.
5. Check if you can read your private messages (using region setting other than Poland or Germany which I believe is true for you right now).
6. Exit the game.
7. Change your system's region setting to Poland (and become one of us, buhahaha).
8. Restart your computer.
9. Run the game.
10. Check if you can read your previously written private messages.
11. Repeat from 6th step for region: Germany.

## Quality Checklist
- [x] Changes have been tested locally

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
