### PR TITLE
fix: nametags visible in first person view

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -37,7 +37,6 @@ namespace DCL.Nametags
         private readonly float maxDistanceSqr;
 
         private SingleInstanceEntity playerCamera;
-        private CameraComponent cameraComponent;
         private bool cameraInitialized;
 
         public NametagPlacementSystem(
@@ -64,11 +63,7 @@ namespace DCL.Nametags
             if (!nametagsData.showNameTags)
                 return;
 
-            if (!cameraInitialized)
-            {
-                cameraComponent = playerCamera.GetCameraComponent(World);
-                cameraInitialized = true;
-            }
+            CameraComponent cameraComponent = playerCamera.GetCameraComponent(World);
 
             float fovScaleFactor = NametagMathHelper.CalculateFovScaleFactor(cameraComponent.Camera.fieldOfView, NAMETAG_SCALE_MULTIPLIER);
             NametagMathHelper.CalculateCameraForward(cameraComponent.Camera.transform.rotation, out float3 cameraForward);


### PR DESCRIPTION
# Pull Request Description
fix [#5157](https://github.com/decentraland/unity-explorer/issues/5157)
fix [#5019](https://github.com/decentraland/unity-explorer/issues/5019)

## What does this PR change?
Fixed player nametag visible in first person view, by properly fetching `CameraComponent` struct with every update, this struct's flag is used in nametag deletion logic

## Test Instructions
- Check if nametag can be seen in first person view (standing, running)


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
