### PR TITLE
fix: added listening status in community browser when already connected to a cvc

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserController.cs
@@ -98,10 +98,10 @@ namespace DCL.Communities.CommunitiesBrowser
             var thumbnailLoader = new ThumbnailLoader(spriteCache);
             commandsLibrary = new CommunitiesBrowserCommandsLibrary(orchestrator, sharedSpaceManager, chatEventBus, selfProfile, nftNamesProvider, mvcManager, spriteCache, dataProvider);
 
-            myCommunitiesPresenter = new CommunitiesBrowserMyCommunitiesPresenter(view.MyCommunitiesView, dataProvider, browserStateService, thumbnailLoader, browserEventBus);
+            myCommunitiesPresenter = new CommunitiesBrowserMyCommunitiesPresenter(view.MyCommunitiesView, dataProvider, browserStateService, thumbnailLoader, browserEventBus, orchestrator);
             myCommunitiesPresenter.ViewAllMyCommunitiesButtonClicked += ViewAllMyCommunitiesResults;
 
-            mainRightSectionPresenter = new CommunitiesBrowserMainRightSectionPresenter(view.RightSectionView, dataProvider, browserStateService, thumbnailLoader, profileRepositoryWrapper, browserEventBus, commandsLibrary);
+            mainRightSectionPresenter = new CommunitiesBrowserMainRightSectionPresenter(view.RightSectionView, dataProvider, browserStateService, thumbnailLoader, profileRepositoryWrapper, browserEventBus, commandsLibrary, orchestrator);
 
             view.SetThumbnailLoader(thumbnailLoader);
             view.InvitesAndRequestsView.Initialize(profileRepositoryWrapper);

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserFilteredCommunitiesPresenter.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserFilteredCommunitiesPresenter.cs
@@ -10,6 +10,7 @@ using DCL.Communities.CommunitiesDataProvider.DTOs;
 using DCL.NotificationsBus;
 using DCL.NotificationsBus.NotificationTypes;
 using DCL.Utility.Types;
+using DCL.VoiceChat;
 
 namespace DCL.Communities.CommunitiesBrowser
 {
@@ -28,6 +29,7 @@ namespace DCL.Communities.CommunitiesBrowser
         private readonly EventSubscriptionScope scope = new ();
         private readonly CommunitiesBrowserEventBus browserEventBus;
         private readonly CommunitiesBrowserCommandsLibrary commandsLibrary;
+        private readonly ICommunityCallOrchestrator orchestrator;
 
         private string currentNameFilter = string.Empty;
         private int currentPageNumberFilter = 1;
@@ -45,13 +47,15 @@ namespace DCL.Communities.CommunitiesBrowser
             ProfileRepositoryWrapper profileRepositoryWrapper,
             CommunitiesBrowserStateService browserStateService,
             CommunitiesBrowserEventBus browserEventBus,
-            CommunitiesBrowserCommandsLibrary commandsLibrary)
+            CommunitiesBrowserCommandsLibrary commandsLibrary,
+            ICommunityCallOrchestrator orchestrator)
         {
             this.view = view;
             this.dataProvider = dataProvider;
             this.browserStateService = browserStateService;
             this.browserEventBus = browserEventBus;
             this.commandsLibrary = commandsLibrary;
+            this.orchestrator = orchestrator;
 
             view.BackButtonClicked += OnBackButtonClicked;
             view.CommunityJoined += OnCommunityJoined;

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserMainRightSectionPresenter.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserMainRightSectionPresenter.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.Communities.CommunitiesBrowser.Commands;
 using DCL.UI.Profiles.Helpers;
+using DCL.VoiceChat;
 using System;
 using System.Threading;
 using Utility;
@@ -24,7 +25,8 @@ namespace DCL.Communities.CommunitiesBrowser
             ThumbnailLoader thumbnailLoader,
             ProfileRepositoryWrapper profileRepositoryWrapper,
             CommunitiesBrowserEventBus browserEventBus,
-            CommunitiesBrowserCommandsLibrary commandsLibrary)
+            CommunitiesBrowserCommandsLibrary commandsLibrary,
+            ICommunityCallOrchestrator orchestrator)
         {
             this.view = view;
             this.browserEventBus = browserEventBus;
@@ -34,10 +36,10 @@ namespace DCL.Communities.CommunitiesBrowser
 
             streamingCommunitiesPresenter.ViewAllClicked += OnViewAllStreamingCommunities;
 
-            filteredCommunitiesPresenter = new CommunitiesBrowserFilteredCommunitiesPresenter(view.FilteredCommunitiesView, dataProvider, profileRepositoryWrapper, browserStateService, browserEventBus, commandsLibrary);
+            filteredCommunitiesPresenter = new CommunitiesBrowserFilteredCommunitiesPresenter(view.FilteredCommunitiesView, dataProvider, profileRepositoryWrapper, browserStateService, browserEventBus, commandsLibrary, orchestrator);
             filteredCommunitiesPresenter.ResultsBackButtonClicked += LoadAllCommunities;
 
-            view.SetDependencies(thumbnailLoader, browserStateService);
+            view.SetDependencies(thumbnailLoader, browserStateService, orchestrator);
             view.LoopGridScrollChanged += TryLoadMoreResults;
         }
 

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserMyCommunitiesPresenter.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserMyCommunitiesPresenter.cs
@@ -3,6 +3,7 @@ using DCL.Diagnostics;
 using DCL.NotificationsBus;
 using DCL.NotificationsBus.NotificationTypes;
 using DCL.Utilities.Extensions;
