### PR TITLE
chore: avoid pollution of logging ANALYTICS_INTERNAL in builds

### DIFF
--- a/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
+++ b/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
@@ -222,12 +222,21 @@ namespace Plugins.RustSegment.SegmentServerWrap
             {
                 string marshaled = Marshal.PtrToStringUTF8(msg) ?? "cannot parse message";
 
+                bool isInternal = marshaled.Contains("(will retry)");
+
                 // Required to avoid polluting Sentry with retry messages
-                string reportCategory = marshaled.Contains("(will retry)")
+                string reportCategory = isInternal
                     ? ReportCategory.ANALYTICS_INTERNAL
                     : ReportCategory.ANALYTICS;
 
+#if UNITY_EDITOR
                 ReportHub.LogException(new Exception($"Segment error: {marshaled}"), reportCategory);
+#else
+                if (isInternal == false) // Avoid logging ANALYTICS_INTERNAL in builds
+                {
+                    ReportHub.LogException(new Exception($"Segment error: {marshaled}"), reportCategory);
+                }
+#endif
             }
             catch
             {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Adds conditional compilation to avoid logging ANALYTICS_INTERNAL in production. Sentry collects those messages as breadcrumbs for some reason despite the logging category is disabled. It's a temporal fix to avoid sentry's breadcrumbs pollution. We should investigate for the root cause.

## Test Instructions

### Test Steps
1. Happy path

## Quality Checklist
- [x] Changes have been tested locally

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
