### PR TITLE
fix: passport call tooltip

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/Assets/VoiceChatButtonPassport.prefab
+++ b/Explorer/Assets/DCL/VoiceChat/Assets/VoiceChatButtonPassport.prefab
@@ -784,7 +784,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Chat
+  m_text: Call
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5923 
Changes the tooltip for the call button in the passport to state "Call" instead of "Chat"

## Test Instructions

### Test Steps
1. Launch the client
2. Open a passport of a random user around you
3. Verify that by hovering the call icon in the top right the tooltip says "Call" and not "Chat"

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
