### PR TITLE
fix: null checks in emote flow

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -126,6 +126,13 @@ namespace DCL.AvatarRendering.Emotes.Load
 
             foreach (IEmote emote in emotes)
             {
+                // Skip emotes with unresolved DTO - treat as failed
+                if (emote.DTO?.Metadata == null)
+                {
+                    emotesWithResponse++;
+                    continue;
+                }
+
                 if (emote.DTO.assetBundleManifestVersion is { assetBundleManifestRequestFailed: true } || emote.Model is { Exception: not null })
                 {
                     emotesWithResponse++;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This does a null-check to avoid the NRE in this [issue](https://github.com/decentraland/unity-explorer/issues/6762).

But a proper long term solution is presented in this [tech debt](https://github.com/decentraland/unity-explorer/issues/6764)



### Test Steps
1. Play with emotes 

- Emote regularly
- Equip new ones
- Do scene emotes
- See other players emotes

It should all work normally



## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
