### PR TITLE
style:  restyle community card voice stream panel

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCard.prefab
@@ -2071,8 +2071,12 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6164589946070249709, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 470
+      objectReference: {fileID: 0}
+    - target: {fileID: 6164589946070249709, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 6
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6164589946070249709, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -2191,6 +2195,10 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7595087787278926623, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 470
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595087787278926623, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 6
       objectReference: {fileID: 0}
@@ -2281,9 +2289,6 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 4515931639978279085, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
       insertIndex: -1
       addedObject: {fileID: 7153150828626057688}
-    - targetCorrespondingSourceObject: {fileID: 1704314129669251257, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3777147522068312579}
     - targetCorrespondingSourceObject: {fileID: 5232576657936602778, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1711381357737375842}
@@ -2879,23 +2884,6 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2150719373246442724}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &2215540314108746868 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1704314129669251257, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
-  m_PrefabInstance: {fileID: 655799890762218701}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &3777147522068312579
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2215540314108746868}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCard.prefab
@@ -1904,7 +1904,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3645950253289182975, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
       propertyPath: m_Padding.m_Top
-      value: 6
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4515931639978279085, guid: e4edf3a7bf4ec44daada2bfe4ce5edb0, type: 3}
       propertyPath: m_IsActive

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/JoinStreamPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/JoinStreamPanel.prefab
@@ -1259,7 +1259,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: -115}
-  m_SizeDelta: {x: 620, y: 140}
+  m_SizeDelta: {x: 740, y: 500}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1741797696145871232
 CanvasRenderer:

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/JoinStreamPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/JoinStreamPanel.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 8253490348279832676}
   - component: {fileID: 6894360445493279163}
   - component: {fileID: 48041118396254369}
+  - component: {fileID: 4931081902414215391}
   m_Layer: 5
   m_Name: Image
   m_TagString: Untagged
@@ -75,6 +76,18 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4931081902414215391
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 164666143365975672}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &350013992452072046
 GameObject:
   m_ObjectHideFlags: 0
@@ -84,6 +97,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1241591880291840230}
+  - component: {fileID: 2752741023280113607}
   m_Layer: 5
   m_Name: Title
   m_TagString: Untagged
@@ -110,9 +124,21 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 24, y: -48}
+  m_AnchoredPosition: {x: 18, y: -48}
   m_SizeDelta: {x: 420, y: 36}
   m_Pivot: {x: 0, y: 1}
+--- !u!114 &2752741023280113607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 350013992452072046}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &687844557255876849
 GameObject:
   m_ObjectHideFlags: 0
@@ -124,6 +150,7 @@ GameObject:
   - component: {fileID: 8612244977143269191}
   - component: {fileID: 4197564376847583722}
   - component: {fileID: 5284330940795768216}
+  - component: {fileID: 1779429289437399620}
   m_Layer: 5
   m_Name: ListenersIcon
   m_TagString: Untagged
@@ -188,6 +215,18 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1779429289437399620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 687844557255876849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2776046935471114832
 GameObject:
   m_ObjectHideFlags: 0
@@ -200,6 +239,7 @@ GameObject:
   - component: {fileID: 1996553316864116529}
   - component: {fileID: 2258303777278825485}
   - component: {fileID: 1062457857513873303}
+  - component: {fileID: 4517966008456636805}
   m_Layer: 5
   m_Name: ListeningButton
   m_TagString: Untagged
@@ -257,7 +297,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 227d70da02d2b4eb482ff4b390e6d27f, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 12dd1efc4e826764f9b02be515a9a033, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -266,7 +306,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 2.3
+  m_PixelsPerUnitMultiplier: 2
 --- !u!114 &1062457857513873303
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -286,12 +326,12 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 2
+  m_Transition: 1
   m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 0.050980393}
-    m_HighlightedColor: {r: 1, g: 1, b: 1, a: 0.101960786}
-    m_PressedColor: {r: 1, g: 1, b: 1, a: 0.050980393}
-    m_SelectedColor: {r: 1, g: 1, b: 1, a: 0.050980393}
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0.03137255}
+    m_HighlightedColor: {r: 1, g: 1, b: 1, a: 0.050980393}
+    m_PressedColor: {r: 1, g: 1, b: 1, a: 0.03137255}
+    m_SelectedColor: {r: 1, g: 1, b: 1, a: 0.03137255}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -311,6 +351,18 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &4517966008456636805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2776046935471114832}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2875937109499904329
 GameObject:
   m_ObjectHideFlags: 0
