### PR TITLE
fix: ensure character preview wearable removal after outfit equip

### DIFF
--- a/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
@@ -1,4 +1,4 @@
-﻿using Arch.Core;
+using Arch.Core;
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.AvatarRendering.Emotes;
@@ -102,9 +102,12 @@ namespace DCL.Backpack.CharacterPreview
             previewAvatarModel.Wearables ??= new List<URN>();
             previewAvatarModel.Wearables.Clear();
             previewAvatarModel.BodyShape = command.BodyShape;
-            
-            foreach(var w in command.Wearables)
-                previewAvatarModel.Wearables.Add(new URN(w));
+
+            foreach (var wearable in wearables)
+            {
+                if (wearable.Type != WearableType.BodyShape)
+                    previewAvatarModel.Wearables.Add(wearable.GetUrn());
+            }
 
             previewAvatarModel.EyesColor = command.EyesColor;
             previewAvatarModel.HairColor = command.HairColor;
@@ -116,7 +119,7 @@ namespace DCL.Backpack.CharacterPreview
 
             OnModelUpdated();
         }
-        
+
         private void OnFilterEvent(string? category, AvatarWearableCategoryEnum? categoryEnum, string? searchText)
         {
             if (categoryEnum is AvatarWearableCategoryEnum c)
@@ -201,7 +204,7 @@ namespace DCL.Backpack.CharacterPreview
             if (emote == null) return;
             PlayEmote(emote.GetUrn().Shorten());
         }
-        
+
         private void OnEmoteSelected(IEmote emote)
         {
             async UniTaskVoid EnsureEmoteAndPlayItAsync(CancellationToken ct)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6944 
Use resolved urns when equipping outfits to ensure correct removal when equipping something on top of it

## Test Instructions

### Test Steps
1. Open app
2. Go to the backpack
3. Equip an outfit
4. Select another type of hair , shoes , etc
5. Check that there's no overlap between items

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
