### PR TITLE
fix: avoid places cache override by world coordinates

### DIFF
--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
@@ -190,6 +190,9 @@ namespace DCL.PlacesAPIService
 
             placesById[placeInfo.id] = placeInfo;
 
+            //Avoid caching worlds by their coordinates as those are shared with genesis city parcels
+            if (!string.IsNullOrEmpty(placeInfo.world_name)) return;
+
             foreach (Vector2Int placeInfoPosition in placeInfo.Positions)
                 placesByCoords[placeInfoPosition] = placeInfo;
         }


### PR DESCRIPTION
# Pull Request Description
Fixes #5322

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR prevents the caching of worlds by coordinates. This is done because they all start at 0,0 which would lead to override Genesiz Plaza.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Follow the repro steps described in the linked issue and verify it now works as intended


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
