### PR TITLE
fix: correctly handle nametags on fetch / release from pool

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Assets/NametagsDocument.uxml
+++ b/Explorer/Assets/DCL/NameTags/Assets/NametagsDocument.uxml
@@ -1,4 +1,4 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="False">
-    <Style src="project://database/Assets/DCL/NameTags/Assets/NametagStyle.uss?fileID=7433441132597879392&amp;guid=7d840ff87e3164a2f87075ae975335de&amp;type=3#NametagStyle" />
-    <DCL.Nametags.NametagElement style="display: none;" />
+    <Style src="project://database/Assets/DCL/NameTags/Assets/NametagStyle.uss?fileID=7433441132597879392&amp;guid=7d840ff87e3164a2f87075ae975335de&amp;type=3#NametagStyle"/>
+    <DCL.Nametags.NametagElement/>
 </ui:UXML>

--- a/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/AvatarPlugin.cs
@@ -208,10 +208,10 @@ namespace DCL.PluginSystem.Global
                 },
                 actionOnRelease: nh =>
                 {
-                    nh.Nametag.SetDisplayed(false);
+                    nh.gameObject.SetActive(false);
                 },
                 actionOnDestroy: UnityObjectUtils.SafeDestroy,
-                actionOnGet: nh => nh.Nametag.SetDisplayed(true));
+                actionOnGet: nh => nh.gameObject.SetActive(true));
         }
 
         private async UniTask CreateMaterialPoolPrewarmedAsync(AvatarShapeSettings settings, CancellationToken ct)

--- a/Explorer/Assets/Plugins/RustSegment/README.md.meta
+++ b/Explorer/Assets/Plugins/RustSegment/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2e5cbc1fe788242e3bec7f7d46aa8e5a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/ProjectSettings/Packages/com.unity.dedicated-server/MultiplayerRolesSettings.asset
+++ b/Explorer/ProjectSettings/Packages/com.unity.dedicated-server/MultiplayerRolesSettings.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 53
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 15023, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEditor.MultiplayerModule.dll::UnityEditor.Multiplayer.Internal.MultiplayerRolesSettings
+  m_MultiplayerRoleForClassicProfile:
+    m_Keys: []
+    m_Values: 


### PR DESCRIPTION
# Pull Request Description

This fixes issues where nametags would retain setups when they were released back into the pool (which happens when the nametag is hidden / shown, either by pressing N or rotating the camera away from it). In those cases they could show incorrect speaking Icons / chat messages etc...

fixes #6646 
fixes #6062 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Nametag GO's are now disabled / enabled, which completely clears them (UITK feature), instead of just being hidden.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

Check that when multiple users are speaking / some are in voice chat, that toggling the nametags on / off does not show states on incorrect users - what could happen before was that if a user had a chat bubble, and the nametags were toggled off and back on, the same nametag will not be assigned to the same user, but the nametag retained it's state (chat bubble / voice chat icon / etc...). Now the state should always be cleared when the nametag is hidden.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
