### PR TITLE
chore: unisex emotes

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarLoaderSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarLoaderSystem.cs
@@ -71,10 +71,6 @@ namespace DCL.AvatarRendering.AvatarShape
             WearablePromise wearablePromise = CreateWearablePromise(profile, partition);
 
             var avatarShapeComponent = new AvatarShapeComponent(profile.Name, profile.UserId, profile.Avatar.BodyShape, wearablePromise, profile.Avatar.SkinColor, profile.Avatar.HairColor, profile.Avatar.EyesColor);
-
-            // No lazy load for main player. Get all emotes, so it can play them accordingly without undesired delays
-            LoadAllEmotes(profile, partition);
-
             World.Add(entity, avatarShapeComponent);
         }
 
@@ -105,9 +101,6 @@ namespace DCL.AvatarRendering.AvatarShape
         [None(typeof(PlayerComponent), typeof(PBAvatarShape), typeof(DeleteEntityIntention))]
         private void UpdateAvatarFromProfile(ref Profile profile, ref AvatarShapeComponent avatarShapeComponent, ref PartitionComponent partition)
         {
-            if (!profile.IsDirty)
-                return;
-
             if (!avatarShapeComponent.WearablePromise.IsConsumed)
                 avatarShapeComponent.WearablePromise.ForgetLoading(World);
 
@@ -125,11 +118,11 @@ namespace DCL.AvatarRendering.AvatarShape
         [Query]
         [All(typeof(PlayerComponent))]
         [None(typeof(PBAvatarShape), typeof(DeleteEntityIntention))]
-        private void UpdateMainPlayerAvatarFromProfile(in Entity entity, ref Profile profile, ref AvatarShapeComponent avatarShapeComponent, ref PartitionComponent partition)
+        private void UpdateMainPlayerAvatarFromProfile(ref Profile profile, ref AvatarShapeComponent avatarShapeComponent, ref PartitionComponent partition)
         {
-            UpdateAvatarFromProfile(ref profile, ref avatarShapeComponent, ref partition);
-
             if (!profile.IsDirty) return;
+
+            UpdateAvatarFromProfile(ref profile, ref avatarShapeComponent, ref partition);
 
             // No lazy load for main player. Get all emotes, so it can play them accordingly without undesired delays
             LoadAllEmotes(profile, partition);

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/Instantiate/AvatarInstantiatorSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/Instantiate/AvatarInstantiatorSystemShould.cs
@@ -110,8 +110,8 @@ namespace DCL.AvatarRendering.AvatarShape.Tests.Instantiate
         {
             (IEmote mockWearable, AttachmentRegularAsset wearableAsset) = GetMockedAvatarAttachment<IEmote>(materialName, category);
 
-            mockWearable.AssetResults.Returns(
-                new StreamableLoadingResult<AttachmentRegularAsset>?[] { new StreamableLoadingResult<AttachmentRegularAsset>(wearableAsset) });
+            mockWearable.AssetResult.Returns(
+                new StreamableLoadingResult<AttachmentRegularAsset>(wearableAsset));
 
             return mockWearable;
         }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/IEmote.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/IEmote.cs
@@ -9,12 +9,10 @@ namespace DCL.AvatarRendering.Emotes
     {
         int Amount { get; set; }
 
-        StreamableLoadingResult<AudioClipData>?[] AudioAssetResults { get; }
-        StreamableLoadingResult<AttachmentRegularAsset>?[] AssetResults { get; }
+        StreamableLoadingResult<AudioClipData>? AudioAssetResult { get; set; }
+        StreamableLoadingResult<AttachmentRegularAsset>? AssetResult { get; set; }
 
         bool IsLooping();
-
-        bool HasSameClipForAllGenders();
 
         public static IEmote NewEmpty() =>
             new Emote();

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/EmbeddedEmotes/EmbeddedEmotes.asset
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/EmbeddedEmotes/EmbeddedEmotes.asset
@@ -18,8 +18,6 @@ MonoBehaviour:
     audioClip: {fileID: 8300000, guid: bbdec9167e5458c4c8f852d49dd77026, type: 3}
     thumbnail: {fileID: 21300000, guid: ff531623182fec8479d734ac8df22d8f, type: 3}
     prefab: {fileID: 8771091787928289351, guid: 902282f4070ec7b469e73bcbdcc0c3dd, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -34,8 +32,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 7938434e632b598489b8b03e6effa995, type: 3}
     prefab: {fileID: 8018143466885850673, guid: 465491e0be2fa411dab6fd5716fe1a54, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -50,8 +46,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: ee783a7da0f7c804c8718704f06ba790, type: 3}
     prefab: {fileID: 8771091787928289351, guid: c4ac165a6ecb9194ba6417ac99aa1d0f, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -66,8 +60,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: e6a1e80b5ad78344ab7aa751eb27c30d, type: 3}
     prefab: {fileID: 8018143466885850673, guid: 555e042d4b9b14ac0a4d086bdb749500, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -82,8 +74,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: fb2a51422f4f0f84ca589e9716428e06, type: 3}
     prefab: {fileID: 8018143466885850673, guid: 37c280bbf7a8f43c5bd4eb8918058365, type: 3}
-    male: {fileID: 8018143466885850673, guid: 37c280bbf7a8f43c5bd4eb8918058365, type: 3}
-    female: {fileID: 8018143466885850673, guid: 8bb64a2e609e8492fae00ad00adb5b16, type: 3}
     entity:
       representations: []
       category: 
@@ -98,8 +88,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 5dc96a095ce3483459044bf3e74ccb59, type: 3}
     prefab: {fileID: 8018143466885850673, guid: c62cead1fc46347a9bb0193ed3259ba2, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -114,8 +102,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 4ee2739d276aba843bd732c5a4a40dad, type: 3}
     prefab: {fileID: 8018143466885850673, guid: 869cd89681c12421da3da0478168e421, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -130,8 +116,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 2b2f4028cd39d984e80dabe0732fdd87, type: 3}
     prefab: {fileID: 8018143466885850673, guid: 7693f9dc71d4e4a58816014d4ece5b06, type: 3}
-    male: {fileID: 8018143466885850673, guid: 7693f9dc71d4e4a58816014d4ece5b06, type: 3}
-    female: {fileID: 8018143466885850673, guid: 3836ede53a59e4965917561b6e227f0c, type: 3}
     entity:
       representations: []
       category: 
@@ -146,8 +130,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 90d19c500d961c44f8941c69dcdae46a, type: 3}
     prefab: {fileID: 8018143466885850673, guid: f38d7869f314e4cb4a908407fed6dbd3, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -162,8 +144,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 5d9d324d9b1257f4cbeed858807c2c06, type: 3}
     prefab: {fileID: 8771091787928289351, guid: 1367a4cc5c746844995474c692ce506f, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -178,8 +158,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 5d9d324d9b1257f4cbeed858807c2c06, type: 3}
     prefab: {fileID: 8771091787928289351, guid: 1367a4cc5c746844995474c692ce506f, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -194,8 +172,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: db09a3000c06f1e46a56c971875a6aa1, type: 3}
     prefab: {fileID: 8018143466885850673, guid: eb3fb75fdcb3b4748863cad3e2fbc570, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -210,8 +186,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 08fb89e42a3f7d44e9b2a391aa41aff6, type: 3}
     prefab: {fileID: 8771091787928289351, guid: 77a28322abe8e2d48889b4bb91fea3c1, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -226,8 +200,6 @@ MonoBehaviour:
     audioClip: {fileID: 8300000, guid: aac9f6c56a8383a40b736ef3481dcac6, type: 3}
     thumbnail: {fileID: 21300000, guid: 8845b5e9671db49409bf747319c8f5c7, type: 3}
     prefab: {fileID: 8771091787928289351, guid: 28c3224df1c472940947608d6984ab5b, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -242,8 +214,6 @@ MonoBehaviour:
     audioClip: {fileID: 8300000, guid: 0bd4a22cf4328f241b7a47f3db620514, type: 3}
     thumbnail: {fileID: 21300000, guid: e2b6332b93b06ab488a93d40b83c69fe, type: 3}
     prefab: {fileID: 8771091787928289351, guid: 73aef91399409734da49e67af4552191, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -258,8 +228,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: ff8a6278dd9d9334da10fa959cdb26dc, type: 3}
     prefab: {fileID: 8018143466885850673, guid: 4c2f52d666b4140cfb9fabb951379dcd, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -274,8 +242,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 736224c3cee06814dbf03a9bc3396382, type: 3}
     prefab: {fileID: 8018143466885850673, guid: f47550258031f44b69d3c23a32aadbac, type: 3}
-    male: {fileID: 8018143466885850673, guid: f47550258031f44b69d3c23a32aadbac, type: 3}
-    female: {fileID: 8018143466885850673, guid: cba09626bb9734de784415e4ae55325b, type: 3}
     entity:
       representations: []
       category: 
@@ -290,8 +256,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: f992e8febb67b5d47a24e9f16d5cc190, type: 3}
     prefab: {fileID: 8018143466885850673, guid: 9cd9034953b9e43d38a38f3cde21226f, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -306,8 +270,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 9622f862db0a54f49a26e220aac90cbe, type: 3}
     prefab: {fileID: 8771091787928289351, guid: 8689dd2ff74a71649a0c3d9229b5c68b, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -322,8 +284,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 84771a68677a08b43a7247d73aa5a6d8, type: 3}
     prefab: {fileID: 8018143466885850673, guid: cbb63c683b55046749f6cb47138ca9bc, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -338,8 +298,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 832a50a328da0294f809c85f37abca0e, type: 3}
     prefab: {fileID: 8018143466885850673, guid: ab5239f8d474a41838f111c6cf9a26f6, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -354,8 +312,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 58f49f496e83e4327a36e0b77fccfdee, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -370,8 +326,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: fe89fdd5fa8082047b39641a3fc66308, type: 3}
     prefab: {fileID: 8018143466885850673, guid: c1d9a11790afd475fbf6ad94eb29306c, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -386,8 +340,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 21300000, guid: 5ff44e022ab99054bb0a1f79b2077c4f, type: 3}
     prefab: {fileID: 8018143466885850673, guid: d667e461497064fcb8e5caf9125cc9d8, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -402,8 +354,6 @@ MonoBehaviour:
     audioClip: {fileID: 8300000, guid: 5caae9f69edac88479351686704e0c94, type: 3}
     thumbnail: {fileID: 21300000, guid: 52e4def7262db19429d325d7cb5f1a7a, type: 3}
     prefab: {fileID: 3460472286760622397, guid: c7a4733cc5ffc1249ada6f436f6dd167, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -418,8 +368,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: e982a29f178d5424a8282d4f1a5caa6a, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -434,8 +382,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 08cba79c456014d3cb6c0a6a148d5951, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -450,8 +396,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 1fec9d1abe94d4765ad558df8af5651d, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -466,8 +410,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 11869768f93ae43ddac9db58c989d161, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -482,8 +424,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 2f30cb19387224c5a97178b7431c085f, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -498,8 +438,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 910309eb34a6643b3b52f4a83ed233df, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -514,8 +452,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: b6c7f4ecdea1d4c06b790a5b918ab049, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -530,8 +466,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 3862f8d18e9df4b848c935c6481199ca, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -546,8 +480,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: ef06206ba169242be86645c339444be4, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -562,8 +494,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: d16e61552f58642b68cefb7eef40e990, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -578,8 +508,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: d2e36af30cd8e4f30859c09b4117c755, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -594,8 +522,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 8cf943739d65448238526f3792b73b48, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -610,8 +536,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 12a124fece040428aa4cfb17819d37c7, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -626,8 +550,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 70c3cc6a6898540deb71a4ca4f62a7c8, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -642,8 +564,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: e5e24dbafc47a4b6eb2020547f215ab7, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -658,8 +578,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 6a8ddbff0f641417487e913aa4b952e5, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 
@@ -674,8 +592,6 @@ MonoBehaviour:
     audioClip: {fileID: 0}
     thumbnail: {fileID: 0}
     prefab: {fileID: 8018143466885850673, guid: 6b75cf59917c8064da482571784ac3cc, type: 3}
-    male: {fileID: 0}
-    female: {fileID: 0}
     entity:
       representations: []
       category: 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/EmbeddedEmotes/EmbeddedEmotesData.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/EmbeddedEmotes/EmbeddedEmotesData.cs
@@ -22,8 +22,6 @@ namespace DCL.AvatarRendering.Emotes
 
         // Represents unisex prefab
         public GameObject prefab;
-        public GameObject male;
-        public GameObject female;
         public EmoteDTO.EmoteMetadataDto.Data entity;
     }
 
@@ -70,41 +68,13 @@ namespace DCL.AvatarRendering.Emotes
                 emote.Model = new StreamableLoadingResult<EmoteDTO>(model);
                 emote.ThumbnailAssetResult = embeddedEmote.thumbnail.ToUnownedSpriteData();
 
-                if (embeddedEmote.male != null)
-                {
-                    AttachmentRegularAsset maleAsset = CreateAttachmentAsset(embeddedEmote.male);
-                    maleAsset.AddReference();
-                    var maleAssetResult = new StreamableLoadingResult<AttachmentRegularAsset>(maleAsset);
-                    emote.AssetResults[BodyShape.MALE] = maleAssetResult;
-                }
 
-                if (embeddedEmote.female != null)
-                {
-                    AttachmentRegularAsset femaleAsset = CreateAttachmentAsset(embeddedEmote.female);
-                    femaleAsset.AddReference();
-                    var femaleAssetResult = new StreamableLoadingResult<AttachmentRegularAsset>(femaleAsset);
-                    emote.AssetResults[BodyShape.FEMALE] = femaleAssetResult;
-                }
+                AttachmentRegularAsset unisexAsset = CreateAttachmentAsset(embeddedEmote.prefab);
+                unisexAsset.AddReference();
+                var unisexAssetResult = new StreamableLoadingResult<AttachmentRegularAsset>(unisexAsset);
+                emote.AssetResult = unisexAssetResult;
 
-                if (embeddedEmote.male == null || embeddedEmote.female == null)
-                {
-                    // If possible, only one allocation for both genders
-                    AttachmentRegularAsset unisexAsset = CreateAttachmentAsset(embeddedEmote.prefab);
-                    unisexAsset.AddReference();
-                    var unisexAssetResult = new StreamableLoadingResult<AttachmentRegularAsset>(unisexAsset);
-
-                    if (embeddedEmote.male == null)
-                        emote.AssetResults[BodyShape.MALE] = unisexAssetResult;
-
-                    if (embeddedEmote.female == null)
-                        emote.AssetResults[BodyShape.FEMALE] = unisexAssetResult;
-                }
-
-                if (embeddedEmote.audioClip != null)
-                {
-                    emote.AudioAssetResults[BodyShape.MALE] = new StreamableLoadingResult<AudioClipData>(new AudioClipData(embeddedEmote.audioClip));
-                    emote.AudioAssetResults[BodyShape.FEMALE] = new StreamableLoadingResult<AudioClipData>(new AudioClipData(embeddedEmote.audioClip));
-                }
+                emote.AudioAssetResult = new StreamableLoadingResult<AudioClipData>(new AudioClipData(embeddedEmote.audioClip));
 
                 emote.ManifestResult = null;
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Emote.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Emote.cs
@@ -12,10 +12,10 @@ namespace DCL.AvatarRendering.Emotes
     public class Emote : IEmote
     {
         public StreamableLoadingResult<SceneAssetBundleManifest>? ManifestResult { get; set; }
-        public StreamableLoadingResult<AttachmentRegularAsset>?[] AssetResults { get; } = new StreamableLoadingResult<AttachmentRegularAsset>?[BodyShape.COUNT];
+        public StreamableLoadingResult<AttachmentRegularAsset>? AssetResult { get; set; }
         public StreamableLoadingResult<SpriteData>.WithFallback? ThumbnailAssetResult { get; set; }
         public StreamableLoadingResult<EmoteDTO> Model { get; set; }
-        public StreamableLoadingResult<AudioClipData>?[] AudioAssetResults { get; } = new StreamableLoadingResult<AudioClipData>?[BodyShape.COUNT];
+        public StreamableLoadingResult<AudioClipData>? AudioAssetResult { get; set; }
         public int Amount { get; set; }
         public bool IsLoading { get; private set; }
 
@@ -54,14 +54,5 @@ namespace DCL.AvatarRendering.Emotes
             //to avoid a breaking null reference we provide safe access to the loop property by using the is pattern
             Model.Asset is { metadata: { emoteDataADR74: { loop: true } } };
 
-        public bool HasSameClipForAllGenders()
-        {
-            IAvatarAttachment attachment = this;
-
-            attachment.TryGetMainFileHash(BodyShape.MALE, out string? maleHash);
-            attachment.TryGetMainFileHash(BodyShape.FEMALE, out string? femaleHash);
-
-            return maleHash == femaleHash;
-        }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/EmoteComponentsUtils.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/EmoteComponentsUtils.cs
@@ -10,7 +10,6 @@ namespace DCL.AvatarRendering.Emotes
     {
         public static GetEmotesByPointersIntention CreateGetEmotesByPointersIntention(BodyShape bodyShape, IReadOnlyCollection<URN> emotes)
         {
-            UnityEngine.Debug.Log($"JUANI WHERE THIS IS COMING FROM {Environment.StackTrace}");
             List<URN> pointers = POINTERS_POOL.Get()!;
 
             foreach (URN emote in emotes)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/EmoteComponentsUtils.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/EmoteComponentsUtils.cs
@@ -1,5 +1,6 @@
 ﻿using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Components;
+using System;
 using System.Collections.Generic;
 using static DCL.AvatarRendering.Wearables.Helpers.WearableComponentsUtils;
 
@@ -9,6 +10,7 @@ namespace DCL.AvatarRendering.Emotes
     {
         public static GetEmotesByPointersIntention CreateGetEmotesByPointersIntention(BodyShape bodyShape, IReadOnlyCollection<URN> emotes)
         {
+            UnityEngine.Debug.Log($"JUANI WHERE THIS IS COMING FROM {Environment.StackTrace}");
             List<URN> pointers = POINTERS_POOL.Get()!;
 
             foreach (URN emote in emotes)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/FinalizeEmoteLoadingSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/FinalizeEmoteLoadingSystem.cs
@@ -132,7 +132,7 @@ namespace DCL.AvatarRendering.Emotes
         }
 
         [Query]
-        private void FinalizeAudioClipPromise(Entity entity, ref IEmote emote, ref AudioPromise promise, in BodyShape bodyShape)
+        private void FinalizeAudioClipPromise(Entity entity, ref IEmote emote, ref AudioPromise promise)
         {
             if (promise.IsCancellationRequested(World))
             {

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -132,7 +132,9 @@ namespace DCL.AvatarRendering.Emotes.Load
                     continue;
                 }
 
-                if (emote.IsLoading) continue;
+                if (emote.IsLoading)
+                    continue;
+
                 if (CreateAssetBundlePromiseIfRequired(emote, in intention, partitionComponent)) continue;
 
                 if (emote.AssetResult is { Succeeded: true })
@@ -210,6 +212,8 @@ namespace DCL.AvatarRendering.Emotes.Load
         {
             if (component.AssetResult == null)
             {
+                UnityEngine.Debug.Log($"JUANI STARTING ASSET RESULT {component.DTO.id}");
+
                 component.TryGetContentHashByKey(component.DTO.Metadata.AbstractData.representations[0].mainFile, out string? hash);
 
                 // The resolution of the AB promise will be finalized by FinalizeEmoteAssetBundleSystem
@@ -227,17 +231,17 @@ namespace DCL.AvatarRendering.Emotes.Load
                     partitionComponent
                 );
 
-                TryCreateAudioClipPromises(component, intention.BodyShape, partitionComponent);
+                TryCreateAudioClipPromises(component, partitionComponent);
 
                 component.UpdateLoadingStatus(true);
 
-                World!.Create(promise, component, intention.BodyShape);
+                World!.Create(promise, component);
                 return true;
             }
             return false;
         }
 
-        private void TryCreateAudioClipPromises(IEmote component, BodyShape bodyShape, IPartitionComponent partitionComponent)
+        private void TryCreateAudioClipPromises(IEmote component, IPartitionComponent partitionComponent)
         {
             ContentDefinition[]? content = component.Model.Asset!.content;
 
@@ -254,7 +258,7 @@ namespace DCL.AvatarRendering.Emotes.Load
 
                 // The resolution of the audio promise will be finalized by FinalizeEmoteAssetBundleSystem
                 AudioPromise promise = AudioUtils.CreateAudioClipPromise(World!, url.Value, audioType, partitionComponent);
-                World!.Create(promise, component, bodyShape);
+                World!.Create(promise, component);
             }
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -212,8 +212,6 @@ namespace DCL.AvatarRendering.Emotes.Load
         {
             if (component.AssetResult == null)
             {
-                UnityEngine.Debug.Log($"JUANI STARTING ASSET RESULT {component.DTO.id}");
-
                 component.TryGetContentHashByKey(component.DTO.Metadata.AbstractData.representations[0].mainFile, out string? hash);
 
                 // The resolution of the AB promise will be finalized by FinalizeEmoteAssetBundleSystem

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadSceneEmotesSystem.cs
@@ -127,9 +127,10 @@ namespace DCL.AvatarRendering.Emotes.Load
 
             if (CreatePromiseIfRequired(ref emote, ref intention, partitionComponent)) return;
 
-            if (emote.AssetResults[intention.BodyShape] is { Succeeded: true })
+            if (emote.AssetResult is { Succeeded: true })
             {
-                emote.AssetResults[intention.BodyShape]?.Asset!.AddReference();
+                //Asset cannot be null if succeeded is true
+                emote.AssetResult.Value.Asset!.AddReference();
             }
             else if (intention is GetSceneEmoteFromLocalSceneIntention)
             {
@@ -146,7 +147,7 @@ namespace DCL.AvatarRendering.Emotes.Load
             IPartitionComponent partitionComponent)
             where TIntention : struct, IEmoteAssetIntention
         {
-            if (emote.AssetResults[intention.BodyShape] != null) return false;
+            if (emote.AssetResult is { IsInitialized: true }) return false;
 
             intention.CreateAndAddPromiseToWorld(World, partitionComponent, customStreamingSubdirectory, emote);
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -262,15 +262,15 @@ namespace DCL.AvatarRendering.Emotes.Play
                         return;
                     }
 
-                    BodyShape bodyShape = avatarShapeComponent.BodyShape;
-
                     //Loading not complete
-                    if (emote.AssetResults[bodyShape] == null)
+                    //TODO (JUANI): Can we take this away?
+                    if (emote.AssetResult == null)
                         return;
 
-                    StreamableLoadingResult<AttachmentRegularAsset> streamableAssetValue = emote.AssetResults[bodyShape].Value;
+                    StreamableLoadingResult<AttachmentRegularAsset> streamableAssetValue = emote.AssetResult.Value;
                     GameObject? mainAsset;
 
+                    //TODO (JUANI): Can this really happen?
                     if (streamableAssetValue is { Succeeded: false } || (mainAsset = streamableAssetValue.Asset?.MainAsset) == null)
                     {
                         // We can't play emote, remove intent, otherwise there is no place to remove it
@@ -279,7 +279,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                     }
 
                     emoteComponent.EmoteUrn = emoteId;
-                    StreamableLoadingResult<AudioClipData>? audioAssetResult = emote.AudioAssetResults[bodyShape];
+                    StreamableLoadingResult<AudioClipData>? audioAssetResult = emote.AudioAssetResult;
                     AudioClip? audioClip = audioAssetResult?.Asset;
 
                     if (!emotePlayer.Play(mainAsset, audioClip, emote.IsLooping(), emoteIntent.Spatial, in avatarView, ref emoteComponent))

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/ResolveBuilderEmotePromisesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/ResolveBuilderEmotePromisesSystem.cs
@@ -77,18 +77,8 @@ namespace DCL.AvatarRendering.Emotes.Systems
             // Check if we already have this emote in storage with assets
             if (emoteStorage.TryGetElement(emote.GetUrn(), out IEmote existingEmote))
             {
-                // For unisex emotes with same clip, check if either bodyshape has assets
-                if (existingEmote.IsUnisex() && existingEmote.HasSameClipForAllGenders())
-                {
-                    if (existingEmote.AssetResults[BodyShape.MALE] != null || existingEmote.AssetResults[BodyShape.FEMALE] != null)
-                        return false; // Already processed
-                }
-                else
-                {
-                    // For non-unisex emotes, check both bodyshapes
-                    if (existingEmote.AssetResults[BodyShape.MALE] != null && existingEmote.AssetResults[BodyShape.FEMALE] != null)
-                        return false; // Already processed
-                }
+                if (existingEmote.AssetResult is { IsInitialized: true })
+                    return false; // Already processed
             }
 
             bool foundGlb = false;
@@ -110,7 +100,7 @@ namespace DCL.AvatarRendering.Emotes.Systems
                             continue;
 
                         // Skip if this bodyshape already has an asset result
-                        if (emote.AssetResults[bodyShape] != null)
+                        if (emote.AssetResult is { Succeeded: true })
                             continue;
 
                         var gltfPromise = GltfPromise.Create(World!, GetGLTFIntention.Create(content.file, content.hash), partitionComponent);

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/FinalizeEmoteLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/FinalizeEmoteLoadingSystemShould.cs
@@ -153,54 +153,21 @@ namespace DCL.AvatarRendering.Emotes.Tests
             var promiseResult = new StreamableLoadingResult<GLTFData>(gltfData);
             world.Add(promise.Entity, promiseResult);
 
-            Assert.IsFalse(mockEmote.AssetResults[bodyShape].HasValue);
+            Assert.IsFalse(mockEmote.AssetResult.HasValue);
 
             system.Update(0);
 
             Assert.IsFalse(world.IsAlive(emoteEntity));
             Assert.IsFalse(world.IsAlive(promise.Entity));
 
-            Assert.IsTrue(mockEmote.AssetResults[bodyShape].HasValue);
-            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResults[bodyShape].Value;
+            Assert.IsTrue(mockEmote.AssetResult.HasValue);
+            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResult.Value;
             Assert.IsTrue(resultValue.Succeeded);
 
             AttachmentRegularAsset? resultingAttachment = resultValue.Asset;
             Assert.IsNotNull(resultingAttachment);
             Assert.AreSame(mockGameObject, resultingAttachment!.MainAsset);
             Assert.AreSame(gltfData, resultingAttachment.assetData);
-        }
-
-        [Test]
-        public void FinalizeGltfEmoteLoadingUnisexCorrectly()
-        {
-            var emoteURN = new URN("urn:gltf:emote_unisex");
-            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockIsUnisexValue = true, MockHasSameClipForAllGendersValue = true };
-            mockEmote.ApplyAndMarkAsLoaded(CreateEmoteDTO(emoteURN, true)); // Mark as unisex for DTO properties
-
-            BodyShape loadingBodyShape = BodyShape.MALE; // System will apply to both if unisex
-            var intention = new GetGLTFIntention { CommonArguments = new CommonLoadingArguments(URLAddress.EMPTY) };
-            Entity emoteEntity = CreateEmoteEntityWithPromise<GLTFData, GetGLTFIntention>(mockEmote, intention, loadingBodyShape, out GltfPromise promise);
-            Entity resultHolderEntity = promise.Entity;
-
-            var gltfData = new GLTFData(null, mockGameObject);
-            world.Add(resultHolderEntity, new StreamableLoadingResult<GLTFData>(gltfData));
-
-            system.Update(0);
-
-            Assert.IsFalse(world.IsAlive(emoteEntity), "Carrier entity should be destroyed.");
-            Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed.");
-
-            // Check assets for both body shapes
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].HasValue, "Male asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].Value.Succeeded, "Male asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.MALE].Value.Asset.MainAsset, "Male asset game object should match.");
-
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].HasValue, "Female asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].Value.Succeeded, "Female asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset.MainAsset, "Female asset game object should match.");
-            Assert.AreSame(mockEmote.AssetResults[BodyShape.MALE].Value.Asset, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset, "Male and Female assets should be the same instance for unisex.");
-
-            Assert.IsFalse(mockEmote.IsLoading, "Emote should not be loading after successful unisex load.");
         }
 
         [Test]
@@ -225,7 +192,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(emoteEntity), "Carrier entity should be destroyed.");
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed by AssetPromise framework (even on failure).");
 
-            Assert.IsNull(mockEmote.AssetResults[bodyShape], "Asset result for body shape should be null on failure.");
+            Assert.IsNull(mockEmote.AssetResult, "Asset result for body shape should be null on failure.");
             Assert.IsFalse(mockEmote.IsLoading, "Emote should not be loading after a failed asset load attempt (status updated).");
         }
 
