### PR TITLE
fix: moved equipped emote number to top right

### DIFF
--- a/Explorer/Assets/DCL/Backpack/Assets/BackpackEmoteGridItem.prefab
+++ b/Explorer/Assets/DCL/Backpack/Assets/BackpackEmoteGridItem.prefab
@@ -32,11 +32,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7150489433940370041}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 17.8, y: 14.3}
-  m_SizeDelta: {x: 22.0485, y: 15.8256}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -8, y: -6}
+  m_SizeDelta: {x: 8, y: 15}
+  m_Pivot: {x: 1, y: 1}
 --- !u!222 &5317681409627806208
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -369,6 +369,7 @@ MonoBehaviour:
   <IsEquipped>k__BackingField: 0
   incompatibleWithBodyShapeContainer: {fileID: 3374162131891453127}
   incompatibleWithBodyShapeHoverContainer: {fileID: 4228669688390808703}
+  <SmartWearableBadgeContainer>k__BackingField: {fileID: 0}
   <EquipWearableAudio>k__BackingField: {fileID: 11400000, guid: d1d7149ae3c90e449b657edfd7109eff, type: 2}
   <UnEquipWearableAudio>k__BackingField: {fileID: 11400000, guid: b78ff33cb1d284d4b8938bf362676581, type: 2}
   <HoverAudio>k__BackingField: {fileID: 11400000, guid: 8b8a0a6a2ec74774c8d3ccac3b54e0e8, type: 2}


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6150 
Moved number of equipped emotes to the top right corner

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. Launch the client
2. Open the backpack
3. Go to the emotes section
4. Verify that the number of the equipped emotes now appears in the top right corner of emotes and not in the bottom left corner

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
