### PR TITLE
fix: Clear LOD bridge assets on realm unload

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
@@ -109,18 +109,6 @@ namespace ECS.SceneLifeCycle.SceneDefinition
 
             foreach (SceneEntityDefinition sceneEntityDefinition in intention.TargetCollection)
             {
-                //TODO: Remove before merge
-
-                if (sceneEntityDefinition.id.Equals("bafkreichelc5ssrjivd3jmolg5yi3qgxcrvir6kh4z4hgolvzmkn6rlupi"))
-                {
-                    sceneEntityDefinition.assetBundleManifestVersion.assets.mac.version = "v2001";
-                    sceneEntityDefinition.assetBundleManifestVersion.assets.mac.buildDate = "2025-11-14Z";
-
-                    sceneEntityDefinition.assetBundleManifestVersion.assets.windows.version = "v2001";
-                    sceneEntityDefinition.assetBundleManifestVersion.assets.windows.buildDate = "2025-11-14Z";
-                }
-
-
                 //Fallback needed for when the asset-bundle-registry does not have the asset bundle manifest.
                 //Could be removed once the asset bundle manifest registry has been battle tested
                 await AssetBundleManifestFallbackHelper.CheckAssetBundleManifestFallbackAsync(World, sceneEntityDefinition, partition, ct, isLSD: isLocalSceneDevelopment);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Invalidates the partition components while doing a realm unload so the finalize components can responde correctly.

In particular, `CleanUpGltfContainerSystem` requires the correct scene partition to determine if the GLTF assets should be reused or not.

On a realm change, the position of a player does not change. So, before this PR, the `PartitionComponent` marked as assets should go to the LOD bridge, when they should unload completely.

On the current state, the PR contains a hardcode to allow the QA team to test it. It will be removed before merge

## Test Instructions


### Test Steps
1. Load genesis plaza regularly
2. Go to `vitsky.dcl.eth`. Genesis Plaza assets should not be there


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
