### PR TITLE
feat: allow absolute paths in use-log-matrix arg

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
@@ -228,7 +228,7 @@ namespace Global.Dynamic
 
             if (applicationParametersParser.TryGetValue(AppArgsFlags.USE_LOG_MATRIX, out string? logMatrixFileName) && !string.IsNullOrEmpty(logMatrixFileName))
             {
-                var jsonOverride = LogMatrixJsonLoader.LoadFromApplicationRoot(logMatrixFileName);
+                var jsonOverride = LogMatrixJsonLoader.Load(logMatrixFileName);
 
                 if (jsonOverride != null)
                 {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Settings/LogMatrixJsonLoader.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Settings/LogMatrixJsonLoader.cs
@@ -6,11 +6,11 @@ namespace DCL.Diagnostics
 {
     public static class LogMatrixJsonLoader
     {
-        public static CategorySeverityMatrixDto? LoadFromApplicationRoot(string fileName)
+        public static CategorySeverityMatrixDto? Load(string fileName)
         {
             try
             {
-                string filePath = GetApplicationRootPath(fileName);
+                var filePath = Path.IsPathRooted(fileName) ? fileName : GetApplicationRootPath(fileName);
 
                 if (!File.Exists(filePath))
                 {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Renames `LogMatrixJsonLoader.LoadFromApplicationRoot` to `Load` and adds support for absolute file paths in the `--use-log-matrix` argument.

Previously, the loader always resolved the file name relative to the application root. Now, if the provided path is absolute (detected via `Path.IsPathRooted`), it is used directly. Relative file names retain the existing behavior.

## Test Instructions

### Prerequisites
- [ ] A build of the explorer

### Test Steps
1. Create a JSON file (e.g. `livekit_logs.json`) with the following content:
```json
{
  "isOverride": true,
  "debugLogMatrix": [
    { "category": "LIVEKIT", "severity": "Log" }
  ],
  "sentryMatrix": []
}
```
2. Run the explorer with `--use-log-matrix /absolute/path/to/livekit_logs.json` — verify it loads from the absolute path

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.