### PR TITLE
fix: normal texture color loaded through gltf node modifiers

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
@@ -76,7 +76,8 @@ namespace DCL.WebRequests
                     if (data == null)
                         throw new Exception("Texture content is empty");
 
-                    texture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+                    texture = new Texture2D(2, 2, TextureFormat.RGBA32, false,
+                        linear: webRequest.textureType == TextureType.NormalMap);
 
                     if (!texture.LoadImage(data)) { throw new Exception($"Failed to load image from data: {webRequest.url}"); }
                 }


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/7038

Fix the way the texture is created when it is loaded through a web request. Normal textures must be created as linear, non-sRGB.

Since all of the textures were created as sRGB color, scenes that was replacing the normal texture through gltf node modifiers looked different and wrong:
```
GltfNodeModifiers.createOrReplace(gltf, {
    modifiers: [
        {
            path: 'partyKitBanner',
            material: {
                material: {
                    $case: 'pbr',
                    pbr: {
                        texture: Material.Texture.Common({
                            src: 'assets/partyKitBanner_mat_basecolor.png'
                        }),
                        bumpTexture: Material.Texture.Common({
                            src: 'assets/partyKitBanner_mat_normal.png'
                        }),
                        roughness: 0.7,
                        metallic: 0
                    },
                },
            },
        },
    ],
});
```

## Test Instructions

Run this scene: [normal-texture-gltf-modifier.zip](https://github.com/user-attachments/files/25392845/normal-texture-gltf-modifier.zip)
One banner has gltf node modifier that replaces the albedo and normal textures, the other does not.
Both banners should look the same

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
