### PR TITLE
fix: ignore share space manager chat when hovering smart wearables sidebar button

### DIFF
--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
@@ -390,10 +390,8 @@ namespace DCL.UI.Sidebar
             await sharedSpaceManager.ShowAsync(PanelsSharingSpace.Explore, new ExplorePanelParameter(section, backpackSection), PanelsSharingSpace.Chat);
         }
 
-        private void OnSmartWearablesButtonHover()
-        {
-            sharedSpaceManager.ShowAsync(PanelsSharingSpace.SmartWearables).Forget();
-        }
+        private void OnSmartWearablesButtonHover() =>
+            sharedSpaceManager.ShowAsync<ControllerNoData>(PanelsSharingSpace.SmartWearables, panelsToIgnore: PanelsSharingSpace.Chat).Forget();
 
         private void OnSmartWearablesButtonUnhover()
         {


### PR DESCRIPTION
# Pull Request Description
Fixes #6267 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR opens the sidebar smart wearables button tooltip (an MVC controller) ignoring the chat in the shared space manager. By doing so, the chat doesn't get minimized but stays open.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Follow the steps reported in the linked issue (and the comments)


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
