### PR TITLE
fix: Current scene is not updated properly after teleporting

### DIFF
--- a/Explorer/Assets/DCL/Chat/Commands/ReloadSceneChatCommand.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ReloadSceneChatCommand.cs
@@ -1,14 +1,10 @@
 ﻿using Arch.Core;
 using Cysharp.Threading.Tasks;
 using DCL.Character.CharacterMotion.Components;
-using DCL.CharacterMotion.Components;
 using DCL.RealmNavigation;
 using ECS.SceneLifeCycle;
-using ECS.SceneLifeCycle.Reporting;
 using System;
 using System.Threading;
-using UnityEngine;
-using Utility;
 
 namespace DCL.Chat.Commands
 {
@@ -44,7 +40,7 @@ namespace DCL.Chat.Commands
             this.teleportController = teleportController;
             this.isLocalSceneDevelopmentMode = isLocalSceneDevelopmentMode;
 
-            this.sceneReadyCondition = () => scenesCache.CurrentScene.Value != null && scenesCache.CurrentScene.Value.IsSceneReady();
+            this.sceneReadyCondition = () => scenesCache.CurrentScene != null && scenesCache.CurrentScene.IsSceneReady();
         }
 
         public async UniTask<string> ExecuteCommandAsync(string[] parameters, CancellationToken ct)

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/IScenesCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/IScenesCache.cs
@@ -9,7 +9,7 @@ namespace ECS.SceneLifeCycle
     public interface IScenesCache
     {
         IReadonlyReactiveProperty<Vector2Int> CurrentParcel { get; }
-        IReadonlyReactiveProperty<ISceneFacade?> CurrentScene { get;}
+        ISceneFacade? CurrentScene { get;}
         IReadOnlyCollection<ISceneFacade> Scenes { get; }
         IReadOnlyCollection<ISceneFacade> PortableExperiencesScenes { get; }
 
@@ -44,7 +44,6 @@ namespace ECS.SceneLifeCycle
 
     public class ScenesCache : IScenesCache
     {
-        private readonly ReactiveProperty<ISceneFacade?> currentScene = new ReactiveProperty<ISceneFacade?>(null);
         private readonly Dictionary<Vector2Int, ISceneFacade> scenesByParcels = new (PoolConstants.SCENES_COUNT);
         private readonly HashSet<Vector2Int> nonRealSceneByParcel = new (PoolConstants.SCENES_COUNT);
         private readonly Dictionary<string, ISceneFacade> portableExperienceScenesByUrn = new (PoolConstants.PORTABLE_EXPERIENCES_INITIAL_COUNT);
@@ -54,7 +53,7 @@ namespace ECS.SceneLifeCycle
         public IReadOnlyCollection<ISceneFacade> Scenes => scenes;
         public IReadOnlyCollection<ISceneFacade> PortableExperiencesScenes => portableExperienceScenesByUrn.Values;
         public IReadonlyReactiveProperty<Vector2Int> CurrentParcel => currentParcel;
-        public IReadonlyReactiveProperty<ISceneFacade?> CurrentScene => currentScene;
+        public ISceneFacade? CurrentScene { get; private set; }
 
         public void Add(ISceneFacade sceneFacade, IReadOnlyList<Vector2Int> parcels)
         {
@@ -115,7 +114,6 @@ namespace ECS.SceneLifeCycle
                     return true;
                 }
             }
-
             return false;
         }
 
@@ -137,12 +135,12 @@ namespace ECS.SceneLifeCycle
 
         public void SetCurrentScene(ISceneFacade? sceneFacade)
         {
-            currentScene.UpdateValue(sceneFacade);
+            CurrentScene = sceneFacade;
         }
 
         public void UpdateCurrentParcel(Vector2Int newParcel)
         {
-            this.currentParcel.UpdateValue(newParcel);
+            currentParcel.UpdateValue(newParcel);
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/UpdateCurrentSceneSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/UpdateCurrentSceneSystem.cs
@@ -78,8 +78,6 @@ namespace ECS.SceneLifeCycle.Systems
             }
             Vector2Int parcel = World.Get<CharacterTransform>(playerEntity).Transform.ParcelPosition();
 
-            if (lastParcel == parcel) return;
-
             lastParcel = parcel;
             UpdateSceneReadiness(parcel);
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/PortableExperiences/ECSPortableExperiencesController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/PortableExperiences/ECSPortableExperiencesController.cs
@@ -127,7 +127,7 @@ namespace PortableExperiences.Controller
         {
             if (!FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.PORTABLE_EXPERIENCE)) return false;
 
-            ISceneFacade currentSceneFacade = scenesCache.CurrentScene.Value;
+            ISceneFacade currentSceneFacade = scenesCache.CurrentScene;
             if (currentSceneFacade == null) return false;
 
             if (PortableExperienceEntities.TryGetValue(ens, out Entity portableExperienceEntity))