@@ -322,6 +374,7 @@ GameObject:
   - component: {fileID: 2632378569868443222}
   - component: {fileID: 1494715346085966419}
   - component: {fileID: 4932871497701169311}
+  - component: {fileID: 775013056770265110}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -447,6 +500,18 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &775013056770265110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2875937109499904329}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3677805713720592863
 GameObject:
   m_ObjectHideFlags: 0
@@ -458,6 +523,7 @@ GameObject:
   - component: {fileID: 4523575715760107649}
   - component: {fileID: 6770191673149140304}
   - component: {fileID: 6466832830933482504}
+  - component: {fileID: 2049616767252826990}
   m_Layer: 5
   m_Name: Icon
   m_TagString: Untagged
@@ -522,6 +588,18 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2049616767252826990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3677805713720592863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4134338872622917041
 GameObject:
   m_ObjectHideFlags: 0
@@ -533,6 +611,7 @@ GameObject:
   - component: {fileID: 3796745844606477645}
   - component: {fileID: 5222751445673233827}
   - component: {fileID: 3777907409556956604}
+  - component: {fileID: 5590122201182173473}
   m_Layer: 5
   m_Name: Title
   m_TagString: Untagged
@@ -658,6 +737,18 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &5590122201182173473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4134338872622917041}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4457175062628153062
 GameObject:
   m_ObjectHideFlags: 0
@@ -669,6 +760,7 @@ GameObject:
   - component: {fileID: 7657294844094291646}
   - component: {fileID: 7814206925826740950}
   - component: {fileID: 6865675239852314381}
+  - component: {fileID: 4075616264533276971}
   m_Layer: 5
   m_Name: Listeners
   m_TagString: Untagged
@@ -794,6 +886,18 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &4075616264533276971
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4457175062628153062}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5218664876280323742
 GameObject:
   m_ObjectHideFlags: 0
@@ -805,6 +909,7 @@ GameObject:
   - component: {fileID: 2736454767231558132}
   - component: {fileID: 7198415757909070322}
   - component: {fileID: 6346945912430294553}
+  - component: {fileID: 7781316522083723513}
   m_Layer: 5
   m_Name: SpeakingInner
   m_TagString: Untagged
@@ -869,6 +974,18 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7781316522083723513
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5218664876280323742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5542484740989447236
 GameObject:
   m_ObjectHideFlags: 0
@@ -880,13 +997,14 @@ GameObject:
   - component: {fileID: 6454376761872852861}
   - component: {fileID: 8687390813497835271}
   - component: {fileID: 3593804647838987316}
+  - component: {fileID: 1358140423015032711}
   m_Layer: 5
   m_Name: IconPulseAnimation
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6454376761872852861
 RectTransform:
   m_ObjectHideFlags: 0
@@ -901,11 +1019,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1241591880291840230}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: -5.8, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -197, y: 0}
   m_SizeDelta: {x: 36, y: 36}
-  m_Pivot: {x: 0, y: 0.5}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8687390813497835271
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -944,6 +1062,18 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1358140423015032711
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5542484740989447236}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5596121175627066559
 GameObject:
   m_ObjectHideFlags: 0
@@ -955,6 +1085,7 @@ GameObject:
   - component: {fileID: 629632495224156664}
   - component: {fileID: 2159391932376606948}
   - component: {fileID: 5774293432089071345}
+  - component: {fileID: 6024894170150516028}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -1080,7 +1211,19 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &6620387985220637773
+--- !u!114 &6024894170150516028
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5596121175627066559}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &5636826584744279765
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1088,23 +1231,24 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5661816919892344166}
-  - component: {fileID: 7853708258985803427}
-  - component: {fileID: 6534537975120678932}
+  - component: {fileID: 891271240201224630}
+  - component: {fileID: 1741797696145871232}
+  - component: {fileID: 5371885048432330475}
+  - component: {fileID: 8856620617704421222}
   m_Layer: 5
-  m_Name: Image
+  m_Name: GlowBottom
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &5661816919892344166
+--- !u!224 &891271240201224630
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6620387985220637773}
+  m_GameObject: {fileID: 5636826584744279765}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -1112,41 +1256,41 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1858757963800134681}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -115}
+  m_SizeDelta: {x: 620, y: 140}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &7853708258985803427
+--- !u!222 &1741797696145871232
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6620387985220637773}
+  m_GameObject: {fileID: 5636826584744279765}
   m_CullTransparentMesh: 1
