### PR TITLE
style: update HandNotificationIcn.png texture

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/Textures/HandNotificationIcn.png
+++ b/Explorer/Assets/DCL/VoiceChat/Textures/HandNotificationIcn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:383b98d29cdae86031c29fb7e5f693ac8351eafd2c062b59cbb803ac6dca1494
-size 261
+oid sha256:ac6c7419212ad7daa95d11df01688d2fdd73b228b15a7805fa525769871fb66a
+size 254


### PR DESCRIPTION
# Pull Request Description
PR created to update the hand icon, which appears in the voice chat title bar to notify there is people who raised their hand. Why? Because the fingers lack on extra space to make the icon legible due to its small size.

<img width="246" height="130" alt="Screenshot 2025-10-13 at 10 57 48" src="https://github.com/user-attachments/assets/e9165a1a-f3e2-4262-9b8e-3b089fdc7867" />

## What does this PR change?
The png file called `HandNotificationIcn.png`
