### PR TITLE
Unbind GateKeeperSceneRoom from SceneCache

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
@@ -40,6 +40,8 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
                 if (decodedMessage.Length == 0)
                     return;
 
+                // TODO: If the room is connected but the scene is not connected **yet** the message will be skipped and forgotten
+
                 if (!sceneRoom.IsSceneConnected(message.Payload.SceneId)) return;
 
                 SubscriberKey key = new (message.Payload.SceneId, msgType);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -367,7 +367,7 @@ namespace Global.Dynamic
 
             var gateKeeperSceneRoomOptions = new GateKeeperSceneRoomOptions(staticContainer.LaunchMode, bootstrapContainer.DecentralandUrlsSource, playSceneMetaDataSource, localDevelopmentMetaDataSource);
 
-            IGateKeeperSceneRoom gateKeeperSceneRoom = new GateKeeperSceneRoom(staticContainer.WebRequestsContainer.WebRequestController, staticContainer.ScenesCache, gateKeeperSceneRoomOptions)
+            IGateKeeperSceneRoom gateKeeperSceneRoom = new GateKeeperSceneRoom(staticContainer.WebRequestsContainer.WebRequestController, gateKeeperSceneRoomOptions)
                .AsActivatable();
 
             var currentAdapterAddress = ICurrentAdapterAddress.NewDefault(staticContainer.RealmData);

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Demo/GateKeeperRoomPlayground.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Demo/GateKeeperRoomPlayground.cs
@@ -13,7 +13,6 @@ using DCL.WebRequests;
 using DCL.WebRequests.Analytics;
 using DCL.WebRequests.RequestsHub;
 using ECS;
-using ECS.SceneLifeCycle;
 using Global.Dynamic.LaunchModes;
 using LiveKit.Internal.FFIClients;
 using UnityEngine;
@@ -48,7 +47,6 @@ namespace DCL.Multiplayer.Connections.Demo
 
             new GateKeeperSceneRoom(
                     webRequests,
-                    new ScenesCache(),
                     options
                 ).StartAsync()
                  .Forget();

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Demo/LocalSceneDevelopmentPlayground.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Demo/LocalSceneDevelopmentPlayground.cs
@@ -12,7 +12,6 @@ using DCL.Web3.Identities;
 using DCL.WebRequests;
 using DCL.WebRequests.Analytics;
 using DCL.WebRequests.RequestsHub;
-using ECS.SceneLifeCycle;
 using Global.Dynamic.LaunchModes;
 using LiveKit.Internal.FFIClients;
 using UnityEngine;
@@ -44,7 +43,6 @@ namespace DCL.Multiplayer.Connections.Demo
 
             new GateKeeperSceneRoom(
                     webRequests,
-                    new ScenesCache(),
                     options
                 ).StartAsync()
                  .Forget();

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/ConstSceneRoomMetaDataSource.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/ConstSceneRoomMetaDataSource.cs
@@ -15,7 +15,7 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
         public ConstSceneRoomMetaDataSource(string name)
         {
             metadataInput = new MetaData.Input(name, Vector2Int.zero);
-            metaData = new MetaData(name, metadataInput);
+            metaData = new MetaData(name, Vector2Int.zero, metadataInput);
         }
 
         public static ConstSceneRoomMetaDataSource FromMachineUUID()

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/MetaData.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/MetaData.cs
@@ -47,16 +47,24 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
 
         public string? sceneId;
 
-
+        /// <summary>
+        ///     Parcel metadata was requested for, not necessarily the base parcel of the scene
+        /// </summary>
         [NonSerialized]
         public readonly Vector2Int Parcel;
 
-        public MetaData(string? sceneId, Input input)
+        /// <summary>
+        ///     Base Parcel of the scene
+        /// </summary>
+        public readonly Vector2Int BaseParcel;
+
+        public MetaData(string? sceneId, Vector2Int baseParcel, Input input)
         {
             realmName = input.RealmName;
             realm = new Realm { serverName = input.RealmName };
             Parcel = input.Parcel;
             this.sceneId = sceneId;
+            BaseParcel = baseParcel;
         }
 
         public string ToJson() =>

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/SceneRoomMetaDataSource.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/SceneRoomMetaDataSource.cs
@@ -69,7 +69,7 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
         {
             // Places API is relevant for Genesis City only
             if (realmData.IsWorld())
-                return Result<MetaData>.SuccessResult(new MetaData(input.RealmName, input));
+                return Result<MetaData>.SuccessResult(new MetaData(input.RealmName, Vector2Int.zero, input));
 
             using PooledObject<List<SceneEntityDefinition>> pooledEntityDefinitionList = ListPool<SceneEntityDefinition>.Get(out List<SceneEntityDefinition>? entityDefinitionList);
             using PooledObject<List<int2>> pooledPointersList = ListPool<int2>.Get(out List<int2>? pointersList);
@@ -86,11 +86,15 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
 
             StreamableLoadingResult<SceneDefinitions> result = promise.Result!.Value;
 
-            return Result<MetaData>.SuccessResult(
-                result.Succeeded && entityDefinitionList.Count > 0
-                    ? new MetaData(entityDefinitionList[0].id, input)
-                    : new MetaData(null, input)
-            );
+            if (result.Succeeded && entityDefinitionList.Count > 0)
+            {
+                SceneEntityDefinition? sceneDefinition = entityDefinitionList[0];
+                string? id = sceneDefinition.id;
+                Vector2Int baseParcel = sceneDefinition.metadata.scene.DecodedBase;
+                return Result<MetaData>.SuccessResult(new MetaData(id, baseParcel, input));
+            }
+
+            return Result<MetaData>.SuccessResult(new MetaData(null, Vector2Int.zero, input));
         }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/IGateKeeperSceneRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/IGateKeeperSceneRoom.cs
