### PR TITLE
fix: marketplace credits focus is lost on chat in order to enter valid email to sign up

### DIFF
--- a/Explorer/Assets/DCL/Chat/SharedArea/ChatSharedAreaController.cs
+++ b/Explorer/Assets/DCL/Chat/SharedArea/ChatSharedAreaController.cs
@@ -127,21 +127,7 @@ namespace DCL.ChatArea
 
             EventSystem.current.RaycastAll(eventData, results);
 
-            // Check if click is inside any chat panel
-            var clickedInsideChat = false;
-            foreach (RaycastResult result in results)
-            {
-                if (result.gameObject.transform.IsChildOf(viewInstance!.transform))
-                {
-                    clickedInsideChat = true;
-                    break;
-                }
-            }
-
-            if (clickedInsideChat)
-                chatSharedAreaEventBus.RaiseClickInsideEvent(results);
-            else
-                chatSharedAreaEventBus.RaiseClickOutsideEvent(results);
+            chatSharedAreaEventBus.RaiseGlobalClickEvent(results);
         }
 
         private static Vector2 GetPointerPosition(InputAction.CallbackContext ctx)

--- a/Explorer/Assets/DCL/Chat/SharedArea/ChatSharedAreaEventBus.cs
+++ b/Explorer/Assets/DCL/Chat/SharedArea/ChatSharedAreaEventBus.cs
@@ -40,11 +40,8 @@ namespace DCL.ChatArea
         public void RaiseMvcViewClosedEvent() =>
             Publish(new ChatSharedAreaEvents.ChatPanelMvcViewClosedEvent());
 
-        public void RaiseClickInsideEvent(System.Collections.Generic.IReadOnlyList<UnityEngine.EventSystems.RaycastResult> raycastResults) =>
-            Publish(new ChatSharedAreaEvents.ChatPanelClickInsideEvent(raycastResults));
-
-        public void RaiseClickOutsideEvent(System.Collections.Generic.IReadOnlyList<UnityEngine.EventSystems.RaycastResult> raycastResults) =>
-            Publish(new ChatSharedAreaEvents.ChatPanelClickOutsideEvent(raycastResults));
+        public void RaiseGlobalClickEvent(System.Collections.Generic.IReadOnlyList<UnityEngine.EventSystems.RaycastResult> raycastResults) =>
+            Publish(new ChatSharedAreaEvents.ChatPanelGlobalClickEvent(raycastResults));
 
         public void RaiseVisibilityStateChangedEvent(bool isVisibleInSharedSpace) =>
             Publish(new ChatSharedAreaEvents.ChatPanelVisibilityStateChangedEvent(isVisibleInSharedSpace));

--- a/Explorer/Assets/DCL/Chat/SharedArea/ChatSharedAreaEvents.cs
+++ b/Explorer/Assets/DCL/Chat/SharedArea/ChatSharedAreaEvents.cs
@@ -8,6 +8,7 @@ namespace DCL.ChatArea
         public struct ChatPanelPointerEnterEvent { }
         public struct ChatPanelPointerExitEvent { }
         public struct ChatPanelFocusEvent { }
