### PR TITLE
chore: using dev cache for new target

### DIFF
--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -133,7 +133,6 @@ def clone_current_target(use_cache):
         print(f"New target found")
         # Create new target with template cache
         if use_cache:
-           if use_cache:
             cache_source = resolve_cache_source(template_target)
             body['settings']['buildTargetCopyCache'] = cache_source
             print(f"Using cache from: {cache_source}")

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -49,6 +49,14 @@ def validate_branch_name(branch_name):
         print(f"Error: Branch name '{branch_name}' contains invalid characters (+, ., or @).")
         sys.exit(1)
 
+def resolve_cache_source(template_target: str) -> str:
+    t = (template_target or "").lower()
+    if t == "t_macos":
+        return os.getenv("CACHE_SOURCE_MACOS", "macos-dev")
+    if t == "t_windows64":
+        return os.getenv("CACHE_SOURCE_WINDOWS", "windows64-dev")
+    return template_target
+
 def get_target(target):
     response = requests.get(f'{URL}/buildtargets/{target}', headers=HEADERS)
 
@@ -125,8 +133,10 @@ def clone_current_target(use_cache):
         print(f"New target found")
         # Create new target with template cache
         if use_cache:
-            body['settings']['buildTargetCopyCache'] = template_target
-            print(f"Using template cache build target: {template_target}")
+           if use_cache:
+            cache_source = resolve_cache_source(template_target)
+            body['settings']['buildTargetCopyCache'] = cache_source
+            print(f"Using cache from: {cache_source}")
         else:
             print(f"Not using cache")
         try:
@@ -509,7 +519,6 @@ else:
     # Also sets the branch to $BRANCH_NAME
     #
     # If the target already exists, it will check if it has running builds on it
-    # If it has running builds, a new target will be created with an added timestamp (Unity can't queue)
     try:
         clone_current_target(True)
     except Exception as e:


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
When making a new PR, we have been creating a new target on unity cloud which meant we had to reimport whole library.
With this change, for new builds we will share the cache from development target. 
This way we can reduce the first build from around 1h30 minutes to 30-40 minutes depending on the changes.

<img width="957" height="98" alt="Screenshot 2025-10-03 165354" src="https://github.com/user-attachments/assets/8ce90be6-625c-4e96-87cb-9282ce5e291f" />

<img width="611" height="102" alt="image" src="https://github.com/user-attachments/assets/b7f4cab9-f6fb-435e-a220-80e8f50733f2" />

