### PR TITLE
feat: Private Communities (Visual Polishments)

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunitiesBrowser_LeftSection.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunitiesBrowser_LeftSection.prefab
@@ -1234,7 +1234,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -10}
-  m_SizeDelta: {x: 0, y: -10}
+  m_SizeDelta: {x: 0, y: -20}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &968378323978756422
 CanvasRenderer:
@@ -5839,7 +5839,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 31746976412255473, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_Colors.m_NormalColor.a
-      value: 0.050980393
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 31746976412255473, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_Colors.m_NormalColor.b
@@ -5855,7 +5855,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 31746976412255473, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_Colors.m_PressedColor.a
-      value: 0.2
+      value: 0.03137255
       objectReference: {fileID: 0}
     - target: {fileID: 31746976412255473, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_Colors.m_PressedColor.b
@@ -5871,7 +5871,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 31746976412255473, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_Colors.m_DisabledColor.a
-      value: 0.101960786
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 31746976412255473, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_Colors.m_DisabledColor.b
@@ -5887,7 +5887,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 31746976412255473, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_Colors.m_SelectedColor.a
-      value: 0.101960786
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 31746976412255473, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_Colors.m_SelectedColor.b
@@ -5903,7 +5903,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 31746976412255473, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_Colors.m_HighlightedColor.a
-      value: 0.101960786
+      value: 0.050980393
       objectReference: {fileID: 0}
     - target: {fileID: 31746976412255473, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_Colors.m_HighlightedColor.b
@@ -6142,6 +6142,22 @@ PrefabInstance:
       propertyPath: m_Colors.m_NormalColor.a
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 414414186835491929, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 414414186835491929, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 414414186835491929, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 414414186835491929, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1251707771264483775, guid: bf26a037105549540a19715161cbca3f, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -6226,6 +6242,18 @@ PrefabInstance:
       propertyPath: m_Name
       value: MyCommunityCard
       objectReference: {fileID: 0}
+    - target: {fileID: 4214954414944188710, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4214954414944188710, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4214954414944188710, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4256434563627273897, guid: bf26a037105549540a19715161cbca3f, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -6254,6 +6282,26 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6203927270216338111, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6203927270216338111, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6203927270216338111, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6203927270216338111, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6203927270216338111, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7503410925582250765, guid: bf26a037105549540a19715161cbca3f, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -6264,6 +6312,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7503410925582250765, guid: bf26a037105549540a19715161cbca3f, type: 3}
       propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7666755062642206979, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7666755062642206979, guid: bf26a037105549540a19715161cbca3f, type: 3}
+      propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7666755062642206979, guid: bf26a037105549540a19715161cbca3f, type: 3}

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
@@ -20,6 +20,8 @@ namespace DCL.Communities.CommunityCreation
         private const string CREATE_COMMUNITY_TITLE = "Create a Community";
         private const string EDIT_COMMUNITY_TITLE = "Edit Community";
         private const string PLACES_DROPDOWN_TITLE = "Select LAND or World";
+        private const string PUBLIC_MEMBERSHIP_OPTION = "<b>Public</b> <size=11>Anyone can become a member, view Community details, and join your Voice Streams</size>";
+        private const string PRIVATE_MEMBERSHIP_OPTION = "<b>Private</b> <size=11>Membership by request/invite; only Community description visible to non-members</size>";
 
         public Action? CancelButtonClicked;
         public Action? GetNameButtonClicked;
@@ -54,7 +56,7 @@ namespace DCL.Communities.CommunityCreation
         [SerializeField] private TMP_InputField creationPanelCommunityDescriptionInputField = null!;
         [SerializeField] private GameObject creationPanelCommunityDescriptionInputFieldOutline = null!;
         [SerializeField] private TMP_Text creationPanelCommunityDescriptionCharCounter = null!;
-        [SerializeField] private ToggleGroupView creationPanelMembershipToggleGroup = null!;
+        [SerializeField] private SelectorButtonView creationPanelMembershipDropdown = null!;
         [SerializeField] private SelectorButtonView creationPanelPlacesDropdown = null!;
         [SerializeField] private Transform placeTagsContainer = null!;
         [SerializeField] private CommunityPlaceTag placeTagPrefab = null!;
