### PR TITLE
fix: reward popup softlock

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -848,7 +848,7 @@ namespace Global.Dynamic
                     notificationsBusController,
                     notificationsRequestController,
                     identityCache),
-                new RewardPanelPlugin(mvcManager, assetsProvisioner, notificationsBusController, staticContainer.WebRequestsContainer.WebRequestController),
+                new RewardPanelPlugin(mvcManager, assetsProvisioner, notificationsBusController, staticContainer.WebRequestsContainer.WebRequestController, dclCursor),
                 new PassportPlugin(
                     assetsProvisioner,
                     mvcManager,

--- a/Explorer/Assets/DCL/PluginSystem/Global/RewardPanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/RewardPanelPlugin.cs
@@ -2,6 +2,7 @@ using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
 using DCL.Backpack;
+using DCL.Input;
 using DCL.NotificationsBusController.NotificationsBus;
 using DCL.NotificationsBusController.NotificationTypes;
 using DCL.RewardPanel;
@@ -20,13 +21,15 @@ namespace DCL.PluginSystem.Global
         private readonly IAssetsProvisioner assetsProvisioner;
         private readonly INotificationsBusController notificationsBusController;
         private readonly IWebRequestController webRequestController;
+        private readonly ICursor cursor;
 
-        public RewardPanelPlugin(IMVCManager mvcManager, IAssetsProvisioner assetsProvisioner, INotificationsBusController notificationsBusController, IWebRequestController webRequestController)
+        public RewardPanelPlugin(IMVCManager mvcManager, IAssetsProvisioner assetsProvisioner, INotificationsBusController notificationsBusController, IWebRequestController webRequestController, ICursor cursor)
         {
             this.mvcManager = mvcManager;
             this.assetsProvisioner = assetsProvisioner;
             this.notificationsBusController = notificationsBusController;
             this.webRequestController = webRequestController;
+            this.cursor = cursor;
 
             this.notificationsBusController.SubscribeToNotificationTypeReceived(NotificationType.REWARD_IN_PROGRESS, OnNewRewardReceived);
         }
@@ -51,7 +54,7 @@ namespace DCL.PluginSystem.Global
             NftTypeIconSO rarityBackgroundsMapping = await assetsProvisioner.ProvideMainAssetValueAsync(settings.RarityBackgroundsMapping, ct);
             NftTypeIconSO categoryIconsMapping = await assetsProvisioner.ProvideMainAssetValueAsync(settings.CategoryIconsMapping, ct);
             RewardPanelView rewardPanelView = (await assetsProvisioner.ProvideMainAssetAsync(settings.RewardPanelView, ct: ct)).Value.GetComponent<RewardPanelView>();
-            RewardPanelController rewardPanelController = new RewardPanelController(RewardPanelController.CreateLazily(rewardPanelView, null), webRequestController, nftRarityColors, rarityBackgroundsMapping, categoryIconsMapping);
+            RewardPanelController rewardPanelController = new RewardPanelController(RewardPanelController.CreateLazily(rewardPanelView, null), webRequestController, nftRarityColors, rarityBackgroundsMapping, categoryIconsMapping, cursor);
             mvcManager.RegisterController(rewardPanelController);
         }
 

--- a/Explorer/Assets/DCL/RewardPanel/RewardPanelController.cs
+++ b/Explorer/Assets/DCL/RewardPanel/RewardPanelController.cs
@@ -1,5 +1,6 @@
 using Cysharp.Threading.Tasks;
 using DCL.Backpack;
+using DCL.Input;
 using DCL.UI;
 using DCL.WebRequests;
 using MVC;
@@ -13,21 +14,26 @@ namespace DCL.RewardPanel
         private readonly NFTColorsSO nftRarityColors;
         private readonly NftTypeIconSO nftRarityBackgrounds;
         private readonly NftTypeIconSO nftCategoryIcons;
-        public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Popup;
+        private readonly ICursor cursor;
+
         private ImageController imageController;
+
+        public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.Popup;
 
         public RewardPanelController(
             ViewFactoryMethod viewFactory,
             IWebRequestController webRequestController,
             NFTColorsSO nftRarityColors,
             NftTypeIconSO nftRarityBackgrounds,
-            NftTypeIconSO nftCategoryIcons
+            NftTypeIconSO nftCategoryIcons,
+            ICursor cursor
         ) : base(viewFactory)
         {
             this.webRequestController = webRequestController;
             this.nftRarityColors = nftRarityColors;
             this.nftRarityBackgrounds = nftRarityBackgrounds;
             this.nftCategoryIcons = nftCategoryIcons;
+            this.cursor = cursor;
         }
 
         protected override void OnViewInstantiated()
@@ -45,6 +51,8 @@ namespace DCL.RewardPanel
             viewInstance.RarityMark.color = nftRarityColors.GetColor(inputData.Rarity);
             viewInstance.RarityBackground.sprite = nftRarityBackgrounds.GetTypeImage(inputData.Rarity);
             viewInstance.CategoryImage.sprite = nftCategoryIcons.GetTypeImage(inputData.Category);
+
+            cursor.Unlock();
         }
 
         protected override UniTask WaitForCloseIntentAsync(CancellationToken ct) =>


### PR DESCRIPTION
# Pull Request Description

This PR will make sure the mouse cursor is unlocked when the reward popup appears.

## What does this PR change?
Makes the `RewardPanelController` unlock the cursor whenever the popup view is displayed.

## Test Instructions
At the moment the only way I could test this properly was to make a new account and play the onboarding scene till I get the reward for the completing the emote quest.

Make sure the mouse is in the locked state (not visible) before receiving the reward.

## Quality Checklist
- [x] Changes have been tested locally