### PR TITLE
hotfix: 12-02-2025

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,18 @@ jobs:
           docker info | sed -n '1,40p'
           df -h /mnt /mnt/docker
 
+      - name: Free disk space (runner)
+        run: |
+          set -euxo pipefail
+          df -h
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /opt/hostedtoolcache || true
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          df -h
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -96,7 +108,7 @@ jobs:
         with:
           path: Explorer/Library
           key: Library-Explorer-Ubuntu
-      
+
       # --- Detect Unity version from the project ---
       - name: Read Unity version from ProjectVersion.txt
         id: unity-version

--- a/Explorer/.gitignore
+++ b/Explorer/.gitignore
@@ -85,5 +85,5 @@ Assets/AddressableAssetsData/link.xml.meta
 Assets/Resources/PerformanceTestRunInfo.*
 Assets/Resources/PerformanceTestRunSettings.*
 
-# Disk caching 
+# Disk caching
 DiskCache/

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Splash.prefab
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/Splash.prefab
@@ -236,7 +236,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 1000
+  m_SortingOrder: 500
   m_TargetDisplay: 0
 --- !u!114 &6219470281071135800
 MonoBehaviour:


### PR DESCRIPTION
# Pull Request Description

SplashScreen was hiding MinSpecRequiremts screen so user wasn't able to continue and get stuck on the infinite SplashScreen.

## Test Instructions
use `--forceMinimumSpecsScreen` app arg and verify that this popup shows and you can continue.

Additionally, verify that transition from SplashScreen to the Authentication is still nice fade-out/fade-in and not a hard cut

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