@@ -104,18 +106,28 @@ namespace DCL.Communities.CommunityCreation
                         creationPanelCommunityDescriptionInputField.text,
                         lands,
                         worlds,
-                        creationPanelMembershipToggleGroup.SelectedToggleIndex == 0 ? CommunityPrivacy.@public : CommunityPrivacy.@private);
+                        creationPanelMembershipDropdown.SelectedIndex == 0 ? CommunityPrivacy.@public : CommunityPrivacy.@private);
                 else
                     SaveCommunityButtonClicked?.Invoke(
                         creationPanelCommunityNameInputField.text,
                         creationPanelCommunityDescriptionInputField.text,
                         lands,
                         worlds,
-                        creationPanelMembershipToggleGroup.SelectedToggleIndex == 0 ? CommunityPrivacy.@public : CommunityPrivacy.@private);
+                        creationPanelMembershipDropdown.SelectedIndex == 0 ? CommunityPrivacy.@public : CommunityPrivacy.@private);
             });
+
+            creationPanelMembershipDropdown.OptionsPanelOpened += OnPlacesPanelOpened;
+            creationPanelMembershipDropdown.OptionsPanelClosed += OnPlacesPanelClosed;
+
             creationPanelPlacesDropdown.OptionClicked += OnPlacesDropdownOptionSelected;
             creationPanelPlacesDropdown.OptionsPanelOpened += OnPlacesPanelOpened;
             creationPanelPlacesDropdown.OptionsPanelClosed += OnPlacesPanelClosed;
+        }
+
+        private void Start()
+        {
+            creationPanelMembershipDropdown.SetOptions(new List<string> { PUBLIC_MEMBERSHIP_OPTION, PRIVATE_MEMBERSHIP_OPTION });
+            SetCommunityPrivacy(CommunityPrivacy.@public, true);
         }
 
         private void OnDestroy()
@@ -130,6 +142,10 @@ namespace DCL.Communities.CommunityCreation
             creationPanelCommunityDescriptionInputField.onValueChanged.RemoveAllListeners();
             creationPanelCommunityDescriptionInputField.onSelect.RemoveAllListeners();
             creationPanelCommunityDescriptionInputField.onDeselect.RemoveAllListeners();
+
+            creationPanelMembershipDropdown.OptionsPanelOpened -= OnPlacesPanelOpened;
+            creationPanelMembershipDropdown.OptionsPanelClosed -= OnPlacesPanelClosed;
+
             creationPanelPlacesDropdown.OptionClicked -= OnPlacesDropdownOptionSelected;
             creationPanelPlacesDropdown.OptionsPanelOpened -= OnPlacesPanelOpened;
             creationPanelPlacesDropdown.OptionsPanelClosed -= OnPlacesPanelClosed;
@@ -218,8 +234,8 @@ namespace DCL.Communities.CommunityCreation
 
         public void SetCommunityPrivacy(CommunityPrivacy privacy, bool isInteractable)
         {
-            creationPanelMembershipToggleGroup.SelectedToggleIndex = (int)privacy;
-            creationPanelMembershipToggleGroup.SetAsInteractable(isInteractable);
+            creationPanelMembershipDropdown.SelectedIndex = (int)privacy;
+            creationPanelMembershipDropdown.SetAsInteractable(isInteractable);
         }
 
         public void SetPlacesSelector(List<string> options)

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/CommunityCreationWizard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/CommunityCreationWizard.prefab
@@ -260,7 +260,7 @@ MonoBehaviour:
   creationPanelCommunityDescriptionInputField: {fileID: 1742210779712872466}
   creationPanelCommunityDescriptionInputFieldOutline: {fileID: 107672421462256528}
   creationPanelCommunityDescriptionCharCounter: {fileID: 3788980449318604006}
-  creationPanelMembershipToggleGroup: {fileID: 1806009870740389182}
+  creationPanelMembershipDropdown: {fileID: 2515644846552597292}
   creationPanelPlacesDropdown: {fileID: 3469131188007961312}
   placeTagsContainer: {fileID: 7556609997558448888}
   placeTagPrefab: {fileID: 3725212863499460695, guid: a9cbb8e8148fce2438b42e92f9b8bf22, type: 3}
