### PR TITLE
fix: auto-login identity expiration date parsing

### DIFF
--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/TokenFileAuthenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/TokenFileAuthenticator.cs
@@ -85,8 +85,7 @@ namespace DCL.Web3.Authenticators
 
             IWeb3Account ephemeralAccount = web3AccountFactory.CreateAccount(new EthECKey(json.identity.ephemeralIdentity.privateKey));
 
-            DateTime expiration = DateTime.ParseExact(json.identity.expiration, "yyyy-MM-ddTHH:mm:ss.fffZ",
-                CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+            DateTime expiration = DateTime.Parse(json.identity.expiration, null, DateTimeStyles.RoundtripKind);
 
             return new DecentralandIdentity(new Web3Address(address), ephemeralAccount, expiration, authChain);
         }


### PR DESCRIPTION
## What does this PR change?

Makes a small fix on how the expiration date is parsed. It is not confirmed that this was actually a real problem, but it is better to apply the fix. It does not use `DateTime.ParseExact` anymore, but instead it uses `DateTimeStyles.RoundtripKind`.

## Test Instructions

1. Go to:` ~/Library/Application Support/DecentralandLauncherLight/` ➜ Delete all contents inside that folder
2. Open Chrome ➜ go to https://decentraland.zone/account ➜ Sign in
3. Download the launcher, install and run it: You should see the Double-click installer flow
4. Once the Explorer starts downloading, backup the identityId file located at: `~/Library/Application Support/DecentralandLauncherLight/auth-token-bridge.txt` (**NOTE: do not share your identityId**)
5. When the Explorer finishes downloading and auto-opens, close it immediately
6. Restore the identityId bridge file
7. Replace the Decentraland app from the launcher folder, for example: `~/Library/Application Support/DecentralandLauncherLight/v0.101.0-alpha` with the build generated by this PR.
7. Run the deeplink in chrome: `decentraland://?dclenv=zone&skip-version-check=true`
8. Explorer should start in Zone with the authenticated account

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
