### PR TITLE
fix: [Discover / Events] Avoid to request live events for date ranges that does not include today

### DIFF
--- a/Explorer/Assets/DCL/Events/EventsCalendarController.cs
+++ b/Explorer/Assets/DCL/Events/EventsCalendarController.cs
@@ -228,19 +228,17 @@ namespace DCL.Events
                 if (ct.IsCancellationRequested)
                     return;
 
-                if (!liveEventsResults.Success)
-                {
-                    NotificationsBusController.Instance.AddNotification(new ServerErrorNotification(GET_LIVE_EVENTS_ERROR_MESSAGE));
-                    return;
-                }
+                if (liveEventsResults.Success)
+                    // In case we have live events prior to today, they have to be also shown on the calendar, so we add them into the current results
+                    foreach (EventDTO liveEventInfo in liveEventsResults.Value)
+                    {
+                        DateTime eventLocalDate = DateTimeOffset.Parse(liveEventInfo.next_start_at).ToLocalTime().DateTime;
+                        if (eventLocalDate.Date < fromDate)
+                            eventsList.Add(liveEventInfo);
+                    }
 
-                // In case we have live events prior to today, they have to be also shown on the calendar, so we add them into the current results
-                foreach (EventDTO liveEventInfo in liveEventsResults.Value)
-                {
-                    DateTime eventLocalDate = DateTimeOffset.Parse(liveEventInfo.next_start_at).ToLocalTime().DateTime;
-                    if (eventLocalDate.Date < fromDate)
-                        eventsList.Add(liveEventInfo);
-                }
+                else
+                    NotificationsBusController.Instance.AddNotification(new ServerErrorNotification(GET_LIVE_EVENTS_ERROR_MESSAGE));
             }
 
             foreach (EventDTO eventInfo in eventsResult.Value)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
It avoids to request live events when the selected events dates range doesn't include the today's day.

### Test Steps
Check that the Events section works properly.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.