### PR TITLE
fix: Chat Toolbar Community thumbnails dont show streaming status

### DIFF
--- a/Explorer/Assets/DCL/Chat/Assets/ConversationToolbar/ChatConversationsToolbarViewItem_Community.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/ConversationToolbar/ChatConversationsToolbarViewItem_Community.prefab
@@ -8,6 +8,30 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 712866191563395188, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 712866191563395188, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 712866191563395188, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 712866191563395188, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 712866191563395188, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 712866191563395188, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1048432849985327357, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -23,6 +47,22 @@ PrefabInstance:
     - target: {fileID: 1048432849985327357, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1464461750609962234, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1464461750609962234, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1464461750609962234, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1464461750609962234, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_Color.r
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2637489220396157912, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
       propertyPath: m_Name
@@ -176,6 +216,18 @@ PrefabInstance:
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6707871415509916608, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6707871415509916608, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6707871415509916608, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7176691815093756675, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
       propertyPath: thumbnailView
       value: 
@@ -208,6 +260,22 @@ PrefabInstance:
       propertyPath: PointerEntered.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 6633483077033816363}
+    - target: {fileID: 9197446564015225041, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9197446564015225041, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9197446564015225041, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9197446564015225041, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 2637885989895282012, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
     - {fileID: 7176691815093756675, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}
@@ -313,6 +381,9 @@ MonoBehaviour:
   claimedNameIcon: {fileID: 9140495448314402907}
   tooltipPosition: {fileID: 272066746090127584}
   offlineThumbnailGreyOutOpacity: 0.6
+  listeningToCallIcon: {fileID: 21300000, guid: 9b2fdd0db3163464ab125fc37f700593, type: 3}
+  hasCallIcon: {fileID: 21300000, guid: c5bb7e203d53d9242bda259090e72c3a, type: 3}
+  iconImage: {fileID: 3261307287814542182}
 --- !u!114 &7030288766036531753 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1280643333913694863, guid: 918d043c7a901cd458ff04ab88561f38, type: 3}

--- a/Explorer/Assets/DCL/Chat/ChatConversationsToolbarViewItem.cs
+++ b/Explorer/Assets/DCL/Chat/ChatConversationsToolbarViewItem.cs
@@ -19,7 +19,7 @@ namespace DCL.Chat
 
         [SerializeField]
         private ProfilePictureView profilePictureView;
-        
+
         [SerializeField]
         protected GameObject thumbnailView;
 
@@ -143,7 +143,7 @@ namespace DCL.Chat
         /// Changes the visual aspect of the connection status indicator.
         /// </summary>
         /// <param name="connectionStatus">The current connection status.</param>
-        public void SetConnectionStatus(OnlineStatus connectionStatus)
+        public virtual void SetConnectionStatus(OnlineStatus connectionStatus)
         {
             connectionStatusIndicator.color = onlineStatusConfiguration.GetConfiguration(connectionStatus).StatusColor;
             connectionStatusIndicatorContainer.SetActive(connectionStatus == OnlineStatus.ONLINE);
@@ -179,10 +179,10 @@ namespace DCL.Chat
             thumbnailView.gameObject.SetActive(false);
         }
 
-        public void Configure(bool isClosable, bool hasOnlineStatus)
+        public void Configure(bool isClosable)
         {
             removeButton.gameObject.SetActive(isClosable);
-            connectionStatusIndicatorContainer.SetActive(hasOnlineStatus);
+            connectionStatusIndicatorContainer.SetActive(false);
         }
 
 

