### PR TITLE
fix: integrated confirmation popup on stream end

### DIFF
--- a/Explorer/Assets/DCL/UI/ConfirmationDialog/ConfirmationDialogView.cs
+++ b/Explorer/Assets/DCL/UI/ConfirmationDialog/ConfirmationDialogView.cs
@@ -47,13 +47,23 @@ namespace DCL.UI.ConfirmationDialog
             confirmButtonText.text = dialogData.ConfirmButtonText;
             rimImage.enabled = dialogData.ShowImageRim;
             quitImage.SetActive(dialogData.ShowQuitImage);
-            mainImage.SetImage(dialogData.Image, true);
 
             bool hasProfileImage = !string.IsNullOrEmpty(dialogData.UserInfo.Address);
 
-            rimImage.gameObject.SetActive(!hasProfileImage);
             profilePictureView.gameObject.SetActive(hasProfileImage);
             profileActionIcon.sprite = dialogData.Image;
+
+            if (dialogData.Image == null)
+            {
+                mainImage.gameObject.SetActive(false);
+                rimImage.gameObject.SetActive(false);
+            }
+            else
+            {
+                mainImage.gameObject.SetActive(true);
+                rimImage.gameObject.SetActive(!hasProfileImage);
+                mainImage.SetImage(dialogData.Image, true);
+            }
 
             if (!hasProfileImage) return;
 

--- a/Explorer/Assets/DCL/UI/ConfirmationDialog/Opener/ConfirmationDialogParameter.cs
+++ b/Explorer/Assets/DCL/UI/ConfirmationDialog/Opener/ConfirmationDialogParameter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using UnityEngine;
 
@@ -23,14 +24,14 @@ namespace DCL.UI.ConfirmationDialog.Opener
         public readonly string SubText;
         public readonly string CancelButtonText;
         public readonly string ConfirmButtonText;
