### PR TITLE
fix: reset mention data on profile clear

### DIFF
--- a/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
@@ -25,7 +25,6 @@ namespace DCL.Profiles
 
         private string userId;
         private string name;
-        private string mentionName;
         private bool hasClaimedName;
 
         public StreamableLoadingResult<SpriteData>.WithFallback? ProfilePicture { get; set; }
@@ -222,7 +221,7 @@ namespace DCL.Profiles
                 DisplayName = $"{result}{WalletId}";
             }
 
-            mentionName = "@" + DisplayName;
+            MentionName = "@" + DisplayName;
         }
 
         public void ClearLinks()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6512 
This PR clears the mention data on profile clear, avoiding pooling issues in specific scenarios

## Test Instructions

### Test Steps
1. Log in
2. Get close to other people
3. Verify that mention in chat works fine

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
