### PR TITLE
fix: remove speaker status on user leave

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChat/CommunityVoiceChatPresenter.cs
+++ b/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChat/CommunityVoiceChatPresenter.cs
@@ -155,7 +155,7 @@ namespace DCL.VoiceChat.CommunityVoiceChat
         private void OpenListenersSection()
         {
             voiceChatOrchestrator.ChangePanelSize(VoiceChatPanelSize.EXPANDED);
-            
+
             view.CommunityVoiceChatSearchView.gameObject.SetActive(true);
             view.CommunityVoiceChatInCallView.gameObject.SetActive(false);
         }
@@ -208,8 +208,12 @@ namespace DCL.VoiceChat.CommunityVoiceChat
         private void RemoveParticipant(string removedParticipantId)
         {
             if (usedPlayerEntriesPresenters.Remove(removedParticipantId, out VoiceChatParticipantEntryPresenter entryPresenter))
-            {
                 entryPresenter.Dispose();
+
+            if (currentlySpeakingUsers.ContainsKey(removedParticipantId))
+            {
+                currentlySpeakingUsers.Remove(removedParticipantId);
+                inCallPresenter.SetTalkingStatus(currentlySpeakingUsers.Count, currentlySpeakingUsers.Count == 1 ? currentlySpeakingUsers.First().Value : string.Empty);
             }
 
             UpdateCounters();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5945
This PR avoids ghost speakers to appear in the speaking status when leaving a call

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] Have two clients with two accounts ready
- [ ] Be mod or owner of a community to start a community voice chat

### Test Steps
1. Launch both clients
2. With one start a community call
3. With the other join
4. Make both users as speakers
5. While talking and while the speaking status in the community voice chat shows a player talking leave the voice chat
6. Verify that the speaking status doesn't keep saying that the user is speaking

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
