### PR TITLE
fix: avoid nullref in event details when related to an unexistant place

### DIFF
--- a/Explorer/Assets/DCL/Navmap/ShowEventInfoCommand.cs
+++ b/Explorer/Assets/DCL/Navmap/ShowEventInfoCommand.cs
@@ -40,7 +40,7 @@ namespace DCL.Navmap
             placesAndEventsPanelController.Toggle(PlacesAndEventsPanelController.Section.EVENT);
             placesAndEventsPanelController.Expand();
 
-            placeInfo ??= await placesAPIService.GetPlaceAsync(new Vector2Int(@event.coordinates[0], @event.coordinates[1]), ct, true);
+            placeInfo ??= await placesAPIService.GetPlaceAsync(new Vector2Int(@event.coordinates[0], @event.coordinates[1]), ct, true) ?? new PlacesData.PlaceInfo(new Vector2Int(@event.coordinates[0], @event.coordinates[1]));
 
             eventInfoPanelController.Set(@event, placeInfo!);
             searchBarController.SetInputText(@event.name);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5977 
The events location is tied to the places api, so if an event is hosted in a parcel that contains no scene, we were getting an error and couldn't teleport to that parcel, as the fetch of the place was failing.
To fix this we now provide a fake place with the coordinates of the event in order to avoid the nullreference and allow the teleport.

## Test Instructions

### Test Steps
1. Launch the client
2. Open the map
3. Check for running events
4. Click on the event
5. Jump to the place of the event and verify it works

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
