### PR TITLE
opti: improve raycast in update cursor system

### DIFF
--- a/Explorer/Assets/DCL/Input/Systems/UpdateCursorInputSystem.cs
+++ b/Explorer/Assets/DCL/Input/Systems/UpdateCursorInputSystem.cs
@@ -26,6 +26,7 @@ namespace DCL.Input.Systems
     public partial class UpdateCursorInputSystem : UpdateInputSystem<CameraInput, CameraComponent>
     {
         private const int MOUSE_BOUNDS_OFFSET = 10;
+        private const float RAYCAST_POSITION_THRESHOLD_SQR = 4f;
         private static readonly Vector2 CURSOR_OFFSET = new (0, 15);
 
         private readonly IEventSystem eventSystem;
@@ -33,15 +34,17 @@ namespace DCL.Input.Systems
         private readonly ICrosshairView crosshairCanvas;
         private readonly DCLInput.CameraActions cameraActions;
         private readonly DCLInput.UIActions uiActions;
+        private readonly Mouse mouseDevice;
+        private readonly DCLInput.ShortcutsActions shortcuts;
+        private readonly InteractionCache interactionCache;
+
         private bool hasHoverCollider;
         private bool isAtDistance;
         private bool isHoveringAnInteractable;
         private bool wantsToUnlockForced;
         private bool shouldBeLocked;
-
-        private readonly Mouse mouseDevice;
-        private readonly DCLInput.ShortcutsActions shortcuts;
-        private readonly InteractionCache interactionCache;
+        private Vector2 lastRaycastPosition;
+        private IReadOnlyList<RaycastResult> cachedRaycastResults = Array.Empty<RaycastResult>();
 
         internal UpdateCursorInputSystem(World world, IEventSystem eventSystem, ICursor cursor, ICrosshairView crosshairCanvas) : base(world)
         {
@@ -116,11 +119,22 @@ namespace DCL.Input.Systems
             IReadOnlyList<RaycastResult> raycastResults;
             if (cursorComponent.CursorState == CursorState.Free)
             {
-                raycastResults = eventSystem.RaycastAll(mousePos);
+                bool positionChanged = (mousePos - lastRaycastPosition).sqrMagnitude > RAYCAST_POSITION_THRESHOLD_SQR;
+                bool inputWantsToLock = cameraActions.Lock.WasPressedThisFrame();
+                bool needsFreshRaycast = positionChanged || inputWantsToLock || shouldBeLocked;
+
+                if (needsFreshRaycast)
+                {
+                    cachedRaycastResults = eventSystem.RaycastAll(mousePos);
+                    lastRaycastPosition = mousePos;
+                }
+
+                raycastResults = cachedRaycastResults;
             }
             else
             {
                 raycastResults = Array.Empty<RaycastResult>();
+                lastRaycastPosition = new Vector2(float.MinValue, float.MinValue);
             }
 
             UpdateCursorLockState(ref cursorComponent, mousePos, raycastResults, exposedCameraData);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6566 
This PR introduces some improvements in the UpdateCursorInputSystem.
Before we were performing a raycast all at each frame, this was heavy as it was constantly raycasting hundreds of objects.
This has now been imporved by:
* avoid raycast when the cursor is locked
* if the cursor is unlucked raycast only on mouse position changes (with a variations of at least 2 pixels)

Before improvements each single frame was like this (profiler with deep profile enabled, so actual results are less visible)
<img width="771" height="115" alt="Screenshot 2026-01-01 at 11 05 02" src="https://github.com/user-attachments/assets/911249b4-6698-4b23-91df-63d101676f99" />

After improvements we have the previous performances only when mouse is unlocked and constantly moving, for the rest of the time (stationary mouse or locked mouse) we have:

<img width="849" height="124" alt="Screenshot 2026-01-01 at 12 28 22" src="https://github.com/user-attachments/assets/771c36a5-284a-46de-b860-39f458065e8a" />



## Test Instructions
We need to smoke test the cursor lock states 

### Test Steps
1. Open the client
2. Try to lock and unlock the cursor
3. Try to click on avatars
4. Try to click on UIs
5. Verify that the behaviour is the same as in prod

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
