### PR TITLE
chore: deleted chat message deletion on unfocused

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/ChatInputView.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/ChatInputView.cs
@@ -61,7 +61,6 @@ namespace DCL.Chat.ChatInput
         [field: Header("Event Bus")]
         [field: SerializeField] internal ViewEventBus inputEventBus { get; private set; }
 
-        private string previousText = string.Empty;
         private ChatConfig.ChatConfig chatConfig;
 
         public void ApplyFocusStyle()
@@ -70,7 +69,6 @@ namespace DCL.Chat.ChatInput
             characterCounterObject.SetActive(true);
             emojiButtonObject.SetActive(true);
             inputPlaceholderObject.text = chatConfig.InputFocusedMessages;
-            InsertTextAtCaretPosition(previousText);
         }
 
         private void ApplyUnfocusStyle()
@@ -80,20 +78,14 @@ namespace DCL.Chat.ChatInput
             emojiButtonObject.SetActive(false);
             inputPlaceholderObject.text = chatConfig.InputUnfocusedMessages;
 
-            // NOTE: Remember the last typed message when going to unfocused state,
-            // NOTE: except when it's a single "/" which is used to trigger commands.
+            // NOTE: Clear text when it's a single "/" which is used to trigger commands.
             // NOTE: This prevents storing incomplete command triggers as normal messages.
-            if (inputField.text.Length > 1 ||
-                (inputField.text.Length == 1 && inputField.text[0] != '/'))
+            if (inputField.text.Length <= 1 &&
+                (inputField.text.Length != 1 || inputField.text[0] == '/'))
             {
-                previousText = inputField.text;
-            }
-            else
-            {
-                previousText = string.Empty;
+                inputField.text = string.Empty;
             }
 
-            inputField.text = string.Empty;
             inputField.DeactivateInputField();
         }
 
@@ -136,7 +128,6 @@ namespace DCL.Chat.ChatInput
         public void ClearInput()
         {
             inputField.text = string.Empty;
-            previousText = string.Empty;
             UpdateCharacterCount();
         }
 


### PR DESCRIPTION
# Pull Request Description
fix [#5674](https://github.com/decentraland/unity-explorer/issues/5674)

## What does this PR change?
Removed chat message deletion on chat lose focus.

### Test Steps
1. Write a message in the chat and dont send it.
2. Click outside of chat panel to unfocus.
3. Message should still be visible.
4. Click chat text field.
5. Message should still be in the chat input field.
- [ ] Check for edge cases related to that message being visible.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
