### PR TITLE
fix: clear equipped wearable/emote caches on identity change / update profile edge case

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Equipped/EquippedWearables.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Equipped/EquippedWearables.cs
@@ -12,7 +12,7 @@ namespace DCL.AvatarRendering.Wearables.Equipped
         private readonly Dictionary<string, IWearable?> wearables = new ();
         private readonly HashSet<string> forceRenderCategories = new ();
         public IReadOnlyCollection<string> ForceRenderCategories => forceRenderCategories;
-        
+
         private Color hairColor;
         private Color eyesColor;
         private Color bodyshapeColor;
@@ -62,6 +62,12 @@ namespace DCL.AvatarRendering.Wearables.Equipped
         {
             forceRenderCategories.Clear();
             foreach (string category in categories) { forceRenderCategories.Add(category); }
+        }
+
+        public void Clear()
+        {
+            wearables.Clear();
+            forceRenderCategories.Clear();
         }
 
         public IReadOnlyDictionary<string, IWearable?> Items() =>

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Equipped/IEquippedWearables.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Equipped/IEquippedWearables.cs
@@ -20,5 +20,7 @@ namespace DCL.AvatarRendering.Wearables.Equipped
 
         IReadOnlyCollection<string> ForceRenderCategories { get; }
         void SetForceRender(IReadOnlyCollection<string> categories);
+
+        void Clear();
     }
 }

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -170,6 +170,9 @@ namespace DCL.Profiles.Self
             }
             catch (Exception e) when (e is not OperationCanceledException)
             {
+                // If we cleared the identity while waiting for the profile to be saved, we just propagate the exception without overwriting the own profile with the old session one
+                if (OwnProfile == null) throw;
+
                 // Revert to the old profile so we are aligned to the catalyst's version
                 // copyOfOwnProfile should never be null at this point
                 Profile oldProfile = profileBuilder.From(copyOfOwnProfile!).Build();
@@ -194,6 +197,9 @@ namespace DCL.Profiles.Self
             // We also need to clear the owned nfts since they need to be re-initialized, otherwise we might end up with wrong nftIds (last part of the urn chunks)
             wearableStorage.ClearOwnedNftRegistry();
             emoteStorage.ClearOwnedNftRegistry();
+
+            equippedWearables.Clear();
+            equippedEmotes.UnEquipAll();
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description
Fixes #5889

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR addresses two race conditions that may happen when changing identity (log out/in):
1. equipped wearable and emotes are populated only from the backpack and they are used to push profile updates to the catalyst: if this update happens without clearing these caches it is possible to push wrong wearables (if they are shared) to the wrong profile, resulting in the apparent avatar swap
2. if the profile update request fails after the identity change, the `OwnProfile` property will be overwritten by the old profile, resulting in the apparent avatar swap

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Refer to the repro step described in the linked issue


## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
