### PR TITLE
fix: prevent fullscreen panels overlap

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
@@ -165,6 +165,10 @@ namespace MVC
             if (windowsStackManager.CurrentFullscreenController == controller)
                 return;
 
+            //Hide current fullscreen if any so it's safe to push a new one
+            if (windowsStackManager.CurrentFullscreenController != null)
+                windowsStackManager.CurrentFullscreenController.HideViewAsync(ct).Forget();
+
             // Push new fullscreen controller
             FullscreenPushInfo fullscreenPushInfo = windowsStackManager.PushFullscreen(controller);
 


### PR DESCRIPTION
# Pull Request Description
Fixes #5138 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes the windows stack manager close any currently shown fullscreen panels when another fullscreen is pushed since only 1 can be handled at a time.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Follow the instructions reported in the linked issue and verify that all bugs are solved

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
