### PR TITLE
fix: track identities resolved through token file as new login (not cached)

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -208,7 +208,12 @@ namespace DCL.AuthenticationScreenFlow
                 bool autoLoginSuccess = await web3Authenticator.TryAutoLoginAsync(ct);
 
                 if (autoLoginSuccess)
-                    fsm.Enter<ProfileFetchingAuthState, (IWeb3Identity identity, bool isCached, CancellationToken ct)>((storedIdentity, true, ct));
+                    fsm.Enter<ProfileFetchingAuthState, (IWeb3Identity identity, bool isCached, CancellationToken ct)>(
+                        (storedIdentity,
+                            // Fixes https://github.com/decentraland/unity-explorer/issues/7016
+                            // Token file identities should be considered as "new logins"
+                            storedIdentity.Source != IWeb3Identity.Web3IdentitySource.TokenFile,
+                            ct));
                 else
                 {
                     SentryTransactionNameMapping.Instance.EndCurrentSpan(LOADING_TRANSACTION_NAME);

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3Authenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3Authenticator.cs
@@ -201,7 +201,7 @@ namespace DCL.Web3.Authenticators
 
                 // To keep cohesiveness between the platform, convert the user address to lower case
                 return new DecentralandIdentity(new Web3Address(response.sender),
-                    ephemeralAccount, sessionExpiration, authChain);
+                    ephemeralAccount, sessionExpiration, authChain, IWeb3Identity.Web3IdentitySource.Dapp);
             }
             catch (Exception)
             {

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/PrivateKeyAuthenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/PrivateKeyAuthenticator.cs
@@ -34,6 +34,7 @@ namespace DCL.Web3.Authenticators
             public bool IsExpired => false;
 
             public AuthChain AuthChain { get; }
+            public IWeb3Identity.Web3IdentitySource Source { get; set; } = IWeb3Identity.Web3IdentitySource.None;
 
             public AuthChain Sign(string entityId)
             {

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/RandomGeneratedWeb3Authenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/RandomGeneratedWeb3Authenticator.cs
@@ -44,7 +44,8 @@ namespace DCL.Web3.Authenticators
                 new Web3Address(signer),
                 ephemeralAccount,
                 expiration,
-                authChain
+                authChain,
+                IWeb3Identity.Web3IdentitySource.None
             ).AsUniTaskResult<IWeb3Identity>();
         }
 

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/ThirdWeb/ThirdWebLoginService.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/ThirdWeb/ThirdWebLoginService.cs
@@ -113,7 +113,7 @@ namespace DCL.Web3.Authenticators
                     signature = signature,
                 });
 
-                return new DecentralandIdentity(new Web3Address(sender), ephemeralAccount, sessionExpiration, authChain);
+                return new DecentralandIdentity(new Web3Address(sender), ephemeralAccount, sessionExpiration, authChain, IWeb3Identity.Web3IdentitySource.OTP);
             }
             catch (Exception)
             {

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/TokenFileAuthenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/TokenFileAuthenticator.cs
@@ -86,7 +86,8 @@ namespace DCL.Web3.Authenticators
             IWeb3Account ephemeralAccount = web3AccountFactory.CreateAccount(new EthECKey(json.identity.ephemeralIdentity.privateKey));
             DateTime expiration = DateTime.Parse(json.identity.expiration, null, DateTimeStyles.RoundtripKind);
 
-            return new DecentralandIdentity(new Web3Address(address), ephemeralAccount, expiration, authChain);
+            return new DecentralandIdentity(new Web3Address(address), ephemeralAccount, expiration, authChain,
+                IWeb3Identity.Web3IdentitySource.TokenFile);
         }
 
         public UniTask LogoutAsync(CancellationToken ct) =>

--- a/Explorer/Assets/DCL/Web3/Identities/DecentralandIdentity.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/DecentralandIdentity.cs
@@ -12,17 +12,20 @@ namespace DCL.Web3.Identities
         public IWeb3Account EphemeralAccount { get; }
         public bool IsExpired => Expiration < DateTime.UtcNow;
         public AuthChain AuthChain { get; }