+using DCL.VoiceChat;
 using System;
 using System.Threading;
 using Utility;
@@ -28,14 +29,15 @@ namespace DCL.Communities.CommunitiesBrowser
             CommunitiesDataProvider.CommunitiesDataProvider dataProvider,
             CommunitiesBrowserStateService browserStateService,
             ThumbnailLoader thumbnailLoader,
-            CommunitiesBrowserEventBus browserEventBus)
+            CommunitiesBrowserEventBus browserEventBus,
+            ICommunityCallOrchestrator orchestrator)
         {
             this.view = view;
             this.dataProvider = dataProvider;
             this.browserStateService = browserStateService;
             this.browserEventBus = browserEventBus;
 
-            view.SetDependencies(browserStateService, thumbnailLoader);
+            view.SetDependencies(browserStateService, thumbnailLoader, orchestrator);
             view.ViewAllMyCommunitiesButtonClicked += OnViewAllMyCommunitiesClicked;
             view.CommunityProfileOpened += OnCommunityProfileOpened;
             view.InitializeCommunitiesList(0);

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserRightSectionMainView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserRightSectionMainView.cs
@@ -1,3 +1,4 @@
+using DCL.VoiceChat;
 using System;
 using UnityEngine;
 using UnityEngine.UI;
@@ -28,10 +29,10 @@ namespace DCL.Communities.CommunitiesBrowser
             LoopGridScrollChanged?.Invoke();
         }
 
-        public void SetDependencies(ThumbnailLoader newThumbnailLoader, CommunitiesBrowserStateService communitiesBrowserStateService)
+        public void SetDependencies(ThumbnailLoader newThumbnailLoader, CommunitiesBrowserStateService communitiesBrowserStateService, ICommunityCallOrchestrator orchestrator)
         {
-            filteredCommunitiesView.SetDependencies(newThumbnailLoader, communitiesBrowserStateService);
-            streamingCommunitiesView.SetDependencies(newThumbnailLoader, communitiesBrowserStateService);
+            filteredCommunitiesView.SetDependencies(newThumbnailLoader, communitiesBrowserStateService, orchestrator);
+            streamingCommunitiesView.SetDependencies(newThumbnailLoader, communitiesBrowserStateService, orchestrator);
         }
 
         public void SetActiveView(CommunitiesViews activeView)

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunityResultCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunityResultCardView.cs
@@ -63,6 +63,7 @@ namespace DCL.Communities.CommunitiesBrowser
         [SerializeField] private Button goToStreamButton = null!;
         [SerializeField] private GameObject actionLoadingSpinner = null!;
         [SerializeField] private ListenersCountView listenersCountView = null!;
