### PR TITLE
fix: HeadIK crash

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/HeadIKSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/HeadIKSystem.cs
@@ -18,6 +18,7 @@ using DCL.FeatureFlags;
 using DCL.InWorldCamera;
 using DCL.Multiplayer.Movement;
 using ECS.Abstract;
+using ECS.LifeCycle.Components;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -85,6 +86,7 @@ namespace DCL.CharacterMotion.Systems
         }
 
         [Query]
+        [None(typeof(DeleteEntityIntention))]
         private void UpdatePreviewAvatarIK([Data] float dt, in CharacterPreviewComponent previewComponent, ref HeadIKComponent headIK,
             ref AvatarBase avatarBase, in CharacterEmoteComponent emoteComponent)
         {
@@ -152,7 +154,7 @@ namespace DCL.CharacterMotion.Systems
         // This prevents all random avatars from moving the head when the player's camera is moved
         [None(typeof(RandomAvatar))]
 #endif
-        [None(typeof(RemotePlayerMovementComponent))]
+        [None(typeof(RemotePlayerMovementComponent), typeof(DeleteEntityIntention))]
         private void UpdateIK([Data] float dt,
             [Data] in CameraComponent cameraComponent,
             [Data] bool inWorldCameraActive,
@@ -185,6 +187,7 @@ namespace DCL.CharacterMotion.Systems
 
         [Query]
         [All(typeof(RemotePlayerMovementComponent))]
+        [None(typeof(DeleteEntityIntention))]
         private void UpdateRemoteIK([Data] float dt, [Data] Vector3 playerPosition, ref HeadIKComponent headIK, ref AvatarBase avatarBase, in CharacterTransform transform)
         {
             // Head IK enabled flag and look-at vector are received from the remote client


### PR DESCRIPTION
### What does this PR change? 

Fixes a native crash in HeadIKSystem.UpdateRemoteIK occurs when operating on entities marked for deletion. When an entity with a remote player avatar is being destroyed, the AvatarBase MonoBehaviour or its HeadIKRig may already be deallocated, but the ECS queries still pick it up, resulting in a native crash.                                                             

The fix adds `[None(typeof(DeleteEntityIntention))]` filters to all three query methods in HeadIKSystem, consistent with the coding guidelines for every other system in the CharacterMotion/Systems folder and with the project's coding guidelines.

  Crash report: [crashes/291da63f-9c54-e470-ea1c-23953af2d41a.json](https://cloud.unity.com/home/organizations/4673197905245/projects/8c12744f-9e98-47b8-b40c-576d04cb8d5c/diagnostics/issues/122a10136d36aa1ee7c911e6c89eba3c)

```
  Stack trace (top frames):
  0  Vector3_get_sqrMagnitude (inlined)
  1  HeadIKSystem_UpdateRemoteIK
  2  HeadIKSystem_UpdateRemoteIKQuery
  3  HeadIKSystem_Update
  4  BaseUnityLoopSystem_Update
```

###  Test Instructions

###  Prerequisites

  - Build with multiplayer/remote players enabled
  - Access a scene with other players present

###  Test Steps

  1. Join a populated scene where remote player avatars are visible
  2. Wait for remote players to leave or disconnect (triggering entity deletion)
  3. Verify no native crash occurs during avatar teardown
  4. Confirm remote player head IK still animates correctly for players that remain in the scene

###  Additional Testing Notes
  - The crash was observed on macOS (Apple M2 Pro, v0.124.0-alpha-main) but the missing filter affects all platforms
  - The fix is purely additive (query filter attribute) with no behavioral change to live entities
