### PR TITLE
fix: prevent creation of community with no name/description and avoid NRE

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionController.cs
@@ -622,7 +622,7 @@ namespace DCL.Communities.CommunityCreation
         private void ShowModerationErrorModal(CommunityModerationResponse communityModerationData)
         {
             string formattedErrorMessage = string.Empty;
-            if (communityModerationData.data != null)
+            if (communityModerationData.data is { issues: not null })
             {
                 if (communityModerationData.data.issues.name is { Length: > 0 })
                     formattedErrorMessage += $"COMMUNITY NAME: {string.Join(", ", communityModerationData.data.issues.name.Select(s => $"[{s}]"))}\n\n";

--- a/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityCreation/CommunityCreationEditionView.cs
@@ -362,12 +362,10 @@ namespace DCL.Communities.CommunityCreation
             creationPanelCommunityDescriptionCharCounter.gameObject.SetActive(false);
         }
 
-        private void UpdateCreateButtonAvailability()
-        {
+        private void UpdateCreateButtonAvailability() =>
             creationPanelCreateButton.interactable =
-                !string.IsNullOrEmpty(creationPanelCommunityNameInputField.text) &&
-                !string.IsNullOrEmpty(creationPanelCommunityDescriptionInputField.text);
-        }
+                !string.IsNullOrEmpty(creationPanelCommunityNameInputField.text) && !string.IsNullOrWhiteSpace(creationPanelCommunityNameInputField.text) &&
+                !string.IsNullOrEmpty(creationPanelCommunityDescriptionInputField.text) && !string.IsNullOrWhiteSpace(creationPanelCommunityDescriptionInputField.text);
 
         private void OpenContentPolicyAndCodeOfEthicsLink(string id) =>
             ContentPolicyAndCodeOfEthicsLinksClicked?.Invoke(id);


### PR DESCRIPTION
# Pull Request Description
Fixes #5362 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR adds a clause to the construction of the moderation modal, preventing the reading of null data (avoids NRE). On top of that, it adds the checks of whitespace-only for the community name and description before submitting it for review. This is done to reflect the backend constraints: both name and description must have a non-null/empty values.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Follow the steps described in the linked issue and verify that you are no longer able to create a community with empty name/description

### Additional Testing Notes
- If for some reason you are able to skip all the checks, the moderation modal should now be able to handle the case without exceptions

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
