### PR TITLE
fix: avoid showing world events in genesis plaza

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents/LiveEventsMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents/LiveEventsMarkersController.cs
@@ -230,6 +230,9 @@ namespace DCL.MapRenderer.MapLayers.Categories
                 IReadOnlyList<EventDTO> events = await eventsApiService.GetEventsAsync(ct, onlyLiveEvents: true);
                 foreach (EventDTO eventDto in events)
                 {
+                    if (eventDto.world)
+                        return;
+                    
                     Vector2Int coords = new Vector2Int(eventDto.x, eventDto.y);
                     if (markers.ContainsKey(coords))
                         continue;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6071 
Avoids showing events hosted in worlds in genesis plaza

## Test Instructions

### Test Steps
1. Enter the client
2. Verify that in GP no evens hosted in worlds are being shown in the map

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
