### PR TITLE
fix: show marketplace credits menu every season new week

### DIFF
--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsMenuController.cs
@@ -362,16 +362,16 @@ namespace DCL.MarketplaceCredits
 
         private static bool TrySetAsShownThisWeek(CreditsProgramProgressResponse creditsProgramProgressResponse)
         {
-            if (string.IsNullOrEmpty(creditsProgramProgressResponse.currentSeason.startDate))
+            if (string.IsNullOrEmpty(creditsProgramProgressResponse.currentWeek.startDate))
                 return false;
 
             string isoString = DCLPlayerPrefs.GetString(DCLPrefKeys.MARKETPLACE_CREDITS_LAST_SEASON_SHOWN_WEEK_START, DateTime.MinValue.ToString("o"));
 
             if (DateTime.TryParse(isoString, null, System.Globalization.DateTimeStyles.RoundtripKind, out DateTime lastShownWeek)
-                && DateTime.TryParse(creditsProgramProgressResponse.currentSeason.startDate, null, System.Globalization.DateTimeStyles.RoundtripKind, out DateTime currentSeasonStart)
+                && DateTime.TryParse(creditsProgramProgressResponse.currentWeek.startDate, null, System.Globalization.DateTimeStyles.RoundtripKind, out DateTime currentSeasonStart)
                 && currentSeasonStart > lastShownWeek)
             {
-                DCLPlayerPrefs.SetString(DCLPrefKeys.MARKETPLACE_CREDITS_LAST_SEASON_SHOWN_WEEK_START, creditsProgramProgressResponse.currentSeason.startDate);
+                DCLPlayerPrefs.SetString(DCLPrefKeys.MARKETPLACE_CREDITS_LAST_SEASON_SHOWN_WEEK_START, creditsProgramProgressResponse.currentWeek.startDate);
                 return true;
             }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR uses the `Week` data to correctly check if a new market place credits week has started within the season in order to show the panel.
Before it was using the season data, which is always the same during the said season -> the menu was shown every new season instead of every new week of the season.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. On first launch verify that the panel is shown
2. Second launch you shouldn't be able to see the panel

### Additional Testing Notes
- If you want to reset the behaviour you have to delete the saved pref:
   - the file is located in your cache's folder (macos: ~/Library/Application Support/Decentraland/Explorer and it's called userdata_0.json. Depending if you are running multiple clients, the file could be userdata_1.json and so on)
      - locate the json property MarketPlaceCredits_LastSeasonShownWeekStart and delete it
      - if you want to test a different date, just change what's saved instead of deleting it

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
