### PR TITLE
fix: added hover audio for explore panel header buttons

### DIFF
--- a/Explorer/Assets/DCL/UI/Assets/TabSelector.prefab
+++ b/Explorer/Assets/DCL/UI/Assets/TabSelector.prefab
@@ -322,6 +322,7 @@ MonoBehaviour:
   <SelectedText>k__BackingField: {fileID: 85566942900833079}
   tabAnimator: {fileID: 0}
   <TabClickAudio>k__BackingField: {fileID: 11400000, guid: 0df7b16e196525d40a3a98032e38abea, type: 2}
+  <HoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
 --- !u!1 &3388056574719437513
 GameObject:
   m_ObjectHideFlags: 0
@@ -436,7 +437,7 @@ MonoBehaviour:
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
-  m_ActiveFontFeatures: 00000000
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1

--- a/Explorer/Assets/DCL/UI/TabSelectorView.cs
+++ b/Explorer/Assets/DCL/UI/TabSelectorView.cs
@@ -32,6 +32,9 @@ namespace DCL.UI
         [field: SerializeField]
         public AudioClipConfig TabClickAudio { get; private set; }
 
+        [field: SerializeField]
+        public AudioClipConfig HoverAudio { get; private set; }
+
         private void OnEnable()
         {
             tabAnimator.enabled = true;
@@ -53,6 +56,7 @@ namespace DCL.UI
 
         public void OnPointerEnter(PointerEventData eventData)
         {
+            UIAudioEventsBus.Instance.SendPlayAudioEvent(HoverAudio);
             if (tabAnimator != null)
                 tabAnimator.SetTrigger(UIAnimationHashes.HOVER);
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6154
Added hover audio for section buttons in the explore panel menu

## Test Instructions

### Test Steps
1. Launch the client
2. Open the explore panel
3. Verify that when you mouse hover the buttons for the different sections (map/settings/...) the generic hover sound plays

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
