### PR TITLE
fix: passport link saving and birthdate constant change

### DIFF
--- a/Explorer/Assets/DCL/Passport/Modules/UserAdditionalFields_PassportSubModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/UserAdditionalFields_PassportSubModuleController.cs
@@ -244,7 +244,7 @@ namespace DCL.Passport.Modules
                         break;
                     case AdditionalFieldType.BIRTH_DATE:
                         if (valueToSave != null)
-                            currentProfile.Birthdate = DateTime.ParseExact(valueToSave, validInputFormatsForDate, CultureInfo.InvariantCulture, DateTimeStyles.None);
+                            currentProfile.Birthdate = DateTime.SpecifyKind(DateTime.ParseExact(valueToSave, validInputFormatsForDate, CultureInfo.InvariantCulture, DateTimeStyles.None), DateTimeKind.Utc);
                         else
                             currentProfile.Birthdate = null;
                         break;

--- a/Explorer/Assets/DCL/Passport/Modules/UserDetailedInfo_PassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/UserDetailedInfo_PassportModuleController.cs
@@ -139,6 +139,10 @@ namespace DCL.Passport.Modules
                 const string ERROR_MESSAGE = "There was an error while trying to save your profile. Please try again!";
                 passportErrorsController.Show(ERROR_MESSAGE);
                 ReportHub.LogError(ReportCategory.PROFILE, $"{ERROR_MESSAGE} ERROR: {e.Message}");
+            }
+            finally
+            {
+                SetInfoSectionAsSavingStatus(false);
                 SetInfoSectionAsEditionMode(false);
             }
         }

--- a/Explorer/Assets/DCL/Passport/Modules/UserLinks_PassportSubModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/UserLinks_PassportSubModuleController.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.ExternalUrlPrompt;
 using DCL.Passport.Fields;
 using DCL.Passport.Modals;
@@ -244,8 +245,18 @@ namespace DCL.Passport.Modules
                     });
                 }
 
-                await passportProfileInfoController.UpdateProfileAsync(currentProfile, ct);
-                SetLinksSectionAsSavingStatus(false);
+                try { await passportProfileInfoController.UpdateProfileAsync(currentProfile, ct); }
+                catch (OperationCanceledException) { }
+                catch (Exception e)
+                {
+                    const string ERROR_MESSAGE = "There was an error while trying to save your profile links. Please try again!";
+                    ReportHub.LogError(ReportCategory.PROFILE, $"{ERROR_MESSAGE} ERROR: {e.Message}");
+                }
+                finally
+                {
+                    SetLinksSectionAsSavingStatus(false);
+                    SetLinksSectionAsEditionMode(false);
+                }
             }
         }
 

--- a/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
@@ -150,19 +150,22 @@ namespace DCL.Profiles
 
             return Compact.Equals(profile.Compact)
                    && HasConnectedWeb3 == profile.HasConnectedWeb3
-                   && Description == profile.Description
+                   && AreStringsEquivalent(Description, profile.Description)
                    && TutorialStep == profile.TutorialStep
-                   && Email == profile.Email
-                   && Country == profile.Country
-                   && EmploymentStatus == profile.EmploymentStatus
-                   && Gender == profile.Gender
-                   && Pronouns == profile.Pronouns
-                   && Language == profile.Language
-                   && Profession == profile.Profession
+                   && AreStringsEquivalent(Email, profile.Email)
+                   && AreStringsEquivalent(Country, profile.Country)
+                   && AreStringsEquivalent(EmploymentStatus, profile.EmploymentStatus)
+                   && AreStringsEquivalent(Gender, profile.Gender)
+                   && AreStringsEquivalent(Pronouns, profile.Pronouns)
+                   && AreStringsEquivalent(Language, profile.Language)
+                   && AreStringsEquivalent(Profession, profile.Profession)
                    && Birthdate == profile.Birthdate
                    && Version == profile.Version
                    && AreLinksSame(links, profile.links);
         }
+        
+        private static bool AreStringsEquivalent(string? a, string? b) =>
+            (string.IsNullOrEmpty(a) && string.IsNullOrEmpty(b)) || a == b;
 
         private static bool AreLinksSame(List<LinkJsonDto>? links1, List<LinkJsonDto>? links2)
         {

--- a/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileConverter.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileConverter.cs
@@ -113,7 +113,7 @@ namespace DCL.Profiles
             profile.Hobbies = jObject["hobbies"]?.Value<string>() ?? "";
 
             long birthdate = jObject["birthDate"]?.Value<long>() ?? 0;
-            profile.Birthdate = birthdate != 0 ? DateTimeOffset.FromUnixTimeSeconds(birthdate).DateTime : null;
+            profile.Birthdate = birthdate != 0 ? DateTimeOffset.FromUnixTimeSeconds(birthdate).UtcDateTime : null;
 
             DeserializeLinks(jObject["links"]!, ref profile.links);
             DeserializeArrayToCollection(jObject["blocked"], ref profile.blocked, static s => s);
@@ -293,7 +293,7 @@ namespace DCL.Profiles
             writer.WriteValue(profile.Hobbies);
 
             writer.WritePropertyName("birthDate");
-            writer.WriteValue(profile.Birthdate != null ? new DateTimeOffset(profile.Birthdate.Value).ToUnixTimeSeconds() : 0);
+            writer.WriteValue(profile.Birthdate != null ? new DateTimeOffset(profile.Birthdate.Value, TimeSpan.Zero).ToUnixTimeSeconds() : 0);
 
             writer.WritePropertyName("links");
             SerializeLinks(writer, profile.links);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR fixes different issues that were present in the passport info editing:
Fix #5326 the birthdate was changing at every update
Fix #6568 links were not savable
We were also forcing a deploy at every update as some fields always resulted different

## Test Instructions

### Test Steps
1. Launch the client
2. Open the passport
3. Edit the birthdate
4. Verify it is always saved correctly and it doesn't change
5. Add links
6. Save them
7. Verify that they are stored correctly

Keep in mind that it takes a while to save the changes (up to 15 seconds) so sometimes you might see the loading wheel for a bit.
Also keep in mind that you can sometimes get errors if you save many times close to eachother as if there is a profile deployment already happening (i.e. the previous save) it might give an error

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
