### PR TITLE
fix: avoid wrong render of map pins clustered

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererChunkComponentsFactory.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererChunkComponentsFactory.cs
@@ -192,6 +192,7 @@ namespace DCL.MapRenderer.ComponentsFactory
             for (var i = 0; i < clusterMarkerObject.renderers.Length; i++)
                 clusterMarkerObject.renderers[i].sortingOrder = MapRendererDrawOrder.CATEGORIES;
 
+            clusterMarkerObject.categorySprite.sortingOrder = MapRendererDrawOrder.CATEGORIES - 1;
             clusterMarkerObject.title.sortingOrder = MapRendererDrawOrder.CATEGORIES + 1;
             coordsUtils.SetObjectScale(clusterMarkerObject);
             return clusterMarkerObject;
@@ -204,6 +205,7 @@ namespace DCL.MapRenderer.ComponentsFactory
             for (var i = 0; i < searchResultClusterObject.renderers.Length; i++)
                 searchResultClusterObject.renderers[i].sortingOrder = MapRendererDrawOrder.SEARCH_RESULTS;
 
+            searchResultClusterObject.categorySprite.sortingOrder = MapRendererDrawOrder.SEARCH_RESULTS - 1;
             searchResultClusterObject.title.sortingOrder = MapRendererDrawOrder.SEARCH_RESULTS + 1;
             coordsUtils.SetObjectScale(searchResultClusterObject);
             return searchResultClusterObject;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #3162 
This PR avoids a broken rendering of the white container for the map pins count in the map

## Test Instructions

### Test Steps
1. Open the client
2. Open the map
3. Verify that the map pins with the number are rendered correctly and that the white circle containing the number is rendered on top of the icon like shown in the issue

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
