### PR TITLE
fix: State of the Community Notifications toggle UI doesn't match the real state

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/CheckCommunityNotificationOptOutResponse.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesDataProvider/DTOs/CheckCommunityNotificationOptOutResponse.cs
@@ -3,10 +3,10 @@
 namespace DCL.Communities.CommunitiesDataProvider.DTOs
 {
     [Serializable]
-    public readonly struct CheckCommunityNotificationOptOutResponse
+    public struct CheckCommunityNotificationOptOutResponse
     {
-        public readonly string scope;
-        public readonly string scopeId;
-        public readonly bool optedOut;
+        public string scope;
+        public string scopeId;
+        public bool optedOut;
     }
 }


### PR DESCRIPTION
# Pull Request Description
Fix #6487 

## What does this PR change?
The state of the toggle UI didn't match the real state from the back-end.

### Test Steps
1. Open the card of any joined community.
2. Click on the 3-dots menu.
3. Set the notifications toggle to OFF.
4. Close the card and re-open it.
5. Check that the toggle continue being OFF.
6. Repeat the same but now setting the toggle as ON.
7. The state of the toggle UI should always matchs the last setting.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.