### PR TITLE
hotfix: ensure media is closed and volume is set to 0 when released to the pool

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerCustomPool.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerCustomPool.cs
@@ -86,6 +86,8 @@ namespace DCL.SDKComponents.MediaStream
             if (UnityObjectUtils.IsQuitting) return;
 
             mediaPlayer.Stop();
+            mediaPlayer.CloseMedia();
+            mediaPlayer.AudioVolume = 0f;
             mediaPlayer.enabled = false;
             mediaPlayer.gameObject.SetActive(false);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR fixes the audios of videos being heard when leaving a scene, this will be released as an hotfix for the ongoing music festival

## Test Instructions
Verify that when leaving a scene you don't hear the audio of previous scenes anymore, test all videos and streams in music festival to verify all works fine

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
