### PR TITLE
Get rid of boxing allocations in ResolveInitialSceneStateLOD

### DIFF
--- a/Explorer/Assets/DCL/LOD/Systems/ResolveISSLODSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/ResolveISSLODSystem.cs
@@ -46,16 +46,8 @@ namespace DCL.LOD.Systems
         private void ResolveInitialSceneStateLOD(ref SceneLODInfo sceneLODInfo, ref SceneDefinitionComponent sceneDefinition)
         {
             InitialSceneStateLOD initialSceneStateLOD = sceneLODInfo.InitialSceneStateLOD;
-            InitialSceneStateLOD.InitialSceneStateLODState InitialSceneStateLODState = initialSceneStateLOD.CurrentState;
 
-            if (InitialSceneStateLODState.Equals(InitialSceneStateLOD.InitialSceneStateLODState.FAILED))
-                return;
-
-            if (InitialSceneStateLODState.Equals(InitialSceneStateLOD.InitialSceneStateLODState.RESOLVED)
-                || InitialSceneStateLODState.Equals(InitialSceneStateLOD.InitialSceneStateLODState.UNINITIALIZED))
-                return;
-
-            if (InitialSceneStateLODState.Equals(InitialSceneStateLOD.InitialSceneStateLODState.PROCESSING))
+            if (initialSceneStateLOD.CurrentState == InitialSceneStateLOD.InitialSceneStateLODState.PROCESSING)
             {
                 // Skip if promise hasn't been created yet or is already consumed
                 if (initialSceneStateLOD.AssetBundlePromise == AssetBundlePromise.NULL || initialSceneStateLOD.AssetBundlePromise.IsConsumed) return;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change gets rid of boxing allocations in ResolveInitialSceneStateLOD. This saves 20 KB of allocations per frame.

## Test Instructions

Just happy path.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
