### PR TITLE
style: update translate icons

### DIFF
--- a/Explorer/Assets/DCL/Chat/Textures/TranslateIcn.png
+++ b/Explorer/Assets/DCL/Chat/Textures/TranslateIcn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:859ce0064f99287a994c3e123d9d2d253ac11d4b150be523ccfe33ad4999e42a
-size 876
+oid sha256:99118d1a3b0f735d7d8df9cab498b38201df957b0096b0b08b905e60293164b5
+size 392

--- a/Explorer/Assets/DCL/Chat/Textures/TranslatedIcn.png
+++ b/Explorer/Assets/DCL/Chat/Textures/TranslatedIcn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:316bcf1027c868a0d4bbeb4d1993f5261fc875e9f47d1c975c9b217776efe09b
-size 753
+oid sha256:ebe8f959d1054e18aa510ee63cbd88814760e220700b46e828b766320ed080bf
+size 316

--- a/Explorer/Assets/DCL/Chat/Textures/TranslatedUndoIcn.png
+++ b/Explorer/Assets/DCL/Chat/Textures/TranslatedUndoIcn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f676a1d6a4dcf47ef2716b57af8ba1eb840d90d79d00a4247111b97e1bd1314e
-size 678
+oid sha256:c57e41f6b741815bfa824871e90b9cab14bbe253d8ff4a5c7b56fd99d9dfe251
+size 336


### PR DESCRIPTION
## What does this PR change?
Updates the sizes of the undo and translated textures, and the style of the translate icon which now has roundness in order to align it to the aesthetic of the rest of the icons along the app.

BEFORE
<img width="351" height="356" alt="Screenshot 2026-01-15 at 18 24 13" src="https://github.com/user-attachments/assets/1c2f9f3b-fbca-44e4-a7a0-2a868e3247aa" />

AFTER
<img width="349" height="333" alt="Screenshot 2026-01-15 at 18 23 55" src="https://github.com/user-attachments/assets/80b0938d-f0cf-4579-a211-74edada6315f" />

### Test Steps
1. Launch the explorer.
2. Open the chat menu, and validate the icon of the auto-translate option shows the new style.
<img width="438" height="562" alt="Screenshot 2026-01-15 at 18 17 43" src="https://github.com/user-attachments/assets/2076f210-7e4b-47a2-bdb6-90651070b4e4" />
