### PR TITLE
fix: user name copy not displaying toast

### DIFF
--- a/Explorer/Assets/DCL/UI/Assets/UserNameElement.prefab
+++ b/Explorer/Assets/DCL/UI/Assets/UserNameElement.prefab
@@ -1190,5 +1190,5 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 1
+  m_SortingOrder: 1000
   m_TargetDisplay: 0


### PR DESCRIPTION
# Pull Request Description
Fix [#4830](https://github.com/decentraland/unity-explorer/issues/4830)

## What does this PR change?
Fixed user name copied toast not being displayed, by changing toast canvas drawing order

## Test Instructions
Check if upon coping the name toast is displayed in player and avatar's profiles


## Quality Checklist
- [x] Changes have been tested locally

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