+        [SerializeField] private GameObject listeningTooltip = null!;
 
         [SerializeField] private MutualFriendsConfig mutualFriends;
 
@@ -168,8 +169,15 @@ namespace DCL.Communities.CommunitiesBrowser
         public void SetDescription(string description) =>
             communityDescription.text = description;
 
+        public void ConfigureListeningTooltip()
+        {
+            listenersCountView.gameObject.SetActive(false);
+            listeningTooltip.gameObject.SetActive(true);
+        }
+
         public void ConfigureListenersCount(bool isActive, int listenersCount)
         {
+            listeningTooltip.gameObject.SetActive(false);
             listenersCountView.gameObject.SetActive(isActive);
 
             stringBuilder.Clear();

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/FilteredCommunitiesView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/FilteredCommunitiesView.cs
@@ -2,6 +2,7 @@ using DCL.Communities.CommunitiesDataProvider.DTOs;
 using DCL.UI;
 using DCL.UI.Profiles.Helpers;
 using DCL.UI.Utilities;
+using DCL.VoiceChat;
 using SuperScrollView;
 using System;
 using System.Collections.Generic;
@@ -35,6 +36,7 @@ namespace DCL.Communities.CommunitiesBrowser
 
         private readonly List<string> currentFilteredIds = new ();
         private CommunitiesBrowserStateService? browserStateService;
+        private ICommunityCallOrchestrator? communityVoiceChatOrchestrator;
 
         private ProfileRepositoryWrapper? profileRepositoryWrapper;
         private ThumbnailLoader? thumbnailLoader;
@@ -56,10 +58,11 @@ namespace DCL.Communities.CommunitiesBrowser
             }
         }
 
-        public void SetDependencies(ThumbnailLoader newThumbnailLoader, CommunitiesBrowserStateService communitiesBrowserStateService)
+        public void SetDependencies(ThumbnailLoader newThumbnailLoader, CommunitiesBrowserStateService communitiesBrowserStateService, ICommunityCallOrchestrator orchestrator)
         {
             browserStateService = communitiesBrowserStateService;
             thumbnailLoader = newThumbnailLoader;
+            communityVoiceChatOrchestrator = orchestrator;
         }
 
         public void SetActiveViewSection(ActiveViewSection newActiveSection)
@@ -182,7 +185,11 @@ namespace DCL.Communities.CommunitiesBrowser
             cardView.SetActionButtonsState(communityData.privacy, communityData.pendingActionType, communityData.role != CommunityMemberRole.none, isStreaming, hasJoined);
             thumbnailLoader!.LoadCommunityThumbnailAsync(communityData.thumbnails?.raw, cardView.communityThumbnail, defaultThumbnailSprite, thumbnailLoadingCts.Token).Forget();
             cardView.SetActionLoadingActive(false);
-            cardView.ConfigureListenersCount(communityData.voiceChatStatus.isActive, communityData.voiceChatStatus.participantCount);
+
+            if (communityVoiceChatOrchestrator?.CurrentCommunityId.Value == communityData.id)
+                cardView.ConfigureListeningTooltip();
+            else
+                cardView.ConfigureListenersCount(communityData.voiceChatStatus.isActive, communityData.voiceChatStatus.participantCount);
 
             // Setup card events
             cardView.MainButtonClicked -= OnCommunityProfileOpened;

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/MyCommunitiesView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/MyCommunitiesView.cs
@@ -1,5 +1,6 @@
 using DCL.UI;
 using DCL.UI.Utilities;
+using DCL.VoiceChat;
 using SuperScrollView;
 using System;
 using System.Collections.Generic;
@@ -27,6 +28,7 @@ namespace DCL.Communities.CommunitiesBrowser
 
         private CommunitiesBrowserStateService browserStateService = null!;
         private ThumbnailLoader? thumbnailLoader;
