### PR TITLE
fix: avatar shape emotes

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
@@ -154,7 +154,7 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         public int GetAnimatorCurrentStateTag() =>
             AvatarAnimator.GetCurrentAnimatorStateInfo(0).tagHash;
 
-        public void ResetTrigger(int hash)
+        public void ResetAnimatorTrigger(int hash)
         {
             AvatarAnimator.ResetTrigger(hash);
         }
@@ -253,6 +253,6 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
 
         int GetAnimatorCurrentStateTag();
 
-        void ResetTrigger(int hash);
+        void ResetAnimatorTrigger(int hash);
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
@@ -11,11 +11,30 @@ namespace DCL.AvatarRendering.Emotes
         public int CurrentAnimationTag;
         public bool StopEmote;
 
-        public bool IsPlayingEmote => CurrentAnimationTag == AnimationHashes.EMOTE || CurrentAnimationTag == AnimationHashes.EMOTE_LOOP;
-
         public float PlayingEmoteDuration => CurrentEmoteReference?.avatarClip
             ? CurrentEmoteReference.avatarClip.length * CurrentEmoteReference.animatorComp!.speed
             : 0f;
+
+        /// <summary>
+        ///     Whether an emote is being played.
+        /// </summary>
+        /// <remarks>
+        ///     In Local Scene Development mode the method behaves slightly differently. Check the implementation for details.
+        /// </remarks>
+        public readonly bool IsPlayingEmote
+        {
+            get
+            {
+                // NOTE in Local Scene Development mode -- where legacy anims are allowed -- we will have different behavior
+
+                // Legacy clips are handled with the legacy animation component
+                if (CurrentEmoteReference && CurrentEmoteReference.legacy) return CurrentEmoteReference.animationComp!.isPlaying;
+
+                // For mecanim animations, we check the actual animator tag
+                // We do that because we can be in a different state even if triggers have been set (e.g., waiting for a jump to finish)
+                return CurrentAnimationTag == AnimationHashes.EMOTE || CurrentAnimationTag == AnimationHashes.EMOTE_LOOP;
+            }
+        }
 
         public void Reset()
         {

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/EmoteReferences.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/EmoteReferences.cs
@@ -9,16 +9,18 @@ namespace DCL.AvatarRendering.Emotes
         public AnimationClip? propClip { get; private set; }
         public Animator? animatorComp { get; private set; }
         public Animation? animationComp { get; private set; }
+        public bool legacy { get; private set; }
 
         public AudioSource? audioSource;
 
-        public void Initialize(AnimationClip? animationClip, AnimationClip? propCLip, Animator? animatorComp, Animation? animationComp, int propClipHash)
+        public void Initialize(AnimationClip? animationClip, AnimationClip? propCLip, Animator? animatorComp, Animation? animationComp, int propClipHash, bool legacy)
         {
             this.avatarClip = animationClip;
             this.propClip = propCLip;
             this.animatorComp = animatorComp;
             this.animationComp = animationComp;
             this.propClipHash = propClipHash;
+            this.legacy = legacy;
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -114,30 +114,28 @@ namespace DCL.AvatarRendering.Emotes.Play
             bool wantsToCancelEmote = emoteComponent.StopEmote;
             emoteComponent.StopEmote = false;
 
-            bool wasPlayingEmote = emoteComponent.CurrentAnimationTag == AnimationHashes.EMOTE || emoteComponent.CurrentAnimationTag == AnimationHashes.EMOTE_LOOP;
-
-            if (!wasPlayingEmote)
-            {
-                avatarView.ResetTrigger(AnimationHashes.EMOTE_STOP);
-                return;
-            }
-
             EmoteReferences? emoteReference = emoteComponent.CurrentEmoteReference;
+            if (!emoteReference) return;
 
-            if (emoteReference == null)
-                return;
-
-            if (wantsToCancelEmote || World.Has<BlockedPlayerComponent>(entity))
+            bool shouldCancelEmote = wantsToCancelEmote || World.Has<BlockedPlayerComponent>(entity);
+            if (shouldCancelEmote)
             {
                 StopEmote(ref emoteComponent, avatarView);
                 return;
             }
 
-            int animatorCurrentStateTag = avatarView.GetAnimatorCurrentStateTag();
-            bool isOnAnotherTag = animatorCurrentStateTag != AnimationHashes.EMOTE && animatorCurrentStateTag != AnimationHashes.EMOTE_LOOP;
+            if (!emoteReference.legacy)
+            {
+                if (!emoteComponent.IsPlayingEmote)
+                {
+                    avatarView.ResetAnimatorTrigger(AnimationHashes.EMOTE_STOP);
+                    return;
+                }
 
-            if (isOnAnotherTag)
-                StopEmote(ref emoteComponent, avatarView);
+                int animatorCurrentStateTag = avatarView.GetAnimatorCurrentStateTag();
+                bool isOnAnotherTag = animatorCurrentStateTag != AnimationHashes.EMOTE && animatorCurrentStateTag != AnimationHashes.EMOTE_LOOP;
+                if (isOnAnotherTag) StopEmote(ref emoteComponent, avatarView);
+            }
         }
 
         // when moving or jumping we detect the emote cancellation, and we take care of getting rid of the emote props and sounds
@@ -165,8 +163,8 @@ namespace DCL.AvatarRendering.Emotes.Play
             emotePlayer.Stop(emoteComponent.CurrentEmoteReference);
 
             // Create a clean slate for the animator before setting the stop trigger
-            avatarView.ResetTrigger(AnimationHashes.EMOTE);
-            avatarView.ResetTrigger(AnimationHashes.EMOTE_RESET);
+            avatarView.ResetAnimatorTrigger(AnimationHashes.EMOTE);
+            avatarView.ResetAnimatorTrigger(AnimationHashes.EMOTE_RESET);
             avatarView.SetAnimatorTrigger(AnimationHashes.EMOTE_STOP);
 
             emoteComponent.Reset();

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
@@ -83,7 +83,7 @@ namespace DCL.AvatarRendering.Emotes.Play
 
             // Scene Emotes in Local Scene Development are loaded as legacy animations
             // (there's no other way to load them in runtime from a GLB)
-            if (emoteReferences.avatarClip is { legacy: true })
+            if (emoteReferences.legacy)
             {
                 // For consistency with processed scene assets in the AB converter (and performance), we only
                 // play legacy animations in Local Scene Dev mode (and only if they follow the naming requirements
@@ -156,7 +156,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             IReadOnlyList<Renderer> renderers = mainGameObject.GetComponentsInChildren<Renderer>();
             List<AnimationClip> uniqueClips = ListPool<AnimationClip>.Get()!;
 
-            ExtractClips(animationClips, uniqueClips, out AnimationClip? avatarClip, out AnimationClip? propClip, out int propClipHash);
+            ExtractClips(animationClips, uniqueClips, out AnimationClip? avatarClip, out AnimationClip? propClip, out int propClipHash, out bool legacy);
 
             if (uniqueClips.Count == 1)
             {
@@ -187,7 +187,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                 }
             }
 
-            references.Initialize(avatarClip, propClip, animatorComp, animationComp, propClipHash);
+            references.Initialize(avatarClip, propClip, animatorComp, animationComp, propClipHash, legacy);
 
             ListPool<AnimationClip>.Release(uniqueClips);
 
@@ -233,9 +233,9 @@ namespace DCL.AvatarRendering.Emotes.Play
             }
 
             // Create a clean slate for the animator before setting the play trigger
