### PR TITLE
Created a tool to generate tree data at edit time

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Config/Editor/TreeDataGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/Config/Editor/TreeDataGenerator.cs
@@ -1,0 +1,93 @@
+﻿using DCL.Diagnostics;
+using DCL.Landscape.Jobs;
+using DCL.Landscape.NoiseGeneration;
+using DCL.Landscape.Settings;
+using DCL.Landscape.Utils;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Unity.Collections;
+using Unity.Mathematics;
+using UnityEditor;
+using UnityEngine;
+
+namespace DCL.Landscape.Config.Editor
+{
+    public sealed class TreeDataGenerator : ScriptableWizard
+    {
+        [field: SerializeField] private TerrainGenerationData? terrainData { get; set; }
+        [field: SerializeField] private int terrainSize { get; set; } = 318;
+        [field: SerializeField] private string treeFilePath { get; set; } = "Trees.bin";
+
+        [MenuItem("Decentraland/Generate Tree Data")]
+        private static void OnMenuItem() =>
+            DisplayWizard<TreeDataGenerator>("Generate Tree Data", "Generate");
+
+        private async void OnWizardCreate()
+        {
+            NativeList<int2> emptyParcels = default;
+            NativeParallelHashMap<int2, int> emptyParcelsData = default;
+            NativeParallelHashMap<int2, EmptyParcelNeighborData> emptyParcelsNeighborData = default;
+            NativeParallelHashSet<int2> ownedParcels = default;
+
+            try
+            {
+                if (terrainData == null)
+                    return;
+
+                int2 minParcel = terrainSize / -2;
+                int2 maxParcel = -minParcel - 1;
+                ownedParcels = new NativeParallelHashSet<int2>(0, Allocator.TempJob);
+
+                TerrainGenerationUtils.ExtractEmptyParcels(minParcel, maxParcel, ref emptyParcels,
+                    ref ownedParcels);
+
+                TerrainGenerationUtils.SetupEmptyParcelsJobs(ref emptyParcelsData,
+                                           ref emptyParcelsNeighborData, emptyParcels.AsArray(),
+                                           ref ownedParcels, minParcel, maxParcel,
+                                           terrainData.heightScaleNerf)
+                                      .Complete();
+
+                var terrainChunkDataGenerator = new TerrainChunkDataGenerator(null,
+                    new TimeProfiler(false), terrainData, ReportCategory.LANDSCAPE);
+
+                terrainChunkDataGenerator.Prepare(1, 16, ref emptyParcelsData,
+                    ref emptyParcelsNeighborData, new NoiseGeneratorCache());
+
+                int sizeInUnits = terrainSize * terrainData.parcelSize;
+                var treeInstances = new List<TreeInstance>();
+
+                await terrainChunkDataGenerator.SetTreesAsync(minParcel, sizeInUnits, treeInstances, 1,
+                    CancellationToken.None, false);
+
+                var writer = new TreeInstanceWriter(terrainData.parcelSize, terrainData.treeAssets);
+                writer.AddChunk(minParcel, sizeInUnits, treeInstances);
+
+                await using var stream = new FileStream(
+                    $"{Application.streamingAssetsPath}/{treeFilePath}", FileMode.Create,
+                    FileAccess.Write);
+
+                writer.Write(stream);
+            }
+            catch (Exception ex) { ReportHub.LogException(ex, ReportCategory.LANDSCAPE); }
+            finally
+            {
+                if (emptyParcels.IsCreated)
+                    emptyParcels.Dispose();
+
+                if (emptyParcelsData.IsCreated)
+                    emptyParcelsData.Dispose();
+
+                if (emptyParcelsNeighborData.IsCreated)
+                    emptyParcelsNeighborData.Dispose();
+
+                if (ownedParcels.IsCreated)
+                    ownedParcels.Dispose();
+            }
+        }
+
+        private void OnWizardUpdate() =>
+            isValid = terrainData != null;
+    }
+}

--- a/Explorer/Assets/DCL/Landscape/Config/Editor/TreeDataGenerator.cs.meta
+++ b/Explorer/Assets/DCL/Landscape/Config/Editor/TreeDataGenerator.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 7ce3a860208246f2abbbe4eb64d9bc50
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - m_ViewDataDictionary: {instanceID: 0}
+  - <terrainData>k__BackingField: {fileID: 11400000, guid: 409e3f2e0a395134cb4def3ba3747c39, type: 2}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Landscape/TerrainChunkDataGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainChunkDataGenerator.cs
@@ -165,7 +165,7 @@ namespace DCL.Landscape
             }
         }
 
