### PR TITLE
fix: disable AB manifest fallback exception

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetBundleManifestFallbackHelper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/AssetBundleManifestFallbackHelper.cs
@@ -38,8 +38,9 @@ namespace ECS.StreamableLoading.AssetBundles
                 //Needed to use the Time.realtimeSinceStartup on the intention creation
                 await UniTask.SwitchToMainThread();
 
-                SentrySdk.AddBreadcrumb($"AB manifest version missing for entity: {entityDefinition.id}");
-                ReportHub.LogException(new Exception("AssetBundleManifestFallbackHelper: AB Manifest Fallback requested"), ReportCategory.ASSET_BUNDLES);
+                // Log breadcrumb and report exception disabled while we have separate flows for backpack and emotes. They need to be re-enabled once we unify the flows with the trimmed version.
+                //SentrySdk.AddBreadcrumb($"AB manifest version missing for entity: {entityDefinition.id}");
+                //ReportHub.LogException(new Exception("AssetBundleManifestFallbackHelper: AB Manifest Fallback requested"), ReportCategory.ASSET_BUNDLES);
 
                 var promise = AssetBundleManifestPromise.Create(world,
                     GetAssetBundleManifestIntention.Create(entityDefinition.id, new CommonLoadingArguments(entityDefinition.id)),


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Disable breadcrumb and exception while we have different flows for emotes and backpack wearables.
This needs to be re-enabled once we merge the flows and have trimmed versions for both objects.


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