--- a/Explorer/Assets/DCL/Chat/CommunityChatConversationsToolbarViewItem.cs
+++ b/Explorer/Assets/DCL/Chat/CommunityChatConversationsToolbarViewItem.cs
@@ -52,8 +52,11 @@ namespace DCL.Chat
 
         private void OnCommunityCallIdChanged(string currentCallId)
         {
-            if (connectionStatusIndicatorContainer.activeInHierarchy)
-                iconImage.sprite = currentCallId.Equals(ChatChannel.GetCommunityIdFromChannelId(Id), StringComparison.InvariantCultureIgnoreCase)? listeningToCallIcon : hasCallIcon;
+            bool isCurrentCommunity = currentCallId.Equals(ChatChannel.GetCommunityIdFromChannelId(Id), StringComparison.InvariantCultureIgnoreCase);
+            if (isCurrentCommunity)
+                connectionStatusIndicatorContainer.SetActive(true);
+
+            iconImage.sprite = isCurrentCommunity? listeningToCallIcon : hasCallIcon;
         }
 
         private void OnCommunityStateUpdated(bool hasActiveCall)

--- a/Explorer/Assets/DCL/Chat/CommunityChatConversationsToolbarViewItem.cs
+++ b/Explorer/Assets/DCL/Chat/CommunityChatConversationsToolbarViewItem.cs
@@ -1,11 +1,8 @@
-using Cysharp.Threading.Tasks;
 using DCL.Chat.History;
-using DCL.Diagnostics;
 using DCL.UI;
 using DCL.UI.Communities;
 using DCL.Utilities;
 using System;
-using System.Threading;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -16,26 +13,11 @@ namespace DCL.Chat
         private IDisposable? communitySubscription;
         private IDisposable? communityCallIdSubscription;
 
-        private IReadonlyReactiveProperty<string> currentCommunityCallId;
+        private IReadonlyReactiveProperty<string>? currentCommunityCallId;
 
-        [field: SerializeField] private Sprite ListeningToCallIcon;
-        [field: SerializeField] private Sprite HasCallIcon;
-        [field: SerializeField] private Image IconImage;
-
-        /// <summary>
-        /// Provides the data required to display the community thumbnail.
-        /// </summary>
-        /// <param name="thumbnailCache">A way to access thumbnail images asynchronously.</param>
-        /// <param name="imageUrl">The URL to the thumbnail picture.</param>
-        /// <param name="ct">A cancellation token for the thumbnail download operation.</param>
-        public void SetThumbnailData(ISpriteCache thumbnailCache, string? imageUrl, CancellationToken ct)
-        {
-            customIcon.gameObject.SetActive(false);
-            thumbnailView.SetActive(true);
-
-            if(imageUrl != null)
-                thumbnailView.GetComponent<CommunityThumbnailView>().LoadThumbnailAsync(thumbnailCache, imageUrl, ct).Forget();
-        }
+        [SerializeField] private Sprite listeningToCallIcon  = null!;
+        [SerializeField] private Sprite hasCallIcon  = null!;
+        [SerializeField] private Image iconImage  = null!;
 
         public override void SetPicture(Sprite? sprite, Color color)
         {
@@ -46,52 +28,49 @@ namespace DCL.Chat
             communityView.SetImage(sprite);
         }
 
-        public void SetLoadedThumbnail(Sprite thumbnail)
-        {
-            customIcon.gameObject.SetActive(false);
-            thumbnailView.SetActive(true);
-
-            var thumbnailComponent = thumbnailView.GetComponent<CommunityThumbnailView>();
-
-            if (thumbnail != null)
-            {
-                thumbnailComponent.SetImage(thumbnail);
-            }
-        }
-
         protected override void Start()
         {
             base.Start();
             removeButton.gameObject.SetActive(true);
         }
 
