### PR TITLE
fix: update deprecated UxmlFactory usage

### DIFF
--- a/Explorer/Assets/DCL/Input/Crosshair/CrosshairCanvas.cs
+++ b/Explorer/Assets/DCL/Input/Crosshair/CrosshairCanvas.cs
@@ -4,7 +4,8 @@ using Utility.UIToolkit;
 
 namespace DCL.Input.Crosshair
 {
-    public class CrosshairCanvas : VisualElement, ICrosshairView
+    [UxmlElement]
+    public partial class CrosshairCanvas : VisualElement, ICrosshairView
     {
         private VisualElement crossHairElement;
         private Sprite crossHair;
@@ -67,7 +68,5 @@ namespace DCL.Input.Crosshair
         {
             VisualElementsExtensions.SetDisplayed(this, displayed);
         }
-
-        public new class UxmlFactory : UxmlFactory<CrosshairCanvas> { }
     }
 }

--- a/Explorer/Assets/DCL/Interaction/HoverCanvas/UI/HoverCanvas.cs
+++ b/Explorer/Assets/DCL/Interaction/HoverCanvas/UI/HoverCanvas.cs
@@ -5,7 +5,8 @@ using UnityEngine.UIElements;
 
 namespace DCL.Interaction.HoverCanvas.UI
 {
-    public class HoverCanvas : VisualElement, IComparer<HoverCanvasTooltipElement>
+    [UxmlElement]
+    public partial class HoverCanvas : VisualElement, IComparer<HoverCanvasTooltipElement>
     {
         private List<HoverCanvasTooltipElement> tooltips;
 
@@ -52,7 +53,5 @@ namespace DCL.Interaction.HoverCanvas.UI
 
         public int Compare(HoverCanvasTooltipElement x, HoverCanvasTooltipElement y) =>
             x.parent.tabIndex.CompareTo(y.parent.tabIndex);
-
-        public new class UxmlFactory : UxmlFactory<HoverCanvas> { }
     }
 }

--- a/Explorer/Assets/DCL/Interaction/HoverCanvas/UI/HoverCanvasTooltipElement.cs
+++ b/Explorer/Assets/DCL/Interaction/HoverCanvas/UI/HoverCanvasTooltipElement.cs
@@ -3,7 +3,8 @@ using Utility.UIToolkit;
 
 namespace DCL.Interaction.HoverCanvas.UI
 {
-    public class HoverCanvasTooltipElement : VisualElement
+    [UxmlElement]
+    public partial class HoverCanvasTooltipElement : VisualElement
     {
         private Label hint;
 
@@ -52,7 +53,5 @@ namespace DCL.Interaction.HoverCanvas.UI
             }
             else inputIcon.SetDisplayed(false);
         }
-
-        public new class UxmlFactory : UxmlFactory<HoverCanvasTooltipElement> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/AverageFpsBannerElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/AverageFpsBannerElement.cs
@@ -2,7 +2,8 @@ using UnityEngine.UIElements;
 
 namespace DCL.DebugUtilities.Views
 {
-    public class AverageFpsBannerElement : DebugElementBase<AverageFpsBannerElement, AverageFpsBannerDef>, IBindable, INotifyValueChanged<AverageFpsBannerData>
+    [UxmlElement]
+    public partial class AverageFpsBannerElement : DebugElementBase<AverageFpsBannerElement, AverageFpsBannerDef>, IBindable, INotifyValueChanged<AverageFpsBannerData>
     {
         private const string USS_FPS_VALUE_LABEL_NAME = "FpsValue";
         private const string USS_MS_VALUE_LABEL_NAME = "MsValue";
@@ -106,7 +107,5 @@ namespace DCL.DebugUtilities.Views
             }
             msLabel.style.color = fpsValueLabel.style.color;
         }
