### PR TITLE
fix: overlap between the mouse and key controls and emote wheel

### DIFF
--- a/Explorer/Assets/DCL/AssetsProvision/Contextual/ContextualImage.cs
+++ b/Explorer/Assets/DCL/AssetsProvision/Contextual/ContextualImage.cs
@@ -17,6 +17,8 @@ namespace DCL.AssetsProvision
     {
         [SerializeField] private Image image = null!;
         [SerializeField] private AssetReferenceT<Sprite> spriteAsset = null!;
+        [SerializeField] private Color unloadedColor = Color.white;
+        [SerializeField] private Color loadedColor = Color.white;
 
         private ContextualAsset<Sprite> asset = null!;
 
@@ -36,10 +38,15 @@ namespace DCL.AssetsProvision
 
         private async UniTask LoadAsync()
         {
+            image.color = unloadedColor;
             Weak<Sprite> sprite = await asset.AssetAsync(destroyCancellationToken);
             Option<Sprite> resource = sprite.Resource;
 
-            if (resource.Has) image.sprite = resource.Value;
+            if (resource.Has)
+            {
+                image.sprite = resource.Value;
+                image.color = loadedColor;
+            }
             else ReportHub.LogError(ReportCategory.UI, "Cannot load grid asset");
         }
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
@@ -140,7 +140,7 @@ namespace DCL.PluginSystem.Global
                 new ProfileWidgetController(() => mainUIView.SidebarView.ProfileWidget, web3IdentityCache, profileRepository, profileChangesBus, profileRepositoryWrapper),
                 new ProfileMenuController(() => mainUIView.SidebarView.ProfileMenuView, web3IdentityCache, profileRepository, world, playerEntity, webBrowser, web3Authenticator, userInAppInitializationFlow, profileCache, mvcManager, profileRepositoryWrapper),
                 new SkyboxMenuController(() => mainUIView.SidebarView.SkyboxMenuView, settings.SettingsAsset, sceneRestrictionBusController),
-                new ControlsPanelController(() => controlsPanelView, mvcManager),
+                new ControlsPanelController(() => controlsPanelView),
                 webBrowser,
                 includeCameraReel,
                 includeFriends,

--- a/Explorer/Assets/DCL/UI/Controls/ControlsPanel.prefab
+++ b/Explorer/Assets/DCL/UI/Controls/ControlsPanel.prefab
@@ -700,3 +700,5 @@ MonoBehaviour:
       Culture=neutral, PublicKeyToken=null
     m_SubObjectGUID: 
     m_EditorAssetChanged: 0
+  unloadedColor: {r: 1, g: 1, b: 1, a: 0}
+  loadedColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Explorer/Assets/DCL/UI/SharedSpaceManager/ISharedSpaceManager.cs
+++ b/Explorer/Assets/DCL/UI/SharedSpaceManager/ISharedSpaceManager.cs
@@ -41,7 +41,7 @@ namespace DCL.UI.SharedSpaceManager
         /// <param name="panel">Which panel to show.</param>
         /// <param name="parameters">Optionally, the parameters the panel will use when shown.</param>
         /// <returns>The async task.</returns>
-        UniTask ShowAsync<TParams>(PanelsSharingSpace panel, TParams parameters = default!);
+        UniTask ShowAsync<TParams>(PanelsSharingSpace panel, TParams parameters = default!, params PanelsSharingSpace[] panelsToIgnore);
 
         /// <summary>
         ///     <inheritdoc cref="ShowAsync{TParams}" /> <br />

--- a/Explorer/Assets/DCL/UI/SharedSpaceManager/PanelsSharingSpace.cs
+++ b/Explorer/Assets/DCL/UI/SharedSpaceManager/PanelsSharingSpace.cs
@@ -12,5 +12,6 @@ namespace DCL.UI.SharedSpaceManager
         SidebarProfile,
         Explore,
         MarketplaceCredits,
+        Controls,
     }
 }

--- a/Explorer/Assets/DCL/UI/SharedSpaceManager/SharedSpaceManagerImpl/SharedSpaceManager.cs
+++ b/Explorer/Assets/DCL/UI/SharedSpaceManager/SharedSpaceManagerImpl/SharedSpaceManager.cs
@@ -61,6 +61,7 @@ namespace DCL.UI.SharedSpaceManager
                 dclInput.Shortcuts.FriendPanel.performed += OnInputShortcutsFriendPanelPerformedAsync;
 
             dclInput.Shortcuts.EmoteWheel.performed += OnInputShortcutsEmoteWheelPerformedAsync;
+            dclInput.Shortcuts.Controls.performed += OnInputShortcutsControlsPanelPerformedAsync;
             dclInput.Shortcuts.OpenChat.performed += OnInputShortcutsOpenChatPerformedAsync;
             dclInput.UI.Submit.performed += OnUISubmitPerformedAsync;
 
@@ -86,6 +87,7 @@ namespace DCL.UI.SharedSpaceManager
                 dclInput.Shortcuts.FriendPanel.performed -= OnInputShortcutsFriendPanelPerformedAsync;
 
             dclInput.Shortcuts.EmoteWheel.performed -= OnInputShortcutsEmoteWheelPerformedAsync;
+            dclInput.Shortcuts.Controls.performed -= OnInputShortcutsControlsPanelPerformedAsync;
             dclInput.Shortcuts.OpenChat.performed -= OnInputShortcutsOpenChatPerformedAsync;
             dclInput.UI.Submit.performed -= OnUISubmitPerformedAsync;
 
@@ -117,7 +119,7 @@ namespace DCL.UI.SharedSpaceManager
             if (controller is IBlocksChat) isCameraReelPanelVisible = false;
         }
 
