### PR TITLE
fix: set selected resolution instead of last saved one

### DIFF
--- a/Explorer/Assets/DCL/Settings/ModuleControllers/ResolutionSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/ResolutionSettingsController.cs
@@ -80,7 +80,7 @@ namespace DCL.Settings.ModuleControllers
             if (appParameters.HasFlag(AppArgsFlags.WINDOWED_MODE) && isInitialSetup)
                 return;
 
-            Resolution targetResolution = WindowModeUtils.GetTargetResolution(possibleResolutions);
+            Resolution targetResolution = index < 0 || index >= possibleResolutions.Count ? WindowModeUtils.GetDefaultResolution(possibleResolutions) : possibleResolutions[index];
             FullScreenMode targetScreenMode = WindowModeUtils.GetTargetScreenMode(appParameters.HasFlag(AppArgsFlags.WINDOWED_MODE));
             Screen.SetResolution(targetResolution.width, targetResolution.height, targetScreenMode, targetResolution.refreshRateRatio);
             DCLPlayerPrefs.SetInt(DCLPrefKeys.SETTINGS_RESOLUTION, index, save: true);

--- a/Explorer/Assets/DCL/Settings/Utils/WindowModeUtils.cs
+++ b/Explorer/Assets/DCL/Settings/Utils/WindowModeUtils.cs
@@ -29,31 +29,31 @@ namespace DCL.Settings.Utils
         {
             return DCLPlayerPrefs.HasKey(DCLPrefKeys.SETTINGS_RESOLUTION)
                 ? GetSavedResolution()
-                : GetDefaultResolution();
+                : GetDefaultResolution(possibleResolutions);
 
             Resolution GetSavedResolution()
             {
                 int index = DCLPlayerPrefs.GetInt(DCLPrefKeys.SETTINGS_RESOLUTION);
-                return index < 0 || index >= possibleResolutions.Count ? GetDefaultResolution() : possibleResolutions[index];
+                return index < 0 || index >= possibleResolutions.Count ? GetDefaultResolution(possibleResolutions) : possibleResolutions[index];
             }
+        }
 
-            Resolution GetDefaultResolution()
+        public static Resolution GetDefaultResolution(List<Resolution> possibleResolutions)
+        {
+            int defaultIndex = 0;
+
+            for (var index = 0; index < possibleResolutions.Count; index++)
             {
-                int defaultIndex = 0;
+                Resolution resolution = possibleResolutions[index];
 
-                for (var index = 0; index < possibleResolutions.Count; index++)
-                {
-                    Resolution resolution = possibleResolutions[index];
+                if (!ResolutionUtils.IsDefaultResolution(resolution))
+                    continue;
 
-                    if (!ResolutionUtils.IsDefaultResolution(resolution))
-                        continue;
-
-                    defaultIndex = index;
-                    break;
-                }
-
-                return possibleResolutions[defaultIndex];
+                defaultIndex = index;
+                break;
             }
+
+            return possibleResolutions[defaultIndex];
         }
 
         public static FullScreenMode GetTargetScreenMode(bool isAppArgWindowedMode)


### PR DESCRIPTION
# Pull Request Description
Fixes #6173 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes sure that the resolution we are setting when a user selects one, is the selected one.

Previously it was setting the last saved one and, after doing that, it was storing which one was selected. By doing that, the next time the user would select a different resolution, the same would apply.
For example:

1. Initial condition:
   - applied 1920x1080
   - saved 1920x1080
2. The user selects 1600x1050
   - client applies 1920x1080 (stored)
   - client saves 1600x1050
3. The user selects 1920x1050
   - client applies 1600x1050 (stored)
   - client saves 1920x1050

Repeat from point 2 in a loop.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Verify that the resolution you select is the one being applied
2. Verify that the last resolution you applied is the one that gets stored (persists between restarts)

### Additional Testing Notes
- If you change your monitors setup between client launches (e.g. plug or unplug a monitor that has different supported resolutions or refresh rate than the other ones), the saved setting may be incorrect and the resolution that will be set may not be the one you selected before

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
