### PR TITLE
fix: do not rethrow an cancellation during disposal to a disonnected promise

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/Messages/FlatFetchResponse.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/Messages/FlatFetchResponse.cs
@@ -15,7 +15,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch.Messages
         public string error;
         public string code;
     }
-    
+
     [Serializable]
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public struct FlatFetchResponse
@@ -37,6 +37,8 @@ namespace SceneRuntime.Apis.Modules.SignedFetch.Messages
             foreach (var header in headers)
                 this.headers.Add(header.Key, header.Value);
         }
+
+        public static FlatFetchResponse Cancelled = new (true, 0, "Cancelled", "Request was canceled.", new Dictionary<string, string>());
     }
 
     public struct FlatFetchResponse<TRequest> : IWebRequestOp<TRequest, FlatFetchResponse> where TRequest : struct, ITypedWebRequest

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
@@ -254,6 +254,13 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                     return new FlatFetchResponse(false, e.ResponseCode, e.ResponseCode.ToString(), e.Error,
                         e.ResponseHeaders);
                 }
+                catch (OperationCanceledException)
+                {
+                    // If we are disposing we don't want to throw an exception into oblivion.
+                    // We cannot rethrow as a response to javascript, so we return a dummy response.
+                    // Code on JS is likely to be stopped execution either way.
+                    return FlatFetchResponse.Cancelled;
+                }
                 catch (Exception e)
                 {
                     ReportHub.LogException(e, new ReportData(ReportCategory.SCENE_FETCH_REQUEST));


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Mitigates [this](https://decentraland.sentry.io/issues/6968703412/?project=4506075736047616&query=is%3Aunresolved&referrer=issue-stream) in sentry. Previously cancellations were rethrown to the disconnected promise. There is no way to return a cancellation to javascript and given that its currently disposing, a dummy response should suffice.

## Test Instructions

### Test Steps
1. Jump around between many scenes
2. They should load and cancel their loading as normal.

## Quality Checklist
- [x] Performance impact has been considered

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
