### PR TITLE
chore: lsd missing try-catch for websocket connection

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
@@ -70,8 +70,11 @@ namespace ECS.SceneLifeCycle.LocalSceneDevelopment
                 {
                     receiveResult = await webSocket.ReceiveAsync(receiveBuffer, ct);
                 }
-                catch (WebSocketException)
+                catch (WebSocketException e)
                 {
+                    if (e.ErrorCode == (int)WebSocketError.ConnectionClosedPrematurely)
+                        ReportHub.LogWarning(ReportCategory.SDK_LOCAL_SCENE_DEVELOPMENT, $"Websocket ConnectionClosedPrematurely: {e.Message}");
+
                     if (ct.IsCancellationRequested || webSocket.State != WebSocketState.Open)
                         break;
 


### PR DESCRIPTION
### WHY

In Unity Editor whenever we stop the playmode, an `System.Net.WebSockets.WebSocketException (0x80004005): The remote party closed the WebSocket connection without completing the close handshake.` exception is thrown in the console.

Issue: https://github.com/decentraland/unity-explorer/issues/6579

### WHAT

Added missing try catch for LSD websocket connection.

### TEST INSTRUCTIONS

Download the build from this PR and connect to any LOCAL SCENE and confirm that the hot-reload works: change the local scene in any way (any space added in the code for example, and saving the file) and confirm that the scene gets reloaded in the Explorer that is connected to it. Do it at least 3 times in a row.