@@ -250,7 +217,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(emoteEntity), "Carrier entity should be destroyed on cancellation.");
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should have been destroyed by ForgetLoading.");
 
-            Assert.IsNull(mockEmote.AssetResults[bodyShape], "Asset result should be null after cancellation.");
+            Assert.IsNull(mockEmote.AssetResult, "Asset result should be null after cancellation.");
             Assert.IsFalse(mockEmote.IsLoading, "Emote should not be loading after cancellation (status updated).");
         }
 
@@ -273,15 +240,15 @@ namespace DCL.AvatarRendering.Emotes.Tests
             var promiseResult = new StreamableLoadingResult<AssetBundleData>(assetBundleData);
             world.Add(promise.Entity, promiseResult);
 
-            Assert.IsFalse(mockEmote.AssetResults[bodyShape].HasValue);
+            Assert.IsFalse(mockEmote.AssetResult.HasValue);
 
             system.Update(0);
 
             Assert.IsFalse(world.IsAlive(emoteEntity));
             Assert.IsFalse(world.IsAlive(promise.Entity));
 
-            Assert.IsTrue(mockEmote.AssetResults[bodyShape].HasValue);
-            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResults[bodyShape].Value;
+            Assert.IsTrue(mockEmote.AssetResult.HasValue);
+            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResult.Value;
             Assert.IsTrue(resultValue.Succeeded);
 
             AttachmentRegularAsset? resultingAttachment = resultValue.Asset;
