### PR TITLE
fix: ProfileBuilder now takes into account the claimed name

### DIFF
--- a/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileBuilder.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileBuilder.cs
@@ -167,7 +167,7 @@ namespace DCL.Profiles
             profile.GetCompact().HasClaimedName = hasClaimedName;
             profile.HasConnectedWeb3 = hasConnectedWeb3;
             profile.GetCompact().UserNameColor = userNameColor;
-            profile.GetCompact().ClaimedNameColor = claimedNameColor;
+            profile.ClaimedNameColor = claimedNameColor;
 
             var avatar = new Avatar();
             profile.Avatar = avatar;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Addresses a corner case in the backpack that was overriding the current profile with and old claimed color

## Test Instructions
- Change your name color and try deploying a new profile by: Opening/Closing the backpack, changing emotes, changing your passport. 
- Check the permutations before and after the deployment is successful (the background in the thumbnail changes to your new color).

### Prerequisites
- [x] List any required setup steps
- [x] Include environment/configuration requirements


## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
