### PR TITLE
fix: Web Request retry controller

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsContainer.cs
+++ b/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsContainer.cs
@@ -68,12 +68,14 @@ namespace DCL.WebRequests.Analytics
             IWebRequestController coreWebRequestController = new WebRequestController(analyticsContainer, web3IdentityProvider, requestHub, chromeDevtoolProtocolClient)
                                                             .WithDebugMetrics(cannotConnectToHostExceptionDebugMetric, requestCompleteDebugMetric)
                                                             .WithLog()
+                                                            .WithRetry()
                                                             .WithArtificialDelay(options)
                                                             .WithBudget(coreBudget, coreAvailableBudget);
 
             IWebRequestController sceneWebRequestController = new WebRequestController(analyticsContainer, web3IdentityProvider, requestHub, chromeDevtoolProtocolClient)
                                                              .WithDebugMetrics(cannotConnectToHostExceptionDebugMetric, requestCompleteDebugMetric)
                                                              .WithLog()
+                                                             .WithRetry()
                                                              .WithArtificialDelay(options)
                                                              .WithBudget(sceneBudget, sceneAvailableBudget);
 

--- a/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsContainer.cs
+++ b/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsContainer.cs
@@ -68,16 +68,16 @@ namespace DCL.WebRequests.Analytics
             IWebRequestController coreWebRequestController = new WebRequestController(analyticsContainer, web3IdentityProvider, requestHub, chromeDevtoolProtocolClient)
                                                             .WithDebugMetrics(cannotConnectToHostExceptionDebugMetric, requestCompleteDebugMetric)
                                                             .WithLog()
-                                                            .WithRetry()
                                                             .WithArtificialDelay(options)
-                                                            .WithBudget(coreBudget, coreAvailableBudget);
+                                                            .WithBudget(coreBudget, coreAvailableBudget)
+                                                            .WithRetry();
 
             IWebRequestController sceneWebRequestController = new WebRequestController(analyticsContainer, web3IdentityProvider, requestHub, chromeDevtoolProtocolClient)
                                                              .WithDebugMetrics(cannotConnectToHostExceptionDebugMetric, requestCompleteDebugMetric)
                                                              .WithLog()
-                                                             .WithRetry()
                                                              .WithArtificialDelay(options)
-                                                             .WithBudget(sceneBudget, sceneAvailableBudget);
+                                                             .WithBudget(sceneBudget, sceneAvailableBudget)
+                                                             .WithRetry();
 
             CreateStressTestUtility();
             CreateWebRequestDelayUtility();

--- a/Explorer/Assets/DCL/WebRequests/BudgetedWebRequestController.cs
+++ b/Explorer/Assets/DCL/WebRequests/BudgetedWebRequestController.cs
@@ -2,7 +2,6 @@
 using DCL.DebugUtilities.UIBindings;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.WebRequests.RequestsHub;
-using System;
 
 namespace DCL.WebRequests
 {
@@ -31,20 +30,12 @@ namespace DCL.WebRequests
             {
                 lock (debugBudget) { debugBudget.Value--; }
 
-                TResult? result = await origin.SendAsync<TWebRequest, TWebRequestArgs, TWebRequestOp, TResult>(envelope, op);
-
-                ReleaseBudget();
-                return result;
+                return await origin.SendAsync<TWebRequest, TWebRequestArgs, TWebRequestOp, TResult>(envelope, op);
             }
-            catch (Exception e)
-            {
-                ReleaseBudget();
-                throw;
-            }
-
-            void ReleaseBudget()
+            finally
             {
                 lock (debugBudget) { debugBudget.Value++; }
+
                 totalBudgetAcquired.Dispose();
             }
         }

--- a/Explorer/Assets/DCL/WebRequests/RequestEnvelope.cs
+++ b/Explorer/Assets/DCL/WebRequests/RequestEnvelope.cs
@@ -55,6 +55,10 @@ namespace DCL.WebRequests
             IgnoreIrrecoverableErrors = ignoreIrrecoverableErrors;
         }
 
+        // Requests with a signature are not idempotent due to the possible signature expiration
+        public bool IsIdempotent() =>
+            default(TWebRequest).Idempotent && !signInfo.HasValue;
+
         public override string ToString() =>
             "RequestEnvelope:"
             + $"\nWebRequestType: {typeof(TWebRequest).Name}"

--- a/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
@@ -230,9 +230,10 @@ namespace DCL.WebRequests
             new DebugMetricsWebRequestController(origin, requestCannotConnectDebugMetric,
                 requestCompleteDebugMetric);
 
-        public static IWebRequestController WithBudget(this IWebRequestController origin, int totalBudget, ElementBinding<ulong> debugBudget)
-        {
-            return new BudgetedWebRequestController(origin, totalBudget, debugBudget);
-        }
+        public static IWebRequestController WithBudget(this IWebRequestController origin, int totalBudget, ElementBinding<ulong> debugBudget) =>
+            new BudgetedWebRequestController(origin, totalBudget, debugBudget);
+
+        public static IWebRequestController WithRetry(this IWebRequestController origin) =>
+            new WebRequestRetryController(origin);
     }
 }

