### PR TITLE
fix: changed text style for cvc listeners count

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardVoiceChatPresenter.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardVoiceChatPresenter.cs
@@ -92,7 +92,9 @@ namespace DCL.Communities.CommunitiesCard
                 return;
 
             stringBuilder.Clear();
+            stringBuilder.Append("<b>");
             stringBuilder.Append(listenersCount);
+            stringBuilder.Append("</b>");
             stringBuilder.Append(" Listening");
             view.ListenersCount.text = stringBuilder.ToString();
         }

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/JoinStreamPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/JoinStreamPanel.prefab
@@ -723,10 +723,10 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 24 Listening
+  m_text: <b>24</b> Listening
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
-  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix [#5442](https://github.com/decentraland/unity-explorer/issues/5442)
Minor text style changes, now the participant number is in semi bold and the text "Listeners" in regular as the following screenshot:
<img width="377" height="155" alt="Screenshot 2025-09-19 at 17 22 24" src="https://github.com/user-attachments/assets/412afb66-1483-437e-aec0-3cfd835b69e5" />


## Test Instructions

### Prerequisites
- [ ] Be owner or moderator of any community to start the stream

### Test Steps
1. Launch the client with --debug and --voice-chat
2. Start a community voice chat
3. Go to the community card and verify that the listeners counter appears like in the screenshot attached above

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
