### PR TITLE
fix: tween systems execution order in systems order fix

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenSequenceUpdaterSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenSequenceUpdaterSystem.cs
@@ -22,9 +22,7 @@ namespace DCL.SDKComponents.Tween
     /// Handles the update logic of PBTween and PBTweenSequence components
     /// </summary>
     [UpdateInGroup(typeof(SyncedSimulationSystemGroup))]
-    [UpdateBefore(typeof(UpdateTransformSystem))]
-    [UpdateAfter(typeof(TweenSequenceLoaderSystem))]
-    [UpdateAfter(typeof(InstantiateTransformSystem))]
+    [UpdateAfter(typeof(UpdateTransformSystem))] // The transform has to be correctly updated at least once before the Tween can use it
     [LogCategory(ReportCategory.TWEEN)]
     public partial class TweenSequenceUpdaterSystem : BaseUnityLoopSystem
     {
@@ -79,7 +77,8 @@ namespace DCL.SDKComponents.Tween
         }
 
         [Query]
-        private void UpdateTweenSequenceState(Entity entity, ref SDKTweenSequenceComponent sdkTweenSequenceComponent, ref SDKTransform sdkTransform, in PBTween pbTween, in PBTweenSequence pbTweenSequence, CRDTEntity sdkEntity, TransformComponent transformComponent)
+        private void UpdateTweenSequenceState(Entity entity, ref SDKTweenSequenceComponent sdkTweenSequenceComponent, ref SDKTransform sdkTransform, in PBTween pbTween, in PBTweenSequence pbTweenSequence,
+            CRDTEntity sdkEntity, ref TransformComponent transformComponent)
         {
             if (pbTween.ModeCase == PBTween.ModeOneofCase.None) return;
 
@@ -96,11 +95,11 @@ namespace DCL.SDKComponents.Tween
                 }
 
                 SetupTweenSequence(ref sdkTweenSequenceComponent, in pbTween, in pbTweenSequence, transformComponent.Transform, material);
-                UpdateTweenSequenceStateAndTransform(sdkEntity, sdkTweenSequenceComponent, ref sdkTransform, transformComponent);
+                UpdateTweenSequenceStateAndTransform(sdkEntity, sdkTweenSequenceComponent, ref sdkTransform, ref transformComponent);
             }
             else
             {
-                UpdateTweenSequenceStateIfChanged(ref sdkTweenSequenceComponent, ref sdkTransform, sdkEntity, transformComponent);
+                UpdateTweenSequenceStateIfChanged(ref sdkTweenSequenceComponent, ref sdkTransform, sdkEntity, ref transformComponent);
             }
         }
 
@@ -123,19 +122,19 @@ namespace DCL.SDKComponents.Tween
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void UpdateTweenSequenceStateIfChanged(ref SDKTweenSequenceComponent sdkTweenSequenceComponent, ref SDKTransform sdkTransform, CRDTEntity sdkEntity, TransformComponent transformComponent)
+        private void UpdateTweenSequenceStateIfChanged(ref SDKTweenSequenceComponent sdkTweenSequenceComponent, ref SDKTransform sdkTransform, CRDTEntity sdkEntity, ref TransformComponent transformComponent)
         {
             TweenStateStatus newState = TweenSDKComponentHelper.GetTweenerState(sdkTweenSequenceComponent.SequenceTweener);
             if (newState != sdkTweenSequenceComponent.TweenStateStatus)
             {
                 sdkTweenSequenceComponent.TweenStateStatus = newState;
-                UpdateTweenSequenceStateAndTransform(sdkEntity, sdkTweenSequenceComponent, ref sdkTransform, transformComponent);
+                UpdateTweenSequenceStateAndTransform(sdkEntity, sdkTweenSequenceComponent, ref sdkTransform, ref transformComponent);
             }
             else if (newState == TweenStateStatus.TsActive)
             {
                 // Update transform while sequence is playing
                 if (sdkTweenSequenceComponent.HasTransformTweens)
-                    UpdateSequenceTransform(sdkEntity, ref sdkTransform, transformComponent);
+                    UpdateSequenceTransform(sdkEntity, ref sdkTransform, ref transformComponent);
             }
         }
 
@@ -173,16 +172,16 @@ namespace DCL.SDKComponents.Tween
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void UpdateTweenSequenceStateAndTransform(CRDTEntity sdkEntity, SDKTweenSequenceComponent sdkTweenSequenceComponent, ref SDKTransform sdkTransform, TransformComponent transformComponent)
+        private void UpdateTweenSequenceStateAndTransform(CRDTEntity sdkEntity, SDKTweenSequenceComponent sdkTweenSequenceComponent, ref SDKTransform sdkTransform, ref TransformComponent transformComponent)
         {
             if (sdkTweenSequenceComponent.HasTransformTweens)
-                UpdateSequenceTransform(sdkEntity, ref sdkTransform, transformComponent);
+                UpdateSequenceTransform(sdkEntity, ref sdkTransform, ref transformComponent);
 
             TweenSDKComponentHelper.WriteTweenStateInCRDT(ecsToCRDTWriter, sdkEntity, sdkTweenSequenceComponent.TweenStateStatus);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void UpdateSequenceTransform(CRDTEntity sdkEntity, ref SDKTransform sdkTransform, TransformComponent transformComponent)
+        private void UpdateSequenceTransform(CRDTEntity sdkEntity, ref SDKTransform sdkTransform, ref TransformComponent transformComponent)
         {
             // Read back from Unity Transform (DOTween Sequence updates it directly)
             TweenSDKComponentHelper.SyncTransformToSDKTransform(transformComponent.Transform, ref sdkTransform, ref transformComponent, sceneStateProvider.IsCurrent);

--- a/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenUpdaterSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/Tween/Systems/TweenUpdaterSystem.cs
@@ -20,9 +20,7 @@ namespace DCL.SDKComponents.Tween
     /// Handles the update logic of PBTween ONLY (when PBTweenSequence runs in SDK Runtime)
     /// </summary>
     [UpdateInGroup(typeof(SyncedSimulationSystemGroup))]
-    [UpdateBefore(typeof(UpdateTransformSystem))]
-    [UpdateAfter(typeof(TweenLoaderSystem))]
-    [UpdateAfter(typeof(InstantiateTransformSystem))]
+    [UpdateAfter(typeof(UpdateTransformSystem))] // The transform has to be correctly updated at least once before the Tween can use it
     [LogCategory(ReportCategory.TWEEN)]
     public partial class TweenUpdaterSystem : BaseUnityLoopSystem
     {


### PR DESCRIPTION
To be merged into https://github.com/decentraland/unity-explorer/pull/6258