### PR TITLE
fix: make facial features and bodyshape equipped wearable unequippable

### DIFF
--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -190,6 +190,11 @@ namespace DCL.Backpack
                                                              || gridWearables[i].GetCategory() == WearableCategories.Categories.BODY_SHAPE;
 
                 backpackItemView.SetEquipButtonsState();
+                backpackItemView.IsUnequippable =
+                    gridWearables[i].GetCategory() != WearableCategories.Categories.BODY_SHAPE
+                    && gridWearables[i].GetCategory() != WearableCategories.Categories.EYES
+                    && gridWearables[i].GetCategory() != WearableCategories.Categories.EYEBROWS
+                    && gridWearables[i].GetCategory() != WearableCategories.Categories.MOUTH;
                 WaitForThumbnailAsync(gridWearables[i], backpackItemView, pageFetchCancellationToken!.Token).Forget();
             }
         }

--- a/Explorer/Assets/DCL/Backpack/BackpackItemView.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackItemView.cs
@@ -59,16 +59,21 @@ namespace DCL.Backpack
         [field: SerializeField]
         public bool IsEquipped { get; set; }
 
+        public bool IsUnequippable { get; set; }
+
         [SerializeField] private GameObject incompatibleWithBodyShapeContainer;
         [SerializeField] private GameObject incompatibleWithBodyShapeHoverContainer;
 
         [field: Header("Audio")]
         [field: SerializeField]
         public AudioClipConfig EquipWearableAudio { get; private set; }
+
         [field: SerializeField]
         public AudioClipConfig UnEquipWearableAudio { get; private set; }
+
         [field: SerializeField]
         public AudioClipConfig HoverAudio { get; private set; }
+
         [field: SerializeField]
         public AudioClipConfig ClickAudio { get; private set; }
 
@@ -104,7 +109,7 @@ namespace DCL.Backpack
         public void SetEquipButtonsState()
         {
             EquipButton.gameObject.SetActive(!IsEquipped && IsCompatibleWithBodyShape);
-            UnEquipButton.gameObject.SetActive(IsEquipped);
+            UnEquipButton.gameObject.SetActive(IsEquipped && IsUnequippable);
         }
 
         private void OnDisable()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5973 
This PR removes the unequip button from the currently equipped eyes, bodyshape, eyebrows and mouth, to avoid users unequipping them and breaking the avatar saving flow

## Test Instructions
### Test Steps
1. Launch the client
2. Go to the backpack
3. Verify that eyes, bodyshape, eyebrows and mouth categories are not unequippable both from the avatar slots and the backpack items grid

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
