### PR TITLE
Fix: Added check of FeaturesRegistry for settings modules

### DIFF
--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
@@ -48,7 +48,7 @@ MonoBehaviour:
       - rid: 5242998342527483919
       - rid: 3511243270148325474
     - <GroupTitle>k__BackingField: Voice Streams & Calls
-      <FeatureFlagName>k__BackingField: 21
+      <FeatureFlagName>k__BackingField: 20
       <Modules>k__BackingField:
       - rid: 3511243270148325473
   <ControlsSectionConfig>k__BackingField:
@@ -72,6 +72,7 @@ MonoBehaviour:
     - rid: 1708279571579404288
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: f999deca82ccdc14ebae40250c8eb0c9
           m_SubObjectName: 
@@ -91,6 +92,7 @@ MonoBehaviour:
     - rid: 1708279571579404289
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: f999deca82ccdc14ebae40250c8eb0c9
           m_SubObjectName: 
@@ -111,6 +113,7 @@ MonoBehaviour:
     - rid: 3126482891795070976
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
           m_SubObjectName: 
@@ -130,6 +133,7 @@ MonoBehaviour:
     - rid: 3126482891795070977
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
           m_SubObjectName: 
@@ -149,6 +153,7 @@ MonoBehaviour:
     - rid: 3511243270148325473
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 20
         <View>k__BackingField:
           m_AssetGUID: f999deca82ccdc14ebae40250c8eb0c9
           m_SubObjectName: 
@@ -166,6 +171,7 @@ MonoBehaviour:
     - rid: 3511243270148325474
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 20
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
           m_SubObjectName: 
@@ -185,6 +191,7 @@ MonoBehaviour:
     - rid: 4494877371389181952
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: f999deca82ccdc14ebae40250c8eb0c9
           m_SubObjectName: 
@@ -205,6 +212,7 @@ MonoBehaviour:
     - rid: 4916151837425664002
       type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 39458b71e0ed84549b1b280c4fb1f105
           m_SubObjectName: 
@@ -220,6 +228,7 @@ MonoBehaviour:
     - rid: 4975969656134959106
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: f999deca82ccdc14ebae40250c8eb0c9
           m_SubObjectName: 
@@ -240,6 +249,7 @@ MonoBehaviour:
     - rid: 5015494041161695532
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
           m_SubObjectName: 
@@ -259,6 +269,7 @@ MonoBehaviour:
     - rid: 5242998342527483906
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: f999deca82ccdc14ebae40250c8eb0c9
           m_SubObjectName: 
@@ -276,6 +287,7 @@ MonoBehaviour:
     - rid: 5242998342527483909
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
           m_SubObjectName: 
@@ -295,6 +307,7 @@ MonoBehaviour:
     - rid: 5242998342527483910
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
           m_SubObjectName: 
@@ -314,6 +327,7 @@ MonoBehaviour:
     - rid: 5242998342527483917
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
           m_SubObjectName: 
@@ -333,6 +347,7 @@ MonoBehaviour:
     - rid: 5242998342527483918
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
           m_SubObjectName: 
@@ -352,6 +367,7 @@ MonoBehaviour:
     - rid: 5242998342527483919
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
           m_SubObjectName: 
@@ -371,6 +387,7 @@ MonoBehaviour:
     - rid: 5242998342527483920
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
           m_SubObjectName: 
@@ -390,6 +407,7 @@ MonoBehaviour:
     - rid: 5242998500334764034
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: f999deca82ccdc14ebae40250c8eb0c9
           m_SubObjectName: 
@@ -407,6 +425,7 @@ MonoBehaviour:
     - rid: 5242998503086751746
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: f999deca82ccdc14ebae40250c8eb0c9
           m_SubObjectName: 
@@ -427,6 +446,7 @@ MonoBehaviour:
     - rid: 5242998503086751747
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
+        <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: f999deca82ccdc14ebae40250c8eb0c9
           m_SubObjectName: 

--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsModuleBindings.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsModuleBindings.cs
@@ -1,6 +1,7 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
 using DCL.Audio;
+using DCL.FeatureFlags;
 using DCL.Friends.UserBlocking;
 using DCL.Landscape.Settings;
 using DCL.Optimization.PerformanceBudgeting;
@@ -25,7 +26,10 @@ namespace DCL.Settings.Configuration
     [Serializable]
     public abstract class SettingsModuleBindingBase
     {
-        public abstract UniTask<SettingsFeatureController> CreateModuleAsync(
+        [field: SerializeField]
+        public FeatureId FeatureId { get; set; } = FeatureId.NONE;
+
+        public abstract UniTask<SettingsFeatureController?> CreateModuleAsync(
             Transform parent,
             RealmPartitionSettingsAsset realmPartitionSettingsAsset,
             VideoPrioritizationSettings videoPrioritizationSettings,

--- a/Explorer/Assets/DCL/Settings/SettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/SettingsController.cs
@@ -175,7 +175,12 @@ namespace DCL.Settings
 
                 foreach (SettingsModuleBindingBase module in group.Modules)
                     if (module != null)
-                        controllers.Add(await module.CreateModuleAsync
+                    {
+                        if (module.FeatureId != FeatureId.NONE && !FeaturesRegistry.Instance.IsEnabled(module.FeatureId))
+                            continue;
+
+                        var controller =
+                        (await module.CreateModuleAsync
                         (
                             generalGroupView.ModulesContainer,
                             realmPartitionSettingsAsset,
@@ -193,6 +198,10 @@ namespace DCL.Settings
                             upscalingController,
                             assetsProvisioner,
                             volumeBus));
+
+                        if (controller != null)
+                            controllers.Add(controller);
+                    }
             }
         }
 


### PR DESCRIPTION
# Pull Request Description
Added an associated feature_ID with settings modules so we can have a finer control over which modules are shown as right now we can only restrict complete groups, but not individual modules.

## Test Instructions

Please check that with the Voice Chat FF disabled (or without the app-args) you cant see the Microphone Selection dropdown, nor the Voice Chat volume settings. And when you use the app-args, you should be able to see both options again.
