### PR TITLE
fix: avoid T hotkey conflicts by removing the open chat shortcut

### DIFF
--- a/Explorer/Assets/DCL/Input/Systems/UpdateCursorInputSystem.cs
+++ b/Explorer/Assets/DCL/Input/Systems/UpdateCursorInputSystem.cs
@@ -55,7 +55,6 @@ namespace DCL.Input.Systems
 
         public override void Initialize()
         {
-            shortcuts.OpenChat.performed += OnShortcutUnlock;
             shortcuts.OpenChatCommandLine.performed += OnShortcutUnlock;
             shortcuts.Backpack.performed += OnShortcutUnlock;
             shortcuts.Map.performed += OnShortcutUnlock;
@@ -65,7 +64,6 @@ namespace DCL.Input.Systems
 
         protected override void OnDispose()
         {
-            shortcuts.OpenChat.performed -= OnShortcutUnlock;
             shortcuts.OpenChatCommandLine.performed -= OnShortcutUnlock;
             shortcuts.Backpack.performed -= OnShortcutUnlock;
             shortcuts.Map.performed -= OnShortcutUnlock;

--- a/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.cs
+++ b/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.cs
@@ -2277,19 +2277,10 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""OpenChat"",
-                    ""type"": ""Button"",
-                    ""id"": ""430e31be-9d28-4c75-a904-851e595a70c1"",
-                    ""expectedControlType"": """",
-                    ""processors"": """",
-                    ""interactions"": """",
-                    ""initialStateCheck"": false
-                },
-                {
                     ""name"": ""OpenChatCommandLine"",
                     ""type"": ""Button"",
                     ""id"": ""df66082b-5afe-4795-a9eb-e5d25d40111e"",
-                    ""expectedControlType"": ""Button"",
+                    ""expectedControlType"": """",
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
@@ -2468,17 +2459,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
                 },
                 {
                     ""name"": """",
-                    ""id"": ""936aa25d-52b8-4067-ab14-76c9c847d3f5"",
-                    ""path"": ""<Keyboard>/t"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": """",
-                    ""action"": ""OpenChat"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
                     ""id"": ""978158e8-1961-43a6-98e4-754ab341d611"",
                     ""path"": ""<Keyboard>/slash"",
                     ""interactions"": """",
@@ -2531,7 +2511,7 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
                     ""name"": ""Slot 1"",
                     ""type"": ""Button"",
                     ""id"": ""3f73f314-6df3-499a-97a9-cc7a8f53da15"",
-                    ""expectedControlType"": ""Button"",
+                    ""expectedControlType"": """",
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
@@ -2959,7 +2939,7 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
                     ""name"": ""Customize"",
                     ""type"": ""Button"",
                     ""id"": ""309cfaf7-2700-4db1-8e05-41175ff3ad09"",
-                    ""expectedControlType"": ""Button"",
+                    ""expectedControlType"": """",
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
@@ -3895,7 +3875,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
         m_Shortcuts_ToggleNametags = m_Shortcuts.FindAction("ToggleNametags", throwIfNotFound: true);
         m_Shortcuts_ToggleSceneDebugConsole = m_Shortcuts.FindAction("ToggleSceneDebugConsole", throwIfNotFound: true);
         m_Shortcuts_ToggleSceneDebugConsoleLarger = m_Shortcuts.FindAction("ToggleSceneDebugConsoleLarger", throwIfNotFound: true);
-        m_Shortcuts_OpenChat = m_Shortcuts.FindAction("OpenChat", throwIfNotFound: true);
         m_Shortcuts_OpenChatCommandLine = m_Shortcuts.FindAction("OpenChatCommandLine", throwIfNotFound: true);
         m_Shortcuts_Controls = m_Shortcuts.FindAction("Controls", throwIfNotFound: true);
         m_Shortcuts_FriendPanel = m_Shortcuts.FindAction("FriendPanel", throwIfNotFound: true);
@@ -4944,7 +4923,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_Shortcuts_ToggleNametags;
     private readonly InputAction m_Shortcuts_ToggleSceneDebugConsole;
     private readonly InputAction m_Shortcuts_ToggleSceneDebugConsoleLarger;
-    private readonly InputAction m_Shortcuts_OpenChat;
     private readonly InputAction m_Shortcuts_OpenChatCommandLine;
     private readonly InputAction m_Shortcuts_Controls;
     private readonly InputAction m_Shortcuts_FriendPanel;
@@ -5004,10 +4982,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "Shortcuts/ToggleSceneDebugConsoleLarger".
         /// </summary>
         public InputAction @ToggleSceneDebugConsoleLarger => m_Wrapper.m_Shortcuts_ToggleSceneDebugConsoleLarger;
-        /// <summary>
-        /// Provides access to the underlying input action "Shortcuts/OpenChat".
-        /// </summary>
-        public InputAction @OpenChat => m_Wrapper.m_Shortcuts_OpenChat;
         /// <summary>
         /// Provides access to the underlying input action "Shortcuts/OpenChatCommandLine".
         /// </summary>
@@ -5083,9 +5057,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
             @ToggleSceneDebugConsoleLarger.started += instance.OnToggleSceneDebugConsoleLarger;
             @ToggleSceneDebugConsoleLarger.performed += instance.OnToggleSceneDebugConsoleLarger;
             @ToggleSceneDebugConsoleLarger.canceled += instance.OnToggleSceneDebugConsoleLarger;
-            @OpenChat.started += instance.OnOpenChat;
-            @OpenChat.performed += instance.OnOpenChat;
-            @OpenChat.canceled += instance.OnOpenChat;
             @OpenChatCommandLine.started += instance.OnOpenChatCommandLine;
             @OpenChatCommandLine.performed += instance.OnOpenChatCommandLine;
             @OpenChatCommandLine.canceled += instance.OnOpenChatCommandLine;
@@ -5142,9 +5113,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
             @ToggleSceneDebugConsoleLarger.started -= instance.OnToggleSceneDebugConsoleLarger;
             @ToggleSceneDebugConsoleLarger.performed -= instance.OnToggleSceneDebugConsoleLarger;
             @ToggleSceneDebugConsoleLarger.canceled -= instance.OnToggleSceneDebugConsoleLarger;
-            @OpenChat.started -= instance.OnOpenChat;
-            @OpenChat.performed -= instance.OnOpenChat;
-            @OpenChat.canceled -= instance.OnOpenChat;
             @OpenChatCommandLine.started -= instance.OnOpenChatCommandLine;
             @OpenChatCommandLine.performed -= instance.OnOpenChatCommandLine;
             @OpenChatCommandLine.canceled -= instance.OnOpenChatCommandLine;
@@ -6412,13 +6380,6 @@ public partial class @DCLInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnToggleSceneDebugConsoleLarger(InputAction.CallbackContext context);
-        /// <summary>
-        /// Method invoked when associated input action "OpenChat" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
-        /// </summary>
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnOpenChat(InputAction.CallbackContext context);
         /// <summary>
         /// Method invoked when associated input action "OpenChatCommandLine" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>

--- a/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.inputactions
+++ b/Explorer/Assets/DCL/Input/UnityInputSystem/DCLInput.inputactions
@@ -2191,19 +2191,10 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "OpenChat",
-                    "type": "Button",
-                    "id": "430e31be-9d28-4c75-a904-851e595a70c1",
-                    "expectedControlType": "",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
-                },
-                {
                     "name": "OpenChatCommandLine",
                     "type": "Button",
                     "id": "df66082b-5afe-4795-a9eb-e5d25d40111e",
-                    "expectedControlType": "Button",
+                    "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
@@ -2382,17 +2373,6 @@
                 },
                 {
                     "name": "",
-                    "id": "936aa25d-52b8-4067-ab14-76c9c847d3f5",
-                    "path": "<Keyboard>/t",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "OpenChat",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "978158e8-1961-43a6-98e4-754ab341d611",
                     "path": "<Keyboard>/slash",
                     "interactions": "",
@@ -2445,7 +2425,7 @@
                     "name": "Slot 1",
                     "type": "Button",
                     "id": "3f73f314-6df3-499a-97a9-cc7a8f53da15",
-                    "expectedControlType": "Button",
+                    "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
@@ -2873,7 +2853,7 @@
                     "name": "Customize",
                     "type": "Button",
                     "id": "309cfaf7-2700-4db1-8e05-41175ff3ad09",
-                    "expectedControlType": "Button",
+                    "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false

--- a/Explorer/Assets/DCL/UI/SharedSpaceManager/SharedSpaceManagerImpl/SharedSpaceManager.cs
+++ b/Explorer/Assets/DCL/UI/SharedSpaceManager/SharedSpaceManagerImpl/SharedSpaceManager.cs
@@ -45,7 +45,7 @@ namespace DCL.UI.SharedSpaceManager
         private bool isExplorePanelVisible => registrations[PanelsSharingSpace.Explore].panel.IsVisibleInSharedSpace;
         private bool isCameraReelPanelVisible { get; set; }
 
-        public SharedSpaceManager(IMVCManager mvcManager, World world, bool isFriendsEnabled, bool isCameraReelEnabled, 
+        public SharedSpaceManager(IMVCManager mvcManager, World world, bool isFriendsEnabled, bool isCameraReelEnabled,
             EmotesBus emotesBus)
         {
             this.mvcManager = mvcManager;
@@ -65,7 +65,7 @@ namespace DCL.UI.SharedSpaceManager
 
         private void OnQuickActionEmotePlayed()
         {
-            if (!registrations[PanelsSharingSpace.EmotesWheel].panel.IsVisibleInSharedSpace) 
+            if (!registrations[PanelsSharingSpace.EmotesWheel].panel.IsVisibleInSharedSpace)
                 lastQuickEmoteTime = Time.time;
         }
 
@@ -76,7 +76,6 @@ namespace DCL.UI.SharedSpaceManager
 
             dclInput.Shortcuts.EmoteWheel.canceled += OnInputShortcutsEmoteWheelPerformedAsync;
             dclInput.Shortcuts.Controls.performed += OnInputShortcutsControlsPanelPerformedAsync;
-            dclInput.Shortcuts.OpenChat.performed += OnInputShortcutsOpenChatPerformedAsync;
             dclInput.UI.Submit.performed += OnUISubmitPerformedAsync;
 
             dclInput.Shortcuts.MainMenu.performed += OnInputShortcutsMainMenuPerformedAsync;
@@ -102,7 +101,6 @@ namespace DCL.UI.SharedSpaceManager
 
             dclInput.Shortcuts.EmoteWheel.canceled -= OnInputShortcutsEmoteWheelPerformedAsync;
             dclInput.Shortcuts.Controls.performed -= OnInputShortcutsControlsPanelPerformedAsync;
-            dclInput.Shortcuts.OpenChat.performed -= OnInputShortcutsOpenChatPerformedAsync;
             dclInput.UI.Submit.performed -= OnUISubmitPerformedAsync;
 
             dclInput.Shortcuts.MainMenu.performed -= OnInputShortcutsMainMenuPerformedAsync;
@@ -327,20 +325,20 @@ namespace DCL.UI.SharedSpaceManager
             {
                 if(!controllerInSharedSpace.Value.panel.IsVisibleInSharedSpace)
                     continue;
-                
+
                 bool shouldIgnore = false;
                 for (int i = 0; i < panelsToIgnore.Length; i++)
                 {
                     if(panelsToIgnore[i] != controllerInSharedSpace.Key)
                         continue;
-                    
+
                     shouldIgnore = true;
                     break;
                 }
 
                 if (shouldIgnore)
                     continue;
-                
+
                 await HideAsync(controllerInSharedSpace.Key);
             }
         }
@@ -485,7 +483,7 @@ namespace DCL.UI.SharedSpaceManager
                 lastQuickEmoteTime = 0;
                 return;
             }
-            
+
             if (!isExplorePanelVisible)
                 await ToggleVisibilityAsync(PanelsSharingSpace.EmotesWheel, new ControllerNoData());
         }
@@ -493,7 +491,7 @@ namespace DCL.UI.SharedSpaceManager
         private async void OnInputShortcutsControlsPanelPerformedAsync(InputAction.CallbackContext obj)
         {
             var panel = PanelsSharingSpace.Controls;
-            
+
             // For hiding the panel, use standard logic.
             if (registrations[panel].panel.IsVisibleInSharedSpace)
             {
@@ -501,7 +499,7 @@ namespace DCL.UI.SharedSpaceManager
             }
             else
             {
-                await ShowAsync(PanelsSharingSpace.Controls, new ControllerNoData(), 
+                await ShowAsync(PanelsSharingSpace.Controls, new ControllerNoData(),
                     PanelsSharingSpace.Chat, PanelsSharingSpace.Explore);
             }
         }
@@ -510,13 +508,6 @@ namespace DCL.UI.SharedSpaceManager
         {
             if (!isExplorePanelVisible && isFriendsFeatureEnabled)
                 await ToggleVisibilityAsync(PanelsSharingSpace.Friends, new FriendsPanelParameter());
-        }
-
-        private async void OnInputShortcutsOpenChatPerformedAsync(InputAction.CallbackContext obj)
-        {
-            if (!isExplorePanelVisible && !isTransitioning)
-                await ToggleVisibilityAsync(PanelsSharingSpace.Chat,
-                    new ChatControllerShowParams(true, true, forceFocusFromShortcut: true));
         }
 
         private async void OnInputShortcutsCommunitiesPerformedAsync(InputAction.CallbackContext obj)
@@ -541,7 +532,7 @@ namespace DCL.UI.SharedSpaceManager
             // Clue: It is handled by ToggleInWorldCameraActivitySystem
         }
 #endregion
-        
+
         /// <summary>
         /// Emote wheel is locked when quick emote action was executed, but not when wheel is already visible, in that
         /// case we want to hide it.
@@ -549,7 +540,7 @@ namespace DCL.UI.SharedSpaceManager
         private bool IsEmoteWheelLocked()
         {
             bool isPanelVisible = registrations[PanelsSharingSpace.EmotesWheel].panel.IsVisibleInSharedSpace;
-            
+
             return !isPanelVisible && lastQuickEmoteTime + QUICK_EMOTE_LOCK_TIME > Time.time;
         }
     }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5501 
This PR removes the hotkey to open the chat (as it opens with Enter) and instead allows mute and unmute of the microphone 

## Test Instructions

### Prerequisites
- [ ] By own or mod of a community to start a voice stream

### Test Steps
1. Launch the build with --debug and --voice-chat
2. Start a voice stream in a community
3. Verify that pressing T enables and disables the microphone (when not typing in the chat)

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
