### PR TITLE
fix: avatar shape rotation

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/SDKAvatarShapesMotionSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/SDKAvatarShapesMotionSystem.cs
@@ -104,7 +104,7 @@ namespace DCL.Character.CharacterMotion.Systems
             if (Quaternion.Dot(characterTransformComponent.Transform.rotation, targetRotation) > DOT_THRESHOLD)
                 return;
 
-            characterTransformComponent.Transform.rotation = Quaternion.Slerp(characterTransformComponent.Transform.localRotation, targetRotation, ROTATION_SPEED * deltaTime);
+            characterTransformComponent.Transform.rotation = Quaternion.Slerp(characterTransformComponent.Transform.rotation, targetRotation, ROTATION_SPEED * deltaTime);
         }
 
         private static void UpdateAnimations(


### PR DESCRIPTION
# Pull Request Description

Fixes https://github.com/decentraland/unity-explorer/issues/5714

## What does this PR change?
Corrected rotation calculation of avatar shapes. There was a place where local rotation was used instead of world rotation.

## Test Instructions
There is a test scene available [here](https://github.com/decentraland-scenes/scene-emote-test)