### PR TITLE
fix: toggle stream on scene changed

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/MediaPlayerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MediaPlayerPlugin.cs
@@ -62,7 +62,7 @@ namespace DCL.PluginSystem.World
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in ECSWorldInstanceSharedDependencies sharedDependencies, in PersistentEntities _, List<IFinalizeWorldSystem> finalizeWorldSystems, List<ISceneIsCurrentListener> sceneIsCurrentListeners)
         {
-            mediaPlayerPluginWrapper.InjectToWorld(ref builder, sharedDependencies.SceneData, sharedDependencies.SceneStateProvider, sharedDependencies.EcsToCRDTWriter, finalizeWorldSystems);
+            mediaPlayerPluginWrapper.InjectToWorld(ref builder, sharedDependencies.SceneData, sharedDependencies.SceneStateProvider, sharedDependencies.EcsToCRDTWriter, finalizeWorldSystems, sceneIsCurrentListeners);
         }
 
         public async UniTask InitializeAsync(MediaPlayerPluginSettings settings, CancellationToken ct)

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs
@@ -101,6 +101,12 @@ namespace DCL.SDKComponents.MediaStream
         [All(typeof(VideoTextureConsumer))]
         private void CreateVideoPlayer(in Entity entity, PBVideoPlayer sdkComponent, ref VideoTextureConsumer videoTextureConsumer, [Data] float dt)
         {
+            var address = MediaAddress.New(sdkComponent.Src!);
+
+            //Streams rely on livekit room being active; which can only be in we are on the same scene. Lets not create media that is wrong
+            if (address.IsLivekitAddress(out _) && !sceneStateProvider.IsCurrent)
+                return;
+
             videoTextureConsumer.IsDirty = true;
             CreateMediaPlayer(dt, entity, sdkComponent.Src, sdkComponent.HasVolume, sdkComponent.Volume);
         }
@@ -108,6 +114,7 @@ namespace DCL.SDKComponents.MediaStream
         private void CreateMediaPlayer(float dt, Entity entity, string url, bool hasVolume, float volume)
         {
             if (!frameTimeBudget.TrySpendBudget()) return;
+
 
             MediaPlayerComponent component = CreateMediaPlayerComponent(entity, url, hasVolume, volume);
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -305,9 +305,16 @@ namespace DCL.SDKComponents.MediaStream
         }
 
         [Query]
-        private void ToggleCurrentStreamsState(ref MediaPlayerComponent mediaPlayerComponent, [Data] bool enteredScene)
+        private void ToggleCurrentStreamsState(Entity entity, MediaPlayerComponent mediaPlayerComponent, [Data] bool enteredScene)
         {
-            if (enteredScene) { }
+            if (mediaPlayerComponent.MediaPlayer.IsLivekitPlayer(out LivekitPlayer livekitPlayer) && !enteredScene)
+            {
+                //Streams rely on livekit room being active; which can only be in we are on the same scene. Next time we enter the scene, it will be recreate by
+                //the regular CreateMediaPlayerSystem
+                mediaPlayerComponent.Dispose();
+                World.Remove<MediaPlayerComponent>(entity);
+            }
+
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -12,6 +12,7 @@ using DCL.Utilities.Extensions;
 using DCL.WebRequests;
 using ECS.Abstract;
 using ECS.Groups;
+using ECS.LifeCycle;
 using ECS.Unity.Textures.Components;
 using ECS.Unity.Transforms.Components;
 using SceneRunner.Scene;
@@ -25,7 +26,7 @@ namespace DCL.SDKComponents.MediaStream
     [UpdateInGroup(typeof(SyncedPresentationSystemGroup))]
     [LogCategory(ReportCategory.MEDIA_STREAM)]
     [ThrottlingEnabled]
-    public partial class UpdateMediaPlayerSystem : BaseUnityLoopSystem
+    public partial class UpdateMediaPlayerSystem : BaseUnityLoopSystem, ISceneIsCurrentListener
     {
         private readonly IWebRequestController webRequestController;
         private readonly ISceneData sceneData;
@@ -296,6 +297,17 @@ namespace DCL.SDKComponents.MediaStream
             volumeBus.OnWorldVolumeChanged -= OnWorldVolumeChanged;
             volumeBus.OnMasterVolumeChanged -= OnMasterVolumeChanged;
 #endif
+        }
+
+        public void OnSceneIsCurrentChanged(bool enteredScene)
+        {
+            ToggleCurrentStreamsStateQuery(World, enteredScene);
+        }
+
+        [Query]
+        private void ToggleCurrentStreamsState(ref MediaPlayerComponent mediaPlayerComponent, [Data] bool enteredScene)
+        {
+            if (enteredScene) { }
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/MediaPlayerPluginWrapper.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/MediaPlayerPluginWrapper.cs
@@ -59,11 +59,12 @@ namespace DCL.SDKComponents.MediaStream.Wrapper
 #endif
         }
 
-        public void InjectToWorld(ref ArchSystemsWorldBuilder<World> builder, ISceneData sceneData, ISceneStateProvider sceneStateProvider, IECSToCRDTWriter ecsToCrdtWriter, List<IFinalizeWorldSystem> finalizeWorldSystems)
+        public void InjectToWorld(ref ArchSystemsWorldBuilder<World> builder, ISceneData sceneData, ISceneStateProvider sceneStateProvider, IECSToCRDTWriter ecsToCrdtWriter, List<IFinalizeWorldSystem> finalizeWorldSystems,
+            List<ISceneIsCurrentListener> sceneIsCurrentListeners)
         {
 #if AV_PRO_PRESENT && !UNITY_EDITOR_LINUX && !UNITY_STANDALONE_LINUX
             CreateMediaPlayerSystem.InjectToWorld(ref builder, webRequestController, roomHub, sceneData, mediaPlayerCustomPool, sceneStateProvider, frameTimeBudget, volumeBus);
-            UpdateMediaPlayerSystem.InjectToWorld(ref builder, webRequestController, sceneData, sceneStateProvider, frameTimeBudget, volumeBus, audioFadeSpeed);
+            sceneIsCurrentListeners.Add(UpdateMediaPlayerSystem.InjectToWorld(ref builder, webRequestController, sceneData, sceneStateProvider, frameTimeBudget, volumeBus, audioFadeSpeed));
 
             if (FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.VIDEO_PRIORITIZATION))
                 UpdateMediaPlayerPrioritizationSystem.InjectToWorld(ref builder, exposedCameraData, videoPrioritizationSettings);

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -92,7 +92,7 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "fb650cc3ec25353400ef801b8a67a41a1225d680"
+      "hash": "0e77b1c83047f3e9f7413a8cef47d25f5276575f"
     },
     "com.gurbu.gpui-pro": {
       "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.gurbu.gpui-pro",


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes #4682 and #5266

Toggles the state of a livekit stream to control how we restart it.

We will lose the crossfade of the audio; since the livekit disconection flow is triggered as soon as we leave the scene, currently there is no way to ensure for how long the stream will be alive.


## Test Instructions


### Test Steps
1. Go to `-133,-42` with a stream on. Check that if you leave the scene, see a room change, and re-enter; the stream works as expected withtout the glitching sound. 


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