+        public IWeb3Identity.Web3IdentitySource Source { get; }
 
         public DecentralandIdentity(
             Web3Address address,
             IWeb3Account ephemeralAccount,
             DateTime expiration,
-            AuthChain authChain)
+            AuthChain authChain,
+            IWeb3Identity.Web3IdentitySource source)
         {
             AssertSigner(authChain);
             AssertEcdsaEphemeral(authChain);
 
             AuthChain = authChain;
+            Source = source;
             Address = address;
             EphemeralAccount = ephemeralAccount;
             Expiration = expiration;

--- a/Explorer/Assets/DCL/Web3/Identities/IWeb3Identity.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/IWeb3Identity.cs
@@ -12,8 +12,18 @@ namespace DCL.Web3.Identities
         IWeb3Account EphemeralAccount { get; }
         bool IsExpired { get; }
         AuthChain AuthChain { get; }
+        Web3IdentitySource Source { get; }
 
         AuthChain Sign(string entityId);
+
+        enum Web3IdentitySource
+        {
+            None,
+            Cached,
+            TokenFile,
+            Dapp,
+            OTP
+        }
 
         class Random : IWeb3Identity
         {
@@ -45,6 +55,7 @@ namespace DCL.Web3.Identities
             public IWeb3Account EphemeralAccount { get; }
             public bool IsExpired { get; }
             public AuthChain AuthChain { get; }
+            public Web3IdentitySource Source { get; set; } = Web3IdentitySource.None;
 
             public AuthChain Sign(string entityId) =>
                 throw new Exception("RandomIdentity cannot sign anything");

--- a/Explorer/Assets/DCL/Web3/Identities/LogWeb3Identity.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/LogWeb3Identity.cs
@@ -3,7 +3,6 @@ using DCL.Web3.Abstract;
 using DCL.Web3.Accounts;
 using DCL.Web3.Chains;
 using System;
-using UnityEngine;
 
 namespace DCL.Web3.Identities
 {
@@ -64,6 +63,18 @@ namespace DCL.Web3.Identities
                     .WithReport(ReportCategory.PROFILE)
                     .Log($"Web3Identity AuthChain requested: {origin.AuthChain}");
                 return origin.AuthChain;
+            }
+        }
+
+        public IWeb3Identity.Web3IdentitySource Source
+        {
+            get
+            {
+                ReportHub
+                   .WithReport(ReportCategory.PROFILE)
+                   .Log($"Web3Identity Source requested: {origin.Source}");
+
+                return origin.Source;
             }
         }
 

--- a/Explorer/Assets/DCL/Web3/Identities/PlayerPrefsIdentityProvider.DecentralandIdentityWithNethereumAccountJsonSerializer.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/PlayerPrefsIdentityProvider.DecentralandIdentityWithNethereumAccountJsonSerializer.cs
@@ -34,7 +34,8 @@ namespace DCL.Web3.Identities
                 return new DecentralandIdentity(new Web3Address(jsonRoot.address),
                     accountFactory.CreateAccount(new EthECKey(jsonRoot.key)),
                     DateTime.Parse(jsonRoot.expiration, null, DateTimeStyles.RoundtripKind),
-                    authChain);
+                    authChain,
+                    IWeb3Identity.Web3IdentitySource.Cached);
             }
 
             public string Serialize(IWeb3Identity identity)


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/7016

Changes include a new property in identities that represents how were they created: None, Cached, TokenFile, Dapp, OTP. This is later used to check if the authentication flow should treat the login as "new account" or an existing account, since identities provided by the token file should be considered new accounts.

## Test Instructions

Check that the authentication flow works as usual by going through different methods:
- login normally with an existing account
- download the client from the web site with a new account and go through authentication screen
- logout and then login with an account in the client

Additionally we could validate with data team if tracking is getting done correctly for each case.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
