### PR TITLE
fix: remove square brackets from community notification text

### DIFF
--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityDeletedContenViolationNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityDeletedContenViolationNotification.cs
@@ -6,7 +6,7 @@ namespace DCL.NotificationsBusController.NotificationTypes
     public class CommunityDeletedContenViolationNotification : NotificationBase
     {
         private const string NOTIFICATION_HEADER = "Your Community Has Been Deleted";
-        private const string NOTIFICATION_TITLE = "The <b>[{0}]</b> Community was deleted for violating Decentraland's Guidelines.";
+        private const string NOTIFICATION_TITLE = "The <b>{0}</b> Community was deleted for violating Decentraland's Guidelines.";
 
         [JsonProperty("metadata")]
         public OwnerCommunityDeletedNotificationMetadata Metadata { get; set; }

--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityDeletedNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityDeletedNotification.cs
@@ -6,7 +6,7 @@ namespace DCL.NotificationsBusController.NotificationTypes
     public class CommunityDeletedNotification : NotificationBase
     {
         private const string NOTIFICATION_HEADER = "Community Deleted";
-        private const string NOTIFICATION_TITLE = "The <b>[{0}]</b> Community has been deleted.";
+        private const string NOTIFICATION_TITLE = "The <b>{0}</b> Community has been deleted.";
 
         [JsonProperty("metadata")]
         public CommunityDeletedNotificationMetadata Metadata { get; set; }

--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityEventCreatedNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityEventCreatedNotification.cs
@@ -7,7 +7,7 @@ namespace DCL.NotificationsBusController.NotificationTypes
     public class CommunityEventCreatedNotification : NotificationBase
     {
         private const string NOTIFICATION_HEADER = "Community Event Added";
-        private const string NOTIFICATION_TITLE = "The <b>[{0}]</b> Community has added a new event.";
+        private const string NOTIFICATION_TITLE = "The <b>{0}</b> Community has added a new event.";
 
         [JsonProperty("metadata")]
         public CommunityEventCreatedNotificationMetadata Metadata { get; set; }

--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityRenamedNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityRenamedNotification.cs
@@ -6,7 +6,7 @@ namespace DCL.NotificationsBusController.NotificationTypes
     public class CommunityRenamedNotification : NotificationBase
     {
         private const string NOTIFICATION_HEADER = "Community Renamed";
-        private const string NOTIFICATION_TITLE = "The <b>[{0}]</b> Community has been renamed to <b>[{1}]</b>.";
+        private const string NOTIFICATION_TITLE = "The <b>{0}</b> Community has been renamed to <b>{1}</b>.";
 
         [JsonProperty("metadata")]
         public CommunityRenamedNotificationMetadata Metadata { get; set; }

--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityUserBannedNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityUserBannedNotification.cs
@@ -6,7 +6,7 @@ namespace DCL.NotificationsBusController.NotificationTypes
     public class CommunityUserBannedNotification : NotificationBase
     {
         private const string NOTIFICATION_HEADER = "Banned From Community";
-        private const string NOTIFICATION_TITLE = "You've been banned from the <b>[{0}]</b> Community.";
+        private const string NOTIFICATION_TITLE = "You've been banned from the <b>{0}</b> Community.";
 
         [JsonProperty("metadata")]
         public CommunityUserBannedNotificationMetadata Metadata { get; set; }

--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityUserInvitedNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityUserInvitedNotification.cs
@@ -6,7 +6,7 @@ namespace DCL.NotificationsBusController.NotificationTypes
     public class CommunityUserInvitedNotification : NotificationBase
     {
         private const string NOTIFICATION_HEADER = "Community Invite Received";
-        private const string NOTIFICATION_TITLE = "You've been invited to join the <b>[{0}]</b> Community.";
+        private const string NOTIFICATION_TITLE = "You've been invited to join the <b>{0}</b> Community.";
 
         [JsonProperty("metadata")]
         public CommunityUserInvitedNotificationMetadata Metadata { get; set; }

--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityUserRemovedNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityUserRemovedNotification.cs
@@ -6,7 +6,7 @@ namespace DCL.NotificationsBusController.NotificationTypes
     public class CommunityUserRemovedNotification : NotificationBase
     {
         private const string NOTIFICATION_HEADER = "Removed from Community";
-        private const string NOTIFICATION_TITLE = "You've been removed from the <b>[{0}]</b> Community.";
+        private const string NOTIFICATION_TITLE = "You've been removed from the <b>{0}</b> Community.";
 
         [JsonProperty("metadata")]
         public CommunityUserRemovedNotificationMetadata Metadata { get; set; }

--- a/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityUserRequestToJoinAcceptedNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBusController/NotificationTypes/CommunityUserRequestToJoinAcceptedNotification.cs
@@ -6,7 +6,7 @@ namespace DCL.NotificationsBusController.NotificationTypes
     public class CommunityUserRequestToJoinAcceptedNotification : NotificationBase
     {
         private const string NOTIFICATION_HEADER = "Membership Request Accepted";
-        private const string NOTIFICATION_TITLE = "Congrats! You're now a member of the <b>[{0}]</b> Community.";
+        private const string NOTIFICATION_TITLE = "Congrats! You're now a member of the <b>{0}</b> Community.";
 
         [JsonProperty("metadata")]
         public CommunityUserRequestToJoinAcceptedNotificationMetadata Metadata { get; set; }


### PR DESCRIPTION
# Pull Request Description
Fixes #5390 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR modifies the text of the community notification in order to remove the square brackets surrounding the community names.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Open the app
2. Verify that all notifications related to community no longer have square brackets surrounding the community name

### Additional Testing Notes
- This applies to new notification and old notification as well

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
