### PR TITLE
fix: debounce friends online status updates

### DIFF
--- a/Explorer/Assets/DCL/Friends/FriendsConnectivityStatusTracker.cs
+++ b/Explorer/Assets/DCL/Friends/FriendsConnectivityStatusTracker.cs
@@ -90,14 +90,7 @@ namespace DCL.Friends
             if (debounceInfo.TryGetValue(friendAddress, out var existingInfo))
                 existingInfo.CancellationTokenSource.SafeCancelAndDispose();
 
-            var cancellationTokenSource = new CancellationTokenSource();
-            var newDebounceInfo = new FriendStatusDebounceInfo
-            {
-                FriendProfile = friendProfile,
-                NewStatus = newStatus,
-                CancellationTokenSource = cancellationTokenSource,
-                LastUpdateTime = DateTime.UtcNow
-            };
+            var newDebounceInfo = new FriendStatusDebounceInfo (friendProfile, newStatus, new CancellationTokenSource(), DateTime.UtcNow);
 
             this.debounceInfo[friendAddress] = newDebounceInfo;
 
@@ -129,23 +122,31 @@ namespace DCL.Friends
             }
         }
 
-        private struct FriendStatusDebounceInfo : IEquatable<FriendStatusDebounceInfo>
+        private readonly struct FriendStatusDebounceInfo : IEquatable<FriendStatusDebounceInfo>
         {
-            public FriendProfile FriendProfile;
-            public OnlineStatus NewStatus;
-            public CancellationTokenSource CancellationTokenSource;
-            public DateTime LastUpdateTime;
+            public readonly FriendProfile FriendProfile;
+            public readonly OnlineStatus NewStatus;
+            public readonly CancellationTokenSource CancellationTokenSource;
+            private readonly DateTime lastUpdateTime;
+
+            public FriendStatusDebounceInfo(FriendProfile friendProfile, OnlineStatus newStatus, CancellationTokenSource cancellationTokenSource, DateTime lastUpdateTime)
+            {
+                FriendProfile = friendProfile;
+                NewStatus = newStatus;
+                CancellationTokenSource = cancellationTokenSource;
+                this.lastUpdateTime = lastUpdateTime;
+            }
 
             public bool Equals(FriendStatusDebounceInfo other) =>
                 FriendProfile.Address.Equals(other.FriendProfile.Address) &&
                 NewStatus == other.NewStatus &&
-                LastUpdateTime == other.LastUpdateTime;
+                lastUpdateTime == other.lastUpdateTime;
 
             public override bool Equals(object? obj) =>
                 obj is FriendStatusDebounceInfo other && Equals(other);
 
             public override int GetHashCode() =>
-                HashCode.Combine(FriendProfile.Address, NewStatus, LastUpdateTime);
+                HashCode.Combine(FriendProfile.Address, NewStatus, lastUpdateTime);
 
             public static bool operator ==(FriendStatusDebounceInfo left, FriendStatusDebounceInfo right) =>
                 left.Equals(right);


### PR DESCRIPTION
# Pull Request Description
Fixes #5936 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR introduces a simple time-based debouncing mechanism to the friends online status change in order to avoid multiple notifications for the same user (might happen with faulty connections).

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Follow the steps described in the linked issue and verify that it no longer happens
2. You can manually trigger online updates by:
   1. using two builds and two different accounts
   2. opening the debug panel
   3. toggling on and off (with like 1s delay) the island room connection of one user
   4. Verify that the online status change is shown only after the last toggle you did (all the others were "filtered")

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