@@ -623,6 +623,14 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 957419972986639337, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 957419972986639337, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1185456049467696351, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -689,6 +697,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2096463222538666977, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2271214591398990373, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2271214591398990373, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2448521439946456097, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
@@ -779,6 +795,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5757341411490673128, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5800817397900643791, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -825,6 +845,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6135224288403869516, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6713642485567123492, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6970276788350834772, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
@@ -927,11 +951,102 @@ PrefabInstance:
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8360221735086221731, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      propertyPath: showSelectedMarkOnOptionSelected
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8360221735086221731, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      propertyPath: changeSelectorButtonTextOnOptionSelected
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 6669832460371067501, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 123008750014820424, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7922773845728300772}
+    - targetCorrespondingSourceObject: {fileID: 4955726326344855859, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3124649350205357300}
+    - targetCorrespondingSourceObject: {fileID: 4934367878633922337, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1290260532306301672}
+    - targetCorrespondingSourceObject: {fileID: 3060112194134185778, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8908873029571800525}
+    - targetCorrespondingSourceObject: {fileID: 8240582663001191437, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1877694672716574048}
+    - targetCorrespondingSourceObject: {fileID: 6918732780190388067, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6179161786983257240}
+    - targetCorrespondingSourceObject: {fileID: 7211502054518005051, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8603954102336802826}
+    - targetCorrespondingSourceObject: {fileID: 1791501796716429658, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5677032354506893644}
+    - targetCorrespondingSourceObject: {fileID: 1403023058664108420, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7527244801511634112}
+    - targetCorrespondingSourceObject: {fileID: 6200276987859759359, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1997239230145893964}
+    - targetCorrespondingSourceObject: {fileID: 6248723276754607853, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2690690251939043161}
+    - targetCorrespondingSourceObject: {fileID: 4087643471237306110, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2057566881753167750}
+    - targetCorrespondingSourceObject: {fileID: 6958597445833160129, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8020157125073601734}
+    - targetCorrespondingSourceObject: {fileID: 8271369831503597231, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5853296515350357709}
+    - targetCorrespondingSourceObject: {fileID: 8564139150208752887, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3397587625275749479}
+    - targetCorrespondingSourceObject: {fileID: 725423291212169366, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2364712205575480545}
   m_SourcePrefab: {fileID: 100100000, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+--- !u!1 &25834408442557538 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6248723276754607853, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2690690251939043161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 25834408442557538}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &65280095160883824 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6200276987859759359, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1997239230145893964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 65280095160883824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &107672421462256528 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6310285833647816991, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
@@ -946,6 +1061,40 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1308966536337759164 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4955726326344855859, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3124649350205357300
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308966536337759164}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1339329984271857070 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4934367878633922337, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1290260532306301672
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1339329984271857070}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &1356991511893353481 stripped
@@ -970,22 +1119,28 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &1806009870740389182 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5763508698044127153, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
-  m_PrefabInstance: {fileID: 6263421827064736399}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d556bae99d44d9f8b67f6969fa1345d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1998900302886066027 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5571412109002997220, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
   m_PrefabInstance: {fileID: 6263421827064736399}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2320985319465973368 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8564139150208752887, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3397587625275749479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2320985319465973368}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &2428634819478053848 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8599652587953539415, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
