### PR TITLE
fix: profile tier implicit cast

### DIFF
--- a/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileTier.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileTier.cs
@@ -31,7 +31,7 @@ namespace DCL.Profiles
             profileTier.Match(c => c, f => f.Compact);
 
         public static implicit operator ProfileTier?(Profile? profile) =>
-            profile == null ? null : FromFull(profile);
+            profile == null ? (ProfileTier?) null : FromFull(profile);
 
         public static implicit operator ProfileTier(Profile profile) =>
             FromFull(profile);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

The implicit cast was faulty when casting from null, leading to a ProfileTier that contained a null value, which lead to errors down the road (first one was the ProfileCache) since the struct was != null and had a value.
With the change it is now properly null.

This was fortunately found thanks to the Donations shape since there is the need of fetching a profile that may not exists.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
