### PR TITLE
fix: media player race condition

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -119,6 +119,7 @@ namespace DCL.SDKComponents.MediaStream
         [Query]
         private void UpdateVideoStream(in Entity entity, ref MediaPlayerComponent component, PBVideoPlayer sdkComponent, [Data] float dt)
         {
+            if (component.MediaPlayer.WaitingForProperties) return;
             if (!frameTimeBudget.TrySpendBudget()) return;
 
             var address = MediaAddress.New(sdkComponent.Src!);
@@ -161,7 +162,7 @@ namespace DCL.SDKComponents.MediaStream
             }
 
             if (ConsumePromise(ref component, false))
-                component.MediaPlayer.SetPlaybackProperties(sdkComponent);
+                component.MediaPlayer.SetPlaybackPropertiesAsync(sdkComponent).Forget();
 
             // Need to re-update state in case an update was needed from the sdk component or promise
             component.UpdateState();


### PR DESCRIPTION
# Pull Request Description

This change ensures that the media player will wait for the initial properties to be set, before anything else is allowed to be done on it, fixing issues where a quick call to update properties (e.g. setting the playback position within 1 second of the media player being created) would be overwritten by the initial properties set on it.

fixes #6974

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

It adds an absolutely atrocious holder class with a flag, which is set / reset before and after the async method call, which the UpdateMediaPlayerSystem checks and blocks the query while the flag is set.

### Test Steps
1. Download and run the local scene from #6974
2. Load into it, and position yourself so you have quick access to the play button
3. Reload the scene with /reload
4. Immediately once the scene loads, press the play button under the video
5. Before the fix, the video started at position 0, now it should correctly start at position 60


## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
