### PR TITLE
hotfix: Asset Bundle System Ordering

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/Load/LoadWearablesByParamSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/Load/LoadWearablesByParamSystem.cs
@@ -11,13 +11,14 @@ using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Diagnostics;
 using DCL.WebRequests;
 using ECS;
+using ECS.Groups;
 using ECS.StreamableLoading.Cache;
 using System;
 using System.Collections.Generic;
 
 namespace DCL.AvatarRendering.Wearables.Systems.Load
 {
-    [UpdateInGroup(typeof(PresentationSystemGroup))]
+    [UpdateInGroup(typeof(LoadGlobalSystemGroup))]
     [LogCategory(ReportCategory.WEARABLE)]
     public partial class LoadWearablesByParamSystem : LoadElementsByIntentionSystem<WearablesResponse, GetWearableByParamIntention, IWearable, WearableDTO>
     {

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/Load/LoadWearablesDTOByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/Load/LoadWearablesDTOByPointersSystem.cs
@@ -7,11 +7,12 @@ using DCL.AvatarRendering.Wearables.Components.Intentions;
 using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Diagnostics;
 using DCL.WebRequests;
+using ECS.Groups;
 using ECS.StreamableLoading.Cache;
 
 namespace DCL.AvatarRendering.Wearables.Systems.Load
 {
-    [UpdateInGroup(typeof(PresentationSystemGroup))]
+    [UpdateInGroup(typeof(LoadGlobalSystemGroup))]
     [LogCategory(ReportCategory.WEARABLE)]
     public partial class LoadWearablesDTOByPointersSystem : LoadElementsByPointersSystem<WearablesDTOList, GetWearableDTOByPointersIntention, WearableDTO>
     {

--- a/Explorer/Assets/DCL/ECS/GlobalPartitioning/GlobalDeferredLoadingSystem.cs
+++ b/Explorer/Assets/DCL/ECS/GlobalPartitioning/GlobalDeferredLoadingSystem.cs
@@ -5,22 +5,18 @@ using DCL.AvatarRendering.Emotes;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.AvatarRendering.Wearables.Components.Intentions;
 using DCL.AvatarRendering.Wearables.Helpers;
-using DCL.CharacterMotion.Components;
 using DCL.Ipfs;
 using DCL.Optimization.PerformanceBudgeting;
+using ECS.Groups;
 using ECS.SceneLifeCycle;
 using ECS.SceneLifeCycle.Components;
 using ECS.SceneLifeCycle.SceneDefinition;
-using ECS.SceneLifeCycle.Systems;
 using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.AudioClips;
 using ECS.StreamableLoading.DeferredLoading;
 using ECS.StreamableLoading.GLTF;
 using ECS.StreamableLoading.Textures;
 using SceneRunner.Scene;
-using UnityEngine;
-using LoadWearablesByParamSystem = DCL.AvatarRendering.Wearables.Systems.Load.LoadWearablesByParamSystem;
-using LoadWearablesDTOByPointersSystem = DCL.AvatarRendering.Wearables.Systems.Load.LoadWearablesDTOByPointersSystem;
 
 namespace DCL.GlobalPartitioning
 {
@@ -29,13 +25,7 @@ namespace DCL.GlobalPartitioning
     /// </summary>
     [UpdateInGroup(typeof(PresentationSystemGroup))]
     [UpdateAfter(typeof(PrepareGlobalAssetBundleLoadingParametersSystem))]
-    [UpdateBefore(typeof(LoadGlobalAssetBundleSystem))]
-    [UpdateBefore(typeof(LoadSceneDefinitionListSystem))]
-    [UpdateBefore(typeof(LoadSceneSystem))]
-    [UpdateBefore(typeof(LoadSceneDefinitionSystem))]
-    [UpdateBefore(typeof(LoadAssetBundleManifestSystem))]
-    [UpdateBefore(typeof(LoadWearablesDTOByPointersSystem))]
-    [UpdateBefore(typeof(LoadWearablesByParamSystem))]
+    [UpdateBefore(typeof(LoadGlobalSystemGroup))]
     public partial class GlobalDeferredLoadingSystem : DeferredLoadingSystem
     {
         private static readonly QueryDescription[] COMPONENT_HANDLERS_SCENES_ASSETS;

--- a/Explorer/Assets/DCL/ECS/GlobalPartitioning/GlobalDeferredLoadingSystem.cs
+++ b/Explorer/Assets/DCL/ECS/GlobalPartitioning/GlobalDeferredLoadingSystem.cs
@@ -29,11 +29,11 @@ namespace DCL.GlobalPartitioning
     /// </summary>
     [UpdateInGroup(typeof(PresentationSystemGroup))]
     [UpdateAfter(typeof(PrepareGlobalAssetBundleLoadingParametersSystem))]
+    [UpdateBefore(typeof(LoadGlobalAssetBundleSystem))]
     [UpdateBefore(typeof(LoadSceneDefinitionListSystem))]
     [UpdateBefore(typeof(LoadSceneSystem))]
     [UpdateBefore(typeof(LoadSceneDefinitionSystem))]
     [UpdateBefore(typeof(LoadAssetBundleManifestSystem))]
-    [UpdateBefore(typeof(LoadGlobalAssetBundleSystem))]
     [UpdateBefore(typeof(LoadWearablesDTOByPointersSystem))]
     [UpdateBefore(typeof(LoadWearablesByParamSystem))]
     public partial class GlobalDeferredLoadingSystem : DeferredLoadingSystem

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Groups/LoadGlobalSystemGroup.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Groups/LoadGlobalSystemGroup.cs
@@ -1,0 +1,8 @@
+using Arch.SystemGroups;
+using Arch.SystemGroups.DefaultSystemGroups;
+
+namespace ECS.Groups
+{
+    [UpdateInGroup(typeof(PresentationSystemGroup))]
+    public partial class LoadGlobalSystemGroup { }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Groups/LoadGlobalSystemGroup.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Groups/LoadGlobalSystemGroup.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 51b315aa7b1a4b70afe0140865ef435b
+timeCreated: 1758115326

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Debug/Systems/AbortSceneLoadingDebugSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Debug/Systems/AbortSceneLoadingDebugSystem.cs
@@ -6,18 +6,17 @@ using DCL.DebugUtilities;
 using DCL.DebugUtilities.UIBindings;
 using DCL.Diagnostics;
 using ECS.Abstract;
+using ECS.Groups;
 using ECS.SceneLifeCycle.Components;
-using ECS.SceneLifeCycle.Systems;
 using ECS.StreamableLoading.Common.Components;
 using SceneRunner.Scene;
 using System;
-using System.Linq;
 using UnityEngine;
 
 namespace ECS.SceneLifeCycle.Debug
 {
     [UpdateInGroup(typeof(PresentationSystemGroup))]
-    [UpdateBefore(typeof(LoadSceneSystem))]
+    [UpdateBefore(typeof(LoadGlobalSystemGroup))]
     [LogCategory(ReportCategory.DEBUG)]
     public partial class AbortSceneLoadingDebugSystem : BaseUnityLoopSystem
     {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
@@ -7,6 +7,7 @@ using DCL.Diagnostics;
 using DCL.Ipfs;
 using DCL.Utilities;
 using DCL.WebRequests;
+using ECS.Groups;
 using ECS.Prioritization.Components;
 using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.Cache;
@@ -31,7 +32,7 @@ namespace ECS.SceneLifeCycle.SceneDefinition
     /// <summary>
     ///     Loads a scene list originated from pointers
     /// </summary>
-    [UpdateInGroup(typeof(PresentationSystemGroup))]
+    [UpdateInGroup(typeof(LoadGlobalSystemGroup))]
     [LogCategory(ReportCategory.SCENE_LOADING)]
     public partial class LoadSceneDefinitionListSystem : LoadSystemBase<SceneDefinitions, GetSceneDefinitionList>
     {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionSystem.cs
@@ -6,6 +6,7 @@ using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Ipfs;
 using DCL.WebRequests;
+using ECS.Groups;
 using ECS.Prioritization.Components;
 using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.Cache;
@@ -18,7 +19,7 @@ namespace ECS.SceneLifeCycle.SceneDefinition
     /// <summary>
     ///     Loads a single scene definition from URN
     /// </summary>
-    [UpdateInGroup(typeof(PresentationSystemGroup))]
+    [UpdateInGroup(typeof(LoadGlobalSystemGroup))]
     [LogCategory(ReportCategory.SCENE_LOADING)]
     public partial class LoadSceneDefinitionSystem : LoadSystemBase<SceneEntityDefinition, GetSceneDefinition>
     {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/SceneFacade/Systems/LoadSceneSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/SceneFacade/Systems/LoadSceneSystem.cs
@@ -4,6 +4,7 @@ using Arch.SystemGroups.DefaultSystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Optimization.PerformanceBudgeting;
+using ECS.Groups;
 using ECS.Prioritization.Components;
 using ECS.SceneLifeCycle.Components;
 using ECS.StreamableLoading.Cache;
@@ -18,7 +19,7 @@ namespace ECS.SceneLifeCycle.Systems
     /// <summary>
     ///     Loads a scene from scene and realm definitions
     /// </summary>
-    [UpdateInGroup(typeof(PresentationSystemGroup))]
+    [UpdateInGroup(typeof(LoadGlobalSystemGroup))]
     [LogCategory(ReportCategory.SCENE_LOADING)]
     public partial class LoadSceneSystem : LoadSystemBase<ISceneFacade, GetSceneFacadeIntention>
     {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/LoadAssetBundleManifestSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/LoadAssetBundleManifestSystem.cs
@@ -6,6 +6,7 @@ using DCL.Diagnostics;
 using DCL.Optimization.Pools;
 using DCL.Platforms;
 using DCL.WebRequests;
+using ECS.Groups;
 using ECS.Prioritization.Components;
 using ECS.StreamableLoading.Cache;
 using ECS.StreamableLoading.Common.Components;
@@ -18,7 +19,7 @@ using Utility;
 
 namespace ECS.StreamableLoading.AssetBundles
 {
-    [UpdateInGroup(typeof(StreamableLoadingGroup))]
+    [UpdateInGroup(typeof(LoadGlobalSystemGroup))]
     [LogCategory(ReportCategory.ASSET_BUNDLES)]
     public partial class LoadAssetBundleManifestSystem : LoadSystemBase<SceneAssetBundleManifest, GetAssetBundleManifestIntention>
     {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/LoadGlobalAssetBundleSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/LoadGlobalAssetBundleSystem.cs
@@ -3,6 +3,7 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.Diagnostics;
 using DCL.WebRequests;
+using ECS.Groups;
 using ECS.StreamableLoading.Cache;
 using ECS.StreamableLoading.Cache.Disk;
 using ECS.StreamableLoading.Common.Components;
@@ -14,7 +15,7 @@ namespace ECS.StreamableLoading.AssetBundles
     /// <summary>
     ///     We need a separate class to override the UpdateInGroup attribute
     /// </summary>
-    [UpdateInGroup(typeof(PresentationSystemGroup))]
+    [UpdateInGroup(typeof(LoadGlobalSystemGroup))]
     [LogCategory(ReportCategory.ASSET_BUNDLES)]
     public partial class LoadGlobalAssetBundleSystem : LoadAssetBundleSystem
     {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/PrepareAssetBundleLoadingParametersSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/PrepareAssetBundleLoadingParametersSystem.cs
@@ -3,6 +3,7 @@ using Arch.System;
 using Arch.SystemGroups;
 using CommunicationData.URLHelpers;
 using DCL.Diagnostics;
+using ECS.Groups;
 using ECS.StreamableLoading.Common.Components;
 using SceneRunner.Scene;
 
@@ -11,8 +12,7 @@ namespace ECS.StreamableLoading.AssetBundles
     /// <summary>
     ///     Prepares Asset Bundle Parameters for loading Asset Bundle in the scene world
     /// </summary>
-    [UpdateInGroup(typeof(StreamableLoadingGroup))]
-    [UpdateBefore(typeof(LoadAssetBundleSystem))]
+    [UpdateInGroup(typeof(SyncedPresentationSystemGroup))]
     [LogCategory(ReportCategory.ASSET_BUNDLES)]
     public partial class PrepareAssetBundleLoadingParametersSystem : PrepareAssetBundleLoadingParametersSystemBase
     {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/PrepareGlobalAssetBundleLoadingParametersSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/PrepareGlobalAssetBundleLoadingParametersSystem.cs
@@ -14,7 +14,6 @@ namespace ECS.StreamableLoading.AssetBundles
     ///     Prepares Asset Bundle Parameters for loading Asset Bundle in the global world
     /// </summary>
     [UpdateInGroup(typeof(PresentationSystemGroup))]
-    [UpdateBefore(typeof(LoadGlobalAssetBundleSystem))]
     [LogCategory(ReportCategory.ASSET_BUNDLES)]
     public partial class PrepareGlobalAssetBundleLoadingParametersSystem : PrepareAssetBundleLoadingParametersSystemBase
     {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/DeferredLoading/AssetsDeferredLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/DeferredLoading/AssetsDeferredLoadingSystem.cs
@@ -1,24 +1,21 @@
 ﻿using Arch.Core;
 using Arch.SystemGroups;
 using DCL.Optimization.PerformanceBudgeting;
+using ECS.Groups;
 using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.AudioClips;
 using ECS.StreamableLoading.GLTF;
 using ECS.StreamableLoading.NFTShapes;
 using ECS.StreamableLoading.Textures;
-using UnityEngine;
 
 namespace ECS.StreamableLoading.DeferredLoading
 {
     /// <summary>
     ///     Weighs asset bundles and textures against each other according to their partition
     /// </summary>
-    [UpdateInGroup(typeof(StreamableLoadingGroup))]
+    [UpdateInGroup(typeof(SyncedPresentationSystemGroup))]
     [UpdateAfter(typeof(PrepareAssetBundleLoadingParametersSystem))]
-    [UpdateBefore(typeof(LoadAssetBundleSystem))]
-    [UpdateBefore(typeof(LoadTextureSystem))]
-    [UpdateBefore(typeof(LoadAudioClipSystem))]
-    [UpdateBefore(typeof(LoadNFTShapeSystem))]
+    [UpdateBefore(typeof(StreamableLoadingGroup))]
     public partial class AssetsDeferredLoadingSystem : DeferredLoadingSystem
     {
         private static readonly QueryDescription[] COMPONENT_HANDLERS;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/DeferredLoading/AssetsDeferredLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/DeferredLoading/AssetsDeferredLoadingSystem.cs
@@ -15,10 +15,10 @@ namespace ECS.StreamableLoading.DeferredLoading
     /// </summary>
     [UpdateInGroup(typeof(StreamableLoadingGroup))]
     [UpdateAfter(typeof(PrepareAssetBundleLoadingParametersSystem))]
+    [UpdateBefore(typeof(LoadAssetBundleSystem))]
     [UpdateBefore(typeof(LoadTextureSystem))]
     [UpdateBefore(typeof(LoadAudioClipSystem))]
     [UpdateBefore(typeof(LoadNFTShapeSystem))]
-    [UpdateBefore(typeof(LoadAssetBundleSystem))]
     public partial class AssetsDeferredLoadingSystem : DeferredLoadingSystem
     {
         private static readonly QueryDescription[] COMPONENT_HANDLERS;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/LoadGlobalTextureSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/LoadGlobalTextureSystem.cs
@@ -3,6 +3,7 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.Diagnostics;
 using DCL.WebRequests;
+using ECS.Groups;
 using ECS.StreamableLoading.Cache;
 using ECS.StreamableLoading.Cache.Disk;
 
@@ -11,7 +12,7 @@ namespace ECS.StreamableLoading.Textures
     /// <summary>
     ///     We need a separate class to override the UpdateInGroup attribute
     /// </summary>
-    [UpdateInGroup(typeof(PresentationSystemGroup))]
+    [UpdateInGroup(typeof(LoadGlobalSystemGroup))]
     [LogCategory(ReportCategory.TEXTURES)]
     public partial class LoadGlobalTextureSystem : LoadTextureSystem
     {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

The code generation that set up system ordering is not working properly. Therefore, we had a rrace condition between 

`PrepareGlobalAssetBundleLoadingSystem`
'GlobalDeferredSystem`
`LoadAssetBundleSystem`

That disorder can cause wearables not to load

To fix this, I packed the global systems in risks into a single group, therefore securing the order.

Just in case, I also resorted the world one, to secure the same order

System order in Global World
<img width="968" height="1388" alt="Screenshot 2025-09-17 at 11 22 31 AM" src="https://github.com/user-attachments/assets/de05a061-474d-466b-bad7-0c64c152946a" />


System order in Scene World
<img width="510" height="443" alt="Screenshot 2025-09-17 at 11 26 14 AM" src="https://github.com/user-attachments/assets/d8cfcd20-9cd9-419d-b07f-fe2f8e22d570" />

## Test Instructions

A smoke test of assets loading. So, everything


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
