### PR TITLE
fix: update ban list when connecting to a room

### DIFF
--- a/Explorer/Assets/DCL/SceneBannedUsers/BannedUsersFromCurrentScene.cs
+++ b/Explorer/Assets/DCL/SceneBannedUsers/BannedUsersFromCurrentScene.cs
@@ -41,6 +41,13 @@ namespace DCL.SceneBannedUsers
 
         private void OnRoomMetadataChanged(string metadata)
         {
+            UpdateBannedList(metadata);
+        }
+
+        private void UpdateBannedList(string metadata)
+        {
+            if (string.IsNullOrEmpty(metadata)) return;
+
             roomMetadata = metadata;
             bannedUsersRoomMetadata = JsonConvert.DeserializeObject<BannedUsersRoomMetadata>(roomMetadata);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

When a user connects or reconnects to a scene room, the ban list was not being refreshed from room metadata. This meant that if a user joined a room where bans had already been set, they wouldn't see the current ban list until the metadata changed again.

This fix subscribes to `ConnectionUpdated` events on the scene room and triggers a metadata refresh (`OnRoomMetadataChanged`) whenever the connection state is `Connected` or `Reconnected`.

## Test Instructions

### Prerequisites
- [x] Access to a scene with ban functionality

### Test Steps
1. Have User A ban User B from a scene
2. Have User B leave and rejoin the scene (or reconnect)
3. Verify that User B is still correctly banned upon reconnection
4. Verify that a fresh user connecting to the room sees the current ban list immediately

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.