### PR TITLE
fix: invalidate community member list data on operation cancel

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityFetchingControllerBase.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityFetchingControllerBase.cs
@@ -41,7 +41,7 @@ namespace DCL.Communities.CommunitiesCard
             FetchNewDataAsync(cancellationToken).Forget();
         }
 
-        protected async UniTaskVoid FetchNewDataAsync(CancellationToken ct)
+        protected async UniTask FetchNewDataAsync(CancellationToken ct)
         {
             isFetching = true;
 

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListController.cs
@@ -23,6 +23,7 @@ using MVC;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using UnityEngine.Pool;
 using Utility;
 using FriendshipStatus = DCL.Friends.FriendshipStatus;
 
@@ -53,6 +54,7 @@ namespace DCL.Communities.CommunitiesCard.Members
         private GetCommunityResponse.CommunityData? communityData = null;
 
         private int requestAmount;
+
         private int RequestsAmount
         {
             get => requestAmount;
@@ -63,6 +65,7 @@ namespace DCL.Communities.CommunitiesCard.Members
                 view.UpdateRequestsCounter(value);
             }
         }
+
         protected override SectionFetchData<ICommunityMemberData> currentSectionFetchData => sectionsFetchData[currentSection];
 
         private CancellationTokenSource friendshipOperationCts = new ();
@@ -148,6 +151,7 @@ namespace DCL.Communities.CommunitiesCard.Members
             {
                 Result<bool> result = await communitiesDataProvider.ManageInviteRequestToJoinAsync(communityData!.Value.id, profile.Id, intention, ct)
                                                                    .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+
                 if (!result.Success || !result.Value)
                 {
                     NotificationsBusController.Instance.AddNotification(new ServerErrorNotification(MANAGE_REQUEST_ERROR_TEXT));
@@ -167,10 +171,9 @@ namespace DCL.Communities.CommunitiesCard.Members
 
                 RefreshGrid(true);
 
-                if(currentSectionFetchData.Items.Count == 0)
+                if (currentSectionFetchData.Items.Count == 0)
                     view.SetEmptyStateActive(true);
             }
-
         }
 
         private void OnMemberListSectionChanged(MembersListView.MemberListSections section)
@@ -208,15 +211,13 @@ namespace DCL.Communities.CommunitiesCard.Members
             try
             {
                 await mvcManager.ShowAsync(BlockUserPromptController.IssueCommand(
-                    new BlockUserPromptParams(new Web3Address(profile.Address), profile.Name, BlockUserPromptParams.UserBlockAction.BLOCK)),
+                        new BlockUserPromptParams(new Web3Address(profile.Address), profile.Name, BlockUserPromptParams.UserBlockAction.BLOCK)),
                     cancellationToken);
+
                 await FetchFriendshipStatusAndRefreshAsync(profile.Address, cancellationToken);
             }
             catch (OperationCanceledException) { }
-            catch (Exception ex)
-            {
-                ReportHub.LogException(ex, ReportCategory.COMMUNITIES);
-            }
+            catch (Exception ex) { ReportHub.LogException(ex, ReportCategory.COMMUNITIES); }
         }
 
         private void OnBanUser(ICommunityMemberData profile)
