### PR TITLE
fix: fix size report upload error during release builds

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -466,8 +466,8 @@ jobs:
         id: size_check
         env:
           # Per-target absolute caps (MB)
-          MAX_MACOS_MB: 410
-          MAX_WINDOWS64_MB: 320
+          MAX_MACOS_MB: 450
+          MAX_WINDOWS64_MB: 360
 
           # Per-platform delta thresholds (MB); 0 = disabled
           DELTA_MACOS_MB:   ${{ github.event.inputs.delta_threshold_macos_mb   || inputs.delta_threshold_macos_mb   || '0' }}
@@ -602,7 +602,7 @@ jobs:
         if: always() && steps.size_check.outputs.result != ''
         uses: actions/upload-artifact@v4
         with:
-          name: size_report_${{ matrix.target }}
+          name: size_report_${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}
           path: size_report/
           if-no-files-found: warn
 

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -117,16 +117,16 @@ jobs:
         run: |
           gh run download "$PREVIOUS_JOB_ID" \
             --repo "$OWNER/$REPO" \
-            --name size_report_windows64 \
+            --name size_report_windows64_launcher \
             --dir size_reports 2>/dev/null || true
           gh run download "$PREVIOUS_JOB_ID" \
             --repo "$OWNER/$REPO" \
-            --name size_report_macos \
+            --name size_report_macos_launcher \
             --dir size_reports 2>/dev/null || true
 
-          WINDOWS_ROW=$(grep "^|" size_reports/size_report_windows64.md 2>/dev/null || true)
-          MACOS_ROW=$(grep "^|" size_reports/size_report_macos.md 2>/dev/null || true)
-          RELEASE_TAG=$(grep "^release_tag=" size_reports/size_report_windows64.md size_reports/size_report_macos.md 2>/dev/null | head -1 | cut -d= -f2 || true)
+          WINDOWS_ROW=$(grep "^|" size_reports/size_report_windows64_launcher.md 2>/dev/null || true)
+          MACOS_ROW=$(grep "^|" size_reports/size_report_macos_launcher.md 2>/dev/null || true)
+          RELEASE_TAG=$(grep "^release_tag=" size_reports/size_report_windows64_launcher.md size_reports/size_report_macos_launcher.md 2>/dev/null | head -1 | cut -d= -f2 || true)
 
           if [ -n "$WINDOWS_ROW" ] || [ -n "$MACOS_ROW" ]; then
             {


### PR DESCRIPTION
# Pull Request Description

Fix artifact naming conflicts in matrix builds and update size caps.                                                                                                                                         
                  
## Changes                                                                                                                                                                                                   
                  
  - **Fix 409 Conflict errors**: Added `install_source` to size report artifact names to prevent duplicate names in matrix builds
  - **Update PR comment workflow**: Download artifacts with new naming scheme (`size_report_*_launcher`)
  - **Update size caps**: Windows64: 320→360 MB, macOS: 410→450 MB (match current builds)

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
