### PR TITLE
fix: Communities | Members scrollbar handle interaction is confusing and inconsistent

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCardMembers.prefab
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Prefabs/CommunityCardMembers.prefab
@@ -6097,13 +6097,13 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4697464940743538001}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -10706,7 +10706,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -18, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &5657371385851263502
 CanvasRenderer:


### PR DESCRIPTION
# Pull Request Description
Fix #6313 

## What does this PR change?
Inconsistent and misleading scroll experience in the members list of a community (see the issue's description).

### Test Steps
1. Open any Community with many members.
2. Go to the Members tab.
3. Make use of the scroll and check that it works as expected.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.