### PR TITLE
hotfix: revert ClearScript version hash

### DIFF
--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -45,7 +45,7 @@
     "decentraland.renderfeatures": "git@github.com:decentraland/unity-explorer-packages.git?path=/RenderGraphs/RenderFeatures",
     "io.sentry.unity": "https://github.com/getsentry/unity.git#2.4.0",
     "net.tnrd.nsubstitute": "https://github.com/decentraland/Unity3D-NSubstitute.git",
-    "org.decentraland.clearscript": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package",
+    "org.decentraland.clearscript": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package#unity",
     "superscrollview": "git@github.com:decentraland/unity-explorer-packages.git?path=/SuperScrollView",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -502,13 +502,13 @@
       "hash": "cdd11bb74398afae73e71b6fe01114f597a6ce08"
     },
     "org.decentraland.clearscript": {
-      "version": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package",
+      "version": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package#unity",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.nuget.newtonsoft-json": "3.2.1"
       },
-      "hash": "04d5ba67d2a314178dc0066aa53da3428c9964b2"
+      "hash": "1ee65c8dfec5402cca38dda85e94a1edfde6d882"
     },
     "superscrollview": {
       "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/SuperScrollView",


### PR DESCRIPTION
This PR is a hotfix that reverts the clearscript version.

This is needed to avoid the issues spotted on mac on main stage, videos not loading or very jittery.

