### PR TITLE
fix: optimize avatar screenshot service

### DIFF
--- a/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/OutfitsPresenter.cs
+++ b/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/OutfitsPresenter.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
-using DCL.Audio;
 using DCL.AvatarRendering.Wearables.Equipped;
 using DCL.Backpack.AvatarSection.Outfits;
 using DCL.Backpack.AvatarSection.Outfits.Banner;
@@ -227,13 +226,13 @@ namespace DCL.Backpack
 
         private async UniTask TakeScreenshotAndDisplayAsync(int slotIndex, CancellationToken ct)
         {
-            byte[]? pngBytes = await screenshotService
-                .CaptureSaveAndGetPngAsync(characterPreviewController, slotIndex, ct);
+            var thumbnail = await screenshotService
+                .CaptureAndSavePngAsync(characterPreviewController, slotIndex, ct);
 
-            if (ct.IsCancellationRequested || pngBytes == null) return;
+            if (ct.IsCancellationRequested || thumbnail == null) return;
 
             var presenter = slotPresenters.FirstOrDefault(p => p.slotIndex == slotIndex);
-            presenter?.SetThumbnailFromPngBytes(pngBytes);
+            presenter?.SetThumbnail(thumbnail);
         }
 
         private void OnDeleteOutfitRequested(int slotIndex)

--- a/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/Services/AvatarScreenshotService.cs
+++ b/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/Services/AvatarScreenshotService.cs
@@ -20,7 +20,7 @@ namespace DCL.Backpack.AvatarSection.Outfits.Services
 
         private Texture2D? screenshotTexture;
         private Material? gammaCorrectionMaterial;
-        
+
         public AvatarScreenshotService(ISelfProfile selfProfile)
         {
             this.selfProfile = selfProfile;
@@ -29,7 +29,18 @@ namespace DCL.Backpack.AvatarSection.Outfits.Services
                 Directory.CreateDirectory(baseOutfitsDirectory);
         }
 
