### PR TITLE
fix: keep roads teleport position

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/TeleportPositionCalculationSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/TeleportPositionCalculationSystem.cs
@@ -46,7 +46,7 @@ namespace DCL.Character.CharacterMotion.Systems
             {
                 teleportIntent.Position = ParcelMathHelper.GetPositionByParcelPosition(parcel).WithErrorCompensation().WithTerrainOffset();
             }
-            else if (TeleportUtils.IsTramLine(sceneDef.metadata.OriginalJson.AsSpan()))
+            else if (TeleportUtils.IsRoad(sceneDef.metadata.OriginalJson.AsSpan()))
             {
                 teleportIntent.Position = ParcelMathHelper.GetPositionByParcelPosition(parcel).WithErrorCompensation();
             }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/TeleportUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/TeleportUtils.cs
@@ -8,9 +8,15 @@ namespace ECS.SceneLifeCycle
     public static class TeleportUtils
     {
         private const string TRAM_LINE_TITLE = "Tram Line";
+        private const string LONG_ROAD_TITLE = "Long Road";
 
-        public static bool IsTramLine(ReadOnlySpan<char> originalJson) =>
-            ExtractTitleValue(originalJson).SequenceEqual(TRAM_LINE_TITLE.AsSpan());
+        public static bool IsRoad(ReadOnlySpan<char> originalJson)
+        {
+            ReadOnlySpan<char> span = ExtractTitleValue(originalJson);
+
+            return span.SequenceEqual(TRAM_LINE_TITLE.AsSpan())
+                || span.SequenceEqual(LONG_ROAD_TITLE.AsSpan());
+        }
 
         private static ReadOnlySpan<char> ExtractTitleValue(ReadOnlySpan<char> json)
         {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/TeleportUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/TeleportUtils.cs
@@ -10,6 +10,10 @@ namespace ECS.SceneLifeCycle
         private const string TRAM_LINE_TITLE = "Tram Line";
         private const string LONG_ROAD_TITLE = "Long Road";
 
+        public static bool IsRoad(string sceneTitle) =>
+            string.Equals(sceneTitle, TRAM_LINE_TITLE, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(sceneTitle, LONG_ROAD_TITLE, StringComparison.OrdinalIgnoreCase);
+
         public static bool IsRoad(ReadOnlySpan<char> originalJson)
         {
             ReadOnlySpan<char> span = ExtractTitleValue(originalJson);

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Categories/CategoryControllers/CategoryMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Categories/CategoryControllers/CategoryMarkersController.cs
@@ -286,7 +286,7 @@ namespace DCL.MapRenderer.MapLayers.Categories
             if (visibleMarkers.TryGetValue(gameObject, out ICategoryMarker marker))
             {
                 marker.ToggleSelection(true);
-                navmapBus.SelectPlaceAsync(marker.PlaceInfo, cts.Token, true).Forget();
+                navmapBus.SelectPlaceAsync(marker.PlaceInfo!, cts.Token, true).Forget();
                 mapRenderMarker = marker;
                 return true;
             }

--- a/Explorer/Assets/DCL/Navmap/INavmapCommand.cs
+++ b/Explorer/Assets/DCL/Navmap/INavmapCommand.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using System;
 using System.Threading;
+using UnityEngine;
 
 namespace DCL.Navmap
 {
@@ -18,11 +19,13 @@ namespace DCL.Navmap
 
     public struct AdditionalParams
     {
-        public bool IsFromSearchResults;
+        public readonly bool IsFromSearchResults;
+        public readonly Vector2Int? OriginalParcel;
 
-        public AdditionalParams(bool isFromSearchResults)
+        public AdditionalParams(bool isFromSearchResults, Vector2Int? originalParcel = null)
         {
             this.IsFromSearchResults = isFromSearchResults;
+            this.OriginalParcel = originalParcel;
         }
     }
 }

--- a/Explorer/Assets/DCL/Navmap/NavmapBus/INavmapBus.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapBus/INavmapBus.cs
@@ -49,7 +49,11 @@ namespace DCL.Navmap
         public event Action<Vector2Int, Vector2> OnLongHover;
         public event Action<Vector2Int, bool, bool> OnSelectPlaceFromResultsPanel;
 
-        UniTask SelectPlaceAsync(PlacesData.PlaceInfo place, CancellationToken ct, bool isFromSearchResults = false);
+        UniTask SelectPlaceAsync(PlacesData.PlaceInfo place, CancellationToken ct, bool isFromSearchResults = false,
+            // We need to know the original coordinates of the requested parcel for handling cases like roads.
+            // Roads begin at one coordinate but may extend across the map.
+            // The user should be able to teleport along the entirety of the road seamlessly.
+            Vector2Int? originalParcel = null);
         UniTask SelectPlaceAsync(Vector2Int parcel, CancellationToken ct, bool isFromSearchResults = false);
 
         UniTask SelectEventAsync(EventDTO @event, CancellationToken ct, PlacesData.PlaceInfo? place = null);

--- a/Explorer/Assets/DCL/Navmap/NavmapBus/SharedNavmapBus.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapBus/SharedNavmapBus.cs
@@ -43,10 +43,11 @@ namespace DCL.Navmap
             obj.OnSelectPlaceFromResultsPanel += OnSelectPlaceFromResultsPanel;
         }
 
-        public async UniTask SelectPlaceAsync(PlacesData.PlaceInfo place, CancellationToken ct, bool isFromSearchResults = false)
+        public async UniTask SelectPlaceAsync(PlacesData.PlaceInfo place, CancellationToken ct,
+            bool isFromSearchResults = false, Vector2Int? originalParcel = null)
         {
             if (source.Object == null) return;
-            await source.Object.SelectPlaceAsync(place, ct, isFromSearchResults);
+            await source.Object.SelectPlaceAsync(place, ct, isFromSearchResults, originalParcel);
         }
 
         public async UniTask SelectPlaceAsync(Vector2Int parcel, CancellationToken ct, bool isFromSearchResults = false)

--- a/Explorer/Assets/DCL/Navmap/NavmapCommandBus.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapCommandBus.cs
@@ -46,7 +46,8 @@ namespace DCL.Navmap
             this.placesAPIService = placesAPIService;
         }
 
-        public async UniTask SelectPlaceAsync(PlacesData.PlaceInfo place, CancellationToken ct, bool isFromSearchResults = false)
+        public async UniTask SelectPlaceAsync(PlacesData.PlaceInfo place, CancellationToken ct,
+            bool isFromSearchResults = false, Vector2Int? originalParcel = null)
         {
             INavmapCommand<AdditionalParams> command = showPlaceInfoFactory.Invoke(place);
 
@@ -54,7 +55,7 @@ namespace DCL.Navmap
                 ClearPlacesFromMap();
 
             MoveCameraTo(place.Positions[0], CAMERA_MOVE_SPEED);
-            await command.ExecuteAsync(new AdditionalParams(isFromSearchResults), ct);
+            await command.ExecuteAsync(new AdditionalParams(isFromSearchResults, originalParcel), ct);
 
             AddCommand(command);
         }
@@ -66,7 +67,7 @@ namespace DCL.Navmap
             // TODO: show empty parcel
             if (place == null) place = new PlacesData.PlaceInfo(parcel);
 
-            await SelectPlaceAsync(place, ct, isFromSearchResults);
+            await SelectPlaceAsync(place, ct, isFromSearchResults, parcel);
         }
 
         public async UniTask SelectEventAsync(EventDTO @event, CancellationToken ct, PlacesData.PlaceInfo? place = null)

--- a/Explorer/Assets/DCL/Navmap/NavmapController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapController.cs
@@ -168,7 +168,7 @@ namespace DCL.Navmap
 
                 if (place == null) place = new PlacesData.PlaceInfo(clickedParcel.Parcel);
 
-                navmapBus.SelectPlaceAsync(place, fetchPlaceAndShowCancellationToken.Token, true).Forget();
+                navmapBus.SelectPlaceAsync(place, fetchPlaceAndShowCancellationToken.Token, true, clickedParcel.Parcel).Forget();
             }
 
             fetchPlaceAndShowCancellationToken = fetchPlaceAndShowCancellationToken.SafeRestart();

