### PR TITLE
fix: avoid error preventing loading screen from showing on community event jump in

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
@@ -208,7 +208,7 @@ namespace MVC
             finally
             {
                 // Pop the stack
-                PopupPopInfo popupPopInfo = windowsStackManager.PopPopup(controller);
+                PopupPopInfo popupPopInfo = windowsStackManager.PopPopup(controller, windowsStackManager.GetControllerClosure(controller)?.Task.Status != UniTaskStatus.Succeeded);
 
                 if (popupPopInfo.NewTopMostController != null)
                 {

--- a/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/IWindowsStackManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/IWindowsStackManager.cs
@@ -36,6 +36,6 @@ namespace MVC
         ///     Returns the previous controller in the stack.
         ///     Controller can be popped from the middle?
         /// </summary>
-        PopupPopInfo PopPopup(IController controller);
+        PopupPopInfo PopPopup(IController controller, bool shouldGracefullyClose = true);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/WindowStackManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/WindowsStackManager/WindowStackManager.cs
@@ -124,17 +124,13 @@ namespace MVC
 
         private void TryGracefulClose(IController controller)
         {
-            for (int i = controllersClosures.Count - 1; i >= 0; i--)
-            {
+            for (int i = 0; i < controllersClosures.Count; i++)
                 if (controllersClosures[i].controller == controller)
                 {
                     controllersClosures[i].closer.TrySetResult();
-                    // Safe check to prevent errors in parallel async flows
-                    if (i < controllersClosures.Count)
-                        controllersClosures.RemoveAt(i);
+                    controllersClosures.RemoveAt(i);
                     break;
                 }
-            }
         }
 
         public UniTaskCompletionSource? GetControllerClosure(IController controller)
@@ -152,10 +148,12 @@ namespace MVC
             topController = null;
         }
 
-        public PopupPopInfo PopPopup(IController controller)
+        public PopupPopInfo PopPopup(IController controller, bool shouldGracefullyClose = true)
         {
             RemovePopup(controller);
-            TryGracefulClose(controller);
+
+            if(shouldGracefullyClose)
+                TryGracefulClose(controller);
 
             if (popupStack.Count == 0)
             {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6314 
This PR fixes a double closure of popups panel in a specific scenario when a top screen caused multiple popups to close

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Open the community browser
2. Open a community card of a community with scheduled events
3. Open one of the events
4. Scroll to the bottom and press "Jump In"
5. Verify that the loading screen appears and when teleported all previous screens are closed


### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