@@ -310,14 +277,9 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(emoteEntity), "Carrier entity should be destroyed.");
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed.");
 
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].HasValue, "Male asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].Value.Succeeded, "Male asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.MALE].Value.Asset.MainAsset, "Male asset game object should match.");
-
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].HasValue, "Female asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].Value.Succeeded, "Female asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset.MainAsset, "Female asset game object should match.");
-            Assert.AreSame(mockEmote.AssetResults[BodyShape.MALE].Value.Asset, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset, "Male and Female assets should be the same instance for unisex.");
+            Assert.IsTrue(mockEmote.AssetResult.HasValue, "Asset should be set for unisex.");
+            Assert.IsTrue(mockEmote.AssetResult.Value.Succeeded, "Asset should succeed.");
+            Assert.AreSame(mockGameObject, mockEmote.AssetResult.Value.Asset.MainAsset, "Asset game object should match.");
 
             Assert.IsFalse(mockEmote.IsLoading, "Emote should not be loading after successful unisex load.");
         }
@@ -345,7 +307,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(emoteEntity), "Carrier entity should be destroyed.");
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed (even on failure).");
 
-            Assert.IsNull(mockEmote.AssetResults[bodyShape], "Asset result should be null on failure.");
+            Assert.IsNull(mockEmote.AssetResult, "Asset result should be null on failure.");
             Assert.IsFalse(mockEmote.IsLoading, "Emote loading status should be false after failure.");
         }
 
