### PR TITLE
fix: avoid showing call button in own passport

### DIFF
--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -368,8 +368,6 @@ namespace DCL.Passport
             viewInstance.JumpInButton.onClick.AddListener(OnJumpToFriendButtonClicked);
             viewInstance.ChatButton.onClick.AddListener(OnChatButtonClicked);
 
-            viewInstance.CallButton.gameObject.SetActive(isCallEnabled);
-
             if (isCallEnabled)
                 viewInstance.CallButton.onClick.AddListener(OnStartCallButtonClicked);
 
@@ -757,9 +755,10 @@ namespace DCL.Passport
                 {
                     // Fetch our own profile since inputData.IsOwnProfile sometimes is wrong
                     Profile? ownProfile = await selfProfile.ProfileAsync(ct);
-
                     // Dont show any interaction for our own user
                     if (ownProfile?.UserId == inputData.UserId) return;
+
+                    viewInstance!.CallButton.gameObject.SetActive(isCallEnabled);
 
                     FriendshipStatus friendshipStatus = await friendService.GetFriendshipStatusAsync(inputData.UserId, ct);
 
@@ -887,6 +886,7 @@ namespace DCL.Passport
             viewInstance.CancelFriendButton.gameObject.SetActive(false);
             viewInstance.RemoveFriendButton.gameObject.SetActive(false);
             viewInstance.UnblockFriendButton.gameObject.SetActive(false);
+            viewInstance.CallButton.gameObject.SetActive(false);
         }
 
         private void RemoveFriend()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5986
This PR removes the call button when opening the own passport

## Test Instructions

### Test Steps
1. Launch the client
2. Open a random passport of someone around us
3. Verify that in the top right the call icon appears
4. Open your own passport
5. Verify that there is no call button in the top right

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
