### PR TITLE
Fix: Context menu is way to big when there's only one community appearing

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListView.cs
@@ -19,7 +19,6 @@ using System.Threading;
 using UnityEngine.UI;
 using Utility;
 using Utility.Types;
-using MemberData = DCL.Communities.CommunitiesDataProvider.DTOs.GetCommunityMembersResponse.MemberData;
 
 namespace DCL.Communities.CommunitiesCard.Members
 {
@@ -40,6 +39,8 @@ namespace DCL.Communities.CommunitiesCard.Members
         private const string KICK_MEMBER_CONFIRM_TEXT = "KICK";
         private const string BAN_MEMBER_CANCEL_TEXT = "CANCEL";
         private const string BAN_MEMBER_CONFIRM_TEXT = "BAN";
+
+        private static readonly Vector2 ITEM_CONTEXT_MENU_SUBMENU_OFFSET = new Vector2(0.0f, -26.0f);
 
         [field: SerializeField] private LoopGridView loopGrid { get; set; } = null!;
         [field: SerializeField] private ScrollRect loopListScrollRect { get; set; } = null!;
@@ -149,7 +150,7 @@ namespace DCL.Communities.CommunitiesCard.Members
             if (invitationButtonHandler == null)
             {
                 invitationButtonHandler = new CommunityInvitationContextMenuButtonHandler(communitiesDataProvider, contextMenuSettings.ElementsSpacing);
-                invitationButtonHandler.AddSubmenuControlToContextMenu(contextMenu, contextMenuSettings.InviteToCommunityText, contextMenuSettings.InviteToCommunitySprite);
+                invitationButtonHandler.AddSubmenuControlToContextMenu(contextMenu, ITEM_CONTEXT_MENU_SUBMENU_OFFSET, contextMenuSettings.InviteToCommunityText, contextMenuSettings.InviteToCommunitySprite);
             }
 
             invitationButtonHandler.SetUserToInvite(profile.Address);

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -74,6 +74,8 @@ namespace DCL.Passport
         private const int CONTEXT_MENU_ELEMENTS_SPACING = 5;
         private const int CONTEXT_MENU_WIDTH = 250;
 
+        private static readonly Vector2 CONTEXT_MENU_SUBMENU_OFFSET = new Vector2(0.0f, -26.0f);
+
         private readonly ICursor cursor;
         private readonly IProfileRepository profileRepository;
         private readonly ICharacterPreviewFactory characterPreviewFactory;
@@ -389,7 +391,7 @@ namespace DCL.Passport
             if (includeCommunities)
             {
                 invitationButtonHandler = new CommunityInvitationContextMenuButtonHandler(communitiesDataProvider, CONTEXT_MENU_ELEMENTS_SPACING);
-                invitationButtonHandler.AddSubmenuControlToContextMenu(contextMenu, viewInstance.InviteToCommunityText, viewInstance.InviteToCommunitySprite);
+                invitationButtonHandler.AddSubmenuControlToContextMenu(contextMenu, CONTEXT_MENU_SUBMENU_OFFSET, viewInstance.InviteToCommunityText, viewInstance.InviteToCommunitySprite);
             }
         }
 

--- a/Explorer/Assets/DCL/UI/Communities/CommunityChatConversationContextMenuSettings.asset
+++ b/Explorer/Assets/DCL/UI/Communities/CommunityChatConversationContextMenuSettings.asset
@@ -19,6 +19,6 @@ MonoBehaviour:
     m_Left: 15
     m_Right: 15
     m_Top: 14
-    m_Bottom: 14
+    m_Bottom: 18
   viewCommunitySprite: {fileID: 21300000, guid: c42ef609dd1154fa9a0e37d744af5614, type: 3}
   viewCommunityText: View Community

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/Communities/CommunityInvitationContextMenuButtonHandler.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/Communities/CommunityInvitationContextMenuButtonHandler.cs
@@ -28,6 +28,7 @@ namespace DCL.UI.GenericContextMenu.Controllers.Communities
         private const int MAXIMUM_HEIGHT_OF_SUBMENU = 600;
         private const int MAXIMUM_WIDTH_OF_SUBMENU = 300;
         private const float SUBMENU_ANCHOR_PADDING = 20;
+        private static readonly RectOffset SUBMENU_VERTICAL_PADDINGS = new RectOffset(8, 8, 8, 12);
 
         private readonly RectOffset scrollViewPaddings = new ();
         private readonly CommunitiesDataProvider communitiesDataProvider;
@@ -55,15 +56,17 @@ namespace DCL.UI.GenericContextMenu.Controllers.Communities
         /// when the user hovers the submenu button.
         /// </summary>
         /// <param name="contextMenu">Any context menu to which to add the button.</param>
+        /// <param name="offsetFromAnchor">The offset to apply to the submenu panel from the parent context menu's anchor.</param>
         /// <param name="buttonText">The text to show in the new button.</param>
         /// <param name="buttonIcon">The icon to show next to the new button.</param>