--- a/Explorer/Assets/DCL/Navmap/ShowPlaceInfoCommand.cs
+++ b/Explorer/Assets/DCL/Navmap/ShowPlaceInfoCommand.cs
@@ -1,18 +1,14 @@
 using Cysharp.Threading.Tasks;
 using DCL.EventsApi;
 using DCL.PlacesAPIService;
-using System;
 using System.Collections.Generic;
 using System.Threading;
-using UnityEngine;
-using Utility;
 
 namespace DCL.Navmap
 {
     public class ShowPlaceInfoCommand : INavmapCommand<AdditionalParams>
     {
         private readonly PlacesData.PlaceInfo placeInfo;
-        private readonly NavmapView navmapView;
         private readonly PlaceInfoPanelController placeInfoPanelController;
         private readonly PlacesAndEventsPanelController placesAndEventsPanelController;
         private readonly IEventsApiService eventsApiService;
@@ -21,14 +17,12 @@ namespace DCL.Navmap
 
         public ShowPlaceInfoCommand(
             PlacesData.PlaceInfo placeInfo,
-            NavmapView navmapView,
             PlaceInfoPanelController placeInfoPanelController,
             PlacesAndEventsPanelController placesAndEventsPanelController,
             IEventsApiService eventsApiService,
             NavmapSearchBarController searchBarController)
         {
             this.placeInfo = placeInfo;
-            this.navmapView = navmapView;
             this.placeInfoPanelController = placeInfoPanelController;
             this.placesAndEventsPanelController = placesAndEventsPanelController;
             this.eventsApiService = eventsApiService;
@@ -45,6 +39,7 @@ namespace DCL.Navmap
             placesAndEventsPanelController.Expand();
 
             placeInfoPanelController.Set(placeInfo);
+            placeInfoPanelController.SetOriginParcel(additionalParams?.OriginalParcel);
             placeInfoPanelController.Toggle(PlaceInfoPanelController.Section.OVERVIEW);
             placeInfoPanelController.HideLiveEvent();
             searchBarController.ToggleClearButton(true);

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -507,7 +507,7 @@ namespace DCL.PluginSystem.Global
                 @params);
 
         private INavmapCommand<AdditionalParams> CreateShowPlaceCommand(PlacesData.PlaceInfo placeInfo) =>
-            new ShowPlaceInfoCommand(placeInfo, navmapView!, placeInfoPanelController!, placesAndEventsPanelController!, eventsApiService,
+            new ShowPlaceInfoCommand(placeInfo, placeInfoPanelController!, placesAndEventsPanelController!, eventsApiService,
                 searchBarController!);
 
         private INavmapCommand CreateShowEventCommand(EventDTO @event, PlacesData.PlaceInfo? place = null) =>

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportController.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportController.cs
@@ -67,7 +67,7 @@ namespace DCL.RealmNavigation
 
             SceneEntityDefinition? sceneDef = await retrieveScene.ByParcelAsync(parcel, ct);
 
-            if (sceneDef != null && !TeleportUtils.IsTramLine(sceneDef.metadata.OriginalJson.AsSpan()))
+            if (sceneDef != null && !TeleportUtils.IsRoad(sceneDef.metadata.OriginalJson.AsSpan()))
             {
                 parcel = sceneDef.metadata.scene.DecodedBase; // Override parcel as it's a new target
 


### PR DESCRIPTION
## What does this PR change?

Fixes #4302 

Check for the `Long Road` scene title to keep the original teleport coordinates.
Additionally the navmap passes the clicked coordinates to the places panel, so it can properly teleport if the destination is a road.

## Test Instructions

Teleport to any road. Spawn point should be the designed coordinates.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
