### PR TITLE
fix: adjust debug console FPS metric when E@ is out of focus

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/ECS/DebugViewProfilingSystem.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/ECS/DebugViewProfilingSystem.cs
@@ -233,7 +233,7 @@ namespace DCL.Profiling.ECS
         private void UpdateAverageFPSValues()
         {
             ulong lastFrameNs = profiler.LastFrameTimeValueNs;
-            if (lastFrameNs > 0)
+            if (lastFrameNs > 0 && Application.isFocused)
             {
                 if (avgFrameWindowCount < AVG_WINDOW_FRAMES)
                 {
@@ -343,6 +343,8 @@ namespace DCL.Profiling.ECS
 
         private static void SetFPS(ElementBinding<string> elementBinding, long value)
         {
+            if (!Application.isFocused) return;
+
             float frameTimeInMS = value * NS_TO_MS;
             float frameRate = 1 / (value * NS_TO_SEC);
 


### PR DESCRIPTION
# Pull Request Description
Fix #4891

## What does this PR change?
When the app is not in focus the debug menu FPS metric will not update and will resume when back in focus.

## Test Instructions
Verify that when switching focus to another app, the FPS metric on the debug menu will stop updating and verify that when switching back to the app the fps metrics will resume updating

### Test Steps
1. Open the app
2. Enable the debug menu with /debug and scroll down so the FPS metrics are visible
3. Move the cursor outside the app and select another app
4. Verify that the FPS metrics stop updating and display the last values
5. Move the cursor back to the app and select it 
6. Verify that the FPS metrics resume updating
7. Make sure to verify that this works on either Fullscreen and Windowed modes

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
