### PR TITLE
chore: put pointer-lock component on initialization

### DIFF
--- a/Explorer/Assets/DCL/Character/Plugin/CharacterContainer.cs
+++ b/Explorer/Assets/DCL/Character/Plugin/CharacterContainer.cs
@@ -112,6 +112,7 @@ namespace DCL.Character.Plugin
             private readonly IExposedTransform exposedTransform;
             private readonly IComponentPool<SDKTransform> sdkTransformPool;
             private readonly IComponentPool<PBMainCamera> mainCameraPool;
+            private readonly IComponentPool<PBPointerLock> pointerLockPool;
 
             public WorldPlugin(IExposedTransform exposedTransform, IExposedCameraData exposedCameraData,
                 IComponentPoolsRegistry componentPoolsRegistry, byte bucketPropagationLimit)
@@ -121,6 +122,7 @@ namespace DCL.Character.Plugin
                 this.exposedCameraData = exposedCameraData;
                 sdkTransformPool = componentPoolsRegistry.GetReferenceTypePool<SDKTransform>();
                 mainCameraPool = componentPoolsRegistry.GetReferenceTypePool<PBMainCamera>();
+                pointerLockPool = componentPoolsRegistry.GetReferenceTypePool<PBPointerLock>();
             }
 
             public void InjectToWorld(ref ArchSystemsWorldBuilder<World> builder, in ECSWorldInstanceSharedDependencies sharedDependencies, in PersistentEntities persistentEntities, List<IFinalizeWorldSystem> finalizeWorldSystems, List<ISceneIsCurrentListener> sceneIsCurrentListeners)
@@ -129,7 +131,7 @@ namespace DCL.Character.Plugin
                     exposedTransform, sharedDependencies.ScenePartition, bucketPropagationLimit, sdkTransformPool, persistentEntities.Player);
 
                 WriteCameraComponentsSystem.InjectToWorld(ref builder, sharedDependencies.EcsToCRDTWriter, exposedCameraData, sharedDependencies.SceneData,
-                    sharedDependencies.ScenePartition, bucketPropagationLimit, sdkTransformPool, mainCameraPool, persistentEntities.Camera);
+                    sharedDependencies.ScenePartition, bucketPropagationLimit, sdkTransformPool, mainCameraPool, pointerLockPool, persistentEntities.Camera);
             }
         }
 


### PR DESCRIPTION
### WHY

Recently a functionality change [was implemented](https://github.com/decentraland/unity-explorer/pull/6068) for the existent `PBPointerLock` component to be manipulable from the scene so that scenes can toggle the pointer locked state.

However we missed actually putting the pointerLock at the initialization of the scene, so that scenes that just want to read its state can do it from the start.

Currently the scene can read the state but ONLY AFTER THE POINTER HAS CHANGED STATE AT LEAST ONCE (from the explorer), which is not very intuitive... the component should be available on the `CameraEntity` from the beginnning.

### WHAT

Added missing `PBPointerLock` component initial put on the `CameraEntity` as we are already doing for `PBCameraMode`.

### TEST INSTRUCTIONS

1. Clone the sdk7-test-scenes repo and enter [this test scene](https://github.com/decentraland/sdk7-test-scenes/tree/main/scenes/31%2C20-pointer-lock-control)
2. In the scene root folder open a terminal and run `npm i` and then `npm run start -- --explorer-alpha`
3. Close the Explorer that auto-opened. Leave the scene running in the console/terminal.
4. Download the build from this PR and open it connected to the local scene (keep in mind its position is `31,20`): https://github.com/decentraland/unity-explorer/wiki/How-to-connect-to-a-local-scene-(Unity-Editor---Custom-Build---Latest-Released-Build)#connecting-a-custom-build-to-the-scene
5. Once you enter the scene confirm that:
- After 10~ seconds the pointer gets locked automatically (every 10 seconds the scene will try to lock the pointer)
- You can unlock the pointer by interacting with the 2nd block
- You can lock the pointer by interacting with the 1st block