@@ -995,6 +1150,51 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2515644846552597292 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8360221735086221731, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73833f3dfda8645469c13caf843fcbb7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2604747438815749152 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8271369831503597231, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5853296515350357709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2604747438815749152}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2643695113841319554 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8240582663001191437, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1877694672716574048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2643695113841319554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &3026729670463483168 stripped
@@ -1024,6 +1224,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73833f3dfda8645469c13caf843fcbb7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &3672758194483279796 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7211502054518005051, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8603954102336802826
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3672758194483279796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &3788980449318604006 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7095717341087278697, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
@@ -1040,6 +1257,74 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 6970276788350834772, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
   m_PrefabInstance: {fileID: 6263421827064736399}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &3926509358578163534 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6958597445833160129, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8020157125073601734
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3926509358578163534}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &3956520269656778220 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6918732780190388067, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6179161786983257240
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3956520269656778220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &5013824694198213387 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1403023058664108420, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7527244801511634112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5013824694198213387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &5634167592825318357 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1791501796716429658, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5677032354506893644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5634167592825318357}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &5895951136704436539 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 522000452717065140, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
@@ -1049,6 +1334,40 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1e79e296834574c5d9138852d94c8998, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &6294105080135867079 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 123008750014820424, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7922773845728300772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6294105080135867079}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &6700542970533259801 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 725423291212169366, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2364712205575480545
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6700542970533259801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &6832696990180888932 stripped
@@ -1098,6 +1417,23 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 4309115723449902765, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
   m_PrefabInstance: {fileID: 6263421827064736399}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &7950576152862817393 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4087643471237306110, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2057566881753167750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7950576152862817393}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &8294393226662565609 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2735864510102371430, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
@@ -1118,5 +1454,22 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &8978936465797594557 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3060112194134185778, guid: 8db4ddf43eb52a540b85b9b0e0d801c4, type: 3}
+  m_PrefabInstance: {fileID: 6263421827064736399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8908873029571800525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8978936465797594557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/CreateOrEditCommunityPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/Prefabs/CreateOrEditCommunityPanel.prefab
@@ -1437,6 +1437,7 @@ RectTransform:
   - {fileID: 5984716159671197510}
   - {fileID: 6931780519488334876}
   - {fileID: 609967523698490458}
+  - {fileID: 8023113490154964779}
   m_Father: {fileID: 2448521439946456097}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -4582,6 +4583,76 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &8797548974337873321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8023113490154964779}
+  - component: {fileID: 5107625082857801499}
+  - component: {fileID: 4900753111784362697}
+  m_Layer: 5
+  m_Name: MembershipSelector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8023113490154964779
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8797548974337873321}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7535371701229009271}
+  m_Father: {fileID: 71727479616604118}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 300, y: -56}
+  m_SizeDelta: {x: 600, y: 46}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &5107625082857801499
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8797548974337873321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: 46
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &4900753111784362697
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8797548974337873321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &9037660316711040665
 GameObject:
   m_ObjectHideFlags: 0
@@ -5312,6 +5383,244 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &7201514098701045560
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8023113490154964779}
+    m_Modifications:
+    - target: {fileID: 370049769538891734, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_Name
+      value: MembershipDropdown
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 46
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1726448438995543707, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: selectorPanelParent
+      value: 
+      objectReference: {fileID: 3343914997614938543}
+    - target: {fileID: 4529298168230838044, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5372504944368239235, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5372504944368239235, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5372504944368239235, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5372504944368239235, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5372504944368239235, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7978578151363091665, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7978578151363091665, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 370049769538891734, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3354026920866073315}
+    - targetCorrespondingSourceObject: {fileID: 4613002614331865853, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 164105563684865535}
+    - targetCorrespondingSourceObject: {fileID: 6612341601901254000, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8380625784675777543}
+    - targetCorrespondingSourceObject: {fileID: 4828902878626993870, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1243101679941892174}
+    - targetCorrespondingSourceObject: {fileID: 1494069765180602260, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6900436483014765968}
+  m_SourcePrefab: {fileID: 100100000, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+--- !u!1 &2374346430797535734 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4828902878626993870, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+  m_PrefabInstance: {fileID: 7201514098701045560}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1243101679941892174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2374346430797535734}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2590774323228308933 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4613002614331865853, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+  m_PrefabInstance: {fileID: 7201514098701045560}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &164105563684865535
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2590774323228308933}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &4049628103286692424 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6612341601901254000, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+  m_PrefabInstance: {fileID: 7201514098701045560}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8380625784675777543
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4049628103286692424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7409059811978879214 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 370049769538891734, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+  m_PrefabInstance: {fileID: 7201514098701045560}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3354026920866073315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7409059811978879214}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &7535371701229009271 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 820761557570041423, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+  m_PrefabInstance: {fileID: 7201514098701045560}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8596503503780100268 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1494069765180602260, guid: 88d41137eeb023244b6d3150a2a81174, type: 3}
+  m_PrefabInstance: {fileID: 7201514098701045560}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6900436483014765968
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8596503503780100268}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7870855987865533293
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5487,6 +5796,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: MembershipToogleGroup
       objectReference: {fileID: 0}