-        public void AddSubmenuControlToContextMenu(GenericContextMenuParameter.GenericContextMenu contextMenu, string buttonText, Sprite buttonIcon)
+        public void AddSubmenuControlToContextMenu(GenericContextMenuParameter.GenericContextMenu contextMenu, Vector2 offsetFromAnchor, string buttonText, Sprite buttonIcon)
         {
             contextMenu.AddControl(new SubMenuContextMenuButtonSettings(buttonText,
                                                                         buttonIcon,
                                                                         new GenericContextMenuParameter.GenericContextMenu(MAXIMUM_WIDTH_OF_SUBMENU,
                                                                                          elementsSpacing: contextMenu.elementsSpacing,
-                                                                                         offsetFromTarget: new Vector2(0, contextMenu.offsetFromTarget.y)),
+                                                                                         offsetFromTarget: offsetFromAnchor,
+                                                                                         verticalLayoutPadding: SUBMENU_VERTICAL_PADDINGS),
                                                                         anchorPadding: SUBMENU_ANCHOR_PADDING,
                                                                         asyncControlSettingsFillingDelegate: CreateInvitationSubmenuItemsAsync,
                                                                         asyncVisibilityResolverDelegate: ResolveInvitationSubmenuVisibilityAsync));

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/GenericUserProfileContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/GenericUserProfileContextMenuController.cs
@@ -41,6 +41,7 @@ namespace DCL.UI.GenericContextMenu.Controllers
         private const int CONTEXT_MENU_WIDTH = 250;
         private static readonly RectOffset CONTEXT_MENU_VERTICAL_LAYOUT_PADDING = new (15, 15, 20, 25);
         private static readonly Vector2 CONTEXT_MENU_OFFSET = new (5, -10);
+        private static readonly Vector2 SUBMENU_CONTEXT_MENU_OFFSET = new (0, -30);
 
         private readonly ObjectProxy<IFriendsService> friendServiceProxy;
         private readonly ObjectProxy<FriendsConnectivityStatusTracker> friendOnlineStatusCacheProxy;
@@ -116,7 +117,7 @@ namespace DCL.UI.GenericContextMenu.Controllers
             contextMenuBlockUserButton = new GenericContextMenuElement(blockButtonControlSettings, false);
             contextMenuCallButton = new GenericContextMenuElement(startCallButtonControlSettings, false);
 
-            contextMenu = new GenericContextMenuParameter.GenericContextMenu(CONTEXT_MENU_WIDTH, CONTEXT_MENU_OFFSET, CONTEXT_MENU_VERTICAL_LAYOUT_PADDING, CONTEXT_MENU_ELEMENTS_SPACING, anchorPoint: ContextMenuOpenDirection.BOTTOM_RIGHT)
+            contextMenu = new GenericContextMenuParameter.GenericContextMenu(CONTEXT_MENU_WIDTH, SUBMENU_CONTEXT_MENU_OFFSET, CONTEXT_MENU_VERTICAL_LAYOUT_PADDING, CONTEXT_MENU_ELEMENTS_SPACING, anchorPoint: ContextMenuOpenDirection.BOTTOM_RIGHT)
                          .AddControl(userProfileControlSettings)
                          .AddControl(new SeparatorContextMenuControlSettings(CONTEXT_MENU_SEPARATOR_HEIGHT, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.left, -CONTEXT_MENU_VERTICAL_LAYOUT_PADDING.right))
                          .AddControl(mentionUserButtonControlSettings)
@@ -129,7 +130,7 @@ namespace DCL.UI.GenericContextMenu.Controllers
             if (includeCommunities)
             {
                 invitationButtonHandler = new CommunityInvitationContextMenuButtonHandler(communitiesDataProvider, CONTEXT_MENU_ELEMENTS_SPACING);
-                invitationButtonHandler.AddSubmenuControlToContextMenu(contextMenu, contextMenuSettings.InviteToCommunityConfig.Text, contextMenuSettings.InviteToCommunityConfig.Sprite);
+                invitationButtonHandler.AddSubmenuControlToContextMenu(contextMenu, new Vector2(0.0f, contextMenu.offsetFromTarget.y), contextMenuSettings.InviteToCommunityConfig.Text, contextMenuSettings.InviteToCommunityConfig.Sprite);
             }
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

It applies different offsets and paddings to the invitation to community submenus.
It fixes this bug: #5258 

## Test Instructions

You need a user that is owner/moderator of only 1 community.

### Check in the chat context menu
1. Open a private conversation in the chat.
2. Open the context menu by clicking on the titlebar.
3. Open the Invite to Community option.
4. The submenu should have the expected height, as well as correct paddings.

### Check in the passport
1. Open the passport of another user.
2. Open the context menu by clicking on button at the top-right corner.
3. Open the Invite to Community option.
4. The submenu should have the expected height, as well as correct paddings.

### Check in the community member list
1. Open a community that is not yours.
2. Open the context menu by clicking on the button of a member in the list.
3. Open the Invite to Community option.
4. The submenu should have the expected height, as well as correct paddings.
