### PR TITLE
fix: passport white rectangle while profile is loading

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -448,6 +448,7 @@ namespace DCL.AuthenticationScreenFlow
                     viewInstance.VerificationCodeHintContainer.SetActive(false);
                     viewInstance.RestrictedUserContainer.SetActive(false);
                     viewInstance.JumpIntoWorldButton.interactable = true;
+                    characterPreviewController?.OnBeforeShow();
                     characterPreviewController?.OnShow();
 
                     break;

--- a/Explorer/Assets/DCL/Backpack/BackpackController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackController.cs
@@ -204,6 +204,7 @@ namespace DCL.Backpack
             backpackSections[currentSection].Activate();
 
             view.gameObject.SetActive(true);
+            backpackCharacterPreviewController.OnBeforeShow();
             backpackCharacterPreviewController.OnShow();
 
             foreach ((BackpackSections section, TabSelectorView? tab) in tabsBySections)

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
@@ -185,6 +185,11 @@ namespace DCL.CharacterPreview
             }
         }
 
+        public void OnBeforeShow()
+        {
+            EnableSpinner();
+        }
+
         /// <summary>
         /// Shows the character preview.
         /// </summary>
@@ -246,7 +251,6 @@ namespace DCL.CharacterPreview
         protected void OnModelUpdated()
         {
             updateModelCancellationToken = updateModelCancellationToken.SafeRestart();
-
             UpdateModelAsync(updateModelCancellationToken.Token).Forget();
             return;
 

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -511,6 +511,11 @@ namespace DCL.Passport
                 if (EnumUtils.HasFlag(alreadyLoadedSections, sectionToLoad))
                     return;
 
+                // Ensure the view is initialized before fetching the profile to prevent rendering artifacts
+                // that may appear while the profile is still loading
+                if (sectionToLoad == PassportSection.OVERVIEW)
+                    characterPreviewController!.OnBeforeShow();
+
                 // Load user profile
                 Profile? profile = await profileRepository.GetAsync(userId, 0, remoteMetadata.GetLambdaDomainOrNull(userId), ct);
 
@@ -637,7 +642,10 @@ namespace DCL.Passport
             previewGO.SetActive(visible);
 
             if (visible)
+            {
+                characterPreviewController?.OnBeforeShow();
                 characterPreviewController?.OnShow(triggerOnShowBusEvent);
+            }
             else
                 characterPreviewController?.OnHide(triggerOnShowBusEvent);
         }


### PR DESCRIPTION
## What does this PR change?

Fixes #5182 

Changes add a new method `OnBeforeShow` to the avatar preview, that setups the view as loading and its called before the profile starts loading. This prevents the avatar's raw render image to be displayed with empty data.

## Test Instructions

Open the friends panel, and click on your friends. Check that the passport is open and you don't see a white rectangle.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
