### PR TITLE
opti: improve update text shape system

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/TextShape/Component/TextShapeComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/TextShape/Component/TextShapeComponent.cs
@@ -28,12 +28,26 @@ namespace DCL.SDKComponents.TextShape.Component
         /// </summary>
         public bool NeedsBoundsRecalculation;
 
+        /// <summary>
+        /// Tracks whether the outline keyword is currently enabled on the material.
+        /// Used to avoid redundant EnableKeyword/DisableKeyword calls which cause allocations in the TMPProSdkExtensions Apply method
+        /// </summary>
+        public bool OutlineKeywordEnabled;
+
+        /// <summary>
+        /// Tracks whether the underlay keyword is currently enabled on the material.
+        /// Used to avoid redundant EnableKeyword/DisableKeyword calls which cause allocations in the TMPProSdkExtensions Apply method
+        /// </summary>
+        public bool UnderlayKeywordEnabled;
+
         public TextShapeComponent(TextMeshPro textShape)
         {
             TextMeshPro = textShape;
             LastValidBoundingBoxSize = textShape.renderer.bounds.size; // Note: Using Renderer because the bounds of the TMP does not return what we need
             IsContainedInScene = false;
             NeedsBoundsRecalculation = true;
+            OutlineKeywordEnabled = false;
+            UnderlayKeywordEnabled = false;
         }
 
         public void Dispose() { }

--- a/Explorer/Assets/DCL/SDKComponents/TextShape/System/InstantiateTextShapeSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/TextShape/System/InstantiateTextShapeSystem.cs
@@ -52,8 +52,8 @@ namespace DCL.SDKComponents.TextShape.System
             var textMeshPro = textMeshProPool.Get();
             textMeshPro.transform.SetParent(transform.Transform, worldPositionStays: false);
 
-            textMeshPro.Apply(textShape, fontsStorage, materialPropertyBlock);
             var component = new TextShapeComponent(textMeshPro);
+            TMPProSdkExtensions.Apply(ref component, textShape, fontsStorage, materialPropertyBlock);
 
             World.Add(entity, component);
 

