### PR TITLE
style: fix start stream button colour

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/StartStreamModeratorPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/StartStreamModeratorPanel.prefab
@@ -536,7 +536,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.082352936, g: 0.5764706, b: 0.17106208, a: 1}
+  m_Color: {r: 0.15686275, g: 0.6745098, b: 0, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1


### PR DESCRIPTION
# Pull Request Description
This PR fixes the colour of the `start stream` button, which is inside an own or moderated community. At the moment looks darker than in the original design.

### Test Steps
1. Launch the explorer.
2. Open the communities section. Then open a community you own or moderate to validate the colour looks like in [Figma](https://www.figma.com/design/1bKyca5vnyvmGUQ0ELeJZz/%F0%9F%97%BA%EF%B8%8F-Community-Voice-Stream-%7C-Explorer-2.0-%7C-09-25?node-id=3776-188058&t=TEKa7FLXIKJlmMDt-1).