### PR TITLE
style: reassign join stream button missing textures

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunityResultCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunityResultCard.prefab
@@ -879,7 +879,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 227d70da02d2b4eb482ff4b390e6d27f, type: 3}
+  m_Sprite: {fileID: 21300000, guid: b1221dc0d7c65a94f9b58f8d0c9c982d, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/JoinStreamPanel.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/JoinStreamPanel.prefab
@@ -1518,7 +1518,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 227d70da02d2b4eb482ff4b390e6d27f, type: 3}
+  m_Sprite: {fileID: 21300000, guid: b1221dc0d7c65a94f9b58f8d0c9c982d, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1557,7 +1557,7 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: 227d70da02d2b4eb482ff4b390e6d27f, type: 3}
+    m_HighlightedSprite: {fileID: 21300000, guid: abdf52b9d215a4893b0aa8ff7d52afee, type: 3}
     m_PressedSprite: {fileID: 21300000, guid: 16ac3fc8ea0e64a1a84656b8494477f4, type: 3}
     m_SelectedSprite: {fileID: 21300000, guid: 16ac3fc8ea0e64a1a84656b8494477f4, type: 3}
     m_DisabledSprite: {fileID: 0}


### PR DESCRIPTION
## What does this PR change?
The `Join Stream` button looks broken on its idle state for both, the Community result card and Community Card when live streaming.

<img width="1173" height="627" alt="image (1)" src="https://github.com/user-attachments/assets/beb0ed14-5c29-4844-a429-cb55eeb27de9" />

<img width="1760" height="1003" alt="image" src="https://github.com/user-attachments/assets/a41aa145-e67b-4fb3-ba87-b8ad673cd232" />

### Test Steps
1. Launch the explorer
2. Open the Communities browser while a Community is live streaming. Click the `View All` button in the Live Streaming Now section, to see the results card. Check that the `Join Stream` button, on its idle state, now looks okay. 
3. Then click the results card to open the Community card. Check that the `Join Stream` button, on its idle state, now looks okay.