+        private ICommunityCallOrchestrator? communityCallOrchestrator;
 
         //TODO FRAN: MAKE THIS HAVE ANY USE!
         private CancellationTokenSource myCommunityThumbnailsLoadingCts = new();
@@ -64,7 +66,12 @@ namespace DCL.Communities.CommunitiesBrowser
             cardView.SetCommunityId(communityData.id);
             cardView.SetTitle(communityData.name);
             cardView.SetUserRole(communityData.role);
-            cardView.ConfigureListenersCount(communityData.voiceChatStatus.isActive, communityData.voiceChatStatus.participantCount);
+
+            if (communityCallOrchestrator?.CurrentCommunityId.Value == communityData.id)
+                cardView.ConfigureListeningTooltip();
+            else
+                cardView.ConfigureListenersCount(communityData.voiceChatStatus.isActive, communityData.voiceChatStatus.participantCount);
+
             cardView.SetRequestsReceived(communityData.requestsReceived);
 
             thumbnailLoader!.LoadCommunityThumbnailAsync(communityData.thumbnails?.raw, cardView.communityThumbnail, defaultThumbnailSprite, myCommunityThumbnailsLoadingCts.Token).Forget();
@@ -115,10 +122,11 @@ namespace DCL.Communities.CommunitiesBrowser
             myCommunitiesMainContainer.SetActive(!isEmpty);
         }
 
-        public void SetDependencies(CommunitiesBrowserStateService communitiesBrowserStateService, ThumbnailLoader newThumbnailLoader)
+        public void SetDependencies(CommunitiesBrowserStateService communitiesBrowserStateService, ThumbnailLoader newThumbnailLoader, ICommunityCallOrchestrator orchestrator)
         {
             browserStateService = communitiesBrowserStateService;
             thumbnailLoader = newThumbnailLoader;
+            communityCallOrchestrator = orchestrator;
         }
     }
 }

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/MyCommunityCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/MyCommunityCardView.cs
@@ -59,6 +59,8 @@ namespace DCL.Communities.CommunitiesBrowser
             listeningTooltip.gameObject.SetActive(false);
             listenersCountView.gameObject.SetActive(isActive);
 
+            if (!isActive) return;
+
             stringBuilder.Clear();
             stringBuilder.Append(listenersCount);
             listenersCountView.ParticipantCount.text = stringBuilder.ToString();

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/MyCommunityCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/MyCommunityCardView.cs
@@ -18,6 +18,7 @@ namespace DCL.Communities.CommunitiesBrowser
         [field: SerializeField] public ImageView communityThumbnail = null!;
         [SerializeField] private Button mainButton = null!;
         [SerializeField] private ListenersCountView listenersCountView;
+        [SerializeField] private GameObject listeningTooltip;
         [SerializeField] private GameObject requestsReceivedContainer = null!;
         [SerializeField] private TMP_Text requestsReceivedText = null!;
 
@@ -47,8 +48,15 @@ namespace DCL.Communities.CommunitiesBrowser
             userRole.text = $"{char.ToUpperInvariant(roleString[0])}{roleString[1..]}";
         }
 
+        public void ConfigureListeningTooltip()
+        {
+            listeningTooltip.gameObject.SetActive(true);
+            listenersCountView.gameObject.SetActive(false);
+        }
+
         public void ConfigureListenersCount(bool isActive, int listenersCount)
         {
+            listeningTooltip.gameObject.SetActive(false);
             listenersCountView.gameObject.SetActive(isActive);
 
             stringBuilder.Clear();

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunityResultCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunityResultCard.prefab
@@ -1846,6 +1846,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 0
+--- !u!1 &6980438496596931844
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2798965137089600552}
+  - component: {fileID: 480158624160891999}
+  - component: {fileID: 7934275105291551550}
+  - component: {fileID: 4427256591945984221}
+  m_Layer: 5
+  m_Name: ListeningIcn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2798965137089600552
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6980438496596931844}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3871066310531660349}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 18}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &480158624160891999
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6980438496596931844}
+  m_CullTransparentMesh: 1
+--- !u!114 &7934275105291551550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6980438496596931844}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1882353, g: 0.8039216, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 9b2fdd0db3163464ab125fc37f700593, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4427256591945984221
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6980438496596931844}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 18
+  m_MinHeight: 18
+  m_PreferredWidth: 18
+  m_PreferredHeight: 18
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &7333502227101479341
 GameObject:
   m_ObjectHideFlags: 0
