### PR TITLE
fix: scene emote propagation

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetEmotesByPointersIntention.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetEmotesByPointersIntention.cs
@@ -35,7 +35,7 @@ namespace DCL.AvatarRendering.Emotes
             SuccessfulPointers = POINTERS_HASHSET_POOL.Get();
             PermittedSources = permittedSources;
             BodyShape = bodyShape;
-            Timeout = new LoadTimeout(timeout);
+            Timeout = new LoadTimeout(timeout, 0);
         }
 
         public bool Equals(GetEmotesByPointersIntention other) =>
@@ -54,6 +54,14 @@ namespace DCL.AvatarRendering.Emotes
             POINTERS_HASHSET_POOL.Release(SuccessfulPointers);
             CancellationTokenSource.Cancel();
             isDisposed = true;
+        }
+
+        public bool IsTimeout(float dt)
+        {
+            // Timeout access returns a temporary value. We need to reassign the field or we lose the changes
+            Timeout = new LoadTimeout(Timeout.Timeout, Timeout.ElapsedTime + dt);
+            bool result = Timeout.IsTimeout;
+            return result;
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetSceneEmoteFromLocalSceneIntention.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetSceneEmoteFromLocalSceneIntention.cs
@@ -21,7 +21,7 @@ namespace DCL.AvatarRendering.Emotes
         public string EmoteHash { get; }
         public bool Loop { get; }
         public BodyShape BodyShape { get; }
-        public LoadTimeout Timeout { get; }
+        public LoadTimeout Timeout { get; private set; }
         public CancellationTokenSource CancellationTokenSource { get; }
 
         public GetSceneEmoteFromLocalSceneIntention(
@@ -38,7 +38,7 @@ namespace DCL.AvatarRendering.Emotes
             BodyShape = bodyShape;
             Loop = loop;
             CancellationTokenSource = new CancellationTokenSource();
-            Timeout = new LoadTimeout(timeout);
+            Timeout = new LoadTimeout(timeout, 0);
         }
 
         public bool Equals(GetSceneEmoteFromLocalSceneIntention other) =>
@@ -54,6 +54,14 @@ namespace DCL.AvatarRendering.Emotes
                 partitionComponent);
 
             world.Create(promise, emote, this.BodyShape);
+        }
+
+        public bool IsTimeout(float deltaTime)
+        {
+            // Timeout access returns a temporary value. We need to reassign the field or we lose the changes
+            Timeout = new LoadTimeout(Timeout.Timeout, Timeout.ElapsedTime + deltaTime);
+            bool result = Timeout.IsTimeout;
+            return result;
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetSceneEmoteFromRealmIntention.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetSceneEmoteFromRealmIntention.cs
@@ -28,7 +28,7 @@ namespace DCL.AvatarRendering.Emotes
         public BodyShape BodyShape { get; }
         public bool IsAssetBundleProcessed { get; set; }
 
-        public LoadTimeout Timeout { get; }
+        public LoadTimeout Timeout { get; private set; }
 
         public GetSceneEmoteFromRealmIntention(
             string sceneId,
@@ -47,7 +47,7 @@ namespace DCL.AvatarRendering.Emotes
             CancellationTokenSource = new CancellationTokenSource();
             PermittedSources = permittedSources;
             BodyShape = bodyShape;
-            Timeout = new LoadTimeout(timeout);
+            Timeout = new LoadTimeout(timeout, 0);
         }
 
         public bool Equals(GetSceneEmoteFromRealmIntention other) =>
@@ -68,6 +68,14 @@ namespace DCL.AvatarRendering.Emotes
                 partitionComponent);
 
             world.Create(promise, emote, this.BodyShape);
