### PR TITLE
fix: community card event date

### DIFF
--- a/Explorer/Assets/DCL/Communities/EventInfo/EventUtilities.cs
+++ b/Explorer/Assets/DCL/Communities/EventInfo/EventUtilities.cs
@@ -21,11 +21,11 @@ namespace DCL.Communities.EventInfo
         {
             string schedule = string.Empty;
 
-            if (eventDTO.StartAtProcessed == default(DateTime)) return schedule;
+            if (eventDTO.NextStartAtProcessed == default(DateTime)) return schedule;
 
             if (eventDTO.Live)
             {
-                TimeSpan elapsed = DateTime.UtcNow - eventDTO.StartAtProcessed;
+                TimeSpan elapsed = DateTime.UtcNow - eventDTO.NextStartAtProcessed;
 
                 if (elapsed.TotalDays >= 1)
                     schedule = string.Format(STARTED_EVENT_TIME_FORMAT, (int)elapsed.TotalDays, DAY_STRING);
@@ -36,7 +36,7 @@ namespace DCL.Communities.EventInfo
             }
             else
             {
-                DateTime localDateTime = eventDTO.StartAtProcessed.ToLocalTime();
+                DateTime localDateTime = eventDTO.NextStartAtProcessed.ToLocalTime();
                 schedule = localDateTime.ToString(EVENT_TIME_FORMAT).ToUpper();
             }
 


### PR DESCRIPTION
# Pull Request Description
Fixes #5736 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR changes the date that is used to render the event in the event list to `NextStartAtProcessed` so that the recurrence of the event is taken into account.

Before it was using  `StartAt` date which was wrong in the case of recurring events.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Follow the steps reported in the linked issue
2. Verify that non-recurring events are displayed correctly
3. Verify that even info panel displays info correctly

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
