### PR TITLE
fix: check material state before setting the the texture scale

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Textures/Components/VideoTextureConsumer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Textures/Components/VideoTextureConsumer.cs
@@ -102,8 +102,8 @@ namespace ECS.Unity.Textures.Components
         {
             foreach (var meshRenderer in renderers)
             {
-                meshRenderer.material.SetTextureScale(ShaderUtils.BaseMap, texScale);
-                meshRenderer.material.SetTextureScale(ShaderUtils.AlphaTexture, texScale);
+                meshRenderer.sharedMaterial.SetTextureScale(ShaderUtils.BaseMap, texScale);
+                meshRenderer.sharedMaterial.SetTextureScale(ShaderUtils.AlphaTexture, texScale);
             }
         }
     }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateVideoMaterialTextureScaleSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateVideoMaterialTextureScaleSystem.cs
@@ -2,6 +2,7 @@
 using Arch.System;
 using Arch.SystemGroups;
 using DCL.Diagnostics;
+using DCL.Optimization.PerformanceBudgeting;
 using ECS.Abstract;
 using ECS.Groups;
 using ECS.Unity.Materials;
@@ -15,8 +16,11 @@ namespace DCL.SDKComponents.MediaStream
     [LogCategory(ReportCategory.MEDIA_STREAM)]
     public partial class UpdateVideoMaterialTextureScaleSystem : BaseUnityLoopSystem
     {
-        public UpdateVideoMaterialTextureScaleSystem(World world) : base(world)
+        private readonly IPerformanceBudget capFrameBudget;
+
+        public UpdateVideoMaterialTextureScaleSystem(World world, IPerformanceBudget capFrameBudget) : base(world)
         {
+            this.capFrameBudget = capFrameBudget;
         }
 
         protected override void Update(float t)
@@ -27,6 +31,9 @@ namespace DCL.SDKComponents.MediaStream
         [Query]
         public void UpdateMaterial(in MediaPlayerComponent mediaPlayerComponent, ref VideoTextureConsumer videoTextureConsumer)
         {
+            if (!capFrameBudget.TrySpendBudget())
+                return;
+
             if (!videoTextureConsumer.IsDirty)
                 return;
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateVideoMaterialTextureScaleSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateVideoMaterialTextureScaleSystem.cs
@@ -4,12 +4,14 @@ using Arch.SystemGroups;
 using DCL.Diagnostics;
 using ECS.Abstract;
 using ECS.Groups;
+using ECS.Unity.Materials;
 using ECS.Unity.Textures.Components;
 using UnityEngine;
 
 namespace DCL.SDKComponents.MediaStream
 {
     [UpdateInGroup(typeof(SyncedPresentationSystemGroup))]
+    [UpdateAfter(typeof(MaterialLoadingGroup))]
     [LogCategory(ReportCategory.MEDIA_STREAM)]
     public partial class UpdateVideoMaterialTextureScaleSystem : BaseUnityLoopSystem
     {

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/MediaPlayerPluginWrapper.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Wrapper/MediaPlayerPluginWrapper.cs
@@ -71,7 +71,7 @@ namespace DCL.SDKComponents.MediaStream.Wrapper
 
             VideoEventsSystem.InjectToWorld(ref builder, ecsToCrdtWriter, sceneStateProvider, frameTimeBudget);
 
-            UpdateVideoMaterialTextureScaleSystem.InjectToWorld(ref builder);
+            UpdateVideoMaterialTextureScaleSystem.InjectToWorld(ref builder, frameTimeBudget);
 
             finalizeWorldSystems.Add(CleanUpMediaPlayerSystem.InjectToWorld(ref builder));
 #endif


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

As it is right now, we have a race condition where we can be setting the texture scale to a renderer which is gonna get its material replaced.

Since material creation is budgeted, this condition is quite possible in low frame rate condition

This PRs resorts the systems and budgets `UpdateScleVideoTextureSystem`; so it respects the same behaviour as the material creations



## Test Instructions


### Test Steps
This is mainly a Windows test. Doesnt hurt to do it in Mac too

1. Test in Windows Art Week. Check that the video in the visitor center (`-139,-86`) is not flipped
2. Try out a stream (let me know and I can see to set one up). Check that its not flipped
3. Check the videos in Prom and Career Center. Once again, check that they are not flipped



## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
