### PR TITLE
fix: Irrecoverably error getting saved resolution

### DIFF
--- a/Explorer/Assets/DCL/Settings/Utils/WindowModeUtils.cs
+++ b/Explorer/Assets/DCL/Settings/Utils/WindowModeUtils.cs
@@ -34,7 +34,7 @@ namespace DCL.Settings.Utils
             Resolution GetSavedResolution()
             {
                 int index = DCLPlayerPrefs.GetInt(DCLPrefKeys.SETTINGS_RESOLUTION);
-                return possibleResolutions[index];
+                return index < 0 || index >= possibleResolutions.Count ? GetDefaultResolution() : possibleResolutions[index];
             }
 
             Resolution GetDefaultResolution()


### PR DESCRIPTION
# Pull Request Description
Fix #6148 

## What does this PR change?
An irrecoverably error that avoided to load the application could occur when we tried to ge the saved resolution from `PlayerPrefs`:

<img width="1149" height="189" alt="image" src="https://github.com/user-attachments/assets/4ab2b10c-9685-4e28-ad51-be77ecb5e0a9" />

We don't know exactly how to provoke the scenario to reproduce it but we were able to do it.

## Test Instructions
- General test.
- Check that the app starts always corrrectly and it doesn't get freezed at the beginning (before reaching the login screen).

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