@@ -2179,6 +2275,125 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8025924327015155934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3871066310531660349}
+  - component: {fileID: 8220607410701181364}
+  - component: {fileID: 4350668464014173729}
+  - component: {fileID: 8076922170921084999}
+  - component: {fileID: 1183563533572770740}
+  m_Layer: 5
+  m_Name: ListeningTooltip
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3871066310531660349
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8025924327015155934}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2798965137089600552}
+  - {fileID: 309707477761794265}
+  m_Father: {fileID: 642764471525080873}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 14, y: -14}
+  m_SizeDelta: {x: 0, y: 26}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &8220607410701181364
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8025924327015155934}
+  m_CullTransparentMesh: 1
+--- !u!114 &4350668464014173729
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8025924327015155934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.08627451, g: 0.08235294, b: 0.09411765, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 12dd1efc4e826764f9b02be515a9a033, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 3
+--- !u!114 &8076922170921084999
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8025924327015155934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 3
+    m_Right: 8
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_Spacing: 2.37
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &1183563533572770740
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8025924327015155934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
 --- !u!1 &8215373150881848067
 GameObject:
   m_ObjectHideFlags: 0
@@ -2215,6 +2430,7 @@ RectTransform:
   - {fileID: 1525929090898206160}
   - {fileID: 4997390486348344830}
   - {fileID: 5514180669078584420}
+  - {fileID: 3871066310531660349}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -2364,6 +2580,7 @@ MonoBehaviour:
   goToStreamButton: {fileID: 5677343231835995831}
   actionLoadingSpinner: {fileID: 340140728143378828}
   listenersCountView: {fileID: 1230501869457849747}
+  listeningTooltip: {fileID: 8025924327015155934}
   mutualFriends:
     thumbnails:
     - root: {fileID: 731689965516973166}
