### PR TITLE
hotfix: [Communities] Events for "Decentraland Foundation" community are not loading

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
@@ -217,11 +217,16 @@ namespace DCL.Communities.CommunitiesCard.Events
                 placeInfoCache.Add(place.id, place);
 
             foreach (var item in eventResponse.Value.data.events)
+            {
+                if (!placeInfoCache.TryGetValue(item.place_id, out PlaceInfo? place))
+                    continue;
+
                 eventsFetchData.Items.Add(new PlaceAndEventDTO
                 {
-                    Place = placeInfoCache[item.place_id],
+                    Place = place,
                     Event = item
                 });
+            }
 
             return eventResponse.Value.data.total;
         }


### PR DESCRIPTION
# Pull Request Description
Fix #6424 

## What does this PR change?
Events for "Decentraland Foundation" community are not loading. They keep in loading state forever:

<img width="1656" height="942" alt="image" src="https://github.com/user-attachments/assets/622ba983-c106-45ad-a903-5791e1ebbe16" />

For some reason, it seems the places associated to some events of this community no longer exist and it generates an exception that break the Events section of the card.

```
KeyNotFoundException: The given key '9411f9bb-7f0c-4048-b598-233b159cf688' was not present in the dictionary.
System.Collections.Generic.Dictionary`2[TKey,TValue].get_Item (TKey key) (at <3272951baa974b2ab5e8de68d60bfc1e>:0)
DCL.Communities.CommunitiesCard.Events.EventListController.FetchDataAsync (System.Threading.CancellationToken ct) (at Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs:220)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1[TResult].GetResult (System.Int16 token) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskCompletionSource.cs:244)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2[TStateMachine,T].GetResult (System.Int16 token) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:342)
Cysharp.Threading.Tasks.UniTask`1+Awaiter[T].GetResult () (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTask.cs:653)
DCL.Communities.CommunitiesCard.CommunityFetchingControllerBase`2[T,U].FetchNewDataAsync (System.Threading.CancellationToken ct) (at Assets/DCL/Communities/CommunitiesCard/CommunityFetchingControllerBase.cs:60)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1[TResult].GetResult (System.Int16 token) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskCompletionSource.cs:244)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1[TStateMachine].GetResult (System.Int16 token) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:218)
Cysharp.Threading.Tasks.UniTask+Awaiter.GetResult () (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTask.cs:312)
Cysharp.Threading.Tasks.UniTaskExtensions+<>c.<Forget>b__16_0 (System.Object state) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskExtensions.cs:572)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
DCL.Diagnostics.DebugLogReportHandler:LogExceptionInternal(Exception, ReportData, Object)
DCL.Diagnostics.ReportHandlerBase:LogException(Exception, ReportData, Object)
DCL.Diagnostics.ReportHubLogger:UnityEngine.ILogHandler.LogException(Exception, Object) (at Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportHubLogger.cs:43)
UnityEngine.Debug:LogException(Exception)
Cysharp.Threading.Tasks.UniTaskScheduler:PublishUnobservedTaskException(Exception) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskScheduler.cs:90)
Cysharp.Threading.Tasks.<>c:<Forget>b__16_0(Object) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskExtensions.cs:576)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1:TrySetException(Exception) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskCompletionSource.cs:167)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1:SetException(Exception) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:210)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskMethodBuilder:SetException(Exception) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs:59)
DCL.Communities.CommunitiesCard.<FetchNewDataAsync>d__9:MoveNext() (at Assets/DCL/Communities/CommunitiesCard/CommunityFetchingControllerBase.cs:71)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`1:Run() (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:189)
Cysharp.Threading.Tasks.AwaiterActions:Continuation(Object) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTask.cs:21)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1:TrySetException(Exception) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskCompletionSource.cs:167)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2:SetException(Exception) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:334)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskMethodBuilder`1:SetException(Exception) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs:186)
DCL.Communities.CommunitiesCard.Events.<FetchDataAsync>d__31:MoveNext() (at Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs:226)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2:Run() (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:313)
Cysharp.Threading.Tasks.AwaiterActions:Continuation(Object) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTask.cs:21)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1:TrySetResult(Result`1) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskCompletionSource.cs:139)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2:SetResult(Result`1) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:328)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskMethodBuilder`1:SetResult(Result`1) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs:201)
DCL.Utilities.Extensions.<SuppressToResultAsync>d__1`1:MoveNext() (at Assets/DCL/Infrastructure/Utility/Extensions/UniTaskExtensions.cs:56)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2:Run() (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:313)
Cysharp.Threading.Tasks.AwaiterActions:Continuation(Object) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTask.cs:21)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1:TrySetResult(PlacesAPIResponse) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskCompletionSource.cs:139)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2:SetResult(PlacesAPIResponse) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:328)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskMethodBuilder`1:SetResult(PlacesAPIResponse) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs:201)
DCL.PlacesAPIService.<GetPlacesByIdsAsync>d__22:MoveNext() (at Assets/DCL/PlacesAPIService/PlacesAPIClient.cs:235)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2:Run() (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:313)
Cysharp.Threading.Tasks.AwaiterActions:Continuation(Object) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTask.cs:21)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1:TrySetResult(PlacesAPIResponse) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskCompletionSource.cs:139)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2:SetResult(PlacesAPIResponse) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:328)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskMethodBuilder`1:SetResult(PlacesAPIResponse) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs:201)
DCL.WebRequests.<SendAsync>d__3`4:MoveNext() (at Assets/DCL/WebRequests/ArtificialDelayWebRequestController.cs:32)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2:Run() (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:313)
Cysharp.Threading.Tasks.AwaiterActions:Continuation(Object) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTask.cs:21)
Cysharp.Threading.Tasks.UniTaskCompletionSourceCore`1:TrySetResult(PlacesAPIResponse) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/UniTaskCompletionSource.cs:139)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTask`2:SetResult(PlacesAPIResponse) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/StateMachineRunner.cs:328)
Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskMethodBuilder`1:SetResult(PlacesAPIResponse) (at ./Library/PackageCache/com.cysharp.unitask@f026e068eaed/Runtime/CompilerServices/AsyncUniTaskMethodBuilder.cs:201)
```

### Test Steps
1. Open the "Decentraland Foundation" community.
2. Check that the events in the right side of the card are being loaded correctly.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.