### PR TITLE
Chore: add analytics for Need Guidance (discord) button on auth screen 

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -96,6 +96,8 @@ namespace DCL.AuthenticationScreenFlow
         public ReactiveProperty<AuthenticationStatus> CurrentState { get; } = new (AuthenticationStatus.Init);
         public string CurrentRequestID { get; private set; } = string.Empty;
 
+        public event Action DiscordButtonClicked;
+
         public AuthenticationScreenController(
             ViewFactoryMethod viewFactory,
             IWeb3VerifiedAuthenticator web3Authenticator,
@@ -617,8 +619,11 @@ namespace DCL.AuthenticationScreenFlow
             viewInstance!.VerificationCodeHintContainer.SetActive(!viewInstance.VerificationCodeHintContainer.activeSelf);
         }
 
-        private void OpenDiscord() =>
+        private void OpenDiscord()
+        {
             webBrowser.OpenUrl(DecentralandUrl.DiscordLink);
+            DiscordButtonClicked?.Invoke();
+        }
 
         private void ExitApplication()
         {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
@@ -88,6 +88,7 @@
             public const string LOGGED_IN = "logged_in";
             public const string LOGIN_REQUESTED = "login_requested";
             public const string VERIFICATION_REQUESTED = "verification_requested";
+            public const string CLICK_COMMUNITY_GUIDANCE = "click_community_guidance";
         }
 
         public static class Friends

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/AuthenticationScreenAnalytics.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/AuthenticationScreenAnalytics.cs
@@ -8,8 +8,6 @@ namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
 {
     public class AuthenticationScreenAnalytics : IDisposable
     {
-        private const string STATE_KEY = "state";
-
         private readonly IAnalyticsController analytics;
         private readonly AuthenticationScreenController authenticationController;
 
@@ -17,13 +15,14 @@ namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
         {
             this.analytics = analytics;
             this.authenticationController = authenticationController;
-
             authenticationController.CurrentState.OnUpdate += OnAuthenticationScreenStateChanged;
+            authenticationController.DiscordButtonClicked += OnDiscordButtonClicked;
         }
 
         public void Dispose()
         {
             authenticationController.CurrentState.OnUpdate -= OnAuthenticationScreenStateChanged;
+            authenticationController.DiscordButtonClicked -= OnDiscordButtonClicked;
         }
 
         private void OnAuthenticationScreenStateChanged(AuthenticationStatus state)
@@ -51,5 +50,8 @@ namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
                     analytics.Track(Authentication.LOGGED_IN, isInstant: true); break;
             }
         }
+
+        private void OnDiscordButtonClicked() =>
+            analytics.Track(Authentication.CLICK_COMMUNITY_GUIDANCE);
     }
 }


### PR DESCRIPTION
# Pull Request Description
adds analytics for Need Guidance (discord) button on auth screen 

## Test Instructions
Test just that it runs normally. PR is small and reactive, shouldn't break anything.

## Quality Checklist
- [ ] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
