### PR TITLE
fix: handle missing profile on chat message

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatEntryUsernameElement.cs
+++ b/Explorer/Assets/DCL/Chat/ChatEntryUsernameElement.cs
@@ -7,7 +7,7 @@ namespace DCL.Chat
 {
     public class ChatEntryUsernameElement : MonoBehaviour
     {
-        public Action UserNameClicked;
+        public Action? UserNameClicked;
 
         [field: SerializeField] internal TMP_Text userName { get; private set; }
         [field: SerializeField] internal TMP_Text walletIdText { get; private set; }

--- a/Explorer/Assets/DCL/Chat/ChatEntryView.cs
+++ b/Explorer/Assets/DCL/Chat/ChatEntryView.cs
@@ -27,7 +27,7 @@ namespace DCL.Chat
         [field: SerializeField] internal CanvasGroup chatEntryCanvasGroup { get; private set; }
 
         [field: Header("Elements")]
-        [field: SerializeField] private ChatEntryUsernameElement usernameElement { get; set; }
+        [field: SerializeField] internal ChatEntryUsernameElement usernameElement { get; set; }
         [field: SerializeField] internal ChatEntryMessageBubbleElement messageBubbleElement { get; private set; }
         [field: SerializeField] internal RectTransform dateDividerElement { get; private set; }
         [field: SerializeField] internal TMP_Text dateDividerText { get; private set; }
@@ -39,6 +39,7 @@ namespace DCL.Chat
         [field: SerializeField] private CanvasGroup usernameElementCanvas;
 
         private ReactivePropertyExtensions.DisposableSubscription<ProfileThumbnailViewModel.WithColor>? profileSubscription;
+        private ReactivePropertyExtensions.DisposableSubscription<ProfileOptionalBasicInfo>? profileDataSubscription;
 
         private ChatMessage chatMessage;
         private readonly Vector3[] cornersCache = new Vector3[4];
@@ -97,6 +98,20 @@ namespace DCL.Chat
 
             profileSubscription?.Dispose();
             profileSubscription = viewModel.ProfileData.UseCurrentValueAndSubscribeToUpdate(usernameElement.userName, (vM, text) => text.color = vM.ProfileColor, viewModel.cancellationToken);
+
+            profileDataSubscription?.Dispose();
+            profileDataSubscription = viewModel.ProfileOptionalBasicInfo.UseCurrentValueAndSubscribeToUpdate(this, (profileInfo, view) =>
+            {
+                view.profileButton.interactable = profileInfo.DataIsPresent;
+
+                if (profileInfo.DataIsPresent)
+                {
+                    view.usernameElement.UserNameClicked += OnUsernameClicked;
+                    view.usernameElement.SetUsername(profileInfo.UserName, profileInfo.UserWalletId);
+                }
+                else
+                    view.usernameElement.UserNameClicked -= OnUsernameClicked;
+            }, viewModel.cancellationToken);
         }
 
         private void OnProfileButtonClicked()

--- a/Explorer/Assets/DCL/Chat/History/ChatMessageFactory.cs
+++ b/Explorer/Assets/DCL/Chat/History/ChatMessageFactory.cs
@@ -9,6 +9,7 @@ namespace DCL.Chat.History
     /// </summary>
     public class ChatMessageFactory
     {
+        public const string LOADING_PROFILE_TEXT = "Loading Profile...";
         private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{3,15}(?:#[A-Za-z0-9]{4})?)(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
 
         private readonly IProfileCache profileCache;
@@ -85,7 +86,7 @@ namespace DCL.Chat.History
                 if (profile != null)
                     userHash = profile.WalletId ?? string.Empty;
                 else
-                    userHash = $"#{senderWalletAddress[^4..]}";
+                    userHash = LOADING_PROFILE_TEXT;
 
                 return userHash;
             }

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/CreateMessageViewModelCommand.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/CreateMessageViewModelCommand.cs
@@ -34,6 +34,7 @@ namespace DCL.Chat.ChatCommands
         {
             ChatMessageViewModel? viewModel = ChatMessageViewModel.POOL.Get();
             viewModel.Message = message;
+            viewModel.ProfileOptionalBasicInfo.UpdateValue(new ProfileOptionalBasicInfo(message.SenderWalletId != ChatMessageFactory.LOADING_PROFILE_TEXT, message.SenderValidatedName, message.SenderWalletId));
 
             // Whether the timestamp is not null (old messages, backward compatibility), it's not the last padding message, and either the message is the first in the feed or the day it was sent is different from the previous messages
             viewModel.ShowDateDivider = message.SentTimestamp.HasValue &&
@@ -66,6 +67,7 @@ namespace DCL.Chat.ChatCommands
             if (profile != null)
             {
                 viewModel.ProfileData.UpdateValue(viewModel.ProfileData.Value.SetColor(profile.UserNameColor));
+                viewModel.ProfileOptionalBasicInfo.UpdateValue(new ProfileOptionalBasicInfo(true, profile.ValidatedName, profile.WalletId));
 
                 await GetProfileThumbnailCommand.Instance.ExecuteAsync(viewModel.ProfileData, chatConfig.DefaultProfileThumbnail,
                     walletId, profile.Avatar.FaceSnapshotUrl, cancellationToken);

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatViewModels/ChatMessageViewModel.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatViewModels/ChatMessageViewModel.cs
@@ -19,6 +19,8 @@ namespace DCL.Chat.ChatViewModels
                 viewModel.Message = default(ChatMessage);
                 viewModel.ProfileData.ClearSubscriptionsList();
                 viewModel.ProfileData.UpdateValue(ProfileThumbnailViewModel.WithColor.Default());
+                viewModel.ProfileOptionalBasicInfo.ClearSubscriptionsList();
+                viewModel.ProfileOptionalBasicInfo.UpdateValue(UI.ProfileElements.ProfileOptionalBasicInfo.Default());
                 viewModel.IsSeparator = false;
                 viewModel.cancellationTokenSource.SafeCancelAndDispose();
                 viewModel.PendingToAnimate = false;
@@ -35,6 +37,9 @@ namespace DCL.Chat.ChatViewModels
         // In case we need more profile information in the future, create a separate ProfileViewModel and update it at once
         public IReactiveProperty<ProfileThumbnailViewModel.WithColor> ProfileData { get; }
             = ProfileThumbnailViewModel.WithColor.DefaultReactive();
+
+        public IReactiveProperty<ProfileOptionalBasicInfo> ProfileOptionalBasicInfo { get; }
+            = new ReactiveProperty<ProfileOptionalBasicInfo>(UI.ProfileElements.ProfileOptionalBasicInfo.Default());
 
         public bool IsSeparator { get; internal set; }
 

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileOptionalBasicInfo.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileOptionalBasicInfo.cs
@@ -1,0 +1,19 @@
+namespace DCL.UI.ProfileElements
+{
+    public readonly struct ProfileOptionalBasicInfo
+    {
+        public readonly string UserName;
+        public readonly string? UserWalletId;
+        public readonly bool DataIsPresent;
+
+        public ProfileOptionalBasicInfo(bool dataIsPresent, string userName, string? userWalletId)
+        {
+            DataIsPresent = dataIsPresent;
+            UserName = userName;
+            UserWalletId = userWalletId;
+        }
+
+        public static ProfileOptionalBasicInfo Default() =>
+            new (false, string.Empty, null);
+    }
+}

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileOptionalBasicInfo.cs.meta
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileOptionalBasicInfo.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fa793276d49a4d27b0c8d3cf38aff5d8
+timeCreated: 1759392233


### PR DESCRIPTION
# Pull Request Description
Fixes #4353
Fixes #5076 
Fixes #5555 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR expands what the `ChatMessageViewModel` carries with some basic profile information. Now when a chat message is displayed and the profile is not in the cache, a placeholder string is displayed in the sender name, so that when the profile is actually fetched, both the thumbnail and claimed name (or wallet address) are correctly retroactively updated (during this loading, the message entry is not interactable: no context menu).

This prevents having chat messages rendered in a "broken" state as described in the lined issues.


This can be further improved by using livekit participant metadata like in voice chat, but its implementation is a big rabbit hole and it also could be done in such a way that could modify how we approach Profiles in general, hence propagated in many aspects (such as voice chat).
For this I've opened another [issue](https://github.com/decentraland/unity-explorer/issues/5672) to keep track of the idea

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Jump to a scene where there's somebody talking (make sure you've never encountered them, not even in a chat message). As soon as the loading screen fades out:
   1. notice that messages are displayed with a name "Load profile..." (this may or may not be visibile as it depends on how fast you are able to fetch their profile). In this state you are not able to open the context menu of the message entry
   2. Verify that the message is then updated with the actual name/wallet/thumbnail. You may now open the context menu
2. You should not be able to see messages as "broken" as described in the linked issue

### Additional Testing Notes
- The testing can be eased by using multiple accounts at the same time
- The test steps can be replicated with a build different from the one in this PR in order to verify that by doing them, you are able to brake the chat messages

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
