### PR TITLE
Hotfix: SOCIAL_EMOTE logs disabled

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsDevelopment.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsDevelopment.asset
@@ -601,15 +601,7 @@ MonoBehaviour:
     - Category: EMOTE_DEBUG
       Severity: 1
     - Category: SOCIAL_EMOTE
-      Severity: 3
-    - Category: SOCIAL_EMOTE
-      Severity: 2
-    - Category: SOCIAL_EMOTE
-      Severity: 0
-    - Category: SOCIAL_EMOTE
       Severity: 4
-    - Category: SOCIAL_EMOTE
-      Severity: 1
   sentryMatrix:
     entries: []
   debounceEnabled: 1

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
@@ -419,15 +419,7 @@ MonoBehaviour:
     - Category: EMOTE_DEBUG
       Severity: 1
     - Category: SOCIAL_EMOTE
-      Severity: 3
-    - Category: SOCIAL_EMOTE
-      Severity: 2
-    - Category: SOCIAL_EMOTE
-      Severity: 0
-    - Category: SOCIAL_EMOTE
       Severity: 4
-    - Category: SOCIAL_EMOTE
-      Severity: 1
   sentryMatrix:
     entries:
     - Category: AUDIO_SOURCES
@@ -790,6 +782,8 @@ MonoBehaviour:
       Severity: 4
     - Category: SOCIAL
       Severity: 1
+    - Category: SOCIAL_EMOTE
+      Severity: 4
   debounceEnabled: 1
   isSentryEnabled: 1
   isDebugLogEnabled: 1


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

All the logs related to the social emotes have been disabled to avoid bloating the log file and affect performance.