### PR TITLE
fix: restore lose chat focus on escape

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatPanelPresenter.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatPanelPresenter.cs
@@ -71,6 +71,7 @@ namespace DCL.Chat
 
             uiScope = new EventSubscriptionScope();
             DCLInput.Instance.Shortcuts.OpenChatCommandLine.performed += OnOpenChatCommandLineShortcutPerformed;
+            DCLInput.Instance.UI.Close.performed += OnUIClose;
             uiScope.Add(eventBus.Subscribe<ChatEvents.ChatStateChangedEvent>(OnChatStateChanged));
 
             communityVoiceChatSubTitleButtonPresenter = new CommunityVoiceChatSubTitleButtonPresenter(
@@ -186,15 +187,17 @@ namespace DCL.Chat
             }
         }
 
-        public void OnUIClose()
+        private void OnUIClose(InputAction.CallbackContext obj)
         {
             if (chatStateMachine.IsMinimized) return;
+
             chatStateMachine.SetVisibility(true);
         }
 
         public void Dispose()
         {
             DCLInput.Instance.Shortcuts.OpenChatCommandLine.performed -= OnOpenChatCommandLineShortcutPerformed;
+            DCLInput.Instance.UI.Close.performed -= OnUIClose;
 
             initCts.SafeCancelAndDispose();
 


### PR DESCRIPTION
# Pull Request Description
Fixes #5718 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR restores the logic for losing chat focus when while typing, the user presses the escape button as it was in [this](https://github.com/decentraland/unity-explorer/pull/4818/files#diff-d02a318ed23b58cdf5337265bfa2bb9e2a2c6c1c23eceef18017044f434e14f0) PR.
Probably this code portion was lost because of merge conflicts during the multiple refactors that have been made with chat and voice chat.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Verify that the steps described in the linked issue are now fixed


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
