### PR TITLE
fix: donection panel insufficient mana visual bug

### DIFF
--- a/Explorer/Assets/DCL/Donations/UI/DonationDefaultView.cs
+++ b/Explorer/Assets/DCL/Donations/UI/DonationDefaultView.cs
@@ -169,7 +169,7 @@ namespace DCL.Donations.UI
 
             donationErrorTip.gameObject.SetActive(number < 1);
 
-            if (number >= currentViewModel.CurrentBalance)
+            if (number > currentViewModel.CurrentBalance)
             {
                 balanceWarningIcon.SetActive(true);
                 balanceManaIcon.SetActive(false);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7340 
Ensures allignment in the UI of donation, hiding the insufficient mana error if we are trying to donate the full amount of mana we currently hold

## Test Instructions


### Test Steps
1. Go to a scene that has the donation icon, for example flagtag in org, or 9,49 in zone
2. type in the max amount of MANA
3. Verify that the donation is allowed and doesn't show the error like shown in issue #7340 

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
