### PR TITLE
fix: adapted spacing of menu tooltip in passport

### DIFF
--- a/Explorer/Assets/DCL/Friends/UI/Prefabs/ContextMenuButton.prefab
+++ b/Explorer/Assets/DCL/Friends/UI/Prefabs/ContextMenuButton.prefab
@@ -262,11 +262,11 @@ RectTransform:
   - {fileID: 3234167463776278794}
   m_Father: {fileID: 11984575599866664}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -31.5, y: 34.9}
-  m_SizeDelta: {x: 63, y: 33}
-  m_Pivot: {x: 0, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 4}
+  m_SizeDelta: {x: 57, y: 33}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &8390962188341983602
 CanvasRenderer:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5424
Sets the spacing between the menu button and menu tooltip in the passport to the same of other tooltips

<img width="233" height="208" alt="Screenshot 2025-10-27 at 11 24 46" src="https://github.com/user-attachments/assets/5d7e570d-1e8d-46b4-8eeb-bc852c9fc11d" />
<img width="233" height="208" alt="Screenshot 2025-10-27 at 11 24 35" src="https://github.com/user-attachments/assets/97686c31-960d-4746-92e9-a87c1f379c6b" />

## Test Instructions

### Test Steps
1. Launch the client
2. Open any passport
3. Verify that the tooltip in the menu button on top right is at the same distance of the other tooltips like in the screenshots above

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
