### PR TITLE
fix: allow worlds to be set as favorite from minimap panel

### DIFF
--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -283,13 +283,16 @@ namespace DCL.Minimap
             {
                 try
                 {
-                    PlacesData.PlaceInfo? placeInfo = await GetPlaceInfoAsync(previousParcelPosition, favoriteCancellationToken.Token);
-                    if (placeInfo == null)
+                    PlacesData.PlaceInfo? info = realmData.ScenesAreFixed
+                        ? await GetWorldInfoAsync(realmData.RealmName, ct)
+                        : await GetPlaceInfoAsync(previousParcelPosition, ct);
+
+                    if (info == null)
                     {
                         viewInstance!.favoriteButton.SetButtonState(false, false);
                         return;
                     }
-                    await placesAPIService.SetPlaceFavoriteAsync(placeInfo!.id, value, ct);
+                    await placesAPIService.SetPlaceFavoriteAsync(info.id, value, ct);
                     viewInstance!.favoriteButton.SetButtonState(value);
                 }
                 catch (OperationCanceledException _) { }
@@ -432,11 +435,17 @@ namespace DCL.Minimap
             if (realmData.ScenesAreFixed)
             {
                 viewInstance!.placeNameText.text = realmData.RealmName.Replace(".dcl.eth", string.Empty);
-                viewInstance!.favoriteButton.SetButtonState(false, false);
 
                 PlacesData.PlaceInfo? worldInfo = await GetWorldInfoAsync(realmData.RealmName, ct);
                 if (worldInfo != null)
+                {
+                    viewInstance!.favoriteButton.SetButtonState(worldInfo.user_favorite);
                     placesAPIService.AddRecentlyVisitedPlace(worldInfo.id);
+                }
+                else
+                {
+                    viewInstance!.favoriteButton.SetButtonState(false, false);
+                }
             }
             else
             {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7061
this PR allows worlds to be set as favorites, before the button was disabled

## Test Instructions

### Test Steps
1. Launch the client
2. Go to a world
3. Check that you can add it as a favorite by pressing the heart button in the minimap header

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
