### PR TITLE
Fixed problem with avatars rotating suddenly while sitting on a bench

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/SocialEmoteInteractionSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/SocialEmoteInteractionSystem.cs
@@ -194,7 +194,8 @@ namespace DCL.AvatarRendering.Emotes.SocialEmotes
         [None(typeof(PlayerComponent))]
         private void InitiatorLooksAtSocialEmoteTarget([Data] string targetWalletAddress, [Data] bool isInitiatorPlayingEmote, in CharacterTransform targetTransform, Profile targetProfile)
         {
-            if (targetWalletAddress == targetProfile.UserId && isInitiatorPlayingEmote)
+            // A remote initiator looks at the target of a directed social emote it sent
+            if (!string.IsNullOrEmpty(targetProfile.UserId) && targetWalletAddress == targetProfile.UserId && isInitiatorPlayingEmote)
                 World.Add(playerEntity, new PlayerLookAtIntent(targetTransform.Position));
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

It happened when a user updated the profile. That causes the cached profile data to reset and there is a condition that compared that empty wallet address of that profile with the target of a directed emote operation (which is not happening). Due to both are empty strings it was meeting the condition and making avatars look at an inexistent initiator of a social emote.

It just checks the profile userId is not empty.

## Test Instructions

### Steps
1. Enter DCL with avatar 1, at Genesis.
2. Make avatar 1 sit on a bench.
3. Enter DCL with avatar 2, at Genesis.
4. With avatar 2, open your own profile. Edit the description. Save.
5. Avatar 1 should stay sitting normally, without rotating.