### PR TITLE
feat: add log when authenticated user is logged in

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LobbyForExistingAccountAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LobbyForExistingAccountAuthState.cs
@@ -1,5 +1,6 @@
 using Cysharp.Threading.Tasks;
 using DCL.CharacterPreview;
+using DCL.Diagnostics;
 using DCL.Profiles;
 using DCL.SceneLoadingScreens.SplashScreen;
 using DCL.UI;
@@ -83,6 +84,8 @@ namespace DCL.AuthenticationScreenFlow
             // Listeners
             view.JumpIntoWorldButton.onClick.AddListener(OnJumpIntoWorld);
             view.DiffAccountButton.onClick.AddListener(OnDiffAccountButtonClicked);
+
+            ReportHub.LogProductionInfo($"Existing account logged in: {profile.WalletId}");
             return;
 
             bool IsNewUser() =>


### PR DESCRIPTION
# Pull Request Description

Adds a single log that prints when the user successfully authenticates and reaches the "jump in" screen. Used by the E2E test to verify auto login works.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Adds a log to `LobbyForExistingAccountAuthState`.

## Test Instructions

No testing needed, no functional changes to our code.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
