### PR TITLE
fix: ultrawide monitor resolution issue

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -62,6 +62,7 @@ namespace DCL.AuthenticationScreenFlow
 
         private const int ANIMATION_DELAY = 300;
         private const float WINDOWED_RESOLUTION_RESIZE_COEFFICIENT = .75f;
+        private const int MAX_WINDOWED_WIDTH = 2560;
         private const FullScreenMode DEFAULT_SCREEN_MODE = FullScreenMode.FullScreenWindow;
 
         private const string REQUEST_BETA_ACCESS_LINK = "https://68zbqa0m12c.typeform.com/to/y9fZeNWm";
@@ -596,7 +597,8 @@ namespace DCL.AuthenticationScreenFlow
         {
             Resolution current = Screen.currentResolution;
 
-            int targetWidth = (int)(current.width * WINDOWED_RESOLUTION_RESIZE_COEFFICIENT);
+            // To avoid ultra-wide window on ultra-wide screens
+            int targetWidth = Mathf.Min((int)(current.width * WINDOWED_RESOLUTION_RESIZE_COEFFICIENT), MAX_WINDOWED_WIDTH);
             int targetHeight = (int)(current.height * WINDOWED_RESOLUTION_RESIZE_COEFFICIENT);
 
             Screen.SetResolution(targetWidth, targetHeight, FullScreenMode.Windowed, current.refreshRateRatio);


### PR DESCRIPTION
# Pull Request Description
Fix #5899 

## What does this PR change?
If already in windowed mode do not force it

## Test Instructions
Configure Explorer in Windowed mode through the settings or use Alt+Enter when in authentication screen to force it and verify that in this case windowed mode is not forced when starting the login process.

### Test Steps

1. Start Signed Out
2. Launch DCL
3. Press Alt + Enter (to toggle to windowed mode)
4. Press SIGN IN
5. Verify the app does not change the resolution/size of its window
6. When logged in configure window mode as "Fullscreen" or "Fullscreen Borderless" through the settings
7. Logout
8. Press SIGN IN
9. Verify that the app does force the app in windowed mode

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
