### PR TITLE
fix: base emotes not returned in search

### DIFF
--- a/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
@@ -143,7 +143,7 @@ namespace DCL.Backpack.EmotesSection
             if (!string.IsNullOrEmpty(command.BodyShape))
                 currentBodyShape = BodyShape.FromStringSafe(command.BodyShape);
         }
-        
+
         private void RequestAndFillEmotes(int pageNumber)
         {
             RequestAndFillEmotes(pageNumber, false);
@@ -189,7 +189,7 @@ namespace DCL.Backpack.EmotesSection
                     IEnumerable<IEmote> filteredEmotes = baseEmotes;
 
                     if (!string.IsNullOrEmpty(currentSearch!))
-                        filteredEmotes = baseEmotes.Where(emote => emote.GetName().Contains(currentSearch));
+                        filteredEmotes = baseEmotes.Where(emote => emote.GetName().Contains(currentSearch, StringComparison.OrdinalIgnoreCase));
 
                     if (!string.IsNullOrEmpty(currentCategory!))
                         filteredEmotes = baseEmotes.Where(emote => emote.GetCategory() == currentCategory);


### PR DESCRIPTION
# Pull Request Description
Fix #6797 

## What does this PR change?
Filtering base emotes by name ignoring case

### Test Steps

1. Open the Backpack
2. Go to the Emotes section
3. Use the search bar
4. Type "cry"
5. Verify that the "Cry" emote is shown

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