@@ -370,7 +332,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(emoteEntity), "Carrier entity should be destroyed on cancellation.");
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed by ForgetLoading.");
 
-            Assert.IsNull(mockEmote.AssetResults[bodyShape], "Asset result should be null after cancellation.");
+            Assert.IsNull(mockEmote.AssetResult, "Asset result should be null after cancellation.");
             Assert.IsFalse(mockEmote.IsLoading, "Emote loading status should be false after cancellation.");
         }
 
@@ -392,9 +354,9 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
             Assert.IsFalse(world.IsAlive(targetEntity));
             Assert.IsFalse(world.IsAlive(promise.Entity));
-            Assert.IsTrue(mockEmote.AudioAssetResults[bodyShape].HasValue);
-            Assert.IsTrue(mockEmote.AudioAssetResults[bodyShape].Value.Succeeded);
-            Assert.AreSame(audioClipData, mockEmote.AudioAssetResults[bodyShape].Value.Asset);
+            Assert.IsTrue(mockEmote.AudioAssetResult.HasValue);
+            Assert.IsTrue(mockEmote.AudioAssetResult.Value.Succeeded);
+            Assert.AreSame(audioClipData, mockEmote.AudioAssetResult.Value.Asset);
         }
 
         [Test]
@@ -420,7 +382,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(carrierEntity), "Carrier entity should be destroyed.");
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed (even on failure).");
 
