### PR TITLE
fix: community members thumbnail not loading

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityFetchingControllerBase.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityFetchingControllerBase.cs
@@ -47,15 +47,12 @@ namespace DCL.Communities.CommunitiesCard
 
             try
             {
-
                 SectionFetchData<T> membersData = currentSectionFetchData;
 
                 view.SetEmptyStateActive(false);
 
                 if (membersData.PageNumber == 0)
                     view.SetLoadingStateActive(true);
-
-                int count = membersData.Items.Count;
 
                 membersData.PageNumber++;
                 membersData.TotalToFetch = await FetchDataAsync(ct);
@@ -65,7 +62,7 @@ namespace DCL.Communities.CommunitiesCard
 
                 view.SetEmptyStateActive(membersData.TotalToFetch == 0);
 
-                view.RefreshGrid(currentSectionFetchData, true);
+                view.RefreshGrid(currentSectionFetchData, membersData.PageNumber > 1);
             }
             finally { isFetching = false; }
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR prevents the looplist to be refreshed while the thumbnails are loading, causing cancellation to happen -> no thumbnails.

It applies the refresh only after the second fetched page, since only updating the looplist item count causes the duplication of some elements as described and addressed [here](https://github.com/decentraland/unity-explorer/pull/5059)

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Open the community passport of a community with more than 20 members (at the time of writing, `Teemo fans`), scroll down and verify that no duplicates are shown
2. Verify that members thumbnails are generally shown (it can happen that some are not loaded straight away because the backend is still producing them)
3. Check that members thumbnails are shown in other communities as well (< 20 members)
4. Verify that all community passport sections load correctly (members and all its subsections, places and events)


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
