### PR TITLE
fix: overlapping chat messages

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatEntryMessageBubbleElement.cs
+++ b/Explorer/Assets/DCL/Chat/ChatEntryMessageBubbleElement.cs
@@ -1,4 +1,5 @@
 using DCL.Chat.History;
+using DCL.Diagnostics;
 using DCL.FeatureFlags;
 using DCL.Translation;
 using System;
@@ -106,7 +107,13 @@ namespace DCL.Chat
 
         private float CalculatePreferredWidth(string displayText, ChatMessage originalMessage)
         {
-            int nameLength = originalMessage.SenderValidatedName.Length;
+            int nameLength = 0;
+
+            if (string.IsNullOrEmpty(originalMessage.SenderValidatedName))
+                ReportHub.LogError(ReportCategory.CHAT_MESSAGES, $"SenderValidatedName is null or empty for message: {originalMessage.MessageId} sent by wallet: {originalMessage.SenderWalletAddress}");
+            else
+                nameLength = originalMessage.SenderValidatedName.Length;
+
             string walletId = originalMessage.SenderWalletId;
             int walletIdLength = string.IsNullOrEmpty(walletId) ? 0 : walletId.Length;
             int nameTotalLength = nameLength + walletIdLength;

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/GetMessageHistoryCommand.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/GetMessageHistoryCommand.cs
@@ -23,11 +23,9 @@ namespace DCL.Chat.ChatCommands
             this.chatHistoryStorage = chatHistoryStorage;
             this.createMessageViewModelCommand = createMessageViewModelCommand;
         }
-        
+
         public async UniTask ExecuteAsync(List<ChatMessageViewModel> targetList, ChatChannel.ChannelId channelId, CancellationToken token)
         {
-            // Return all elements from the list to the pool
-            targetList.ForEach(ChatMessageViewModel.RELEASE);
             targetList.Clear();
 
             token.ThrowIfCancellationRequested();


### PR DESCRIPTION
# Pull Request Description
Fixes #6375 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR fixes a scenario where the chat message separator was released to the chat message view model pool even if it is used as a single instance. The release was setting its properties to default values (separator = false and Message = default -> SenderValidatedName null). This was breaking the message rendering because looplist was trying to add the separator which was no longer flagged as separator, meaning it was following the message path -> the sender name was null, hence the NRE while calculating dimensions.

As a safeguard an error log has been added when a message contains a null SenderValidatedName (which shouldn't be possible in any other way other than the mentioned one) + the NRE is avoided using a 0 length.


## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Follow the repro steps described in the issue (?)
2. Stress test the chat by clearing the history after spamming messages (both while being at the bottom and after having scrolled up), you should see no weird rendering error
3. Spam messages and switch accounts, the chat should present no weird rendering error


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
