### PR TITLE
fix: prevent chat folding when clicking sidebar button

### DIFF
--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
@@ -382,7 +382,7 @@ namespace DCL.UI.Sidebar
         private async UniTaskVoid OpenExplorePanelInSectionAsync(ExploreSections section, BackpackSections backpackSection = BackpackSections.Avatar)
         {
             // Note: The buttons of these options (map, backpack, etc.) are not highlighted because they are not visible anyway
-            await sharedSpaceManager.ShowAsync(PanelsSharingSpace.Explore, new ExplorePanelParameter(section, backpackSection));
+            await sharedSpaceManager.ShowAsync(PanelsSharingSpace.Explore, new ExplorePanelParameter(section, backpackSection), PanelsSharingSpace.Chat);
         }
 #endregion
     }


### PR DESCRIPTION
# Pull Request Description
Fixes #5468

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR prevent the chat folding when any section of the explore panel is opened using the sidebar buttons.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Follow the steps described in the linked issue and verify that now it behaves as expected


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
