### PR TITLE
fix: debugging crash over emote classes

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Emote.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Emote.cs
@@ -47,7 +47,7 @@ namespace DCL.AvatarRendering.Emotes
         }
 
         public override string ToString() =>
-            ((IAvatarAttachment<EmoteDTO>)this).ToString();
+            $"Emote({DTO.GetHash()} | {this.GetUrn()})";
 
         public bool IsLooping() =>
             //as the Asset is nullable the loop property might be retrieved in situations in which the Asset has not been yet loaded

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
@@ -22,9 +22,6 @@ namespace DCL.AvatarRendering.Loading.Components
 
         int Amount { get; }
         void SetAmount(int amount);
-        
-        public string ToString() =>
-            $"AvatarAttachment({DTO.GetHash()} | {this.GetUrn()})";
 
         // IThumbnailAttachment implementation
         URLPath IThumbnailAttachment.GetThumbnail()


### PR DESCRIPTION
## What does this PR change?

Fixes a crash some developers have when setting breakpoints on classes related to emotes (like `CharacterEmoteSystem` or `LoadEmotesByPointersSystem`).
Removes the default implementation from `IAvatarAttachment.ToString()` and also removes the cast and the explicit call from `Emote.ToString()`. Since it was not a conventional interface implementation, it was provoking a crash in the unity debugger.

## Test Instructions

Check emotes works normally.

For developers:
Try to set a breakpoint on any of the affected classes, specially systems. You should not get a crash anymore when breakpoint hits.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
