### PR TITLE
feat: Multi-scene world spawn point

### DIFF
--- a/Explorer/Assets/DCL/NetworkDefinitions/WorldManifest.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/WorldManifest.cs
@@ -14,14 +14,8 @@ namespace ECS
     public struct WorldManifest : IDisposable
     {
         public int total;
-
-        [JsonProperty("spawn_coordinate")]
         public SpawnCoordinateData? spawn_coordinate;
-
-        [JsonIgnore]
         private NativeHashSet<int2> occupiedParcels;
-
-        [JsonIgnore]
         private bool isEmpty;
 
         public WorldManifest(int2[] valueOccupiedParcels)
@@ -95,13 +89,13 @@ namespace ECS
             occupiedParcels = EMPTY_SET,
             isEmpty = true
         };
+    }
 
-        [Serializable]
-        public class SpawnCoordinateData
-        {
-            public int x;
-            public int y;
-        }
+    [Serializable]
+    public class SpawnCoordinateData
+    {
+        public int x;
+        public int y;
     }
 
     /// <summary>
@@ -116,6 +110,6 @@ namespace ECS
         public int total;
 
         [JsonProperty("spawn_coordinate")]
-        public WorldManifest.SpawnCoordinateData spawn_coordinate;
+        public SpawnCoordinateData? spawn_coordinate;
     }
 }

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/TeleportToSpawnPointOperationBase.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/TeleportToSpawnPointOperationBase.cs
@@ -101,11 +101,22 @@ namespace DCL.RealmNavigation.TeleportOperations
         {
             AssetPromise<SceneEntityDefinition, GetSceneDefinition>[]? promises = await realmController.WaitForFixedScenePromisesAsync(ct);
 
-            if (!promises.Any(p =>
-                    p.Result.HasValue
-                    && (p.Result.Value.Asset?.metadata.scene.DecodedParcels.Contains(parcelToTeleport) ?? false)
-                ))
+            // If the WorldManifest defines an explicit spawn coordinate, always use it
+            // (e.g. worlds with a fixed or curated spawn point)
+            WorldManifest manifest = realmController.RealmData.WorldManifest;
+
+            if (manifest is { IsEmpty: false, spawn_coordinate: { } spawn })
+            {
+                parcelToTeleport = new Vector2Int(spawn.x, spawn.y);
+            }
+            // Otherwise, verify that the chosen parcel is actually owned by at least one loaded scene.
+            // If it isn't inside any scene's DecodedParcels, fall back to the first scene's DecodedBase.
+            else if (!promises.Any(p =>
+                         p.Result.HasValue &&
+                         (p.Result.Value.Asset?.metadata.scene.DecodedParcels.Contains(parcelToTeleport) ?? false)))
+            {
                 parcelToTeleport = promises[0].Result!.Value.Asset!.metadata.scene.DecodedBase;
+            }
 
             WaitForSceneReadiness? waitForSceneReadiness =
                 await teleportController.TeleportToSceneSpawnPointAsync(parcelToTeleport, processReport, ct);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Integrates the spawn point for worlds

## Test Instructions


### Prerequisites

### Test Steps
1. Use the params `--dclenv zone --realm pastrami.dcl.eth`. You should appear on `10,10`
2. Go to any other world, and confirm that you land on the correct spot (by default its 0,0)


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
