### PR TITLE
Fix rocks clipping into scenes

### DIFF
--- a/Explorer/Assets/DCL/Landscape/TreeData.cs
+++ b/Explorer/Assets/DCL/Landscape/TreeData.cs
@@ -75,14 +75,7 @@ namespace DCL.Landscape
                              .LerpScale(float2(instance.ScaleXZ, instance.ScaleY) * (1f / 255f))
                              .xyx;
 
-            bool overlaps = OverlapsOccupiedParcel(float2(position.x, position.z),
-                prototype.radius * scale.x);
-
-            if (all(parcel == int2(-114, -36)))
-                ReportHub.Log(ReportCategory.ALWAYS,
-                    $"x: {position.x}, z: {position.z}, prototype: {prototype.name}, radius: {prototype.radius}, scale: {scale.x}, overlaps: {overlaps}");
-
-            if (overlaps)
+            if (OverlapsOccupiedParcel(float2(position.x, position.z), prototype.radius * scale.x))
             {
                 position.y = 0f;
                 rotation = default(Quaternion);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change has the game take into account the random scale of trees and rocks when checking if they overlap with scenes. This fixes issue #5550.

## Test Instructions

Go to -114, -37 and check that the rock that was clipping into The Cathouse is gone. Spot check of any other wrongly placed rocks or trees.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
