### PR TITLE
fix: Null Ref on BannedUsersPlugin

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/BannedUsersPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/BannedUsersPlugin.cs
@@ -15,7 +15,7 @@ namespace DCL.PluginSystem.Global
         private readonly ILoadingStatus loadingStatus;
         private readonly bool includeBannedUsersFromScene;
 
-        private PlayerBannedScenesController playerBannedScenesController;
+        private PlayerBannedScenesController? playerBannedScenesController;
 
         public BannedUsersPlugin(
             IRoomHub roomHub,
@@ -42,6 +42,6 @@ namespace DCL.PluginSystem.Global
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments) { }
 
         public void Dispose() =>
-            playerBannedScenesController.Dispose();
+            playerBannedScenesController?.Dispose();
     }
 }


### PR DESCRIPTION
# Pull Request Description
Fix #5925 

## What does this PR change?
It fixes the null ref exception that was being triggered in the `Dispose()` method in `BannedUsersPlugin` when the "**Ban user from scene**" feature is disabled (Feature Flag: `alfa-banned-users-from-scene`).

### Test Steps
This bug didn't affect to the normal behavior of the application but only the error logging when the app was closed, so I guess it would be enough to do a general smoke test.

####  Steps to check that the error is fixed
1. Play the build having the `alfa-banned-users-from-scene` FF deactivated.
2. Enter the world.
3. Close the build.
4. Check that you don't have this error in the logs:
```
System.NullReferenceException: Object reference not set to an instance of an object.
  File "BannedUsersPlugin.cs", line 45, in Dispose
  File "DisposableUtils.cs", line 14, in SafeDispose
  File "MainSceneLoader.cs", line 106, in OnDestroy
```

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.