-        public async UniTask<byte[]?> CaptureSaveAndGetPngAsync(
+        /// <summary>
+        ///     Captures the current avatar preview, creates a downscaled sRGB thumbnail,
+        ///     saves the full image as a PNG file tied to the user's outfit slot,
+        ///     and returns the thumbnail texture.
+        ///     The method hides the platform and resets the avatar pose to stabilize the capture,
+        ///     performs GPU-based downscaling and color conversion,
+        ///     asynchronously reads back the image data from the GPU,
+        ///     encodes it to PNG, writes it to disk on a background thread,
+        ///     and finally restores the UI state and releases temporary resources.
+        ///     Returns null on failure or cancellation.
+        /// </summary>
+        public async UniTask<Texture2D?> CaptureAndSavePngAsync(
             CharacterPreviewControllerBase controller, int slotIndex, CancellationToken ct)
         {
             string? userId = await GetCurrentUserIdAsync(ct);
@@ -40,86 +51,90 @@ namespace DCL.Backpack.AvatarSection.Outfits.Services
             }
 
             RenderTexture? downscaledSRGB = null;
+            Texture2D? thumbnailTex = null;
 
             try
             {
                 await UniTask.SwitchToMainThread(ct);
 
-                // Stabilize the shot: hide platform,
-                // reset pose, give the frame pipeline a tick to settle
+                // Stabilize the shot: hide platform
+                // reset pose/zoom, give one frame to settle
                 controller.SetPlatformVisible(false);
                 controller.ResetAvatarMovement();
                 controller.ResetZoom();
-                
-                await UniTask.Yield(PlayerLoopTiming.Update, ct);
 
+                // NOTE: unfortunately we have to wait few frames
+                // NOTE: until zoom stabilizes (if it was zoomed out thumbnail will not be
+                // NOTE: taken from the reset position)
+                await UniTask.DelayFrame(2, PlayerLoopTiming.PostLateUpdate, ct);
+                await UniTask.Yield(PlayerLoopTiming.Update);
+                
                 var source = controller.CurrentRenderTexture;
                 if (source == null) return null;
 
-                // Thumbnail size (halve the preview resolution)
-                // adjust if you prefer a fixed cap (e.g., 512x512)
-                int w = source.width  / 2;
+                int w = source.width / 2;
                 int h = source.height / 2;
 
-                // Build a UNorm8 + sRGB-capable RT so the GPU performs linear->sRGB conversion on store.
-                // Prefer BGRA8 on macOS/Metal; fallback to RGBA8 elsewhere.
                 var desc = new RenderTextureDescriptor(w, h)
                 {
-                    graphicsFormat  = OutFmt(), sRGB = true, msaaSamples = 1, depthBufferBits = 0,
+                    graphicsFormat = GetOutputGraphicsFormat(), sRGB = true, msaaSamples = 1, depthBufferBits  = 0,
                     mipCount = 1, useMipMap = false
                 };
 
                 downscaledSRGB = RenderTexture.GetTemporary(desc);
 
-                // GPU downscale + sRGB encode in one pass
+                // Downscale + write into sRGB target (GPU does linear->sRGB on store)
                 Graphics.Blit(source, downscaledSRGB);
 
-                // Async readback: avoids render-thread stalls, completion occurs on a later frame
-                var req = await AsyncGPUReadback.Request(downscaledSRGB).WithCancellation(ct);
+                // Build thumbnail on GPU result
+                thumbnailTex = MakeThumbnailFromRT(downscaledSRGB);
+
+                // GPU readback (await without custom awaitable)
+                var req = await AsyncGPUReadback
+                    .Request(downscaledSRGB)
+                    .WithCancellation(ct);
+
                 if (req.hasError)
                 {
                     ReportHub.LogError(ReportCategory.OUTFITS, "GPU readback failed.");
                     return null;
                 }
 
-                ct.ThrowIfCancellationRequested();
-
-                var srgbNative = req.GetData<byte>();
-
-                byte[] pngBytes;
-                // Encode PNG directly from the readback buffer
-                // (no Texture2D.Get/SetPixels, no CPU gamma conversion)
+                var srgbNative = req.GetData<byte>(); // raw sRGB bytes from RT
                 using (var pngNative = ImageConversion.EncodeNativeArrayToPNG(
                            srgbNative, downscaledSRGB.graphicsFormat, (uint)w, (uint)h))
                 {
-                    pngBytes = pngNative.ToArray();
+                    string filePath = GetFilePathForSlot(userId, slotIndex);
+                    Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+                    await UniTask.SwitchToThreadPool();
+                    await using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
+                    {
+                        stream.Write(pngNative);
+                    }
                 }
 
-                // Persist to disk on a background thread
-                string filePath = GetFilePathForSlot(userId, slotIndex);
-                Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
-
-                await UniTask.SwitchToThreadPool();
-                await File.WriteAllBytesAsync(filePath, pngBytes, ct);
-                await UniTask.SwitchToMainThread(ct);
-
-                // Return bytes so UI can display thumbnail
-                // immediately (no disk read required)
-                return pngBytes;
+                await UniTask.SwitchToMainThread();
+                return thumbnailTex;
+            }
+            catch (OperationCanceledException)
+            {
+                if (thumbnailTex) Object.Destroy(thumbnailTex);
+                return null;
             }
             catch (Exception e)
             {
                 ReportHub.LogException(e, $"Failed to save screenshot for slot {slotIndex}: {e.Message}");
+                if (thumbnailTex) Object.Destroy(thumbnailTex);
                 return null;
             }
             finally
             {
                 if (downscaledSRGB != null) RenderTexture.ReleaseTemporary(downscaledSRGB);
-                await UniTask.SwitchToMainThread(ct);
+                await UniTask.SwitchToMainThread();
                 controller.SetPlatformVisible(true);
             }
         }
-        
+
         public async UniTask<Texture2D> LoadScreenshotAsync(int slotIndex, CancellationToken ct)
         {
             string? userId = await GetCurrentUserIdAsync(ct);
@@ -200,11 +215,41 @@ namespace DCL.Backpack.AvatarSection.Outfits.Services
             return profile?.UserId;
         }
 
-        private GraphicsFormat OutFmt()
+        private GraphicsFormat GetOutputGraphicsFormat()
         {
-            if (SystemInfo.IsFormatSupported(GraphicsFormat.B8G8R8A8_UNorm, GraphicsFormatUsage.Render))
-                return GraphicsFormat.B8G8R8A8_UNorm;
-            return GraphicsFormat.R8G8B8A8_UNorm;
+            // Prefer BGRA8 on Metal/DirectX (fast path), else RGBA8.
+            var preferred = GraphicsFormat.B8G8R8A8_SRGB;
+            var fallback  = GraphicsFormat.R8G8B8A8_SRGB;
+
+            // Try preferred, then fallback; both must support RT rendering.
+            if (SystemInfo.IsFormatSupported(preferred, GraphicsFormatUsage.Render))
+                return preferred;
+
+            if (SystemInfo.IsFormatSupported(fallback, GraphicsFormatUsage.Render))
+                return fallback;
+
+            // Last resort: ask Unity for a compatible format closest to RGBA8 sRGB.
+            var compat = SystemInfo.GetCompatibleFormat(GraphicsFormat.R8G8B8A8_SRGB, GraphicsFormatUsage.Render);
+            if (compat != GraphicsFormat.None)
+                return compat;
+
+            // Extremely unlikely on modern platforms. If we’re here, sRGB RTs aren’t supported.
+            // You can either:
+            // 1) Return linear UNorm8 and set desc.sRGB = false, then do linear->sRGB in a Blit material,
+            // 2) Or accept slightly wrong gamma in the PNG (not recommended).
+            var linearFallback = GraphicsFormat.R8G8B8A8_UNorm;
+            if (SystemInfo.IsFormatSupported(linearFallback, GraphicsFormatUsage.Render))
+                return linearFallback;
+
+            // Absolute last ditch: whatever Unity thinks is renderable.
+            return SystemInfo.GetCompatibleFormat(GraphicsFormat.R8G8B8A8_UNorm, GraphicsFormatUsage.Render);
+        }
+
+        private Texture2D MakeThumbnailFromRT(RenderTexture src)
+        {
+            var tex = new Texture2D(src.width, src.height, src.graphicsFormat, TextureCreationFlags.None);
+            Graphics.CopyTexture(src, tex);
+            return tex;
         }
     }
 }