-        public void SetupCommunityUpdates(ReactiveProperty<bool> communityUpdates, IReadonlyReactiveProperty<string> currentCommunityCallId)
+        public void SetupCommunityUpdates(IReadonlyReactiveProperty<bool> communityUpdates, IReadonlyReactiveProperty<string> communityCallId)
         {
             communitySubscription?.Dispose();
             communitySubscription = communityUpdates.Subscribe(OnCommunityStateUpdated);
 
-            this.currentCommunityCallId = currentCommunityCallId;
+            this.currentCommunityCallId = communityCallId;
 
             communityCallIdSubscription?.Dispose();
-            communityCallIdSubscription = currentCommunityCallId.Subscribe(OnCommunityCallIdChanged);
+            communityCallIdSubscription = communityCallId.Subscribe(OnCommunityCallIdChanged);
 
 
             connectionStatusIndicatorContainer.SetActive(communityUpdates.Value);
             if (!communityUpdates.Value) return;
-            IconImage.sprite = currentCommunityCallId.Value.Equals(ChatChannel.GetCommunityIdFromChannelId(Id), StringComparison.InvariantCultureIgnoreCase)? ListeningToCallIcon : HasCallIcon;
+            iconImage.sprite = communityCallId.Value.Equals(ChatChannel.GetCommunityIdFromChannelId(Id), StringComparison.InvariantCultureIgnoreCase)? listeningToCallIcon : hasCallIcon;
         }
 
         private void OnCommunityCallIdChanged(string currentCallId)
         {
-            IconImage.sprite = currentCallId.Equals(ChatChannel.GetCommunityIdFromChannelId(Id), StringComparison.InvariantCultureIgnoreCase)? ListeningToCallIcon : HasCallIcon;
+            if (connectionStatusIndicatorContainer.activeInHierarchy)
+                iconImage.sprite = currentCallId.Equals(ChatChannel.GetCommunityIdFromChannelId(Id), StringComparison.InvariantCultureIgnoreCase)? listeningToCallIcon : hasCallIcon;
         }
 
         private void OnCommunityStateUpdated(bool hasActiveCall)
         {
             connectionStatusIndicatorContainer.SetActive(hasActiveCall);
             if (!hasActiveCall) return;
-
-            IconImage.sprite = currentCommunityCallId.Value.Equals(ChatChannel.GetCommunityIdFromChannelId(Id), StringComparison.InvariantCultureIgnoreCase)? ListeningToCallIcon : HasCallIcon;
+            if (currentCommunityCallId != null)
+                iconImage.sprite = currentCommunityCallId.Value.Equals(ChatChannel.GetCommunityIdFromChannelId(Id), StringComparison.InvariantCultureIgnoreCase)?
+                    listeningToCallIcon :
+                    hasCallIcon;
         }
+
+        //We override it to avoid the original method to change the color or disable the connectionStatusIndicator
+        public override void SetConnectionStatus(OnlineStatus connectionStatus)
+        {
+            //Do nothing.
+        }
+
     }
 }

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatChannels/ChatChannelsView.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatChannels/ChatChannelsView.cs
@@ -269,13 +269,13 @@ namespace DCL.Chat
                 case NearbyChannelViewModel nearby:
                     newItem.SetConversationName(nearby.DisplayName);
                     newItem.SetConversationIcon(nearby.Icon);
-                    newItem.Configure(isClosable: false, hasOnlineStatus: false);
+                    newItem.Configure(isClosable: false);
                     break;
 
                 case UserChannelViewModel user:
                     newItem.SetConversationName(user.DisplayName);
                     newItem.SetClaimedNameIconVisibility(user.HasClaimedName);
-                    newItem.Configure(isClosable: true, hasOnlineStatus: false);
+                    newItem.Configure(isClosable: true);
                     newItem.BindProfileThumbnail(user.ProfilePicture);
                     newItem.SetConnectionStatus(OnlineStatus.OFFLINE);
 
@@ -284,7 +284,10 @@ namespace DCL.Chat
                 case CommunityChannelViewModel community:
                     newItem.SetConversationName(community.DisplayName);
                     newItem.SetPicture(community.Thumbnail, Color.white);
-                    newItem.Configure(isClosable: true, hasOnlineStatus: false);
+                    newItem.Configure(isClosable: true);
+                    var communityItem = newItem as CommunityChatConversationsToolbarViewItem;
+                    if (communityItem != null)
+                        communityItem.SetupCommunityUpdates(community.CommunityConnectionUpdates, community.CurrentCommunityCallId);
                     break;
             }
 

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/CommandRegistry.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/CommandRegistry.cs
@@ -12,6 +12,7 @@ using DCL.Utilities;
 using System;
 using DCL.Chat.EventBus;
 using DCL.Communities.CommunitiesDataProvider;
