### PR TITLE
fix: Error message when profile fails to update

### DIFF
--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -174,7 +174,17 @@ namespace DCL.Profiles.Self
                     false, IProfileRepository.FetchBehaviour.ENFORCE_SINGLE_GET | IProfileRepository.FetchBehaviour.DELAY_UNTIL_RESOLVED);
 
                 if (savedProfile == null || savedProfile.Version < expectedVersion)
+                {
+                    //We are gonna make the current profile whatever was returned from the registry
+                    //If its null, we are gonna keep what was set already.
+                    //TODO: But this will show a very corrupted state, because the registry has no profile stored. Which is bad. What do we do in these situation?
+                    if (savedProfile != null)
+                    {
+                        copyOfOwnProfile?.Dispose();
+                        copyOfOwnProfile = profileBuilder.From(savedProfile!).Build();
+                    }
                     throw new Exception($"Profile update could not be confirmed. Expected version {expectedVersion}, got {savedProfile?.Version.ToString() ?? "null"}");
+                }
 
                 // We need to re-update the avatar in-world with the new profile because the save operation invalidates the previous profile
                 // breaking the avatar and the backpack

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -202,6 +202,7 @@ namespace DCL.Profiles.Self
                 profileCache.Set(oldProfile.UserId, oldProfile);
                 UpdateAvatarInWorld(oldProfile);
                 OwnProfile = oldProfile;
+                isProfileUpdatePending = false;
                 throw;
             }
         }

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -175,7 +175,9 @@ namespace DCL.Profiles.Self
             try
             {
                 await profileRepository.SetAsync(newProfile, ct);
+
                 Profile? savedProfile = await profileRepository.GetAsync(newProfile.UserId, expectedVersion, ct,
+
                     // force to fetch the profile: there are some fields that might change, like the profile picture url
                     false, IProfileRepository.FetchBehaviour.ENFORCE_SINGLE_GET | IProfileRepository.FetchBehaviour.DELAY_UNTIL_RESOLVED);
 
@@ -186,7 +188,6 @@ namespace DCL.Profiles.Self
                 // breaking the avatar and the backpack
                 profileCache.Set(savedProfile.UserId, savedProfile);
                 UpdateAvatarInWorld(savedProfile!);
-                isProfileUpdatePending = false;
                 copyOfOwnProfile?.Dispose();
                 copyOfOwnProfile = profileBuilder.From(savedProfile!).Build();
                 return savedProfile;
@@ -202,8 +203,11 @@ namespace DCL.Profiles.Self
                 profileCache.Set(oldProfile.UserId, oldProfile);
                 UpdateAvatarInWorld(oldProfile);
                 OwnProfile = oldProfile;
-                isProfileUpdatePending = false;
                 throw;
+            }
+            finally
+            {
+                isProfileUpdatePending = false;
             }
         }
 

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -180,17 +180,7 @@ namespace DCL.Profiles.Self
                     false, IProfileRepository.FetchBehaviour.ENFORCE_SINGLE_GET | IProfileRepository.FetchBehaviour.DELAY_UNTIL_RESOLVED);
 
                 if (savedProfile == null || savedProfile.Version < expectedVersion)
-                {
-                    //We are gonna make the current profile whatever was returned from the registry
-                    //If its null, we are gonna keep what was set already.
-                    //TODO: But this will show a very corrupted state, because the registry has no profile stored. Which is bad. What do we do in these situation?
-                    if (savedProfile != null)
-                    {
-                        copyOfOwnProfile?.Dispose();
-                        copyOfOwnProfile = profileBuilder.From(savedProfile!).Build();
-                    }
                     throw new Exception($"Profile update could not be confirmed. Expected version {expectedVersion}, got {savedProfile?.Version.ToString() ?? "null"}");
-                }
 
                 // We need to re-update the avatar in-world with the new profile because the save operation invalidates the previous profile
                 // breaking the avatar and the backpack

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -26,6 +26,7 @@ namespace DCL.Profiles.Self
         private readonly IEquippedWearables equippedWearables;
         private readonly IEquippedEmotes equippedEmotes;
         private Profile? copyOfOwnProfile;
+        private bool isProfileUpdatePending;
 
         public Profile? OwnProfile { get; private set; }
 
@@ -87,7 +88,7 @@ namespace DCL.Profiles.Self
             if (OwnProfile == null || profile.Version > OwnProfile.Version)
                 OwnProfile = profile;
 
-            if (copyOfOwnProfile == null || profile.Version > copyOfOwnProfile.Version)
+            if (!isProfileUpdatePending && (copyOfOwnProfile == null || profile.Version > copyOfOwnProfile.Version))
             {
                 copyOfOwnProfile?.Dispose();
                 copyOfOwnProfile = profileBuilder.From(profile).Build();
@@ -153,12 +154,17 @@ namespace DCL.Profiles.Self
                 if (savedProfile != null)
                 {
                     profileCache.Set(savedProfile.UserId, savedProfile);
+                    isProfileUpdatePending = false;
                     copyOfOwnProfile?.Dispose();
                     copyOfOwnProfile = profileBuilder.From(savedProfile).Build();
                 }
 
                 return savedProfile;
             }