-            view.ResetTrigger(AnimationHashes.EMOTE_STOP);
-            view.ResetTrigger(AnimationHashes.EMOTE);
-            view.ResetTrigger(AnimationHashes.EMOTE_RESET);
+            view.ResetAnimatorTrigger(AnimationHashes.EMOTE_STOP);
+            view.ResetAnimatorTrigger(AnimationHashes.EMOTE);
+            view.ResetAnimatorTrigger(AnimationHashes.EMOTE_RESET);
 
             view.SetAnimatorTrigger(view.IsAnimatorInTag(AnimationHashes.EMOTE) || view.IsAnimatorInTag(AnimationHashes.EMOTE_LOOP) ? AnimationHashes.EMOTE_RESET : AnimationHashes.EMOTE);
             view.SetAnimatorBool(AnimationHashes.EMOTE_LOOP, emoteComponent.EmoteLoop);
@@ -260,7 +260,8 @@ namespace DCL.AvatarRendering.Emotes.Play
             List<AnimationClip> uniqueClips,
             out AnimationClip? avatarClip,
             out AnimationClip? propClip,
-            out int propClipHash)
+            out int propClipHash,
+            out bool legacy)
         {
             avatarClip = null;
             propClip = null;
@@ -293,6 +294,8 @@ namespace DCL.AvatarRendering.Emotes.Play
                     }
                 }
             }
+
+            legacy = avatarClip && avatarClip.legacy;
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/Components/SDKAvatarShapeComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/Components/SDKAvatarShapeComponent.cs
@@ -1,8 +1,8 @@
 using Arch.Core;
-using RealmSceneEmotePromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution,
-    DCL.AvatarRendering.Emotes.GetSceneEmoteFromRealmIntention>;
 using LocalSceneEmotePromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution,
     DCL.AvatarRendering.Emotes.GetSceneEmoteFromLocalSceneIntention>;
+using RealmSceneEmotePromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution,
+    DCL.AvatarRendering.Emotes.GetSceneEmoteFromRealmIntention>;
 
 namespace ECS.Unity.AvatarShape.Components
 {
@@ -11,12 +11,16 @@ namespace ECS.Unity.AvatarShape.Components
         public Entity GlobalWorldEntity;
         public RealmSceneEmotePromise? RealmSceneEmotePromise;
         public LocalSceneEmotePromise? LocalSceneEmotePromise;
+        public string? EmoteId;
+        public long EmoteTimestamp;
 
         public SDKAvatarShapeComponent(Entity globalWorldEntity)
         {
             this.GlobalWorldEntity = globalWorldEntity;
             RealmSceneEmotePromise = null;
             LocalSceneEmotePromise = null;
+            EmoteId = null;
+            EmoteTimestamp = 0;
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description

Fixes https://github.com/decentraland/unity-explorer/issues/5323

Better handling of emotes playback for avatar shapes:

- Can stop avatar shape emotes playback by setting `ExpressionTriggerId` to undefined or empty
- In general, setting other properties of `PBAvatarShape` doesn't restart playback of emotes, except for `ExpressionTriggerTimestamp`
- Setting `ExpressionTriggerTimestamp` to a value greater than the current one will restart the emote playblack

**NOTE looping emotes are NOT supported yet. There is another ticket requesting to add that feature.**

## Test Instructions
- You can use this [test scene (v2)](https://github.com/user-attachments/files/22884705/Emotes.Test.zip)
- You will see there's 2 rows of cubes, and each row has a test avatar shape
- The avatar labeled HALL OF FAME plays a one-frame emote where the avatar is holding a cup
- The avatar labeled CLAP plays the standard clap animation
- The 3 boxes in each row can be used to:
  1. Start anim playback. Clicking it multiple times should NOT restart the anim. With this cube the anim can only be restarted once it finishes
  2. Start anim playback as well, but clicking again allows to restart the anim at any time
  3. Stop the current anim, if any

_NOTE the reason we have to different cubes to play the anim is to the test the timestamp functionality._
