### PR TITLE
fix: rotating platforms

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/CharacterPlatformUpdateSceneTickSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/CharacterPlatformUpdateSceneTickSystem.cs
@@ -10,7 +10,6 @@ using SceneRunner.Scene;
 namespace DCL.CharacterMotion.Systems
 {
     [UpdateInGroup(typeof(PresentationSystemGroup))]
-    [UpdateAfter(typeof(ChangeCharacterPositionGroup))]
     [UpdateAfter(typeof(RotateCharacterSystem))]
     public partial class CharacterPlatformUpdateSceneTickSystem : BaseUnityLoopSystem
     {


### PR DESCRIPTION
# Pull Request Description

Fixes https://github.com/decentraland/unity-explorer/issues/6122

## Dev Notes
Not exactly sure why in order to achieve correct ordering I had to remove one of the `UpdateAfter` attributes. I don't see any cyclic deps or anything like that, everything seems in order. Yet, without removing that attribute, the system is updated BEFORE `RotateCharacterSystem`, even if that shouldn't be the case.

Either I am missing something or there's a bug in Arch.

## Test Instructions
The issue was affecting all rotating platforms, so testing in any place with them is fine.

In the ticket a few of them are mentioned, for example `/goto goerli`.
