### PR TITLE
fix: fixed nullref on application close for running livekit stream

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
@@ -20,9 +20,9 @@ namespace DCL.SDKComponents.MediaStream
             actionOnGet: static source => source.gameObject.SetActive(true),
             actionOnRelease: static source =>
             {
-                source.Stop();
-                source.Free();
-                source.gameObject.SetActive(false);
+                source?.Stop();
+                source?.Free();
+                source?.gameObject.SetActive(false);
             });
 
         private readonly IRoom room;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6185 
Adds nullcheck in disposal of LivekitPlayer to avoid a nullreference when disposing the audioSource.
This nullcheck is required as the audioSource is a monobehaviour, and if we close the game while in a scene with a livekit stream we cannot ensure that the audioStream is not yet destroyed when disposing the player.

## Test Instructions

### Test Steps
1. Launch the client
2. Start an obs stream
3. Verify that it works as always

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