+using DCL.VoiceChat;
 using DCL.Web3.Identities;
 using Utility;
 
@@ -61,7 +62,8 @@ namespace DCL.Chat.ChatCommands
             ISpriteCache spriteCache,
             ObjectProxy<IFriendsService> friendsServiceProxy,
             AudioClipConfig sendMessageSound,
-            GetParticipantProfilesCommand getParticipantProfilesCommand)
+            GetParticipantProfilesCommand getParticipantProfilesCommand,
+            IVoiceChatOrchestrator voiceChatOrchestrator)
         {
             RestartChatServices = new RestartChatServicesCommand(
                 privateConversationUserStateService,
@@ -144,7 +146,8 @@ namespace DCL.Chat.ChatCommands
                 chatConfig,
                 profileRepositoryWrapper,
                 GetUserChatStatusCommand,
-                GetCommunityThumbnail);
+                GetCommunityThumbnail,
+                voiceChatOrchestrator);
 
             ResolveInputStateCommand = new ResolveInputStateCommand(GetUserChatStatusCommand, currentChannelService);
 

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/CreateChannelViewModelCommand.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/CreateChannelViewModelCommand.cs
@@ -8,6 +8,7 @@ using DCL.Communities.CommunitiesDataProvider.DTOs;
 using DCL.Profiles;
 using DCL.UI.ProfileElements;
 using DCL.UI.Profiles.Helpers;
+using DCL.VoiceChat;
 using System;
 using System.Threading;
 using UnityEngine;
@@ -22,6 +23,7 @@ namespace DCL.Chat.ChatCommands
         private readonly ChatConfig.ChatConfig chatConfig;
         private readonly ProfileRepositoryWrapper profileRepository;
         private readonly GetCommunityThumbnailCommand getCommunityThumbnailCommand;
+        private readonly IVoiceChatOrchestrator voiceChatOrchestrator;
         private readonly GetUserChatStatusCommand getUserChatStatusCommand;
 
         public CreateChannelViewModelCommand(
@@ -30,7 +32,8 @@ namespace DCL.Chat.ChatCommands
             ChatConfig.ChatConfig chatConfig,
             ProfileRepositoryWrapper profileRepository,
             GetUserChatStatusCommand getUserChatStatusCommand,
-            GetCommunityThumbnailCommand getCommunityThumbnailCommand)
+            GetCommunityThumbnailCommand getCommunityThumbnailCommand,
+            IVoiceChatOrchestrator voiceChatOrchestrator)
         {
             this.eventBus = eventBus;
             this.communityDataService = communityDataService;
@@ -38,6 +41,7 @@ namespace DCL.Chat.ChatCommands
             this.profileRepository = profileRepository;
             this.getUserChatStatusCommand = getUserChatStatusCommand;
             this.getCommunityThumbnailCommand = getCommunityThumbnailCommand;
+            this.voiceChatOrchestrator = voiceChatOrchestrator;
         }
 
         public BaseChannelViewModel CreateViewModelAndFetch(ChatChannel channel, CancellationToken ct)
@@ -94,6 +98,8 @@ namespace DCL.Chat.ChatCommands
             {
                 viewModel.DisplayName = communityData.name;
                 viewModel.ImageUrl = communityData.thumbnails?.raw;
+                viewModel.CommunityConnectionUpdates = voiceChatOrchestrator.CommunityConnectionUpdates(ChatChannel.GetCommunityIdFromChannelId(channel.Id));
+                viewModel.CurrentCommunityCallId = voiceChatOrchestrator.CurrentCommunityId;
 
                 FetchCommunityThumbnailAndUpdateAsync(viewModel, ct).Forget();
             }

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatViewModels/ChannelViewModels/ComunityChannelViewModel.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatViewModels/ChannelViewModels/ComunityChannelViewModel.cs
@@ -1,4 +1,7 @@
 ﻿using DCL.Chat.History;
+using DCL.Communities.CommunitiesDataProvider.DTOs;
+using DCL.Utilities;
+using DCL.VoiceChat;
 using UnityEngine;
 
 namespace DCL.Chat.ChatViewModels
