### PR TITLE
feat: add player global and scene position in debug panel

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/UpdateCurrentSceneSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/UpdateCurrentSceneSystem.cs
@@ -19,10 +19,13 @@ namespace ECS.SceneLifeCycle.Systems
     [UpdateInGroup(typeof(RealmGroup))]
     public partial class UpdateCurrentSceneSystem : BaseUnityLoopSystem
     {
+        private const string NO_DATA_STRING = "<No data>";
+
         private static readonly int SRC_BLEND = Shader.PropertyToID("_SrcBlend");
         private static readonly int DST_BLEND = Shader.PropertyToID("_DstBlend");
         private static readonly int CULL = Shader.PropertyToID("_Cull");
         private static readonly int SURFACE = Shader.PropertyToID("_Surface");
+
         private readonly Entity playerEntity;
         private readonly IRealmData realmData;
         private readonly IScenesCache scenesCache;
@@ -33,6 +36,8 @@ namespace ECS.SceneLifeCycle.Systems
         private readonly ElementBinding<string> sceneParcelsBinding;
         private readonly ElementBinding<string> sceneHeightBinding;
         private readonly ElementBinding<string> sdk6Binding;
+        private readonly ElementBinding<string> globalPositionBinding;
+        private readonly ElementBinding<string> sceneRelativePositionBinding;
         private readonly DebugWidgetVisibilityBinding debugInfoVisibilityBinding;
         private bool showDebugCube;
         private GameObject? sceneBoundsCube;
@@ -58,6 +63,8 @@ namespace ECS.SceneLifeCycle.Systems
             sceneNameBinding = new ElementBinding<string>(string.Empty);
             sceneParcelsBinding = new ElementBinding<string>(string.Empty);
             sceneHeightBinding = new ElementBinding<string>(string.Empty);
+            globalPositionBinding = new ElementBinding<string>(string.Empty);
+            sceneRelativePositionBinding = new ElementBinding<string>(string.Empty);
 
             debugBuilder.TryAddWidget(IDebugContainerBuilder.Categories.CURRENT_SCENE)?
                          .SetVisibilityBinding(debugInfoVisibilityBinding)
@@ -65,6 +72,8 @@ namespace ECS.SceneLifeCycle.Systems
                          .AddCustomMarker("Name:", sceneNameBinding)
                          .AddCustomMarker("Parcels:", sceneParcelsBinding)
                          .AddCustomMarker("Height (m):", sceneHeightBinding)
+                         .AddCustomMarker("Global Pos:", globalPositionBinding)
+                         .AddCustomMarker("Scene Pos:", sceneRelativePositionBinding)
                          .AddToggleField("Show scene bounds:", state => { showDebugCube = state.newValue; }, false);
             this.debugBuilder = debugBuilder;
         }
@@ -125,9 +134,16 @@ namespace ECS.SceneLifeCycle.Systems
         {
             sdk6Binding.Value = currentActiveScene != null ? bool.FalseString : bool.TrueString;
 
+            Vector3 globalPosition = World.Get<CharacterTransform>(playerEntity).Transform.position;
+            globalPositionBinding.Value = FormatPositionVector(globalPosition);
+
             if (currentActiveScene != null)
             {
                 sceneBoundsCube?.SetActive(showDebugCube);
+
+                Vector3 sceneBasePosition = currentActiveScene.SceneData.Geometry.BaseParcelPosition;
+                Vector3 sceneRelativePosition = globalPosition.FromGlobalToSceneRelativePosition(sceneBasePosition);
+                sceneRelativePositionBinding.Value = FormatPositionVector(sceneRelativePosition);
 
                 if (sceneNameBinding.Value != currentActiveScene.Info.Name)
                 {
@@ -150,12 +166,16 @@ namespace ECS.SceneLifeCycle.Systems
             }
             else
             {
-                sceneNameBinding.Value = "<No data>";
-                sceneParcelsBinding.Value = "<No data>";
-                sceneHeightBinding.Value = "<No data>";
+                sceneNameBinding.Value = NO_DATA_STRING;
+                sceneParcelsBinding.Value = NO_DATA_STRING;
+                sceneHeightBinding.Value = NO_DATA_STRING;
+                sceneRelativePositionBinding.Value = NO_DATA_STRING;
                 sceneBoundsCube?.SetActive(false);
             }
         }
+
+        private static string FormatPositionVector(Vector3 position) =>
+            $"{position.x:F1}, {position.y:F1}, {position.z:F1}";
 
         private static GameObject CreateDebugCube()
         {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6537
Adds global and local position of the player in the debug panel

## Test Instructions

### Test Steps
1. Launch the client
2. Open the debug panel
3. Verify that in the section "Current scene" 2 new strings are available, one for global position and one for scene position
4. Verify they update when walking around

<img width="239" height="193" alt="Screenshot 2026-01-06 at 09 59 57" src="https://github.com/user-attachments/assets/3e22e900-1916-486c-9e52-1d513b44fca6" />


## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