--- a/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
@@ -215,8 +215,8 @@ namespace Global
 
             diagnosticsContainer.AddSentryScopeConfigurator(scope =>
             {
-                if (container.ScenesCache.CurrentScene.Value != null)
-                    diagnosticsContainer.Sentry!.AddCurrentSceneToScope(scope, container.ScenesCache.CurrentScene.Value.Info);
+                if (container.ScenesCache.CurrentScene != null)
+                    diagnosticsContainer.Sentry!.AddCurrentSceneToScope(scope, container.ScenesCache.CurrentScene.Info);
             });
 
             diagnosticsContainer.AddSentryScopeConfigurator(scope =>

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -26,13 +26,11 @@ using DCL.UI.SharedSpaceManager;
 using DCL.Chat.Commands;
 using DCL.Chat.History;
 using DCL.Chat.MessageBus;
-using DCL.Utilities;
 using DG.Tweening;
 using ECS;
 using ECS.SceneLifeCycle;
 using ECS.SceneLifeCycle.Realm;
 using MVC;
-using SceneRunner.Scene;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -76,8 +74,6 @@ namespace DCL.Minimap
         private IMapCameraController? mapCameraController;
         private Vector2Int previousParcelPosition;
         private SceneRestrictionsController? sceneRestrictionsController;
-
-        private IDisposable sceneChangeSubscription;
 
         public IReadOnlyDictionary<MapLayer, IMapLayerParameter> LayersParameters { get; } = new Dictionary<MapLayer, IMapLayerParameter>
             { { MapLayer.PlayerMarker, new PlayerMarkerParameter { BackgroundIsActive = false } } };
@@ -127,7 +123,6 @@ namespace DCL.Minimap
             mapPathEventBus.OnShowPinInMinimapEdge -= ShowPinInMinimapEdge;
             mapPathEventBus.OnHidePinInMinimapEdge -= HidePinInMinimapEdge;
 
-            sceneChangeSubscription?.Dispose();
             sceneRestrictionsController?.Dispose();
             viewInstance?.minimapContextualButtonView.Button.onClick.RemoveAllListeners();
         }
@@ -142,11 +137,6 @@ namespace DCL.Minimap
         {
             SetGenesisMode(realmKind is RealmKind.GenesisCity);
             previousParcelPosition = new Vector2Int(int.MaxValue, int.MaxValue);
-        }
-
-        private void OnSceneChanged(ISceneFacade? scene)
-        {
-            SetGenesisMode(realmData.IsGenesis());
         }
 
         protected override void OnViewInstantiated()
@@ -166,7 +156,7 @@ namespace DCL.Minimap
             mapPathEventBus.OnHidePinInMinimapEdge += HidePinInMinimapEdge;
             mapPathEventBus.OnRemovedDestination += HidePinInMinimapEdge;
             mapPathEventBus.OnUpdatePinPositionInMinimapEdge += UpdatePinPositionInMinimapEdge;
-            sceneChangeSubscription = scenesCache.CurrentScene.Subscribe(OnSceneChanged);
+
             viewInstance.destinationPinMarker.HidePin();
             viewInstance.sdk6Label.gameObject.SetActive(false);
 
@@ -296,7 +286,7 @@ namespace DCL.Minimap
             previousParcelPosition = playerParcelPosition;
             placesApiCts.SafeCancelAndDispose();
             placesApiCts = new CancellationTokenSource();
-            RetrieveParcelInfoAsync(playerParcelPosition).Forget();
+            RetrieveParcelInfoAsync().Forget();
 
             // This is disabled until we figure out a better way to inform the user if the current is scene is SDK6 or not
             // bool isNotEmptyParcel = scenesCache.Contains(playerParcelPosition);
@@ -305,7 +295,7 @@ namespace DCL.Minimap
 
             return;
 
