### PR TITLE
chore: add minimum requirements analytics

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -42,6 +42,7 @@ using ECS.StreamableLoading.Cache.Disk.CleanUp;
 using ECS.StreamableLoading.Cache.Disk.Lock;
 using ECS.StreamableLoading.Common;
 using ECS.StreamableLoading.Common.Components;
+using Newtonsoft.Json.Linq;
 using Global.AppArgs;
 using Global.Dynamic.RealmUrl;
 using Global.Dynamic.RealmUrl.Names;
@@ -368,6 +369,25 @@ namespace Global.Dynamic
             bool forceShow = applicationParametersParser.HasFlag(AppArgsFlags.FORCE_MINIMUM_SPECS_SCREEN);
 
             bootstrapContainer.DiagnosticsContainer.AddSentryScopeConfigurator(scope => { bootstrapContainer.DiagnosticsContainer.Sentry!.AddMeetMinimumRequirements(scope, hasMinimumSpecs); });
+
+            var specsProperties = new JObject
+            {
+                ["meets_requirements"] = hasMinimumSpecs,
+            };
+
+            foreach (SpecResult result in minimumSpecsGuard.Results)
+            {
+                string categoryKey = result.Category.ToString().ToLowerInvariant();
+                specsProperties[$"{categoryKey}_met"] = result.IsMet;
+
+                if (!result.IsMet)
+                {
+                    specsProperties[$"{categoryKey}_required"] = result.Required;
+                    specsProperties[$"{categoryKey}_actual"] = result.Actual;
+                }
+            }
+
+            analytics.Track(AnalyticsEvents.General.MEETS_MINIMUM_REQUIREMENTS, specsProperties);
 
             bool shouldShowScreen = forceShow || (!userWantsToSkip && !hasMinimumSpecs);
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/AnalyticsEvents.cs
@@ -1,4 +1,4 @@
-﻿namespace DCL.PerformanceAndDiagnostics.Analytics
+namespace DCL.PerformanceAndDiagnostics.Analytics
 {
     /// <summary>
     ///     IMPORTANT!!
@@ -16,6 +16,7 @@
             public const string ERROR = "error";
             public const string CRASH = "crash";
             public const string LOADING_ERROR = "loading_error";
+            public const string MEETS_MINIMUM_REQUIREMENTS = "meets_minimum_requirements";
         }
 
         public static class World


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7070 
Add new analytics to track if users meet minimum requirements, send a breakdown of all requirements and the non met ones in case they are not met in the following format:
```
Track: meets_minimum_requirements 
 meets_requirements = False 
 os_met = True 
 cpu_met = True 
 gpu_met = True 
 vram_met = False 
 vram_required = 6 GB 
 vram_actual = 0 GB 
 ram_met = True 
 storage_met = True
```

## Test Instructions

### Test Steps
1. Launch the client
2. Verify you can log in normallu
3. Launch the client with a PC that doesn't meet the minimum requirements (or with --forceMinimumSpecsScreen app parameter)
4. Verify you can log in normally

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
