### PR TITLE
fix: dont request page 0 of backpack in authentication screen

### DIFF
--- a/Explorer/Assets/DCL/Backpack/AvatarSection/AvatarTabNavigator.cs
+++ b/Explorer/Assets/DCL/Backpack/AvatarSection/AvatarTabNavigator.cs
@@ -81,7 +81,6 @@ namespace DCL.Backpack
         public void InitializeAndEnable()
         {
             WireTabMappingHandlers();
-            ActivateDefault();
         }
 
         public void Show()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes #6075 

## Test Instructions


### Test Steps
1. Start the client, and just check that you dont hear the backpack loading in the authentication screen


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
