### PR TITLE
fix: avatar shape parenting

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
@@ -34,7 +34,7 @@ namespace DCL.PluginSystem.World
         {
             ResetDirtyFlagSystem<PBAvatarShape>.InjectToWorld(ref builder);
             finalizeWorldSystems.Add(AvatarShapeHandlerSystem.InjectToWorld(ref builder, globalWorld, globalTransformPool, sharedDependencies.SceneData, launchMode.CurrentMode == LaunchMode.LocalSceneDevelopment));
-            UpdateAvatarShapeInterpolateMovementSystem.InjectToWorld(ref builder, globalWorld, sharedDependencies.SceneData.SceneShortInfo.BaseParcel);
+            UpdateAvatarShapeInterpolateMovementSystem.InjectToWorld(ref builder, globalWorld);
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/UpdateAvatarShapeInterpolateMovementSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/UpdateAvatarShapeInterpolateMovementSystem.cs
@@ -9,6 +9,7 @@ using DCL.SDKComponents.Tween.Components;
 using ECS.Abstract;
 using ECS.Groups;
 using ECS.Unity.AvatarShape.Components;
+using ECS.Unity.Transforms.Components;
 using ECS.Unity.Transforms.Systems;
 using UnityEngine;
 using Utility;
@@ -16,7 +17,7 @@ using Utility;
 namespace DCL.SDKComponents.AvatarShape.Systems
 {
     [UpdateInGroup(typeof(SyncedSimulationSystemGroup))]
-    [UpdateBefore(typeof(UpdateTransformSystem))]
+    [UpdateAfter(typeof(UpdateTransformSystem))]
     [LogCategory(ReportCategory.AVATAR)]
     public partial class UpdateAvatarShapeInterpolateMovementSystem : BaseUnityLoopSystem
     {
@@ -37,18 +38,18 @@ namespace DCL.SDKComponents.AvatarShape.Systems
 
         [Query]
         [None(typeof(SDKTweenComponent))]
-        private void UpdateAvatarInterpolationMovement(in SDKAvatarShapeComponent sdkAvatarShapeComponent, in SDKTransform sdkTransform)
+        private void UpdateAvatarInterpolationMovement(in SDKAvatarShapeComponent sdkAvatarShapeComponent, in SDKTransform sdkTransform, in TransformComponent transform)
         {
             if (!sdkTransform.IsDirty)
                 return;
 
-            UpdateInterpolationMovement(in sdkAvatarShapeComponent, in sdkTransform, false, false);
+            UpdateInterpolationMovement(in sdkAvatarShapeComponent, in transform, false, false);
         }
 
         [Query]
         private void UpdateAvatarWithTweenInterpolationMovement(
             in SDKAvatarShapeComponent sdkAvatarShapeComponent,
-            in SDKTransform sdkTransform,
+            in TransformComponent transform,
             in SDKTweenComponent sdkTweenComponent)
         {
             if ((sdkTweenComponent.TweenMode != PBTween.ModeOneofCase.Move && sdkTweenComponent.TweenMode != PBTween.ModeOneofCase.Rotate) ||
@@ -57,14 +58,14 @@ namespace DCL.SDKComponents.AvatarShape.Systems
 
             UpdateInterpolationMovement(
                 in sdkAvatarShapeComponent,
-                in sdkTransform,
+                in transform,
                 sdkTweenComponent.TweenMode == PBTween.ModeOneofCase.Move,
                 sdkTweenComponent.TweenMode == PBTween.ModeOneofCase.Rotate);
         }
 
         private void UpdateInterpolationMovement(
             in SDKAvatarShapeComponent sdkAvatarShapeComponent,
-            in SDKTransform sdkTransform,
+            in TransformComponent transform,
             bool isPositionManagedByTween,
             bool isRotationManagedByTween)
         {
@@ -75,8 +76,8 @@ namespace DCL.SDKComponents.AvatarShape.Systems
             if (!hasCharacterInterpolationMovement)
                 return;
 
-            characterInterpolationMovementComponent.TargetPosition = sdkTransform.Position.Value.FromSceneRelativeToGlobalPosition(sceneBaseParcel);
-            characterInterpolationMovementComponent.TargetRotation = sdkTransform.Rotation.Value;
+            characterInterpolationMovementComponent.TargetPosition = transform.Cached.WorldPosition;
+            characterInterpolationMovementComponent.TargetRotation = transform.Cached.WorldRotation;
             characterInterpolationMovementComponent.IsPositionManagedByTween = isPositionManagedByTween;
             characterInterpolationMovementComponent.IsRotationManagedByTween = isRotationManagedByTween;
         }

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/UpdateAvatarShapeInterpolateMovementSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/UpdateAvatarShapeInterpolateMovementSystem.cs
@@ -12,7 +12,6 @@ using ECS.Unity.AvatarShape.Components;
 using ECS.Unity.Transforms.Components;
 using ECS.Unity.Transforms.Systems;
 using UnityEngine;
-using Utility;
 
 namespace DCL.SDKComponents.AvatarShape.Systems
 {
@@ -22,12 +21,10 @@ namespace DCL.SDKComponents.AvatarShape.Systems
     public partial class UpdateAvatarShapeInterpolateMovementSystem : BaseUnityLoopSystem
     {
         private readonly World globalWorld;
-        private readonly Vector2Int sceneBaseParcel;
 
-        private UpdateAvatarShapeInterpolateMovementSystem(World world, World globalWorld, Vector2Int sceneBaseParcel) : base(world)
+        private UpdateAvatarShapeInterpolateMovementSystem(World world, World globalWorld) : base(world)
         {
             this.globalWorld = globalWorld;
-            this.sceneBaseParcel = sceneBaseParcel;
         }
 
         protected override void Update(float t)


### PR DESCRIPTION
# Pull Request Description

Fixes https://github.com/decentraland/unity-explorer/issues/5100

## What does this PR change?
The `UpdateAvatarShapeInterpolateMovementSystem` system was storing the target position of the avatar shapes in local space, but the `SDKAvatarShapesMotionSystem` actually sets the world position of the game object when interpolating to it.

The fix consists of using world space target position in `UpdateAvatarShapeInterpolateMovementSystem` too.

Same applies to rotation.

## Test Instructions
1. The test scene repository is linked in the ticket, but here's the [SCENE](https://drive.google.com/file/d/1Y7tRosPUssM_5AB0Jjh0Y2vaD5fErnpS/view?usp=sharing) in zip format, probably easier to just download it
2. Run the scene locally
3. There's a little button in the top right corner of the screen, partially hidden by the debug menu. It can be pressed if the mouse is positioned carefully (refer to the attached video please)
4. Select the action as shown in the video
5. You'll see in the video that you can cycle through 3 objects
6. Their positions should be as in the video and the displayed wearables should display NO animation
7. NOTICE one of the wearables -- some shoes -- is below the ground. This is OK (the value comes from a spreadsheet, the client is applying it correctly)

https://github.com/user-attachments/assets/8ece903f-431a-470e-97e6-8d495a5dda0e

## Quality Checklist
- [x] Changes have been tested locally
