### PR TITLE
Fix: skybox day cycle is too fast

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -53,6 +53,7 @@ using DCL.Optimization.PerformanceBudgeting;
 using DCL.UI.Profiles.Helpers;
 using DCL.SDKComponents.MediaStream.Settings;
 using DCL.Settings.Settings;
+using DCL.SkyBox;
 using DCL.UI;
 using DCL.UI.Profiles;
 using DCL.UI.SharedSpaceManager;
@@ -367,6 +368,7 @@ namespace DCL.PluginSystem.Global
                 settings.VideoPrioritizationSettings,
                 landscapeData.Value,
                 settings.QualitySettingsAsset,
+                settings.SkyboxSettingsAsset,
                 settings.ControlsSettingsAsset,
                 systemMemoryCap,
                 settings.ChatSettingsAsset,
@@ -540,6 +542,8 @@ namespace DCL.PluginSystem.Global
 
             [field: SerializeField]
             public QualitySettingsAsset QualitySettingsAsset { get; private set; }
+            [field: SerializeField]
+            public SkyboxSettingsAsset SkyboxSettingsAsset { get; private set; }
 
             [field: SerializeField]
             public ControlsSettingsAsset ControlsSettingsAsset { get; private set; }

--- a/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
@@ -266,6 +266,7 @@ MonoBehaviour:
           m_SubObjectGUID: 
           m_EditorAssetChanged: 0
         <QualitySettingsAsset>k__BackingField: {fileID: 11400000, guid: 58ab8549017bacb42b310dbb452a2f6e, type: 2}
+        <SkyboxSettingsAsset>k__BackingField: {fileID: 11400000, guid: 9891b090dc6dc574d9415313003375f0, type: 2}
         <ControlsSettingsAsset>k__BackingField: {fileID: 11400000, guid: 26489687fb2f3419886df8e49f34b006, type: 2}
         <ChatSettingsAsset>k__BackingField: {fileID: 11400000, guid: a358ab6eb8d31ca488364e13b54f5f9c, type: 2}
         <CategoryMappingSO>k__BackingField:

--- a/Explorer/Assets/DCL/PluginSystem/Global/SkyboxPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SkyboxPlugin.cs
@@ -10,7 +10,6 @@ using ECS.SceneLifeCycle;
 using System;
 using System.Threading;
 using UnityEngine;
-using UnityEngine.AddressableAssets;
 using Object = UnityEngine.Object;
 
 namespace DCL.SkyBox

--- a/Explorer/Assets/DCL/Settings/Configuration/DropdownModuleBinding.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/DropdownModuleBinding.cs
@@ -15,6 +15,7 @@ using ECS.SceneLifeCycle.IncreasingRadius;
 using System;
 using UnityEngine;
 using UnityEngine.Audio;
