### PR TITLE
Fix: Removed duplicated buttons in Context Menu

### DIFF
--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/GenericUserProfileContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/GenericUserProfileContextMenuController.cs
@@ -143,9 +143,7 @@ namespace DCL.UI
                          .AddControl(mentionUserButtonControlSettings)
                          .AddControl(openUserProfileButtonControlSettings)
                          .AddControl(openConversationControlSettings)
-                         .AddControl(contextMenuCallButton)
-                         .AddControl(contextMenuJumpInButton)
-                         .AddControl(contextMenuBlockUserButton);
+                         .AddControl(contextMenuCallButton);
 
             if (FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.GIFTING_ENABLED))
                 contextMenu.AddControl(contextGiftButton);


### PR DESCRIPTION
We accidentally introduced duplicated buttons for Jump To Location and Block user in the context menu. 
I just removed the duplicated entries :)


**Test?**
Just make sure the context menu has a single instance of the buttons and that they work as expected, nothing else is changed.