### PR TITLE
chore: removed unused bones in wearables hierarchy

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetUtility.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetUtility.cs
@@ -63,15 +63,6 @@ namespace DCL.AvatarRendering.Loading.Assets
             if (pooledList.Value.Count == 0)
                 return;
 
-            // Re-parent all renderer GameObjects directly to the wearable root to reduce the hierarchy clutter
-            foreach (Renderer renderer in pooledList.Value)
-            {
-                Transform transform = renderer.transform;
-
-                if (transform != wearableRoot && transform.parent != wearableRoot)
-                    transform.SetParent(wearableRoot, true);
-            }
-
             for (int i = wearableRoot.childCount - 1; i >= 0; i--)
             {
                 Transform child = wearableRoot.GetChild(i);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6396 
this pr removes the unused bones game objects from the hierarchy of the wearables asset bundles after the mesh data has been extrapolated by the skinning compute shader.
This reduces the clutter we have in the hierarchy of the ab for wearables, child of each avatar

## Test Instructions
This PR removes unused stuff, so it shouldn't have any impact visually, but to make sure we need to do a proper testing with many wearables, verify that wearables are correctly equipped when changed in the backpack.
Check also that other people are rendered as expected and animations don't break wearables in general.

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
