### PR TITLE
fix: enable stream volume control on windows

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -32,9 +32,7 @@ namespace DCL.SDKComponents.MediaStream
         private readonly ISceneData sceneData;
         private readonly ISceneStateProvider sceneStateProvider;
         private readonly IPerformanceBudget frameTimeBudget;
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         private readonly VolumeBus volumeBus;
-#endif
 
         private readonly float audioFadeSpeed;
 
@@ -62,13 +60,11 @@ namespace DCL.SDKComponents.MediaStream
             //the volume control for the video and audio streams, as it doesn’t allow to route audio
             //from HLS through to Unity. This is a limitation of Apple’s AVFoundation framework
             //Similar issue reported here https://github.com/RenderHeads/UnityPlugin-AVProVideo/issues/1086
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
             this.volumeBus = volumeBus;
             this.volumeBus.OnWorldVolumeChanged += OnWorldVolumeChanged;
             this.volumeBus.OnMasterVolumeChanged += OnMasterVolumeChanged;
             masterVolumePercentage = volumeBus.GetSerializedMasterVolume();
             worldVolumePercentage = volumeBus.GetSerializedWorldVolume();
-#endif
         }
 
         private void OnWorldVolumeChanged(float volume)

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/MasterVolumeSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/MasterVolumeSettingsController.cs
@@ -31,10 +31,7 @@ namespace DCL.Settings.ModuleControllers
         {
             generalAudioMixer.SetFloat(MASTER_VOLUME_EXPOSED_PARAM,  AudioUtils.PercentageVolumeToDecibel(volumePercentage));
             DCLPlayerPrefs.SetFloat(DCLPrefKeys.SETTINGS_MASTER_VOLUME, volumePercentage, save: true);
-
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
             volumeBus.SetMasterVolume(volumePercentage / 100);
-#endif
         }
 
         public override void Dispose()

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/WorldSoundsVolumeSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/WorldSoundsVolumeSettingsController.cs
@@ -31,10 +31,7 @@ namespace DCL.Settings.ModuleControllers
         {
             generalAudioMixer.SetFloat(WORLD_VOLUME_EXPOSED_PARAM,  AudioUtils.PercentageVolumeToDecibel(volumePercentage));
             DCLPlayerPrefs.SetFloat(DCLPrefKeys.SETTINGS_WORLD_VOLUME, volumePercentage, save: true);
-
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
             volumeBus.SetWorldVolume(volumePercentage / 100);
-#endif
         }
 
         public override void Dispose()


### PR DESCRIPTION
## What does this PR change?

Fixes #2294 

The volume control was disabled on windows. Fix removes any platform dependency on volume control.

## Test Instructions

Start explorer on windows.
Check video streams on different scenes, including live-stream. Volume should work correctly.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
