### PR TITLE
fix: wire gift analytics

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/AnalyticsPlugin.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/AnalyticsPlugin.cs
@@ -37,6 +37,7 @@ namespace DCL.PluginSystem.Global
         private readonly WalkedDistanceAnalytics walkedDistanceAnalytics;
         private AutoTranslateAnalytics? autoTranslateAnalytics;
         private OutfitsAnalytics outfitsAnalytics;
+        private GiftAnalytics giftAnalytics;
         private HomeMarkerAnalytics homeMarkerAnalytics;
         private readonly PlayerParcelChangedAnalytics playerParcelChangedAnalytics;
 
@@ -83,6 +84,7 @@ namespace DCL.PluginSystem.Global
 
             autoTranslateAnalytics = new AutoTranslateAnalytics(analytics, eventBus, translationSettings);
             outfitsAnalytics = new OutfitsAnalytics(analytics, eventBus);
+            giftAnalytics = new GiftAnalytics(analytics, eventBus);
             homeMarkerAnalytics = new HomeMarkerAnalytics(analytics, eventBus);
 
             PerformanceAnalyticsSystem.InjectToWorld(ref builder, analytics, loadingStatus, realmData, profiler, entityParticipantTable, new JsonObjectBuilder());


### PR DESCRIPTION
# Pull Request Description
Wire gift analytics

## What does this PR change?
fixes #6822 

### Prerequisites
- enable analytics logs

### Test Steps
1. Open gifting popup
2. Transfer item
3. Observe logs "sent_gift", "failed_gift", "successful_gift" or "canceled_gift" are present in the logs depending on the outcome

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
