### PR TITLE
fix: handle null voice chat status in communities response

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/GetCommunityResponse.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/GetCommunityResponse.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 
 namespace DCL.Communities.CommunitiesDataProvider.DTOs
 {
@@ -6,6 +7,7 @@ namespace DCL.Communities.CommunitiesDataProvider.DTOs
     public class GetCommunityResponse
     {
         [Serializable]
+        [JsonConverter(typeof(VoiceChatStatusJsonConverter))]
         public struct VoiceChatStatus
         {
             public bool isActive;

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/GetUserCommunitiesResponse.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/GetUserCommunitiesResponse.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 
 namespace DCL.Communities.CommunitiesDataProvider.DTOs
 {
@@ -24,6 +25,7 @@ namespace DCL.Communities.CommunitiesDataProvider.DTOs
             public CommunityPrivacy privacy;
             public CommunityMemberRole role;
             public FriendInCommunity[] friends;
+            [JsonConverter(typeof(VoiceChatStatusJsonConverter))]
             public GetCommunityResponse.VoiceChatStatus voiceChatStatus;
 
             public string inviteOrRequestId;

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/VoiceChatStatusJsonConverter.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/VoiceChatStatusJsonConverter.cs
@@ -1,0 +1,48 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace DCL.Communities.CommunitiesDataProvider.DTOs
+{
+    public class VoiceChatStatusJsonConverter : JsonConverter<GetCommunityResponse.VoiceChatStatus>
+    {
+        public override void WriteJson(JsonWriter writer, GetCommunityResponse.VoiceChatStatus value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("isActive");
+            writer.WriteValue(value.isActive);
+            writer.WritePropertyName("participantCount");
+            writer.WriteValue(value.participantCount);
+            writer.WritePropertyName("moderatorCount");
+            writer.WriteValue(value.moderatorCount);
+            writer.WriteEndObject();
+        }
+
+        public override GetCommunityResponse.VoiceChatStatus ReadJson(JsonReader reader, Type objectType, GetCommunityResponse.VoiceChatStatus existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return new GetCommunityResponse.VoiceChatStatus
+                {
+                    isActive = false,
+                    participantCount = 0,
+                    moderatorCount = 0
+                };
+            }
+
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jsonObject = JObject.Load(reader);
+                
+                return new GetCommunityResponse.VoiceChatStatus
+                {
+                    isActive = jsonObject["isActive"]?.Value<bool>() ?? false,
+                    participantCount = jsonObject["participantCount"]?.Value<int>() ?? 0,
+                    moderatorCount = jsonObject["moderatorCount"]?.Value<int>() ?? 0
+                };
+            }
+
+            return serializer.Deserialize<GetCommunityResponse.VoiceChatStatus>(reader);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/VoiceChatStatusJsonConverter.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/VoiceChatStatusJsonConverter.cs
@@ -1,14 +1,13 @@
 using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using UnityEngine.Scripting;
 
 namespace DCL.Communities.CommunitiesDataProvider.DTOs
 {
+    [Preserve]
     public class VoiceChatStatusJsonConverter : JsonConverter<GetCommunityResponse.VoiceChatStatus>
     {
-        //parameterless constructor to ensure that IL2CPP build can locate the constructor
-        public VoiceChatStatusJsonConverter() { }
-
         public override void WriteJson(JsonWriter writer, GetCommunityResponse.VoiceChatStatus value, JsonSerializer serializer)
         {
             writer.WriteStartObject();
@@ -36,7 +35,7 @@ namespace DCL.Communities.CommunitiesDataProvider.DTOs
             if (reader.TokenType == JsonToken.StartObject)
             {
                 var jsonObject = JObject.Load(reader);
-                
+
                 return new GetCommunityResponse.VoiceChatStatus
                 {
                     isActive = jsonObject["isActive"]?.Value<bool>() ?? false,

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/VoiceChatStatusJsonConverter.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/VoiceChatStatusJsonConverter.cs
@@ -6,6 +6,9 @@ namespace DCL.Communities.CommunitiesDataProvider.DTOs
 {
     public class VoiceChatStatusJsonConverter : JsonConverter<GetCommunityResponse.VoiceChatStatus>
     {
+        //parameterless constructor to ensure that IL2CPP build can locate the constructor
+        public VoiceChatStatusJsonConverter() { }
+
         public override void WriteJson(JsonWriter writer, GetCommunityResponse.VoiceChatStatus value, JsonSerializer serializer)
         {
             writer.WriteStartObject();

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/VoiceChatStatusJsonConverter.cs.meta
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/VoiceChatStatusJsonConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1e6fd00a6cd484f4697a9cdef6cf20f4


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5546 
This PR is needed due to a change in BE, when a community is private and we are not part of it the voice chat status is sent to null, this was breaking serialization, this has been fixed by handling the null as a non active voice chat status in serialization.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [x] Have two clients ready, one with a user part of a private community (owner or moderator of it) and one not part of that community
- [x] Use the clients in the .zone environment

### Test Steps
1. Launch both clients with --debug and --voice-chat in .zone environment
2. With the user inside the private community start a community voice chat
3. With the other user go to the community browser and verify that in the list of communities you don't see the streaming status of the private community you are not part of
