### PR TITLE
fix: cdp notifications error PR compilation broken

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/Analytics/Plugin/ShowWebRequestsAnalyticsSystem.cs
+++ b/Explorer/Assets/DCL/WebRequests/Analytics/Plugin/ShowWebRequestsAnalyticsSystem.cs
@@ -4,13 +4,14 @@ using Arch.SystemGroups.DefaultSystemGroups;
 using CDPBridges;
 using DCL.DebugUtilities;
 using DCL.DebugUtilities.UIBindings;
-using DCL.NotificationsBusController.NotificationTypes;
 using DCL.Profiling;
 using DCL.WebRequests.Analytics.Metrics;
 using DCL.WebRequests.ChromeDevtool;
 using ECS.Abstract;
 using System;
 using System.Collections.Generic;
+using DCL.NotificationsBus;
+using DCL.NotificationsBus.NotificationTypes;
 
 namespace DCL.WebRequests.Analytics
 {
@@ -64,8 +65,6 @@ namespace DCL.WebRequests.Analytics
 
                                              if (errorMessage != null)
                                                  NotificationsBusController
-                                                    .NotificationsBus
-                                                    .NotificationsBusController
                                                     .Instance
                                                     .AddNotification(new ServerErrorNotification(errorMessage));
                                          })


### PR DESCRIPTION
Corrected old usage of NotificationsBusController.

### TEST INSTRUCTIONS

Follow the test instructions of the PR that broke compilation in `dev`: https://github.com/decentraland/unity-explorer/pull/5535