### PR TITLE
hotfix: fixed darker looking streams

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -181,7 +181,14 @@ namespace DCL.SDKComponents.MediaStream
                 assignedTexture.Resize(avText.width, avText.height);
 
             if (playerComponent.MediaPlayer.GetTexureScale.Equals(new Vector2(1, -1)))
-                Graphics.Blit(avText, assignedTexture.Texture, flipMaterial);
+            {
+                //Regular blit or blit with material are called based on the source color space, we blit with material only
+                //in case we are in linear and need to convert the colorspace as well as target assigned texture is always in gamma
+                if (avText.isDataSRGB)
+                    Graphics.Blit(avText, assignedTexture.Texture, new Vector2(1, -1), new Vector2(0, 1));
+                else
+                    Graphics.Blit(avText, assignedTexture.Texture, flipMaterial);
+            }
             else
                 Graphics.CopyTexture(avText, assignedTexture.Texture);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR fixes the livestreams colors, avoiding them to look less dark then before.
This was caused by a wrong color space correction on the blit to flip the UVs

## Test Instructions

### Test Steps
1. Launch the client in a scene with admin tools
2. Test normal videos and livestreams and verify that they don't look too dark or washed out

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