--- a/Explorer/Assets/DCL/SDKComponents/TextShape/System/UpdateTextShapeSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/TextShape/System/UpdateTextShapeSystem.cs
@@ -50,7 +50,7 @@ namespace DCL.SDKComponents.TextShape.System
         {
             if (textShape.IsDirty)
             {
-                textShapeComponent.TextMeshPro.Apply(textShape, fontsStorage, materialPropertyBlock);
+                TMPProSdkExtensions.Apply(ref textShapeComponent, textShape, fontsStorage, materialPropertyBlock);
                 textShapeComponent.NeedsBoundsRecalculation = true; // Mark for deferred bounds calculation next frame
                 changedTextMeshes.Add(entity, textShapeComponent);
             }

--- a/Explorer/Assets/DCL/SDKComponents/TextShape/TMPProSdkExtensions.cs
+++ b/Explorer/Assets/DCL/SDKComponents/TextShape/TMPProSdkExtensions.cs
@@ -1,4 +1,5 @@
-﻿using DCL.ECSComponents;
+using DCL.ECSComponents;
+using DCL.SDKComponents.TextShape.Component;
 using DCL.SDKComponents.TextShape.Fonts;
 using ECS.Unity.ColorComponent;
 using System;
@@ -18,8 +19,10 @@ namespace DCL.SDKComponents.TextShape
         private const string OUTLINE_ON_KEYWORD = "OUTLINE_ON";
         private const string UNDERLAY_ON_KEYWORD = "UNDERLAY_ON";
 
-         public static void Apply(this TextMeshPro tmpText, PBTextShape textShape, IFontsStorage fontsStorage, MaterialPropertyBlock materialPropertyBlock)
+        public static void Apply(ref TextShapeComponent textShapeComponent, PBTextShape textShape, IFontsStorage fontsStorage, MaterialPropertyBlock materialPropertyBlock)
         {
+            TextMeshPro tmpText = textShapeComponent.TextMeshPro;
+
             tmpText.font = fontsStorage.Font(textShape.Font) ?? tmpText.font;
 
             // NOTE: previously width and height weren't working (setting sizeDelta before anchors and offset result in sizeDelta being reset to 0,0)
@@ -58,22 +61,48 @@ namespace DCL.SDKComponents.TextShape
 
             tmpText.renderer.GetPropertyBlock(materialPropertyBlock);
 
-            if (textShape.OutlineWidth > 0f)
+            bool needsOutline = textShape.OutlineWidth > 0f;
+            bool needsUnderlay = textShape.ShadowOffsetX != 0 || textShape.ShadowOffsetY != 0;
+
+            // Only access fontMaterial and modify keywords when state actually changes to avoid allocations
+            if (needsOutline != textShapeComponent.OutlineKeywordEnabled || needsUnderlay != textShapeComponent.UnderlayKeywordEnabled)
             {
-                tmpText.fontMaterial.EnableKeyword(OUTLINE_ON_KEYWORD);
+                Material fontMat = tmpText.fontMaterial;
+
+                if (needsOutline != textShapeComponent.OutlineKeywordEnabled)
+                {
+                    if (needsOutline)
+                        fontMat.EnableKeyword(OUTLINE_ON_KEYWORD);
+                    else
+                        fontMat.DisableKeyword(OUTLINE_ON_KEYWORD);
+
+                    textShapeComponent.OutlineKeywordEnabled = needsOutline;
+                }
+
+                if (needsUnderlay != textShapeComponent.UnderlayKeywordEnabled)
+                {
+                    if (needsUnderlay)
+                        fontMat.EnableKeyword(UNDERLAY_ON_KEYWORD);
+                    else
+                        fontMat.DisableKeyword(UNDERLAY_ON_KEYWORD);
+
+                    textShapeComponent.UnderlayKeywordEnabled = needsUnderlay;
+                }
+            }
+
+            if (needsOutline)
+            {
                 materialPropertyBlock.SetColor(ID_OUTLINE_COLOR, textShape.OutlineColor?.ToUnityColor() ?? Color.white);
                 materialPropertyBlock.SetFloat(ID_OUTLINE_WIDTH, textShape.OutlineWidth);
             }
             else
             {
-                tmpText.fontMaterial.DisableKeyword(OUTLINE_ON_KEYWORD);
                 materialPropertyBlock.SetColor(ID_OUTLINE_COLOR, Color.clear);
                 materialPropertyBlock.SetFloat(ID_OUTLINE_WIDTH, 0.0f);
             }
 
-            if (textShape.ShadowOffsetX != 0 || textShape.ShadowOffsetY != 0)
+            if (needsUnderlay)
             {
-                tmpText.fontMaterial.EnableKeyword(UNDERLAY_ON_KEYWORD);
                 materialPropertyBlock.SetColor(ID_UNDERLAY_COLOR, textShape.ShadowColor?.ToUnityColor() ?? Color.white);
                 materialPropertyBlock.SetFloat(ID_UNDERLAY_SOFTNESS, textShape.ShadowBlur);
                 materialPropertyBlock.SetFloat(ID_UNDERLAY_OFFSET_X, textShape.ShadowOffsetX);
@@ -81,13 +110,11 @@ namespace DCL.SDKComponents.TextShape
             }
             else
             {
-                tmpText.fontMaterial.DisableKeyword(UNDERLAY_ON_KEYWORD);
                 materialPropertyBlock.SetColor(ID_UNDERLAY_COLOR, Color.clear);
                 materialPropertyBlock.SetFloat(ID_UNDERLAY_SOFTNESS, 0.0f);
                 materialPropertyBlock.SetFloat(ID_UNDERLAY_OFFSET_X, 0.0f);
                 materialPropertyBlock.SetFloat(ID_UNDERLAY_OFFSET_Y, 0.0f);
             }
-
 
             tmpText.renderer.SetPropertyBlock(materialPropertyBlock);
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6737
This PR improves the UpdateTextShapeSystem by:
1. deferring the bounds update to avoid the expensive ForceMeshUpdate call
This removes the spikes we were getting when an entity with a text shape component was being updated
Before we had spikes like this:
<img width="1191" height="32" alt="image (40)" src="https://github.com/user-attachments/assets/729805c4-999e-446c-93fc-beb02ff6fcfc" />
And now it stays consistent at this:
<img width="1170" height="34" alt="image (41)" src="https://github.com/user-attachments/assets/9bd00685-4d73-480c-bfdd-9ea8ad344292" />

2. Access the font material once instead of 2 times by caching it, this avoids internal unity allocations caused by multiple accesses to the font material of the tmpText

3. Enables/Disables the outline and underline shader keywords only when it is actually required, internally loads of sting allocations are generated when using the Enable/Disable keywords, by doing this we avoid allocating each time


## Test Instructions

### Test Steps
1. Check that in genesis plaza all texts are appearing correctly, specifically in the boards and mini games leaderboards
2. If you know of any scene with text moving out of bounds verify that the text is disabled properly when outside of the scene bounds
3. Verify in general that no issues appear with texts in different scenes

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