---- !u!114 &6534537975120678932
+--- !u!114 &5371885048432330475
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6620387985220637773}
+  m_GameObject: {fileID: 5636826584744279765}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_Color: {r: 0.54901963, g: 0.16470589, b: 0.9372549, a: 0.5019608}
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: fe46e0aab0f234247bf8bacad7e4c76e, type: 3}
-  m_Type: 1
+  m_Sprite: {fileID: 21300000, guid: 00cc69ba88b8143baa8ef5d80c99ab63, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -1155,6 +1299,18 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8856620617704421222
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5636826584744279765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6649534716191400601
 GameObject:
   m_ObjectHideFlags: 0
@@ -1164,6 +1320,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7777748750959314408}
+  - component: {fileID: 7949907911216249229}
   m_Layer: 5
   m_Name: Header
   m_TagString: Untagged
@@ -1189,9 +1346,21 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 24, y: -89.2}
+  m_AnchoredPosition: {x: 17.999977, y: -89.2}
   m_SizeDelta: {x: 420, y: 20}
   m_Pivot: {x: 0, y: 1}
+--- !u!114 &7949907911216249229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6649534716191400601}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8074349111793713872
 GameObject:
   m_ObjectHideFlags: 0
@@ -1203,6 +1372,7 @@ GameObject:
   - component: {fileID: 946022934385183424}
   - component: {fileID: 2826048800835420252}
   - component: {fileID: 4722672647592587259}
+  - component: {fileID: 8740878289682305342}
   m_Layer: 5
   m_Name: SpeakingOuter
   m_TagString: Untagged
@@ -1267,6 +1437,18 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8740878289682305342
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8074349111793713872}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8105066226455064007
 GameObject:
   m_ObjectHideFlags: 0
@@ -1279,6 +1461,7 @@ GameObject:
   - component: {fileID: 6427622133333675334}
   - component: {fileID: 7630499828804308405}
   - component: {fileID: 8365283399798510755}
+  - component: {fileID: 4468833609959490643}
   m_Layer: 5
   m_Name: JoinStreamButton
   m_TagString: Untagged
@@ -1389,6 +1572,18 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &4468833609959490643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8105066226455064007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8281390216486335577
 GameObject:
   m_ObjectHideFlags: 0
@@ -1399,7 +1594,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1858757963800134681}
   - component: {fileID: 6528546835943486542}
-  - component: {fileID: 3103029569443571174}
+  - component: {fileID: 8007742802221593709}
   m_Layer: 5
   m_Name: JoinStreamPanel
   m_TagString: Untagged
@@ -1419,7 +1614,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5661816919892344166}
+  - {fileID: 891271240201224630}
   - {fileID: 1241591880291840230}
   - {fileID: 7777748750959314408}
   - {fileID: 4400877338096838512}
@@ -1439,33 +1634,31 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8281390216486335577}
   m_CullTransparentMesh: 1
---- !u!114 &3103029569443571174
+--- !u!114 &8007742802221593709
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8281390216486335577}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 0bac33ade27cf4542bd53b1b13d90941, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: fe46e0aab0f234247bf8bacad7e4c76e, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1.3
+  _source: 1
+  _separateMask: {fileID: 0}
+  _sprite: {fileID: 0}
+  _spriteBorderMode: 0
+  _spritePixelsPerUnitMultiplier: 1
+  _texture: {fileID: 0}
+  _textureUVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  _channelWeights: {r: 0, g: 0, b: 0, a: 1}
+  _raycastThreshold: 0
+  _invertMask: 0
+  _invertOutsides: 0

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/JoinStreamPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/JoinStreamPanel.prefab
@@ -1167,8 +1167,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 17
-  m_fontSizeBase: 17
+  m_fontSize: 14
+  m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/StartStreamModeratorPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/StartStreamModeratorPanel.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 8927999660438522633}
   - component: {fileID: 9085804163767413935}
   - component: {fileID: 3282952379219250407}
+  - component: {fileID: 845949116276606862}
   m_Layer: 5
   m_Name: Image
   m_TagString: Untagged
@@ -75,6 +76,18 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &845949116276606862
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 936558845121949427}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2254486885327755209
 GameObject:
   m_ObjectHideFlags: 0
@@ -86,6 +99,7 @@ GameObject:
   - component: {fileID: 857630483991571457}
   - component: {fileID: 4225399603577583192}
   - component: {fileID: 3054335332895293299}