+    - target: {fileID: 3221873678144687217, guid: fe0f91b5a19f4be42b3909c610e977f5, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7871806658679262717, guid: fe0f91b5a19f4be42b3909c610e977f5, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -5558,7 +5871,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8669832226481238598, guid: fe0f91b5a19f4be42b3909c610e977f5, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 8669832226481238598, guid: fe0f91b5a19f4be42b3909c610e977f5, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Explorer/Assets/DCL/UI/Assets/SelectorButton.prefab
+++ b/Explorer/Assets/DCL/UI/Assets/SelectorButton.prefab
@@ -270,6 +270,8 @@ MonoBehaviour:
   optionItemGameObject: {fileID: 1261629992894967956}
   backgroundCloseButton: {fileID: 7424665203201326611}
   defaultPoolCapacity: 10
+  changeSelectorButtonTextOnOptionSelected: 0
+  showSelectedMarkOnOptionSelected: 0
 --- !u!1 &568733401536827907
 GameObject:
   m_ObjectHideFlags: 0
@@ -339,6 +341,7 @@ RectTransform:
   m_Children:
   - {fileID: 9020296309833072249}
   - {fileID: 6698667960263727816}
+  - {fileID: 1759821752412147950}
   m_Father: {fileID: 4529298168230838044}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -405,6 +408,9 @@ MonoBehaviour:
   <Button>k__BackingField: {fileID: 8706506989951255970}
   <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7, type: 2}
   <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
+  <images>k__BackingField: []
+  interactableColor: {r: 1, g: 1, b: 1, a: 1}
+  hoverColor: {r: 0.54, g: 0.54, b: 0.54, a: 1}
 --- !u!114 &1261629992894967956
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -419,6 +425,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   optionButton: {fileID: 8706506989951255970}
   optionText: {fileID: 8782468501516622616}
+  selectedMark: {fileID: 5450490487784895507}
 --- !u!1 &1494069765180602260
 GameObject:
   m_ObjectHideFlags: 0
@@ -436,7 +443,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &5196600299966827827
 RectTransform:
   m_ObjectHideFlags: 0
@@ -802,6 +809,9 @@ MonoBehaviour:
   <Button>k__BackingField: {fileID: 6430276237837877534}
   <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7, type: 2}
   <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
+  <images>k__BackingField: []
+  interactableColor: {r: 1, g: 1, b: 1, a: 1}
+  hoverColor: {r: 0.54, g: 0.54, b: 0.54, a: 1}
 --- !u!1 &4828902878626993870
 GameObject:
   m_ObjectHideFlags: 0
@@ -974,7 +984,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 2.9415283, y: 0.000061035156}
-  m_SizeDelta: {x: 5.8831, y: 20}
+  m_SizeDelta: {x: 5.8831, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &4360673372053178369
 MonoBehaviour:
@@ -1016,6 +1026,81 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 1
+--- !u!1 &5450490487784895507
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1759821752412147950}
+  - component: {fileID: 4577407161746160768}
+  - component: {fileID: 5009269239716976875}
+  m_Layer: 5
+  m_Name: SelectedMarkImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1759821752412147950
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5450490487784895507}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5372504944368239235}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -10, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &4577407161746160768
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5450490487784895507}
+  m_CullTransparentMesh: 1
+--- !u!114 &5009269239716976875
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5450490487784895507}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.454902, b: 0.22352943, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 83f2ed27562d744b3a2590374eb3d5b5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6612341601901254000
 GameObject:
   m_ObjectHideFlags: 0
@@ -1380,7 +1465,7 @@ RectTransform:
   m_Father: {fileID: 2429785461079363608}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.99999976}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Explorer/Assets/DCL/UI/SelectorButton/SelectorButtonOptionItemView.cs
