### PR TITLE
fix: force black screen on video deactivation in scene

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -182,7 +182,7 @@ namespace DCL.SDKComponents.MediaStream
         {
             if (!playerComponent.IsPlaying)
             {
-                if (playerComponent.State == VideoState.VsError)
+                if (playerComponent.State is VideoState.VsError or VideoState.VsNone)
                 {
                     RenderBlackTexture(ref assignedTexture);
                     return;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6192 
This PR sets the screen to black when a video source is deactivated in a scene with admin tools

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] Be admin of a scene where to test admin tools

### Test Steps
1. Enter the scene
2. play a video via admin tools
3. Verify that if i deactivate the video the screen appears black
4. Verify that nothing changed with other behaviours like switching to livekit stream, etc...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
