### PR TITLE
fix: avoid chat hiding on emote wheel and backpack close

### DIFF
--- a/Explorer/Assets/DCL/EmotesWheel/EmotesWheelController.cs
+++ b/Explorer/Assets/DCL/EmotesWheel/EmotesWheelController.cs
@@ -244,7 +244,7 @@ namespace DCL.EmotesWheel
 
         private async void OpenBackpackAsync()
         {
-            await sharedSpaceManager.ShowAsync(PanelsSharingSpace.Explore, new ExplorePanelParameter(ExploreSections.Backpack, BackpackSections.Emotes));
+            await sharedSpaceManager.ShowAsync(PanelsSharingSpace.Explore, new ExplorePanelParameter(ExploreSections.Backpack, BackpackSections.Emotes), PanelsSharingSpace.Chat);
         }
 
         private void UnblockUnwantedInputs()

--- a/Explorer/Assets/DCL/ExplorePanel/ExplorePanelController.cs
+++ b/Explorer/Assets/DCL/ExplorePanel/ExplorePanelController.cs
@@ -24,8 +24,9 @@ using Utility;
 
 namespace DCL.ExplorePanel
 {
-    public class ExplorePanelController : ControllerBase<ExplorePanelView, ExplorePanelParameter>, IControllerInSharedSpace<ExplorePanelView, ExplorePanelParameter>
+    public class ExplorePanelController : ControllerBase<ExplorePanelView, ExplorePanelParameter>, IControllerInSharedSpace<ExplorePanelView, ExplorePanelParameter>, IBlocksChat
     {
+
         private readonly BackpackController backpackController;
         private readonly ProfileWidgetController profileWidgetController;
         private readonly ProfileMenuController profileMenuController;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5681 
This PR fixes the chat hiding behaviour when opening the mouse wheel and then opening the backpack and closing it

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] Own or be a moderator of a community in order to start a community voice chat

### Test Steps
1. Launch the client with --debug and --voice-chat
2. Start a community voice chat
3. Open the emote wheel and then press E to open backpack
4. Close the explore panel
5. Verify that the voice chat is still visible

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
