### PR TITLE
Fix: Props and assets intermittently disappear during emotes in crowded scenes

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteComponent.cs
@@ -93,8 +93,8 @@ namespace DCL.AvatarRendering.Emotes
             SocialEmote.HasOutcomeAnimationStarted = false;
             SocialEmote.TargetAvatarWalletAddress = string.Empty;
             SocialEmote.InteractionId = 0;
+            CurrentEmoteReference = null;
             // These fields are not reset, on purpose (old code depends on it)
-            //        CurrentEmoteReference = null;
             //        CurrentAnimationTag = 0;
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -535,7 +535,6 @@ namespace DCL.AvatarRendering.Emotes.Play
                 GameObject mainAsset = emote.AssetResults[bodyShape]!.Value.Asset!.MainAsset;
 
                 // Existing emoteComponent is overwritten with new emote info
-                emoteComponent.Reset();
                 emoteComponent.EmoteUrn = emoteIntent.EmoteId;
                 emoteComponent.Metadata = (EmoteDTO.EmoteMetadataDto)emote.DTO.Metadata;
                 StreamableLoadingResult<AudioClipData>? audioAssetResult = emote.AudioAssetResults[bodyShape];


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes: #6467

The problem: when stopping the emote, CurrentEmoteReference still has a value despite the instance was returned to the pool, if you play it again CurrentEmoteReference is checked in EmotePlayer.Play() and it reuses it. If other player got that emote instance in the meantime, both are pointing to the same emote which is repositioned every time the loop iterates.

With this change, that property is nullified when stopped, and the next time it's played it takes a different instance from the pool.

## Test Instructions

### Prerequisites
- 2 wallets with the same looping emote that has props.
- A world so there are no interferences.

### Test Steps
1. Avatar 1 plays emote.
2. Avatar 2 plays the same emote.
3. Both avatars should be playing the same emote normally.

### Additional Testing Notes
Repeat the test in the release build https://github.com/decentraland/unity-explorer/pull/6405 to reproduce the problem (one avatar will steal the props of the other, when both emote).

Please do a general tests related to social emotes in order to make sure nothing else broke.