@@ -2546,6 +2763,142 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 2.5
+--- !u!1 &8875135950534999875
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 309707477761794265}
+  - component: {fileID: 4194844807124732896}
+  - component: {fileID: 7904210749564058473}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &309707477761794265
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8875135950534999875}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3871066310531660349}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 12}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4194844807124732896
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8875135950534999875}
+  m_CullTransparentMesh: 1
+--- !u!114 &7904210749564058473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8875135950534999875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Listening
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294769916
+  m_fontColor: {r: 0.9882353, g: 0.9882353, b: 0.9882353, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1001 &16654785817010036
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3797,7 +4150,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 450748936901195079, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 66
+      value: 61.120003
       objectReference: {fileID: 0}
     - target: {fileID: 450748936901195079, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_SizeDelta.y
@@ -3851,6 +4204,46 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1526228241171632978, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1526228241171632978, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1526228241171632978, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1526228241171632978, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 1526228241171632978, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -13
+      objectReference: {fileID: 0}
+    - target: {fileID: 4014368384364834723, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4014368384364834723, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4014368384364834723, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 18.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 4014368384364834723, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 48.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 4014368384364834723, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -13
+      objectReference: {fileID: 0}
     - target: {fileID: 6672193002422552484, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_Name
       value: ListenersCounter
@@ -3858,6 +4251,46 @@ PrefabInstance:
     - target: {fileID: 6672193002422552484, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975171418376010189, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975171418376010189, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975171418376010189, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975171418376010189, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 38
+      objectReference: {fileID: 0}
+    - target: {fileID: 6975171418376010189, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -13
+      objectReference: {fileID: 0}
+    - target: {fileID: 9173349808348785566, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9173349808348785566, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9173349808348785566, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 9173349808348785566, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 29
+      objectReference: {fileID: 0}
+    - target: {fileID: 9173349808348785566, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -13
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/MyCommunityCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/MyCommunityCard.prefab
@@ -174,6 +174,7 @@ MonoBehaviour:
   <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7, type: 2}
   <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
   <images>k__BackingField: []
+  <text>k__BackingField: {fileID: 0}
   interactableColor: {r: 1, g: 1, b: 1, a: 1}
   hoverColor: {r: 0.54, g: 0.54, b: 0.54, a: 1}
 --- !u!114 &6027808750942155950
@@ -194,6 +195,7 @@ MonoBehaviour:
   communityThumbnail: {fileID: 1354081087228632267}
   mainButton: {fileID: 322440660326183502}
   listenersCountView: {fileID: 8338091303072002149}
+  listeningTooltip: {fileID: 8878474248328302130}
   requestsReceivedContainer: {fileID: 3583162425481750790}
   requestsReceivedText: {fileID: 4956868563150437188}
 --- !u!1 &3303900259441115049
@@ -701,6 +703,7 @@ RectTransform:
   m_Children:
   - {fileID: 1321246573552026464}
   - {fileID: 3324511021088731538}
+  - {fileID: 2445358543601204433}
   m_Father: {fileID: 1251707771264483775}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
@@ -1037,6 +1040,204 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &8396993645428306920
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3639059241261980356}
+  - component: {fileID: 1368741715440763571}
+  - component: {fileID: 8812233598154868178}
+  - component: {fileID: 2965519779149524529}
+  - component: {fileID: 5927901361376071628}
+  m_Layer: 5
+  m_Name: StreamIcn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3639059241261980356
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8396993645428306920}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2445358543601204433}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 12, y: -13}
+  m_SizeDelta: {x: 18, y: 18}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1368741715440763571
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8396993645428306920}
+  m_CullTransparentMesh: 1
+--- !u!114 &8812233598154868178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8396993645428306920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1882353, g: 0.8039216, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 9b2fdd0db3163464ab125fc37f700593, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2965519779149524529
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8396993645428306920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 18
+  m_MinHeight: 18
+  m_PreferredWidth: 18
+  m_PreferredHeight: 18
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &5927901361376071628
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8396993645428306920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &8878474248328302130
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2445358543601204433}
+  - component: {fileID: 7368473989454358360}
+  - component: {fileID: 2898012509173145805}
+  - component: {fileID: 6294020764572478990}
+  m_Layer: 5
+  m_Name: ListeningTooltip
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2445358543601204433
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8878474248328302130}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3639059241261980356}
+  m_Father: {fileID: 1038682947352842987}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 7, y: -7}
+  m_SizeDelta: {x: 24.0366, y: 26}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &7368473989454358360
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8878474248328302130}
+  m_CullTransparentMesh: 1
+--- !u!114 &2898012509173145805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8878474248328302130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.08627451, g: 0.08235294, b: 0.09411765, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 12dd1efc4e826764f9b02be515a9a033, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 3
+--- !u!114 &6294020764572478990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8878474248328302130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eddc1fbd4bd796345832996a9560b9bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8929885782025950683
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/StreamingCommunityResultCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/StreamingCommunityResultCard.prefab
@@ -1,5 +1,356 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &520626782527769979
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8673720798536962785}
+  - component: {fileID: 5054278427473836504}
+  - component: {fileID: 1270604018223565137}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8673720798536962785
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 520626782527769979}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5308539032102766597}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 54.695, y: -13}
+  m_SizeDelta: {x: 62.41, y: 12}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5054278427473836504
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 520626782527769979}
+  m_CullTransparentMesh: 1
+--- !u!114 &1270604018223565137
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 520626782527769979}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Listening
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 2164260863
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.5019608}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1401391298192554726
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5308539032102766597}
+  - component: {fileID: 1010500327486067596}
+  - component: {fileID: 4644301629850358809}
+  - component: {fileID: 866256527228066431}
+  - component: {fileID: 7818159413017360780}
+  m_Layer: 5
+  m_Name: ListeningTooltip
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5308539032102766597
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401391298192554726}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6540521494661639696}
+  - {fileID: 8673720798536962785}
+  m_Father: {fileID: 642764471525080873}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 14, y: -14}
+  m_SizeDelta: {x: 93.9, y: 26}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &1010500327486067596
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401391298192554726}
+  m_CullTransparentMesh: 1
+--- !u!114 &4644301629850358809
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401391298192554726}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.08627451, g: 0.08235294, b: 0.09411765, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 12dd1efc4e826764f9b02be515a9a033, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 3
+--- !u!114 &866256527228066431
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401391298192554726}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 3
+    m_Right: 8
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_Spacing: 2.49
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &7818159413017360780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401391298192554726}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
+--- !u!1 &2075048402452711228
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6540521494661639696}
+  - component: {fileID: 8843574240084227687}
+  - component: {fileID: 1301337401021460742}
+  - component: {fileID: 4711807800345549541}
+  m_Layer: 5
+  m_Name: StreamIcn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6540521494661639696
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2075048402452711228}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5308539032102766597}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 12, y: -13}
+  m_SizeDelta: {x: 18, y: 18}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8843574240084227687
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2075048402452711228}
+  m_CullTransparentMesh: 1
+--- !u!114 &1301337401021460742
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2075048402452711228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1882353, g: 0.8039216, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 9b2fdd0db3163464ab125fc37f700593, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4711807800345549541
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2075048402452711228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 18
+  m_MinHeight: 18
+  m_PreferredWidth: 18
+  m_PreferredHeight: 18
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &2126714781980682832
 GameObject:
   m_ObjectHideFlags: 0
