### PR TITLE
fix: defensive guards against circular rightOf of UiEntity

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Components/UITransformComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Components/UITransformComponent.cs
@@ -1,5 +1,6 @@
 using Arch.Core;
 using CRDT;
+using DCL.Diagnostics;
 using DCL.ECSComponents;
 using DCL.SDKComponents.SceneUI.Utils;
 using System;
@@ -67,8 +68,17 @@ namespace DCL.SDKComponents.SceneUI.Components
             // Instead of creating a new collection with VisualElements keep the index in the tabIndex
 
             int i = 0;
+            int maxNodes = RelationData.NodeCount;
+
             for (UITransformRelationLinkedData.Node node = RelationData.head; node != null; node = node.Next)
             {
+                if (i > maxNodes)
+                {
+                    ReportHub.LogError(ReportCategory.SCENE_UI,
+                        "Cycle detected in sibling linked list during SortIfRequired — aborting sort");
+                    break;
+                }
+
                 var childEntityId = node.EntityId;
 
                 if (entitiesMap.TryGetValue(childEntityId, out var child))

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Components/UITransformRelationLinkedData.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Components/UITransformRelationLinkedData.cs
@@ -1,5 +1,6 @@
 ﻿using Arch.Core;
 using CRDT;
+using DCL.Diagnostics;
 using DCL.Optimization.Pools;
 using System.Collections.Generic;
 using UnityEngine.Assertions;
@@ -52,6 +53,8 @@ namespace DCL.SDKComponents.SceneUI.Components
         /// Indicates that resorting is required
         /// </summary>
         internal bool layoutIsDirty;
+
+        internal int NodeCount => nodes?.Count ?? 0;
 
         internal bool ContainsNode(CRDTEntity entity) =>
             nodes != null && nodes.ContainsKey(entity);
@@ -108,9 +111,19 @@ namespace DCL.SDKComponents.SceneUI.Components
         {
             if (pendingRightOf.TryGetValue(newlyAddedEntityId, out var rightNode))
             {
+                // Guard: skip if this would create a self-cycle or if rightNode is already linked
+                if (rightNode == leftNode || rightNode.Previous != null || rightNode.Next != null)
+                {
+                    ReportHub.LogError(ReportCategory.SCENE_UI,
+                        $"Skipping ResolvePending for entity {newlyAddedEntityId}: would create a cycle in the sibling linked list");
+                    pendingRightOf.Remove(newlyAddedEntityId);
+                    return;
+                }
+
                 if (leftNode.Next != null)
                     leftNode.Next.Previous = rightNode;
 
+                rightNode.Next = leftNode.Next;
                 leftNode.Next = rightNode;
                 rightNode.Previous = leftNode;
 
@@ -119,8 +132,16 @@ namespace DCL.SDKComponents.SceneUI.Components
                 if (rightNode == head)
                 {
                     // if the current head is the right node then the left-most becomes the new head
+                    int maxIterations = nodes.Count;
+
                     for (head = rightNode; head.Previous != null; head = head.Previous)
                     {
+                        if (--maxIterations <= 0)
+                        {
+                            ReportHub.LogError(ReportCategory.SCENE_UI,
+                                "Cycle detected in sibling linked list while finding head node");
+                            break;
+                        }
                     }
                 }
 
@@ -169,12 +190,11 @@ namespace DCL.SDKComponents.SceneUI.Components
 
         public void Dispose()
         {
-            // Release all nodes
-            while (head != null)
+            // Release all nodes via dictionary to avoid traversing a potentially cyclic list
+            if (nodes != null)
             {
-                Node next = head.Next!;
-                Node.POOL.Release(head);
-                head = next;
+                foreach (var node in nodes.Values)
+                    Node.POOL.Release(node);
             }
 
             nodes?.Clear();

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UITransform/UITransformParentingSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UITransform/UITransformParentingSystem.cs
@@ -22,6 +22,7 @@ namespace DCL.SDKComponents.SceneUI.Systems.UITransform
     {
         private readonly Entity sceneRoot;
         private readonly IReadOnlyDictionary<CRDTEntity, Entity> entitiesMap;
+        private readonly List<CRDTEntity> tempChildEntities = new (16);
 
         internal UITransformParentingSystem(World world, IReadOnlyDictionary<CRDTEntity, Entity> entitiesMap, Entity sceneRoot) : base(world)
         {
@@ -46,20 +47,35 @@ namespace DCL.SDKComponents.SceneUI.Systems.UITransform
             var head = uiTransformComponentToBeDeleted.RelationData.head;
             if (head == null) return;
 
+            // Collect child entity IDs before iterating, because RemoveChild releases
+            // nodes back to the pool (resetting Next to null) and would break iteration.
+            int maxNodes = uiTransformComponentToBeDeleted.RelationData.NodeCount;
+            tempChildEntities.Clear();
+
+            int i = 0;
+
             for (var current = head; current != null; current = current.Next)
             {
-                if (entitiesMap.TryGetValue(current.EntityId, out Entity childEntity))
+                if (++i > maxNodes) break; // cycle guard
+                tempChildEntities.Add(current.EntityId);
+            }
+
+            for (int j = 0; j < tempChildEntities.Count; j++)
+            {
+                var childEntityId = tempChildEntities[j];
+
+                if (entitiesMap.TryGetValue(childEntityId, out Entity childEntity))
                 {
                     ref UITransformComponent uiTransform = ref World.TryGetRef<UITransformComponent>(childEntity, out bool exists);
 
                     if (!exists)
                     {
-                        ReportHub.LogError(GetReportData(), $"Trying to unparent an ${nameof(UITransformComponent)}'s child but no component has been found on entity {current.EntityId}");
+                        ReportHub.LogError(GetReportData(), $"Trying to unparent an ${nameof(UITransformComponent)}'s child but no component has been found on entity {childEntityId}");
                         continue;
                     }
 
-                    uiTransformComponentToBeDeleted.RelationData.RemoveChild(current.EntityId, ref uiTransform.RelationData);
-                    SetNewChild(ref uiTransform, current.EntityId, sceneRoot);
+                    uiTransformComponentToBeDeleted.RelationData.RemoveChild(childEntityId, ref uiTransform.RelationData);
+                    SetNewChild(ref uiTransform, childEntityId, sceneRoot);
                 }
             }
         }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UITransformParentingSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UITransformParentingSystemShould.cs
@@ -47,5 +47,51 @@ namespace DCL.SDKComponents.SceneUI.Tests
             Assert.That(parentUiTransformComponent.RelationData.ContainsNode(childSdkEntity), Is.False);
             Assert.That(parentUiTransformComponent.RelationData.head, Is.Null);
         }
+
+        [Test]
+        public void OrphanAllChildrenWhenDeletedEntityHasMultipleChildren()
+        {
+            // Arrange: parent with 3 children (A, B, C) — parent gets deleted
+            var parentUiTransformComponent = new UITransformComponent();
+            parentUiTransformComponent.InitializeAsRoot(new VisualElement());
+            var parentSdkEntity = new CRDTEntity(100);
+            Entity parentEntity = world.Create(parentSdkEntity, parentUiTransformComponent);
+            entitiesMap.Add(parentSdkEntity, parentEntity);
+
+            var childA = new UITransformComponent();
+            var childASdk = new CRDTEntity(200);
+            childA.InitializeAsChild("A", childASdk, -1);
+            Entity childAEntity = world.Create(childASdk, childA, new PBUiTransform());
+            entitiesMap.Add(childASdk, childAEntity);
+
+            var childB = new UITransformComponent();
+            var childBSdk = new CRDTEntity(300);
+            childB.InitializeAsChild("B", childBSdk, 200);
+            Entity childBEntity = world.Create(childBSdk, childB, new PBUiTransform());
+            entitiesMap.Add(childBSdk, childBEntity);
+
+            var childC = new UITransformComponent();
+            var childCSdk = new CRDTEntity(400);
+            childC.InitializeAsChild("C", childCSdk, 300);
+            Entity childCEntity = world.Create(childCSdk, childC, new PBUiTransform());
+            entitiesMap.Add(childCSdk, childCEntity);
+
+            parentUiTransformComponent.RelationData.AddChild(parentEntity, childASdk, ref childA.RelationData);
+            parentUiTransformComponent.RelationData.AddChild(parentEntity, childBSdk, ref childB.RelationData);
+            parentUiTransformComponent.RelationData.AddChild(parentEntity, childCSdk, ref childC.RelationData);
+
+            Assert.AreEqual(3, parentUiTransformComponent.RelationData.NodeCount);
+
+            // Mark parent for deletion
+            world.Add(parentEntity, new DeleteEntityIntention());
+
+            // Act
+            system.Update(0);
+
+            // Assert: all children should be removed from the deleted parent
+            Assert.That(parentUiTransformComponent.RelationData.ContainsNode(childASdk), Is.False);
+            Assert.That(parentUiTransformComponent.RelationData.ContainsNode(childBSdk), Is.False);
+            Assert.That(parentUiTransformComponent.RelationData.ContainsNode(childCSdk), Is.False);
+        }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UITransformRelationLinkedDataShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UITransformRelationLinkedDataShould.cs
@@ -1,0 +1,138 @@
+using Arch.Core;
+using CRDT;
+using DCL.SDKComponents.SceneUI.Components;
+using NUnit.Framework;
+
+namespace DCL.SDKComponents.SceneUI.Tests
+{
+    public class UITransformRelationLinkedDataShould
+    {
+        private World world;
+        private Entity parentEntity;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = World.Create();
+            parentEntity = world.Create();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            world.Dispose();
+        }
+
+        [Test]
+        public void NotCreateSelfCycleWhenRightOfPointsToSelf()
+        {
+            // Arrange: entity A with rightOf = A (self-reference)
+            var parentData = new UITransformRelationLinkedData();
+            var childData = new UITransformRelationLinkedData { rightOf = new CRDTEntity(10) };
+
+            // Act: Add child A where A.rightOf = A
+            parentData.AddChild(parentEntity, new CRDTEntity(10), ref childData);
+
+            // Assert: list should not cycle — head.Next must not point back to head
+            Assert.IsNotNull(parentData.head);
+            Assert.IsNull(parentData.head.Next, "Self-referencing rightOf should not create a cycle");
+            Assert.AreEqual(1, parentData.NodeCount);
+        }
+
+        [Test]
+        public void NotCreateMutualCycleWhenRightOfIsCircular()
+        {
+            // Arrange: A.rightOf = B, B.rightOf = A (mutual reference)
+            var parentData = new UITransformRelationLinkedData();
+            var childDataA = new UITransformRelationLinkedData { rightOf = new CRDTEntity(20) }; // A wants to be after B
+            var childDataB = new UITransformRelationLinkedData { rightOf = new CRDTEntity(10) }; // B wants to be after A
+
+            // Act
+            parentData.AddChild(parentEntity, new CRDTEntity(10), ref childDataA); // Add A (B not found yet, goes to pending)
+            parentData.AddChild(parentEntity, new CRDTEntity(20), ref childDataB); // Add B (A found, triggers ResolvePending for A)
+
+            // Assert: traversing the list must terminate within NodeCount steps
+            int count = 0;
+            int max = parentData.NodeCount;
+
+            for (var node = parentData.head; node != null; node = node.Next)
+            {
+                count++;
+                Assert.LessOrEqual(count, max + 1, "Linked list traversal exceeded node count — cycle detected");
+            }
+
+            Assert.AreEqual(2, parentData.NodeCount);
+        }
+
+        [Test]
+        public void MaintainCorrectOrderForNonCircularChildren()
+        {
+            // Arrange: A (first), B after A, C after B — no cycles
+            var parentData = new UITransformRelationLinkedData();
+            var childDataA = new UITransformRelationLinkedData { rightOf = new CRDTEntity(0) };
+            var childDataB = new UITransformRelationLinkedData { rightOf = new CRDTEntity(10) };
+            var childDataC = new UITransformRelationLinkedData { rightOf = new CRDTEntity(20) };
+
+            // Act
+            parentData.AddChild(parentEntity, new CRDTEntity(10), ref childDataA);
+            parentData.AddChild(parentEntity, new CRDTEntity(20), ref childDataB);
+            parentData.AddChild(parentEntity, new CRDTEntity(30), ref childDataC);
+
+            // Assert: list order should be A → B → C
+            Assert.IsNotNull(parentData.head);
+            Assert.AreEqual(new CRDTEntity(10), parentData.head.EntityId);
+            Assert.IsNotNull(parentData.head.Next);
+            Assert.AreEqual(new CRDTEntity(20), parentData.head.Next.EntityId);
+            Assert.IsNotNull(parentData.head.Next.Next);
+            Assert.AreEqual(new CRDTEntity(30), parentData.head.Next.Next.EntityId);
+            Assert.IsNull(parentData.head.Next.Next.Next);
+            Assert.AreEqual(3, parentData.NodeCount);
+        }
+
+        [Test]
+        public void MaintainCorrectOrderWhenChildrenAddedOutOfOrder()
+        {
+            // Arrange: add C first, then A, then B — pending resolution should build A → B → C
+            var parentData = new UITransformRelationLinkedData();
+            var childDataC = new UITransformRelationLinkedData { rightOf = new CRDTEntity(20) }; // C after B
+            var childDataA = new UITransformRelationLinkedData { rightOf = new CRDTEntity(0) };  // A first
+            var childDataB = new UITransformRelationLinkedData { rightOf = new CRDTEntity(10) }; // B after A
+
+            // Act: add in shuffled order
+            parentData.AddChild(parentEntity, new CRDTEntity(30), ref childDataC); // C (B not found, pending)
+            parentData.AddChild(parentEntity, new CRDTEntity(10), ref childDataA); // A (first)
+            parentData.AddChild(parentEntity, new CRDTEntity(20), ref childDataB); // B after A (resolves C pending on B)
+
+            // Assert: traversal terminates and all 3 nodes are reachable
+            int count = 0;
+
+            for (var node = parentData.head; node != null; node = node.Next)
+            {
+                count++;
+                if (count > parentData.NodeCount) break;
+            }
+
+            Assert.AreEqual(3, count);
+            Assert.AreEqual(3, parentData.NodeCount);
+        }
+
+        [Test]
+        public void DisposeWithoutHangingOnCyclicList()
+        {
+            // Arrange: create a normal list then manually corrupt it into a cycle
+            var parentData = new UITransformRelationLinkedData();
+            var childDataA = new UITransformRelationLinkedData { rightOf = new CRDTEntity(0) };
+            var childDataB = new UITransformRelationLinkedData { rightOf = new CRDTEntity(10) };
+
+            parentData.AddChild(parentEntity, new CRDTEntity(10), ref childDataA);
+            parentData.AddChild(parentEntity, new CRDTEntity(20), ref childDataB);
+
+            // Manually corrupt: make B.Next point back to A (simulate a cycle)
+            parentData.head.Next.Next = parentData.head;
+
+            // Act & Assert: Dispose should not hang (it uses dictionary iteration, not list traversal)
+            Assert.DoesNotThrow(() => parentData.Dispose());
+            Assert.IsNull(parentData.head);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UITransformRelationLinkedDataShould.cs.meta
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UITransformRelationLinkedDataShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c509c109f8eb149e3888b1fd13da6873


### PR DESCRIPTION
## Problem

The renderer's UI sibling ordering uses a doubly-linked list (`UITransformRelationLinkedData`) where each child node is positioned based on its `rightOf` value received from the SDK. If the SDK sends circular `rightOf` values (e.g., A.rightOf = B and B.rightOf = A), several code paths would enter infinite loops or silently corrupt state:

1. **`SortIfRequired()` in `UITransformComponent`** (line 70): The `for` loop traversing the linked list via `node.Next` would never terminate if the list contained a cycle, freezing the application.

2. **`ResolvePending()` in `UITransformRelationLinkedData`** (line 107): When resolving pending nodes with circular references, it could create self-cycles (A.Next = A) or mutual cycles (A.Next = B, B.Next = A). The head-finding loop (line 122) was also vulnerable to infinite traversal.

3. **`Dispose()` in `UITransformRelationLinkedData`** (line 170): The `while (head != null)` loop traversed the linked list to release nodes, which would hang on a cyclic list.

4. **`OrphanChildrenOfDeletedEntity()` in `UITransformParentingSystem`** (line 49): Iterated the linked list with `current.Next` while simultaneously calling `RemoveChild` on the current node. `RemoveChild` releases the node to the pool, which calls `Reset()` setting `Next = null`. This caused the loop to stop after the first child — remaining children were never re-parented to the scene root.

The root cause was an SDK-side bug (fixed separately in js-sdk-toolchain-alt), but the renderer should never hang or corrupt state regardless of what data the SDK sends.

## Fixes

### `UITransformRelationLinkedData.cs`

- **`ResolvePending()` cycle guard**: Before linking a pending node, checks if it would create a self-cycle (`rightNode == leftNode`) or if `rightNode` is already linked in the list (`Previous != null || Next != null`). If so, skips the resolution and logs an error via `ReportHub`.

- **`ResolvePending()` missing `rightNode.Next` assignment**: The original code set `leftNode.Next = rightNode` without first preserving `leftNode.Next` into `rightNode.Next`. Added `rightNode.Next = leftNode.Next` before the reassignment to avoid losing the rest of the list.

- **`ResolvePending()` head-finding loop guard**: Added a max-iteration counter (`nodes.Count`) to the loop that walks backward to find the new head. Breaks and logs an error if exceeded.

- **`Dispose()` cycle-safe iteration**: Changed from linked-list traversal (`while (head != null)`) to dictionary-based iteration (`foreach (var node in nodes.Values)`), which is immune to list cycles.

- **`NodeCount` property**: Exposed `nodes.Count` as an internal property for use by iteration guards.

### `UITransformComponent.cs`

- **`SortIfRequired()` iteration guard**: Added a check that breaks the traversal loop if the iteration count exceeds `NodeCount`. Logs an error via `ReportHub` instead of hanging.

### `UITransformParentingSystem.cs`

- **`OrphanChildrenOfDeletedEntity()` safe iteration**: Collects all child entity IDs into a reusable temp list (`tempChildEntities`) before processing removals. The collection phase has its own cycle guard. The processing phase then iterates the snapshot list, so `RemoveChild` pool releases no longer interfere with iteration. This ensures all children are re-parented, not just the first one.

## New tests

### `UITransformRelationLinkedDataShould.cs` (new file, 5 tests)

- **`NotCreateSelfCycleWhenRightOfPointsToSelf`**: Adds entity A with `rightOf = A`. Verifies the list has one node with `Next = null` (no self-cycle).

- **`NotCreateMutualCycleWhenRightOfIsCircular`**: Adds A with `rightOf = B`, then B with `rightOf = A`. Verifies list traversal terminates within `NodeCount` steps.

- **`MaintainCorrectOrderForNonCircularChildren`**: Adds A, B, C in order with valid `rightOf` chain. Verifies correct list order A -> B -> C with proper termination.

- **`MaintainCorrectOrderWhenChildrenAddedOutOfOrder`**: Adds C, A, B in shuffled order relying on pending resolution. Verifies all 3 nodes are reachable and traversal terminates.

- **`DisposeWithoutHangingOnCyclicList`**: Creates a normal 2-node list, then manually corrupts `B.Next` to point back to A. Verifies `Dispose()` completes without hanging.

### `UITransformParentingSystemShould.cs` (1 new test)

- **`OrphanAllChildrenWhenDeletedEntityHasMultipleChildren`**: Creates a parent with 3 children (A, B, C), marks the parent for deletion, runs the system, and verifies all 3 children are removed from the parent's node list. This test would have failed with the old code (only the first child was processed).
