### PR TITLE
fix: race condition for chat suggestion processing

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/SuggestionPanelChatInputState.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/SuggestionPanelChatInputState.cs
@@ -1,4 +1,5 @@
-﻿using DCL.Audio;
+﻿using Cysharp.Threading.Tasks;
+using DCL.Audio;
 using DCL.Chat.ChatCommands;
 using DCL.Chat.ChatServices;
 using DCL.Emoji;
@@ -10,6 +11,7 @@ using MVC;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Threading;
 using UnityEngine.Pool;
 
 namespace DCL.Chat.ChatInput
@@ -62,7 +64,7 @@ namespace DCL.Chat.ChatInput
             clickDetectionHandler.Dispose();
         }
 
-        internal bool TryFindMatch(string inputText)
+        internal async UniTask<bool> TryFindMatchAsync(string inputText, CancellationToken ct)
         {
             //With this we are detecting only the last word (where the current caret position is) and checking for matches there.
             //This regex already pre-matches the starting patterns for both Emoji ":" and Profile "@" patterns, and only sends the match further to validate other specific conditions
@@ -73,14 +75,14 @@ namespace DCL.Chat.ChatInput
             if (wordMatch.Success)
             {
                 wordMatchIndex = wordMatch.Index;
-                lastMatch = suggestionPanelController.HandleSuggestionsSearch(wordMatch.Value, EMOJI_PATTERN_REGEX, InputSuggestionType.EMOJIS, emojiSuggestionsDictionary);
+                lastMatch = await suggestionPanelController.HandleSuggestionsSearchAsync(wordMatch.Value, EMOJI_PATTERN_REGEX, InputSuggestionType.EMOJIS, emojiSuggestionsDictionary, ct);
 
                 if (lastMatch.Success) return true;
 
                 //If we don't find any emoji pattern only then we look for username patterns
 
                 UpdateProfileNameMap();
-                lastMatch = suggestionPanelController.HandleSuggestionsSearch(wordMatch.Value, PROFILE_PATTERN_REGEX, InputSuggestionType.PROFILE, profileSuggestionsDictionary);
+                lastMatch = await suggestionPanelController.HandleSuggestionsSearchAsync(wordMatch.Value, PROFILE_PATTERN_REGEX, InputSuggestionType.PROFILE, profileSuggestionsDictionary, ct);
 
                 if (lastMatch.Success) return true;
             }

--- a/Explorer/Assets/DCL/UI/InputSuggestions/InputSuggestionPanelController.cs
+++ b/Explorer/Assets/DCL/UI/InputSuggestions/InputSuggestionPanelController.cs
@@ -14,8 +14,6 @@ namespace DCL.UI.SuggestionPanel
         // public event SuggestionSelectedDelegate SuggestionSelected;
 
         private readonly InputSuggestionPanelView suggestionPanel;
-
-        private CancellationTokenSource searchCts = new ();
         private string lastMatch;
 
         public InputSuggestionPanelController(InputSuggestionPanelView suggestionPanel)
@@ -46,14 +44,15 @@ namespace DCL.UI.SuggestionPanel
         /// <param name="suggestionDataMap"> The Dictionary that contains all the possible suggestion data values to display</param>
         /// <typeparam name="T"> The type of suggestion element data</typeparam>
         /// <returns> The match if there was one or an empty match if there was none </returns>
-        public Match HandleSuggestionsSearch<T>(string inputText, Regex regex, InputSuggestionType suggestionType, Dictionary<string, T> suggestionDataMap) where T : IInputSuggestionElementData
+        public async UniTask<Match> HandleSuggestionsSearchAsync<T>(string inputText, Regex regex, InputSuggestionType suggestionType, Dictionary<string, T> suggestionDataMap, CancellationToken ct) where T : IInputSuggestionElementData
         {
             Match match = regex.Match(inputText);
 
             if (match.Success && match.Groups.Count > 1)
             {
-                searchCts = searchCts.SafeRestart();
-                SearchAndSetSuggestionsAsync(match.Groups[1].Value, suggestionType, suggestionDataMap, searchCts.Token).Forget();
+                // Fixes https://github.com/decentraland/unity-explorer/issues/6965
+                // This operation needs to be awaited otherwise a race condition occurs between the suggested elements generated and the submitted element processed
+                await SearchAndSetSuggestionsAsync(match.Groups[1].Value, suggestionType, suggestionDataMap, ct);
                 return match;
             }
 
@@ -64,12 +63,11 @@ namespace DCL.UI.SuggestionPanel
             return Match.Empty;
         }
 
-        private async UniTaskVoid SearchAndSetSuggestionsAsync<T>(string value, InputSuggestionType suggestionType, Dictionary<string, T> suggestionDataMap, CancellationToken ct) where T : IInputSuggestionElementData
+        private async UniTask SearchAndSetSuggestionsAsync<T>(string value, InputSuggestionType suggestionType, Dictionary<string, T> suggestionDataMap, CancellationToken ct) where T : IInputSuggestionElementData
         {
             var resultList = new List<T>();
             string searchValue = suggestionType == InputSuggestionType.EMOJIS ? value.Replace(":", "") : value;
             await DictionaryUtils.GetKeysContainingTextAsync(suggestionDataMap, searchValue, resultList, ct);
-
 
             suggestionPanel.SetSuggestionValues(suggestionType, resultList);
 
@@ -79,7 +77,6 @@ namespace DCL.UI.SuggestionPanel
 
         public void Dispose()
         {
-            searchCts.SafeCancelAndDispose();
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/6965

There was a race condition between the suggestion elements generation and the submit action in case there were many elements in the list to check, therefore only happened on emojis.
The solution consists on awaiting the processing tasks before showing the panel, so the elements are correctly set when the submit is processed.

## Test Instructions

Use the @mention in the chat. In the same input try to submit an emoji (ie: :wave:). The emoji should be set as expected.
Also check that suggestions panel works fine, even by clicking elements.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