+
+            // Prevent concurrent ProfileAsync calls (e.g. from ProfileBroadcast) from overwriting
+            // copyOfOwnProfile with the unconfirmed optimistic cache entry
+            isProfileUpdatePending = true;
 
             // Update profile immediately to prevent UI inconsistencies
             // Without this immediate update, temporary desync can occur between backpack closure and catalyst validation
@@ -190,6 +196,7 @@ namespace DCL.Profiles.Self
                 // breaking the avatar and the backpack
                 profileCache.Set(savedProfile.UserId, savedProfile);
                 UpdateAvatarInWorld(savedProfile!);
+                isProfileUpdatePending = false;
                 copyOfOwnProfile?.Dispose();
                 copyOfOwnProfile = profileBuilder.From(savedProfile!).Build();
                 return savedProfile;
@@ -218,6 +225,7 @@ namespace DCL.Profiles.Self
 
         private void InvalidateOwnProfile()
         {
+            isProfileUpdatePending = false;
             copyOfOwnProfile = null;
             OwnProfile = null;
             // We also need to clear the owned nfts since they need to be re-initialized, otherwise we might end up with wrong nftIds (last part of the urn chunks)

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -136,6 +136,10 @@ namespace DCL.Profiles.Self
             newProfile.UserId = web3IdentityCache.Identity.Address;
             newProfile.Version++;
 
+            // Capture version before async operations — newProfile may be disposed by the
+            // profile cache when a fetched profile replaces it, resetting Version to 0
+            int expectedVersion = newProfile.Version;
+
             OwnProfile = newProfile;
 
             if (!updateAvatarInWorld)
@@ -165,13 +169,16 @@ namespace DCL.Profiles.Self
             try
             {
                 await profileRepository.SetAsync(newProfile, ct);
-                Profile? savedProfile = await profileRepository.GetAsync(newProfile.UserId, newProfile.Version, ct,
+                Profile? savedProfile = await profileRepository.GetAsync(newProfile.UserId, expectedVersion, ct,
                     // force to fetch the profile: there are some fields that might change, like the profile picture url
                     false, IProfileRepository.FetchBehaviour.ENFORCE_SINGLE_GET | IProfileRepository.FetchBehaviour.DELAY_UNTIL_RESOLVED);
 
+                if (savedProfile == null || savedProfile.Version < expectedVersion)
+                    throw new Exception($"Profile update could not be confirmed. Expected version {expectedVersion}, got {savedProfile?.Version.ToString() ?? "null"}");
+
                 // We need to re-update the avatar in-world with the new profile because the save operation invalidates the previous profile
                 // breaking the avatar and the backpack
-                profileCache.Set(savedProfile!.UserId, savedProfile);
+                profileCache.Set(savedProfile.UserId, savedProfile);
                 UpdateAvatarInWorld(savedProfile!);
                 copyOfOwnProfile?.Dispose();
                 copyOfOwnProfile = profileBuilder.From(savedProfile!).Build();

--- a/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/SelfProfile.cs
@@ -154,7 +154,6 @@ namespace DCL.Profiles.Self
                 if (savedProfile != null)
                 {
                     profileCache.Set(savedProfile.UserId, savedProfile);
-                    isProfileUpdatePending = false;
                     copyOfOwnProfile?.Dispose();
                     copyOfOwnProfile = profileBuilder.From(savedProfile).Build();
                 }
@@ -187,9 +186,9 @@ namespace DCL.Profiles.Self
                 // We need to re-update the avatar in-world with the new profile because the save operation invalidates the previous profile
                 // breaking the avatar and the backpack
                 profileCache.Set(savedProfile.UserId, savedProfile);
-                UpdateAvatarInWorld(savedProfile!);
+                UpdateAvatarInWorld(savedProfile);
                 copyOfOwnProfile?.Dispose();
-                copyOfOwnProfile = profileBuilder.From(savedProfile!).Build();
+                copyOfOwnProfile = profileBuilder.From(savedProfile).Build();
                 return savedProfile;
             }
             catch (Exception e) when (e is not OperationCanceledException)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Right now, if the profile fails to update (meaning, the retrieved profile from the registry is not the same as the one in world) we just rollback in world, but we are not showing the necessary error message. 

## Test Instructions


### Test Steps
1. Try to update your profile, waiting for a fail
2. See that the error message appears accordingly (The `There was an error updating your avatar profile...` message 

<img width="1114" height="624" alt="image" src="https://github.com/user-attachments/assets/6687bde5-3f14-4c76-9b36-02445e7feac6" />


## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
