### PR TITLE
fix: add Serializable attribute to settings classes

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MapRendererContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MapRendererContainer.cs
@@ -88,6 +88,7 @@ namespace Global.Dynamic
             mapRendererSettings = await assetsProvisioner.ProvideMainAssetAsync(settings.MapRendererSettings, ct, nameof(settings.MapRendererSettings));
         }
 
+        [Serializable]
         public class Settings : IDCLPluginSettings
         {
             [field: SerializeField] public MapRendererSettingsRef MapRendererSettings { get; private set; } = null!;

--- a/Explorer/Assets/DCL/PluginSystem/GenericContextMenuPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/GenericContextMenuPlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
@@ -77,6 +78,7 @@ namespace DCL.PluginSystem
             mvcManager.RegisterController(genericContextMenuController);
         }
 
+        [Serializable]
         public class GenericContextMenuSettings : IDCLPluginSettings
         {
             [field: Header(nameof(GenericContextMenuPlugin) + "." + nameof(GenericContextMenuSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChangeRealmPromptPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChangeRealmPromptPlugin.cs
@@ -49,6 +49,7 @@ namespace DCL.PluginSystem.Global
             changeRealmPromptController?.Dispose();
         }
 
+        [Serializable]
         public class ChangeRealmPromptSettings : IDCLPluginSettings
         {
             [field: Header(nameof(ChangeRealmPromptPlugin) + "." + nameof(ChangeRealmPromptSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/Global/CharacterPreviewPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/CharacterPreviewPlugin.cs
@@ -43,6 +43,7 @@ namespace DCL.PluginSystem.Global
             cacheCleaner.Register(gameObjectPool);
         }
 
+        [Serializable]
         public class CharacterPreviewSettings : IDCLPluginSettings
         {
             [field: Header(nameof(CharacterPreviewPlugin) + "." + nameof(CharacterPreviewSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
@@ -434,6 +434,7 @@ namespace DCL.PluginSystem.Global
         }
     }
 
+    [Serializable]
     public class ChatPluginSettings : IDCLPluginSettings
     {
         [field: SerializeField] public ChatSettingsAsset ChatSettingsAsset { get; private set; }

--- a/Explorer/Assets/DCL/PluginSystem/Global/ColorPickerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ColorPickerPlugin.cs
@@ -48,6 +48,7 @@ namespace DCL.PluginSystem.Global
             mvcManager.RegisterController(colorPickerController);
         }
 
+        [Serializable]
         public class Settings : IDCLPluginSettings
         {
             [Serializable]

--- a/Explorer/Assets/DCL/PluginSystem/Global/DuplicateIdentityPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/DuplicateIdentityPlugin.cs
@@ -66,6 +66,7 @@ namespace DCL.PluginSystem.Global
             }
         }
 
+        [Serializable]
         public class DuplicateIdentitySettings : IDCLPluginSettings
         {
             [field: SerializeField] public DuplicateIdentityWindowViewRef DuplicateIdentityWindow { get; private set; } = null!;

--- a/Explorer/Assets/DCL/PluginSystem/Global/ErrorPopupPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ErrorPopupPlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
@@ -42,6 +43,7 @@ namespace DCL.PluginSystem.Global
             mvcManager.RegisterController(loadErrorGuardController);
         }
 
+        [Serializable]
         public class ErrorPopupSettings : IDCLPluginSettings
         {
             [field: SerializeField] public AssetReferenceGameObject ErrorPopup { get; private set; } = null!;

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Arch.Core;
 using Arch.SystemGroups;
 using CommunicationData.URLHelpers;
@@ -646,6 +647,7 @@ namespace DCL.PluginSystem.Global
             new ShowEventInfoCommand(@event, eventInfoPanelController!, placesAndEventsPanelController!,
                 searchBarController!, placesAPIService, place);
 
+        [Serializable]
         public class ExplorePanelSettings : IDCLPluginSettings
         {
             [field: Header(nameof(ExplorePanelPlugin) + "." + nameof(ExplorePanelSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExternalUrlPromptPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExternalUrlPromptPlugin.cs
@@ -1,4 +1,5 @@
-﻿using Arch.SystemGroups;
+﻿using System;
+using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
 using DCL.Browser;
@@ -49,6 +50,7 @@ namespace DCL.PluginSystem.Global
             externalUrlPromptController?.Dispose();
         }
 
+        [Serializable]
         public class ExternalUrlPromptSettings : IDCLPluginSettings
         {
             [field: Header(nameof(ExternalUrlPromptPlugin) + "." + nameof(ExternalUrlPromptSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/Global/GenericPopupsPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/GenericPopupsPlugin.cs
@@ -61,6 +61,7 @@ namespace DCL.PluginSystem.Global
             mvcManager.RegisterController(chatEntryMenuPopupController);
         }
 
+        [Serializable]
         public class Settings : IDCLPluginSettings
         {
             [Serializable]

--- a/Explorer/Assets/DCL/PluginSystem/Global/GiftingPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/GiftingPlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
@@ -224,6 +225,7 @@ namespace DCL.PluginSystem.Global
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments) { }
 
+        [Serializable]
         public class GiftingSettings : IDCLPluginSettings
         {
             [field: Header(nameof(GiftingPlugin) + "." + nameof(GiftingSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/Global/LoadingScreenPlugin.LoadingScreenPluginSettings.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/LoadingScreenPlugin.LoadingScreenPluginSettings.cs
@@ -8,6 +8,7 @@ namespace DCL.PluginSystem.Global
 {
     public partial class LoadingScreenPlugin
     {
+        [Serializable]
         public struct LoadingScreenPluginSettings : IDCLPluginSettings
         {
             [field: Header(nameof(LoadingScreenPlugin) + "." + nameof(LoadingScreenPluginSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/Global/MarketplaceCreditsPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/MarketplaceCreditsPlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
@@ -115,6 +116,7 @@ namespace DCL.PluginSystem.Global
             marketplaceCreditsMenuController?.Dispose();
     }
 
+    [Serializable]
     public class MarketplaceCreditsPluginSettings : IDCLPluginSettings
     {
         [field: SerializeField]

--- a/Explorer/Assets/DCL/PluginSystem/Global/MinimapPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/MinimapPlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.Chat.Commands;
@@ -132,6 +133,7 @@ namespace DCL.PluginSystem.Global
             mvcManager.RegisterController(minimapController);
         }
 
+        [Serializable]
         public class MinimapPluginSettings : IDCLPluginSettings
         {
             [field: SerializeField] public MinimapContextMenuSettings MinimapContextMenuSettings;

--- a/Explorer/Assets/DCL/PluginSystem/Global/NftPromptPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/NftPromptPlugin.cs
@@ -61,6 +61,7 @@ namespace DCL.PluginSystem.Global
             nftPromptController?.Dispose();
         }
 
+        [Serializable]
         public class NftPromptSettings : IDCLPluginSettings
         {
             [field: Header(nameof(NftPromptPlugin) + "." + nameof(NftPromptSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/Global/NotificationPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/NotificationPlugin.cs
@@ -89,6 +89,7 @@ namespace DCL.PluginSystem.Global
                                           .Forget();
         }
 
+        [Serializable]
         public class NotificationSettings : IDCLPluginSettings
         {
             [field: SerializeField]

--- a/Explorer/Assets/DCL/PluginSystem/Global/PassportPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/PassportPlugin.cs
@@ -33,6 +33,7 @@ using MVC;
 using System.Threading;
 using DCL.InWorldCamera;
 using DCL.InWorldCamera.CameraReelGallery.Components;
+using System;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 
@@ -233,6 +234,7 @@ namespace DCL.PluginSystem.Global
                 webBrowser, selfProfile, nftNamesProvider, decentralandUrlsSource, profileChangesBus));
         }
 
+        [Serializable]
         public class PassportSettings : IDCLPluginSettings
         {
             [field: Header(nameof(PassportPlugin) + "." + nameof(PassportSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/Global/RewardPanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/RewardPanelPlugin.cs
@@ -61,6 +61,7 @@ namespace DCL.PluginSystem.Global
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments) { }
 
+        [Serializable]
         public class RewardPanelSettings : IDCLPluginSettings
         {
             [field: SerializeField]

--- a/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
@@ -31,6 +31,7 @@ using DCL.WebRequests;
 using ECS;
 using MVC;
 using Runtime.Wearables;
+using System;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -174,6 +175,7 @@ namespace DCL.PluginSystem.Global
             ));
         }
 
+        [Serializable]
         public class SidebarSettings : IDCLPluginSettings
         {
             [field: SerializeField]

--- a/Explorer/Assets/DCL/PluginSystem/Global/SkyboxPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SkyboxPlugin.cs
@@ -117,6 +117,7 @@ namespace DCL.SkyBox
             }
         }
 
+        [Serializable]
         public class SkyboxTimeSettings : IDCLPluginSettings
         {
             [field: SerializeField]

--- a/Explorer/Assets/DCL/PluginSystem/Global/TeleportPromptPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/TeleportPromptPlugin.cs
@@ -1,4 +1,5 @@
-﻿using Arch.SystemGroups;
+﻿using System;
+using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
 using DCL.Chat.MessageBus;
@@ -59,6 +60,7 @@ namespace DCL.PluginSystem.Global
             teleportPromptController?.Dispose();
         }
 
+        [Serializable]
         public class TeleportPromptSettings : IDCLPluginSettings
         {
             [field: Header(nameof(TeleportPromptPlugin) + "." + nameof(TeleportPromptSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/Global/Web3AuthenticationPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Web3AuthenticationPlugin.cs
@@ -141,6 +141,7 @@ namespace DCL.PluginSystem.Global
         }
     }
 
+    [Serializable]
     public struct Web3AuthPluginSettings : IDCLPluginSettings
     {
         [field: Header(nameof(Web3AuthenticationPlugin) + "." + nameof(Web3AuthPluginSettings))]

--- a/Explorer/Assets/DCL/PluginSystem/World/AvatarLocomotionOverridesGlobalPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AvatarLocomotionOverridesGlobalPlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Arch.Core;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
@@ -31,6 +32,7 @@ namespace DCL.SDKComponents.AvatarLocomotion
             ApplyAvatarLocomotionOverridesSystem.InjectToWorld(ref builder, settings);
         }
 
+        [Serializable]
         public class Settings : IDCLPluginSettings
         {
             public float MaxMovementSpeed = 500;

--- a/Explorer/Assets/DCL/PluginSystem/World/LightSourcePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/LightSourcePlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
@@ -105,6 +106,7 @@ namespace DCL.PluginSystem.World
             light.cookie = null;
         }
 
+        [Serializable]
         public class LightSourcePluginSettings : IDCLPluginSettings
         {
             public AssetReferenceGameObject LightSourcePrefab;

--- a/Explorer/Assets/DCL/PluginSystem/World/PointerInputAudioPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/PointerInputAudioPlugin.cs
@@ -37,6 +37,7 @@ namespace DCL.PluginSystem.Global
             interactionsAudioConfigs = await assetsProvisioner.ProvideMainAssetAsync(settings.InteractionsAudioConfigsReference, ct: ct);
         }
 
+        [Serializable]
         public class Settings : IDCLPluginSettings
         {
             [field: SerializeField] public InteractionsAudioConfigsReference InteractionsAudioConfigsReference { get; private set; }

--- a/Explorer/Assets/DCL/PluginSystem/World/SkyboxTimePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/SkyboxTimePlugin.cs
@@ -1,4 +1,5 @@
-﻿using Arch.Core;
+﻿using System;
+using Arch.Core;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.PluginSystem;
@@ -36,6 +37,7 @@ namespace DCL.SDKComponents.SkyboxTime
             return UniTask.CompletedTask;
         }
 
+        [Serializable]
         public class SkyboxTimeSettings : IDCLPluginSettings
         {
             [field: SerializeField]

--- a/Explorer/Assets/DCL/PluginSystem/World/SmartWearablesGlobalPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/SmartWearablesGlobalPlugin.cs
@@ -1,4 +1,5 @@
-﻿using Arch.SystemGroups;
+﻿using System;
+using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
 using DCL.AvatarRendering.Wearables;
@@ -95,6 +96,7 @@ namespace DCL.PluginSystem.SmartWearables
                 web3IdentityCache);
         }
 
+        [Serializable]
         public class Settings : IDCLPluginSettings
         {
             public AssetReferenceGameObject AuthorizationPopup;


### PR DESCRIPTION
# Pull Request Description

Fixes serialization warnings we started getting after updating Unity. One warning remains in the Localization package that can't be fixed by us, [unfortunately](https://discussions.unity.com/t/localization-1-5-8-bug/1696393).

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Adds the Serializable attribute where necessary.

## Test Instructions

No testing needed, the changes only suppress the warnings (Unity will correctly handle the classes with or without the annotation).

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
