### PR TITLE
chore: updated launcher download urls

### DIFF
--- a/Explorer/Assets/DCL/ApplicationsGuards/ApplicationVersionGuard/ApplicationVersionGuard.cs
+++ b/Explorer/Assets/DCL/ApplicationsGuards/ApplicationVersionGuard/ApplicationVersionGuard.cs
@@ -25,10 +25,10 @@ namespace DCL.ApplicationVersionGuard
         private const string LAUNCHER_EXECUTABLE_FILENAME = "dcl_launcher.exe";
         private const string LAUNCHER_PATH_MAC = "/Applications/" + LAUNCHER_EXECUTABLE_NAME + ".app";
         private const string LEGACY_LAUNCHER_PATH_MAC = "/Applications/" + LEGACY_LAUNCHER_EXECUTABLE_NAME + ".app";
-        private const string DECENTRALAND_LAUNCHER_WIN_X64_EXE = "Decentraland_x64-setup.exe";
-        private const string DECENTRALAND_LAUNCHER_MAC_ARM_64DMG = "Decentraland_aarch64.dmg";
+        private const string DECENTRALAND_LAUNCHER_WIN_X64_EXE = "Decentraland_installer.exe";
+        private const string DECENTRALAND_LAUNCHER_MAC_ARM_64DMG = "Decentraland_installer.dmg";
         //Aga: Rust version of launcher does not support intel macs, until fully deprecating it, we need to keep the old launcher for intel based macs
-        private const string DECENTRALAND_LEGACY_LAUNCHER_MAC_X_64DMG = "Decentraland Launcher-mac-x64.dmg";
+        private const string DECENTRALAND_LEGACY_LAUNCHER_MAC_X_64DMG = "Decentraland Outdated-mac-x64.dmg";
 
         private readonly IWebRequestController webRequestController;
         private readonly IWebBrowser webBrowser;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Updated launcher download urls to match new names

They should match:
- macOS (Intel): https://explorer-artifacts.decentraland.org/launcher/dcl/Decentraland%20Outdated-mac-x64.dmg
- macOS (Apple Silicon): https://explorer-artifacts.decentraland.org/launcher-rust/Decentraland_installer.dmg
- Windows: https://explorer-artifacts.decentraland.org/launcher-rust/Decentraland_installer.exe
## Test Instructions

To trigger the popup us this command ".\Decentraland.exe" --simulateVersion 0.84.0-alpha

### Test Steps
1. Launcher should not be installed
2. Open client with force version check
3. Check the urls are downloading the launcher after clicking Update now button

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
