### PR TITLE
fix: make join voice stream title opaque

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/JoinCommunityLiveStreamChatSubTitleButtonView.cs
+++ b/Explorer/Assets/DCL/VoiceChat/JoinCommunityLiveStreamChatSubTitleButtonView.cs
@@ -15,7 +15,7 @@ namespace DCL.VoiceChat
         public void SetFocusedState(bool isFocused, bool animate, float duration)
         {
             canvasGroup.DOKill();
-            float targetAlpha = isFocused ? 0.9f : 0.0f;
+            float targetAlpha = isFocused ? 1f : 0.0f;
             canvasGroup.DOFade(targetAlpha, animate ? duration : 0f);
         }
     }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5677
This PR makes the join voice stream title bar in chat fully opaque when visible

## Test Instructions

### Prerequisites
- [ ] Own or be mods of a community in order to start a voice stream
- [ ] Launch 2 clients

### Test Steps
1. With the first client start a voice stream in a community
2. With the second client open the chat of that community and verify that the purple header "Join stream" is fully opaque and not transparent

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