-        public async UniTask ShowAsync<TParams>(PanelsSharingSpace panel, TParams parameters = default!)
+        public async UniTask ShowAsync<TParams>(PanelsSharingSpace panel, TParams parameters = default!, params PanelsSharingSpace[] panelsToIgnore)
         {
             if (!IsRegistered(panel))
             {
@@ -136,7 +138,7 @@ namespace DCL.UI.SharedSpaceManager
 
             try
             {
-                await HideAllAsync(panelToIgnore: PanelsSharingSpace.Chat);
+                await HideAllAsync(panelsToIgnore: panelsToIgnore);
 
                 PanelRegistration<TParams> registration = registrations[panel].GetByParams<TParams>();
                 IPanelInSharedSpace<TParams> panelInSharedSpace = registration.instance;
@@ -189,6 +191,7 @@ namespace DCL.UI.SharedSpaceManager
                     case PanelsSharingSpace.Explore:
                     case PanelsSharingSpace.SidebarProfile:
                     case PanelsSharingSpace.MarketplaceCredits:
+                    case PanelsSharingSpace.Controls:
                     {
                         if (!panelInSharedSpace.IsVisibleInSharedSpace)
                         {
@@ -291,17 +294,33 @@ namespace DCL.UI.SharedSpaceManager
 
                 await HideAsync(panel);
             }
-
         }
 
         private bool IsRegistered(PanelsSharingSpace panel) =>
             registrations.ContainsKey(panel);
 
-        private async UniTask HideAllAsync(PanelsSharingSpace? panelToIgnore = null)
+        private async UniTask HideAllAsync(params PanelsSharingSpace[] panelsToIgnore)
         {
             foreach (KeyValuePair<PanelsSharingSpace, PanelRegistration> controllerInSharedSpace in registrations)
-                if ((!panelToIgnore.HasValue || controllerInSharedSpace.Key != panelToIgnore) && controllerInSharedSpace.Value.panel.IsVisibleInSharedSpace)
-                    await HideAsync(controllerInSharedSpace.Key);
+            {
+                if(!controllerInSharedSpace.Value.panel.IsVisibleInSharedSpace)
+                    continue;
+                
+                bool shouldIgnore = false;
+                for (int i = 0; i < panelsToIgnore.Length; i++)
+                {
+                    if(panelsToIgnore[i] != controllerInSharedSpace.Key)
+                        continue;
+                    
+                    shouldIgnore = true;
+                    break;
+                }
+
+                if (shouldIgnore)
+                    continue;
+                
+                await HideAsync(controllerInSharedSpace.Key);
+            }
         }
 
         private void OnPanelViewShowingComplete(IPanelInSharedSpace panel)
@@ -440,6 +459,22 @@ namespace DCL.UI.SharedSpaceManager
         {
             if (!isExplorePanelVisible)
                 await ToggleVisibilityAsync(PanelsSharingSpace.EmotesWheel, new ControllerNoData());
+        }
+
+        private async void OnInputShortcutsControlsPanelPerformedAsync(InputAction.CallbackContext obj)
+        {
+            var panel = PanelsSharingSpace.Controls;
+            
+            // For hiding the panel, use standard logic.
+            if (registrations[panel].panel.IsVisibleInSharedSpace)
+            {
+                await ToggleVisibilityAsync(PanelsSharingSpace.Controls, new ControllerNoData());
+            }
+            else
+            {
+                await ShowAsync(PanelsSharingSpace.Controls, new ControllerNoData(), 
+                    PanelsSharingSpace.Chat, PanelsSharingSpace.Explore);
+            }
         }
 
         private async void OnInputShortcutsFriendPanelPerformedAsync(InputAction.CallbackContext obj)

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
@@ -171,6 +171,7 @@ namespace DCL.UI.Sidebar
 
             sharedSpaceManager.RegisterPanel(PanelsSharingSpace.Notifications, notificationsMenuController);
             sharedSpaceManager.RegisterPanel(PanelsSharingSpace.Skybox, skyboxMenuController);
+            sharedSpaceManager.RegisterPanel(PanelsSharingSpace.Controls, controlsPanelController);
             sharedSpaceManager.RegisterPanel(PanelsSharingSpace.SidebarProfile, profileMenuController);
             sharedSpaceManager.RegisterPanel(PanelsSharingSpace.SidebarSettings, viewInstance!.sidebarSettingsWidget);
 


### PR DESCRIPTION
# Pull Request Description
Fix [#4852](https://github.com/decentraland/unity-explorer/issues/4852)

## What does this PR change?
Fixed overlap between the mouse and key controls and emote wheel by re-implementing that panel as IControllerInSharedSpace. 
Also fixed white box shown in space of controls image for a frame, by adding unloaded and loaded color for `ContextualImage`.

Panel in question for reference:
<img width="1474" height="783" alt="image" src="https://github.com/user-attachments/assets/df475202-ab50-4a71-a2fc-ea03d012d03a" />


## Test Instructions
Check Controls panel with both its icon from side bar, and its shortcut `H`, and how it interacts with other panels. 

**Should hide:**
- [x] Menu 
<img width="618" height="145" alt="image" src="https://github.com/user-attachments/assets/2a7f383f-9789-4e8d-97dd-71c8b5b17d3c" />

- [x] Profile/Account
<img width="326" height="339" alt="image" src="https://github.com/user-attachments/assets/15743243-4e93-48b4-883e-69403bc71f81" />

- [x] Notifications
- [x] credits
- [x] Night/day
- [x] Emotes `B`
- [x] Friends
- [x] Chat HUD (not preview)

**Should NOT hide** (being shown on top of them):
- [x] Explore panel (communities, map, backpack, gallery, settings)


## Additional info
This panel will not open from Passport panel.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