+  - component: {fileID: 5167272852220590364}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -211,6 +225,18 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &5167272852220590364
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2254486885327755209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5762207963605357010
 GameObject:
   m_ObjectHideFlags: 0
@@ -222,6 +248,7 @@ GameObject:
   - component: {fileID: 8985247705211068866}
   - component: {fileID: 1156116192573019592}
   - component: {fileID: 6780315495813464098}
+  - component: {fileID: 2749561121758046728}
   m_Layer: 5
   m_Name: Header
   m_TagString: Untagged
@@ -245,7 +272,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 20, y: -54}
+  m_AnchoredPosition: {x: 20, y: -50}
   m_SizeDelta: {x: 135.15, y: 20}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &1156116192573019592
@@ -347,6 +374,106 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &2749561121758046728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5762207963605357010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &6079746139067527976
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3395789308250071935}
+  - component: {fileID: 8277783772854472828}
+  - component: {fileID: 8202634669171245787}
+  - component: {fileID: 3995420541888060098}
+  m_Layer: 5
+  m_Name: GlowBottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3395789308250071935
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6079746139067527976}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7208412289321226793}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -79.74805}
+  m_SizeDelta: {x: 622.9247, y: 142.1244}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8277783772854472828
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6079746139067527976}
+  m_CullTransparentMesh: 1
+--- !u!114 &8202634669171245787
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6079746139067527976}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.54901963, g: 0.16470589, b: 0.9372549, a: 0.5019608}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 00cc69ba88b8143baa8ef5d80c99ab63, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3995420541888060098
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6079746139067527976}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6908157698278189852
 GameObject:
   m_ObjectHideFlags: 0
@@ -359,6 +486,7 @@ GameObject:
   - component: {fileID: 5687621057547581866}
   - component: {fileID: 5057582804960617181}
   - component: {fileID: 93723926661932247}
+  - component: {fileID: 6667913764572143114}
   m_Layer: 5
   m_Name: StartStreamButton
   m_TagString: Untagged
@@ -408,7 +536,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.1882353, g: 0.8039216, b: 0, a: 1}
+  m_Color: {r: 0.16078432, g: 0.7137255, b: 0.22352941, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -424,7 +552,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 2.3
+  m_PixelsPerUnitMultiplier: 2
 --- !u!114 &93723926661932247
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -469,6 +597,18 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &6667913764572143114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6908157698278189852}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6913403163867305455
 GameObject:
   m_ObjectHideFlags: 0
@@ -479,7 +619,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7208412289321226793}
   - component: {fileID: 8282626665724767998}
-  - component: {fileID: 6831218530703830422}
+  - component: {fileID: 5234689497352908966}
   m_Layer: 5
   m_Name: StartStreamModeratorPanel
   m_TagString: Untagged
@@ -500,6 +640,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8985247705211068866}
+  - {fileID: 3395789308250071935}
   - {fileID: 6123270911493094292}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -516,7 +657,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6913403163867305455}
   m_CullTransparentMesh: 1
---- !u!114 &6831218530703830422
+--- !u!114 &5234689497352908966
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -525,24 +666,22 @@ MonoBehaviour:
   m_GameObject: {fileID: 6913403163867305455}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 0bac33ade27cf4542bd53b1b13d90941, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: fe46e0aab0f234247bf8bacad7e4c76e, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1.3
+  _source: 1
+  _separateMask: {fileID: 0}
+  _sprite: {fileID: 0}
+  _spriteBorderMode: 0
+  _spritePixelsPerUnitMultiplier: 1
+  _texture: {fileID: 0}
+  _textureUVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  _channelWeights: {r: 0, g: 0, b: 0, a: 1}
+  _raycastThreshold: 0
+  _invertMask: 0
+  _invertOutsides: 0

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/StartStreamModeratorPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/StartStreamModeratorPanel.prefab
@@ -421,8 +421,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -79.74805}
-  m_SizeDelta: {x: 622.9247, y: 142.1244}
+  m_AnchoredPosition: {x: 0, y: -150}
+  m_SizeDelta: {x: 740, y: 500}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8277783772854472828
 CanvasRenderer:

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/StartStreamModeratorPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/StartStreamModeratorPanel.prefab
@@ -181,8 +181,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 17
-  m_fontSizeBase: 17
+  m_fontSize: 14
+  m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/VoiceChatContainer.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/VoiceChatContainer.prefab
@@ -145,7 +145,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1858757963800134681, guid: 076d4d2c030d64f75b9920fd1d94590f, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 458
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 1858757963800134681, guid: 076d4d2c030d64f75b9920fd1d94590f, type: 3}
       propertyPath: m_SizeDelta.y
