### PR TITLE
fix: equip avatar shape

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableProviderHelper.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableProviderHelper.cs
@@ -15,8 +15,19 @@ namespace DCL.AvatarRendering.Wearables.Helpers
 {
     public static class WearableProviderHelper
     {
-        public static async UniTaskVoid FetchWearableByPointerAndExecuteAsync(string pointer, IWearablesProvider wearablesProvider, IReadOnlyEquippedWearables equippedWearables, Action<IWearable> onWearableFetched, CancellationToken ct)
+        public static async UniTaskVoid FetchWearableByPointerAndExecuteAsync(string pointer,
+            IWearablesProvider wearablesProvider,
+            IWearableStorage wearableStorage,
+            IReadOnlyEquippedWearables equippedWearables,
+            Action<IWearable> onWearableFetched,
+            CancellationToken ct)
         {
+            if (wearableStorage.TryGetElement(pointer, out var wearable))
+            {
+                onWearableFetched(wearable);
+                return;
+            }
+
             List<URN> urnRequest = ListPool<URN>.Get();
             try
             {

--- a/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackBusController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackBusController.cs
@@ -97,24 +97,14 @@ namespace DCL.Backpack.BackpackBus
         private void HandleFilterCommand(BackpackFilterCommand command) =>
             backpackEventBus.SendFilter(command.Category, command.CategoryEnum, command.SearchText);
 
-        private void HandleSelectWearableCommand(BackpackSelectWearableCommand command)
-        {
-            if (wearableStorage.TryGetElement(command.Id, out IWearable wearable))
-                SelectWearable(wearable);
-            else
-                WearableProviderHelper.FetchWearableByPointerAndExecuteAsync(command.Id, wearablesProvider, equippedWearables, SelectWearable, fetchWearableCts.Token).Forget();
-        }
+        private void HandleSelectWearableCommand(BackpackSelectWearableCommand command) =>
+            WearableProviderHelper.FetchWearableByPointerAndExecuteAsync(command.Id, wearablesProvider, wearableStorage, equippedWearables, SelectWearable, fetchWearableCts.Token).Forget();
 
         private void SelectWearable(IWearable wearable) =>
             backpackEventBus.SendWearableSelect(wearable);
 
-        private void HandleEquipWearableCommand(BackpackEquipWearableCommand command)
-        {
-            if (wearableStorage.TryGetElement(command.Id, out IWearable wearable))
-                EquipWearable(wearable, command);
-            else
-                WearableProviderHelper.FetchWearableByPointerAndExecuteAsync(command.Id, wearablesProvider, equippedWearables, item => EquipWearable(item, command), fetchWearableCts.Token).Forget();
-        }
+        private void HandleEquipWearableCommand(BackpackEquipWearableCommand command) =>
+            WearableProviderHelper.FetchWearableByPointerAndExecuteAsync(command.Id, wearablesProvider, wearableStorage, equippedWearables, item => EquipWearable(item, command), fetchWearableCts.Token).Forget();
 
         private void EquipWearable(IWearable wearable, BackpackEquipWearableCommand command)
         {

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -228,7 +228,7 @@ namespace DCL.Backpack
         }
 
         private void EquipItem(int slot, string itemId) =>
-            WearableProviderHelper.FetchWearableByPointerAndExecuteAsync(itemId, wearablesProvider, equippedWearables,
+            WearableProviderHelper.FetchWearableByPointerAndExecuteAsync(itemId, wearablesProvider, wearableStorage, equippedWearables,
                 wearable => TryEquippingItemAsync(wearable, itemId, CancellationToken.None).Forget(),
                 CancellationToken.None).Forget();
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR firstly uses the wearable storage instead of fetching the wearable for the currently equipped avatar shape. By doing so, it enables equipping different avatar shapes.

Before, in order to equip baseMale, it was requesting the baseFemale version (if that was equipped), leading to unsolvable wearables.

This also reduces the fetching requests as the equip button now exploits the cache.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Verify you are able to equip the avatar shape wearable

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
