### PR TITLE
fix: enter doesnt send chat message

### DIFF
--- a/Explorer/Assets/DCL/UI/SharedSpaceManager/SharedSpaceManagerImpl/SharedSpaceManager.cs
+++ b/Explorer/Assets/DCL/UI/SharedSpaceManager/SharedSpaceManagerImpl/SharedSpaceManager.cs
@@ -119,6 +119,11 @@ namespace DCL.UI.SharedSpaceManager
             if (controller is IBlocksChat) isCameraReelPanelVisible = false;
         }
 
+        public async UniTask ShowAsync<TParams>(PanelsSharingSpace panel, TParams parameters = default!)
+        {
+            ShowAsync(panel, parameters, PanelsSharingSpace.Chat);
+        }
+
         public async UniTask ShowAsync<TParams>(PanelsSharingSpace panel, TParams parameters = default!, params PanelsSharingSpace[] panelsToIgnore)
         {
             if (!IsRegistered(panel))


### PR DESCRIPTION
# Pull Request Description
fix [#5337](https://github.com/decentraland/unity-explorer/issues/5337)

## What does this PR change?
Fixed chat messages not being send, by returning old `SharedSpaceManager's` panels hiding, which I missed in last PR

## Test Instructions
- [ ] Check if you can send messages with Enter
- [ ] Check panels interaction with each other like emote wheel hides skybox panel and so on (panels affected: Chat, Friends, Notifications, Skybox, EmotesWheel, SidebarSettings, SidebarProfile, Explore, MarketplaceCredits, Controls). 


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
