### PR TITLE
fix: input blocked after closing the marketplace credits popup

### DIFF
--- a/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsWelcomeSubController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Sections/MarketplaceCreditsWelcomeSubController.cs
@@ -81,6 +81,9 @@ namespace DCL.MarketplaceCredits.Sections
         {
             subView.gameObject.SetActive(false);
             inputBlock.Enable(InputMapComponent.BLOCK_USER_INPUT);
+            // We need to cancel the operation, otherwise after it finishes, it will disable the input, even if the ui is closed already,
+            // making it impossible to move the avatar again
+            fetchProgramRegistrationInfoCts.SafeCancelAndDispose();
         }
 
         public void Dispose()


### PR DESCRIPTION
## What does this PR change?

Fixes #5158 

The issue was caused by a race condition between the "open" and "close" operations. The "open" operation asynchronously disables user input when it completes, while the "close" operation enables input again. If the "close" operation is triggered while the asynchronous "open" operation is still in progress, the late completion of the "open" flow could incorrectly disable user input even though the UI is already hidden. 

The solution involves canceling the operation responsible for fetching the program registration information when the UI is closed. This ensures that the "open" flow cannot disable user input once the UI has been closed, preventing scenarios where the avatar would become immobile due to disabled input.

## Test Instructions

1. Open the client with an account that is not registered into the marketplace credits program.
2. When you jump-in world, click something in the screen as soon as the marketplace credits popup appears
3. After the popup closes, check that you can still move the avatar, lock the mouse and you can do things normally

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