-            Assert.IsNull(mockEmote.AudioAssetResults[bodyShape], "Audio asset result should be null on failure.");
+            Assert.IsNull(mockEmote.AudioAssetResult, "Audio asset result should be null on failure.");
 
             // IsLoading is not directly managed by FinalizeAudioClipPromise for the IEmote itself, only asset is set or not.
         }
@@ -445,7 +407,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(carrierEntity), "Carrier entity should be destroyed on cancellation.");
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should have been destroyed by ForgetLoading.");
 
-            Assert.IsNull(mockEmote.AudioAssetResults[bodyShape], "Audio asset result should be null after cancellation.");
+            Assert.IsNull(mockEmote.AudioAssetResult, "Audio asset result should be null after cancellation.");
         }
 
         [Test]
@@ -596,7 +558,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             public readonly MockEmoteStorage storageRef;
             public URN Urn { get; }
             public StreamableLoadingResult<SceneAssetBundleManifest>? ManifestResult { get; set; }
-            public StreamableLoadingResult<AttachmentRegularAsset>?[] AssetResults { get; }
+            public StreamableLoadingResult<AttachmentRegularAsset>? AssetResult { get; set;  }
             public StreamableLoadingResult<AudioClipData>?[] SocialEmoteOutcomeAudioAssetResults { get; set; }
             public bool IsSocial { get; }
             public int Amount { get; set; }
