### PR TITLE
fix: fixed player entries in cvc panel to show always speakers and listeners

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChatCallStatusService.cs
+++ b/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChatCallStatusService.cs
@@ -307,6 +307,7 @@ namespace DCL.VoiceChat
         {
             communityVoiceChatCalls.Clear();
             activeCommunityVoiceChats.Clear();
+            SetCallId(string.Empty);
             locallyStartedCommunityId = null;
         }
 

--- a/Explorer/Assets/DCL/VoiceChat/VoiceChatDisconnectReasonHelper.cs
+++ b/Explorer/Assets/DCL/VoiceChat/VoiceChatDisconnectReasonHelper.cs
@@ -27,7 +27,7 @@ namespace DCL.VoiceChat
                        DisconnectReason.ConnectionTimeout => true,
                        DisconnectReason.StateMismatch => true,
                        DisconnectReason.Migration => true,
-                       DisconnectReason.UnknownReason => false,
+                       DisconnectReason.UnknownReason => true,
                        DisconnectReason.UserUnavailable => true,
                        DisconnectReason.SipTrunkFailure => true,
                        _ => false,


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix [#5397](https://github.com/decentraland/unity-explorer/issues/5397)
This PR fixes the visibility of speakers when leaving and rejoining the same community voice stream.
The issue was caused by player metadata not being refreshes with manual disconnection as livekit is not propagating the correct disconnect reason.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] Own or be a mod of a community to start a stream

### Test Steps
1. Launch 2 clients with --debug and --voice-chat
2. With one client start a community stream
3. With the other client join in and check that speakers and listeners are visible correctly
4. Leave the stream with the second client and reconnect
5. Verify that speakers and listeners are still correctly visible

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
