### PR TITLE
fix: replace jump to genesis city to reload scene in preview mode

### DIFF
--- a/Explorer/Assets/DCL/Chat/Commands/ChatTeleporter.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ChatTeleporter.cs
@@ -82,6 +82,7 @@ namespace DCL.Chat.Commands
                        ChangeRealmError.SameRealm => $"🟡 You are already in {realm}!",
                        ChangeRealmError.NotReachable => $"🔴 Error. The world {realm} doesn't exist or not reachable!",
                        ChangeRealmError.ChangeCancelled => "🔴 Error. The operation was canceled!",
+                       ChangeRealmError.LocalSceneDevelopmentBlocked => "🔴 Error. Realm changes are not allowed in local scene development mode",
                        _ => throw new ArgumentOutOfRangeException()
                    };
         }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Realm/IRealmNavigator.cs
@@ -13,6 +13,7 @@ namespace ECS.SceneLifeCycle.Realm
         ChangeCancelled,
         SameRealm,
         NotReachable,
+        LocalSceneDevelopmentBlocked
     }
 
     public static class ChangeRealmErrors
@@ -24,6 +25,7 @@ namespace ECS.SceneLifeCycle.Realm
                 ChangeRealmError.ChangeCancelled => TaskError.Cancelled,
                 ChangeRealmError.SameRealm => TaskError.MessageError,
                 ChangeRealmError.NotReachable => TaskError.MessageError,
+                ChangeRealmError.LocalSceneDevelopmentBlocked => TaskError.MessageError,
                 _ => throw new ArgumentOutOfRangeException(nameof(e), e, null)
             };
 
@@ -38,7 +40,7 @@ namespace ECS.SceneLifeCycle.Realm
             };
 
         public static bool IsRecoverable(this ChangeRealmError error) =>
-            error is ChangeRealmError.SameRealm or ChangeRealmError.NotReachable;
+            error is ChangeRealmError.SameRealm or ChangeRealmError.NotReachable or ChangeRealmError.LocalSceneDevelopmentBlocked;
     }
 
     public interface IRealmNavigator

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -548,6 +548,7 @@ namespace Global.Dynamic
                 sharedSpaceManager,
                 clipboard,
                 bootstrapContainer.DecentralandUrlsSource,
+                chatMessagesBus,
                 reloadSceneChatCommand
             );
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -489,6 +489,8 @@ namespace Global.Dynamic
                         ct
                     );
 
+            // TODO instantiate ReloadSceneChatCommand a single time since it is re-used
+
             var minimap = new MinimapController(
                 mainUIView.MinimapView.EnsureNotNull(),
                 mapRendererContainer.MapRenderer,
@@ -502,7 +504,8 @@ namespace Global.Dynamic
                 dynamicWorldParams.StartParcel.Peek(),
                 sharedSpaceManager,
                 clipboard,
-                bootstrapContainer.DecentralandUrlsSource
+                bootstrapContainer.DecentralandUrlsSource,
+                new ReloadSceneChatCommand(reloadSceneController, globalWorld, playerEntity, staticContainer.ScenesCache, teleportController, localSceneDevelopment)
             );
 
             var worldInfoHub = new LocationBasedWorldInfoHub(

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -489,25 +489,6 @@ namespace Global.Dynamic
                         ct
                     );
 
