### PR TITLE
fix: set messages from yesterday to yesterday

### DIFF
--- a/Explorer/Assets/DCL/Chat/ChatEntryView.cs
+++ b/Explorer/Assets/DCL/Chat/ChatEntryView.cs
@@ -19,7 +19,7 @@ namespace DCL.Chat
         private const float PROFILE_BUTTON_Y_OFFSET = -18;
         private const float USERNAME_Y_OFFSET = -13f;
         private const string DATE_DIVIDER_TODAY = "Today";
-        private const string DATE_DIVIDER_YESTERDAY = "Today";
+        private const string DATE_DIVIDER_YESTERDAY = "Yesterday";
 
         public delegate void ChatEntryClickedDelegate(string walletAddress, Vector2 contextMenuPosition);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7465
Fixed naming of label for yesterday's messages that was misstyped as today

## Test Instructions

### Test Steps
1. Open a private conversation with a user with messages from yesterday
2. Verify that the messages are under "Yesterday" label and not "Today" label
3. Check the issue description if not clear

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