+++ b/Explorer/Assets/DCL/UI/SelectorButton/SelectorButtonOptionItemView.cs
@@ -12,9 +12,11 @@ namespace DCL.UI.SelectorButton
 
         [SerializeField] private Button? optionButton;
         [SerializeField] private TMP_Text? optionText;
+        [SerializeField] private GameObject? selectedMark;
 
         public string OptionTitle => optionText != null ? optionText.text : string.Empty;
         public bool IsHidden => !this.gameObject.activeSelf;
+        public bool IsSelected { get; set; }
 
         private void OnEnable() =>
             optionButton?.onClick.AddListener(OnClick);
@@ -35,6 +37,9 @@ namespace DCL.UI.SelectorButton
             this.gameObject.SetActive(!isHidden);
             VisibilityChanged?.Invoke();
         }
+
+        public void SetSelectedMarkActive(bool isActive) =>
+            selectedMark?.SetActive(isActive);
 
         private void OnClick() =>
             Clicked?.Invoke(this);

--- a/Explorer/Assets/DCL/UI/SelectorButton/SelectorButtonView.cs
+++ b/Explorer/Assets/DCL/UI/SelectorButton/SelectorButtonView.cs
@@ -24,6 +24,37 @@ namespace DCL.UI.SelectorButton
         [SerializeField] private SelectorButtonOptionItemView optionItemGameObject;
         [SerializeField] private Button backgroundCloseButton;
         [SerializeField] private int defaultPoolCapacity = 10;
+        [SerializeField] private bool changeSelectorButtonTextOnOptionSelected = false;
+        [SerializeField] private bool showSelectedMarkOnOptionSelected = false;
+
+        public int SelectedIndex
+        {
+            get
+            {
+                for (int i = 0; i < currentOptions.Count; i++)
+                {
+                    if (currentOptions[i].IsSelected)
+                        return i;
+                }
+
+                return -1;
+            }
+
+            set
+            {
+                if (value < 0 || value >= currentOptions.Count)
+                    return;
+
+                for (int i = 0; i < currentOptions.Count; i++)
+                {
+                    currentOptions[i].IsSelected = i == value;
+                    currentOptions[i].SetSelectedMarkActive(showSelectedMarkOnOptionSelected && i == value);
+
+                    if (changeSelectorButtonTextOnOptionSelected && i == value)
+                        SetMainButtonText(currentOptions[i].OptionTitle);
+                }
+            }
+        }
 
         private IObjectPool<SelectorButtonOptionItemView> optionsPool;
         private readonly List<SelectorButtonOptionItemView> currentOptions = new ();
@@ -104,6 +135,9 @@ namespace DCL.UI.SelectorButton
             return null;
         }
 
+        public void SetAsInteractable(bool isInteractable) =>
+            selectorButton.interactable = isInteractable;
+
         private void ClearOptions()
         {
             foreach (SelectorButtonOptionItemView optionItemView in currentOptions)
@@ -119,6 +153,7 @@ namespace DCL.UI.SelectorButton
             if (index < 0)
                 return;
 
+            SelectedIndex = index;
             OptionClicked?.Invoke(index);
             OnCloseOptionsPanel();
         }


### PR DESCRIPTION
# Pull Request Description
Fix #5135 

## What does this PR change?
- Increase bottom margin for ‘My communities’ scrollview.

<img width="320" height="801" alt="image" src="https://github.com/user-attachments/assets/7bc87cdb-5e2c-4e91-9d75-4bf7ddb35d47" />

- Fix ‘Invites & Request’ tint button colors:
```
Idle: #FFFFFF transparency 0%
Hover: #FFFFFF transparency 5%
Pressed: #FFFFFF transparency 3%
Selected: #FFFFFF transparency 0%
```

<img width="320" height="276" alt="image" src="https://github.com/user-attachments/assets/677c290a-f9b4-4029-8d81-7f690de226d4" />

- Change the private/public selector in the Wizard by a dropdown.

<img width="664" height="712" alt="image" src="https://github.com/user-attachments/assets/c7ebce32-d1ad-45e3-869b-b1a6cd21e97b" />

### Test Steps
- Check the visual refinements described in the description above.
- Test the Community creation/edition flow, specially the change of the privacy between "Public" and "Private".

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.