### PR TITLE
Depend on ClearScript for which we have debug symbols

### DIFF
--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -45,7 +45,7 @@
     "decentraland.renderfeatures": "git@github.com:decentraland/unity-explorer-packages.git?path=/RenderGraphs/RenderFeatures",
     "io.sentry.unity": "https://github.com/getsentry/unity.git#2.4.0",
     "net.tnrd.nsubstitute": "https://github.com/decentraland/Unity3D-NSubstitute.git",
-    "org.decentraland.clearscript": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package#unity",
+    "org.decentraland.clearscript": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package",
     "superscrollview": "git@github.com:decentraland/unity-explorer-packages.git?path=/SuperScrollView",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -502,13 +502,13 @@
       "hash": "cdd11bb74398afae73e71b6fe01114f597a6ce08"
     },
     "org.decentraland.clearscript": {
-      "version": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package#unity",
+      "version": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.nuget.newtonsoft-json": "3.2.1"
       },
-      "hash": "1ee65c8dfec5402cca38dda85e94a1edfde6d882"
+      "hash": "04d5ba67d2a314178dc0066aa53da3428c9964b2"
     },
     "superscrollview": {
       "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/SuperScrollView",


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change has the game depend on a ClearScript version for which we have debug symbols. This is only a rebuild of binaries. No code has been changed.

This change will help diagnose the crashes we've been having. See #6114

## Test Instructions

Test that scenes work.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