+
         public struct ChatPanelVisibilityEvent
         {
             public bool IsVisible { get; }
@@ -35,20 +36,11 @@ namespace DCL.ChatArea
         public struct ChatPanelMvcViewShowedEvent { }
         public struct ChatPanelMvcViewClosedEvent { }
 
-        public struct ChatPanelClickInsideEvent
+        public struct ChatPanelGlobalClickEvent
         {
             public IReadOnlyList<RaycastResult> RaycastResults { get; }
 
-            public ChatPanelClickInsideEvent(IReadOnlyList<RaycastResult> raycastResults)
-            {
-                RaycastResults = raycastResults;
-            }
-        }
-        public struct ChatPanelClickOutsideEvent
-        {
-            public IReadOnlyList<RaycastResult> RaycastResults { get; }
-
-            public ChatPanelClickOutsideEvent(IReadOnlyList<RaycastResult> raycastResults)
+            public ChatPanelGlobalClickEvent(IReadOnlyList<RaycastResult> raycastResults)
             {
                 RaycastResults = raycastResults;
             }

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatPanelPresenter.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatPanelPresenter.cs
@@ -223,15 +223,8 @@ namespace DCL.Chat
             chatStateMachine.Minimize();
         }
 
-        private void HandleClickInside(ChatSharedAreaEvents.ChatPanelClickInsideEvent evt)
-        {
+        private void HandleGlobalClick(ChatSharedAreaEvents.ChatPanelGlobalClickEvent evt) =>
             chatClickDetectionService.ProcessRaycastResults(evt.RaycastResults);
-        }
-
-        private void HandleClickOutside(ChatSharedAreaEvents.ChatPanelClickOutsideEvent evt)
-        {
-            chatClickDetectionService.ProcessRaycastResults(evt.RaycastResults);
-        }
 
         private void SubscribeToCoordinationEvents()
         {
@@ -245,8 +238,7 @@ namespace DCL.Chat
             chatAreaEventBusScope.Add(chatSharedAreaEventBus.Subscribe<ChatSharedAreaEvents.ChatPanelHiddenInSharedSpaceEvent>(OnHiddenInSharedSpace));
             chatAreaEventBusScope.Add(chatSharedAreaEventBus.Subscribe<ChatSharedAreaEvents.ChatPanelMvcViewShowedEvent>(OnMvcViewShowed));
             chatAreaEventBusScope.Add(chatSharedAreaEventBus.Subscribe<ChatSharedAreaEvents.ChatPanelMvcViewClosedEvent>(OnMvcViewClosed));
-            chatAreaEventBusScope.Add(chatSharedAreaEventBus.Subscribe<ChatSharedAreaEvents.ChatPanelClickInsideEvent>(HandleClickInside));
-            chatAreaEventBusScope.Add(chatSharedAreaEventBus.Subscribe<ChatSharedAreaEvents.ChatPanelClickOutsideEvent>(HandleClickOutside));
+            chatAreaEventBusScope.Add(chatSharedAreaEventBus.Subscribe<ChatSharedAreaEvents.ChatPanelGlobalClickEvent>(HandleGlobalClick));
         }
 
         private void OnChatStateChanged(ChatEvents.ChatStateChangedEvent evt)

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/ChatClickDetectionService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/ChatClickDetectionService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -40,19 +41,14 @@ namespace DCL.Chat.ChatServices
             if (IsIgnored(results[0].gameObject))
                 return;
 
-            var clickedInside = false;
-
-            foreach (RaycastResult result in results)
-            {
-                if (result.gameObject.transform.IsChildOf(targetArea))
-                {
-                    clickedInside = true;
-                    break;
-                }
-            }
-
-            if (clickedInside) OnClickInside?.Invoke();
+            if (IsClickInsideChat()) OnClickInside?.Invoke();
             else OnClickOutside?.Invoke();
+
+            return;
+
+            bool IsClickInsideChat() =>
+                results.FirstOrDefault()
+                       .gameObject?.transform.IsChildOf(targetArea) == true;
         }
 
         private bool IsIgnored(GameObject clickedObject)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -13,6 +13,7 @@ using DCL.Backpack.BackpackBus;
 using DCL.BadgesAPIService;
 using DCL.Browser;
 using DCL.CharacterPreview;
+using DCL.Chat.ChatServices;
 using DCL.Chat.Commands;
 using DCL.Chat.EventBus;
 using DCL.Chat.History;
@@ -666,6 +667,17 @@ namespace Global.Dynamic
 
             var thumbnailProvider = new ECSThumbnailProvider(staticContainer.RealmData, globalWorld);
 