@@ -307,7 +307,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7208412289321226793, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 458
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 7208412289321226793, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_SizeDelta.y

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/VoiceChatContainer.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/VoiceChatContainer.prefab
@@ -145,7 +145,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1858757963800134681, guid: 076d4d2c030d64f75b9920fd1d94590f, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 47
+      value: 470
       objectReference: {fileID: 0}
     - target: {fileID: 1858757963800134681, guid: 076d4d2c030d64f75b9920fd1d94590f, type: 3}
       propertyPath: m_SizeDelta.y
@@ -198,6 +198,14 @@ PrefabInstance:
     - target: {fileID: 1858757963800134681, guid: 076d4d2c030d64f75b9920fd1d94590f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5774293432089071345, guid: 076d4d2c030d64f75b9920fd1d94590f, type: 3}
+      propertyPath: m_fontSize
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 5774293432089071345, guid: 076d4d2c030d64f75b9920fd1d94590f, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 8281390216486335577, guid: 076d4d2c030d64f75b9920fd1d94590f, type: 3}
       propertyPath: m_Name
@@ -269,6 +277,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1343062598926575025}
     m_Modifications:
+    - target: {fileID: 3054335332895293299, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
+      propertyPath: m_fontSize
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 3054335332895293299, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 14
+      objectReference: {fileID: 0}
     - target: {fileID: 6123270911493094292, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 22
@@ -307,7 +323,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7208412289321226793, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 47
+      value: 470
       objectReference: {fileID: 0}
     - target: {fileID: 7208412289321226793, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_SizeDelta.y
@@ -343,11 +359,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7208412289321226793, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 6
+      value: 211.5
       objectReference: {fileID: 0}
     - target: {fileID: 7208412289321226793, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -6
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 7208412289321226793, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/VoiceChatContainer.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/VoiceChatContainer.prefab
@@ -211,6 +211,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: JoinStreamPanel
       objectReference: {fileID: 0}
+    - target: {fileID: 8281390216486335577, guid: 076d4d2c030d64f75b9920fd1d94590f, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -359,11 +363,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7208412289321226793, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 211.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7208412289321226793, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7208412289321226793, guid: dfab61ee7078845f28ed58cf19eb1f72, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Explorer/Assets/DCL/Communities/Textures/JoinContainerIdle.png
+++ b/Explorer/Assets/DCL/Communities/Textures/JoinContainerIdle.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1f5c91545fb46245c189b2852870271000e8fdcead144f7f74818a7a5b3eb2f
-size 277
+oid sha256:296a968c9e353d22c7a6f230b03fef06af11b57c33f9c6f83f561fe6b4bb5bcd
+size 241

--- a/Explorer/Assets/DCL/Communities/Textures/JoinContainerIdle_CommunityCard.png
+++ b/Explorer/Assets/DCL/Communities/Textures/JoinContainerIdle_CommunityCard.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1f5c91545fb46245c189b2852870271000e8fdcead144f7f74818a7a5b3eb2f
-size 277
+oid sha256:296a968c9e353d22c7a6f230b03fef06af11b57c33f9c6f83f561fe6b4bb5bcd
+size 241


### PR DESCRIPTION
# Pull Request Description
Since people reported confusing the close button of the community card by a button that closes the voice stream panel, the design team discussed a restyling alternative to avoid this issue.

The lilac rounded container, which gave the appearance of a sub-card inside the community card, was removed. Now there is only a background glow with a mask that visually divides the voice stream section from the events list.

**New look**
<img width="980" height="552" alt="Screenshot 2025-09-18 at 19 00 57" src="https://github.com/user-attachments/assets/440517b1-71f9-4eeb-a761-a6dd42861729" />
<img width="983" height="556" alt="Screenshot 2025-09-18 at 19 01 10" src="https://github.com/user-attachments/assets/d781c131-ad1a-450f-aee6-ec1e329bd0a6" />

### Test Steps
1. Launch the explorer.
2. Open the communities section.
3. Open a community card from a community you own or manage. Check the Voice Stream panel supports the new look and feel. Then press the `Start Stream` button (I agree, the string is long :P).
4. As you have been taken out from the communities section, re-open you community card. To do so, you can click the in the title bar of the voice stream panel the thumbnail+name of your community.
5. Check that the Voice Stream panel, while listening, has the new look and feel.