### PR TITLE
chore: reduced resolution of loading screen tips images

### DIFF
--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/ArtWeek.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/ArtWeek.png.meta
@@ -50,7 +50,7 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
-  spriteGenerateFallbackPhysicsShape: 1
+  spriteGenerateFallbackPhysicsShape: 0
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Badges.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Badges.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/BringYourVibe.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/BringYourVibe.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Camera.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Camera.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Communities.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Communities.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/CreatorHub.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/CreatorHub.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Emotes.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Emotes.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Events.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Events.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/FestiveTrail_LoadingScreen.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/FestiveTrail_LoadingScreen.png.meta
@@ -50,7 +50,7 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
-  spriteGenerateFallbackPhysicsShape: 1
+  spriteGenerateFallbackPhysicsShape: 0
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/FrightNight.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/FrightNight.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/GenesisCity.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/GenesisCity.png.meta
@@ -50,7 +50,7 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
-  spriteGenerateFallbackPhysicsShape: 1
+  spriteGenerateFallbackPhysicsShape: 0
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/MarketplaceCredits.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/MarketplaceCredits.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/MusicFestival.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/MusicFestival.png.meta
@@ -50,7 +50,7 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
-  spriteGenerateFallbackPhysicsShape: 1
+  spriteGenerateFallbackPhysicsShape: 0
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Wearables.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Wearables.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Worlds.png.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Textures/Worlds.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
The loading screen tips were consuming quite a bit of useless memory:
<img width="849" height="244" alt="Screenshot 2026-01-01 at 14 39 36" src="https://github.com/user-attachments/assets/a82b5592-bdf4-4ada-bcef-44aa5eaeb082" />
They were on a 2048x2048 resolution and considering the size it could have easily been set to 1024x1024, so I did and we got a tiny bit of memory:
<img width="946" height="262" alt="Screenshot 2026-01-01 at 14 43 19" src="https://github.com/user-attachments/assets/1fd16f56-748f-44ab-a21f-2571940b249d" />

## Test Instructions
Just verify that the loading screen tips are correctly displayed

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
