### PR TITLE
Duct tape a null reference in chat presenter

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatMessages/ChatMessageFeedPresenter.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatMessages/ChatMessageFeedPresenter.cs
@@ -228,6 +228,13 @@ namespace DCL.Chat.ChatMessages
                 ReportHub.LogWarning(ReportCategory.CHAT_HISTORY, $"{nameof(UpdateChannelMessages)} called but no current channel is set. Aborting.");
                 return;
             }
+            else if (currentChannelService.UserStateService == null)
+            {
+                ReportHub.LogWarning(ReportCategory.CHAT_HISTORY,
+                    $"{nameof(UpdateChannelMessages)} called, but {nameof(currentChannelService.UserStateService)} is null. Aborting.");
+
+                return;
+            }
 
             loadChannelCts = loadChannelCts.SafeRestart();
 
@@ -247,7 +254,7 @@ namespace DCL.Chat.ChatMessages
 
                     Subscribe();
 
-                    view.SetUserConnectivityProvider(currentChannelService.UserStateService!.OnlineParticipants);
+                    view.SetUserConnectivityProvider(currentChannelService.UserStateService.OnlineParticipants);
 
                     view.ReconstructScrollView(true);
                     ScrollToNewMessagesSeparator();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change duct tapes (if error, do nothing) a null reference exception in chat message feed presenter.

## Test Instructions

### Test Steps
1. Spawn in Genesis Plaza
2. See that there no longer is a null reference exception in the log file related to chat message feed presenter

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
