### PR TITLE
chore: Implement Claude Review workflow for QA-approved PR

### DIFF
--- a/.github/workflows/claude-pr-review-auto.yml
+++ b/.github/workflows/claude-pr-review-auto.yml
@@ -12,7 +12,8 @@ jobs:
     if: |
       ${{ github.event.review.state == 'approved' &&
       !contains(github.event.pull_request.labels.*.name, 'no QA needed') &&
-      !contains(github.event.pull_request.labels.*.name, 'no review') }}
+      !contains(github.event.pull_request.labels.*.name, 'no review') &&
+      !contains(github.event.pull_request.labels.*.name, 'auto-pr') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,9 +43,18 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "10"
           direct_prompt: |
-            This PR has been approved by QA and requires automated analysis focused on actionable improvements only.
-            Review Focus
-            Identify and report ONLY issues that require fixes:
+            This PR has been approved by QA and requires automated analysis.
+          
+            Review the PR diff using mcp__github__get_pull_request_diff, then:
+          
+            1. Create a pending review with mcp__github__create_pending_pull_request_review
+            2. For each issue found, add a comment with mcp__github__add_pull_request_review_comment_to_pending_review
+            3. Submit the review with mcp__github__submit_pull_request_review using:
+               - event: "REQUEST_CHANGES" if you found any bugs, security vulnerabilities, or required fixes
+               - event: "APPROVE" if the code is production-ready with no required changes
+               - event: "COMMENT" if you have only minor observations that don't block merging
+          
+            Review Focus — report ONLY issues that require fixes:
             1. Code quality violations per CLAUDE.md standards
             2. Bugs or potential runtime errors
             3. Security vulnerabilities
@@ -52,16 +62,13 @@ jobs:
             5. Bad practices or anti-patterns
             6. Missing error handling
             7. Unclear or problematic logic
-            Response Format
+          
             For each issue found:
-            1. Location: File and line number
-            2. Problem: What is wrong (be specific)
-            3. Fix: Exact change needed
-            4. Why: Brief explanation of the impact
-            What NOT to Include
-            1. Praise for correct code
-            2. General observations about what works well
-            3. Style preferences that don't violate standards
-            4. Suggestions that are "nice-to-have" rather than necessary
+            - Location: File and line number
+            - Problem: What is wrong (be specific)
+            - Fix: Exact change needed
+            - Why: Brief explanation of the impact
+          
+            Do NOT include praise, style preferences, or nice-to-have suggestions.
             Focus entirely on what needs to be changed to make this PR production-ready.
           allowed_tools: "mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pull_request_review,mcp__github__get_pull_request_diff"


### PR DESCRIPTION
### What does this PR change?
Adds a new GitHub Actions workflow (.github/workflows/claude-review-on-qa-approval.yml) that automatically triggers a Claude-powered code review when a QA team member approves a pull request.
The workflow:

- Fires on pull_request_review submitted events
- Only runs if the approving user belongs to the QA group (Ludmilafantaniella, anicalbano, dafgreco)
Skips PRs labeled no QA needed or no review
- Uses anthropics/claude-code-action@beta to perform a focused review via the Anthropic API, reporting only actionable issues (bugs, security vulnerabilities, performance problems, missing error handling, code quality violations)