### PR TITLE
fix: show nearby only chat bubbles if config shows only those

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/ChatWorldBubbleService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/ChatWorldBubbleService.cs
@@ -66,7 +66,9 @@ namespace DCL.Chat.ChatServices
 
         public void CreateChatBubble(ChatChannel channel, ChatMessage chatMessage, bool isSentByOwnUser, string? communityName = null)
         {
-            if (!nametagsData.showNameTags || chatSettings.chatBubblesVisibilitySettings == ChatBubbleVisibilitySettings.NONE)
+            if (!nametagsData.showNameTags
+                || chatSettings.chatBubblesVisibilitySettings == ChatBubbleVisibilitySettings.NONE
+                || (channel.ChannelType != ChatChannel.ChatChannelType.NEARBY && chatSettings.chatBubblesVisibilitySettings == ChatBubbleVisibilitySettings.NEARBY_ONLY))
                 return;
 
             if (chatMessage.IsSentByOwnUser == false && entityParticipantTable.TryGet(chatMessage.SenderWalletAddress, out var entry))


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6687 
When setting the chat bubble config to show only nearby messages as chat bubbles, all messages were being displayed as chat bubbles, now that is fixed

## Test Instructions
Use 2 accounts, one for sending messages and one for receiving

### Test Steps
1. Open Settings.
2. Go to Chat.
3. Under In-World Chat Bubbles, select Nearby only.
4. Send messages in nearby/community chat and dm with the other account
5. Verify only nearby chat bubbles appear

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