-            async UniTaskVoid RetrieveParcelInfoAsync(Vector2Int playerParcelPosition)
+            async UniTaskVoid RetrieveParcelInfoAsync()
             {
                 await realmData.WaitConfiguredAsync();
 
@@ -341,7 +331,7 @@ namespace DCL.Minimap
 
         private void ToggleObjects(bool isGenesisModeActivated)
         {
-            foreach (GameObject go in viewInstance.objectsToActivateForGenesis)
+            foreach (GameObject go in viewInstance!.objectsToActivateForGenesis)
                 go.SetActive(isGenesisModeActivated);
 
             foreach (GameObject go in viewInstance.objectsToActivateForWorlds)
@@ -351,7 +341,7 @@ namespace DCL.Minimap
         private void ConfigureContextualButton(bool isGenesisModeActivated)
         {
             // Interactivity
-            viewInstance.minimapContextualButtonView.SetInteractable(CanInteractWithContextualButton(isGenesisModeActivated));
+            viewInstance!.minimapContextualButtonView.SetInteractable(CanInteractWithContextualButton(isGenesisModeActivated));
 
             // Text
             string buttonText = GetContextualButtonText(isGenesisModeActivated);
@@ -399,7 +389,7 @@ namespace DCL.Minimap
 
         private void SetAnimatorController(bool isGenesisModeActivated)
         {
-            viewInstance.minimapAnimator.runtimeAnimatorController =
+            viewInstance!.minimapAnimator.runtimeAnimatorController =
                 isGenesisModeActivated
                     ? viewInstance.genesisCityAnimatorController
                     : viewInstance.worldsAnimatorController;

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/PlayerParcelChangedAnalyticsSystem.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/PlayerParcelChangedAnalyticsSystem.cs
@@ -42,8 +42,8 @@ namespace DCL.Analytics.Systems
             {
                 { "old_parcel", oldParcel == MIN_INT2 ? "(NaN, NaN)" : oldParcel.ToString() },
                 { "new_parcel", newParcel.ToString() },
-                { "scene_hash", scenesCache.CurrentScene.Value?.Info.Name},
-                { "is_empty_scene", scenesCache.CurrentScene.Value?.IsEmpty},
+                { "scene_hash", scenesCache.CurrentScene?.Info.Name},
+                { "is_empty_scene", scenesCache.CurrentScene?.IsEmpty},
             });
 
             oldParcel = newParcel;

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/ECS/UpdateProfilerSystem.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/ECS/UpdateProfilerSystem.cs
@@ -64,9 +64,9 @@ namespace DCL.Profiling.ECS
 
             profiler.CurrentSceneHasStats = false;
 
-            if (scenesCache.CurrentScene.Value is { SceneStateProvider: { IsCurrent: true } })
+            if (scenesCache.CurrentScene is { SceneStateProvider: { IsCurrent: true } })
             {
-                var scene = (SceneFacade)scenesCache.CurrentScene.Value;
+                var scene = (SceneFacade)scenesCache.CurrentScene;
                 var heapInfo = scene.runtimeInstance.RuntimeHeapInfo;
 
                 if (heapInfo != null)

--- a/Explorer/Assets/DCL/SkyBox/SDKComponentState.cs
+++ b/Explorer/Assets/DCL/SkyBox/SDKComponentState.cs
@@ -25,7 +25,7 @@ namespace DCL.SkyBox
         // The logic of this behavior is mostly processed at SkyboxTimeHandlerSystem
         public bool Applies() =>
             skyboxSettings.CurrentSDKControlledScene != null
-            && scenes.CurrentScene.Value?.Info.BaseParcel == skyboxSettings.CurrentSDKControlledScene;
+            && scenes.CurrentScene?.Info.BaseParcel == skyboxSettings.CurrentSDKControlledScene;
 
         public void Enter()
         {

--- a/Explorer/Assets/DCL/SkyBox/SceneMetadataState.cs
+++ b/Explorer/Assets/DCL/SkyBox/SceneMetadataState.cs
@@ -25,7 +25,7 @@ namespace DCL.SkyBox
 
         public bool Applies()
         {
-            SceneMetadata? metadata = scenes.CurrentScene.Value?.SceneData.SceneEntityDefinition.metadata;
+            SceneMetadata? metadata = scenes.CurrentScene?.SceneData.SceneEntityDefinition.metadata;
 
             if (metadata == null) return false;
 
@@ -36,7 +36,7 @@ namespace DCL.SkyBox
         {
             transition.Enter();
 
-            SceneMetadata? sceneMetadata = scenes.CurrentScene.Value?.SceneData.SceneEntityDefinition.metadata;
+            SceneMetadata? sceneMetadata = scenes.CurrentScene?.SceneData.SceneEntityDefinition.metadata;
 
             if (sceneMetadata is { worldConfiguration: { SkyboxConfig: { fixedTime: var worldTime } } })
                 ApplyFixedTime(worldTime);


### PR DESCRIPTION
I was this years old when I found out that when you change 60k lines of code in a PR, you can introduce bugs xD

So, the issue detected by Pravs and Juani is the following:
> Hey guys with Juani Molteni we just noticed, testing something unrelated, that basic interactions like pointer events are not working on scenes when you first teleport to them:
> Easiest example -> running [this test scene](https://github.com/decentraland/sdk7-test-scenes/tree/main/scenes/73%2C-8-animator-tests-shark) locally, as soon as you enter the scene directly, you can see that the shark is no longer clickable nor does its green outline for the hover feedback appear (attached video).
> If you walk out of the scene and re-enter it starts working as expected.
> Potentially this can be affecting any other features that rely on sceneStateProvider.IsCurrent (haven't checked others)

So, TLDR, when you first teleport to a scene, the interactions wont work as it thinks we are not in it. As its not marked as the current one.

This fixes that :)

Also, re-converted CurrentScene into a normal property and removed its reactive property state as apparently we never wanted to have an event fired when this changed xD Also removed it from the minimap as it was not needed (we only need to update the minimap go-to-genesis button when we change realms).

### Dear QAs:
So please check teleporting to scenes and worlds with interactable and highlightable stuff and check that they all work as expected 🙏 