### PR TITLE
chore: CDP notifications on launch error

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/Analytics/Plugin/ShowWebRequestsAnalyticsSystem.cs
+++ b/Explorer/Assets/DCL/WebRequests/Analytics/Plugin/ShowWebRequestsAnalyticsSystem.cs
@@ -1,8 +1,10 @@
 ﻿using Arch.Core;
 using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
+using CDPBridges;
 using DCL.DebugUtilities;
 using DCL.DebugUtilities.UIBindings;
+using DCL.NotificationsBusController.NotificationTypes;
 using DCL.Profiling;
 using DCL.WebRequests.Analytics.Metrics;
 using DCL.WebRequests.ChromeDevtool;
@@ -55,7 +57,18 @@ namespace DCL.WebRequests.Analytics
 
             DebugWidgetBuilder? widget = debugContainerBuilder
                                         .TryAddWidget(IDebugContainerBuilder.Categories.WEB_REQUESTS)
-                                       ?.AddSingleButton("Open Chrome DevTools", () => chromeDevtoolProtocolClient.StartAndOpen())
+                                       ?.AddSingleButton("Open Chrome DevTools", () =>
+                                         {
+                                             BridgeStartResult result = chromeDevtoolProtocolClient.StartAndOpen();
+                                             string? errorMessage = ErrorMessageFromBridgeResult(result);
+
+                                             if (errorMessage != null)
+                                                 NotificationsBusController
+                                                    .NotificationsBus
+                                                    .NotificationsBusController
+                                                    .Instance
+                                                    .AddNotification(new ServerErrorNotification(errorMessage));
+                                         })
                                         .SetVisibilityBinding(visibilityBinding = new DebugWidgetVisibilityBinding(true));
 
             foreach (RequestType requestType in requestTypes)
@@ -72,6 +85,22 @@ namespace DCL.WebRequests.Analytics
 
                 ongoingRequests[requestType.Type] = bindings;
             }
+        }
+
+        // ReSharper disable once ReturnTypeCanBeNotNullable
+        private static string? ErrorMessageFromBridgeResult(BridgeStartResult result)
+        {
+            string message = result.Match(
+                onSuccess: static () => null!,
+                onBridgeStartError: static e => e.Match(
+                    onWebSocketError: static e => $"Cannot start WebSocket server: {e.Exception.Message}",
+                    onBrowserOpenError: static e => e.Match(
+                        onErrorChromeNotInstalled: static () => "Chrome not installed",
+                        onException: static e => $"Cannot open DevTools: {e.Message}")
+                )
+            );
+
+            return message;
         }
 
         protected override void Update(float t)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Added explicit notification popup if CDP failed to launch
<img width="920" height="523" alt="Screenshot 2025-09-23 at 01 40 11" src="https://github.com/user-attachments/assets/ec260525-432d-4952-85b1-c971f43d05c8" />


## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Uninstall Creator Hub
2. Try open CDP from Client
3. Observe error popup
4. Don't close the Client
5. Install Creator Hub
6. Try open CDP from Client again
7. CDP opens successfully

## Quality Checklist
- [x] Changes have been tested locally

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
