### PR TITLE
fix: avatar shapes dont show in backpack

### DIFF
--- a/Explorer/Assets/DCL/Ipfs/AssetBundleManifestVersion.cs
+++ b/Explorer/Assets/DCL/Ipfs/AssetBundleManifestVersion.cs
@@ -90,8 +90,8 @@ public class AssetBundleManifestVersion
         {
             var assetBundleManifestVersion = new AssetBundleManifestVersion();
             var assets = new AssetBundleManifestVersionPerPlatform();
-            assets.mac = new PlatformInfo(AB_MIN_SUPPORTED_VERSION_WINDOWS.ToString(), "1");
-            assets.windows = new PlatformInfo(AB_MIN_SUPPORTED_VERSION_MAC.ToString(), "1");
+            assets.mac = new PlatformInfo(AB_MIN_SUPPORTED_VERSION_WINDOWS.ToString(), "1699288905291");
+            assets.windows = new PlatformInfo(AB_MIN_SUPPORTED_VERSION_MAC.ToString(), "1699288905291");
             assetBundleManifestVersion.assets = assets;
             assetBundleManifestVersion.HasHashInPath();
 


### PR DESCRIPTION
I traced the issue to a change in the PlatformInfo when creating a CreateManualManifest where we used to set the build date to 1699288905291 which if its UNIX time It is 2 years ago. Changing it to this value instead of 1, fixes the issue 🤷

## How to test
Please make sure avatar shapes load properly in the backpack and that all other functionality related to wearables in the backpack works as expected. Please check that the logic in the LSD remains the same as in this ticket:
https://github.com/decentraland/unity-explorer/pull/6093