@@ -8,6 +11,8 @@ namespace DCL.Chat.ChatViewModels
         public string DisplayName { get; set; }
         public string ImageUrl { get; set; }
         public Sprite? Thumbnail { get; set; }
+        public IReadonlyReactiveProperty<bool> CommunityConnectionUpdates { get; set;}
+        public IReadonlyReactiveProperty<string> CurrentCommunityCallId { get; set; }
 
         public CommunityChannelViewModel(ChatChannel.ChannelId id, int unreadMessagesCount, bool hasUnreadMentions)
             : base(id, ChatChannel.ChatChannelType.COMMUNITY, unreadMessagesCount, hasUnreadMentions)

--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/GetUserCommunitiesResponse.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/GetUserCommunitiesResponse.cs
@@ -40,7 +40,8 @@ namespace DCL.Communities.CommunitiesDataProvider.DTOs
                 CommunityPrivacy privacy,
                 CommunityMemberRole role,
                 string ownerAddress,
-                int membersCount)
+                int membersCount,
+                GetCommunityResponse.VoiceChatStatus voiceChatStatus)
             {
                 this.id = id;
                 this.thumbnails = thumbnails;
@@ -50,6 +51,7 @@ namespace DCL.Communities.CommunitiesDataProvider.DTOs
                 this.role = role;
                 this.ownerAddress = ownerAddress;
                 this.membersCount = membersCount;
+                this.voiceChatStatus = voiceChatStatus;
             }
 
             public void SetAsJoined(bool isJoined)

--- a/Explorer/Assets/DCL/Communities/CommunityDataService/CommunityDataService.cs
+++ b/Explorer/Assets/DCL/Communities/CommunityDataService/CommunityDataService.cs
@@ -3,7 +3,6 @@ using DCL.Chat.History;
 using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
-using DCL.Chat;
 using DCL.Communities.CommunitiesCard;
 using DCL.Communities.CommunitiesDataProvider.DTOs;
 using DCL.Diagnostics;
@@ -92,14 +91,16 @@ namespace DCL.Communities
             var data = result.Value.data;
             var channelId = ChatChannel.NewCommunityChannelId(data.id);
 
-            communities[channelId] = new GetUserCommunitiesData.CommunityData(data.id,
+            communities[channelId] = new GetUserCommunitiesData.CommunityData(
+                data.id,
                 data.thumbnails,
                 data.name,
                 data.description,
                 data.privacy,
                 data.role,
                 data.ownerAddress,
-                data.membersCount);
+                data.membersCount,
+                data.voiceChatStatus);
 
             // Notify anyone who cares (titlebar, channels list, etc.)
             CommunityMetadataUpdated?.Invoke(new CommunityMetadataUpdatedEvent(channelId));
@@ -170,7 +171,8 @@ namespace DCL.Communities
                     response.data.privacy,
                     response.data.role,
                     response.data.ownerAddress,
-                    response.data.membersCount));
+                    response.data.membersCount,
+                    response.data.voiceChatStatus));
 
                 chatHistory.AddOrGetChannel(ChatChannel.NewCommunityChannelId(response.data.id), ChatChannel.ChatChannelType.COMMUNITY);
 
@@ -192,7 +194,8 @@ namespace DCL.Communities
                 newCommunity.privacy,
                 CommunityMemberRole.owner,
                 newCommunity.ownerAddress,
-                1);
+                1,
+                new GetCommunityResponse.VoiceChatStatus());
 
             chatHistory.AddOrGetChannel(channelId, ChatChannel.ChatChannelType.COMMUNITY);
         }

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
@@ -267,7 +267,8 @@ namespace DCL.PluginSystem.Global
                 thumbnailCache,
                 friendsServiceProxy,
                 settings.ChatSendMessageAudio,
-                getParticipantProfilesCommand
+                getParticipantProfilesCommand,
+                voiceChatOrchestrator
             );
 
             pluginScope.Add(commandRegistry);

