### PR TITLE
fix: added check to avoid moveplayerto under the ground

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/RestrictedActionsAPIImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/RestrictedActionsAPIImplementation.cs
@@ -160,6 +160,10 @@ namespace CrdtEcsBridge.RestrictedActions
 
         private bool IsPositionValid(Vector3 floorPosition)
         {
+            //Avoid teleports below ground level
+            if(floorPosition.y < 0)
+                return false;
+
             var parcelToCheck = floorPosition.ToParcel();
 
             foreach (Vector2Int sceneParcel in sceneData.Parcels)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6230 
Avoids moveplayerto restricted action to teleport player below ground level

## Test Instructions

### Test Steps
1. Launch the client
2. Go to 17,59
3. There are two cubes
4. Press the white cube and verify that you are teleported in the air
5. Press the red cube (that should teleport you under the ground in current production) and verify that no teleport happens

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
