### PR TITLE
chore: Update the shared deps for a shader fault

### DIFF
--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -92,7 +92,7 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "da34743b0e4c01191c72f58af715bf2c0dfc2d67"
+      "hash": "c346fe721d9a61109aee1a50c5d4bf955fe04c05"
     },
     "com.gurbu.gpui-pro": {
       "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.gurbu.gpui-pro",


### PR DESCRIPTION
I've updated the shared deps so that a scene shader for the LODs doesn't have an error.

To test: Just make sure the scene lods are rendering properly and aren't pink due to a failed shader compilation.