--- a/Explorer/Assets/DCL/WebRequests/WebRequestRetryController.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestRetryController.cs
@@ -1,0 +1,63 @@
+using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
+using DCL.WebRequests.RequestsHub;
+using Sentry;
+using System;
+using System.Text;
+using System.Threading;
+
+namespace DCL.WebRequests
+{
+    public class WebRequestRetryController : IWebRequestController
+    {
+        private readonly IWebRequestController origin;
+
+        public WebRequestRetryController(IWebRequestController origin)
+        {
+            this.origin = origin;
+        }
+
+        private static readonly ThreadLocal<StringBuilder> BREADCRUMB_BUILDER = new (() => new StringBuilder(150));
+
+        public async UniTask<TResult?> SendAsync<TWebRequest, TWebRequestArgs, TWebRequestOp, TResult>(RequestEnvelope<TWebRequest, TWebRequestArgs> envelope, TWebRequestOp op) where TWebRequest: struct, ITypedWebRequest where TWebRequestArgs: struct where TWebRequestOp: IWebRequestOp<TWebRequest, TResult>
+        {
+            var attemptNumber = 0;
+            RetryPolicy retryPolicy = envelope.CommonArguments.RetryPolicy;
+
+            while (true)
+            {
+                try
+                {
+                    attemptNumber++;
+                    return await origin.SendAsync<TWebRequest, TWebRequestArgs, TWebRequestOp, TResult>(envelope, op);
+                }
+                catch (UnityWebRequestException exception)
+                {
+                    if (!envelope.SuppressErrors)
+
+                        // Print verbose
+                        ReportHub.LogError(
+                            envelope.ReportData,
+                            $"Exception (code {exception.ResponseCode}) occured on loading {typeof(TWebRequest).Name} from {envelope.CommonArguments.URL} with {envelope}\n"
+                            + $"Attempt: {attemptNumber}/{retryPolicy.maxRetriesCount + 1}"
+                        );
+
+                    (bool canBeRepeated, TimeSpan retryDelay) = WebRequestUtils.CanBeRepeated(attemptNumber, retryPolicy, envelope.IsIdempotent(), exception);
+
+                    if (!canBeRepeated && !envelope.IgnoreIrrecoverableErrors)
+                    {
+                        // Ignore the file error as we always try to read from the file first
+                        if (!envelope.CommonArguments.URL.Value.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+                            SentrySdk.AddBreadcrumb($"{envelope.ReportData.Category}: Irrecoverable exception (code {exception.ResponseCode}) occured on executing {envelope.GetBreadcrumbString(BREADCRUMB_BUILDER.Value)}", level: BreadcrumbLevel.Info);
+
+                        throw;
+                    }
+
+                    await UniTask.Delay(retryDelay, DelayType.Realtime, cancellationToken: envelope.Ct);
+                }
+            }
+        }
+
+        IRequestHub IWebRequestController.requestHub => origin.requestHub;
+    }
+}

--- a/Explorer/Assets/DCL/WebRequests/WebRequestRetryController.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestRetryController.cs
@@ -10,6 +10,7 @@ namespace DCL.WebRequests
 {
     public class WebRequestRetryController : IWebRequestController
     {
+        private static readonly ThreadLocal<StringBuilder> BREADCRUMB_BUILDER = new (() => new StringBuilder(150));
         private readonly IWebRequestController origin;
 
         public WebRequestRetryController(IWebRequestController origin)
@@ -17,7 +18,6 @@ namespace DCL.WebRequests
             this.origin = origin;
         }
 
-        private static readonly ThreadLocal<StringBuilder> BREADCRUMB_BUILDER = new (() => new StringBuilder(150));
 
         public async UniTask<TResult?> SendAsync<TWebRequest, TWebRequestArgs, TWebRequestOp, TResult>(RequestEnvelope<TWebRequest, TWebRequestArgs> envelope, TWebRequestOp op) where TWebRequest: struct, ITypedWebRequest where TWebRequestArgs: struct where TWebRequestOp: IWebRequestOp<TWebRequest, TResult>
         {

--- a/Explorer/Assets/DCL/WebRequests/WebRequestRetryController.cs.meta
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestRetryController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 98c04a3b6490404886c1018318d9f6e1
+timeCreated: 1764189175

--- a/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
@@ -27,11 +27,6 @@ namespace DCL.WebRequests
             catch (UnityWebRequestException e) { throw newExceptionFactoryMethod(e); }
         }
 
-        public static bool IsIdempotent<TWebRequest>(this TWebRequest webRequest, in WebRequestSignInfo? signInfo) where TWebRequest: ITypedWebRequest =>
-
-            // Requests with a signature are not idempotent due to the possible signature expiration
-            webRequest.Idempotent && !signInfo.HasValue;
-
         public static (bool canBeRepeated, TimeSpan retryDelay) CanBeRepeated(int attemptNumber, RetryPolicy retryPolicy, bool idempotent, UnityWebRequestException webRequestException)
         {
             // Retries count are exhausted (attemptNumber is 1-based)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Due to the exponential backoff, web requests could get stuck. 

This was detected with the profile images requested [here](https://github.com/decentraland/unity-explorer/blob/ab21961558c6bc8a222ccf721484d6dbbe9859f2/Explorer/Assets/DCL/UI/Profiles/Helpers/ProfileRepositoryWrapper.cs#L21).

Have enough profile images fail, and the exponential backoff could block the entire queue budget.

To avoid this, I ve introduced a new decorator that doesnt block the budget.

## Test Instructions


### Test Steps
1. Go to `zone`, with an account you know you have friends
2. Check your `Core Budget` value in `Web REquest Debug Metrics`. It should not be stuck in a value below 15. It can ping pong, but not get stuck


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