@@ -606,7 +568,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 Amount = amount;
             }
 
-            public StreamableLoadingResult<AudioClipData>?[] AudioAssetResults { get; }
+            public StreamableLoadingResult<AudioClipData>? AudioAssetResult { get; set;  }
             public EmoteDTO DTO { get; private set; }
             public bool IsLoading { get; set; }
             public int ApplyAndMarkAsLoadedCallCount { get; private set; }
@@ -622,8 +584,6 @@ namespace DCL.AvatarRendering.Emotes.Tests
             {
                 Urn = urn;
                 storageRef = storage;
-                AssetResults = new StreamableLoadingResult<AttachmentRegularAsset>?[BodyShape.COUNT];
-                AudioAssetResults = new StreamableLoadingResult<AudioClipData>?[BodyShape.COUNT];
                 IsLoading = true;
             }
 

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
@@ -22,7 +22,7 @@ namespace DCL.AvatarRendering.Loading.Components
 
         int Amount { get; }
         void SetAmount(int amount);
-        
+
         public string ToString() =>
             $"AvatarAttachment({DTO.GetHash()} | {this.GetUrn()})";
 
@@ -165,10 +165,14 @@ namespace DCL.AvatarRendering.Loading.Components
                 var representation = dto.Metadata.AbstractData.representations[i];
 
                 for (var id = 0; id < representation.bodyShapes.Length; id++)
