### PR TITLE
fix: free runner disk space before Unity tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,18 @@ jobs:
           docker info | sed -n '1,40p'
           df -h /mnt /mnt/docker
 
+      - name: Free disk space (runner)
+        run: |
+          set -euxo pipefail
+          df -h
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /opt/hostedtoolcache || true
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          df -h
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -96,7 +108,7 @@ jobs:
         with:
           path: Explorer/Library
           key: Library-Explorer-Ubuntu
-      
+
       # --- Detect Unity version from the project ---
       - name: Read Unity version from ProjectVersion.txt
         id: unity-version

--- a/Explorer/.gitignore
+++ b/Explorer/.gitignore
@@ -85,5 +85,5 @@ Assets/AddressableAssetsData/link.xml.meta
 Assets/Resources/PerformanceTestRunInfo.*
 Assets/Resources/PerformanceTestRunSettings.*
 
-# Disk caching 
+# Disk caching
 DiskCache/


### PR DESCRIPTION
- Added a disk cleanup step at the start of the Unity test workflow to avoid runner space issues
- Removed heavy preinstalled toolchains (dotnet, Android SDK, GHC, hostedtoolcache) and cleared apt caches to free up ~20GB before pulling the Unity image
- Included simple `df -h` checks before and after cleanup to make future disk problems easier to spot