### PR TITLE
fix: avoid requesting parcels out of BE bounds

### DIFF
--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
@@ -1,4 +1,4 @@
-﻿using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using DCL.Optimization.Pools;
 using System;
 using System.Collections.Generic;
@@ -10,6 +10,14 @@ namespace DCL.PlacesAPIService
     public class PlacesAPIService : IPlacesAPIService
     {
         private static readonly ListObjectPool<string> COORDS_TO_REQ_POOL = new ();
+
+        /// <summary>
+        /// The maximum absolute coordinate value allowed by the Places API backend.
+        /// The backend validates coordinates with regex pattern ^-?\d{1,3},-?\d{1,3}$
+        /// which only allows 1-3 digit numbers (0-999). Even if this value is way above the parcel bounds
+        /// we introudced the check to avoid an error spam of users moving with portable experiences in odd places
+        /// </summary>
+        private const int MAX_COORDINATE_VALUE = 999;
 
         private readonly Dictionary<string, PlacesData.PlaceInfo> placesById = new ();
         private readonly Dictionary<Vector2Int, PlacesData.PlaceInfo> placesByCoords = new ();
@@ -24,6 +32,9 @@ namespace DCL.PlacesAPIService
         {
             this.client = client;
         }
+
+        private static bool AreCoordinatesWithinBounds(Vector2Int coords) =>
+            Mathf.Abs(coords.x) <= MAX_COORDINATE_VALUE && Mathf.Abs(coords.y) <= MAX_COORDINATE_VALUE;
 
         public async UniTask<PlacesData.IPlacesAPIResponse> SearchPlacesAsync(int pageNumber, int pageSize,
             CancellationToken ct,
@@ -48,6 +59,9 @@ namespace DCL.PlacesAPIService
 
         public async UniTask<PlacesData.PlaceInfo?> GetPlaceAsync(Vector2Int coords, CancellationToken ct, bool renewCache = false)
         {
+            if (!AreCoordinatesWithinBounds(coords))
+                return null;
+
             if (renewCache)
                 placesByCoords.Remove(coords);
             else if (placesByCoords.TryGetValue(coords, out PlacesData.PlaceInfo placeInfo))
@@ -98,6 +112,9 @@ namespace DCL.PlacesAPIService
 
             foreach (Vector2Int coords in coordsList)
             {
+                if (!AreCoordinatesWithinBounds(coords))
+                    continue;
+
                 if (renewCache)
                 {
                     placesByCoords.Remove(coords);
@@ -163,11 +180,11 @@ namespace DCL.PlacesAPIService
         {
             placesById.TryGetValue(placeId, out var place);
             bool cachedIsFavorite = place?.user_favorite ?? false;
-            
+
             // Pre-warming cache with change for instant return in case of repeated call from different places.
             // Example: Explore's PlaceInfoPanel and minimap race.
             TryUpdateCachedPlaceFavorite(placeId, isFavorite);
-            
+
             try
             {
                 await client.SetPlaceFavoriteAsync(placeId, isFavorite, ct);
@@ -184,7 +201,7 @@ namespace DCL.PlacesAPIService
         {
             if (string.IsNullOrEmpty(placeId) || !placesById.TryGetValue(placeId, out var place))
                 return;
-            
+
             place.user_favorite = isFavorite;
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6747 
This PR avoids requesting parcels outside of the bounds defined in the BE (that ranges from -999 to 999)
This was causing an error on sentry being spammed if users were in odd coordinates, probably due to specific PXs: https://decentraland.sentry.io/issues/7148786946/?referrer=github_integration

## Test Instructions

### Test Steps
1. Launch the client
2. Teleport around
3. Use the map to retrieve info of places around (by clicking them on the map)
4. Verify that in the info panel of the map and in the minimap the name of the place appears correctly

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
