### PR TITLE
fix: fix official icon chat masking

### DIFF
--- a/Explorer/Assets/DCL/Chat/Assets/ChatEntries/ChatEntryUsernameElement.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/ChatEntries/ChatEntryUsernameElement.prefab
@@ -128,7 +128,7 @@ MonoBehaviour:
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 0
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Explorer/Assets/DCL/Chat/Assets/ConversationToolbar/ChatConversationsToolbarViewTooltip.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/ConversationToolbar/ChatConversationsToolbarViewTooltip.prefab
@@ -714,6 +714,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7952237847612314218, guid: faaa81bda20189649961c29e42d56d57, type: 3}
+      propertyPath: m_Maskable
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8512937881895506565, guid: faaa81bda20189649961c29e42d56d57, type: 3}
       propertyPath: m_MinWidth
       value: 16


### PR DESCRIPTION
# Pull Request Description

Fixes DCL Official icons from chat messages being visible outside of the chat.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Correctly sets up masking (icon maskable by default, disabled in tooltip).

## Test Instructions

Spam chat messages with an official account and verify the icon is not visible when chat bubbles go outside of the chat viewport. Also ensure that the tooltips in the shat sidebar (username hover) correctly display the icon.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
