### PR TITLE
fix: stop the livekit connection on timeout at startup

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
@@ -44,7 +44,7 @@ namespace DCL.UserInAppInitializationFlow
         {
             ILoadingStatus? loadingStatus = staticContainer.LoadingStatus;
 
-            var ensureLivekitConnectionStartupOperation = new EnsureLivekitConnectionStartupOperation(liveKitHealthCheck);
+            var ensureLivekitConnectionStartupOperation = new EnsureLivekitConnectionStartupOperation(liveKitHealthCheck, roomHub);
             var preloadProfileStartupOperation = new PreloadProfileStartupOperation(loadingStatus, selfProfile);
             var blocklistCheckStartupOperation = new BlocklistCheckStartupOperation(staticContainer.WebRequestsContainer, bootstrapContainer.IdentityCache!, bootstrapContainer.DecentralandUrlsSource);
             var loadPlayerAvatarStartupOperation = new LoadPlayerAvatarStartupOperation(loadingStatus, selfProfile, staticContainer.MainPlayerAvatarBaseProxy);

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Connective/IConnectiveRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Connective/IConnectiveRoom.cs
@@ -82,7 +82,7 @@ namespace DCL.Multiplayer.Connections.Rooms.Connective
                 : UniTask.FromResult(true);
 
         public static UniTask StopIfNotAsync(this IConnectiveRoom room) =>
-            room.CurrentState() is IConnectiveRoom.State.Running
+            room.CurrentState() is IConnectiveRoom.State.Running or IConnectiveRoom.State.Starting
                 ? room.StopAsync()
                 : UniTask.CompletedTask;
 

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/EnsureLivekitConnectionStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/EnsureLivekitConnectionStartupOperation.cs
@@ -1,5 +1,6 @@
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
+using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Multiplayer.HealthChecks;
 using DCL.Utility.Types;
 using System;
@@ -10,11 +11,13 @@ namespace DCL.UserInAppInitializationFlow
     public class EnsureLivekitConnectionStartupOperation
     {
         private readonly IHealthCheck healthCheck;
+        private readonly IRoomHub roomHub;
         private static readonly TimeSpan LIVEKIT_TIMEOUT = TimeSpan.FromSeconds(30);
 
-        public EnsureLivekitConnectionStartupOperation(IHealthCheck healthCheck)
+        public EnsureLivekitConnectionStartupOperation(IHealthCheck healthCheck, IRoomHub roomHub)
         {
             this.healthCheck = healthCheck;
+            this.roomHub = roomHub;
         }
 
         public async UniTask<EnumResult<TaskError>> LaunchLivekitConnectionAsync(CancellationToken ct)
@@ -27,9 +30,18 @@ namespace DCL.UserInAppInitializationFlow
             catch (TimeoutException)
             {
                 ReportHub.Log(ReportCategory.LIVEKIT, $"Livekit handshake timed out");
-                return EnumResult<TaskError>.ErrorResult(TaskError.Timeout,"Multiplayer services are offline. Try again later");
+
+                try
+                {
+                    // Fixes: https://github.com/decentraland/unity-explorer/issues/5346
+                    // We need to manually stop in case of timeout. Livekit keeps trying to connect (thus cancellation tokens are not supported)
+                    // and will skip the process the next time this task is executed
+                    await roomHub.StopAsync().Timeout(LIVEKIT_TIMEOUT);
+                }
+                catch (Exception e) { ReportHub.LogException(e, ReportCategory.LIVEKIT); }
+
+                return EnumResult<TaskError>.ErrorResult(TaskError.Timeout, "Multiplayer services are offline. Try again later");
             }
         }
-
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fixes #5346 

The initial attempt to connect to Livekit is an internal operation that does not terminate on its own.
We have our custom timeout to cancel the startup operation, but Livekit remains in a broken state. This causes subsequent connection attempts to be skipped, leaving the system in a corrupted state when attempting to re-enter the world.

To address this issue, we must manually stop the connection in the event of a timeout. By doing so, we force Livekit to reset its state, ensuring that the connection process is executed properly on subsequent attempts.

A more elegant approach would be to make a proper support of cancellation tokens at `IConnectiveRoom.StartAsync()`, but this could lead into a more risky solution just for the initial startup case.

## Test Instructions

AFAIK there is no way to force a real failure in livekit. So just check if you can run the startup process normally.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
