### PR TITLE
fix: handle avatar textures separately in texture intentions

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/GetTextureIntention.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/GetTextureIntention.cs
@@ -12,7 +12,6 @@ namespace ECS.StreamableLoading.Textures
     {
         public CommonLoadingArguments CommonArguments { get; set; }
         public string ReportSource;
-        public bool IsAvatarTexture;
 
         public readonly TextureWrapMode WrapMode;
         public readonly FilterMode FilterMode;
@@ -26,13 +25,16 @@ namespace ECS.StreamableLoading.Textures
 
         public CancellationTokenSource CancellationTokenSource => CommonArguments.CancellationTokenSource;
 
+        public readonly string? AvatarTextureUserId;
+
+        public readonly bool IsAvatarTexture => !string.IsNullOrEmpty(AvatarTextureUserId);
+
         // Note: Depending on the origin of the texture, it may not have a file hash, so the source URL is used in equality comparisons
         private readonly string cacheKey => string.IsNullOrEmpty(FileHash) ? CommonArguments.URL.Value : FileHash;
 
         public GetTextureIntention(string url, string fileHash, TextureWrapMode wrapMode, FilterMode filterMode, TextureType textureType,
             string reportSource,
-            int attemptsCount = StreamableLoadingDefaults.ATTEMPTS_COUNT,
-            bool isAvatarTexture = false)
+            int attemptsCount = StreamableLoadingDefaults.ATTEMPTS_COUNT)
         {
             CommonArguments = new CommonLoadingArguments(url, attempts: attemptsCount);
             WrapMode = wrapMode;
@@ -41,7 +43,23 @@ namespace ECS.StreamableLoading.Textures
             IsVideoTexture = false;
             VideoPlayerEntity = -1;
             FileHash = fileHash;
-            IsAvatarTexture = isAvatarTexture;
+            AvatarTextureUserId = null;
+            ReportSource = reportSource;
+        }
+
+        public GetTextureIntention(string userId,
+            TextureWrapMode wrapMode, FilterMode filterMode, TextureType textureType,
+            string reportSource,
+            int attemptsCount = StreamableLoadingDefaults.ATTEMPTS_COUNT)
+        {
+            CommonArguments = new CommonLoadingArguments(string.Empty, attempts: attemptsCount);
+            WrapMode = wrapMode;
+            FilterMode = filterMode;
+            TextureType = textureType;
+            IsVideoTexture = false;
+            VideoPlayerEntity = -1;
+            FileHash = string.Empty;
+            AvatarTextureUserId = userId;
             ReportSource = reportSource;
         }
 
@@ -54,7 +72,7 @@ namespace ECS.StreamableLoading.Textures
             IsVideoTexture = true;
             VideoPlayerEntity = videoPlayerEntity;
             TextureType = TextureType.Albedo; //Ignored
-            IsAvatarTexture = false;
+            AvatarTextureUserId = null;
             ReportSource = "Video Texture";
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/LoadTextureSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/LoadTextureSystem.cs
@@ -30,7 +30,7 @@ namespace ECS.StreamableLoading.Textures
             // A replacement of IProfileRepository to avoid cyclic dependencies
             IAvatarTextureUrlProvider avatarTextureUrlProvider)
             : base(
-                world, cache, 
+                world, cache,
                 new DiskCacheOptions<Texture2DData, GetTextureIntention>(diskCache, GetTextureIntention.DiskHashCompute.INSTANCE, "tex")
             )
         {
@@ -42,14 +42,14 @@ namespace ECS.StreamableLoading.Textures
         {
             if (intention.IsVideoTexture) throw new NotSupportedException($"{nameof(LoadTextureSystem)} does not support video textures. They should be handled by {nameof(VideoTextureUtils)}");
 
-            IOwnedTexture2D? result = null;
+            IOwnedTexture2D? result;
 
             if (intention.IsAvatarTexture)
             {
-                URLAddress? url = await avatarTextureUrlProvider.GetAsync(intention.CommonArguments.URL.Value, ct);
+                URLAddress? url = await avatarTextureUrlProvider.GetAsync(intention.AvatarTextureUserId!, ct);
 
                 if (url == null)
-                    throw new Exception($"No profile found for {intention.CommonArguments.URL}");
+                    throw new Exception($"No profile found for {intention.AvatarTextureUserId}");
 
                 result = await TryResolveAvatarTextureAsync(url.Value, intention, ct);
             }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Materials/Systems/StartMaterialsLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Materials/Systems/StartMaterialsLoadingSystem.cs
@@ -229,7 +229,22 @@ namespace ECS.Unity.Materials.Systems
 
                 promise = Promise.CreateFinalized(intention, result);
             }
+            else if (textureComponentValue.IsAvatarTexture)
+            {
+                promise = Promise.Create(
+                    World!,
+                    new GetTextureIntention(
+                        userId: textureComponentValue.Src,
+                        wrapMode: textureComponentValue.WrapMode,
+                        filterMode: textureComponentValue.FilterMode,
+                        textureType: textureComponentValue.TextureType,
+                        reportSource: nameof(StartMaterialsLoadingSystem)
+                    ),
+                    partitionComponent
+                );
+            }
             else
+            {
                 promise = Promise.Create(
                     World!,
                     new GetTextureIntention(
@@ -239,11 +254,11 @@ namespace ECS.Unity.Materials.Systems
                         textureComponentValue.FilterMode,
                         textureComponentValue.TextureType,
                         attemptsCount: attemptsCount,
-                        isAvatarTexture: textureComponentValue.IsAvatarTexture,
                         reportSource: nameof(StartMaterialsLoadingSystem)
                     ),
                     partitionComponent
                 );
+            }
 
             return true;
         }

