### PR TITLE
hotfix: fixed issue with orchestrator current service

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/VoiceChatOrchestrator.cs
+++ b/Explorer/Assets/DCL/VoiceChat/VoiceChatOrchestrator.cs
@@ -173,8 +173,9 @@ namespace DCL.VoiceChat
         {
             if (currentVoiceChatType.Value != VoiceChatType.COMMUNITY)
             {
-                SetActiveCallService(VoiceChatType.PRIVATE);
                 privateVoiceChatCallStatusService.OnPrivateVoiceChatUpdateReceived(update);
+                if (update.Status is not (PrivateVoiceChatStatus.VoiceChatEnded or PrivateVoiceChatStatus.VoiceChatExpired or PrivateVoiceChatStatus.VoiceChatRejected))
+                    SetActiveCallService(VoiceChatType.PRIVATE);
             }
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
The issues was that when we received any notification from BE about private calls and we were not in any call, we would switch the current service provider to Private Calls, even if the notification was "Call Ended", this made it so even thou we were finishing the call properly because we detected the disconnection from Livekit, the notification from BE would re-set the current service and future checks will think we were still in a private call.
This addresses that.

To test is just to make private calls and end them and try calling again. Now, no matter who ends the call, it should be handled properly.

addresses #5905 