+            var chatPanelViewInstance = mainUIView.ChatMainView.ChatPanelView;
+
+            // Ignore buttons that would lead to the conflicting state
+            var chatClickDetectionService = new ChatClickDetectionService((RectTransform)chatPanelViewInstance.transform,
+                chatPanelViewInstance.TitlebarView.CloseChatButton.transform,
+                chatPanelViewInstance.TitlebarView.CloseMemberListButton.transform,
+                chatPanelViewInstance.TitlebarView.OpenMemberListButton.transform,
+                chatPanelViewInstance.TitlebarView.BackFromMemberList.transform,
+                chatPanelViewInstance.InputView.inputField.transform,
+                mainUIView.SidebarView.unreadMessagesButton.transform);
+
             var globalPlugins = new List<IDCLGlobalPlugin>
             {
                 new MultiplayerPlugin(
@@ -764,7 +776,8 @@ namespace Global.Dynamic
                     voiceChatContainer.VoiceChatOrchestrator,
                     mainUIView.SidebarView.unreadMessagesButton.transform,
                     eventBus,
-                    chatSharedAreaEventBus),
+                    chatSharedAreaEventBus,
+                    chatClickDetectionService),
                 new ExplorePanelPlugin(
                     assetsProvisioner,
                     mvcManager,
@@ -927,7 +940,8 @@ namespace Global.Dynamic
                         staticContainer.WebRequestsContainer.WebRequestController,
                         assetsProvisioner,
                         chatSharedAreaEventBus,
-                        debugBuilder)
+                        debugBuilder,
+                        chatClickDetectionService)
                 );
 
             if (!appArgs.HasDebugFlag() || !appArgs.HasFlagWithValueFalse(AppArgsFlags.LANDSCAPE_TERRAIN_ENABLED))

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
@@ -83,11 +83,11 @@ namespace DCL.PluginSystem.Global
         private PrivateConversationUserStateService? chatUserStateService;
         private ChatHistoryService? chatBusListenerService;
         private CommunityUserStateService communityUserStateService;
-        private readonly Transform chatViewRectTransform;
         private readonly IEventBus eventBus;
         private readonly EventSubscriptionScope pluginScope = new ();
         private readonly CancellationTokenSource pluginCts;
         private readonly ChatSharedAreaEventBus chatSharedAreaEventBus;
+        private readonly ChatClickDetectionService chatClickDetectionService;
 
         private CommandRegistry commandRegistry;
         private ChatPanelPresenter? chatPanelPresenter;
@@ -124,7 +124,8 @@ namespace DCL.PluginSystem.Global
             IVoiceChatOrchestrator voiceChatOrchestrator,
             Transform chatViewRectTransform,
             IEventBus eventBus,
-            ChatSharedAreaEventBus chatSharedAreaEventBus)
+            ChatSharedAreaEventBus chatSharedAreaEventBus,
+            ChatClickDetectionService chatClickDetectionService)
         {
             this.mvcManager = mvcManager;
             this.mvcManagerMenusAccessFacade = mvcManagerMenusAccessFacade;
@@ -159,9 +160,9 @@ namespace DCL.PluginSystem.Global
             this.thumbnailCache = thumbnailCache;
             this.communitiesEventBus = communitiesEventBus;
             this.communityDataService = communityDataService;
-            this.chatViewRectTransform = chatViewRectTransform;
             this.eventBus = eventBus;
             this.chatSharedAreaEventBus = chatSharedAreaEventBus;
+            this.chatClickDetectionService = chatClickDetectionService;
 
             pluginCts = new CancellationTokenSource();
         }
@@ -219,15 +220,6 @@ namespace DCL.PluginSystem.Global
                 roomHub.ChatRoom());
 
             var chatInputBlockingService = new ChatInputBlockingService(inputBlock, world);
