### PR TITLE
fix: camera ctrl does not slow movement

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/InWorldCameraComponents.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/InWorldCameraComponents.cs
@@ -28,6 +28,7 @@ namespace DCL.InWorldCamera
         public float Panning;
         public float Tilting;
         public bool IsRunning;
+        public bool IsWalking;
 
         public Vector2 Aim;
         public bool MouseIsDragging;

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Settings/InWorldCameraMovementSettings.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Settings/InWorldCameraMovementSettings.cs
@@ -9,6 +9,7 @@ namespace DCL.InWorldCamera.Settings
         [field: SerializeField] public float TranslationSpeed { get; private set; } = 5f;
         [field: SerializeField] public float MouseTranslationSpeed { get; private set; } = 0.05f;
         [field: SerializeField] public float RunSpeedMultiplayer { get; private set; } = 2;
+        [field: SerializeField] public float WalkSpeedMultiplayer { get; private set; } = .5f;
 
         [field: Header("FOV")]
         [field: SerializeField] public float FOVChangeSpeed { get; private set; } = 3;

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/EmitInWorldCameraInputSystem.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/EmitInWorldCameraInputSystem.cs
@@ -43,6 +43,7 @@ namespace DCL.InWorldCamera.Systems
                 input.Panning = inputSchema.Panning.ReadValue<float>();
                 input.Tilting = inputSchema.Tilting.ReadValue<float>();
                 input.IsRunning = inputSchema.Run.IsPressed();
+                input.IsWalking = inputSchema.Walk.IsPressed();
 
                 input.Aim = inputSchema.Rotation.ReadValue<Vector2>();
                 input.MouseIsDragging = inputSchema.MouseDrag.IsPressed();

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/MoveInWorldCameraSystem.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/MoveInWorldCameraSystem.cs
@@ -146,7 +146,14 @@ namespace DCL.InWorldCamera.Systems
             Vector3 horizontal = target.right.normalized * input.Translation.x;
             Vector3 vertical = target.up.normalized * input.Panning;
 
-            float speed = input.IsRunning ? moveSpeed * settings.RunSpeedMultiplayer : moveSpeed;
+            float speed = moveSpeed;
+
+            if (input.IsRunning)
+                speed *= settings.RunSpeedMultiplayer;
+
+            if (input.IsWalking)
+                speed *= settings.WalkSpeedMultiplayer;
+
             return (forward + horizontal + vertical) * (speed * deltaTime);
         }
 

--- a/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.cs
+++ b/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.cs
@@ -3319,6 +3319,15 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Walk"",
+                    ""type"": ""Button"",
+                    ""id"": ""7e9e5ae9-8eb6-4cec-9b81-98717cdc5729"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -3783,6 +3792,39 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
                     ""action"": ""ToggleNametags"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""38e2c487-bb88-42d9-93a0-5e899e648477"",
+                    ""path"": ""<Keyboard>/leftCtrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Walk"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""d0a8f602-c633-4015-867e-b32c53fbe6a5"",
+                    ""path"": ""<Gamepad>/rightStickPress"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Walk"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""943f8268-3c6e-4068-a150-73dee1f4fd24"",
+                    ""path"": ""<Gamepad>/buttonSouth"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Walk"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
                 }
             ]
         },
@@ -3941,6 +3983,7 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
         m_InWorldCamera_ShowHide = m_InWorldCamera.FindAction("ShowHide", throwIfNotFound: true);
         m_InWorldCamera_Close = m_InWorldCamera.FindAction("Close", throwIfNotFound: true);
         m_InWorldCamera_ToggleNametags = m_InWorldCamera.FindAction("ToggleNametags", throwIfNotFound: true);
+        m_InWorldCamera_Walk = m_InWorldCamera.FindAction("Walk", throwIfNotFound: true);
         // VoiceChat
         m_VoiceChat = asset.FindActionMap("VoiceChat", throwIfNotFound: true);
         m_VoiceChat_Talk = m_VoiceChat.FindAction("Talk", throwIfNotFound: true);
@@ -5619,6 +5662,7 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_InWorldCamera_ShowHide;
     private readonly InputAction m_InWorldCamera_Close;
     private readonly InputAction m_InWorldCamera_ToggleNametags;
+    private readonly InputAction m_InWorldCamera_Walk;
     /// <summary>
     /// Provides access to input actions defined in input action map "InWorldCamera".
     /// </summary>
@@ -5682,6 +5726,10 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "InWorldCamera/ToggleNametags".
         /// </summary>
         public InputAction @ToggleNametags => m_Wrapper.m_InWorldCamera_ToggleNametags;
+        /// <summary>
+        /// Provides access to the underlying input action "InWorldCamera/Walk".
+        /// </summary>
+        public InputAction @Walk => m_Wrapper.m_InWorldCamera_Walk;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -5747,6 +5795,9 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
             @ToggleNametags.started += instance.OnToggleNametags;
             @ToggleNametags.performed += instance.OnToggleNametags;
             @ToggleNametags.canceled += instance.OnToggleNametags;
+            @Walk.started += instance.OnWalk;
+            @Walk.performed += instance.OnWalk;
+            @Walk.canceled += instance.OnWalk;
         }
 
         /// <summary>
@@ -5797,6 +5848,9 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
             @ToggleNametags.started -= instance.OnToggleNametags;
             @ToggleNametags.performed -= instance.OnToggleNametags;
             @ToggleNametags.canceled -= instance.OnToggleNametags;
+            @Walk.started -= instance.OnWalk;
+            @Walk.performed -= instance.OnWalk;
+            @Walk.canceled -= instance.OnWalk;
         }
 
         /// <summary>
@@ -6716,6 +6770,13 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnToggleNametags(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Walk" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnWalk(InputAction.CallbackContext context);
     }
     /// <summary>
     /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "VoiceChat" which allows adding and removing callbacks.

--- a/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.inputactions
+++ b/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.inputactions
@@ -3233,6 +3233,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "Walk",
+                    "type": "Button",
+                    "id": "7e9e5ae9-8eb6-4cec-9b81-98717cdc5729",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -3695,6 +3704,39 @@
                     "processors": "",
                     "groups": "",
                     "action": "ToggleNametags",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "38e2c487-bb88-42d9-93a0-5e899e648477",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Walk",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "d0a8f602-c633-4015-867e-b32c53fbe6a5",
+                    "path": "<Gamepad>/rightStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Walk",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "943f8268-3c6e-4068-a150-73dee1f4fd24",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Walk",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }


### PR DESCRIPTION
# Pull Request Description
Fix #5232 

## What does this PR change?
Implemented ctrl action to slow down camera movement. 
[Shift] doubles the speed, configured value for [Ctrl] halves the speed.

### Test Steps

1. Open the camera [C].
2. Move the camera using the controls.
3. Hold [Shift] – observe the speed increases.
4. Hold [Ctrl] – observe that the speed does decrease.

### Additional Testing Notes
- Multipliers are added independently so when holding both keys both multipliers are applied.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
