### PR TITLE
fix: avoid showing listening header in invites and request communities

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesInvitesAndRequestsView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesInvitesAndRequestsView.cs
@@ -247,6 +247,7 @@ namespace DCL.Communities.CommunitiesBrowser
             invitedCommunityCardView.SetInviteOrRequestId(community.id);
             invitedCommunityCardView.SetActionButtonsState(community.privacy, community.type, community.role != CommunityMemberRole.none);
             invitedCommunityCardView.SetActionLoadingActive(false);
+            invitedCommunityCardView.ConfigureListenersCount(false, 0);
             thumbnailLoader!.LoadCommunityThumbnailAsync(community.thumbnails?.raw, invitedCommunityCardView.communityThumbnail, defaultThumbnailSprite, thumbnailsCts.Token).Forget();
 
             // Setup card events


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5661 
Avoids displaying the listening indicator in the communities under invites and requests

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Launch the client with --debug and --voice-chat
2. Go to the communities tab
3. Go to invites and requests
4. Verify that the communities results do not show the listening indicator

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
