### PR TITLE
chore: Add asset bundle version to Scene Emotes

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetSceneEmoteFromRealmIntention.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/Intents/GetSceneEmoteFromRealmIntention.cs
@@ -27,7 +27,7 @@ namespace DCL.AvatarRendering.Emotes
         public AssetSource PermittedSources { get; }
         public BodyShape BodyShape { get; }
 
-        private AssetBundleManifestVersion SceneAssetBundleManifestVersion;
+        public AssetBundleManifestVersion SceneAssetBundleManifestVersion;
 
         public LoadTimeout Timeout { get; private set; }
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
@@ -6,6 +6,7 @@ using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Components;
 using DCL.AvatarRendering.Loading.DTO;
 using DCL.Diagnostics;
+using DCL.Ipfs;
 using ECS.Abstract;
 using ECS.Prioritization.Components;
 using ECS.StreamableLoading.Common.Components;
@@ -51,7 +52,7 @@ namespace DCL.AvatarRendering.Emotes.Load
                     static i => $"Scene emote request cancelled {i.EmoteHash}"))
                 return;
 
-            ProcessSceneEmoteIntention(dt, entity, ref intention, ref partitionComponent);
+            ProcessSceneEmoteIntention(dt, entity, ref intention, ref partitionComponent, intention.SceneAssetBundleManifestVersion);
         }
 
         [Query]
@@ -60,18 +61,19 @@ namespace DCL.AvatarRendering.Emotes.Load
             ref GetSceneEmoteFromLocalSceneIntention intention,
             ref IPartitionComponent partitionComponent)
         {
-            ProcessSceneEmoteIntention(dt, entity, ref intention, ref partitionComponent);
+            ProcessSceneEmoteIntention(dt, entity, ref intention, ref partitionComponent, AssetBundleManifestVersion.CreateLSDAsset());
         }
 
         private void ProcessSceneEmoteIntention<TIntention>(
             float dt,
             Entity entity,
             ref TIntention intention,
-            ref IPartitionComponent partitionComponent
+            ref IPartitionComponent partitionComponent,
+            AssetBundleManifestVersion sceneAssetBundleManifest
         ) where TIntention : struct, IEmoteAssetIntention
         {
             URN urn = intention.NewSceneEmoteURN();
-            
+
             if (intention.IsTimeout(dt))
             {
                 if (!World.Has<StreamableResult>(entity))
@@ -87,6 +89,7 @@ namespace DCL.AvatarRendering.Emotes.Load
                 var dto = new EmoteDTO
                 {
                     id = urn,
+                    assetBundleManifestVersion = sceneAssetBundleManifest,
                     metadata = new EmoteDTO.EmoteMetadataDto
                     {
                         id = urn,

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -232,7 +232,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                     AudioClip? audioClip = audioAssetResult?.Asset;
 
                     if (!emotePlayer.Play(mainAsset, audioClip, emote.IsLooping(), emoteIntent.Spatial, in avatarView, ref emoteComponent))
-                        ReportHub.LogWarning(GetReportData(), $"Emote {emote.Model.Asset?.metadata.name} cant be played, AB version: {emote.DTO.assetBundleManifestVersion.GetAssetBundleManifestVersion()} should be >= 16");
+                        ReportHub.LogError(ReportCategory.EMOTE, $"Emote name:{emoteId} cant be played.");
 
                     World.Remove<CharacterEmoteIntent>(entity);
                 }

--- a/Explorer/Assets/DCL/Ipfs/AssetBundleManifestVersion.cs
+++ b/Explorer/Assets/DCL/Ipfs/AssetBundleManifestVersion.cs
@@ -64,10 +64,7 @@ public class AssetBundleManifestVersion
             var assetBundleManifestVersion = new AssetBundleManifestVersion();
             var assets = new AssetBundleManifestVersionPerPlatform();
             assets.mac = new PlatformInfo(assetBundleManifestVersionMac, buildDate);
-            ;
             assets.windows = new PlatformInfo(assetBundleManifestVersionWin, buildDate);
-            ;
-
             assetBundleManifestVersion.assets = assets;
             assetBundleManifestVersion.HasHashInPath();
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

- Adds missing asset bundle version info for scene emotes
- Sets the LSD setting for GLTF emotes
- Cleans up the error message in Emote Player. Emotes could fail for different reasons, not only for the AB. Im leaving it to the developer to analyze what can go wrong

## Test Instructions


### Test Steps
1. Test regular emotes
2. Test an emote collection
3. Go to a scene with scene emotes. Test them there as well (like Goerli, `80,-1`)


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
