### PR TITLE
fix: nametags rendered on top of geometry

### DIFF
--- a/Explorer/Assets/Rendering/ForwardRenderer - High.asset
+++ b/Explorer/Assets/Rendering/ForwardRenderer - High.asset
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_Active: 1
   settings:
     passTag: RenderNameTags
-    Event: 600
+    Event: 550
     filterSettings:
       RenderQueueType: 1
       LayerMask:

--- a/Explorer/Assets/Rendering/ForwardRenderer - Low.asset
+++ b/Explorer/Assets/Rendering/ForwardRenderer - Low.asset
@@ -219,7 +219,7 @@ MonoBehaviour:
   m_Active: 1
   settings:
     passTag: RenderNameTags
-    Event: 600
+    Event: 550
     filterSettings:
       RenderQueueType: 1
       LayerMask:

--- a/Explorer/Assets/Rendering/ForwardRenderer - Medium.asset
+++ b/Explorer/Assets/Rendering/ForwardRenderer - Medium.asset
@@ -232,7 +232,7 @@ MonoBehaviour:
   m_Active: 1
   settings:
     passTag: RenderNameTags
-    Event: 600
+    Event: 550
     filterSettings:
       RenderQueueType: 1
       LayerMask:


### PR DESCRIPTION
# Pull Request Description

This fixes nametags being rendered on top of all geometry, by moving their rendering to before PostProcessing. Now they should be rendered  correctly in the 3D world, getting occluded by 3D objects, but still behind outlines of intractable objects.

With one exception - if the nametag is rendered behind the outline, it will hide the outline, that is expected, and won't be fixed:
<img width="296" height="184" alt="image" src="https://github.com/user-attachments/assets/bfb86f0b-d618-4cfe-8d40-ceddba4505c1" />

fixes #5722

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->
Changes Nametag objects to be rendered before post processing.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->
Check that nametags are correctly rendered behind 3D objects, but in front of on-hover outlines.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
