### PR TITLE
feat: join the vibe loading screen tip

### DIFF
--- a/Explorer/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-English (en).asset
+++ b/Explorer/Assets/AddressableAssetsData/AssetGroups/Localization-Assets-English (en).asset
@@ -15,6 +15,12 @@ MonoBehaviour:
   m_GroupName: Localization-Assets-English (en)
   m_GUID: bbf196456d6041d4e9cb25f216e21f0c
   m_SerializeEntries:
+  - m_GUID: 2475d2ea34b451047936aaecb0ef9ad3
+    m_Address: Assets/DCL/SceneLoadingScreens/Assets/Textures/BringYourVibe.png
+    m_ReadOnly: 1
+    m_SerializedLabels:
+    - Locale-en
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 3d9c80e4179389748acbca560257f6e2
     m_Address: Camera
     m_ReadOnly: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/BringYourVibe.png
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/BringYourVibe.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3df04e86765912d6f611958d1f9ec02846d56edd10d9922f9ebdf46a3cd4934
+size 1776464

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/BringYourVibe.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/BringYourVibe.png.meta
@@ -1,0 +1,117 @@
+fileFormatVersion: 2
+guid: 2475d2ea34b451047936aaecb0ef9ad3
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 0
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages Shared Data.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages Shared Data.asset
@@ -59,6 +59,10 @@ MonoBehaviour:
     m_Key: IMAGE-10
     m_Metadata:
       m_Items: []
+  - m_Id: 231133291010285568
+    m_Key: IMAGE-11
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items:
     - rid: 4107643858754469895
@@ -126,6 +130,9 @@ MonoBehaviour:
           m_TableCodes:
           - en
         - m_KeyId: 218914508204138496
+          m_TableCodes:
+          - en
+        - m_KeyId: 231133291010285568
           m_TableCodes:
           - en
         m_TypeString: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultImages_en.asset
@@ -70,6 +70,10 @@ MonoBehaviour:
     m_Localized: be91903945b0c44fdb1908049ce868b1
     m_Metadata:
       m_Items: []
+  - m_Id: 231133291010285568
+    m_Localized: 2475d2ea34b451047936aaecb0ef9ad3
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips Shared Data.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips Shared Data.asset
@@ -103,6 +103,14 @@ MonoBehaviour:
     m_Key: BODY-10
     m_Metadata:
       m_Items: []
+  - m_Id: 232214342377889792
+    m_Key: TITLE-11
+    m_Metadata:
+      m_Items: []
+  - m_Id: 232214434111512576
+    m_Key: BODY-11
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
+++ b/Explorer/Assets/Locales/Localization Tables/SceneLoadingDefaultTips_en.asset
@@ -127,6 +127,15 @@ MonoBehaviour:
       and more."
     m_Metadata:
       m_Items: []
+  - m_Id: 232214342377889792
+    m_Localized: Join The Vibe
+    m_Metadata:
+      m_Items: []
+  - m_Id: 232214434111512576
+    m_Localized: "Join DCL Regenesis Labs first hackathon\n(Oct 13\u2013Nov 9). Vibe
+      coding, spooky vibes, and $7.5K+ in prizes await!"
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
## What does this PR change?
Added the "Join the vibe" loading screen tip.

## Test Instructions
Check with @m3taphysics that the feature flag alfa-loading-screen-tips includes the new loading screen: Join The Vibe.
Start the app normally and check that you can see the loading screen for the art week.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