-        public readonly Sprite Image;
+        public readonly Sprite? Image;
         public readonly bool ShowImageRim;
         public readonly bool ShowQuitImage;
         public readonly UserData UserInfo;
         public Action<ConfirmationResult>? ResultCallback;
 
         public ConfirmationDialogParameter(string text, string cancelButtonText, string confirmButtonText,
-            Sprite image, bool showImageRim, bool showQuitImage,
+            Sprite? image, bool showImageRim, bool showQuitImage,
             Action<ConfirmationResult>? resultCallback = null,
             string subText = "", UserData userInfo = default)
         {

--- a/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChat/CommunityVoiceChatInCallController.cs
+++ b/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChat/CommunityVoiceChatInCallController.cs
@@ -38,7 +38,7 @@ namespace DCL.VoiceChat.CommunityVoiceChat
             currentVoiceChatPanelSize = voiceChatOrchestrator.CurrentVoiceChatPanelSize;
             thumbnailController = new ImageController(view.CommunityThumbnail, webRequestController);
 
-            view.EndStreamButton.onClick.AddListener(OnEndStreamButtonClicked);
+            view.EndStreamButtonCLicked += OnEndStreamButtonClicked;
             view.CommunityButton.onClick.AddListener(OnCommunityButtonClicked);
             view.CollapseButton.onClick.AddListener(OnToggleCollapseButtonClicked);
 
@@ -70,10 +70,11 @@ namespace DCL.VoiceChat.CommunityVoiceChat
 
         public void Dispose()
         {
+            view.EndStreamButtonCLicked -= OnEndStreamButtonClicked;
+
             expandedPanelButtonsPresenter.Dispose();
             collapsedPanelButtonsPresenter.Dispose();
             panelSizeChangeSubscription.Dispose();
-            view.EndStreamButton.onClick.RemoveListener(OnEndStreamButtonClicked);
             view.CommunityButton.onClick.RemoveListener(OnCommunityButtonClicked);
             view.CollapseButton.onClick.RemoveListener(OnToggleCollapseButtonClicked);
         }

--- a/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChat/CommunityVoiceChatInCallView.cs
+++ b/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChat/CommunityVoiceChatInCallView.cs
@@ -1,17 +1,29 @@
 using Cysharp.Threading.Tasks;
 using DCL.Audio;
+using DCL.Diagnostics;
 using DCL.UI;
+using DCL.UI.ConfirmationDialog.Opener;
+using DCL.Utilities.Extensions;
+using MVC;
+using System;
 using System.Threading;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Serialization;
 using UnityEngine.UI;
+using Utility;
+using Utility.Types;
 
 namespace DCL.VoiceChat.CommunityVoiceChat
 {
     public class CommunityVoiceChatInCallView : MonoBehaviour
     {
         private const string TOOLTIP_CONTENT = "{0} requested to speak";
+        private const string END_COMMUNITY_STREAM_TEXT_FORMAT = "Are you sure you want to end {0}'s live voice stream?";
+        private const string END_COMMUNITY_STREAM_CONFIRM_TEXT = "YES";
+        private const string END_COMMUNITY_STREAM_CANCEL_TEXT = "NO";
+
+        public event Action EndStreamButtonCLicked;
 
         [field: SerializeField]
         public TMP_Text CommunityName { get; private set; }
@@ -82,6 +94,31 @@ namespace DCL.VoiceChat.CommunityVoiceChat
 
         [field: SerializeField] public AudioClipConfig EndStreamAudio { get; private set; } = null!;
 
+        private CancellationTokenSource? endStreamButtonConfirmationDialogCts;
+
+        public void Start()
+        {
+            EndStreamButton.onClick.AddListener(() =>
+            {
+                endStreamButtonConfirmationDialogCts = endStreamButtonConfirmationDialogCts.SafeRestart();
+                ShowDeleteInvitationConfirmationDialogAsync(endStreamButtonConfirmationDialogCts.Token).Forget();
+                return;
+
+                async UniTask ShowDeleteInvitationConfirmationDialogAsync(CancellationToken ct)
+                {
+                    Result<ConfirmationResult> dialogResult = await ViewDependencies.ConfirmationDialogOpener.OpenConfirmationDialogAsync(new ConfirmationDialogParameter(string.Format(END_COMMUNITY_STREAM_TEXT_FORMAT, CommunityName.text),
+                                                                                         END_COMMUNITY_STREAM_CANCEL_TEXT,
+                                                                                         END_COMMUNITY_STREAM_CONFIRM_TEXT,
+                                                                                         default,
+                                                                                         false, false), ct)
+                                                                                    .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
+                    if (ct.IsCancellationRequested || !dialogResult.Success || dialogResult.Value == ConfirmationResult.CANCEL) return;
+
+                    EndStreamButtonCLicked?.Invoke();
+                }
+            });
+        }
 
         public void SetCommunityName(string communityName)
         {

--- a/Explorer/Assets/DCL/VoiceChat/DCL.VoiceChat.asmdef
+++ b/Explorer/Assets/DCL/VoiceChat/DCL.VoiceChat.asmdef
@@ -46,7 +46,8 @@
         "GUID:e0eedfa2deb9406daf86fd8368728e39",
         "GUID:ace653ac543d483ba8abee112a3ba2a6",
         "GUID:91cf8206af184dac8e30eb46747e9939",
-        "GUID:3db07cecf8bc76f49bd3ffb446a18d11"
+        "GUID:3db07cecf8bc76f49bd3ffb446a18d11",
+        "GUID:36cf0712f9b9c4da5a8ae98277cd3d6e"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5452 
Adds a confirmation popup when trying to end a running stream like in the below screenshot:
<img width="1538" height="856" alt="Screenshot 2025-09-19 at 10 29 04" src="https://github.com/user-attachments/assets/a9bf3d54-e7fd-4c89-af65-0b2ba51d77d9" />


## Test Instructions

### Prerequisites
- [ ] Be owner or mod of a community

### Test Steps
1. Launch the build with --debug and --voice-chat parameters
2. Start a voice stream in a community
3. Press the end stream button
4. Verify that a popup with the confirmation appears on screen
5. Verify that pressing no doesn't end the stream
6. Verify that pressing yes ends the stream

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
