### PR TITLE
fix: unwanted stripping of builder emote code

### DIFF
--- a/Explorer/Assets/link.xml
+++ b/Explorer/Assets/link.xml
@@ -2,7 +2,7 @@
 	<assembly fullname="Unity.RenderPipelines.Universal.Runtime" preserve="all" />
 	<assembly fullname="Unity.RenderPipelines.Core.Runtime" preserve="all" />
 	<assembly fullname="UnityEngine.UIElementsModule" preserve="all" />
-    
+    <assembly fullname="Wearables" preserve="all" />
     <assembly fullname="SceneRuntime" preserve="all" />
     <assembly fullname="NotificationsBus" preserve="all" />
     <assembly fullname="Decentraland.ClearScript" preserve="all" />


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Builder emote DTO code was being stripped; and we dont want this. This PR stops that from happening

## Test Instructions


### Test Steps

1. Make sure the unreleased/builder emotes can be played, following the test steps from this other [PR](https://github.com/decentraland/unity-explorer/pull/5309)

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
