### PR TITLE
fix: removed protocol from realm response to sdk

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/Runtime/IRuntime.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/Runtime/IRuntime.cs
@@ -59,26 +59,22 @@ namespace SceneRuntime.Apis.Modules.Runtime
             public int networkId;
             public string commsAdapter;
             public bool isPreview;
-            public string protocol;
 
             public RealmInfo(IRealmData realmData) : this(
                 new Uri(realmData.Ipfs.CatalystBaseUrl.Value).GetLeftPart(UriPartial.Authority),
                 realmData.RealmName,
                 realmData.NetworkId,
                 realmData.CommsAdapter,
-                realmData.IsLocalSceneDevelopment,
-                realmData.Protocol
+                realmData.IsLocalSceneDevelopment
             ) { }
 
-            public RealmInfo(string baseUrl, string realmName, int networkId, string commsAdapter, bool isPreview,
-                string protocol)
+            public RealmInfo(string baseUrl, string realmName, int networkId, string commsAdapter, bool isPreview)
             {
                 this.baseUrl = baseUrl;
                 this.realmName = realmName;
                 this.networkId = networkId;
                 this.commsAdapter = commsAdapter;
                 this.isPreview = isPreview;
-                this.protocol = protocol;
             }
         }
 


### PR DESCRIPTION
## What does this PR change?

Fixes #3042 

Removes the `protocol` field from the `getRealm` response to the sdk as it is not defined in the docs.

## Test Instructions

Run a scene like this:

```
import {getRealm} from '~system/Runtime'

export async function main() {
    const { realmInfo } = await getRealm({})
    console.log(`${JSON.stringify(realmInfo)}`);
}
```

You should see in the scene logs a json like this on which `protocol` is not there:
```
{"baseUrl":"http://127.0.0.1:8000","realmName":"LocalPreview","networkId":0,"commsAdapter":"ws-room:ws://127.0.0.1:8000/mini-comms/room-1","isPreview":true}
```

Scene files: [get-realm-info.zip](https://github.com/user-attachments/files/23777288/get-realm-info.zip)

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
