### PR TITLE
fix: prevent friends panel overlapping the chat

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatMainController.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatMainController.cs
@@ -16,6 +16,7 @@ using DCL.Chat.History;
 using DCL.Chat.MessageBus;
 using DCL.Communities;
 using DCL.UI.Profiles.Helpers;
+using System.Collections.Generic;
 using UnityEngine.InputSystem;
 using Utility;
 
@@ -40,6 +41,7 @@ namespace DCL.Chat
         private EventSubscriptionScope uiScope;
         private readonly ChatContextMenuService chatContextMenuService;
         private readonly ChatClickDetectionService chatClickDetectionService;
+        private readonly HashSet<IBlocksChat> chatBlockers = new ();
         public event IPanelInSharedSpace.ViewShowingCompleteDelegate? ViewShowingComplete;
 
         public event Action? PointerEntered;
@@ -190,6 +192,7 @@ namespace DCL.Chat
         {
             if (chatStateMachine == null) return;
             if (chatStateMachine.IsMinimized) return;
+            if (chatBlockers.Count > 0) return;
 
             chatStateMachine?.SetVisibility(true);
         }
@@ -277,17 +280,24 @@ namespace DCL.Chat
             uiScope?.Dispose();
 
             chatMemberListService.Dispose();
+            chatBlockers.Clear();
         }
 
         private void OnMvcViewShowed(IController controller)
         {
-            if (controller is IBlocksChat)
-                chatStateMachine?.Minimize();
+            if (controller is not IBlocksChat blocker) return;
+
+            chatStateMachine?.Minimize();
+            chatBlockers.Add(blocker);
         }
 
         private void OnMvcViewClosed(IController controller)
         {
-            if (controller is IBlocksChat)
+            if (controller is not IBlocksChat blocker) return;
+
+            chatBlockers.Remove(blocker);
+
+            if (chatBlockers.Count == 0)
                 chatStateMachine?.PopState();
         }
     }

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/FriendsPanelController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/FriendsPanelController.cs
@@ -20,7 +20,7 @@ using Utility;
 
 namespace DCL.Friends.UI.FriendPanel
 {
-    public class FriendsPanelController : ControllerBase<FriendsPanelView, FriendsPanelParameter>, IControllerInSharedSpace<FriendsPanelView, FriendsPanelParameter>
+    public class FriendsPanelController : ControllerBase<FriendsPanelView, FriendsPanelParameter>, IControllerInSharedSpace<FriendsPanelView, FriendsPanelParameter>, IBlocksChat
     {
         public enum FriendsPanelTab
         {


### PR DESCRIPTION
# Pull Request Description
Fixes #5171 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes the `FriendsPanelController` implement `IBlocksChat` so that it can be correctly registered in `ChatMainController` in order to correctly pop chat states.
It also adds a set of `IBlocksChat` since multiple controllers can be rendered on top of the chat and they all must close before the chat can be shown again. Before, one was enough to show it again.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Follow the steps mentioned in the linked issue
2. Chat should behave as before


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