-            // TODO instantiate ReloadSceneChatCommand a single time since it is re-used
-
-            var minimap = new MinimapController(
-                mainUIView.MinimapView.EnsureNotNull(),
-                mapRendererContainer.MapRenderer,
-                mvcManager,
-                placesAPIService,
-                staticContainer.RealmData,
-                realmNavigator,
-                staticContainer.ScenesCache,
-                mapPathEventBus,
-                staticContainer.SceneRestrictionBusController,
-                dynamicWorldParams.StartParcel.Peek(),
-                sharedSpaceManager,
-                clipboard,
-                bootstrapContainer.DecentralandUrlsSource,
-                new ReloadSceneChatCommand(reloadSceneController, globalWorld, playerEntity, staticContainer.ScenesCache, teleportController, localSceneDevelopment)
-            );
-
             var worldInfoHub = new LocationBasedWorldInfoHub(
                 new WorldInfoHub(staticContainer.SingletonSharedDependencies.SceneMapping),
                 staticContainer.CharacterContainer.CharacterObject
@@ -521,6 +502,8 @@ namespace Global.Dynamic
 
             var chatTeleporter = new ChatTeleporter(realmNavigator, new ChatEnvironmentValidator(bootstrapContainer.Environment), bootstrapContainer.DecentralandUrlsSource);
 
+            var reloadSceneChatCommand = new ReloadSceneChatCommand(reloadSceneController, globalWorld, playerEntity, staticContainer.ScenesCache, teleportController, localSceneDevelopment);
+
             var chatCommands = new List<IChatCommand>
             {
                 new GoToChatCommand(chatTeleporter, staticContainer.WebRequestsContainer.WebRequestController, bootstrapContainer.DecentralandUrlsSource),
@@ -528,7 +511,7 @@ namespace Global.Dynamic
                 new WorldChatCommand(chatTeleporter),
                 new DebugPanelChatCommand(debugBuilder),
                 new ShowEntityChatCommand(worldInfoHub),
-                new ReloadSceneChatCommand(reloadSceneController, globalWorld, playerEntity, staticContainer.ScenesCache, teleportController, localSceneDevelopment),
+                reloadSceneChatCommand,
                 new LoadPortableExperienceChatCommand(staticContainer.PortableExperiencesController),
                 new KillPortableExperienceChatCommand(staticContainer.PortableExperiencesController),
                 new VersionChatCommand(dclVersion),
@@ -550,6 +533,23 @@ namespace Global.Dynamic
             IChatMessagesBus chatMessagesBus = dynamicWorldParams.EnableAnalytics
                 ? new ChatMessagesBusAnalyticsDecorator(coreChatMessageBus, bootstrapContainer.Analytics!, profileCache, selfProfile)
                 : coreChatMessageBus;
+
+            var minimap = new MinimapController(
+                mainUIView.MinimapView.EnsureNotNull(),
+                mapRendererContainer.MapRenderer,
+                mvcManager,
+                placesAPIService,
+                staticContainer.RealmData,
+                realmNavigator,
+                staticContainer.ScenesCache,
+                mapPathEventBus,
+                staticContainer.SceneRestrictionBusController,
+                dynamicWorldParams.StartParcel.Peek(),
+                sharedSpaceManager,
+                clipboard,
+                bootstrapContainer.DecentralandUrlsSource,
+                reloadSceneChatCommand
+            );
 
             var coreBackpackEventBus = new BackpackEventBus();
 

--- a/Explorer/Assets/DCL/Minimap/Minimap.asmdef
+++ b/Explorer/Assets/DCL/Minimap/Minimap.asmdef
@@ -30,7 +30,8 @@
         "GUID:5462d37de7d4344df8aade58a45b403e",
         "GUID:b97826ed91484ac1af953a8afc03316e",
         "GUID:91cf8206af184dac8e30eb46747e9939",
-        "GUID:99c2bc0e6d3e24728952ed68726bf91b"
+        "GUID:99c2bc0e6d3e24728952ed68726bf91b",
+        "GUID:4d7a7b59acaf5954db4a5fa15a5b160c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -24,6 +24,8 @@ using DCL.UI.GenericContextMenu.Controls.Configs;
 using DCL.UI.GenericContextMenuParameter;
 using DCL.UI.SharedSpaceManager;
 using DCL.Chat.Commands;
+using DCL.Chat.History;
+using DCL.Chat.MessageBus;
 using DG.Tweening;
 using ECS;
 using ECS.SceneLifeCycle;
@@ -48,6 +50,7 @@ namespace DCL.Minimap
             { "onboardingdcl.dcl.eth", "EXIT TUTORIAL" }
         };
         private const float ANIMATION_TIME = 0.2f;
+        private const string RELOAD_SCENE_COMMAND_ORIGIN = "minimap";
 
         private readonly IMapRenderer mapRenderer;
         private readonly IMVCManager mvcManager;
@@ -62,8 +65,9 @@ namespace DCL.Minimap
         private readonly ISharedSpaceManager sharedSpaceManager;
         private readonly ISystemClipboard systemClipboard;
         private readonly IDecentralandUrlsSource decentralandUrls;
-
+        private readonly IChatMessagesBus chatMessagesBus;
         private readonly ReloadSceneChatCommand reloadSceneCommand;
+
         private GenericContextMenu? contextMenu;
         private CancellationTokenSource? placesApiCts;
         private MapRendererTrackPlayerPosition mapRendererTrackPlayerPosition;
@@ -90,6 +94,7 @@ namespace DCL.Minimap
             ISharedSpaceManager sharedSpaceManager,
             ISystemClipboard systemClipboard,
             IDecentralandUrlsSource decentralandUrls,
+            IChatMessagesBus chatMessagesBus,
             ReloadSceneChatCommand reloadSceneCommand
         ) : base(() => minimapView)
         {
@@ -105,6 +110,7 @@ namespace DCL.Minimap
             this.sharedSpaceManager = sharedSpaceManager;
             this.systemClipboard = systemClipboard;
             this.decentralandUrls = decentralandUrls;
+            this.chatMessagesBus = chatMessagesBus;
             this.reloadSceneCommand = reloadSceneCommand;
             minimapView.SetCanvasActive(false);
             disposeCts = new CancellationTokenSource();
@@ -345,8 +351,11 @@ namespace DCL.Minimap
             }
             else
             {
-                buttonAction = () => reloadSceneCommand
-                                    .ExecuteCommandAsync(Array.Empty<string>(), disposeCts.Token).Forget();
+                buttonAction = () => chatMessagesBus.Send(
+                    ChatChannel.NEARBY_CHANNEL,
+                    $"/{reloadSceneCommand.Command}",
+                    RELOAD_SCENE_COMMAND_ORIGIN
+                );
             }
 
             viewInstance.goToGenesisCityButton.onClick.AddListener(buttonAction);

