### PR TITLE
fix: crash on upload handler

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/GenericPost/BufferedStringUploadHandler.cs
+++ b/Explorer/Assets/DCL/WebRequests/GenericPost/BufferedStringUploadHandler.cs
@@ -328,11 +328,13 @@ namespace DCL.WebRequests
 
         public override unsafe string ToString()
         {
-            if (preservedBufferPtr != null)
-                return Encoding.UTF8.GetString(preservedBufferPtr, preservedBufferLength);
-
             if (buffer.IsCreated)
+            {
+                if (preservedBufferPtr != null)
+                    return Encoding.UTF8.GetString(preservedBufferPtr, preservedBufferLength);
+
                 return Encoding.UTF8.GetString(buffer.GetUnsafePtr(), buffer.Length);
+            }
 
             throw new ObjectDisposedException(nameof(buffer));
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This PR fixes a crash caused by unsafe UTF-8 string reconstruction inside `BufferedStringUploadHandler.ToString()`.

### Problem

Crash reports were symbolicated and consistently pointed to:

```
UTF8Encoding_GetCharCount
String_CreateStringFromEncoding
GenericPostArguments_ToString
BufferedStringUploadHandler.ToString
```

Symbolicated stack excerpt:

```
UTF8Encoding_GetCharCount
String_CreateStringFromEncoding
GenericPostArguments_ToString
RequestEnvelope<T>.ToString
U3CSendAsyncU3Ed__8.MoveNext
UnityWebRequestAsyncOperationConfiguredSource.MoveNext
```

The closest code in our codebase is:

```csharp
public override unsafe string ToString()
{
    if (preservedBufferPtr != null)
        return Encoding.UTF8.GetString(preservedBufferPtr, preservedBufferLength);

    if (buffer.IsCreated)
        return Encoding.UTF8.GetString(buffer.GetUnsafePtr(), buffer.Length);

    throw new ObjectDisposedException(nameof(buffer));
}
```

IL2CPP generated code confirms that `BufferedStringUploadHandler.ToString()` is directly invoked at the crashing frame:

```
il2cppOutput/DCL.Network.cpp (16387)
BufferedStringUploadHandler_ToString(...)
```

### Root Cause

`Encoding.UTF8.GetString(byte*, int)` was called using `preservedBufferPtr` without verifying that the underlying `NativeList<byte>` (`buffer`) was still valid.

If:

* `buffer` was disposed, OR
* memory was invalidated after upload handler creation,

then the saved native pointer could become dangling.
This leads to an invalid memory read inside `UTF8Encoding_GetCharCount`, causing `EXC_BAD_ACCESS`.

Due to IL2CPP stripping/inlining, the intermediate frame is not visible, but only two unsafe calls exist in this method. The preserved pointer branch is the most likely crash source.

### Solution

We now validate `buffer.IsCreated` **before** using `preservedBufferPtr`.
No API changes.

---

## Test Instructions

### Test Steps

1. Happy path, behaviour should preserve the same

### Expected Result

* No crashes in `UTF8Encoding_GetCharCount`
* No `EXC_BAD_ACCESS`
* Request logging continues to function correctly

---

## Quality Checklist

* [x] Changes have been tested locally
* [x] Performance impact has been considered (no additional allocations introduced)
* [x] Unsafe lifetime validated

---

## Code Review Reference

Please review our [[Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md)](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.