--- a/Explorer/Assets/DCL/Profiles/Helpers/ProfileUtils.cs
+++ b/Explorer/Assets/DCL/Profiles/Helpers/ProfileUtils.cs
@@ -1,5 +1,6 @@
 using Arch.Core;
 using DCL.Utilities.Extensions;
+using DCL.WebRequests;
 using ECS.Prioritization.Components;
 using ECS.StreamableLoading.Common.Components;
 using ECS.StreamableLoading.Textures;
@@ -21,12 +22,11 @@ namespace DCL.Profiles.Helpers
             }
 
             var promise = Promise.Create(world,
-                new GetTextureIntention
-                {
-                    CommonArguments = new CommonLoadingArguments(profile.Avatar.FaceSnapshotUrl),
-                    IsAvatarTexture = true,
-                    ReportSource = nameof(ProfileUtils),
-                },
+                new GetTextureIntention(userId: profile.UserId,
+                    wrapMode: TextureWrapMode.Clamp,
+                    filterMode: FilterMode.Bilinear,
+                    textureType: TextureType.Albedo,
+                    reportSource: nameof(ProfileUtils)),
                 partitionComponent);
 
             world.Create(profile, promise, partitionComponent);

--- a/Explorer/Assets/DCL/SDKComponents/LightSource/Systems/LightSourceApplyPropertiesSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/LightSource/Systems/LightSourceApplyPropertiesSystem.cs
@@ -141,14 +141,28 @@ namespace DCL.SDKComponents.LightSource.Systems
             // Dispose of the existing cookie we might have, since it has changed
             cookie.CleanUp(World);
 
-            var intention = new GetTextureIntention(
-                textureComponentValue.Src,
-                textureComponentValue.FileHash,
-                textureComponentValue.WrapMode,
-                textureComponentValue.FilterMode,
-                textureComponentValue.TextureType,
-                nameof(LightSourceApplyPropertiesSystem),
-                attemptsCount: GET_TEXTURE_MAX_ATTEMPT_COUNT);
+            GetTextureIntention intention;
+
+            if (textureComponentValue.IsAvatarTexture)
+            {
+                intention = new GetTextureIntention(userId: textureComponentValue.Src,
+                    textureComponentValue.WrapMode,
+                    textureComponentValue.FilterMode,
+                    textureComponentValue.TextureType,
+                    nameof(LightSourceApplyPropertiesSystem),
+                    attemptsCount: GET_TEXTURE_MAX_ATTEMPT_COUNT);
+            }
+            else
+            {
+                intention = new GetTextureIntention(
+                    textureComponentValue.Src,
+                    textureComponentValue.FileHash,
+                    textureComponentValue.WrapMode,
+                    textureComponentValue.FilterMode,
+                    textureComponentValue.TextureType,
+                    nameof(LightSourceApplyPropertiesSystem),
+                    attemptsCount: GET_TEXTURE_MAX_ATTEMPT_COUNT);
+            }
 
             cookie.LoadingIntention = intention;
             cookie.LoadingPromise = TexturePromise.Create(World, intention, partitionComponent);

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIBackground/UIBackgroundInstantiationSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UIBackground/UIBackgroundInstantiationSystem.cs
@@ -146,18 +146,33 @@ namespace DCL.SDKComponents.SceneUI.Systems.UIBackground
 
             ReportHub.Log(ReportCategory.SCENE_UI, $"Start loading texture for UI background for source {textureComponentValue.Src} | Scene {sceneData.SceneShortInfo.ToString()}");
 
-            promise = Promise.Create(
-                World,
-                new GetTextureIntention(
-                    textureComponentValue.Src,
-                    textureComponentValue.FileHash,
-                    textureComponentValue.WrapMode,
-                    textureComponentValue.FilterMode,
-                    textureComponentValue.TextureType,
-                    attemptsCount: ATTEMPTS_COUNT,
-                    isAvatarTexture: textureComponentValue.IsAvatarTexture,
-                    reportSource: nameof(UIBackgroundInstantiationSystem)),
-                partitionComponent);
+            if (textureComponentValue.IsAvatarTexture)
+            {
+                promise = Promise.Create(
+                    World,
+                    new GetTextureIntention(
+                        userId: textureComponentValue.Src,
+                        textureComponentValue.WrapMode,
+                        textureComponentValue.FilterMode,
+                        textureComponentValue.TextureType,
+                        attemptsCount: ATTEMPTS_COUNT,
+                        reportSource: nameof(UIBackgroundInstantiationSystem)),
+                    partitionComponent);
+            }
+            else
+            {
+                promise = Promise.Create(
+                    World,
+                    new GetTextureIntention(
+                        url: textureComponentValue.Src,
+                        textureComponentValue.FileHash,
+                        textureComponentValue.WrapMode,
+                        textureComponentValue.FilterMode,
+                        textureComponentValue.TextureType,
+                        attemptsCount: ATTEMPTS_COUNT,
+                        reportSource: nameof(UIBackgroundInstantiationSystem)),
+                    partitionComponent);
+            }
         }
 
         private void TryAddAbortIntention(ref Promise? promise)


### PR DESCRIPTION
## What does this PR change?

Fixes #5235 

Fixed an issue where reports were incorrectly generated for avatar profile pictures when the profile did not exist.

This change separates avatar texture creation from other texture types by introducing a dedicated `userId` field. This makes the data flow more explicit and improves clarity in both processing and reporting.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
