### PR TITLE
feat: added entry point and app arg to force onboarding flow

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -39,6 +39,8 @@
 
         public const string IDENTITY_EXPIRATION_DURATION = "identity-expiration-duration";
 
+        public const string FORCE_ONBOARDING = "force-onboarding";
+
         public const string SIMULATE_MEMORY = "simulateMemory";
 
         public const string LAUNCH_CDP_MONITOR_ON_START = "launch-cdp-monitor-on-start";

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapAnalyticsDecorator.cs
@@ -78,11 +78,12 @@ namespace Global.Dynamic
             IAppArgs appArgs,
             ICoroutineRunner coroutineRunner,
             DCLVersion dclVersion,
-            CancellationToken ct)
+            CancellationToken ct,
+            bool forceOnboarding)
         {
             (DynamicWorldContainer? container, bool) result =
                 await core.LoadDynamicWorldContainerAsync(bootstrapContainer, staticContainer, scenePluginSettingsContainer,
-                    settings, dynamicSettings, backgroundMusic, worldInfoTool, playerEntity, appArgs, coroutineRunner, dclVersion, ct);
+                    settings, dynamicSettings, backgroundMusic, worldInfoTool, playerEntity, appArgs, coroutineRunner, dclVersion, ct, forceOnboarding);
 
             analytics.Track(General.INITIAL_LOADING, new JsonObject
             {

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/Bootstraper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/Bootstraper.cs
@@ -140,7 +140,8 @@ namespace Global.Dynamic
             IAppArgs appArgs,
             ICoroutineRunner coroutineRunner,
             DCLVersion dclVersion,
-            CancellationToken ct)
+            CancellationToken ct,
+            bool forceOnboarding)
         {
             dynamicWorldDependencies = new DynamicWorldDependencies
             (
@@ -180,7 +181,8 @@ namespace Global.Dynamic
                 coroutineRunner,
                 dclVersion,
                 realmUrls,
-                ct);
+                ct,
+                forceOnboarding);
 
             if (tuple.container != null)
                 profileRepositoryProxy.SetObject(tuple.container.ProfileRepository);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DebugSettings/DebugSettings.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DebugSettings/DebugSettings.cs
@@ -19,7 +19,10 @@ namespace Global.Dynamic.DebugSettings
         private bool enableLandscape;
         [SerializeField]
         private bool enableLOD;
-        [SerializeField] private bool enableVersionUpdateGuard;
+        [SerializeField]
+        private bool enableVersionUpdateGuard;
+        [SerializeField]
+        private bool forceOnboarding;
         [SerializeField]
         private bool enableEmulateNoLivekitConnection;
         [SerializeField] [Tooltip("Enable Portable Experiences obtained from Feature Flags from loading at the start of the game")]
@@ -45,6 +48,7 @@ namespace Global.Dynamic.DebugSettings
                 enableLandscape = true,
                 enableLOD = true,
                 enableVersionUpdateGuard = true,
+                forceOnboarding = false,
                 portableExperiencesEnsToLoad = null,
                 enableEmulateNoLivekitConnection = false,
                 overrideConnectionQuality = false,
@@ -64,6 +68,7 @@ namespace Global.Dynamic.DebugSettings
         public bool EnableLandscape => Application.isEditor ? this.enableLandscape : RELEASE_SETTINGS.enableLandscape;
         public bool EnableLOD => Application.isEditor ? this.enableLOD : RELEASE_SETTINGS.enableLOD;
         public bool EnableVersionUpdateGuard => Application.isEditor ? this.enableVersionUpdateGuard : RELEASE_SETTINGS.enableVersionUpdateGuard;
+        public bool ForceOnboarding => Application.isEditor ? this.forceOnboarding : RELEASE_SETTINGS.forceOnboarding;
         public bool EnableEmulateNoLivekitConnection => Application.isEditor? this.enableEmulateNoLivekitConnection : RELEASE_SETTINGS.enableEmulateNoLivekitConnection;
         public bool OverrideConnectionQuality => Application.isEditor ? this.overrideConnectionQuality : RELEASE_SETTINGS.overrideConnectionQuality;
         public ConnectionQuality ConnectionQuality => Application.isEditor ? this.connectionQuality : RELEASE_SETTINGS.connectionQuality;

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -199,7 +199,8 @@ namespace Global.Dynamic
             ICoroutineRunner coroutineRunner,
             DCLVersion dclVersion,
             RealmUrls realmUrls,
