### PR TITLE
fix: prevent multiple clicks in community card's sections

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardView.cs
@@ -129,6 +129,7 @@ namespace DCL.Communities.CommunitiesCard
         private GenericContextMenuElement? leaveCommunityContextMenuElement;
         private GenericContextMenuElement? deleteCommunityContextMenuElement;
         private CancellationToken cancellationToken;
+        private Sections currentSection;
 
         private void Awake()
         {
@@ -277,6 +278,10 @@ namespace DCL.Communities.CommunitiesCard
 
         private void ToggleSection(Sections section, bool invokeEvent = true)
         {
+            if (section == currentSection) return;
+
+            currentSection = section;
+
             photosSectionSelection.SetActive(section == Sections.PHOTOS);
             membersSectionSelection.SetActive(section == Sections.MEMBERS);
             placesSectionSelection.SetActive(section == Sections.PLACES);


### PR DESCRIPTION
# Pull Request Description
Fixes #6050 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR prevents multiple invocations of `SectionChanged` when clicking multiple times on the same section of the community card, avoiding multiple photo loadings.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Verify the steps described in the linked issue


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
