### PR TITLE
chore: add debug-dcl sub-agent orchestrator for the dcl project

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -1,0 +1,153 @@
+# DCL Stack Trace Debugger
+
+An orchestrated debugging system for the decentraland/unity-explorer project. Uses parallel sub-agent investigations to quickly pinpoint root causes.
+
+## Setup
+
+Copy the commands folder to your project:
+```bash
+cp -r commands/ /path/to/unity-explorer/.claude/
+```
+
+Your structure should look like:
+```
+unity-explorer/
+├── .claude/
+│   └── commands/
+│       ├── debug-dcl.md          # Main orchestrator
+│       ├── debug-dcl-ecs.md      # ECS component investigation
+│       ├── debug-dcl-plugin.md   # Plugin/DI investigation
+│       ├── debug-dcl-asset.md    # Asset loading investigation
+│       ├── debug-dcl-async.md    # Async/UniTask investigation
+│       ├── debug-dcl-lifecycle.md # Entity/World lifecycle
+│       └── debug-dcl-adjacent.md # Adjacent code review
+├── Explorer/
+└── ...
+```
+
+## Usage
+
+### Quick Start
+
+When you have an exception, run:
+```
+/debug-dcl NullReferenceException: Object reference not set to an instance of an object.
+   at DCL.ECS.Systems.AvatarSystem.Update() in AvatarSystem.cs:line 47
+   at Arch.SystemGroups...
+```
+
+The orchestrator will:
+1. Parse the exception
+2. Identify the crash context (ECS, Plugin, Async, etc.)
+3. Spawn parallel investigations
+4. Synthesize findings into a root cause analysis
+
+### Manual Sub-agent Invocation
+
+You can run individual investigations directly:
+
+**ECS Component Issues:**
+```
+/debug-dcl-ecs COMPONENT="AvatarComponent" ENTITY_CONTEXT="player" CRASH_FILE="AvatarSystem.cs" CRASH_LINE="47"
+```
+
+**Plugin/DI Issues:**
+```
+/debug-dcl-plugin SERVICE="IAvatarService" CRASH_FILE="AvatarController.cs" CRASH_LINE="23"
+```
+
+**Asset Loading Issues:**
+```
+/debug-dcl-asset ASSET_EXPRESSION="settings.AvatarPrefab.Value" CRASH_FILE="AvatarPlugin.cs" CRASH_LINE="31"
+```
+
+**Async/UniTask Issues:**
+```
+/debug-dcl-async METHOD_NAME="LoadAvatarAsync" CRASH_FILE="AvatarLoader.cs" CRASH_LINE="55"
+```
+
+**Lifecycle Issues:**
+```
+/debug-dcl-lifecycle ENTITY_OR_WORLD="playerEntity" CRASH_FILE="PlayerSystem.cs" CRASH_LINE="28"
+```
+
+**Adjacent Code Review:**
+```
+/debug-dcl-adjacent CRASH_FILE="AvatarSystem.cs" CRASH_LINE="47" CRASH_DIR="Explorer/Assets/DCL/ECS/Avatar"
+```
+
+## Investigation Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      /debug-dcl [exception]                      │
+│                         (Orchestrator)                           │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              │ Parses exception, identifies context
+                              │
+         ┌────────────────────┼────────────────────┐
+         │                    │                    │
+         ▼                    ▼                    ▼
+┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
+│   debug-dcl-    │  │   debug-dcl-    │  │   debug-dcl-    │
+│      ecs        │  │     plugin      │  │     asset       │
+│                 │  │                 │  │                 │
+│ • Component     │  │ • DI registration│ │ • AssetRef      │
+│   lifecycle     │  │ • Settings      │  │   configuration │
+│ • System order  │  │ • World inject  │  │ • Load timing   │
+│ • Query vs Add  │  │ • Initialization│  │ • Disposal      │
+└────────┬────────┘  └────────┬────────┘  └────────┬────────┘
+         │                    │                    │
+         │    ┌───────────────┼───────────────┐    │
+         │    │               │               │    │
+         ▼    ▼               ▼               ▼    ▼
+┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
+│   debug-dcl-    │  │   debug-dcl-    │  │   debug-dcl-    │
+│     async       │  │    lifecycle    │  │    adjacent     │
+│                 │  │                 │  │                 │
+│ • Cancellation  │  │ • Entity refs   │  │ • Similar code  │
+│ • UniTask flow  │  │ • World scope   │  │ • Null patterns │
+│ • Result pattern│  │ • Disposal order│  │ • TODOs/FIXMEs  │
+└────────┬────────┘  └────────┬────────┘  └────────┬────────┘
+         │                    │                    │
+         └────────────────────┼────────────────────┘
+                              │
+                              ▼
+                    ┌─────────────────┐
+                    │   SYNTHESIS     │
+                    │                 │
+                    │ • Root cause    │
+                    │ • Causal chain  │
+                    │ • Fixes         │
+                    └─────────────────┘
+```
+
+## Common Null Categories in DCL
+
+| Category | Sub-agent | Common Causes |
+|----------|-----------|---------------|
+| ECS Component | debug-dcl-ecs | Component not added, wrong system order, entity destroyed |
+| Plugin/DI | debug-dcl-plugin | Service not registered, settings not configured, world not injected |
+| Asset Loading | debug-dcl-asset | AssetReference empty, .Value before load, cancelled load |
+| Async | debug-dcl-async | CancellationToken not checked, Result not validated |
+| Lifecycle | debug-dcl-lifecycle | Entity destroyed, world disposed, stale EntityReference |
+
+## Output
+
+The orchestrator produces a comprehensive report including:
+- Summary of exception and context
+- Findings from each sub-agent investigation
+- Root cause analysis with causal chain
+- Immediate fix (stop the crash)
+- Root cause fix (prevent the null)
+- Verification checklist
+- Files examined
+
+## Tips
+
+1. **Let the orchestrator decide**: Start with `/debug-dcl` - it will spawn the right investigations
+2. **Parallel is faster**: Sub-agents run concurrently, faster than sequential debugging
+3. **Check Unity Inspector**: Many DCL nulls are missing asset references in PluginSettingsContainer
+4. **System order matters**: Use `[UpdateAfter]` and `[UpdateBefore]` attributes
+5. **Use EntityReference**: Never store raw `Entity` outside ECS

--- a/.claude/commands/debug-dcl-adjacent.md
+++ b/.claude/commands/debug-dcl-adjacent.md
@@ -1,0 +1,157 @@
+# Investigate Adjacent Code - Sub-agent
+
+You are reviewing code adjacent to a crash site in decentraland/unity-explorer.
+
+## Parameters
+- CRASH_FILE: File where crash occurred
+- CRASH_LINE: Line number
+- CRASH_DIR: Directory containing crash file
+
+## Investigation Tasks
+
+### 1. Read Full Crash File
+```bash
+cat -n {{CRASH_FILE}}
+```
+- Understand the full context of the class
+- Note initialization, dependencies, disposal
+
+### 2. Find Related Systems in Same Group
+```bash
+rg "\[UpdateInGroup\(" -n {{CRASH_DIR}} --type cs -A 1
+```
+- What SystemGroup is this in?
+- What other systems are in the same group?
+
+### 3. Check System Dependencies
+```bash
+rg "\[UpdateAfter\(typeof|UpdateBefore\(typeof" -n {{CRASH_DIR}} --type cs
+```
+- What systems must run before this one?
+- What systems run after?
+
+### 4. Find Similar Patterns
+```bash
+# Find similar null-prone patterns in same directory
+rg "\.Get<|\.Value|FirstOrDefault|SingleOrDefault" -n {{CRASH_DIR}} --type cs
+```
+- Are there similar access patterns?
+- Do others have null checks?
+
+### 5. Check for Defensive Patterns
+```bash
+rg "TryGet|\.HasValue|\?\.|!= null|== null" -n {{CRASH_DIR}} --type cs
+```
+- Is defensive coding used elsewhere?
+- Is crash site missing these patterns?
+
+### 6. Look for TODO/FIXME Comments
+```bash
+rg "TODO|FIXME|HACK|BUG|XXX" -n {{CRASH_FILE}} --type cs
+rg "TODO|FIXME|HACK|BUG|XXX" -n {{CRASH_DIR}} --type cs
+```
+- Any known issues flagged?
+- Any incomplete implementations?
+
+### 7. Check Git History (if available)
+```bash
+git log --oneline -10 -- {{CRASH_FILE}} 2>/dev/null || echo "Git not available"
+git blame -L {{CRASH_LINE-5}},{{CRASH_LINE+5}} {{CRASH_FILE}} 2>/dev/null || echo "Git blame not available"
+```
+- Recent changes to this file?
+- Who last modified crash area?
+
+### 8. Find Test Coverage
+```bash
+rg "$(basename {{CRASH_FILE}} .cs)" -n Explorer/Assets --type cs | grep -i "test"
+```
+- Are there tests for this code?
+- Do tests cover the null scenario?
+
+### 9. Check Error Handling in File
+```bash
+rg "try|catch|throw|Exception" -n {{CRASH_FILE}} --type cs
+```
+- Is there error handling?
+- Should there be more?
+
+### 10. Find Interface/Base Class
+```bash
+head -50 {{CRASH_FILE}} | grep -E "class.*:|interface"
+rg "abstract|virtual|override" -n {{CRASH_FILE}} --type cs
+```
+- What does this class inherit from?
+- Are there virtual methods that might behave differently?
+
+### 11. Check Parallel/Similar Implementations
+```bash
+# Find files with similar names
+ls -la {{CRASH_DIR}}/*.cs 2>/dev/null
+# Find similar class patterns
+rg "class.*$(basename {{CRASH_FILE}} .cs | sed 's/System//')" -n Explorer/Assets --type cs -l
+```
+- Are there similar systems/classes?
+- How do they handle nulls?
+
+## Output Format
+
+```markdown
+## Adjacent Code Review: {{CRASH_FILE}}
+
+### File Overview
+- **Class Name**: [name]
+- **Type**: [System / Plugin / Controller / Service]
+- **Base Class**: [if any]
+- **SystemGroup**: [if applicable]
+
+### Related Code
+| File | Relationship | Null Handling |
+|------|--------------|---------------|
+| [file1] | [same group / depends on / depended by] | [defensive / not defensive] |
+
+### Patterns Analysis
+| Pattern | In Crash File | In Adjacent Files |
+|---------|---------------|-------------------|
+| TryGet<> | [used/not used] | [used/not used] |
+| Null checks | [present/absent] | [present/absent] |
+| ?. operator | [used/not used] | [used/not used] |
+
+### Code Quality Indicators
+- **TODO/FIXME found**: [yes/no - list if yes]
+- **Error handling**: [comprehensive / partial / none]
+- **Test coverage**: [found / not found]
+- **Recent changes**: [yes - summary / no / unknown]
+
+### Similar Patterns Found
+```csharp
+// From adjacent file that handles nulls properly
+[example of defensive pattern]
+```
+
+```csharp
+// From crash file that lacks defense
+[example of vulnerable pattern]
+```
+
+### Issues Found
+- [ ] Inconsistent null handling compared to similar code
+- [ ] Missing defensive patterns used elsewhere
+- [ ] TODO/FIXME indicates known issue
+- [ ] Recent changes may have introduced bug
+- [ ] No test coverage for null scenario
+
+### Recommendations
+1. [Specific recommendation based on findings]
+2. [Additional pattern to apply]
+
+### Files to Also Review
+| File | Reason |
+|------|--------|
+| [file] | [why relevant] |
+
+### Confidence: [High/Medium/Low]
+```
+
+## Execute
+
+Review `{{CRASH_FILE}}` and adjacent code to find patterns and potential related issues.

--- a/.claude/commands/debug-dcl-asset.md
+++ b/.claude/commands/debug-dcl-asset.md
@@ -1,0 +1,150 @@
+# Investigate Asset Loading - Sub-agent
+
+You are investigating an asset loading related null in decentraland/unity-explorer.
+
+## Parameters
+- ASSET_EXPRESSION: The asset access that might be null
+- CRASH_FILE: File where crash occurred
+- CRASH_LINE: Line number
+
+## DCL Asset Loading Context
+
+- **IAssetsProvisioner**: Main interface for loading assets
+- **ProvidedAsset<T>**: Wrapper for loaded ScriptableObjects, Materials, etc.
+- **ProvidedInstance<T>**: Wrapper for instantiated prefabs (ComponentReference)
+- **AssetReferenceT<T>**: Addressable reference to assets
+- **ComponentReference<T>**: Reference to component on prefab
+- **AssetPromise<TAsset, TLoadingIntention>**: ECS-friendly async loading pattern
+
+## Investigation Tasks
+
+### 1. Find Asset Access at Crash Site
+```bash
+sed -n '{{CRASH_LINE-10}},{{CRASH_LINE+10}}p' {{CRASH_FILE}} | cat -n
+```
+- What asset is being accessed?
+- Is `.Value` used directly?
+- Is there null checking?
+
+### 2. Find Asset Reference Definition
+```bash
+rg "AssetReferenceT|AssetReference<|ComponentReference" -n Explorer/Assets --type cs | grep -i "$(echo {{ASSET_EXPRESSION}} | grep -oE '[A-Za-z]+' | head -1)"
+```
+- Where is the reference defined?
+- What type is it?
+
+### 3. Find Asset Loading Call
+```bash
+rg "ProvideMainAssetAsync|ProvideInstanceAsync|assetsProvisioner\." -n {{CRASH_FILE}} --type cs -B 3 -A 5
+```
+- Where is the asset loaded?
+- Is loading awaited properly?
+- Is CancellationToken handled?
+
+### 4. Check Loading Pattern
+```bash
+rg "ProvidedAsset|ProvidedInstance|\.Value" -n {{CRASH_FILE}} --type cs -B 2 -A 2
+```
+
+**Safe pattern:**
+```csharp
+var provided = await assetsProvisioner.ProvideMainAssetAsync(settings.AssetRef, ct: ct);
+if (provided.Value != null) // Check before use
+    DoSomething(provided.Value);
+```
+
+**Dangerous pattern:**
+```csharp
+var provided = await assetsProvisioner.ProvideMainAssetAsync(settings.AssetRef, ct: ct);
+DoSomething(provided.Value); // Crashes if not resolved
+```
+
+### 5. Check Settings Configuration
+```bash
+rg "Settings" -n {{CRASH_FILE}} --type cs | head -5
+SETTINGS_CLASS=$(rg "class.*Settings" -n {{CRASH_FILE_DIR}} --type cs -l | head -1)
+cat -n $SETTINGS_CLASS 2>/dev/null | head -50
+```
+- What settings class contains this reference?
+- Is it IDCLPluginSettings?
+
+### 6. Check AssetPromise Pattern (ECS)
+```bash
+rg "AssetPromise|LoadSystemBase|TLoadingIntention" -n Explorer/Assets --type cs | grep -i "$(echo {{ASSET_EXPRESSION}} | grep -oE '[A-Za-z]+' | head -1)"
+```
+- Is this using the ECS promise pattern?
+- Is the promise polled before consumption?
+
+### 7. Check Disposal/Cleanup
+```bash
+rg "Dispose|Release|Unload" -n {{CRASH_FILE}} --type cs
+rg "ProvidedAsset.*Dispose|ProvidedInstance.*Dispose" -n Explorer/Assets --type cs
+```
+- Is asset disposed before access?
+- Is there reference counting issue?
+
+### 8. Check Addressables Configuration
+```bash
+rg "Addressables|AddressableAssetSettings" -n Explorer/Assets --type cs | head -10
+```
+- Could asset be missing from Addressables?
+
+## Output Format
+
+```markdown
+## Asset Investigation: {{ASSET_EXPRESSION}}
+
+### Asset Access
+- **Location**: {{CRASH_FILE}}:{{CRASH_LINE}}
+- **Expression**: `{{ASSET_EXPRESSION}}`
+- **Access Pattern**: [.Value direct / null-checked / TryGet]
+
+### Asset Reference
+- **Type**: [AssetReferenceT<X> / ComponentReference<X>]
+- **Defined In**: [settings class file:line]
+- **Configured**: [Check Unity Inspector]
+
+### Loading Flow
+```
+1. [Settings.AssetRef defined]
+   ↓
+2. [ProvideMainAssetAsync called at file:line]
+   ↓
+3. [await completes - or does it?]
+   ↓
+4. [.Value accessed at crash site]
+```
+
+### Potential Null Scenarios
+| Scenario | Likelihood | Evidence |
+|----------|------------|----------|
+| Reference not assigned in Inspector | [High/Med/Low] | [check required] |
+| Loading cancelled | [High/Med/Low] | [CT handling] |
+| Loading failed silently | [High/Med/Low] | [error handling] |
+| Accessed before await | [High/Med/Low] | [code pattern] |
+| Asset disposed | [High/Med/Low] | [disposal code] |
+
+### Issues Found
+- [ ] .Value accessed without null check
+- [ ] AssetReference not configured in PluginSettingsContainer
+- [ ] CancellationToken not checked after await
+- [ ] No error handling for load failure
+- [ ] Asset disposed before access
+
+### Evidence
+```csharp
+[Key code snippets showing the issue]
+```
+
+### Verification Steps
+1. Open PluginSettingsContainer in Unity Inspector
+2. Find the settings for [plugin name]
+3. Check if [asset reference field] is assigned
+4. If missing, assign the correct asset
+
+### Confidence: [High/Medium/Low]
+```
+
+## Execute
+
+Trace `{{ASSET_EXPRESSION}}` through DCL's asset loading system and report findings.

--- a/.claude/commands/debug-dcl-async.md
+++ b/.claude/commands/debug-dcl-async.md
@@ -1,0 +1,173 @@
+# Investigate Async/UniTask - Sub-agent
+
+You are investigating an async/UniTask related null in decentraland/unity-explorer.
+
+## Parameters
+- METHOD_NAME: The async method or context
+- CRASH_FILE: File where crash occurred
+- CRASH_LINE: Line number
+
+## DCL Async Context
+
+- **UniTask**: Primary async library (not standard Task)
+- **CancellationToken**: Passed through most async operations
+- **AssetPromise**: ECS-friendly polling-based async pattern
+- **Result pattern**: Exception-free flow using `Result.SuccessResult()` / `Result.ErrorResult()`
+- **SuppressToResultAsync**: Converts exceptions to Result
+
+## Investigation Tasks
+
+### 1. Find Async Method Definition
+```bash
+rg "async.*{{METHOD_NAME}}|UniTask.*{{METHOD_NAME}}" -n Explorer/Assets --type cs -A 20
+```
+- Is it UniTask or Task?
+- What does it return?
+- Does it accept CancellationToken?
+
+### 2. Check Cancellation Handling
+```bash
+rg "CancellationToken|\.IsCancellationRequested|ThrowIfCancellationRequested" -n {{CRASH_FILE}} --type cs -B 2 -A 2
+```
+
+**Safe pattern:**
+```csharp
+if (ct.IsCancellationRequested)
+    return Result.CancelledResult();
+```
+
+**Dangerous pattern:**
+```csharp
+ct.ThrowIfCancellationRequested(); // Throws, might not be caught
+```
+
+### 3. Find All Await Points
+```bash
+rg "await " -n {{CRASH_FILE}} --type cs
+```
+- Are all awaits before the crash line?
+- Could any await be skipped?
+- Is there early return before await completes?
+
+### 4. Check Result Pattern Usage
+```bash
+rg "Result\.|SuppressToResultAsync|SuccessResult|ErrorResult|CancelledResult" -n {{CRASH_FILE}} --type cs -B 2 -A 2
+```
+- Is this method using exception-free Result pattern?
+- Is Result checked before using value?
+
+### 5. Check AssetPromise Pattern
+```bash
+rg "AssetPromise|LoadSystemBase|TLoadingIntention" -n Explorer/Assets --type cs | grep -i "{{METHOD_NAME}}"
+```
+For ECS async:
+```csharp
+// Promise entity created, polled each frame until resolved
+// Consumed when ready, entity destroyed
+```
+- Is promise consumed before resolved?
+
+### 6. Find Exception Handling
+```bash
+rg "try|catch|finally" -n {{CRASH_FILE}} --type cs -A 5
+rg "OperationCanceledException" -n {{CRASH_FILE}} --type cs
+```
+- Are cancellation exceptions caught?
+- Is there proper cleanup in finally?
+
+### 7. Check Continuation/Callback
+```bash
+rg "ContinueWith|\.Then|ContinueInitialization|callback|Action<|Func<" -n {{CRASH_FILE}} --type cs
+```
+- Is crash in a continuation?
+- Could callback execute after disposal?
+
+### 8. Check Race Conditions
+```bash
+rg "lock|Interlocked|volatile|concurrent" -n {{CRASH_FILE}} --type cs
+```
+- Are there shared resources?
+- Could multiple async ops conflict?
+
+### 9. Trace Async Call Chain
+```bash
+rg "{{METHOD_NAME}}" -n Explorer/Assets --type cs | grep -v "{{CRASH_FILE}}"
+```
+- Who calls this method?
+- What do they do with the result?
+
+## Output Format
+
+```markdown
+## Async Investigation: {{METHOD_NAME}}
+
+### Method Signature
+- **Location**: [file:line]
+- **Return Type**: [UniTask / UniTask<T> / Task]
+- **Cancellation**: [CancellationToken param? yes/no]
+
+### Async Flow Analysis
+```
+1. [Caller invokes method]
+   ↓
+2. [await #1 at line X] - [what it awaits]
+   ↓
+3. [await #2 at line Y] - [what it awaits]
+   ↓
+4. [Crash point at line Z]
+```
+
+### Cancellation Handling
+| Check Point | Handled? | Pattern |
+|-------------|----------|---------|
+| Before await #1 | [yes/no] | [IsCancellationRequested / ThrowIf / none] |
+| After await #1 | [yes/no] | [...] |
+| At crash site | [yes/no] | [...] |
+
+### Exception Handling
+- **Try/Catch**: [present/absent]
+- **SuppressToResultAsync**: [used/not used]
+- **OperationCanceledException**: [caught/not caught]
+
+### Potential Issues
+| Issue | Likelihood | Evidence |
+|-------|------------|----------|
+| Cancelled but result used | [High/Med/Low] | [code] |
+| Exception not caught | [High/Med/Low] | [code] |
+| Race condition | [High/Med/Low] | [code] |
+| Promise consumed early | [High/Med/Low] | [code] |
+| Continuation after disposal | [High/Med/Low] | [code] |
+
+### Issues Found
+- [ ] CancellationToken not checked after await
+- [ ] Result used without checking Success
+- [ ] ThrowIfCancellationRequested without catch
+- [ ] Missing SuppressToResultAsync wrapper
+- [ ] Callback executes on disposed object
+
+### Null Scenario
+[Explain how async flow leads to null at crash site]
+
+### Evidence
+```csharp
+[Key code snippets]
+```
+
+### Recommended Fix
+```csharp
+// Add proper cancellation check
+if (ct.IsCancellationRequested)
+    return; // or Result.CancelledResult()
+
+// Check result before use
+var result = await SomeAsyncOp(ct);
+if (!result.Success)
+    return Result.ErrorResult(result.ErrorMessage);
+```
+
+### Confidence: [High/Medium/Low]
+```
+
+## Execute
+
+Trace the async flow of `{{METHOD_NAME}}` and identify where cancellation or async timing could cause null.

--- a/.claude/commands/debug-dcl-ecs.md
+++ b/.claude/commands/debug-dcl-ecs.md
@@ -1,0 +1,124 @@
+# Investigate ECS - Sub-agent
+
+You are investigating an ECS-related null reference in decentraland/unity-explorer.
+
+## Parameters
+- COMPONENT: The component type to trace
+- ENTITY_CONTEXT: Where the entity comes from
+- CRASH_FILE: File where crash occurred
+- CRASH_LINE: Line number
+
+## DCL ECS Context
+
+This project uses **Arch ECS** (not Unity DOTS):
+- Components are structs or classes added to entities
+- Systems run in groups with defined order
+- Two worlds: Global (single) and Scene (per JS scene)
+- `SingleInstanceEntity` pattern for unique entities
+- `EntityReference` for safe cross-frame entity storage
+
+## Investigation Tasks
+
+### 1. Find Component Definition
+```bash
+rg "struct {{COMPONENT}}|class {{COMPONENT}}" -n Explorer/Assets --type cs -A 10
+```
+- Is it a struct (value type) or class (reference type)?
+- What fields does it contain?
+- Are any fields nullable?
+
+### 2. Find Where Component Is Added
+```bash
+rg "\.Add\(.*{{COMPONENT}}|\.Add<{{COMPONENT}}|AddComponent.*{{COMPONENT}}" -n Explorer/Assets --type cs -B 3 -A 3
+```
+- Which system/method adds this component?
+- Is it added conditionally?
+- What are the prerequisites?
+
+### 3. Find Where Component Is Queried
+```bash
+rg "Query<.*{{COMPONENT}}|\.Get<{{COMPONENT}}|\.TryGet<{{COMPONENT}}" -n Explorer/Assets --type cs -B 2 -A 2
+```
+- Which systems read this component?
+- Do they use `Get<>` (throws) or `TryGet<>` (safe)?
+- Is there a mismatch between add and query locations?
+
+### 4. Find Where Component Is Removed
+```bash
+rg "\.Remove<{{COMPONENT}}|RemoveComponent.*{{COMPONENT}}" -n Explorer/Assets --type cs -B 2 -A 2
+```
+- Is the component removed before it's queried?
+- Is removal conditional?
+
+### 5. Check System Execution Order
+```bash
+rg "\[UpdateInGroup\(typeof\(|UpdateAfter\(typeof\(|UpdateBefore\(typeof\(" -n {{CRASH_FILE}} --type cs
+rg "class.*System.*:.*BaseSystem|ComponentSystemBase" -n Explorer/Assets --type cs | head -20
+```
+- What SystemGroup is the crashing system in?
+- What systems run before/after it?
+- Could a dependency system not have run yet?
+
+### 6. Check Entity Lifecycle
+```bash
+rg "EntityReference|SingleInstanceEntity|world\.Create\(|\.Destroy\(" -n Explorer/Assets --type cs | grep -i "{{COMPONENT}}\|{{ENTITY_CONTEXT}}"
+```
+- Is entity created before component is queried?
+- Is entity destroyed prematurely?
+- Is EntityReference used correctly?
+
+### 7. Check World Context
+```bash
+rg "GlobalWorld|SceneWorld|ISceneFacade" -n {{CRASH_FILE}} --type cs
+```
+- Is this Global or Scene world?
+- Could there be cross-world access issues?
+
+## Output Format
+
+```markdown
+## ECS Investigation: {{COMPONENT}}
+
+### Component Definition
+- **Type**: [struct/class]
+- **Location**: [file:line]
+- **Fields**: [list nullable fields]
+
+### Lifecycle Analysis
+| Stage | Location | Conditional? |
+|-------|----------|--------------|
+| Created | [file:line] | [yes/no] |
+| Added | [file:line] | [yes/no] |
+| Queried | [file:line] | [yes/no] |
+| Removed | [file:line] | [yes/no] |
+
+### System Order
+```
+[Previous System] 
+  ↓ (adds component?)
+[Crashing System] ← queries component here
+  ↓
+[Next System]
+```
+
+### Issues Found
+- [ ] Component added conditionally but queried unconditionally
+- [ ] System order incorrect - queried before added
+- [ ] Entity destroyed before query
+- [ ] Using Get<> instead of TryGet<>
+- [ ] Wrong world context
+
+### Null Scenario
+[Explain the specific conditions where component would be missing]
+
+### Evidence
+```csharp
+[Key code snippets]
+```
+
+### Confidence: [High/Medium/Low]
+```
+
+## Execute
+
+Search for `{{COMPONENT}}` through its full lifecycle in the DCL codebase and report findings.

--- a/.claude/commands/debug-dcl-lifecycle.md
+++ b/.claude/commands/debug-dcl-lifecycle.md
@@ -1,0 +1,189 @@
+# Investigate Lifecycle - Sub-agent
+
+You are investigating an entity/world lifecycle related null in decentraland/unity-explorer.
+
+## Parameters
+- ENTITY_OR_WORLD: The entity or world context
+- CRASH_FILE: File where crash occurred
+- CRASH_LINE: Line number
+
+## DCL Lifecycle Context
+
+**Worlds:**
+- **Global World**: Single instance, handles realm, scenes lifecycle, player, camera, avatars
+- **Scene World**: Per JavaScript scene, fully independent, disposed when scene unloads
+- Worlds are **fully independent** - can't reference entities from other worlds
+
+**Entities:**
+- `Entity` is just an integer - doesn't contain world reference
+- `EntityReference` for safe cross-frame storage
+- `SingleInstanceEntity` for unique entities (cached query pattern)
+
+**Disposal:**
+- Scene worlds disposed on scene unload
+- Entities destroyed don't notify - stale references crash
+- Plugins must cleanup in Dispose()
+
+## Investigation Tasks
+
+### 1. Find Entity/World Access at Crash
+```bash
+sed -n '{{CRASH_LINE-10}},{{CRASH_LINE+10}}p' {{CRASH_FILE}} | cat -n
+```
+- Is it accessing entity components?
+- Is it querying a world?
+- Is there an EntityReference being resolved?
+
+### 2. Check Entity Creation
+```bash
+rg "world\.Create\(|\.Create\(\)|CreateEntity" -n Explorer/Assets --type cs | grep -i "{{ENTITY_OR_WORLD}}"
+```
+- Where is the entity created?
+- Is creation conditional?
+- Which world owns it?
+
+### 3. Check Entity Destruction
+```bash
+rg "\.Destroy\(|DestroyEntity|world\.Destroy" -n Explorer/Assets --type cs | grep -i "{{ENTITY_OR_WORLD}}"
+```
+- Where is entity destroyed?
+- Could it be destroyed before crash site?
+
+### 4. Check EntityReference Usage
+```bash
+rg "EntityReference" -n {{CRASH_FILE}} --type cs -B 2 -A 2
+rg "EntityReference" -n Explorer/Assets --type cs | grep -i "{{ENTITY_OR_WORLD}}"
+```
+- Is EntityReference used for cross-frame storage?
+- Is raw Entity stored (dangerous)?
+
+### 5. Check SingleInstanceEntity Pattern
+```bash
+rg "SingleInstanceEntity" -n {{CRASH_FILE}} --type cs -B 3 -A 3
+rg "SingleInstanceEntity" -n Explorer/Assets --type cs | head -20
+```
+- Is this a single-instance entity?
+- Is it cached properly?
+- Could cache be stale?
+
+### 6. Check World Context
+```bash
+rg "GlobalWorld|SceneWorld|ISceneFacade|sceneWorld|globalWorld" -n {{CRASH_FILE}} --type cs
+```
+- Is this Global or Scene world?
+- Could there be cross-world access (forbidden)?
+
+### 7. Check World Injection
+```bash
+rg "ArchSystemsWorldBuilder|InjectToWorld|GlobalPluginArguments" -n {{CRASH_FILE}} --type cs -B 3 -A 5
+```
+- Is world injected via ContinueInitialization?
+- Could world be accessed before injection?
+
+### 8. Check Disposal Order
+```bash
+rg "IDisposable|Dispose\(\)|OnDestroy" -n {{CRASH_FILE}} --type cs -A 10
+rg "Dispose" -n Explorer/Assets --type cs | grep -i "{{ENTITY_OR_WORLD}}"
+```
+- Is there proper disposal implementation?
+- Could access happen after disposal?
+
+### 9. Check Scene Lifecycle
+```bash
+rg "ISceneFacade|SceneLoading|SceneUnloading|sceneLifecycle" -n Explorer/Assets --type cs | grep -i "{{ENTITY_OR_WORLD}}"
+```
+- Is entity tied to scene lifecycle?
+- Could scene unload before access?
+
+### 10. Find World/Entity References
+```bash
+rg "{{ENTITY_OR_WORLD}}" -n {{CRASH_FILE}} --type cs
+```
+- How many references exist?
+- Are any stored outside ECS (bad practice)?
+
+## Output Format
+
+```markdown
+## Lifecycle Investigation: {{ENTITY_OR_WORLD}}
+
+### Context
+- **Type**: [Entity / World / SingleInstanceEntity]
+- **World Scope**: [Global / Scene / Unknown]
+- **Storage**: [EntityReference / Raw Entity / SingleInstanceEntity cache]
+
+### Lifecycle Flow
+```
+1. [Creation point - file:line]
+   ↓
+2. [Usage during lifetime]
+   ↓  
+3. [Destruction/Disposal - file:line]
+   ↓
+4. [Crash site - accessing after destruction?]
+```
+
+### World Analysis
+| Aspect | Status |
+|--------|--------|
+| World Type | [Global / Scene] |
+| World Injected | [yes / no / unknown] |
+| Cross-world Access | [none / detected] |
+
+### Entity Analysis
+| Aspect | Status |
+|--------|--------|
+| Created | [file:line] |
+| Reference Type | [EntityReference / raw / SingleInstance] |
+| Destroyed | [file:line or N/A] |
+| Stale Reference Risk | [High / Med / Low] |
+
+### Disposal Chain
+```
+1. [First thing disposed]
+2. [Second thing disposed]
+...
+N. [Entity/World accessed here - after disposal?]
+```
+
+### Issues Found
+- [ ] Raw Entity stored instead of EntityReference
+- [ ] SingleInstanceEntity cache not refreshed
+- [ ] Entity accessed after destruction
+- [ ] World accessed before injection
+- [ ] Cross-world entity access attempted
+- [ ] Scene unloaded but entity still referenced
+- [ ] Disposal order incorrect
+
+### Null Scenario
+[Explain specific lifecycle timing that causes null]
+
+### Evidence
+```csharp
+[Key code showing lifecycle issue]
+```
+
+### Recommended Fix
+```csharp
+// Use EntityReference for safe storage
+private EntityReference _entityRef;
+
+// Check validity before access
+if (_entityRef.TryGetEntity(world, out var entity))
+{
+    // Safe to use entity
+}
+
+// Or for SingleInstanceEntity
+if (_singleInstance.TryGetEntity(world, out var entity))
+{
+    // Safe to use
+}
+```
+
+### Confidence: [High/Medium/Low]
+```
+
+## Execute
+
+Trace the lifecycle of `{{ENTITY_OR_WORLD}}` and identify timing/disposal issues.

--- a/.claude/commands/debug-dcl-plugin.md
+++ b/.claude/commands/debug-dcl-plugin.md
@@ -1,0 +1,146 @@
+# Investigate Plugin/DI - Sub-agent
+
+You are investigating a Plugin or Dependency Injection related null in decentraland/unity-explorer.
+
+## Parameters
+- SERVICE: The service/plugin/dependency name
+- CRASH_FILE: File where crash occurred
+- CRASH_LINE: Line number
+
+## DCL Plugin Architecture
+
+- **Plugins**: `IDCLPlugin`, `DCLGlobalPluginBase<TSettings>`, `DCLWorldPluginBase<TSettings>`
+- **Containers**: `StaticContainer` (shared deps), `DynamicWorldContainer` (global plugins)
+- **Settings**: `IDCLPluginSettings` stored in `PluginSettingsContainer` ScriptableObject
+- **Asset References**: `AssetReferenceT<T>`, `ComponentReference<T>` for Addressables
+- **Provisioning**: `IAssetsProvisioner` loads assets, returns `ProvidedAsset<T>`
+
+## Investigation Tasks
+
+### 1. Find Service/Plugin Definition
+```bash
+rg "class {{SERVICE}}|interface I{{SERVICE}}" -n Explorer/Assets --type cs -A 20
+```
+- Is it a plugin, service, or controller?
+- What does it depend on?
+
+### 2. Find Plugin Settings
+```bash
+rg "{{SERVICE}}Settings|class.*Settings.*{{SERVICE}}" -n Explorer/Assets --type cs -A 30
+```
+- Does it have IDCLPluginSettings?
+- What AssetReferences does it need?
+- Are there ComponentReferences?
+
+### 3. Check Container Registration
+```bash
+rg "{{SERVICE}}" -n Explorer/Assets --type cs | grep -i "container\|static\|dynamic"
+rg "StaticContainer|DynamicWorldContainer" -n Explorer/Assets --type cs -A 50 | grep -i "{{SERVICE}}"
+```
+- Where is it created/registered?
+- What scope (static, global, scene)?
+
+### 4. Check Plugin Initialization
+```bash
+rg "InitializeAsync|InitializeAsyncInternal|ContinueInitialization" -n Explorer/Assets --type cs | grep -i "{{SERVICE}}"
+```
+- Is initialization async?
+- Does it use ContinueInitialization pattern?
+- Is world injection required?
+
+### 5. Find Asset Provisioning
+```bash
+rg "ProvideMainAssetAsync|ProvidedAsset|ProvidedInstance" -n Explorer/Assets --type cs | grep -i "{{SERVICE}}"
+rg "assetsProvisioner\." -n {{CRASH_FILE}} --type cs -B 2 -A 5
+```
+- Are assets loaded before use?
+- Is `.Value` accessed safely?
+
+### 6. Check World Injection Timing
+```bash
+rg "ArchSystemsWorldBuilder|GlobalPluginArguments|InjectToWorld" -n Explorer/Assets --type cs | grep -i "{{SERVICE}}"
+```
+For global plugins:
+```csharp
+// Pattern: World available only in continuation
+return (ref ArchSystemsWorldBuilder<World> world, in GlobalPluginArguments _) =>
+{
+    // Safe to use world here
+};
+```
+- Is service used before world injection?
+
+### 7. Check Disposal
+```bash
+rg "Dispose|IDisposable" -n Explorer/Assets --type cs | grep -i "{{SERVICE}}"
+```
+- Is service disposed prematurely?
+- Is there cleanup order issue?
+
+### 8. Find Usage Site
+```bash
+rg "{{SERVICE}}" -n {{CRASH_FILE}} --type cs -B 5 -A 5
+```
+- How is it accessed at crash site?
+- Is it injected via constructor?
+- Is it accessed statically?
+
+## Output Format
+
+```markdown
+## Plugin/DI Investigation: {{SERVICE}}
+
+### Service Definition
+- **Type**: [Plugin / Service / Controller]
+- **Location**: [file:line]
+- **Base Class**: [DCLGlobalPluginBase / DCLWorldPluginBase / none]
+
+### Dependencies
+| Dependency | Source | Nullable? |
+|------------|--------|-----------|
+| [dep1] | [container/injection] | [yes/no] |
+
+### Settings Configuration
+- **Settings Class**: [name or N/A]
+- **Asset References**:
+  | Reference | Type | Configured? |
+  |-----------|------|-------------|
+  | [ref1] | AssetReferenceT<X> | [check Unity Inspector] |
+
+### Initialization Flow
+```
+1. [Container creates service]
+   ↓
+2. [InitializeAsyncInternal loads assets]
+   ↓
+3. [ContinueInitialization injects world] ← Is crash before this?
+   ↓
+4. [Service ready for use]
+```
+
+### Issues Found
+- [ ] Service used before initialization complete
+- [ ] Asset reference not configured in PluginSettingsContainer
+- [ ] World accessed before injection
+- [ ] Dependency not registered in container
+- [ ] Disposed before consumer finished
+
+### Null Scenario
+[Explain specific conditions where service/dependency would be null]
+
+### Evidence
+```csharp
+[Key code snippets]
+```
+
+### Action Required
+- [ ] Check PluginSettingsContainer in Unity Inspector
+- [ ] Verify asset references assigned
+- [ ] Check initialization order
+
+### Confidence: [High/Medium/Low]
+```
+
+## Execute
+
+Trace `{{SERVICE}}` through DCL's plugin and DI system and report findings.

--- a/.claude/commands/debug-dcl.md
+++ b/.claude/commands/debug-dcl.md
@@ -1,0 +1,217 @@
+# Debug DCL - Orchestrator
+
+You are debugging an exception in the decentraland/unity-explorer project. You will orchestrate multiple parallel investigations to find the root cause.
+
+## Project Context
+
+- Unity 6.3 with Arch ECS (not Unity DOTS)
+- Two worlds: Global World (single instance) and Scene Worlds (per JS scene)
+- Plugin system: `IDCLPlugin`, `DCLGlobalPluginBase<TSettings>`, `DCLWorldPluginBase`
+- Containers: `StaticContainer`, `DynamicWorldContainer`
+- Async: `UniTask`, `AssetPromise<TAsset, TLoadingIntention>`
+- Assets: `IAssetsProvisioner`, Addressables, `ProvidedAsset<T>`
+
+## Step 1: Parse Exception
+
+Extract from the stack trace:
+```
+EXCEPTION_TYPE: [e.g., NullReferenceException]
+MESSAGE: [exception message]
+CRASH_FILE: [filename]
+CRASH_LINE: [line number]
+CRASH_METHOD: [method name]
+CALL_CHAIN: [full stack]
+```
+
+Classify the crash context:
+- [ ] ECS System (`*System.cs`, has `Update()`, uses `Query<>`)
+- [ ] Plugin (`*Plugin.cs`, implements `IDCLPlugin`)
+- [ ] Controller (`*Controller.cs`, MVC pattern)
+- [ ] Async/Promise (inside `UniTask`, callback, or `LoadSystemBase`)
+- [ ] MonoBehaviour (Unity lifecycle)
+
+## Step 2: Read Crash Site
+
+```bash
+cat -n [CRASH_FILE]
+```
+
+Identify ALL expressions on the crash line that could be null. List them:
+```
+NULL_CANDIDATES:
+1. [expression] - [why it might be null]
+2. [expression] - [why it might be null]
+```
+
+## Step 3: Spawn Parallel Investigations
+
+Based on the crash context and null candidates, spawn these sub-agents using TodoWrite. **Spawn ALL relevant investigations in parallel:**
+
+### If ECS-related (components, entities, queries):
+```
+Todo: [ECS Investigation] Trace component lifecycle for [COMPONENT_NAME]
+- Find where component is defined (struct/class)
+- Find all systems that Add/Remove this component
+- Find all systems that Query for this component
+- Check system execution order ([UpdateInGroup], [UpdateAfter], [UpdateBefore])
+- Determine if component could be missing at crash point
+Files to search: Explorer/Assets/DCL/ECS/, Explorer/Assets/Scripts/
+```
+
+### If Plugin/DI-related (services, settings, injection):
+```
+Todo: [Plugin Investigation] Trace initialization of [SERVICE/PLUGIN_NAME]
+- Find plugin registration and settings class
+- Check PluginSettingsContainer configuration
+- Trace dependency injection through containers
+- Check initialization order and world injection timing
+- Verify all AssetReferenceT<> and ComponentReference<> are assigned
+Files to search: Explorer/Assets/DCL/Plugins/, *Container.cs, *Settings.cs
+```
+
+### If Asset-related (loading, addressables, promises):
+```
+Todo: [Asset Investigation] Trace asset loading for [ASSET_EXPRESSION]
+- Find IAssetsProvisioner usage
+- Trace ProvidedAsset/ProvidedInstance lifecycle
+- Check if asset reference is configured in settings
+- Verify async loading completion before .Value access
+- Check for disposal/cleanup issues
+Files to search: *Provisioner*, *Asset*, *Settings.cs
+```
+
+### If Async-related (UniTask, cancellation, promises):
+```
+Todo: [Async Investigation] Trace async flow for [METHOD_NAME]
+- Find all await points and UniTask usage
+- Check CancellationToken handling
+- Trace AssetPromise resolution
+- Check for Result usage after cancellation
+- Verify SuppressToResultAsync patterns
+Files to search: *.cs files with async, UniTask, CancellationToken
+```
+
+### If World/Entity lifecycle-related:
+```
+Todo: [Lifecycle Investigation] Trace entity/world lifecycle for [ENTITY/WORLD]
+- Check EntityReference vs raw Entity usage
+- Find world injection points (ArchSystemsWorldBuilder)
+- Trace SingleInstanceEntity caching
+- Check disposal and cleanup order
+- Verify Global vs Scene world context
+Files to search: *World*, *Entity*, *System.cs
+```
+
+### Always spawn - Adjacent Code Review:
+```
+Todo: [Adjacent Code] Review related code in [CRASH_FILE_DIRECTORY]
+- Check other systems in same SystemGroup
+- Look for similar patterns that might fail
+- Find recent changes (git blame if available)
+- Check for TODO/FIXME comments about null handling
+```
+
+## Step 4: Await Results
+
+After spawning investigations, wait for all sub-agents to complete. Collect their findings:
+
+```
+FINDINGS:
+- ECS: [summary]
+- Plugin: [summary]
+- Asset: [summary]
+- Async: [summary]
+- Lifecycle: [summary]
+- Adjacent: [summary]
+```
+
+## Step 5: Synthesize
+
+Once all investigations complete, determine:
+
+1. **What is null?** (the immediate cause)
+2. **Where does the null originate?** (trace back through DCL systems)
+3. **Why is it null?** (the root cause in DCL architecture terms)
+4. **When does this occur?** (conditions, timing, order of operations)
+
+## Step 6: Generate Report
+
+```markdown
+# DCL Exception Analysis
+
+## Summary
+| | |
+|---|---|
+| **Exception** | [TYPE]: [MESSAGE] |
+| **Location** | [FILE:LINE] |
+| **Context** | [ECS System / Plugin / Controller / Async] |
+| **Root Cause** | [One sentence] |
+| **Confidence** | [High / Medium / Low] |
+
+## Investigation Results
+
+### ECS Analysis
+[Findings from ECS sub-agent]
+
+### Plugin/DI Analysis
+[Findings from Plugin sub-agent]
+
+### Asset Loading Analysis
+[Findings from Asset sub-agent]
+
+### Async Flow Analysis
+[Findings from Async sub-agent]
+
+### Lifecycle Analysis
+[Findings from Lifecycle sub-agent]
+
+## Root Cause
+
+**Category**: [ECS Component Missing / Asset Not Loaded / Plugin Not Initialized / World Not Injected / Async Cancelled / Entity Destroyed]
+
+[Detailed explanation referencing specific findings]
+
+## Causal Chain
+
+```
+1. [Root cause - e.g., "Component not added in InitializeSystem"]
+   ↓
+2. [Propagation - e.g., "RenderSystem queries for component"]
+   ↓
+3. [Failure - e.g., "entity.Get<T>() throws because component missing"]
+```
+
+## Recommended Fixes
+
+### Immediate Fix (stop the crash)
+**File**: [file:line]
+```csharp
+// Add defensive check
+```
+
+### Root Cause Fix (prevent the null)
+**File**: [file:line]
+```csharp
+// Fix initialization/registration/lifecycle
+```
+
+### Architectural Improvements
+- [ ] [Suggestion 1]
+- [ ] [Suggestion 2]
+
+## Verification Checklist
+- [ ] Check PluginSettingsContainer in Unity Inspector
+- [ ] Verify system execution order
+- [ ] Confirm asset references assigned
+- [ ] Test with fresh scene load
+- [ ] Check for race conditions in async code
+
+## Files Examined
+| File | Investigation | Finding |
+|------|---------------|---------|
+| [file1] | [which sub-agent] | [key finding] |
+```
+
+---
+
+$ARGUMENTS

--- a/.claude/debug-dcl.md
+++ b/.claude/debug-dcl.md
@@ -1,0 +1,266 @@
+# Debug Stack Trace - Decentraland Unity Explorer
+
+You are debugging an exception in the decentraland/unity-explorer project. This is a Unity 6 project using the Arch ECS framework, UniTask for async operations, and a plugin-based architecture.
+
+## Project Context
+
+**Architecture:**
+- ECS-based using Arch library (not Unity DOTS)
+- Two world types: Global World (single instance) and Scene Worlds (per JavaScript scene)
+- Plugin system: `IDCLPlugin` with `DCLGlobalPluginBase<TSettings>` and world plugins
+- Dependency injection via containers: `StaticContainer`, `DynamicWorldContainer`
+- Asset loading via `IAssetsProvisioner` and Addressables
+- Async operations use `UniTask` with `AssetPromise<TAsset, TLoadingIntention>` pattern
+
+**Key Directories:**
+```
+Explorer/
+├── Assets/
+│   ├── DCL/                    # Core Decentraland logic
+│   │   ├── ECS/               # Entity-Component-System
+│   │   │   ├── Components/    # Data structures
+│   │   │   └── Systems/       # Logic that transforms components
+│   │   ├── Plugins/           # Feature plugins
+│   │   └── Controllers/       # MVC controllers
+│   ├── Scripts/
+│   │   ├── Global/            # Global world systems
+│   │   └── SceneRuntime/      # Per-scene systems
+│   └── Protocol/              # Protobuf definitions
+```
+
+**Common Null Sources in This Project:**
+1. **ECS Queries**: Entity doesn't have expected component
+2. **Asset Promises**: `ProvidedAsset<T>` or `ProvidedInstance<T>` not resolved
+3. **Plugin Settings**: `IDCLPluginSettings` fields not configured in `PluginSettingsContainer`
+4. **Addressable References**: `AssetReferenceT<T>` or `ComponentReference<T>` not loaded
+5. **World/Entity Access**: Accessing disposed world or destroyed entity
+6. **SingleInstanceEntity**: Not cached or world not injected yet
+7. **Scene Facade**: `ISceneFacade` accessed before scene initialization
+8. **UniTask Cancellation**: Operation cancelled but result used
+
+## Investigation Protocol
+
+### Step 1: Parse the Stack Trace
+
+Extract:
+- Exception type and message
+- Crash file, line, method
+- Full call chain
+- Identify if it's in a System, Plugin, Controller, or async callback
+
+### Step 2: Read Crash Site
+
+```bash
+# Read the failing file
+cat -n [FILE]
+```
+
+Identify null candidates specific to this project:
+- `entity.Get<TComponent>()` calls
+- `world.Query<T>()` results
+- `.Value` access on promises/nullable
+- `_settings.SomeReference` access
+- `SingleInstanceEntity` access
+
+### Step 3: Project-Specific Investigations
+
+**For ECS-related nulls:**
+```bash
+# Find component registration
+rg "struct.*Component|class.*Component" -n Explorer/Assets --type cs
+
+# Find systems that modify this component
+rg "Query<.*ComponentName" -n Explorer/Assets --type cs
+
+# Check if component is added
+rg "\.Add\(.*ComponentName|AddComponent.*ComponentName" -n Explorer/Assets --type cs
+```
+
+**For Plugin/DI nulls:**
+```bash
+# Find plugin registration
+rg "class.*Plugin.*:.*IDCLPlugin|DCLGlobalPluginBase|DCLWorldPluginBase" -n Explorer/Assets --type cs
+
+# Find settings configuration
+rg "IDCLPluginSettings|PluginSettingsContainer" -n Explorer/Assets --type cs
+
+# Check container initialization
+rg "StaticContainer|DynamicWorldContainer" -n Explorer/Assets --type cs
+```
+
+**For Asset loading nulls:**
+```bash
+# Find asset provisioning
+rg "IAssetsProvisioner|ProvideMainAssetAsync|ProvidedAsset|ProvidedInstance" -n Explorer/Assets --type cs
+
+# Check addressable references
+rg "AssetReferenceT|ComponentReference" -n Explorer/Assets --type cs
+```
+
+**For UniTask/async nulls:**
+```bash
+# Find async patterns
+rg "UniTask|async.*Task|\.AsUniTask|SuppressToResultAsync" -n Explorer/Assets --type cs
+
+# Check cancellation handling
+rg "CancellationToken|\.IsCancellationRequested|ThrowIfCancellationRequested" -n Explorer/Assets --type cs
+
+# Find promise patterns
+rg "AssetPromise|LoadSystemBase" -n Explorer/Assets --type cs
+```
+
+**For World/Entity lifecycle nulls:**
+```bash
+# Check world injection
+rg "ArchSystemsWorldBuilder|InjectToWorld|GlobalPluginArguments" -n Explorer/Assets --type cs
+
+# Find entity references
+rg "EntityReference|SingleInstanceEntity" -n Explorer/Assets --type cs
+
+# Check disposal patterns
+rg "IDisposable|Dispose\(\)|\.Destroy\(" -n Explorer/Assets --type cs
+```
+
+### Step 4: Check Related Systems
+
+```bash
+# Find systems in same group
+rg "\[UpdateInGroup\(typeof\(.*Group" -n [CRASH_FILE_DIR] --type cs
+
+# Find system dependencies
+rg "\[UpdateAfter\(typeof|UpdateBefore\(typeof" -n Explorer/Assets --type cs
+```
+
+### Step 5: Check Scene vs Global World Context
+
+Determine if the crash is in:
+- Global world (single instance, handles realms, player, camera, avatars)
+- Scene world (per-scene, JavaScript scene reflection)
+
+```bash
+# Check world type
+rg "GlobalWorld|SceneWorld|ISceneFacade" -n [CRASH_FILE] --type cs
+```
+
+## Common Patterns in This Project
+
+### Pattern: Unresolved Asset Promise
+```csharp
+// Problem: Accessing .Value before promise resolved
+var asset = await assetsProvisioner.ProvideMainAssetAsync(settings.SomeRef, ct);
+var component = asset.Value.GetComponent<T>(); // Null if not resolved
+
+// Check: Is the AssetReference configured in PluginSettingsContainer?
+```
+
+### Pattern: ECS Component Not Added
+```csharp
+// Problem: Querying entity without component
+ref var component = ref entity.Get<SomeComponent>(); // Throws if missing
+
+// Check: Is component added in initialization system?
+```
+
+### Pattern: World Not Injected Yet
+```csharp
+// Problem: Using world before ContinueInitialization called
+protected override async UniTask<ContinueInitialization?> InitializeAsyncInternal(...)
+{
+    // Assets loaded here...
+    return (ref ArchSystemsWorldBuilder<World> world, in GlobalPluginArguments _) =>
+    {
+        // World available here only
+    };
+}
+```
+
+### Pattern: Disposed/Destroyed Access
+```csharp
+// Problem: Using entity after scene disposed
+// Check: Is there proper cleanup in Dispose()? Is entity reference stale?
+```
+
+### Pattern: Cancelled UniTask
+```csharp
+// Problem: Using result after cancellation
+// Check: Is CancellationToken checked before using results?
+if (ct.IsCancellationRequested)
+    return Result.CancelledResult();
+```
+
+## Output Format
+
+```markdown
+# Stack Trace Analysis: [BRIEF_DESCRIPTION]
+
+## Summary
+| | |
+|---|---|
+| **Exception** | [Type]: [Message] |
+| **Location** | [File:Line] in [Method] |
+| **Context** | [Global Plugin / Scene System / Controller / Async callback] |
+| **Null Value** | [What was null] |
+
+## Root Cause
+
+**Category**: [ECS Component / Asset Loading / Plugin Init / World Lifecycle / Async/Cancel]
+
+[Explanation of why the value is null in context of DCL architecture]
+
+## Evidence
+
+### Crash Site
+```csharp
+[Code snippet]
+```
+
+### Origin of Null
+```csharp
+[Code showing where null comes from]
+```
+
+## Causal Chain
+1. [Initial condition]
+2. [How it propagates through DCL systems]
+3. [Null dereference]
+
+## Fixes
+
+### Immediate Fix
+```csharp
+// Add null check or TryGet pattern
+if (entity.TryGet<Component>(out var comp))
+{
+    // safe to use
+}
+```
+
+### Root Cause Fix
+```csharp
+// Fix initialization, registration, or lifecycle
+```
+
+### DCL-Specific Recommendations
+- [ ] Check PluginSettingsContainer in Unity Inspector
+- [ ] Verify system update order with [UpdateAfter/Before]
+- [ ] Ensure component is added before querying
+- [ ] Check asset Addressable is assigned
+- [ ] Verify world injection timing
+
+## Files to Review
+| File | Relevance |
+|------|-----------|
+| [file] | [why] |
+```
+
+## Execute Now
+
+1. Parse the exception
+2. Identify if it's ECS, Plugin, Asset, or Async related
+3. Use project-specific search patterns
+4. Check component lifecycle and world context
+5. Provide DCL-architecture-aware fix
+
+---
+
+$ARGUMENTS


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Adds the `/debug-dcl [stacktrace]` command to claude code, which has existing context of the explorer project. It will orchestrate a set of sub-agents to diagnose a specific stack trace and offer suggestions of fixes. It includes sub agents that:

**debug-dcl.md** - Main orchestrator - parses exception, spawns sub-agents, synthesizes results.
**debug-dcl-ecs.md** - Traces ECS component lifecycle, system order, query vs add patterns
**debug-dcl-plugin.md** - Investigates DI registration, plugin settings, world injection timing
**debug-dcl-asset.md** - Traces asset loading, Addressables, ProvidedAsset/ProvidedInstance
**debug-dcl-async.md** - Analyzes UniTask flow, cancellation handling, Result pattern
**debug-dcl-lifecycle.md** - Checks entity/world lifecycle, EntityReference, disposal order
**debug-dcl-adjacent.md** - Reviews related code, similar patterns, TODOs, git history

## Test Instructions
N/A