### PR TITLE
Autopilot: make the performance test longer

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/AutoPilot/AutoPilot.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/AutoPilot/AutoPilot.cs
@@ -86,7 +86,7 @@ namespace DCL.PerformanceAndDiagnostics.AutoPilot
         {
             float startTime = Time.realtimeSinceStartup;
 
-            while (Time.realtimeSinceStartup - startTime < 60f)
+            while (Time.realtimeSinceStartup - startTime < 90f)
             {
                 await WriteSampleAsync();
                 await UniTask.Yield();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change increases the performance test length from 60 seconds to 90.

## Test Instructions

On Windows, when using Command Prompt, the command line is  
`Decentraland.exe --autopilot --csv "%CD%\frames.csv"`

On Windows, when using PowerShell, the command line is
`./Decentraland.exe --autopilot --csv "$PWD\frames.csv"`

On macOS, the command line is  
`open Decentraland.app --args --autopilot --csv "$PWD/frames.csv"`

### Prerequisites
- You must be logged in already such that the login screen can be skipped.

### Test Steps
1. Run the game from the command line
2. Wait for the game to load into the world and then, after a while, quit on its own
3. Check that there's a frames.csv file in the folder you launched the game from
4. Check that that file contains at least 1000 lines of text

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
