### PR TITLE
opti: cached frame time to avoid multiple checks per frame

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/PerformanceBudgeting/FrameTimeCapBudget.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/PerformanceBudgeting/FrameTimeCapBudget.cs
@@ -12,7 +12,6 @@ namespace DCL.Optimization.PerformanceBudgeting
 
         private int cachedFrameNumber = -1;
         private bool cachedIsLoadingScreenOn;
-        private bool cachedIsWithinBudget;
 
         public FrameTimeCapBudget(float budgetCapInMS, IBudgetProfiler profiler, Func<bool> isLoadingScreenOn) : this(
             TimeSpan.FromMilliseconds(budgetCapInMS),
@@ -43,14 +42,13 @@ namespace DCL.Optimization.PerformanceBudgeting
             if (cachedFrameNumber != currentFrame)
             {
                 cachedIsLoadingScreenOn = isLoadingScreenOn.Invoke();
-                cachedIsWithinBudget = profiler.CurrentFrameTimeValueNs < totalBudgetAvailable;
                 cachedFrameNumber = currentFrame;
             }
 
             if (cachedIsLoadingScreenOn)
                 return true;
 
-            return cachedIsWithinBudget;
+            return profiler.CurrentFrameTimeValueNs < totalBudgetAvailable;
         }
 
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6255 
This PR optimises the time spent when checking the loading screen status in FrameTimeCapBudget.TrySpendBudget.
Instead of checking at each call (multiple times per frame, roughly 500+ in GP) it caches the frame time and checks only once per frame the status of the loading screen.

Before:
<img width="1151" height="187" alt="Screenshot 2025-11-24 at 09 35 02" src="https://github.com/user-attachments/assets/22f78cb4-7eb9-4988-9f1a-548e4c175566" />

After:
<img width="1151" height="132" alt="Screenshot 2025-11-24 at 09 47 28" src="https://github.com/user-attachments/assets/52e556a2-209a-49e9-9109-a88ba02c789c" />


## Test Instructions
This is an internal optimisation, just do a smoke test that loading in game works fine and teleporting around just makes everything work like before

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
