### PR TITLE
style: communities minor fixes

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCardHeader.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCardHeader.prefab
@@ -515,7 +515,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 270, y: -110}
-  m_SizeDelta: {x: 210, y: 20}
+  m_SizeDelta: {x: 600, y: 20}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &7961663442072066581
 MonoBehaviour:

--- a/Explorer/Assets/DCL/Communities/EventInfo/Prefabs/EventInfoPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/EventInfo/Prefabs/EventInfoPanel.prefab
@@ -2644,7 +2644,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_PixelsPerUnitMultiplier: 2
 --- !u!114 &2211521694010102538
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Communities/EventInfo/Prefabs/EventInfoPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/EventInfo/Prefabs/EventInfoPanel.prefab
@@ -2164,7 +2164,7 @@ MonoBehaviour:
   m_Spacing: 20
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 1
+  m_ChildControlWidth: 0
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
@@ -2919,7 +2919,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 740, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &5524457223147355152
 CanvasRenderer:
@@ -2949,10 +2949,10 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Wednesday, Aug 30 from 04:00pm to 05:00pm (UTC-3)
+  m_text: 'Wednesday, Aug 30 from 04:00pm to 05:00pm UTC-3)
 
-    Wednesday, Sep
-    06 from 04:00pm to 05:00pm (UTC-3)
+    Wednesday, Sep 06
+    from 04:00pm to 05:00pm (UTC-3)
 
     Wednesday, Sep 13 from 04:00pm to 05:00pm
     (UTC-3)'
@@ -3178,7 +3178,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 24, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &2170808393521143006
 CanvasRenderer:
@@ -3882,7 +3882,7 @@ MonoBehaviour:
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 0
+  m_ChildAlignment: 3
   m_Spacing: 20
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 0
@@ -4582,8 +4582,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 6952247620005373462}
   m_HandleRect: {fileID: 175607292521401437}
   m_Direction: 2
-  m_Value: 1
-  m_Size: 0.86813825
+  m_Value: 0.9999995
+  m_Size: 0.8681382
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/Explorer/Assets/DCL/Communities/Textures/Gradient.png
+++ b/Explorer/Assets/DCL/Communities/Textures/Gradient.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07717105951e2d6caddbf9194e2c13fed8ff45105e283d373cb1bedd379be6ca
-size 3303
+oid sha256:1c611906685f596613571b8da461e803b909e859a3051c6737e812dbbc0eff1e
+size 3811

--- a/Explorer/Assets/DCL/Communities/Textures/Gradient.png.meta
+++ b/Explorer/Assets/DCL/Communities/Textures/Gradient.png.meta
@@ -49,7 +49,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
-  spriteBorder: {x: 0, y: 0, z: 0, w: 164}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 212}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1


### PR DESCRIPTION
# Pull Request Description
This PR fixes the text box size of the `n members` in the header of the community card, in order to avoid a double line.
<img width="458" height="73" alt="Screenshot 2025-09-19 at 18 36 04" src="https://github.com/user-attachments/assets/929c25f8-a466-4174-8f11-067b3ce80c8a" />

Also fixes the layout issue of the events card, which cause the overlapping of the dates and times with the place.
<img width="1556" height="456" alt="Screenshot 2025-09-19 at 20 18 53" src="https://github.com/user-attachments/assets/17397272-123f-428e-9327-b0fdcacfa574" />

### Test Steps
1. Launch the explorer
2. Open the communities section, and explore as many communities you can to validate the members text box is a single line.
3. Then Browse a community with an upcoming event. Open the event info panel and scroll down to check that the dates + times are not overlapping the location.