-        public async UniTask SetTreesAsync(int2 chunkMinParcel, int chunkSize, TerrainData terrainData, uint baseSeed, CancellationToken cancellationToken,
+        public async UniTask SetTreesAsync(int2 chunkMinParcel, int chunkSize, List<TreeInstance> terrainData, uint baseSeed, CancellationToken cancellationToken,
             bool useCache = true)
         {
             if (useCache && localCache.IsValid())
@@ -173,7 +173,7 @@ namespace DCL.Landscape
                 using (timeProfiler.Measure(t => ReportHub.Log(reportData, $"- [Cache] SetTreesAsync from Cache {t}ms")))
                 {
                     var array = await localCache.GetTreesAsync(chunkMinParcel.x, chunkMinParcel.y);
-                    terrainData.SetTreeInstances(array, true);
+                    terrainData.AddRange(array);
                 }
             }
             else
@@ -256,7 +256,7 @@ namespace DCL.Landscape
                     using (timeProfiler.Measure(t => ReportHub.Log(reportData, $"    - [Trees] SetTreeInstances {t}ms")))
                     {
                         TreeInstance[] instances = array.ToArray();
-                        terrainData.SetTreeInstances(instances, true);
+                        terrainData.AddRange(instances);
 
                         if (useCache)
                             localCache.SaveTreeInstances(chunkMinParcel.x, chunkMinParcel.y, instances);

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -176,7 +176,9 @@ namespace DCL.Landscape
                 {
                     using (timeProfiler.Measure(t => ReportHub.Log(reportData, $"[{t:F2}ms] Empty Parcel Setup")))
                     {
-                        TerrainGenerationUtils.ExtractEmptyParcels(TerrainModel, ref emptyParcels, ref ownedParcels);
+                        TerrainGenerationUtils.ExtractEmptyParcels(TerrainModel.MinParcel,
+                            TerrainModel.MaxParcel, ref emptyParcels, ref ownedParcels);
+
                         await SetupEmptyParcelDataAsync(TerrainModel, cancellationToken);
                     }
 
@@ -694,18 +696,6 @@ namespace DCL.Landscape
             }
 
             return false;
-        }
-
-        // TODO where is it called from?
-        private static void SaveTrees(ChunkModel[] chunks, TerrainGenerationData terrainData)
-        {
-            var writer = new TreeInstanceWriter(terrainData.parcelSize, terrainData.treeAssets);
-
-            foreach (ChunkModel chunk in chunks)
-                writer.AddTerrain(chunk.terrain);
-
-            using var stream = new FileStream(treeFilePath, FileMode.Create, FileAccess.Write);
-            writer.Write(stream);
         }
 
         private async UniTask LoadTreesAsync()

--- a/Explorer/Assets/DCL/Landscape/TreeInstanceWriter.cs
+++ b/Explorer/Assets/DCL/Landscape/TreeInstanceWriter.cs
@@ -27,22 +27,21 @@ namespace DCL.Landscape
             this.prototypes = prototypes;
         }
 
-        public void AddTerrain(Terrain unityTerrain)
+        public void AddChunk(int2 chunkMinParcel, int chunkSizeInUnits,
+            List<TreeInstance> treeInstances)
         {
-            var terrainData = unityTerrain.terrainData;
-            var treeInstances = terrainData.treeInstances;
-
-            Matrix4x4 unityTerrainToWorld = unityTerrain.transform.localToWorldMatrix
-                                            * Matrix4x4.Scale(terrainData.size);
+            Matrix4x4 chunkToWorld = Matrix4x4.TRS(
+                new Vector3(chunkMinParcel.x * parcelSize, 0f, chunkMinParcel.y * parcelSize),
+                Quaternion.identity, new Vector3(chunkSizeInUnits, 0f, chunkSizeInUnits));
 
             foreach (var treeInstance in treeInstances)
             {
-                Vector3 position = unityTerrainToWorld.MultiplyPoint3x4(treeInstance.position);
+                Vector3 position = chunkToWorld.MultiplyPoint3x4(treeInstance.position);
                 int2 parcel = (int2)floor(float3(position).xz / parcelSize);
 
                 if (!parcelMap.TryGetValue(parcel, out List<TreeInstanceData> treeInstancesInParcel))
                 {
-                    treeInstancesInParcel = new();
+                    treeInstancesInParcel = new List<TreeInstanceData>();
                     parcelMap.Add(parcel, treeInstancesInParcel);
                     minParcel = min(minParcel, parcel);
                     maxParcel = max(maxParcel, parcel);

--- a/Explorer/Assets/DCL/Landscape/Utils/TerrainGenerationUtils.cs
+++ b/Explorer/Assets/DCL/Landscape/Utils/TerrainGenerationUtils.cs
@@ -31,13 +31,14 @@ namespace DCL.Landscape
             return colorMapRenderer;
         }
 
-        public static void ExtractEmptyParcels(TerrainModel terrainModel, ref NativeList<int2> emptyParcels, ref NativeParallelHashSet<int2> ownedParcels)
+        public static void ExtractEmptyParcels(int2 minParcel, int2 maxParcel,
+            ref NativeList<int2> emptyParcels, ref NativeParallelHashSet<int2> ownedParcels)
         {
             if (!emptyParcels.IsCreated)
                 emptyParcels = new NativeList<int2>(Allocator.Persistent);
 
-            for (int x = terrainModel.MinParcel.x; x <= terrainModel.MaxParcel.x; x++)
-            for (int y = terrainModel.MinParcel.y; y <= terrainModel.MaxParcel.y; y++)
+            for (int x = minParcel.x; x <= maxParcel.x; x++)
+            for (int y = minParcel.y; y <= maxParcel.y; y++)
             {
                 var currentParcel = new int2(x, y);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change adds a tool to generate tree data at edit time. Minor changes to existing terrain code that could affect worlds were made.

## Test Instructions

Check that terrain and trees are still correct both in the city and in worlds.

### Test Steps
1. Teleport to empty parcels
2. Teleport to, for example, pravus.dcl.eth
3. See that trees and stuff are right

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
