### PR TITLE
fix: disable event interested counter in community card

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListItemView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListItemView.cs
@@ -90,7 +90,8 @@ namespace DCL.Communities.CommunitiesCard.Events
         public void UpdateInterestedCounter()
         {
             eventInterestedUsersText.text = eventData!.Value.Event.total_attendees.ToString();
-            interestedContainer.SetActive(eventData!.Value.Event is { live: false, total_attendees: > 0 });
+            //Disabled because of https://github.com/decentraland/unity-explorer/issues/5154. Old condition: eventData!.Value.Event is { live: false, total_attendees: > 0 }
+            interestedContainer.SetActive(false);
         }
 
         public void SubscribeToInteractions(Action<PlaceAndEventDTO> mainAction,

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListItemView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListItemView.cs
@@ -89,9 +89,12 @@ namespace DCL.Communities.CommunitiesCard.Events
 
         public void UpdateInterestedCounter()
         {
-            eventInterestedUsersText.text = eventData!.Value.Event.total_attendees.ToString();
-            //Disabled because of https://github.com/decentraland/unity-explorer/issues/5154. Old condition: eventData!.Value.Event is { live: false, total_attendees: > 0 }
+            //Disabled because of https://github.com/decentraland/unity-explorer/issues/5154
             interestedContainer.SetActive(false);
+            return;
+
+            eventInterestedUsersText.text = eventData!.Value.Event.total_attendees.ToString();
+            interestedContainer.SetActive(eventData!.Value.Event is { live: false, total_attendees: > 0 });
         }
 
         public void SubscribeToInteractions(Action<PlaceAndEventDTO> mainAction,


### PR DESCRIPTION
# Pull Request Description
Fixes #5154 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR disables the activation of the counter of the amount of people interested in a given event of a community event in the community passport.

The prefab and logic are still present (as the whole community feature requirements are often changing), only the activation logic has been modified.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. This can be also tested by checking already existing community events
2. Follow the steps described in the issue (if you go this route, you may want to test in `zone` since new events need approval)

### Additional Testing Notes
- Can be tested in both `org` and `zone`

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
