### PR TITLE
chore: update force-build label logic

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -2,8 +2,6 @@ name: Unity Cloud Build
 
 on:
   pull_request:
-    paths:
-      - 'Explorer/**'
     types:
       - opened
       - reopened
@@ -184,7 +182,58 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
+      - name: Detect changes under Explorer/**
+        id: changed_explorer
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
+        with:
+          files: |
+            Explorer/**
+
+      - name: Decide whether to build
+        id: decide
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Non-PR triggers that reached prebuild => build
+          echo "[check non-PR] event_name='${{ github.event_name }}' != 'pull_request'"
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "[non-PR] TRUE -> should_build=true -> exiting 0"
+            exit 0
+          fi
+
+          labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
+          echo "labels='$labels'"
+
+          has_override=false
+          echo "[check override] searching for 'force-build|clean-build' in labels"
+          echo "$labels" | grep -qwE 'force-build|clean-build' && has_override=true
+
+          echo "has_override='$has_override'"
+          if [ "$has_override" = "true" ]; then
+            echo "[override] TRUE -> should_build=true -> exiting 0"
+            exit 0
+          fi
+
+          # If still draft and no override => do not build
+          is_draft="${{ github.event.pull_request.draft }}"
+          echo "[check draft] is_draft='$is_draft'"
+          if [ "$is_draft" = "true" ]; then
+            echo "[draft] TRUE -> should_build=false -> exiting 1"
+            exit 1
+          fi
+
+          explorer_changed="${{ steps.changed_explorer.outputs.any_changed }}"
+          echo "[check explorer_changed] explorer_changed='$explorer_changed'"
+          if [ "$explorer_changed" = "true" ]; then
+            echo "[explorer_changed] TRUE -> should_build=true -> exiting 0"
+            exit 0
+          fi
+
+          echo "[explorer_changed] FALSE -> should_build=false -> exiting 1"
+          exit 1
+
       - name: Get commit SHA
         id: get_commit_sha
         run: |
@@ -207,7 +256,6 @@ jobs:
         with:
           commit_sha: ${{ steps.get_commit_sha.outputs.commit_sha }}
 
-          
       - name: Get Sentry parameters
         id: get_sentry
         run: |


### PR DESCRIPTION
- Removed `paths: Explorer/**` from trigger and moved change detection inside workflow using `step-security/changed-files`
- Added explicit `Decide whether to build` step to centralize build gating logic
- Ensured `force-build` / `clean-build` labels override file-change and draft checks
- Prebuild now exits with non-zero status when build conditions are not met (hard stop)