-
-        public new class UxmlFactory : UxmlFactory<AverageFpsBannerElement> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugButtonElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugButtonElement.cs
@@ -2,7 +2,8 @@ using UnityEngine.UIElements;
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugButtonElement : DebugElementBase<DebugButtonElement, DebugButtonDef>
+    [UxmlElement]
+    public partial class DebugButtonElement : DebugElementBase<DebugButtonElement, DebugButtonDef>
     {
         protected override void ConnectBindings()
         {
@@ -10,7 +11,5 @@ namespace DCL.DebugUtilities.Views
             definition.Text.Connect(button);
             button.clicked += definition.OnClick;
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugButtonElement> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugConstLabelElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugConstLabelElement.cs
@@ -2,14 +2,13 @@ using UnityEngine.UIElements;
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugConstLabelElement : DebugElementBase<DebugConstLabelElement, DebugConstLabelDef>
+    [UxmlElement]
+    public partial class DebugConstLabelElement : DebugElementBase<DebugConstLabelElement, DebugConstLabelDef>
     {
         protected override void ConnectBindings()
         {
             Label label = this.Q<Label>();
             label.text = definition.Text;
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugConstLabelElement> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugContainer.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugContainer.cs
@@ -6,7 +6,8 @@ namespace DCL.DebugUtilities.Views
     /// <summary>
     ///     Container with the scroll view for all possible debug utilities
     /// </summary>
-    public class DebugContainer : VisualElement
+    [UxmlElement]
+    public partial class DebugContainer : VisualElement
     {
         internal VisualElement containerRoot => this.Q<VisualElement>("Parent");
         private VisualElement mainPanel;
@@ -33,7 +34,5 @@ namespace DCL.DebugUtilities.Views
 
         public void HideToggleButton() =>
             toolButton.style.display = DisplayStyle.None;
-
-        public new class UxmlFactory : UxmlFactory<DebugContainer> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugControl.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugControl.cs
@@ -5,11 +5,11 @@ namespace DCL.DebugUtilities.Views
     /// <summary>
     ///     Contains one or two debug visual elements
     /// </summary>
-    public class DebugControl : VisualElement
+    [UxmlElement]
+    public partial class DebugControl : VisualElement
     {
         public VisualElement Left => this.Q<VisualElement>("Left");
 
         public VisualElement Right => this.Q<VisualElement>("Right");
-        public new class UxmlFactory : UxmlFactory<DebugControl> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugDropdownElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugDropdownElement.cs
@@ -2,7 +2,8 @@ using UnityEngine.UIElements;
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugDropdownElement : DebugElementBase<DebugDropdownElement, DebugDropdownDef>
+    [UxmlElement]
+    public partial class DebugDropdownElement : DebugElementBase<DebugDropdownElement, DebugDropdownDef>
     {
         protected override void ConnectBindings()
         {
@@ -12,7 +13,5 @@ namespace DCL.DebugUtilities.Views
 
             definition.Binding.Connect(this.Q<DropdownField>());
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugDropdownElement, UxmlTraits> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugFloatFieldElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugFloatFieldElement.cs
@@ -2,13 +2,12 @@
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugFloatFieldElement : DebugElementBase<DebugFloatFieldElement, DebugFloatFieldDef>
+    [UxmlElement]
+    public partial class DebugFloatFieldElement : DebugElementBase<DebugFloatFieldElement, DebugFloatFieldDef>
     {
         protected override void ConnectBindings()
         {
             definition.Binding.Connect(this.Q<FloatField>());
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugFloatFieldElement, UxmlTraits> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugFloatSliderElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugFloatSliderElement.cs
@@ -2,10 +2,9 @@ using UnityEngine.UIElements;
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugFloatSliderElement : DebugElementBase<DebugFloatSliderElement, DebugFloatSliderDef>
+    [UxmlElement]
+    public partial class DebugFloatSliderElement : DebugElementBase<DebugFloatSliderElement, DebugFloatSliderDef>
     {
-        public new class UxmlFactory : UxmlFactory<DebugFloatSliderElement, UxmlTraits> { }
-
         protected override void ConnectBindings()
         {
             Slider slider = this.Q<Slider>();

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugHintElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugHintElement.cs
@@ -2,7 +2,8 @@
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugHintElement : DebugElementBase<DebugHintElement, DebugHintDef>
+    [UxmlElement]
+    public partial class DebugHintElement : DebugElementBase<DebugHintElement, DebugHintDef>
     {
         internal const string INFO_STYLE = "debug-hint--info";
         internal const string WARNING_STYLE = "debug-hint--warning";
@@ -51,7 +52,5 @@ namespace DCL.DebugUtilities.Views
                     break;
             }
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugHintElement, UxmlTraits> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugIntFieldElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugIntFieldElement.cs
@@ -2,13 +2,12 @@
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugIntFieldElement : DebugElementBase<DebugIntFieldElement, DebugIntFieldDef>
+    [UxmlElement]
+    public partial class DebugIntFieldElement : DebugElementBase<DebugIntFieldElement, DebugIntFieldDef>
     {
         protected override void ConnectBindings()
         {
             definition.Binding.Connect(this.Q<IntegerField>());
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugIntFieldElement, UxmlTraits> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugIntSliderElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugIntSliderElement.cs
@@ -2,10 +2,9 @@
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugIntSliderElement : DebugElementBase<DebugIntSliderElement, DebugIntSliderDef>
+    [UxmlElement]
+    public partial class DebugIntSliderElement : DebugElementBase<DebugIntSliderElement, DebugIntSliderDef>
     {
-        public new class UxmlFactory : UxmlFactory<DebugIntSliderElement, UxmlTraits> { }
-
         protected override void ConnectBindings()
         {
             SliderInt sliderInt = this.Q<SliderInt>();

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugLongMarkerElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugLongMarkerElement.cs
@@ -2,7 +2,8 @@
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugLongMarkerElement : DebugElementBase<DebugLongMarkerElement, DebugLongMarkerDef>, INotifyValueChanged<ulong>
+    [UxmlElement]
+    public partial class DebugLongMarkerElement : DebugElementBase<DebugLongMarkerElement, DebugLongMarkerDef>, INotifyValueChanged<ulong>
     {
         private Label cachedLabel;
 
@@ -51,7 +52,5 @@ namespace DCL.DebugUtilities.Views
                     return $"{value}";
             }
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugLongMarkerElement> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugOngoingWebRequestWidget.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugOngoingWebRequestWidget.cs
@@ -3,7 +3,8 @@ using UnityEngine.UIElements;
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugOngoingWebRequestWidget : DebugElementBase<DebugOngoingWebRequestWidget, DebugOngoingWebRequestDef>, INotifyValueChanged<DebugOngoingWebRequestDef.DataSource>
+    [UxmlElement]
+    public partial class DebugOngoingWebRequestWidget : DebugElementBase<DebugOngoingWebRequestWidget, DebugOngoingWebRequestDef>, INotifyValueChanged<DebugOngoingWebRequestDef.DataSource>
     {
         // 5 seconds
         private const ulong WARNING_LEVEL_NS = 5 * 1_000_000_000UL;
@@ -98,7 +99,5 @@ namespace DCL.DebugUtilities.Views
 
         void INotifyValueChanged<DebugOngoingWebRequestDef.DataSource>.SetValueWithoutNotify(DebugOngoingWebRequestDef.DataSource newValue) =>
             value = newValue;
-
-        public new class UxmlFactory : UxmlFactory<DebugOngoingWebRequestWidget, UxmlTraits> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugSetOnlyLabelElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugSetOnlyLabelElement.cs
@@ -2,14 +2,13 @@
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugSetOnlyLabelElement : DebugElementBase<DebugSetOnlyLabelElement, DebugSetOnlyLabelDef>
+    [UxmlElement]
+    public partial class DebugSetOnlyLabelElement : DebugElementBase<DebugSetOnlyLabelElement, DebugSetOnlyLabelDef>
     {
         protected override void ConnectBindings()
         {
             Label label = this.Q<Label>();
             definition.Binding.Connect(label);
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugSetOnlyLabelElement, UxmlTraits> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugTextFieldElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugTextFieldElement.cs
@@ -2,13 +2,12 @@ using UnityEngine.UIElements;
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugTextFieldElement : DebugElementBase<DebugTextFieldElement, DebugTextFieldDef>
+    [UxmlElement]
+    public partial class DebugTextFieldElement : DebugElementBase<DebugTextFieldElement, DebugTextFieldDef>
     {
         protected override void ConnectBindings()
         {
             definition.Binding.Connect(this.Q<TextField>());
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugTextFieldElement, UxmlTraits> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugToggleElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugToggleElement.cs
@@ -2,13 +2,12 @@ using UnityEngine.UIElements;
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugToggleElement : DebugElementBase<DebugToggleElement, DebugToggleDef>
+    [UxmlElement]
+    public partial class DebugToggleElement : DebugElementBase<DebugToggleElement, DebugToggleDef>
     {
         protected override void ConnectBindings()
         {
             definition.Binding.Connect(this.Q<Toggle>());
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugToggleElement, UxmlTraits> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugVector2IntFieldElement.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugVector2IntFieldElement.cs
@@ -2,13 +2,12 @@
 
 namespace DCL.DebugUtilities.Views
 {
-    public class DebugVector2IntFieldElement : DebugElementBase<DebugVector2IntFieldElement, DebugVector2IntFieldDef>
+    [UxmlElement]
+    public partial class DebugVector2IntFieldElement : DebugElementBase<DebugVector2IntFieldElement, DebugVector2IntFieldDef>
     {
         protected override void ConnectBindings()
         {
             definition.Binding.Connect(this.Q<Vector2IntField>());
         }
-
-        public new class UxmlFactory : UxmlFactory<DebugVector2IntFieldElement, UxmlTraits> { }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugWidget.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugWidget.cs
@@ -6,7 +6,8 @@ namespace DCL.DebugUtilities.Views
     /// <summary>
     ///     Widgets corresponds to a single feature scope
     /// </summary>
-    public class DebugWidget : VisualElement
+    [UxmlElement]
+    public partial class DebugWidget : VisualElement
     {
         private Foldout foldout;
         private string prefsKey;
@@ -37,7 +38,5 @@ namespace DCL.DebugUtilities.Views
 
         private static string ConstructPrefsKey(string title) =>
             string.Format(DCLPrefKeys.DEBUG_WIDGET_FOLDOUT, title);
-
-        public new class UxmlFactory : UxmlFactory<DebugWidget> { }
     }
 }


### PR DESCRIPTION
# Pull Request Description

No functional changes, just updated how UIToolkit elements are defined, as we were using a deprecated API.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Changed UIToolkit elements from using a UxmlFactory to the new [UxmlElement] annotation, and partial classes (the factory and related code is auto generated by unity)

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

Just a smoke test. Verify that the Debug menu and "on hover" ui still shows up.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
