### PR TITLE
Create profiling profiles

### DIFF
--- a/Explorer/Assets/Settings/Build Profiles.meta
+++ b/Explorer/Assets/Settings/Build Profiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad10d7941f57b433eb4aa1a095c1ec41
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Settings/Build Profiles/Profile Windows.asset
+++ b/Explorer/Assets/Settings/Build Profiles/Profile Windows.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 15003, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: Profile Windows
+  m_EditorClassIdentifier: UnityEditor.dll::UnityEditor.Build.Profile.BuildProfile
+  m_AssetVersion: 1
+  m_BuildTarget: 19
+  m_Subtarget: 2
+  m_PlatformId: 4e3c793746204150860bf175a9a41a05
+  m_PlatformBuildProfile:
+    rid: -2
+  m_OverrideGlobalSceneList: 0
+  m_Scenes: []
+  m_ScriptingDefines:
+  - ENABLE_PROFILING
+  m_PlayerSettingsYaml:
+    m_Settings: []
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Explorer/Assets/Settings/Build Profiles/Profile Windows.asset.meta
+++ b/Explorer/Assets/Settings/Build Profiles/Profile Windows.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 66d1e7416c4444e939dbab45cbe1d1ed
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/Settings/Build Profiles/Profile macOS.asset
+++ b/Explorer/Assets/Settings/Build Profiles/Profile macOS.asset
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 15003, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: Profile macOS
+  m_EditorClassIdentifier: UnityEditor.dll::UnityEditor.Build.Profile.BuildProfile
+  m_AssetVersion: 1
+  m_BuildTarget: 2
+  m_Subtarget: 2
+  m_PlatformId: 0d2129357eac403d8b359c2dcbf82502
+  m_PlatformBuildProfile:
+    rid: 7785599648904773722
+  m_OverrideGlobalSceneList: 0
+  m_Scenes: []
+  m_ScriptingDefines:
+  - ENABLE_PROFILING
+  m_PlayerSettingsYaml:
+    m_Settings: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 7785599648904773722
+      type: {class: OSXStandaloneBuildProfile, ns: UnityEditor.OSXStandalone, asm: UnityEditor.OSXStandalone.Extensions}
+      data:
+        m_Development: 1
+        m_ConnectProfiler: 0
+        m_BuildWithDeepProfilingSupport: 1
+        m_AllowDebugging: 0
+        m_WaitForManagedDebugger: 0
+        m_ManagedDebuggerFixedPort: 0
+        m_ExplicitNullChecks: 0
+        m_ExplicitDivideByZeroChecks: 0
+        m_ExplicitArrayBoundsChecks: 0
+        m_CompressionType: 0
+        m_InstallInBuildFolder: 0
+        m_InsightsSettingsContainer:
+          m_BuildProfileEngineDiagnosticsState: 2
+        m_MacOSXcodeBuildConfig: 1
+        m_Architecture: 2
+        m_CreateXcodeProject: 0

--- a/Explorer/Assets/Settings/Build Profiles/Profile macOS.asset.meta
+++ b/Explorer/Assets/Settings/Build Profiles/Profile macOS.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44dde460678e645b3a0bedcc68321913
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change adds profiling (as in, measuring performance) profiles (as in, presets) to the build profiles window for easy creation of local profiling builds.

<img width="735" height="616" alt="image" src="https://github.com/user-attachments/assets/43dfa675-4057-44c1-84ec-582dc90425d3" />

## Test Instructions

Just happy path. This change does not change any game code or assets.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
