### PR TITLE
chore: add version to summary on release build

### DIFF
--- a/.github/workflows/build-release-main.yml
+++ b/.github/workflows/build-release-main.yml
@@ -24,6 +24,11 @@ jobs:
         id: get_version
         uses: ./.github/actions/version
 
+      - name: Write job summary
+        run: |
+          echo "## Release Build" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** \`${{ steps.get_version.outputs.next_short_version }}\` | **Tag:** \`${{ steps.get_version.outputs.next_tag_version }}\`" >> $GITHUB_STEP_SUMMARY
+
   # Run a clean build (no cache)
   build:
     name: Build Unity Cloud


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
 - Adds a GitHub Actions job summary to build-release-main.yml that prints the release version and tag after the Get Info step resolves them                                                                  
  - Summary is written once in the get-info job (not per matrix combination) since the version is identical across all builds      

