### PR TITLE
fix: use correct default community thumbnail in chat

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/GetCommunityThumbnailCommand.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/GetCommunityThumbnailCommand.cs
@@ -38,7 +38,7 @@ namespace DCL.Chat.ChatCommands
                         $"Community thumbnail download failed for {thumbnailUrl}");
                 }
 
-                return chatConfig.DefaultProfileThumbnail;
+                return chatConfig.DefaultCommunityThumbnail;
             }
         }
     }


### PR DESCRIPTION
# Pull Request Description
Fixes #5960 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR fixes a probable typo error that made the community thumbnail fetching chat command return the wrong default thumbnail on failure.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Verify that communities that don't have a thumbnail set, are correctly displayed in the chat with the default thumbnail

Community `Test nick` is an example

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