+        }
+
+        public bool IsTimeout(float deltaTime)
+        {
+            // Timeout access returns a temporary value. We need to reassign the field or we lose the changes
+            Timeout = new LoadTimeout(Timeout.Timeout, Timeout.ElapsedTime + deltaTime);
+            bool result = Timeout.IsTimeout;
+            return result;
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetSceneEmoteFromRealmIntention.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetSceneEmoteFromRealmIntention.cs
@@ -56,6 +56,44 @@ namespace DCL.AvatarRendering.Emotes
         public readonly URN NewSceneEmoteURN() =>
             $"{SCENE_EMOTE_PREFIX}:{SceneId}-{EmoteHash}-{Loop.ToString().ToLower()}";
 
+        public static bool TryParseFromURN(URN urn, out string sceneId, out string emoteHash, out bool loop)
+        {
+            string urnStr = urn.ToString();
+            
+            sceneId = string.Empty;
+            emoteHash = string.Empty;
+            loop = false;
+
+            if (string.IsNullOrEmpty(urnStr))
+                return false;
+
+            string prefixWithColon = $"{SCENE_EMOTE_PREFIX}:";
+            if (!urnStr.StartsWith(prefixWithColon, StringComparison.Ordinal))
+                return false;
+
+            string payload = urnStr.Substring(prefixWithColon.Length);
+
+            // payload format: {sceneId}-{emoteHash}-{loop}
+            int lastDash = payload.LastIndexOf('-');
+            if (lastDash <= 0 || lastDash == payload.Length - 1)
+                return false;
+
+            string loopStr = payload.Substring(lastDash + 1);
+            if (!bool.TryParse(loopStr, out loop))
+                return false;
+
+            string rest = payload.Substring(0, lastDash);
+
+            int secondLastDash = rest.LastIndexOf('-');
+            if (secondLastDash <= 0 || secondLastDash == rest.Length - 1)
+                return false;
+
+            emoteHash = rest.Substring(secondLastDash + 1);
+            sceneId = rest.Substring(0, secondLastDash);
+
+            return !string.IsNullOrEmpty(sceneId) && !string.IsNullOrEmpty(emoteHash);
+        }
+
         public void CreateAndAddPromiseToWorld(World world, IPartitionComponent partitionComponent, URLSubdirectory? customStreamingSubdirectory, IEmote emote)
         {
             var promise = AssetBundlePromise.Create(world,

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/IEmoteAssetIntention.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/IEmoteAssetIntention.cs
@@ -9,9 +9,9 @@ namespace DCL.AvatarRendering.Emotes
     public interface IEmoteAssetIntention : IAssetIntention
     {
         BodyShape BodyShape { get; }
-        LoadTimeout Timeout { get; }
         bool Loop { get; }
         URN NewSceneEmoteURN();
         void CreateAndAddPromiseToWorld(World world, IPartitionComponent partitionComponent, URLSubdirectory? customStreamingSubdirectory, IEmote emote);
+        bool IsTimeout(float deltaTime);
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/LoadTimeout.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/LoadTimeout.cs
@@ -1,20 +1,16 @@
 namespace DCL.AvatarRendering.Emotes
 {
-    public struct LoadTimeout
+    public readonly struct LoadTimeout
     {
         public int Timeout { get; }
 
-        public float ElapsedTime { get; private set; }
+        public float ElapsedTime { get; }
+        public bool IsTimeout => ElapsedTime >= Timeout;
 
-        public LoadTimeout(int timeout) : this()
+        public LoadTimeout(int timeout, float elapsedTime) : this()
         {
             Timeout = timeout;
-        }
-
-        public bool IsTimeout(float deltaTime)
-        {
-            ElapsedTime += deltaTime;
-            return ElapsedTime >= Timeout;
+            ElapsedTime = elapsedTime;
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -82,7 +82,7 @@ namespace DCL.AvatarRendering.Emotes.Load
 
             ExtractMissingPointersAndResolvedEmotes(in intention, pointersToRequest!, resolvedEmotesTmp);
 
-            if (intention.Timeout.IsTimeout(dt))
+            if (intention.IsTimeout(dt))
             {
                 var pointersStrLog = string.Join(",", intention.Pointers);
                 ReportHub.LogWarning(GetReportCategory(), $"Loading emotes timed out, {pointersStrLog}");

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
@@ -71,8 +71,8 @@ namespace DCL.AvatarRendering.Emotes.Load
         ) where TIntention : struct, IEmoteAssetIntention
         {
             URN urn = intention.NewSceneEmoteURN();
-
-            if (intention.Timeout.IsTimeout(dt))
+            
+            if (intention.IsTimeout(dt))
             {
                 if (!World.Has<StreamableResult>(entity))
                 {

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -24,12 +24,15 @@ using ECS.StreamableLoading.AudioClips;
 using ECS.StreamableLoading.Common.Components;
 using Global.AppArgs;
 using System;
-using System.Linq;
 using System.Runtime.CompilerServices;
+using ECS.SceneLifeCycle;
+using SceneRunner.Scene;
 using UnityEngine;
 using Utility.Animations;
 using EmotePromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution,
     DCL.AvatarRendering.Emotes.GetEmotesByPointersIntention>;
+using SceneEmoteFromRealmPromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution,
+    DCL.AvatarRendering.Emotes.GetSceneEmoteFromRealmIntention>;
 
 namespace DCL.AvatarRendering.Emotes.Play
 {
@@ -44,6 +47,7 @@ namespace DCL.AvatarRendering.Emotes.Play
     {
         // todo: use this to add nice Debug UI to trigger any emote?
         private readonly IDebugContainerBuilder debugContainerBuilder;
+        private readonly IScenesCache scenesCache;
 
         private readonly IEmoteStorage emoteStorage;
         private readonly EmotePlayer emotePlayer;
@@ -57,11 +61,13 @@ namespace DCL.AvatarRendering.Emotes.Play
             AudioSource audioSource,
             IDebugContainerBuilder debugContainerBuilder,
             bool localSceneDevelopment,
-            IAppArgs appArgs) : base(world)
+            IAppArgs appArgs,
+            IScenesCache scenesCache) : base(world)
         {
             this.messageBus = messageBus;
             this.emoteStorage = emoteStorage;
             this.debugContainerBuilder = debugContainerBuilder;
+            this.scenesCache = scenesCache;
             emotePlayer = new EmotePlayer(audioSource, legacyAnimationsEnabled: localSceneDevelopment || appArgs.HasFlag(AppArgsFlags.SELF_PREVIEW_BUILDER_COLLECTIONS));
         }
 
@@ -235,7 +241,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                 else
                 {
                     // Request the emote when not it cache. It will eventually endup in the emoteStorage so it can be played by this query
-                    World.Create(CreateEmotePromise(emoteId, avatarShapeComponent.BodyShape));
+                    CreateEmotePromise(emoteId, avatarShapeComponent.BodyShape);
                 }
 
             }
@@ -271,12 +277,22 @@ namespace DCL.AvatarRendering.Emotes.Play
             characterController.enabled = !emoteComponent.IsPlayingEmote;
         }
 
-        private EmotePromise CreateEmotePromise(URN urn, BodyShape bodyShape)
+        private void CreateEmotePromise(URN urn, BodyShape bodyShape)
         {
             loadEmoteBuffer[0] = urn;
 
-            return EmotePromise.Create(World, EmoteComponentsUtils.CreateGetEmotesByPointersIntention(bodyShape, loadEmoteBuffer),
-                PartitionComponent.TOP_PRIORITY);
+            if (GetSceneEmoteFromRealmIntention.TryParseFromURN(urn, out string sceneId, out string emoteHash, out bool loop))
+            {
+                if (!scenesCache.TryGetBySceneId(sceneId, out ISceneFacade? scene)) return;
+                    
+                SceneEmoteFromRealmPromise.Create(World,
+                    new GetSceneEmoteFromRealmIntention(sceneId, scene!.SceneData.AssetBundleManifest, emoteHash, loop, bodyShape),
+                    PartitionComponent.TOP_PRIORITY);
+            }
+            else
+                EmotePromise.Create(World,
+                    EmoteComponentsUtils.CreateGetEmotesByPointersIntention(bodyShape, loadEmoteBuffer),
+                    PartitionComponent.TOP_PRIORITY);
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/RestrictedActions/GlobalWorldActions.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/RestrictedActions/GlobalWorldActions.cs
@@ -108,12 +108,15 @@ namespace CrdtEcsBridge.RestrictedActions
 
             promise = await promise.ToUniTaskAsync(world, cancellationToken: ct);
 
-            using var consumed = promise.Result!.Value.Asset.ConsumeEmotes();
-            var value = consumed.Value[0]!;
-            URN urn = value.GetUrn();
-            bool isLooping = value.IsLooping();
+            if (promise.Result is {Succeeded: true})
+            {
+                using var consumed = promise.Result!.Value.Asset.ConsumeEmotes();
+                var value = consumed.Value[0];
+                URN urn = value.GetUrn();
+                bool isLooping = value.IsLooping();
 
-            TriggerEmote(urn, isLooping);
+                TriggerEmote(urn, isLooping);
+            }
         }
 
         private async UniTask TriggerSceneEmoteFromLocalSceneAsync(ISceneData sceneData, string emotePath, string emoteHash, bool loop, CancellationToken ct)
@@ -127,11 +130,15 @@ namespace CrdtEcsBridge.RestrictedActions
                 PartitionComponent.TOP_PRIORITY);
 
             promise = await promise.ToUniTaskAsync(world, cancellationToken: ct);
-            var consumed = promise.Result!.Value.Asset.ConsumeEmotes();
-            var value = consumed.Value[0]!;
-            URN urn = value.GetUrn();
 
-            TriggerEmote(urn, loop);
+            if (promise.Result is {Succeeded: true})
+            {
+                var consumed = promise.Result!.Value.Asset.ConsumeEmotes();
+                var value = consumed.Value[0]!;
+                URN urn = value.GetUrn();
+
+                TriggerEmote(urn, loop);
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -680,7 +680,7 @@ namespace Global.Dynamic
                 new CharacterCameraPlugin(assetsProvisioner, realmSamplingData, exposedGlobalDataContainer.ExposedCameraData, debugBuilder, dynamicWorldDependencies.CommandLineArgs),
                 new WearablePlugin(assetsProvisioner, staticContainer.WebRequestsContainer.WebRequestController, staticContainer.RealmData, assetBundlesURL, staticContainer.CacheCleaner, wearableCatalog, builderContentURL.Value, builderCollectionsPreview),
                 new EmotePlugin(staticContainer.WebRequestsContainer.WebRequestController, emotesCache, staticContainer.RealmData, multiplayerEmotesMessageBus, debugBuilder,
-                    assetsProvisioner, selfProfile, mvcManager, staticContainer.CacheCleaner, identityCache, entityParticipantTable, assetBundlesURL, dclCursor, staticContainer.InputBlock, globalWorld, playerEntity, builderContentURL.Value, localSceneDevelopment, sharedSpaceManager, builderCollectionsPreview, appArgs),
+                    assetsProvisioner, selfProfile, mvcManager, staticContainer.CacheCleaner, identityCache, entityParticipantTable, assetBundlesURL, dclCursor, staticContainer.InputBlock, globalWorld, playerEntity, builderContentURL.Value, localSceneDevelopment, sharedSpaceManager, builderCollectionsPreview, appArgs, staticContainer.ScenesCache),
                 new ProfilingPlugin(staticContainer.Profiler, staticContainer.RealmData, staticContainer.SingletonSharedDependencies.MemoryBudget, debugBuilder, staticContainer.ScenesCache, dclVersion, dynamicSettings.AdaptivePhysicsSettings, staticContainer.SceneLoadingLimit),
                 new AvatarPlugin(
                     staticContainer.ComponentsContainer.ComponentPoolsRegistry,

--- a/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
@@ -26,6 +26,7 @@ using MVC;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using ECS.SceneLifeCycle;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using CharacterEmoteSystem = DCL.AvatarRendering.Emotes.Play.CharacterEmoteSystem;
@@ -57,10 +58,11 @@ namespace DCL.PluginSystem.Global
         private readonly Entity playerEntity;
         private AudioSource? audioSourceReference;
         private EmotesWheelController? emotesWheelController;
-        private bool localSceneDevelopment;
+        private readonly bool localSceneDevelopment;
         private readonly ISharedSpaceManager sharedSpaceManager;
         private readonly bool builderCollectionsPreview;
         private readonly IAppArgs appArgs;
+        private readonly IScenesCache scenesCache;
 
         public EmotePlugin(IWebRequestController webRequestController,
             IEmoteStorage emoteStorage,
@@ -82,7 +84,8 @@ namespace DCL.PluginSystem.Global
             bool localSceneDevelopment,
             ISharedSpaceManager sharedSpaceManager,
             bool builderCollectionsPreview,
-            IAppArgs appArgs)
+            IAppArgs appArgs,
+            IScenesCache scenesCache)
         {
             this.messageBus = messageBus;
             this.debugBuilder = debugBuilder;
@@ -104,6 +107,7 @@ namespace DCL.PluginSystem.Global
             this.sharedSpaceManager = sharedSpaceManager;
             this.builderCollectionsPreview = builderCollectionsPreview;
             this.appArgs = appArgs;
+            this.scenesCache = scenesCache;
 
             audioClipsCache = new AudioClipsCache();
             cacheCleaner.Register(audioClipsCache);
@@ -131,7 +135,7 @@ namespace DCL.PluginSystem.Global
             if(builderCollectionsPreview)
                 ResolveBuilderEmotePromisesSystem.InjectToWorld(ref builder, emoteStorage);
 
-            CharacterEmoteSystem.InjectToWorld(ref builder, emoteStorage, messageBus, audioSourceReference, debugBuilder, localSceneDevelopment, appArgs);
+            CharacterEmoteSystem.InjectToWorld(ref builder, emoteStorage, messageBus, audioSourceReference, debugBuilder, localSceneDevelopment, appArgs, scenesCache);;
 
             LoadAudioClipGlobalSystem.InjectToWorld(ref builder, audioClipsCache, webRequestController);
 


### PR DESCRIPTION
## What does this PR change?

Fixes #5201 

Two main problems were found:
- The emote load intention was incorrectly created: the scene emote goes through the standard propagation process, including the multiplayer systems. When reaching the peer, since the emote was missing in the cache, the data was requested though pointers, which was never solved. The changes now identifies if the emote is from a scene and then make the load intention accordingly.
- The intention timeout was not working: the processing of the elapsed time was getting lost due to a temporal reference issue, thus the original reference was not getting impacted.

**TODO note**: local scene development mode is still missing this fix and will probably not work yet, at least if you are testing it with different machines. It is problematic to solve, because we cannot get the emote's source path at the emote system.

## Test Instructions

1. Go to `drkrillo.dcl.eth` world with two users and two different machines
2. Approach to the interaction item and either press F or E
3. The emote should be propagated to the peer
4. The peer should also be able to play the same emote on the interaction
5. Additionally play any other emote from the wheel. The emote should be propagated to the peer

### Prerequisites
- Have two different machines running decentraland, ideally windows and mac.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
