### PR TITLE
fix: Navmap places search filtered by SDK7 only

### DIFF
--- a/Explorer/Assets/DCL/Navmap/SearchForPlaceAndShowResultsCommand.cs
+++ b/Explorer/Assets/DCL/Navmap/SearchForPlaceAndShowResultsCommand.cs
@@ -109,19 +109,23 @@ namespace DCL.Navmap
 
                 if (@params.filter == NavmapSearchPlaceFilter.All)
                 {
-                    using PlacesData.IPlacesAPIResponse response = await placesAPIService.SearchPlacesAsync(@params.page, @params.pageSize, ct,
+                    using PlacesData.IPlacesAPIResponse response = await placesAPIService.SearchDestinationsAsync(@params.page, @params.pageSize, ct,
                         searchText: @params.text,
                         sortBy: sort, sortDirection: sortDirection,
-                        category: @params.category is "All" or "Favorites" ? string.Empty : @params.category);
+                        category: @params.category is "All" or "Favorites" ? string.Empty : @params.category,
+                        onlySdk7: true,
+                        onlyPlaces: true);
                     places.AddRange(response.Data);
                     totalResultCount = response.Total;
                 }
                 else if (@params.filter == NavmapSearchPlaceFilter.Favorites)
                 {
-                    using PlacesData.IPlacesAPIResponse response = await placesAPIService.GetFavoritesAsync(
+                    using PlacesData.IPlacesAPIResponse response = await placesAPIService.GetFavoritesDestinationsAsync(
                         ct,
                         pageNumber: @params.page, pageSize: @params.pageSize,
-                        sortByBy: sort, sortDirection: sortDirection);
+                        sortByBy: sort, sortDirection: sortDirection,
+                        onlySdk7: true,
+                        onlyPlaces: true);
                     places.AddRange(response.Data);
                     totalResultCount = response.Total;
                 }

--- a/Explorer/Assets/DCL/PlacesAPIService/IPlacesAPIService.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/IPlacesAPIService.cs
@@ -19,7 +19,8 @@ namespace DCL.PlacesAPIService
             string? category = null,
             bool? withConnectedUsers = null,
             bool? onlySdk7 = null,
-            bool? withLiveEvents = null);
+            bool? withLiveEvents = null,
+            bool? onlyPlaces = null);
 
         UniTask<PlacesData.PlaceInfo?> GetPlaceAsync(Vector2Int coords, CancellationToken ct, bool renewCache = false);
 
@@ -34,7 +35,8 @@ namespace DCL.PlacesAPIService
             SortBy sortByBy = SortBy.MOST_ACTIVE, SortDirection sortDirection = SortDirection.DESC,
             bool? withConnectedUsers = null,
             bool? onlySdk7 = null,
-            bool? withLiveEvents = null);
+            bool? withLiveEvents = null,
+            bool? onlyPlaces = null);
 
         UniTask<PoolExtensions.Scope<List<PlacesData.PlaceInfo>>> GetPlacesByCoordsListAsync(IEnumerable<Vector2Int> coordsList, CancellationToken ct, bool renewCache = false);
         UniTask<PlacesData.IPlacesAPIResponse> GetPlacesByIdsAsync(IEnumerable<string> placeIds, CancellationToken ct, bool renewCache = false);

--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
@@ -68,7 +68,8 @@ namespace DCL.PlacesAPIService
             string? category = null,
             bool? withConnectedUsers = null,
             bool? onlySdk7 = null,
-            bool? withLiveEvents = null)
+            bool? withLiveEvents = null,
+            bool? onlyPlaces = null)
         {
             string sortByStr = string.Empty;
             string sortDirectionStr = string.Empty;
@@ -84,7 +85,8 @@ namespace DCL.PlacesAPIService
                 sortByStr, sortDirectionStr, category, addRealmDetails: true,
                 withConnectedUsers: withConnectedUsers,
                 onlySdk7: onlySdk7,
-                withLiveEvents: withLiveEvents);
+                withLiveEvents: withLiveEvents,
+                onlyPlaces: onlyPlaces);
         }
 
         public async UniTask<PlacesData.PlaceInfo?> GetPlaceAsync(Vector2Int coords, CancellationToken ct, bool renewCache = false)
@@ -226,7 +228,8 @@ namespace DCL.PlacesAPIService
             IPlacesAPIService.SortDirection sortDirection = IPlacesAPIService.SortDirection.DESC,
             bool? withConnectedUsers = null,
             bool? onlySdk7 = null,
-            bool? withLiveEvents = null)
+            bool? withLiveEvents = null,
+            bool? onlyPlaces = null)
         {
             string sortByStr = string.Empty;
             string sortDirectionStr = string.Empty;
@@ -243,7 +246,8 @@ namespace DCL.PlacesAPIService
                 onlyFavorites: true,
                 withConnectedUsers: withConnectedUsers,
                 onlySdk7: onlySdk7,
-                withLiveEvents: withLiveEvents);
+                withLiveEvents: withLiveEvents,
+                onlyPlaces: onlyPlaces);
         }
 
         public async UniTask SetPlaceFavoriteAsync(string placeId, bool isFavorite, CancellationToken ct)


### PR DESCRIPTION
# Pull Request Description
Fix #4854 

## What does this PR change?
Before this fix, in the places search that we have inside the navmap, we showed all places but they often included SDK6 scenes which are not supported.

<img width="704" height="1620" alt="Image" src="https://github.com/user-attachments/assets/a541cbfc-b0e6-4ed2-8543-fd443b9b148a" />

With this fix, we use the same endpoint that we currnetly use for the "Places" making it filters by "only places" (here we don't want to show worlds) and by "only SDK7 scenes".

### Test Steps
1. Open the map.
2. Use the places searching (through the search box or clicking in any place category).
3. Check that now the results are not including any sdk6 scene.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.