### PR TITLE
fix: inverted listeners scrollview handle bar

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/Assets/CommunityVoiceChat/SearchContent.prefab
+++ b/Explorer/Assets/DCL/VoiceChat/Assets/CommunityVoiceChat/SearchContent.prefab
@@ -474,7 +474,7 @@ RectTransform:
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -3, y: 10}
   m_SizeDelta: {x: 10, y: -16}
-  m_Pivot: {x: 1, y: 0}
+  m_Pivot: {x: 1, y: 1}
 --- !u!222 &4169115780866657125
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -555,9 +555,9 @@ MonoBehaviour:
   m_Interactable: 1
   m_TargetGraphic: {fileID: 4312212762944095487}
   m_HandleRect: {fileID: 4903379226511969603}
-  m_Direction: 3
-  m_Value: 0
-  m_Size: 1
+  m_Direction: 2
+  m_Value: 1
+  m_Size: 0
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
This PR inverts the scroll handle of the listeners section in the community voice chat

## Test Instructions

### Prerequisites
- [ ] Own or be mod of a community in order to start a community voice chat

### Test Steps
1. Launch the client with --debug and --voice-chat
2. Start a community voice chat
3. Have enough listeners to see the scrollbar
4. Verify that the scrollbar handle is at the top and dragging it to the bottom scrolls the list of listeners

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
