### PR TITLE
fix: prevent user context menu spawn if cancelled

### DIFF
--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendsSectionDoubleCollectionController.cs
@@ -31,7 +31,6 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
         private CancellationTokenSource openPassportCts = new ();
         private bool elementClicked;
         private CancellationTokenSource? popupCts;
-        private UniTaskCompletionSource contextMenuTask = new ();
 
         internal event Action<string>? OnlineFriendClicked;
         internal event Action<string, Vector2Int>? JumpInClicked;
@@ -117,7 +116,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
 
         private void OnContextMenuClicked(FriendProfile friendProfile, Vector2 buttonPosition, FriendListUserView elementView)
         {
-            jumpToFriendLocationCts = jumpToFriendLocationCts.SafeRestart();
+            popupCts = popupCts.SafeRestart();
             elementView.CanUnHover = false;
 
             bool isFriendOnline = friendsConnectivityStatusTracker.GetFriendStatus(friendProfile.Address) != OnlineStatus.OFFLINE;
@@ -125,14 +124,8 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
             if (isFriendOnline)
                 OnlineFriendClicked?.Invoke(friendProfile.Address);
 
-            popupCts = popupCts.SafeRestart();
-            contextMenuTask.TrySetResult();
-
-            contextMenuTask = new UniTaskCompletionSource();
-            UniTask menuTask = UniTask.WhenAny(panelLifecycleTask.Task, contextMenuTask.Task);
-
             ViewDependencies.GlobalUIViews.ShowUserProfileContextMenuFromWalletIdAsync(new Web3Address(friendProfile.Address),
-                buttonPosition, default(Vector2), popupCts.Token, closeMenuTask: menuTask, onHide: () => elementView.CanUnHover = true
+                buttonPosition, default(Vector2), popupCts.Token, closeMenuTask: panelLifecycleTask!.Task, onHide: () => elementView.CanUnHover = true
                 ,anchorPoint: MenuAnchorPoint.TOP_RIGHT).Forget();
         }
 

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/GenericUserProfileContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/GenericUserProfileContextMenuController.cs
@@ -189,6 +189,8 @@ namespace DCL.UI
             if (includeCommunities)
                 invitationButtonHandler.SetUserToInvite(profile.UserId);
 
+            if (ct.IsCancellationRequested) return;
+
             await mvcManager.ShowAsync(GenericContextMenuController.IssueCommand(
                 new GenericContextMenuParameter(contextMenu, position, actionOnHide: onContextMenuHide, closeTask: closeTask)), ct);
         }


### PR DESCRIPTION
# Pull Request Description
Fixes #5423 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

 This PR avoids to invoke the context menu when the cancellation token has been already cancelled. Previously this was possible by spamming the context menu button in the friend list so fast that the flow was letting the cancelled token to pass, making the context menu un-closable therefore blocking most of the rest of the UIs.

On top of that, some useless tasks before the invocation were removed.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Follow the repro steps in the linked issue
2. It seems that the bug was also triggered by just spamming one single context menu button (can be checked against a different build from the one in this PR)


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
