### PR TITLE
fix: jump to event location

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
@@ -114,12 +114,7 @@ namespace MVC
 
             // Hide all popups in the stack and clear it
             if (overlayPushInfo.PopupControllers != null)
-            {
-                foreach ((IController controller, int orderInLayer) popupController in overlayPushInfo.PopupControllers)
-                    popupController.controller.HideViewAsync(ct).Forget();
-
-                overlayPushInfo.PopupControllers.Clear();
-            }
+                CloseAllPopups(overlayPushInfo.PopupControllers, ct);
 
             // Hide fullscreen UI if any
             if (overlayPushInfo.FullscreenController != null)
@@ -155,6 +150,15 @@ namespace MVC
             }
         }
 
+        private void CloseAllPopups(List<(IController, int)> popupControllers, CancellationToken ct)
+        {
+            // Hide all popups in the stack and clear it
+            for (int i = popupControllers.Count - 1; i >= 0; i--)
+                popupControllers[i].Item1.HideViewAsync(ct).Forget();
+
+            popupControllers.Clear();
+        }
+
         private async UniTask ShowFullScreenAsync<TView, TInputData>(ShowCommand<TView, TInputData> command, IController controller, CancellationToken ct)
             where TView: IView
         {
@@ -166,11 +170,7 @@ namespace MVC
 
             try
             {
-                // Hide all popups in the stack and clear it
-                for (int i = fullscreenPushInfo.PopupControllers.Count - 1; i >= 0; i--)
-                    fullscreenPushInfo.PopupControllers[i].Item1.HideViewAsync(ct).Forget();
-
-                fullscreenPushInfo.PopupControllers.Clear();
+                CloseAllPopups(fullscreenPushInfo.PopupControllers, ct);
 
                 // Hide the popup closer
                 popupCloser.HideAsync(ct).Forget();


### PR DESCRIPTION
# Pull Request Description
Fixes #5121 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR fixes the process of closing all popups when an overlay is pushed avoiding the modification of the iterated collection.

This fixes the jump to an event location from a community event info panel.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Verify the steps described in the linked issue


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
