### PR TITLE
fix: added safeguard to errorcallback in rust segment analytics service

### DIFF
--- a/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
+++ b/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
@@ -182,6 +182,8 @@ namespace Plugins.RustSegment.SegmentServerWrap
         [MonoPInvokeCallback(typeof(NativeMethods.SegmentFfiCallback))]
         private static void ErrorCallback(IntPtr msg)
         {
+            if (current == null) return;
+
             string marshaled = Marshal.PtrToStringUTF8(msg) ?? "cannot parse message";
 
             // Required to avoid polluting Sentry with retry messages


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6889
this pr adds a safeguard in the error callback for the rust segment analytics service, this will now behave like the regular callbacks

## Test Instructions

### Test Steps
1. Launch the client
2. Close the client
3. Verify if it crashes
4. This PR should fix a rare crash so just perform a smoke test of opening and closing the client

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
