### PR TITLE
fix: modify allowed tools in issue deduplication workflow

### DIFF
--- a/.github/workflows/issue-deduplication.yml
+++ b/.github/workflows/issue-deduplication.yml
@@ -60,4 +60,4 @@ jobs:
 
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --allowedTools "mcp__github__get_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__create_issue_comment,mcp__github__update_issue,mcp__github__get_issue_comments"
+            --allowedTools "mcp__github__get_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__add_issue_comment,mcp__github__update_issue,mcp__github__get_issue_comments"


### PR DESCRIPTION
Updated the allowed tools for the issue deduplication process to include 'mcp__github__add_issue_comment'.