@@ -459,6 +810,7 @@ RectTransform:
   - {fileID: 4997390486348344830}
   - {fileID: 8248086660844423295}
   - {fileID: 5514180669078584420}
+  - {fileID: 5308539032102766597}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -584,6 +936,7 @@ MonoBehaviour:
   communityThumbnail: {fileID: 1563201233504633467}
   mainButton: {fileID: 7446897494615956440}
   listenersCountView: {fileID: 1230501869457849747}
+  listeningTooltip: {fileID: 1401391298192554726}
 --- !u!114 &3873405496694831746
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -705,7 +1058,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 450748936901195079, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 61.120003
       objectReference: {fileID: 0}
     - target: {fileID: 450748936901195079, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_SizeDelta.y
@@ -761,43 +1114,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1526228241171632978, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1526228241171632978, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1526228241171632978, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 1526228241171632978, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 1526228241171632978, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -13
       objectReference: {fileID: 0}
     - target: {fileID: 4014368384364834723, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4014368384364834723, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4014368384364834723, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 18.12
       objectReference: {fileID: 0}
     - target: {fileID: 4014368384364834723, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 48.06
       objectReference: {fileID: 0}
     - target: {fileID: 4014368384364834723, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -13
       objectReference: {fileID: 0}
     - target: {fileID: 6672193002422552484, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_Name
@@ -809,43 +1162,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6975171418376010189, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6975171418376010189, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6975171418376010189, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6975171418376010189, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 6975171418376010189, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -13
       objectReference: {fileID: 0}
     - target: {fileID: 9173349808348785566, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9173349808348785566, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9173349808348785566, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 9173349808348785566, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 9173349808348785566, guid: 3c1584e5b9339461b8c75d34cd68662c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -13
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -878,11 +1231,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4906287755250558190, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4906287755250558190, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4906287755250558190, guid: bf63ab8a4820b4024a7aedaf81568166, type: 3}
       propertyPath: m_SizeDelta.x

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/StreamingCommunitiesView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/StreamingCommunitiesView.cs
@@ -1,5 +1,6 @@
 using DCL.UI;
 using DCL.UI.Utilities;
+using DCL.VoiceChat;
 using SuperScrollView;
 using System;
 using System.Collections.Generic;
@@ -24,6 +25,7 @@ namespace DCL.Communities.CommunitiesBrowser
 
         private readonly List<string> streamingResultsIds = new ();
         private CommunitiesBrowserStateService? browserStateService;
+        private ICommunityCallOrchestrator? communityCallOrchestrator;
         private ThumbnailLoader? thumbnailLoader;
 
         private void Awake()
@@ -95,7 +97,12 @@ namespace DCL.Communities.CommunitiesBrowser
 
             cardView.SetCommunityId(communityData.id);
             cardView.SetTitle(communityData.name);
-            cardView.ConfigureListenersCount(communityData.voiceChatStatus.isActive, communityData.voiceChatStatus.participantCount);
+
+            if (communityCallOrchestrator?.CurrentCommunityId.Value == communityData.id)
+                cardView.ConfigureListeningTooltip();
+            else
+                cardView.ConfigureListenersCount(communityData.voiceChatStatus.isActive, communityData.voiceChatStatus.participantCount);
+
             thumbnailLoader!.LoadCommunityThumbnailAsync(communityData.thumbnails?.raw, cardView.communityThumbnail, defaultThumbnailSprite, default(CancellationToken)).Forget();
 
             cardView.MainButtonClicked -= JoinStreamClicked;
@@ -109,10 +116,11 @@ namespace DCL.Communities.CommunitiesBrowser
             JoinStream?.Invoke(communityId);
         }
 
-        public void SetDependencies(ThumbnailLoader newThumbnailLoader, CommunitiesBrowserStateService communitiesBrowserStateService)
+        public void SetDependencies(ThumbnailLoader newThumbnailLoader, CommunitiesBrowserStateService communitiesBrowserStateService, ICommunityCallOrchestrator orchestrator)
         {
             browserStateService = communitiesBrowserStateService;
             thumbnailLoader = newThumbnailLoader;
+            communityCallOrchestrator = orchestrator;
         }
     }
 }

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/StreamingCommunityResultCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/StreamingCommunityResultCardView.cs
@@ -79,6 +79,8 @@ namespace DCL.Communities.CommunitiesBrowser
             listenersCountView.gameObject.SetActive(isActive);
             listeningTooltip.SetActive(false);
 
+            if (!isActive) return;
+
             stringBuilder.Clear();
             stringBuilder.Append(listenersCount);
             listenersCountView.ParticipantCount.text = stringBuilder.ToString();

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/StreamingCommunityResultCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/StreamingCommunityResultCardView.cs
@@ -19,6 +19,7 @@ namespace DCL.Communities.CommunitiesBrowser
         [SerializeField] public ImageView communityThumbnail = null!;
         [SerializeField] private Button mainButton = null!;
         [SerializeField] private ListenersCountView listenersCountView = null!;
+        [SerializeField] private GameObject listeningTooltip = null!;
 
         private readonly StringBuilder stringBuilder = new ();
 
@@ -67,9 +68,17 @@ namespace DCL.Communities.CommunitiesBrowser
         public void SetTitle(string title) =>
             communityTitle.text = title;
 
+        public void ConfigureListeningTooltip()
+        {
+            listenersCountView.gameObject.SetActive(false);
+            listeningTooltip.SetActive(true);
+        }
+
         public void ConfigureListenersCount(bool isActive, int listenersCount)
         {
             listenersCountView.gameObject.SetActive(isActive);
+            listeningTooltip.SetActive(false);
+
             stringBuilder.Clear();
             stringBuilder.Append(listenersCount);
             listenersCountView.ParticipantCount.text = stringBuilder.ToString();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5448
This PR introduces the listening label in community cards in the communities browser when you are already connected to a stream and check that panel, like in the following screenshot:
<img width="1728" height="872" alt="Screenshot 2025-09-30 at 17 52 38" src="https://github.com/user-attachments/assets/bc33a9dd-0bca-42df-93e9-9a324cf767b2" />


## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] Own or be a mod of a community to start a voice chat 

### Test Steps
1. Open the client with --debug and --voice-chat
2. Start a community voice chat
3. Go to the community panel
4. Verify that, like in the screenshot above, the card of the community you are currently talking in has the listening icon or listening text
