### PR TITLE
Fix: Chat conversation icons are not moving to top when receiving messages

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatChannels/ChatChannelsPresenter.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatChannels/ChatChannelsPresenter.cs
@@ -231,7 +231,8 @@ namespace DCL.Chat
 
         private void OnMessageAdded(ChatChannel destinationChannel, ChatMessage addedMessage, int _)
         {
-            if (addedMessage is { IsSentByOwnUser: true, IsSystemMessage: false }) return;
+            if (addedMessage is { IsSentByOwnUser: true, IsSystemMessage: true })
+                return;
 
             if (chatHistory.Channels.TryGetValue(destinationChannel.Id, out var channel))
             {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes this bug: https://github.com/decentraland/unity-explorer/issues/5275

## Test Instructions

You need several open conversations.

### Test Steps
1. Go to the chat and open the conversation whose icon is at the bottom of the toolbar.
2. Send any message there.
3. The icon of that conversation should jump to the top of the toolbar, beneath Nearby.