### PR TITLE
fix: AVPro not restarting when failed url

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -119,12 +119,12 @@ namespace DCL.SDKComponents.MediaStream
         [Query]
         private void UpdateVideoStream(in Entity entity, ref MediaPlayerComponent component, PBVideoPlayer sdkComponent, [Data] float dt)
         {
-            if (component.MediaPlayer.WaitingForProperties) return;
-            if (!frameTimeBudget.TrySpendBudget()) return;
-
             var address = MediaAddress.New(sdkComponent.Src!);
 
             if (TryReInitializeOnSourceChange(entity, ref component, address)) return;
+
+            if (component.MediaPlayer.WaitingForProperties) return;
+            if (!frameTimeBudget.TrySpendBudget()) return;
 
             component.UpdateState();
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

- AVPro was failling to restart after a wrong URL was set. The refresh was hold because the system was still waiting for the original video to refresh properties, and that would never happen.

## Test Instructions

### Test Steps
1. Go to a scene with streaming capabilities
2. Swap between working videos and wrong urls. The working videos should always restart



## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
