### PR TITLE
fix: world time not synchronized

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -916,7 +916,7 @@ namespace Global.Dynamic
                 new CharacterPreviewPlugin(staticContainer.ComponentsContainer.ComponentPoolsRegistry, assetsProvisioner, staticContainer.CacheCleaner),
                 staticContainer.WebRequestsContainer.CreatePlugin(localSceneDevelopment),
                 new Web3AuthenticationPlugin(assetsProvisioner, dynamicWorldDependencies.Web3Authenticator, debugBuilder, mvcManager, selfProfile, webBrowser, staticContainer.RealmData, identityCache, characterPreviewFactory, dynamicWorldDependencies.SplashScreen, audioMixerVolumesController, staticContainer.InputBlock, characterPreviewEventBus, backgroundMusic, globalWorld, bootstrapContainer.ApplicationParametersParser),
-                new SkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, staticContainer.ScenesCache, staticContainer.SceneRestrictionBusController, featureFlags),
+                new SkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, staticContainer.ScenesCache, staticContainer.SceneRestrictionBusController),
                 new LoadingScreenPlugin(assetsProvisioner, mvcManager, audioMixerVolumesController,
                     staticContainer.InputBlock, debugBuilder, staticContainer.LoadingStatus, featureFlags),
                 new ExternalUrlPromptPlugin(assetsProvisioner, webBrowser, mvcManager, dclCursor),

--- a/Explorer/Assets/DCL/PluginSystem/Global/SkyboxPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SkyboxPlugin.cs
@@ -21,7 +21,6 @@ namespace DCL.SkyBox
         private readonly Light directionalLight;
         private readonly IScenesCache scenesCache;
         private readonly ISceneRestrictionBusController sceneRestrictionController;
-        private readonly FeatureFlagsConfiguration featureFlags;
 
         private SkyboxSettings settingsJson;
 
@@ -31,14 +30,12 @@ namespace DCL.SkyBox
         public SkyboxPlugin(IAssetsProvisioner assetsProvisioner,
             Light directionalLight,
             IScenesCache scenesCache,
-            ISceneRestrictionBusController sceneRestrictionController,
-            FeatureFlagsConfiguration featureFlags)
+            ISceneRestrictionBusController sceneRestrictionController)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.directionalLight = directionalLight;
             this.scenesCache = scenesCache;
             this.sceneRestrictionController = sceneRestrictionController;
-            this.featureFlags = featureFlags;
         }
 
         public void Dispose() { }
@@ -55,7 +52,7 @@ namespace DCL.SkyBox
                 skyboxSettings = pluginSettings.Settings;
                 skyboxSettings.Reset();
 
-                if (featureFlags.TryGetJsonPayload(FeatureFlagsStrings.SKYBOX_SETTINGS, FeatureFlagsStrings.SKYBOX_SETTINGS_VARIANT, out settingsJson))
+                if (FeatureFlagsConfiguration.Instance.TryGetJsonPayload(FeatureFlagsStrings.SKYBOX_SETTINGS, FeatureFlagsStrings.SKYBOX_SETTINGS_VARIANT, out settingsJson))
                 {
                     float normalizedTime = SkyboxSettingsAsset.NormalizeTime(settingsJson.time);
                     skyboxSettings.TimeOfDayNormalized = normalizedTime;


### PR DESCRIPTION
# Pull Request Description
Fix #6480 

## What does this PR change?
`SkyboxSettingsAsset.TimeOfDayNormalized` and `SkyboxSettingsAsset.TargetTimeOfDayNormalized` are initialized to FF value, if present.

### Test Steps
1. Enter the client
2. Open the skybox menu 
3. Verify that the time is not set to midday 12:00 pm but to whatever the FF is set to (during my tests it was always set to 81410 so around 22:40)

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
