### PR TITLE
fix: Put JS cache while in editor on the correct path

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Factory/JsSource/Cache/FileJsSourcesCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Factory/JsSource/Cache/FileJsSourcesCache.cs
@@ -16,7 +16,7 @@ namespace SceneRuntime.Factory.WebSceneSource.Cache
 
         public void Cache(string path, ReadOnlySpan<byte> sourceCode)
         {
-            using var stream = new FileStream(path, FileMode.Create,
+            using var stream = new FileStream(FilePath(path), FileMode.Create,
                 FileAccess.Write, FileShare.None);
 
             stream.Write(sourceCode);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Editor was not placing the js file on the correct path. If not, we are getting the following noise on git:

<img width="720" height="396" alt="image" src="https://github.com/user-attachments/assets/ffeb781c-856d-42b7-948c-7bae0382e67b" />

Another question would be, do we even want to persist them there? But I guess someone uses them, so Im leaving them there

## Test Instructions


### Test Steps
1. Check that GP loads



## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
