### PR TITLE
fix: apply filter to only non message bus requests

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SDKMessageBus/SDKMessageBusCommsAPIImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SDKMessageBus/SDKMessageBusCommsAPIImplementation.cs
@@ -25,7 +25,7 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications.SDKMessageBus
         public void Send(string data)
         {
             byte[] dataBytes = Encoding.UTF8.GetBytes(data);
-            EncodeAndSendMessage(ISceneCommunicationPipe.MsgType.String, dataBytes, ISceneCommunicationPipe.ConnectivityAssertiveness.DROP_IF_NOT_CONNECTED, null);
+            EncodeAndSendMessage(ISceneCommunicationPipe.MsgType.String, dataBytes, ISceneCommunicationPipe.ConnectivityAssertiveness.DROP_IF_NOT_CONNECTED, null, false);
         }
 
         protected override void OnMessageReceived(ISceneCommunicationPipe.DecodedMessage message)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Only filters messages that are not via the messagebus to fix a problem with syncEntity.

## Test Instructions

- Load goerli plaza
- Load the piano scene
- Have a friend join in your piano playing skills
- Ensure that the piano playing synchronises
<img width="1875" height="1191" alt="image" src="https://github.com/user-attachments/assets/840a886c-81b1-47ae-a1aa-0c5f384737bc" />


## Quality Checklist
- [x] Changes have been tested locally

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
