### PR TITLE
fix: error in sentry transaction manager when closing early

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/SentryTransactionManager.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/SentryTransactionManager.cs
@@ -185,15 +185,17 @@ namespace DCL.PerformanceAndDiagnostics
 
         private void FinishAllTransactions()
         {
-            foreach (KeyValuePair<string,ITransactionTracer> transaction in sentryTransactions)
+            var transactionKeys = new List<string>(sentryTransactions.Keys);
+            
+            foreach (string transactionKey in transactionKeys)
             {
                 try
                 {
-                    EndTransaction(transaction.Key);
+                    EndTransaction(transactionKey);
                 }
                 catch (Exception ex)
                 {
-                    ReportHub.Log(new ReportData(ReportCategory.ANALYTICS), $"Error finishing transaction '{transaction.Key}' during application quit: {ex.Message}");
+                    ReportHub.Log(new ReportData(ReportCategory.ANALYTICS), $"Error finishing transaction '{transactionKey}' during application quit: {ex.Message}");
                 }
             }
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fixed an error on sentry transactions ending on application quit, before it was removing a transaction from a collection that was still used

## Test Instructions

### Test Steps
1. Smoke test of the initial loading and authentication screen, nothing has changed, just some inner tracking sent to sentry

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
