### PR TITLE
fix: Emotes playback and inconsistencies, NRE if mainAsset is null

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -508,7 +508,11 @@ namespace DCL.AvatarRendering.Emotes.Play
         private void PlayNewEmote(Entity entity, ref CharacterEmoteComponent emoteComponent, ref CharacterEmoteIntent emoteIntent,
             in IAvatarView avatarView, ref AvatarShapeComponent avatarShapeComponent)
         {
-            if(emoteIntent.EmoteAsset == null || emoteIntent.SocialEmote.IsInitiatorOutcomeAnimationWaitingForReceiverAnimationLoop)
+            BodyShape bodyShape = avatarShapeComponent.BodyShape;
+            GameObject? mainAsset = emoteIntent.EmoteAsset?.AssetResults[bodyShape]?.Asset?.MainAsset;
+
+            if (mainAsset is null
+                    || emoteIntent.SocialEmote.IsInitiatorOutcomeAnimationWaitingForReceiverAnimationLoop)
                 return;
 
             ReportHub.Log(ReportCategory.SOCIAL_EMOTE, "PlayNewEmote()");
@@ -530,9 +534,6 @@ namespace DCL.AvatarRendering.Emotes.Play
                 if (avatarView.IsAnimatorInTag(AnimationHashes.JUMPING_TAG) ||
                     (avatarView.GetAnimatorFloat(AnimationHashes.MOVEMENT_BLEND) > 0.1f && !emoteIntent.SocialEmote.UseOutcomeReactionAnimation)) // Note: When playing the outcome animation of an avatar that is reacting, there is no movement blending
                     return;
-
-                BodyShape bodyShape = avatarShapeComponent.BodyShape;
-                GameObject mainAsset = emote.AssetResults[bodyShape]!.Value.Asset!.MainAsset;
 
                 // Existing emoteComponent is overwritten with new emote info
                 emoteComponent.Reset();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This PR fixes **emote prop flickering** observed in crowded scenes by **tightening the validity check for the emote main asset** before proceeding with emote playback.

### Problem

In high avatar density scenarios, emotes that spawn props could enter an **invalid transient state** where:

* `EmoteAsset` exists,
* but the **resolved `MainAsset` for the current `BodyShape` is null or not yet available**.

EmoteSystem might throw the Exception:

```
InvalidOperationException: Nullable object must have a value.
System.Nullable`1[T].get_Value () (at <048969093d6c400cac9599b0ce4feb00>:0)
DCL.AvatarRendering.Emotes.Play.CharacterEmoteSystem.PlayNewEmote (Arch.Core.Entity entity, DCL.AvatarRendering.Emotes.CharacterEmoteComponent& emoteComponent, DCL.AvatarRendering.Emotes.CharacterEmoteIntent& emoteIntent, DCL.AvatarRendering.AvatarShape.UnityInterface.IAvatarView& avatarView, DCL.AvatarRendering.AvatarShape.Components.AvatarShapeComponent& avatarShapeComponent) (at Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs:535)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
DCL.Diagnostics.DebugLogReportHandler:LogExceptionInternal(Exception, ReportData, Object)
DCL.Diagnostics.ReportHandlerBase:LogException(Exception, ReportData, Object)
DCL.Diagnostics.ReportHubLogger:LogException(Exception, ReportData, ReportHandler)
DCL.Diagnostics.ReportHub:LogException(Exception, ReportData, ReportHandler)
DCL.AvatarRendering.Emotes.Play.CharacterEmoteSystem:PlayNewEmote(Entity, CharacterEmoteComponent&, CharacterEmoteIntent&, IAvatarView&, AvatarShapeComponent&) (at Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs:577)
DCL.AvatarRendering.Emotes.Play.CharacterEmoteSystem:PlayNewEmoteQuery(World) (at Arch.System.SourceGenerator/Arch.System.SourceGenerator.QueryGenerator/CharacterEmoteSystem.PlayNewEmote(Entity, ref CharacterEmoteComponent, ref CharacterEmoteIntent, in IAvatarView, ref AvatarShapeComponent).g.cs:41)
DCL.AvatarRendering.Emotes.Play.CharacterEmoteSystem:Update(Single) (at Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs:116)
ECS.Abstract.BaseUnityLoopSystem:Update(Single&) (at Assets/DCL/Infrastructure/ECS/Abstract/BaseUnityLoopSystem.cs:60)
Arch.SystemGroups.ExecutionNode`1:Update(Single&, Boolean) (at ./Library/PackageCache/com.arch.systemgroups@30d4d502ace9/ExecutionNode.cs:78)
Arch.SystemGroups.SystemGroup:Update(Info&) (at ./Library/PackageCache/com.arch.systemgroups@30d4d502ace9/SystemGroup.cs:107)
Arch.SystemGroups.DefaultSystemGroups.PresentationSystemGroup:Update() (at ./Library/PackageCache/com.arch.systemgroups@30d4d502ace9/DefaultSystemGroups/PresentationSystemGroup.cs:23)
Arch.SystemGroups.SystemGroupAggregate:TriggerUpdate() (at ./Library/PackageCache/com.arch.systemgroups@30d4d502ace9/PlayerLoopHelper/Aggregation/SystemGroupAggregate.cs:36)

```

This allowed the emote flow to continue with **incomplete asset state**, causing repeated attach/detach cycles and visible **flickering** of props during emote playback.

The issue was amplified under load (crowded scenes, social emotes), where asset resolution and state sync are more likely to race.

### Solution

* Resolve the `MainAsset` **explicitly and early**, using the current `BodyShape`.
* Cancel emote playback if the resolved `MainAsset` is `null`.

This ensures emote execution only proceeds when **all required invariants are satisfied**, preventing invalid intermediate states from propagating down the pipeline.

### Summary

```csharp
BodyShape bodyShape = avatarShapeComponent.BodyShape;
GameObject? mainAsset = emoteIntent.EmoteAsset?.AssetResults[bodyShape]?.Asset?.MainAsset;

if (mainAsset is null
    || emoteIntent.SocialEmote.IsInitiatorOutcomeAnimationWaitingForReceiverAnimationLoop)
    return;
```

This replaces a weaker check that only validated `EmoteAsset` existence, not the resolved runtime asset.

### Impact

* Eliminates prop flickering for emotes with spawned assets.
* Stabilizes emote playback under high load.
* No functional changes to animation logic or asset loading order.

---

## Test Instructions

### Test Steps

1. Enter a crowded scene with multiple active avatars.
2. Trigger emotes that spawn props and ask others to do the same.
3. Observe emotes during full playback duration.
4. Repeat with multiple users triggering emotes simultaneously.

### Expected Result

* Emote props remain **consistently visible** for the full emote duration.
* No flickering, popping, or repeated spawn/despawn behavior.

### Additional Testing Notes

* Verify both **initiator** and **receiver** sides of social emotes.
* Observe behavior under rapid emote triggering.
* No regression expected for emotes without props.

---

## Code Review Reference

Please review our [[Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md)](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.