--- a/Explorer/Assets/DCL/RealmNavigation/RealmNavigator.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/RealmNavigator.cs
@@ -197,7 +197,7 @@ namespace DCL.RealmNavigation
             if (ct.IsCancellationRequested)
                 return EnumResult<TaskError>.CancelledResult(TaskError.Cancelled);
 
-            if (realmController.RealmData.IsLocalSceneDevelopment)
+            if (!isLocal && realmController.RealmData.IsLocalSceneDevelopment)
                 return EnumResult<TaskError>.ErrorResult(TaskError.MessageError, TELEPORT_NOT_ALLOWED_LOCAL_SCENE);
 
             Result parcelCheckResult = landscape.IsParcelInsideTerrain(parcel, isLocal);

--- a/Explorer/Assets/DCL/RealmNavigation/RealmNavigator.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/RealmNavigator.cs
@@ -22,6 +22,8 @@ namespace DCL.RealmNavigation
     public class RealmNavigator : IRealmNavigator
     {
         private const int MAX_REALM_CHANGE_RETRIES = 3;
+        private const string TELEPORT_NOT_ALLOWED_LOCAL_SCENE =
+            "Teleport is not allowed in local scene development mode";
 
         public event Action<Vector2Int>? NavigationExecuted;
 
@@ -85,6 +87,9 @@ namespace DCL.RealmNavigation
         {
             if (ct.IsCancellationRequested)
                 return EnumResult<ChangeRealmError>.ErrorResult(ChangeRealmError.ChangeCancelled);
+
+            if (realmController.RealmData.IsLocalSceneDevelopment)
+                return EnumResult<ChangeRealmError>.ErrorResult(ChangeRealmError.LocalSceneDevelopmentBlocked);
 
             if (CheckIsNewRealm(realm) == false)
                 return EnumResult<ChangeRealmError>.ErrorResult(ChangeRealmError.SameRealm);
@@ -191,6 +196,9 @@ namespace DCL.RealmNavigation
         {
             if (ct.IsCancellationRequested)
                 return EnumResult<TaskError>.CancelledResult(TaskError.Cancelled);
+
+            if (realmController.RealmData.IsLocalSceneDevelopment)
+                return EnumResult<TaskError>.ErrorResult(TaskError.MessageError, TELEPORT_NOT_ALLOWED_LOCAL_SCENE);
 
             Result parcelCheckResult = landscape.IsParcelInsideTerrain(parcel, isLocal);
 


### PR DESCRIPTION
# Pull Request Description
Replaced "JUMP BACK TO GENESIS CITY" with "RELOAD SCENE" in local scene preview, global teleporting has been disabled as well.

## What does this PR change?
The minimap button now reads "RELOAD SCENE" instead of "JUMP BACK TO GENESIS CITY" when in local scene preview.
In this mode the button actually executes the /reload command so that command feedback is shown in the chat panel.

Also, checks have been added to teleporting logic so that in local scene preview teleporting has been disabled to prevent inconsistencies and dedicated errors are displayed. Local teleporting is still allowed. 
See this comment: https://github.com/decentraland/unity-explorer/issues/3176#issuecomment-2988611958

NOTE:
Even though logic allows for local teleporting in local scene preview I found it to not be working, this is a pre-existing issue and should be addressed.
Also, the errors thrown by parcel teleporting send the user back to the authentication screen with an error popup, this is due to existing logic as well and should not be considered a bug in the context of this PR.

## Test Instructions
Verify that the new "RELOAD SCENE" button works as intended.
Also verify that teleporting is blocked in local scene preview and works as before in all other contexts.

### Test Steps
1. Launch a local scene preview
2. When inside the scene press the "RELOAD SCENE" minimap button
3. Verify that the scene reloads
4. Verify that a feedback message is shown in the chat panel (same as running the /reload command)
5. Verify that /goto <x,y> does not teleport the user and shows a dedicated error message instead
6. Verify that /goto NAME.dcl.eth does not teleport the user and shows a dedicated error message instead
7. Verify that /goto crowd does not teleport the user and shows a dedicated error message instead

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
