### PR TITLE
fix: apply org environment on today

### DIFF
--- a/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Browser/DecentralandUrls/DecentralandUrlsSource.cs
@@ -20,9 +20,9 @@ namespace DCL.Browser.DecentralandUrls
 
         public DecentralandUrlsSource(DecentralandEnvironment environment, ILaunchMode launchMode)
         {
-            Environment = environment;
-            DecentralandDomain = environment.ToString()!.ToLower();
             this.launchMode = launchMode;
+            Environment = environment;
+            DecentralandDomain = environment.ToString().ToLower();
 
             if (environment == DecentralandEnvironment.Today)
             {
@@ -34,14 +34,14 @@ namespace DCL.Browser.DecentralandUrls
                 Url(DecentralandUrl.AssetBundlesCDN);
                 CONTENT_URL_OVERRIDE = "https://peer-testing.decentraland.org/content/";
                 LAMBDAS_URL_OVERRIDE = "https://peer-testing.decentraland.org/lambdas/";
-                DecentralandDomain = DecentralandEnvironment.Org.ToString()!.ToLower();
+                Environment = DecentralandEnvironment.Org;
+                DecentralandDomain = nameof(DecentralandEnvironment.Org).ToLower();
             }
             else
             {
                 CONTENT_URL_OVERRIDE = "NO_CONTENT_URL_OVERRIDE";
                 LAMBDAS_URL_OVERRIDE = "NO_LAMBDAS_URL_OVERRIDE";
             }
-
         }
 
         public string Url(DecentralandUrl decentralandUrl)


### PR DESCRIPTION
## What does this PR change?

Fixes #5168 

Applies the `org` environment to keep aligned to the domain change on `.today`.

The issue was failing due to a lot of missing content, either in the content server or the asset bundles. The content has been synced to prevent load failures.

## Test Instructions

Start the client with `--dclenv today`.
Load decentraland normally, check that your wearables loads as expected. Teleport to different scenes, check that everything works normally.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