@@ -228,7 +229,7 @@ namespace DCL.Communities.CommunitiesCard.Members
             async UniTaskVoid BanUserAsync(CancellationToken token)
             {
                 Result<bool> result = await communitiesDataProvider.BanUserFromCommunityAsync(profile.Address, communityData?.id, token)
-                                                           .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+                                                                   .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
                 if (token.IsCancellationRequested)
                     return;
@@ -284,7 +285,7 @@ namespace DCL.Communities.CommunitiesCard.Members
             async UniTaskVoid KickUserAsync(CancellationToken token)
             {
                 Result<bool> result = await communitiesDataProvider.KickUserFromCommunityAsync(profile.Address, communityData?.id, token)
-                                                           .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+                                                                   .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
                 if (token.IsCancellationRequested)
                     return;
@@ -305,12 +306,15 @@ namespace DCL.Communities.CommunitiesCard.Members
             List<ICommunityMemberData> memberList = sectionsFetchData[MembersListView.MemberListSections.MEMBERS].Items;
 
             string? userAddress = web3IdentityCache.Identity?.Address;
+
             for (int i = 0; i < memberList.Count; i++)
                 if (memberList[i].Address.Equals(userAddress, StringComparison.OrdinalIgnoreCase))
                 {
                     memberList.RemoveAt(i);
+
                     if (currentSection == MembersListView.MemberListSections.MEMBERS)
                         RefreshGrid(true);
+
                     break;
                 }
         }
@@ -324,7 +328,7 @@ namespace DCL.Communities.CommunitiesCard.Members
             async UniTaskVoid AddModeratorAsync(CancellationToken token)
             {
                 Result<bool> result = await communitiesDataProvider.SetMemberRoleAsync(profile.Address, communityData?.id, CommunityMemberRole.moderator, token)
-                                                           .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+                                                                   .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
                 if (token.IsCancellationRequested)
                     return;
@@ -358,9 +362,8 @@ namespace DCL.Communities.CommunitiesCard.Members
 
             async UniTaskVoid RemoveModeratorAsync(CancellationToken token)
             {
-
                 Result<bool> result = await communitiesDataProvider.SetMemberRoleAsync(profile.Address, communityData?.id, CommunityMemberRole.member, token)
-                                                           .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+                                                                   .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
                 if (token.IsCancellationRequested)
                     return;
@@ -372,6 +375,7 @@ namespace DCL.Communities.CommunitiesCard.Members
                 }
 
                 List<ICommunityMemberData> memberList = sectionsFetchData[MembersListView.MemberListSections.MEMBERS].Items;
+
                 foreach (ICommunityMemberData member in memberList)
                     if (member.Address.Equals(profile.Address))
                     {
@@ -407,10 +411,7 @@ namespace DCL.Communities.CommunitiesCard.Members
                 chatEventBus.OpenPrivateConversationUsingUserId(profile.Address);
             }
             catch (OperationCanceledException) { }
-            catch (Exception ex)
-            {
-                ReportHub.LogException(ex, ReportCategory.COMMUNITIES);
-            }
+            catch (Exception ex) { ReportHub.LogException(ex, ReportCategory.COMMUNITIES); }
         }
 
         private void OpenProfilePassport(ICommunityMemberData profile) =>
@@ -455,8 +456,9 @@ namespace DCL.Communities.CommunitiesCard.Members
                         break;
                     case UserProfileContextMenuControlSettings.FriendshipStatus.BLOCKED:
                         await mvcManager.ShowAsync(BlockUserPromptController.IssueCommand(new BlockUserPromptParams(
-                            new Web3Address(userData.userAddress), userData.userName, BlockUserPromptParams.UserBlockAction.UNBLOCK)),
+                                new Web3Address(userData.userAddress), userData.userName, BlockUserPromptParams.UserBlockAction.UNBLOCK)),
                             ct);
+
                         break;
                     case UserProfileContextMenuControlSettings.FriendshipStatus.FRIEND:
                         await mvcManager.ShowAsync(UnfriendConfirmationPopupController.IssueCommand(new UnfriendConfirmationPopupController.Params
@@ -480,10 +482,7 @@ namespace DCL.Communities.CommunitiesCard.Members
                 await FetchFriendshipStatusAndRefreshAsync(userData.userAddress, ct);
             }
             catch (OperationCanceledException) { }
-            catch (Exception ex)
-            {
-                ReportHub.LogException(ex, ReportCategory.COMMUNITIES);
-            }
+            catch (Exception ex) { ReportHub.LogException(ex, ReportCategory.COMMUNITIES); }
         }
 
         private async UniTask FetchFriendshipStatusAndRefreshAsync(string userId, CancellationToken ct)
@@ -513,8 +512,7 @@ namespace DCL.Communities.CommunitiesCard.Members
 
             Result<ICommunityMemberPagedResponse> response = await responseTask.SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