+                {
                     if (Equals(representation.bodyShapes[id], (string)bodyShape))
+                    {
                         return avatarAttachment.TryGetContentHashByKey(representation.mainFile, out hash);
-            }
+                    }
+                }
 
+            }
             hash = null;
             return false;
         }

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
@@ -24,7 +24,7 @@ namespace DCL.CharacterPreview
         {
             "wave", "fistpump", "dab"
         };
-        
+
         protected readonly CharacterPreviewInputEventBus inputEventBus;
 
         private readonly CharacterPreviewView view;
@@ -116,7 +116,6 @@ namespace DCL.CharacterPreview
             initialized = true;
 
             ResetAvatarMovement();
-            OnModelUpdated();
         }
 
         public void Dispose()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?


- Makes emotes unisex, since they are like that by design. IE: In builder, you cannot upload two different emote models depending on BodyShape 

- `AvatarLoaderSystem`

Removes one redudant code that initiated a `GetEmotesByPointers` promise
Remoes one redundante profile clean check

- `CharacterPreviewControllerBase`

Removes a OnModelUpdate invoke, since its now handled by the new MVC manager. This avoids a redudant `GetEmotesByPointers` system

## Test Instructions

1. Test the single player emote flow. Test regular emotes and emotes 2.0 (props and sounds)
- Load your avatar and play emotes
- Change emotes in backpack
- Play emotes in world
2. Get a friend and play emotes together. See that they work fine
3. Create a collection and test builder emotes
4. Test a scene emote. You can test the ones in GP  (pidgeon, water plantes). Keep in my mind that if you have the pidgeon emote in your backpack, then that wont count as a scene emote if you start it like that.



## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