--- a/Explorer/Assets/DCL/UI/Communities/CommunityThumbnailView.cs
+++ b/Explorer/Assets/DCL/UI/Communities/CommunityThumbnailView.cs
@@ -90,7 +90,7 @@ namespace DCL.UI.Communities
         ///     NEW METHOD: Directly sets the thumbnail image from a pre-loaded sprite.
         /// </summary>
         /// <param name="sprite">The sprite to display.</param>
-        public void SetImage(Sprite sprite)
+        public void SetImage(Sprite? sprite)
         {
             // Cancel any async loading operations that might be in progress.
             cts.SafeCancelAndDispose();

--- a/Explorer/Assets/DCL/VoiceChat/CommunityStreamButtonPresenter.cs
+++ b/Explorer/Assets/DCL/VoiceChat/CommunityStreamButtonPresenter.cs
@@ -145,7 +145,7 @@ namespace DCL.VoiceChat
             ReportHub.Log(ReportCategory.COMMUNITY_VOICE_CHAT, $"{TAG} HandleChangeToCommunityChannelAsync: Setting button active={shouldSeeButton} for community {communityId} (isVoiceChatActive={isVoiceChatActive}");
             view.gameObject.SetActive(shouldSeeButton);
 
-            currentCommunityCallStatusSubscription = orchestrator.SubscribeToCommunityUpdates(communityId)?.Subscribe(OnCurrentCommunityActiveCallStatusChanged);
+            currentCommunityCallStatusSubscription = orchestrator.CommunityConnectionUpdates(communityId).Subscribe(OnCurrentCommunityActiveCallStatusChanged);
         }
     }
 }

--- a/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChatCallStatusService.cs
+++ b/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChatCallStatusService.cs
@@ -332,10 +332,7 @@ namespace DCL.VoiceChat
                 activeCommunityVoiceChats.Remove(communityUpdate.CommunityId);
 
                 if (communityVoiceChatCalls.TryGetValue(communityUpdate.CommunityId, out ReactiveProperty<bool>? existingData))
-                {
                     existingData.Value = false;
-                    ReportHub.Log(ReportCategory.COMMUNITY_VOICE_CHAT, $"{TAG} Community voice chat ended for {communityUpdate.CommunityId}");
-                }
 
                 // Clear locally started community ID if this was the one we started
                 if (communityUpdate.CommunityId == locallyStartedCommunityId)
@@ -344,6 +341,8 @@ namespace DCL.VoiceChat
                 // Delegate scene unregistration to the tracker
                 voiceChatSceneTrackerService.UnregisterCommunityFromScene(communityUpdate.CommunityId);
                 voiceChatSceneTrackerService.RemoveActiveCommunityVoiceChat(communityUpdate.CommunityId);
+
+                ReportHub.Log(ReportCategory.COMMUNITY_VOICE_CHAT, $"{TAG} Community voice chat ended for {communityUpdate.CommunityId}");
                 return;
             }
 
@@ -446,11 +445,8 @@ namespace DCL.VoiceChat
             return communityVoiceChatCalls.TryGetValue(communityId, out ReactiveProperty<bool>? callData) && callData.Value;
         }
 
