### PR TITLE
fix: sentry values on release build

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -351,7 +351,7 @@ jobs:
           PARAM_BUILD_VERSION: ${{ needs.prebuild.outputs.version }}
           # solves https://github.com/decentraland/unity-explorer/issues/6789
           # use pre-defined sentry dsn, but in case it is not defined, use the development sentry project
-          PARAM_SENTRY_DSN: ${{ inputs.is_release_build == 'true' && secrets.SENTRY_DSN || secrets.SENTRY_DSN_DEV }}
+          PARAM_SENTRY_DSN: ${{ inputs.is_release_build && secrets.SENTRY_DSN || secrets.SENTRY_DSN_DEV }}
           PARAM_SENTRY_ENVIRONMENT: ${{ needs.prebuild.outputs.sentry_environment }}
           PARAM_SENTRY_ENABLED: ${{ needs.prebuild.outputs.sentry_enabled }}
           PARAM_SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
@@ -570,7 +570,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CLI_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ inputs.is_release_build == 'true' && vars.SENTRY_PROJECT || vars.SENTRY_PROJECT_DEV }}
+          SENTRY_PROJECT: ${{ inputs.is_release_build && vars.SENTRY_PROJECT || vars.SENTRY_PROJECT_DEV }}
         run: |
           npx --yes @sentry/cli debug-files upload \
             --org "$SENTRY_ORG" \


### PR DESCRIPTION
## What does this PR change?

Fixes the condition to switch from dev values to production values for sentry on the build process.

## Test Instructions

Everything should work normally. The release should be reporting to sentry `unity-explorer` project.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
