### PR TITLE
style: reduce community thumbnail roundness in the chat panel

### DIFF
--- a/Explorer/Assets/DCL/UI/Communities/CommunityThumbnailView.prefab
+++ b/Explorer/Assets/DCL/UI/Communities/CommunityThumbnailView.prefab
@@ -144,6 +144,10 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4153455439339242846, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+      propertyPath: _spritePixelsPerUnitMultiplier
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4561718667523275783, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -154,6 +158,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 609007630589666506, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+    - {fileID: 6268008304506398115, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
+    - {fileID: 1592991949209245285, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:


### PR DESCRIPTION
# Pull Request Description
PR created to reduce community thumbnail roundness in the chat panel.

BEFORE
<img width="373" height="628" alt="Screenshot 2026-02-04 at 09 49 21" src="https://github.com/user-attachments/assets/1204b930-66df-45f9-a746-30e669353c94" />

AFTER
<img width="325" height="553" alt="Screenshot 2026-02-04 at 10 55 58" src="https://github.com/user-attachments/assets/f1132fb6-b62c-4a99-b236-0657257350cf" />

### Test Steps
1. Launch the explorer.
2. Open the chat panel and check in the toolbar (sidebar at the right) that the roundness of the thumbnails has been reduce.