### PR TITLE
fix: dont invalidate portable experiences partitions on realm change

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -29,7 +29,7 @@ using Global.AppArgs;
 using Unity.Mathematics;
 using Utility;
 
- namespace Global.Dynamic
+namespace Global.Dynamic
 {
     public class RealmController : IGlobalRealmController
     {
@@ -43,7 +43,8 @@ using Utility;
                                                                          .WithNone<DeleteEntityIntention, ISceneFacade>();
 
         private static readonly QueryDescription INVALIDATE_PARTITIONS = new QueryDescription()
-           .WithAll<PartitionComponent, ISceneFacade>();
+                                                                        .WithAll<PartitionComponent, ISceneFacade>()
+                                                                        .WithNone<PortableExperienceComponent, SmartWearableId>();
 
         private readonly List<ISceneFacade> allScenes = new (PoolConstants.SCENES_COUNT);
         private readonly ServerAbout serverAbout = new ();
@@ -303,10 +304,7 @@ using Utility;
         private void InvalidateScenePartitions(World world)
         {
             world.Query(in INVALIDATE_PARTITIONS,
-                (ref PartitionComponent partitionComponent) =>
-                {
-                    partitionComponent.Bucket = byte.MaxValue;
-                });
+                (ref PartitionComponent partitionComponent) => { partitionComponent.Bucket = byte.MaxValue; });
         }
 
         private void ComplimentWithVolatilePointers(World world, Entity realmEntity)


### PR DESCRIPTION
## What does this PR change?

Fixes #6331 

Filters portable experiences from the `ScenePartition` invalidation query, since PXs are not needed to be invalidated. Otherwise they stop executing when changing the realm.

## Test Instructions

1. Go to music festival (-69,-61).
2. Check that the PX is spawned. You should see the icon on the right of the screen.
3. Go to any world (lorux0r.dcl.eth). Check that the icon is not there anymore.
4. Go back to music festival. Check that the PX spawns again and the icon becomes visible and interactable.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
