### PR TITLE
fix: InWorldCamera locking after shortcut spam

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/ToggleInWorldCameraActivitySystem.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/ToggleInWorldCameraActivitySystem.cs
@@ -124,7 +124,9 @@ namespace DCL.InWorldCamera.Systems
 
         private void DisableCamera(CameraMode? targetMode)
         {
-            if(hudController.State == ControllerState.ViewHiding || hudController.State == ControllerState.ViewHidden)
+            if(hudController.State == ControllerState.ViewHiding 
+                || hudController.State == ControllerState.ViewHidden 
+                || hudController.State == ControllerState.ViewShowing)
                 return;
 
             if (debugContainerBuilder?.Container != null)


### PR DESCRIPTION
fix [#5491](https://github.com/decentraland/unity-explorer/issues/5491)

## What does this PR change?
Screenshot camera locked itself after spamming 'C' shortcut, because this functionality could be enabled when `ControllerBase.State` was in `ControllerState.ViewShowing` state. Trying to hide the view in this state caused going though show and hide flow simultaneously, thus at one point setting `ControllerBase.State == ControllerState.ViewFocused' even though panel was disabled. In this state ToggleInWorldCameraRequest was locked in trying to enable camera, and failing every time because view was set to enabled, and camera being disabled at once. 

Fixed it by checking also if view is already showing before scheduling disabling of this panel.


### Test INSTRUCTIONS
- [ ] Spam 'C' shortcut and see if you can lock it from working.