-            CancellationToken ct)
+            CancellationToken ct,
+            bool forceOnboarding)
         {
             DynamicSettings dynamicSettings = dynamicWorldDependencies.DynamicSettings;
             StaticContainer staticContainer = dynamicWorldDependencies.StaticContainer;
@@ -464,7 +465,8 @@ namespace Global.Dynamic
                 backgroundMusic,
                 roomHub,
                 localSceneDevelopment,
-                staticContainer.CharacterContainer);
+                staticContainer.CharacterContainer,
+                forceOnboarding);
 
             IRealmNavigator realmNavigator = realmNavigatorContainer.RealmNavigator;
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/IBootstrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/IBootstrap.cs
@@ -43,7 +43,8 @@ namespace Global.Dynamic
             IAppArgs appArgs,
             ICoroutineRunner coroutineRunner,
             DCLVersion dclVersion,
-            CancellationToken ct);
+            CancellationToken ct,
+            bool forceOnboarding);
 
         UniTask<bool> InitializePluginsAsync(StaticContainer staticContainer, DynamicWorldContainer dynamicWorldContainer,
             PluginSettingsContainer scenePluginSettingsContainer, PluginSettingsContainer globalPluginSettingsContainer,

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
@@ -40,7 +40,8 @@ namespace DCL.UserInAppInitializationFlow
             AudioClipConfig backgroundMusic,
             IRoomHub roomHub,
             bool localSceneDevelopment,
-            CharacterContainer characterContainer)
+            CharacterContainer characterContainer,
+            bool forceOnboarding)
         {
             ILoadingStatus? loadingStatus = staticContainer.LoadingStatus;
 
@@ -49,7 +50,7 @@ namespace DCL.UserInAppInitializationFlow
             var blocklistCheckStartupOperation = new BlocklistCheckStartupOperation(staticContainer.WebRequestsContainer, bootstrapContainer.IdentityCache!, bootstrapContainer.DecentralandUrlsSource);
             var loadPlayerAvatarStartupOperation = new LoadPlayerAvatarStartupOperation(loadingStatus, selfProfile, staticContainer.MainPlayerAvatarBaseProxy);
             var loadLandscapeStartupOperation = new LoadLandscapeStartupOperation(loadingStatus, terrainContainer.Landscape);
-            var checkOnboardingStartupOperation = new CheckOnboardingStartupOperation(loadingStatus, selfProfile, decentralandUrlsSource, appArgs, realmNavigationContainer.RealmNavigator);
+            var checkOnboardingStartupOperation = new CheckOnboardingStartupOperation(loadingStatus, selfProfile, decentralandUrlsSource, appArgs, realmNavigationContainer.RealmNavigator, forceOnboarding);
             var teleportStartupOperation = new TeleportStartupOperation(loadingStatus, realmContainer.RealmController, staticContainer.ExposedGlobalDataContainer.ExposedCameraData.CameraEntityProxy, realmContainer.TeleportController, staticContainer.ExposedGlobalDataContainer.CameraSamplingData, dynamicWorldParams.StartParcel);
 
             var loadingOperations = new List<IStartupOperation>()

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -236,7 +236,8 @@ namespace Global.Dynamic
                     applicationParametersParser,
                     coroutineRunner: this,
                     dclVersion,
-                    destroyCancellationToken);
+                    destroyCancellationToken,
+                    debugSettings.ForceOnboarding);
 
                 if (!isLoaded)
                 {

--- a/Explorer/Assets/Scenes/Main.unity
+++ b/Explorer/Assets/Scenes/Main.unity
@@ -403,6 +403,7 @@ MonoBehaviour:
     enableLandscape: 0
     enableLOD: 0
     enableVersionUpdateGuard: 0
+    forceOnboarding: 0
     enableEmulateNoLivekitConnection: 0
     enableRemotePortableExperiences: 0
     portableExperiencesEnsToLoad: []


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR adds an entry point checkmark and an app arg that force the onboarding flow as if we were new users.
This will simplify testing the flow instead of creating a new account every time.
Keep in mind that this is not 100% as if we were starting with a new account as the profile is not erased, it just forces on client side the onboarding flow in the initial loading

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites

### Test Steps
1. Launch the client with a new user and check that the onboarding flow is working correctly

1. Launch the client with an old user and verify that the onboarding flow doesn't happen

1. Launch the client with an old user with the parameter --force-onboarding and verify that even if the account is old the onboarding flow happens

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
