### PR TITLE
fix: avoid color space conversion when already in gamma for video blitting

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -181,7 +181,14 @@ namespace DCL.SDKComponents.MediaStream
                 assignedTexture.Resize(avText.width, avText.height);
 
             if (playerComponent.MediaPlayer.GetTexureScale.Equals(new Vector2(1, -1)))
-                Graphics.Blit(avText, assignedTexture.Texture, flipMaterial);
+            {
+                //Regular blit or blit with material are called based on the source color space, we blit with material only
+                //in case we are in linear and need to convert the colorspace as well as target assigned texture is always in gamma
+                if (avText.isDataSRGB)
+                    Graphics.Blit(avText, assignedTexture.Texture, new Vector2(1, -1), new Vector2(0, 1));
+                else
+                    Graphics.Blit(avText, assignedTexture.Texture, flipMaterial);
+            }
             else
                 Graphics.CopyTexture(avText, assignedTexture.Texture);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
