### PR TITLE
fix: enforce scene emotes naming in LSD for AvatarShape

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
@@ -37,6 +37,8 @@ namespace ECS.Unity.AvatarShape.Systems
     [ThrottlingEnabled]
     public partial class AvatarShapeHandlerSystem : BaseUnityLoopSystem, IFinalizeWorldSystem
     {
+        private const string SCENE_EMOTE_NAMING = "_emote.glb";
+
         private readonly World globalWorld;
         private readonly IComponentPool<Transform> globalTransformPool;
         private readonly ISceneData sceneData;
@@ -124,6 +126,11 @@ namespace ECS.Unity.AvatarShape.Systems
             // Scene emote files have to be loaded before the CharacterEmoteIntent can be used...
             if (localSceneDevelopment)
             {
+                // For consistent behavior, we only play local scene emotes if they have the same requirements we impose on the Asset
+                // Bundle Converter, otherwise creators may end up seeing scene emotes playing locally that won't play in deployed scenes
+                if (!emoteId.ToLower().EndsWith(SCENE_EMOTE_NAMING))
+                    return;
+
                 if (sdkAvatarShapeComponent.LocalSceneEmotePromise.HasValue)
                     sdkAvatarShapeComponent.LocalSceneEmotePromise.Value.ForgetLoading(globalWorld);
 


### PR DESCRIPTION
### WHY

In production Scene Emotes only play if they follow the needed naming convention (filename ending in `_emote.glb`), otherwise the Asset Bundle converter cannot filter them out to be correctly converted.

Technically we can play scene emotes without such convention during Local Scene Dev mode, but it's better to enforce the convention in that scenario as well, so that creators don't see an inconsistency between LSD and Prod (emotes playing in local and not in Prod).

We were already enforcing it for Scene Emotes played on the player, but we missed enforcing it for Scene Emotes played on AvatarShapes.

### WHAT

Added naming convention enforcing for LSD.

#### TEST INSTRUCTIONS

(...)