-
-            // Ignore buttons that would lead to the conflicting state
-            var chatClickDetectionService = new ChatClickDetectionService((RectTransform)viewInstance.transform,
-                viewInstance.TitlebarView.CloseChatButton.transform,
-                viewInstance.TitlebarView.CloseMemberListButton.transform,
-                viewInstance.TitlebarView.OpenMemberListButton.transform,
-                viewInstance.TitlebarView.BackFromMemberList.transform,
-                viewInstance.InputView.inputField.transform,
-                chatViewRectTransform);
 
             var chatContextMenuService = new ChatContextMenuService(mvcManagerMenusAccessFacade,
                 chatClickDetectionService);

--- a/Explorer/Assets/DCL/PluginSystem/Global/VoiceChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/VoiceChatPlugin.cs
@@ -2,6 +2,7 @@ using Arch.Core;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
+using DCL.Chat.ChatServices;
 using DCL.ChatArea;
 using DCL.Communities.CommunitiesDataProvider;
 using DCL.DebugUtilities;
@@ -33,6 +34,7 @@ namespace DCL.PluginSystem.Global
         private readonly Entity playerEntity;
         private readonly VoiceChatOrchestrator voiceChatOrchestrator;
         private readonly ChatSharedAreaEventBus chatSharedAreaEventBus;
+        private readonly ChatClickDetectionService chatClickDetectionService;
 
         private ProvidedAsset<VoiceChatPluginSettings> voiceChatPluginSettingsAsset;
         private VoiceChatMicrophoneHandler? voiceChatHandler;
@@ -56,7 +58,8 @@ namespace DCL.PluginSystem.Global
             IWebRequestController webRequestController,
             IAssetsProvisioner assetsProvisioner,
             ChatSharedAreaEventBus chatSharedAreaEventBus,
-            IDebugContainerBuilder debugContainer)
+            IDebugContainerBuilder debugContainer,
+            ChatClickDetectionService chatClickDetectionService)
         {
             this.roomHub = roomHub;
             this.voiceChatPanelView = voiceChatPanelView;
@@ -68,6 +71,7 @@ namespace DCL.PluginSystem.Global
             this.webRequestController = webRequestController;
             this.assetsProvisioner = assetsProvisioner;
             this.chatSharedAreaEventBus = chatSharedAreaEventBus;
+            this.chatClickDetectionService = chatClickDetectionService;
             this.debugContainer = debugContainer;
             voiceChatOrchestrator = voiceChatContainer.VoiceChatOrchestrator;
         }
@@ -120,7 +124,7 @@ namespace DCL.PluginSystem.Global
             var unmuteMicrophoneAudio = pluginSettings.UnmuteMicrophoneAudio;
             microphoneAudioToggleController = new MicrophoneAudioToggleController(voiceChatHandler, muteMicrophoneAudio, unmuteMicrophoneAudio);
 
-            voiceChatPanelController = new VoiceChatPanelPresenter(voiceChatPanelView, profileDataProvider, communityDataProvider, webRequestController, voiceChatOrchestrator, voiceChatHandler, roomManager, roomHub, playerEntry, chatSharedAreaEventBus);
+            voiceChatPanelController = new VoiceChatPanelPresenter(voiceChatPanelView, profileDataProvider, communityDataProvider, webRequestController, voiceChatOrchestrator, voiceChatHandler, roomManager, roomHub, playerEntry, chatSharedAreaEventBus, chatClickDetectionService);
 
             voiceChatDebugContainer = new VoiceChatDebugContainer(this.debugContainer, trackManager);
         }


### PR DESCRIPTION
# Pull Request Description
Fix #5332 

## What does this PR change?
Chat panel now no longer "steals" focus from the marketplace credits welcome screen (and from any other UI outside its hierarchy).

### Test Steps
1. Open app with a new account
2. Check that the marketplace credits program appears
3. Once it appears click on the text box
4. Check that the focus remains in the email input box and it accepts input

### Additional Testing Notes
Should also verify that chat interaction is intact (buttons, context menus, etc.) .

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
