### PR TITLE
fix: skybox persisted from realm data

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -136,6 +136,8 @@ namespace Global.Dynamic
 
             try
             {
+                serverAbout.Clear();
+
                 GenericDownloadHandlerUtils.Adapter<GenericGetRequest, GenericGetArguments> genericGetRequest = webRequestController.GetAsync(new CommonArguments(url), ct, ReportCategory.REALM);
                 ServerAbout result = await genericGetRequest.OverwriteFromJsonAsync(serverAbout, WRJsonParser.Unity);
                 WorldManifest worldManifest = await worldManifestProvider.FetchWorldManifestAsync(URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.AssetBundleRegistry)), result.configurations.realmName, environment, ct);

--- a/Explorer/Assets/DCL/NetworkDefinitions/ServerAbout.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/ServerAbout.cs
@@ -18,5 +18,26 @@ namespace DCL.Ipfs
             this.lambdas = lambdas ?? new ContentEndpoint(string.Empty);
             this.comms = comms;
         }
+
+        /// <summary>
+        ///     Clears all fields before reusing this instance with FromJsonOverwrite.
+        ///     Unity's JsonUtility.FromJsonOverwrite only overwrites properties present in the JSON,
+        ///     so absent fields (e.g. configurations.skybox when switching to genesis) would otherwise retain previous values.
+        /// </summary>
+        public void Clear()
+        {
+            configurations.networkId = 0;
+            configurations.realmName = string.Empty;
+            configurations.scenesUrn?.Clear();
+            configurations.skybox = new ServerSkyboxConfig { fixedHour = -1 };
+
+            content.publicUrl = string.Empty;
+            content.healthy = false;
+
+            lambdas.publicUrl = string.Empty;
+            lambdas.healthy = false;
+
+            comms = null;
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

When going to a realm with skybox data (like `ryumi`) the values were persisted in the server about we use for overwriting new realm data.

The fix is to clear the data before overwriting.

Fix #7287 

## Test Instructions


### Test Steps
1. Go to ryumi and back. The skybox should be controllable



## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
