### PR TITLE
fix: light sources hot reload

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/LightSource/Systems/LightSourceLifecycleSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/LightSource/Systems/LightSourceLifecycleSystem.cs
@@ -10,6 +10,7 @@ using ECS.LifeCycle.Components;
 using ECS.Unity.Transforms.Components;
 using SceneRunner.Scene;
 using UnityEngine;
+using Utility;
 
 namespace DCL.SDKComponents.LightSource.Systems
 {
@@ -49,8 +50,8 @@ namespace DCL.SDKComponents.LightSource.Systems
             }
 
             Light lightSourceInstance = poolRegistry.Get();
-            lightSourceInstance.transform.localScale = Vector3.one;
             lightSourceInstance.transform.SetParent(transform.Transform, false);
+            lightSourceInstance.transform.ResetLocalTRS();
 
             var lightSourceComponent = new LightSourceComponent(lightSourceInstance);
             World.Add(entity, lightSourceComponent);


### PR DESCRIPTION
# Pull Request Description

Fixes https://github.com/decentraland/unity-explorer/issues/5879

## What does this PR change?
Fixes a small issue with pooled light sources retaining their local transform. This caused lights to be positioned incorrectly after hot-reloading a scene.

## Test Instructions
Can run the scene attached to the ticket, and observe how lights still look correct after hot-reloading.