### PR TITLE
Fix: When playing start animation with sound and then outcome without sound it was still playing

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -551,11 +551,14 @@ namespace DCL.AvatarRendering.Emotes.Play
                 if (emoteComponent.Metadata.IsSocialEmote &&
                     emoteIntent.TriggerSource != TriggerSource.PREVIEW &&
                     emoteComponent.SocialEmote.IsPlayingOutcome &&
-                    emote.SocialEmoteOutcomeAudioAssetResults != null && emote.SocialEmoteOutcomeAudioAssetResults[emoteComponent.SocialEmote.CurrentOutcome].HasValue)
+                    emote.SocialEmoteOutcomeAudioAssetResults != null)
                 {
                     ReportHub.Log(ReportCategory.SOCIAL_EMOTE, "PlayNewEmote() AUDIO for outcome " + emoteComponent.SocialEmote.CurrentOutcome);
 
-                    audioClip = emote.SocialEmoteOutcomeAudioAssetResults[emoteComponent.SocialEmote.CurrentOutcome]!.Value.Asset;
+                    if (emote.SocialEmoteOutcomeAudioAssetResults[emoteComponent.SocialEmote.CurrentOutcome].HasValue)
+                        audioClip = emote.SocialEmoteOutcomeAudioAssetResults[emoteComponent.SocialEmote.CurrentOutcome]!.Value.Asset;
+                    else
+                        audioClip = null; // Playing outcome animation without sound after a start animation that had a sound
                 }
 
                 bool playedSuccessfully = emotePlayer.Play(mainAsset, audioClip, emote.IsLooping(), emoteIntent.Spatial, in avatarView, ref emoteComponent);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Audio clip is now null when outcome animation does not have sound.

## Test Instructions

Prerrequisites: Needs an emote that plays a sound in the start animation, no sound in one outcome and other sound in other outcome. Ask @QThund for it.

### Outcome without sound
1. Play start animation. Hear the sound repeating.
2. React using other avatar, choosing the outcome without sound. Both play outcome animation. No sound plays.

### Outcome with sound
1. Play start animation. Hear the sound repeating.
2. React using other avatar, choosing the outcome with sound. Both play outcome animation. The other sound plays.