### PR TITLE
fix: Enforce only opaque objects to get highlight ability

### DIFF
--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -494,7 +494,7 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "f57b137a6bd76527ea144b7e03cd7743f1b39599"
+      "hash": "d5e6427e41422d069e8c0b9b4a8d9ab606877b70"
     },
     "io.sentry.unity": {
       "version": "https://github.com/getsentry/unity.git#4.0.0",


### PR DESCRIPTION
# Enforce only opaque objects to get highlight ability

fixes #7142

## What does this PR change?
Removed the ability for alpha clip and transparents from being rendered in the Avatar highlight.

## Test Instructions
Before:
<img width="454" height="686" alt="image" src="https://github.com/user-attachments/assets/eaebe62b-9ddf-47ad-9b6f-90a58a8de13e" />
After:
<img width="457" height="673" alt="image" src="https://github.com/user-attachments/assets/77f9d376-5ed5-44f4-be83-11623e9aa5f7" />

### Test Steps
1. Download build
2. Enter Explorer
3. Find an avatar with alpha clip or transparency meshes
4. Hover the mouse or centring icon over avatar to get highlight to appear
5. alpha clip and/or transparents shouldn't have highlights.