-            if (ct.IsCancellationRequested)
-                return 0;
+            ct.ThrowIfCancellationRequested();
 
             if (!response.Success)
             {
@@ -537,29 +535,43 @@ namespace DCL.Communities.CommunitiesCard.Members
 
         public void ShowMembersList(GetCommunityResponse.CommunityData community, CancellationToken ct)
         {
-            cancellationToken = ct;
-
-            if (communityData is not null && community.id.Equals(communityData.Value.id)) return;
-
-            communityData = community;
-            view.SetSectionButtonsActive(communityData?.role is CommunityMemberRole.moderator or CommunityMemberRole.owner);
-            panelLifecycleTask = new UniTaskCompletionSource();
-            view.SetCommunityData(community, panelLifecycleTask!.Task);
-
-            FetchNewDataAsync(ct).Forget();
-
-            if (community.privacy == CommunityPrivacy.@private && communityData?.role is CommunityMemberRole.owner or CommunityMemberRole.moderator)
-                FetchRequestsToJoinAsync(ct).Forget();
-
+            ShowMemberListAsync().Forget();
             return;
 
-            async UniTaskVoid FetchRequestsToJoinAsync(CancellationToken ctkn)
+            async UniTaskVoid ShowMemberListAsync()
+            {
+                List<UniTask> tasks = ListPool<UniTask>.Get();
+
+                try
+                {
+                    cancellationToken = ct;
+
+                    if (communityData is not null && community.id.Equals(communityData.Value.id)) return;
+
+                    communityData = community;
+                    view.SetSectionButtonsActive(communityData?.role is CommunityMemberRole.moderator or CommunityMemberRole.owner);
+                    panelLifecycleTask = new UniTaskCompletionSource();
+                    view.SetCommunityData(community, panelLifecycleTask!.Task);
+
+                    tasks.Add(FetchNewDataAsync(ct));
+
+                    if (community.privacy == CommunityPrivacy.@private && communityData?.role is CommunityMemberRole.owner or CommunityMemberRole.moderator)
+                        tasks.Add(FetchRequestsToJoinAsync(ct));
+
+                    await UniTask.WhenAll(tasks);
+                }
+
+                // Fixes https://github.com/decentraland/unity-explorer/issues/6317
+                catch (OperationCanceledException) { communityData = null; }
+                finally { ListPool<UniTask>.Release(tasks); }
+            }
+
+            async UniTask FetchRequestsToJoinAsync(CancellationToken ctkn)
             {
                 Result<ICommunityMemberPagedResponse> response = await communitiesDataProvider.GetCommunityInviteRequestAsync(communityData?.id, InviteRequestAction.request_to_join, 1, 0, ctkn)
                                                                                               .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
-                if (ct.IsCancellationRequested)
-                    return;
+                ct.ThrowIfCancellationRequested();
 
                 if (!response.Success)
                     return;
@@ -582,9 +594,8 @@ namespace DCL.Communities.CommunitiesCard.Members
 
             async UniTaskVoid UnbanUserAsync(CancellationToken ct)
             {
-
                 Result<bool> result = await communitiesDataProvider.UnBanUserFromCommunityAsync(profile.Address, communityData?.id, ct)
-                                                           .SuppressToResultAsync(ReportCategory.COMMUNITIES);
+                                                                   .SuppressToResultAsync(ReportCategory.COMMUNITIES);
 
                 if (ct.IsCancellationRequested)
                     return;


### PR DESCRIPTION
## What does this PR change?

Fixes #6317 

The member list resolved data was marked as set when it was requested, but it was not invalidated if the operation was canceled, even though the data was never actually resolved. As a result, subsequent attempts did not trigger a new data request.
In order to be able to detect the operation was cancelled, it was required to improve the async calls and the exception handling on the member list retrieval process.

## Test Instructions

1. Open community browser
2. Select any community
3. Open the member list
4. Quickly switch to places tab
5. Go back to member list
6. It should load as expected

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
