### PR TITLE
fix: nametag corner glitch

### DIFF
--- a/Explorer/Assets/DCL/NameTags/Assets/NametagStyle.uss
+++ b/Explorer/Assets/DCL/NameTags/Assets/NametagStyle.uss
@@ -1,6 +1,7 @@
 :root {
     --message-transition-duration: 0.3s;
     --message-transition-easing: ease-out-back;
+    align-items: center;
 }
 
 .nametag {

--- a/Explorer/Assets/DCL/NameTags/Assets/NametagUIDocument.prefab
+++ b/Explorer/Assets/DCL/NameTags/Assets/NametagUIDocument.prefab
@@ -50,9 +50,9 @@ MonoBehaviour:
   sourceAsset: {fileID: 9197481963319205126, guid: ff97446fbd9fc4199b5646f7c971f778, type: 3}
   m_SortingOrder: 0
   m_Position: 0
-  m_WorldSpaceSizeMode: 0
-  m_WorldSpaceWidth: 1920
-  m_WorldSpaceHeight: 1080
+  m_WorldSpaceSizeMode: 1
+  m_WorldSpaceWidth: 200
+  m_WorldSpaceHeight: 35
   m_PivotReferenceSize: 0
   m_Pivot: 7
   m_WorldSpaceCollider: {fileID: 0}


### PR DESCRIPTION
# Pull Request Description

Fixes the artifact issue, where a dark semi circle (the edge of the nametag) would appear in the top right corner when nametags were taken from the pool

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->
Nametag UIDocument now uses a fixed size instead of dynamic, it seems dynamic size glitches sometimes for a single frame).

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->
The easiest way to reproduce the issue is to spawn 30 avatars from the debug menu, and quickly rotate the camera over them, so they go off screen / come on screen. After this change no artifact should be visible in the top right corner.

Additionally, verify that the nametags behave the same way as they did before - that they are positioned and centered correctly, and that chat bubbles work.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
