### PR TITLE
fix: avoid loading emotes when in the backpack wearables section

### DIFF
--- a/Explorer/Assets/DCL/Backpack/BackpackController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackController.cs
@@ -246,7 +246,6 @@ namespace DCL.Backpack
 
             Avatar avatar = world.Get<Profile>(playerEntity).Avatar;
             backpackGridController.RequestPage(1, true);
-            backpackEmoteGridController.RequestAndFillEmotes(1, true);
             backpackCharacterPreviewController.Initialize(avatar, CharacterPreviewUtils.AVATAR_POSITION_1);
 
             while (!avatarShapeComponent.WearablePromise.IsConsumed)

--- a/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
@@ -109,6 +109,7 @@ namespace DCL.Backpack.EmotesSection
             eventBus.FilterEvent += OnFilterEvent;
             backpackSortController.OnSortChanged += OnSortChanged;
             backpackSortController.OnCollectiblesOnlyChanged += OnCollectiblesOnlyChanged;
+            RequestAndFillEmotes(1, true);
         }
 
         public void Deactivate()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6794 
Before this PR, when opening the backpack, even if we were only in the wearables section we were also loading the first page of emotes, this caused a duplicated sound of loaded elements (the sound of when wearables appear in the grid).
Now with this change emotes are loaded only when we go to the emotes section

## Test Instructions

### Test Steps
1. Quick smoke test of backpack
2. Go to wearable section and verify it works
3. Go to emotes section and verify it works

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
