### PR TITLE
Fix autopilot culture

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/AutoPilot/AutoPilot.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/AutoPilot/AutoPilot.cs
@@ -116,8 +116,8 @@ namespace DCL.PerformanceAndDiagnostics.AutoPilot
                 {
                     string line = await csv.ReadLineAsync();
                     string[] columns = line.Split(',');
-                    cpuTimes.Add(float.Parse(columns[1]));
-                    gpuTimes.Add(float.Parse(columns[2]));
+                    cpuTimes.Add(float.Parse(columns[1], CultureInfo.InvariantCulture));
+                    gpuTimes.Add(float.Parse(columns[2], CultureInfo.InvariantCulture));
                 }
             }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change fixes autopilot output in cultures where the decimal separator is the comma and not the dot.

## Test Instructions

On Windows, the command line is  
`Decentraland.exe --autopilot --csv frames.csv --summary summary.txt`

On macOS, the command line is  
`open Decentraland.app --args --autopilot --csv "$PWD/frames.csv" --summary "$PWD/summary.txt"`

### Prerequisites

- You must be logged in already such that the login screen can be skipped.
- Your computer must be set to a culture where the decimal separator is the comma

### Test Steps

1. Run the game from the command line
2. Wait for the game to load into the world and then, after a while, quit on its own
3. Check that there are frames.csv and summary.txt files in the folder you launched the game from
4. Check that numbers in them use dots for decimals

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
