### PR TITLE
fix: disable listening tip on request to join communities

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunityResultCard.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/Prefabs/CommunityResultCard.prefab
@@ -1879,10 +1879,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3871066310531660349}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 18}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 12, y: -13}
+  m_SizeDelta: {x: 18, y: 18}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &480158624160891999
 CanvasRenderer:
@@ -2294,7 +2294,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &3871066310531660349
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2314,7 +2314,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 14, y: -14}
-  m_SizeDelta: {x: 0, y: 26}
+  m_SizeDelta: {x: 84.86, y: 26}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &8220607410701181364
 CanvasRenderer:
@@ -2795,10 +2795,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3871066310531660349}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 12}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 50.114998, y: -13}
+  m_SizeDelta: {x: 53.49, y: 12}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4194844807124732896
 CanvasRenderer:


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5661 
Avoid listening tooltip from appearing in the request to join communities section

## Test Instructions

### Test Steps
1. Launch the client
2. Go to communities browser
3. Go to the request to join/invitations section
4. Verify that no "Listening" tooltip appears in the communities (check the issue if not clear)

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
