### PR TITLE
chore: correct pointer-lock multiple Add() call

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/Systems/UpdatePointerLockSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Systems/UpdatePointerLockSystem.cs
@@ -6,6 +6,7 @@ using DCL.Input.Component;
 using ECS.Abstract;
 using ECS.Groups;
 using SceneRunner.Scene;
+using Utility.Arch;
 
 namespace DCL.CharacterCamera.Systems
 {
@@ -45,7 +46,7 @@ namespace DCL.CharacterCamera.Systems
         {
             if (!sdkPointerLock.IsDirty) return;
 
-            globalWorld.Add(cameraData.CameraEntityProxy.Object, new PointerLockIntention(sdkPointerLock.IsPointerLocked));
+            globalWorld.AddOrSet(cameraData.CameraEntityProxy.Object, new PointerLockIntention(sdkPointerLock.IsPointerLocked));
 
             sdkPointerLock.IsDirty = false;
         }


### PR DESCRIPTION
### WHY

Whenever we update the `PointerLock` state from a scene at `UpdatePointerLockSystem.UpdateLockFromScene()` we are using `World.Add()`. 

That is can trigger Arch errors as an addition is being done one an Entity that already has the component (after the first call). And actually Arch Debug mode shows that potential error.

### WHAT

Fixed potential problem of multiple `world.Add()` calls on the same entity replacing it with the corresopnding `AddOrSet()` call.

### TEST INSTRUCTIONS

Please follow the test instructions of this other recently merged PR: https://github.com/decentraland/unity-explorer/pull/6572

