### PR TITLE
fix: community context menu on chat header

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/GetTitlebarViewModelCommand.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/GetTitlebarViewModelCommand.cs
@@ -60,7 +60,11 @@ namespace DCL.Chat.ChatCommands
             Sprite thumbnail = await getCommunityThumbnailCommand
                 .ExecuteAsync(communityData.thumbnailUrl, ct);
 
-            var viewModel = new ChatTitlebarViewModel(communityData.id, communityData.name, string.Empty);
+            var viewModel = new ChatTitlebarViewModel(communityData.id, communityData.name, string.Empty)
+            {
+                ViewMode = TitlebarViewMode.Community,
+            };
+
             viewModel.Thumbnail.UpdateValue(ProfileThumbnailViewModel.FromLoaded(thumbnail, false, Color.gray, true));
 
             return viewModel;


### PR DESCRIPTION
## What does this PR change?

Fixes #6629 

Sets the `TitlebarViewMode.Community` when the channel model is created.

## Test Instructions

Open the chat, select a community channel and click on the chat header. Check that the context menu is opened.

### Additional Testing Notes

I've been checking the thing with the thumbnails, but i dont find any problem there.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
