### PR TITLE
feat: integrate art week loading screen

### DIFF
--- a/Explorer/Assets/AddressableAssetsData/AssetGroups/Essentials.asset
+++ b/Explorer/Assets/AddressableAssetsData/AssetGroups/Essentials.asset
@@ -210,6 +210,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: be91903945b0c44fdb1908049ce868b1
+    m_Address: ArtWeek.png
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: c7939fa59480e654a8537b6fc2f007e3
     m_Address: MediaPlayer
     m_ReadOnly: 0

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/ArtWeek.png
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/ArtWeek.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ee074971eda0d795359b830613d0f2ac134b870b7dbcf6c85001ad9e2e01578
+size 1824000

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/ArtWeek.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/ArtWeek.png.meta
@@ -1,0 +1,117 @@
+fileFormatVersion: 2
+guid: be91903945b0c44fdb1908049ce868b1
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages Shared Data.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages Shared Data.asset
@@ -55,6 +55,10 @@ MonoBehaviour:
     m_Key: IMAGE-9
     m_Metadata:
       m_Items: []
+  - m_Id: 218914508204138496
+    m_Key: IMAGE-10
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items:
     - rid: 4107643858754469895
@@ -119,6 +123,9 @@ MonoBehaviour:
           m_TableCodes:
           - en
         - m_KeyId: 196316170002882560
+          m_TableCodes:
+          - en
+        - m_KeyId: 218914508204138496
           m_TableCodes:
           - en
         m_TypeString: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages_en.asset
@@ -66,6 +66,10 @@ MonoBehaviour:
     m_Localized: cab127bf632384449be1ce1e91be26db
     m_Metadata:
       m_Items: []
+  - m_Id: 218914508204138496
+    m_Localized: be91903945b0c44fdb1908049ce868b1
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips Shared Data.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips Shared Data.asset
@@ -95,6 +95,14 @@ MonoBehaviour:
     m_Key: BODY-9
     m_Metadata:
       m_Items: []
+  - m_Id: 219996672412868608
+    m_Key: TITLE-10
+    m_Metadata:
+      m_Items: []
+  - m_Id: 219996789945655296
+    m_Key: BODY-10
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
@@ -116,6 +116,16 @@ MonoBehaviour:
       the community!
     m_Metadata:
       m_Items: []
+  - m_Id: 219996672412868608
+    m_Localized: Art Week
+    m_Metadata:
+      m_Items: []
+  - m_Id: 219996789945655296
+    m_Localized: "Can virtual art make us feel more human?\nFind out Sept 24\u201327,
+      2025 through 30+ immersive installations, creator tours, workshops, parties,
+      and more."
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
## What does this PR change?

Adds a new loading screen for art week.

## Test Instructions

Check with @aixaCode that the feature flag `alfa-loading-screen-tips` includes the new loading screen.
Start the app normally and check that you can see the loading screen for the art week.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
