### PR TITLE
fix: avoid native crash on mac on parallel hls stream open

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -29,6 +29,11 @@ namespace DCL.SDKComponents.MediaStream
         private readonly float audioFadeSpeed;
         private readonly Material flipMaterial;
 
+#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
+        private static float lastOpenMediaTime;
+        private const float MIN_OPEN_MEDIA_INTERVAL_SECONDS = 0.5f;
+#endif
+
         public UpdateMediaPlayerSystem(
             World world,
             ISceneData sceneData,
@@ -271,8 +276,26 @@ namespace DCL.SDKComponents.MediaStream
             if (!component.OpenMediaPromise.IsResolved) return false;
             if (component.OpenMediaPromise.IsConsumed) return false;
 
+#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
+            // On macOS, enforce minimum gap between HLS stream opens to prevent
+            // AVFoundation crashes when opening multiple streams simultaneously.
+            // If too soon since last open, defer the opening.
+            float currentTime = UnityEngine.Time.realtimeSinceStartup;
+            float timeSinceLastOpen = currentTime - lastOpenMediaTime;
+
+            if (timeSinceLastOpen < MIN_OPEN_MEDIA_INTERVAL_SECONDS)
+                return false;
+#endif
+
             if (component.OpenMediaPromise.IsReachableConsume(component.MediaAddress))
             {
+#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
+                lastOpenMediaTime = currentTime;
+
+                ReportHub.Log(ReportCategory.MEDIA_STREAM,
+                    $"[OpenMedia] Opening media: {component.MediaAddress}, Time: {currentTime:F3}, TimeSinceLastOpen: {timeSinceLastOpen:F3}s");
+#endif
+
                 Profiler.BeginSample(component.MediaPlayer.HasControl
                     ? "MediaPlayer.OpenMedia"
                     : "MediaPlayer.InitialiseAndOpenMedia");


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6824
This PR defers by 500ms the open of any media streams on MacOS to avoid parallel opening of HLS or other streams that would cause a native crash due to Mac AVFoundation behaviour.

## Test Instructions

### Test Steps
1. Verify that videos are working the same as in production

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