@@ -1,23 +1,24 @@
 using Cysharp.Threading.Tasks;
+using DCL.Multiplayer.Connections.GateKeeper.Meta;
 using DCL.Multiplayer.Connections.Rooms.Connective;
-using SceneRunner.Scene;
+using UnityEngine;
 
 namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
 {
     public interface IGateKeeperSceneRoom : IActivatableConnectiveRoom
     {
-        public ISceneData? ConnectedScene { get; }
+        public MetaData? ConnectedScene { get; }
 
         /// <summary>
-        ///     Tells if no communication channel is attached to the given scene
+        ///     Tells if no communication channel is attached to the given scene.
         /// </summary>
         /// <param name="sceneId"></param>
-        /// <returns></returns>
+        /// <returns>Returns false if the LiveKit room is connected but the scene itself is not loaded yet</returns>
         bool IsSceneConnected(string? sceneId);
 
         class Fake : Null, IGateKeeperSceneRoom
         {
-            public ISceneData? ConnectedScene { get; } = new ISceneData.Fake();
+            public MetaData? ConnectedScene { get; } = new MetaData("Fake", Vector2Int.zero, new MetaData.Input());
 
             public bool Activated => true;
 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Systems/Debug/DebugWidgetGateKeeperRoomDisplay.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Systems/Debug/DebugWidgetGateKeeperRoomDisplay.cs
@@ -33,7 +33,7 @@ namespace DCL.Multiplayer.Connections.Systems.Debug
         protected override void UpdateInternal()
         {
             base.UpdateInternal();
-            associatedParcel.SetAndUpdate(connectiveRoom.ConnectedScene?.SceneShortInfo.BaseParcel ?? Vector2Int.zero);
+            associatedParcel.SetAndUpdate(connectiveRoom.ConnectedScene?.BaseParcel ?? Vector2Int.zero);
         }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/Poses/RemoteMetadata.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/Poses/RemoteMetadata.cs
@@ -1,6 +1,7 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
+using DCL.Multiplayer.Connections.GateKeeper.Meta;
 using DCL.Multiplayer.Connections.GateKeeper.Rooms;
 using DCL.Multiplayer.Connections.RoomHubs;
 using ECS;
@@ -77,7 +78,7 @@ namespace DCL.Multiplayer.Profiles.Poses
                     return;
 
                 IGateKeeperSceneRoom sceneRoom = roomHub.SceneRoom();
-                ISceneData? sceneInfo = sceneRoom.ConnectedScene;
+                MetaData? sceneInfo = sceneRoom.ConnectedScene;
                 if (sceneInfo == null) return;
 
                 SceneRoomMetadata message;
@@ -85,7 +86,7 @@ namespace DCL.Multiplayer.Profiles.Poses
                 try { message = JsonUtility.FromJson<SceneRoomMetadata>(participant.Metadata); }
                 catch (Exception) { return; }
 
-                ParticipantsOnUpdatesFromParticipant(participant, new IRemoteMetadata.ParticipantMetadata(sceneInfo.SceneShortInfo.BaseParcel, URLDomain.FromString(message.lambdasEndpoint)));
+                ParticipantsOnUpdatesFromParticipant(participant, new IRemoteMetadata.ParticipantMetadata(sceneInfo.Value.BaseParcel, URLDomain.FromString(message.lambdasEndpoint)));
             }
         }
 


### PR DESCRIPTION
Fixes #5320

## Why the issue appeared

- We started to load LiveKit rooms in parallel with other start-up operations
- At the moment when the scene room has connected the scene object has not loaded yet leading to `scenesCache.TryGetByParcel(meta.Parcel, out connectedScene);` return `null` and set `ConnectedScene = null`. It's resolved only once when the connection string changes, preserving `null` until the player leaves the scene (changes the connection string)
- `IGateKeeperSceneRoom.IsSceneConnected`, thus, returns `false`
- It's accessed by `WriteRealmInfoSystem` which propagates `PBRealmInfo` to the JS scene only **once** when the corresponding data changes.
   - The data doesn't change until `IslandSId` or `IsSceneConnected` changes
- On the JavaScript Side there is most likely reliance on the realm readiness and the scene connectivity status. It'd explain why the video URL has not updated

## Solution

- `GateKeeperSceneRoom` should not depend on the availability of the scene in the cache as the loading operations flow was changed explicitly and on purpose to run LiveKit connection in parallel to other operation, including the loading of the scene itself
- I removed reliance on the scene object in favor of the scene DTO which is already retrieved by `ISceneRoomMetaDataSource` and contains all necessary information

## Worth mentioning

The LiveKit pipe starts receiving data immediately once connected.
Thus, if the scene itself is not ready but `Scene` message, that contains network entities data, is received, it will be skipped and forgotten leading to the scene desync.

It requires further attention (added `TODO` in `SceneCommunicationPipe`) but, currently, Network Entities API is not widely spread so it's minor.