+using DCL.SkyBox;
 
 namespace DCL.Settings.Configuration
 {
@@ -46,6 +47,7 @@ namespace DCL.Settings.Configuration
             LandscapeData landscapeData,
             AudioMixer generalAudioMixer,
             QualitySettingsAsset qualitySettingsAsset,
+            SkyboxSettingsAsset skyboxSettingsAsset,
             ControlsSettingsAsset controlsSettingsAsset,
             ChatSettingsAsset chatSettingsAsset,
             ISystemMemoryCap systemMemoryCap,
@@ -63,7 +65,7 @@ namespace DCL.Settings.Configuration
 
             SettingsFeatureController controller = Feature switch
             {
-                DropdownFeatures.GRAPHICS_QUALITY_FEATURE => new GraphicsQualitySettingsController(viewInstance, realmPartitionSettingsAsset, landscapeData, qualitySettingsAsset),
+                DropdownFeatures.GRAPHICS_QUALITY_FEATURE => new GraphicsQualitySettingsController(viewInstance, realmPartitionSettingsAsset, landscapeData, qualitySettingsAsset, skyboxSettingsAsset),
                 DropdownFeatures.CAMERA_LOCK_FEATURE => new CameraLockSettingsController(viewInstance),
                 DropdownFeatures.CAMERA_SHOULDER_FEATURE => new CameraShoulderSettingsController(viewInstance),
                 DropdownFeatures.RESOLUTION_FEATURE => new ResolutionSettingsController(viewInstance, upscalingController),

--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsModuleBindings.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsModuleBindings.cs
@@ -9,6 +9,7 @@ using DCL.SDKComponents.MediaStream.Settings;
 using DCL.Settings.ModuleControllers;
 using DCL.Settings.ModuleViews;
 using DCL.Settings.Settings;
+using DCL.SkyBox;
 using DCL.Utilities;
 using ECS.Prioritization;
 using ECS.SceneLifeCycle.IncreasingRadius;
@@ -31,6 +32,7 @@ namespace DCL.Settings.Configuration
             LandscapeData landscapeData,
             AudioMixer generalAudioMixer,
             QualitySettingsAsset qualitySettingsAsset,
+            SkyboxSettingsAsset skyboxSettingsAsset,
             ControlsSettingsAsset controlsSettingsAsset,
             ChatSettingsAsset chatSettingsAsset,
             ISystemMemoryCap systemMemoryCap,

--- a/Explorer/Assets/DCL/Settings/Configuration/SliderModuleBinding.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/SliderModuleBinding.cs
@@ -13,6 +13,7 @@ using ECS.Prioritization;
 using ECS.SceneLifeCycle.IncreasingRadius;
 using System;
 using DCL.Audio;
+using DCL.SkyBox;
 using UnityEngine;
 using UnityEngine.Audio;
 
@@ -45,6 +46,7 @@ namespace DCL.Settings.Configuration
             LandscapeData landscapeData,
             AudioMixer generalAudioMixer,
             QualitySettingsAsset qualitySettingsAsset,
+            SkyboxSettingsAsset skyboxSettingsAsset,
             ControlsSettingsAsset controlsSettingsAsset,
             ChatSettingsAsset chatSettingsAsset,
             ISystemMemoryCap systemMemoryCap,

--- a/Explorer/Assets/DCL/Settings/Configuration/ToggleModuleBinding.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/ToggleModuleBinding.cs
@@ -9,6 +9,7 @@ using DCL.SDKComponents.MediaStream.Settings;
 using DCL.Settings.ModuleControllers;
 using DCL.Settings.ModuleViews;
 using DCL.Settings.Settings;
+using DCL.SkyBox;
 using DCL.Utilities;
 using ECS.Prioritization;
 using ECS.SceneLifeCycle.IncreasingRadius;
@@ -36,6 +37,7 @@ namespace DCL.Settings.Configuration
             LandscapeData landscapeData,
             AudioMixer generalAudioMixer,
             QualitySettingsAsset qualitySettingsAsset,
+            SkyboxSettingsAsset skyboxSettingsAsset,
             ControlsSettingsAsset controlsSettingsAsset,
             ChatSettingsAsset chatSettingsAsset,
             ISystemMemoryCap systemMemoryCap,

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/GraphicsQualitySettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/GraphicsQualitySettingsController.cs
@@ -60,15 +60,7 @@ namespace DCL.Settings.ModuleControllers
                 ForceSetQualityLevel(index);
 
             DCLPlayerPrefs.SetInt(DCLPrefKeys.SETTINGS_GRAPHICS_QUALITY, index, save: true);
-
-            // Update skybox refresh interval based on our quality preset
-            // Mapping: Low(0)=5s, Medium(1 or others)=1s, High(2)=0s
-            skyboxSettingsAsset.RefreshInterval = index switch
-                                                  {
-                                                      0 => 5f,
-                                                      2 => 0f,
-                                                      _ => 1f,
-                                                  };
+            skyboxSettingsAsset.SetRefreshInterval(index);
         }
 
         private void ForceSetQualityLevel(int index)

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/GraphicsQualitySettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/GraphicsQualitySettingsController.cs
@@ -6,6 +6,7 @@ using DCL.Settings.ModuleViews;
 using ECS.Prioritization;
 using TMPro;
 using UnityEngine;
+using DCL.SkyBox;
 
 namespace DCL.Settings.ModuleControllers
 {
@@ -13,21 +14,23 @@ namespace DCL.Settings.ModuleControllers
     {
         // Used when system doesn't meet minimum requirements
         public const int MIN_SPECS_GRAPHICS_QUALITY_LEVEL = 0;
-        
+
         private const int DEFAULT_QUALITY_LEVEL_INDEX = 1;
 
         private readonly SettingsDropdownModuleView view;
         private readonly RealmPartitionSettingsAsset realmPartitionSettingsAsset;
         private readonly LandscapeData landscapeData;
         private readonly QualitySettingsAsset qualitySettingsAsset;
+        private readonly SkyboxSettingsAsset skyboxSettingsAsset;
 
-        public GraphicsQualitySettingsController(SettingsDropdownModuleView view, RealmPartitionSettingsAsset realmPartitionSettingsAsset, LandscapeData landscapeData, QualitySettingsAsset qualitySettingsAsset)
+        public GraphicsQualitySettingsController(SettingsDropdownModuleView view, RealmPartitionSettingsAsset realmPartitionSettingsAsset, LandscapeData landscapeData, QualitySettingsAsset qualitySettingsAsset, SkyboxSettingsAsset skyboxSettingsAsset)
         {
             this.view = view;
 
             this.realmPartitionSettingsAsset = realmPartitionSettingsAsset;
             this.landscapeData = landscapeData;
             this.qualitySettingsAsset = qualitySettingsAsset;
+            this.skyboxSettingsAsset = skyboxSettingsAsset;
 
             LoadGraphicsQualityOptions();
 
@@ -57,6 +60,15 @@ namespace DCL.Settings.ModuleControllers
                 ForceSetQualityLevel(index);
 
             DCLPlayerPrefs.SetInt(DCLPrefKeys.SETTINGS_GRAPHICS_QUALITY, index, save: true);
+
+            // Update skybox refresh interval based on our quality preset
+            // Mapping: Low(0)=5s, Medium(1 or others)=1s, High(2)=0s
+            skyboxSettingsAsset.RefreshInterval = index switch
+                                                  {
+                                                      0 => 5f,
+                                                      2 => 0f,
+                                                      _ => 1f,
+                                                  };
         }
 
         private void ForceSetQualityLevel(int index)

--- a/Explorer/Assets/DCL/Settings/Settings.asmdef
+++ b/Explorer/Assets/DCL/Settings/Settings.asmdef
@@ -22,7 +22,8 @@
         "GUID:ace653ac543d483ba8abee112a3ba2a6",
         "GUID:45f6fff651a0a514f8edfdaf9cce45af",
         "GUID:9e24947de15b9834991c9d8411ea37cf",
-        "GUID:e7751264a6735a942a64770d71eb49e0"
+        "GUID:e7751264a6735a942a64770d71eb49e0",
+        "GUID:571dc9f8bded0034f98595106462e3d0"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Settings/SettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/SettingsController.cs
@@ -11,6 +11,7 @@ using DCL.SDKComponents.MediaStream.Settings;
 using DCL.Settings.Configuration;
 using DCL.Settings.ModuleControllers;
 using DCL.Settings.Settings;
+using DCL.SkyBox;
 using DCL.UI;
 using DCL.Utilities;
 using ECS.Prioritization;
@@ -41,6 +42,7 @@ namespace DCL.Settings
         private readonly VideoPrioritizationSettings videoPrioritizationSettings;
         private readonly LandscapeData landscapeData;
         private readonly QualitySettingsAsset qualitySettingsAsset;
+        private readonly SkyboxSettingsAsset skyboxSettingsAsset;
         private readonly VoiceChatSettingsAsset voiceChatSettings;
         private readonly ISystemMemoryCap memoryCap;
         private readonly SceneLoadingLimit sceneLoadingLimit;
@@ -64,6 +66,7 @@ namespace DCL.Settings
             VideoPrioritizationSettings videoPrioritizationSettings,
             LandscapeData landscapeData,
             QualitySettingsAsset qualitySettingsAsset,
+            SkyboxSettingsAsset skyboxSettingsAsset,
             ControlsSettingsAsset controlsSettingsAsset,
             ISystemMemoryCap memoryCap,
             ChatSettingsAsset chatSettingsAsset,
@@ -81,6 +84,7 @@ namespace DCL.Settings
             this.realmPartitionSettingsAsset = realmPartitionSettingsAsset;
             this.landscapeData = landscapeData;
             this.qualitySettingsAsset = qualitySettingsAsset;
+            this.skyboxSettingsAsset = skyboxSettingsAsset;
             this.memoryCap = memoryCap;
             this.chatSettingsAsset = chatSettingsAsset;
             this.volumeBus = volumeBus;
@@ -181,6 +185,7 @@ namespace DCL.Settings
                             landscapeData,
                             generalAudioMixer,
                             qualitySettingsAsset,
+                            skyboxSettingsAsset,
                             controlsSettingsAsset,
                             chatSettingsAsset,
                             memoryCap,

--- a/Explorer/Assets/DCL/SkyBox/GlobalTimeState.cs
+++ b/Explorer/Assets/DCL/SkyBox/GlobalTimeState.cs
@@ -43,14 +43,14 @@ namespace DCL.SkyBox
                 isTransitioning = false;
             }
 
-            globalTimeOfDay += dt * (settings.SpeedMultiplier / SkyboxSettingsAsset.SECONDS_IN_DAY);
+            globalTimeOfDay += dt * settings.FullCycleSpeed;
 
             while (globalTimeOfDay >= 1f)
                 globalTimeOfDay -= 1f;
 
             refreshAccumulatedTime += dt;
 
-            if (refreshAccumulatedTime >= SkyboxSettingsAsset.REFRESH_INTERVAL)
+            if (refreshAccumulatedTime >= settings.RefreshInterval)
             {
                 settings.TimeOfDayNormalized = globalTimeOfDay;
                 refreshAccumulatedTime = 0f;

--- a/Explorer/Assets/DCL/SkyBox/SkyboxSettings.asset
+++ b/Explorer/Assets/DCL/SkyBox/SkyboxSettings.asset
@@ -14,7 +14,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   fullDayCycleInMinutes: 120
   transitionSpeed: 0.25
-  <RefreshInterval>k__BackingField: 10
+  refreshIntervalByQuality:
+  - 5
+  - 1
+  - 0.5
+  <RefreshInterval>k__BackingField: 1
   SkyboxRenderControllerPrefab:
     m_AssetGUID: 1dbd1decb60282248bd089c32bec5d02
     m_SubObjectName: 

--- a/Explorer/Assets/DCL/SkyBox/SkyboxSettings.asset
+++ b/Explorer/Assets/DCL/SkyBox/SkyboxSettings.asset
@@ -14,6 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   fullDayCycleInMinutes: 120
   transitionSpeed: 0.25
+  <RefreshInterval>k__BackingField: 10
   SkyboxRenderControllerPrefab:
     m_AssetGUID: 1dbd1decb60282248bd089c32bec5d02
     m_SubObjectName: 

--- a/Explorer/Assets/DCL/SkyBox/SkyboxSettings.asset
+++ b/Explorer/Assets/DCL/SkyBox/SkyboxSettings.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1162b863c0b747f59404c4a323168f3a, type: 3}
   m_Name: SkyboxSettings
   m_EditorClassIdentifier: 
-  speedMultiplier: 60
+  fullDayCycleInMinutes: 120
   transitionSpeed: 0.25
   SkyboxRenderControllerPrefab:
     m_AssetGUID: 1dbd1decb60282248bd089c32bec5d02

--- a/Explorer/Assets/DCL/SkyBox/SkyboxSettingsAsset.cs
+++ b/Explorer/Assets/DCL/SkyBox/SkyboxSettingsAsset.cs
@@ -2,6 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.Serialization;
 
 namespace DCL.SkyBox
 {
@@ -14,16 +15,15 @@ namespace DCL.SkyBox
     [CreateAssetMenu(menuName = "DCL/SO/Skybox Settings", fileName = "SkyboxSettings")]
     public class SkyboxSettingsAsset : ScriptableObject
     {
-        private const float DEFAULT_SPEED = 1 * 60f; // 1 minute per second
+        private const int SECONDS_IN_DAY = 86400;
 
         // We need to subtract 1 minute to make the slider range is between 00:00 and 23:59
         public const int TOTAL_MINUTES_IN_DAY = 1439; // 23:59 in minutes
-        public const int SECONDS_IN_DAY = 86400;
         public const float INITIAL_TIME_OF_DAY = 0.5f; // Midday
-        public const float REFRESH_INTERVAL = 5f;
 
-        [SerializeField] private float speedMultiplier = DEFAULT_SPEED;
+        [SerializeField] private float fullDayCycleInMinutes = 120;
         [SerializeField] private float transitionSpeed = 1f;
+        [field: SerializeField] public float RefreshInterval { get; private set; } = 5f;
 
         private float timeOfDayNormalized;
         private bool isDayCycleEnabled;
@@ -35,6 +35,7 @@ namespace DCL.SkyBox
         public Material SkyboxMaterial = null!;
         public AssetReferenceT<AnimationClip> SkyboxAnimationCycle = null!;
 
+        public float FullCycleSpeed => 1f / (fullDayCycleInMinutes * 60f);
         public bool IsUIControlled { get; set; }
         public float UIOverrideTimeOfDayNormalized { get; set; }
         public Vector2Int? CurrentSDKControlledScene { get; set; }
@@ -51,8 +52,6 @@ namespace DCL.SkyBox
 
         }
         public TransitionMode TransitionMode { get; set; }
-
-        public float SpeedMultiplier => speedMultiplier;
 
         public float TransitionSpeed => transitionSpeed;
 

--- a/Explorer/Assets/DCL/SkyBox/SkyboxSettingsAsset.cs
+++ b/Explorer/Assets/DCL/SkyBox/SkyboxSettingsAsset.cs
@@ -2,7 +2,6 @@
 using System;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
-using UnityEngine.Serialization;
 
 namespace DCL.SkyBox
 {
@@ -23,7 +22,7 @@ namespace DCL.SkyBox
 
         [SerializeField] private float fullDayCycleInMinutes = 120;
         [SerializeField] private float transitionSpeed = 1f;
-        [field: SerializeField] public float RefreshInterval { get; private set; } = 5f;
+        [field: SerializeField] public float RefreshInterval { get; set; } = 5f;
 
         private float timeOfDayNormalized;
         private bool isDayCycleEnabled;

--- a/Explorer/Assets/DCL/SkyBox/SkyboxSettingsAsset.cs
+++ b/Explorer/Assets/DCL/SkyBox/SkyboxSettingsAsset.cs
@@ -22,6 +22,7 @@ namespace DCL.SkyBox
 
         [SerializeField] private float fullDayCycleInMinutes = 120;
         [SerializeField] private float transitionSpeed = 1f;
+        [SerializeField] private float[] refreshIntervalByQuality;
         [field: SerializeField] public float RefreshInterval { get; set; } = 5f;
 
         private float timeOfDayNormalized;
@@ -76,6 +77,12 @@ namespace DCL.SkyBox
             TransitionMode = TransitionMode.FORWARD;
             IsUIControlled = false;
             CurrentSDKControlledScene = null;
+        }
+
+        // Mapping: 0 - Low, 1 - Medium, 2 - High
+        public void SetRefreshInterval(int qualityPresetId)
+        {
+            RefreshInterval = refreshIntervalByQuality[qualityPresetId];
         }
 
         public static float NormalizeTime(float time)


### PR DESCRIPTION
# Pull Request Description
Fix #4995

Skybox cycle was too fast - it was 24 minutes for the cycle instead of 2 hours. That resulted in visible popping when changing update interval or very fast moving shadows when update interval was set to zero. 

In this PR I refactor the logic, so settings are matching more clearly to the design. Also, update interval throttling approach isn't really needed, since GPU always draws skybox (I consulted with our graphics engineer on this topic). Thus, refresh interval is only purpose is to not make shadows glitchy. Since it highly depends on quality settings, I extended skybox settings to provide mapping to different quality presets that designer can adjust. 

## What does this PR change?
- simplify skybox full cycle setting
- increased skybox full cycle to match design - 2 hours (120 minutes) for 1 cycle
- map refresh interval of skybox to quality presets

### For designers: 
- Adjust `Full Day Cycle In Minutes` to check it matches the design (set it to 1 to see full day cycle passing in 1 minute)
- Adjust `Refresh Interval by Minutes`  on different quality settings to check that shadows moving correctly (check benches on roads). I found current settings to be the best for 120 minutes cycle

<img width="637" height="902" alt="image" src="https://github.com/user-attachments/assets/1625dffa-b3c3-45b7-8d5b-d1627aeec8c3" />

## Test Instructions
See attached related bug ticket. 

- GIVEN you are in place with shadows (roads for example, benches are good to check shadows)
- WHEN sun position changes (happens each frame, but check 5 sec for example=
- THEN shadow change has not noticeable popping. 
- AND full cycle finishes in approximately 2 hours. 

Try different quality settings (Low/Mid/High). Make an exploratory testing with overriding skybox by scene or forcing it by user settings to some fixed value. 

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
