### PR TITLE
fix: prevent build cancelation on labels other than force-build or clean-build

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -133,7 +133,13 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.install_source }}
-  cancel-in-progress: true
+  cancel-in-progress: >-
+    ${{
+      github.event_name != 'pull_request' ||
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'force-build' ||
+      github.event.label.name == 'clean-build'
+    }}
 
 jobs:
   prebuild:

--- a/Explorer/.gitignore
+++ b/Explorer/.gitignore
@@ -85,5 +85,5 @@ Assets/AddressableAssetsData/link.xml.meta
 Assets/Resources/PerformanceTestRunInfo.*
 Assets/Resources/PerformanceTestRunSettings.*
 
-# Disk caching
+# Disk caching 
 DiskCache/


### PR DESCRIPTION
- Prevent Unity Cloud builds from being cancelled when unrelated PR labels are added, avoiding cases where a build is cancelled and the replacement run is skipped
- Keep cancellation behavior for new commits and PR state changes
- Allow force-build and clean-build labels to still replace an in-progress build