--- a/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/Services/IAvatarScreenshotService.cs
+++ b/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/Services/IAvatarScreenshotService.cs
@@ -7,40 +7,8 @@ namespace DCL.Backpack.AvatarSection.Outfits.Services
 {
     public interface IAvatarScreenshotService
     {
-        /// <summary>
-        /// Captures the avatar preview into a color-correct (sRGB) thumbnail PNG, saves it to disk,
-        /// and returns the PNG bytes for immediate UI display.
-        /// </summary>
-        /// <remarks>
-        /// Pipeline overview:
-        /// 1) Ensure main thread and stabilize the preview (hide platform, reset pose/zoom, wait a couple frames).
-        /// 2) Create a temporary downscaled RenderTexture with <c>sRGB = true</c> and a UNorm8 graphics format
-        ///    (BGRA8 preferred on macOS). This makes the GPU perform linear→sRGB conversion on store.
-        /// 3) <see cref="Graphics.Blit(UnityEngine.Texture, UnityEngine.RenderTexture)"/> downscales and bakes the sRGB curve in one pass.
-        /// 4) <see cref="UnityEngine.Rendering.AsyncGPUReadback"/> reads pixels back asynchronously (no render-thread stall).
-        /// 5) Encode PNG directly from the readback buffer (<see cref="ImageConversion.EncodeNativeArrayToPNG"/>), save to the per-slot path,
-        ///    and return the PNG bytes for immediate thumbnail display.
-        /// 
-        /// Why sRGB?: The preview renders in Linear color space (good for lighting). PNG viewers assume sRGB. Without converting,
-        /// screenshots appear darker. Using an sRGB RT guarantees correct brightness on all platforms.
-        /// 
-        /// Threading: Unity/Graphics on main thread; file I/O on a thread pool. Temporary RT is always released in <c>finally</c>.
-        /// </remarks>
-        /// <param name="controller">Provides the current preview <see cref="RenderTexture"/> to capture.</param>
-        /// <param name="slotIndex">Outfit slot index; used to build the destination file path.</param>
-        /// <param name="ct">Cancellation token: honored before/after GPU readback and before file I/O.</param>
-        /// <returns>PNG byte array on success; <c>null</c> on failure or if user ID is unavailable.</returns>
-        UniTask<byte[]?> CaptureSaveAndGetPngAsync(CharacterPreviewControllerBase controller, int slotIndex, CancellationToken ct);
-            
-        /// <summary>
-        ///     Loads a previously saved outfit screenshot from the local disk.
-        /// </summary>
-        /// <returns>The Texture2D if found, otherwise null.</returns>
+        UniTask<Texture2D?> CaptureAndSavePngAsync(CharacterPreviewControllerBase controller, int slotIndex, CancellationToken ct);
         UniTask<Texture2D> LoadScreenshotAsync(int slotIndex, CancellationToken ct);
-
-        /// <summary>
-        ///     Deletes the screenshot file associated with a specific user and outfit slot.
-        /// </summary>
         UniTask DeleteScreenshotAsync(int slotIndex, CancellationToken ct);
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Optimizes creation of the avatar thumbnail for Outfit slots (tech debt from the Outfits shape)

## Test Instructions
There should be no visible difference (GPU optimization under the hood), all functionality related to outfits and 
creating of thumbnails should remain the same

### Test Steps
1. Create outfit
2. Observe thumbnail correctly created

### Additional Testing Notes
- There are some changes how thumbnail image format are selected it should work correctly both on MacOS and Windows
- 
## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