-        public ReactiveProperty<bool>? SubscribeToCommunityUpdates(string communityId)
+        public IReadonlyReactiveProperty<bool> CommunityConnectionUpdates(string communityId)
         {
-            if (string.IsNullOrEmpty(communityId))
-                return null;
-
             if (communityVoiceChatCalls.TryGetValue(communityId, out ReactiveProperty<bool>? existingData)) { return existingData; }
 
             // Create new call data with no active call

--- a/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChatCallStatusServiceNull.cs
+++ b/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChatCallStatusServiceNull.cs
@@ -24,7 +24,7 @@ namespace DCL.VoiceChat
         public bool HasActiveVoiceChatCall(string communityId) =>
             false;
 
-        public ReactiveProperty<bool>? SubscribeToCommunityUpdates(string communityId) =>
+        public IReadonlyReactiveProperty<bool> CommunityConnectionUpdates(string communityId) =>
             null;
 
         public bool TryGetActiveCommunityVoiceChat(string communityId, out ActiveCommunityVoiceChat activeCommunityVoiceChat)

--- a/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChatSubTitleButtonPresenter.cs
+++ b/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChatSubTitleButtonPresenter.cs
@@ -83,7 +83,7 @@ namespace DCL.VoiceChat
 
         private async UniTaskVoid HandleChangeToCommunityChannelAsync(string communityId)
         {
-            currentCommunityCallStatusSubscription = communityCallOrchestrator.SubscribeToCommunityUpdates(communityId)?.Subscribe(OnCurrentCommunityCallStatusChanged);
+            currentCommunityCallStatusSubscription = communityCallOrchestrator.CommunityConnectionUpdates(communityId)?.Subscribe(OnCurrentCommunityCallStatusChanged);
 
             bool isOurCurrentConversation = communityCallOrchestrator.CurrentCommunityId.Value.Equals(communityId, StringComparison.InvariantCultureIgnoreCase);
             if (isOurCurrentConversation) return;

--- a/Explorer/Assets/DCL/VoiceChat/ICommunityVoiceChatCallStatusService.cs
+++ b/Explorer/Assets/DCL/VoiceChat/ICommunityVoiceChatCallStatusService.cs
@@ -14,7 +14,7 @@ namespace DCL.VoiceChat
         /// <summary>
         ///     Subscribes to updates for a specific community
         /// </summary>
-        ReactiveProperty<bool>? SubscribeToCommunityUpdates(string communityId);
+        IReadonlyReactiveProperty<bool> CommunityConnectionUpdates(string communityId);
 
         bool TryGetActiveCommunityVoiceChat(string communityId, out ActiveCommunityVoiceChat activeCommunityVoiceChat);
 

--- a/Explorer/Assets/DCL/VoiceChat/IVoiceChatOrchestrator.cs
+++ b/Explorer/Assets/DCL/VoiceChat/IVoiceChatOrchestrator.cs
@@ -54,7 +54,7 @@ namespace DCL.VoiceChat
         IReadonlyReactiveProperty<string> CurrentCommunityId { get; }
         IReadonlyReactiveProperty<ActiveCommunityVoiceChat?> CurrentSceneActiveCommunityVoiceChatData { get; }
         bool HasActiveVoiceChatCall(string communityId);
-        ReactiveProperty<bool>? SubscribeToCommunityUpdates(string communityId);
+        IReadonlyReactiveProperty<bool> CommunityConnectionUpdates(string communityId);
         bool TryGetActiveCommunityData(string communityId, out ActiveCommunityVoiceChat activeCommunityData);
     }
 

--- a/Explorer/Assets/DCL/VoiceChat/VoiceChatOrchestrator.cs
+++ b/Explorer/Assets/DCL/VoiceChat/VoiceChatOrchestrator.cs
@@ -315,7 +315,7 @@ namespace DCL.VoiceChat
         public bool TryGetActiveCommunityData(string communityId, out ActiveCommunityVoiceChat activeCommunityData) =>
             communityVoiceChatCallStatusService.TryGetActiveCommunityVoiceChat(communityId, out activeCommunityData);
 
-        public ReactiveProperty<bool>? SubscribeToCommunityUpdates(string communityId) =>
-            communityVoiceChatCallStatusService.SubscribeToCommunityUpdates(communityId);
+        public IReadonlyReactiveProperty<bool> CommunityConnectionUpdates(string communityId) =>
+            communityVoiceChatCallStatusService.CommunityConnectionUpdates(communityId);
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
We were missing the streaming icons on the chat toolbar for communities. Now we have them :)
They had broken when the new chat was introduced.

## How to test?

Just start many community streams and check that the thumbnails in the toolbar get a special icon. If you join the call, the icon should change and if you exit the call, it should change again.
All users that can connect to the stream should get these icons in their chat.

There is one caveat. The stream ended notification can take up to 45 seconds to arrive, so even if the call ended the icon will remain visible until that notification arrives.

Addresses: #5392 