### PR TITLE
fix: prevent mic auto-unmute when listener promoted to speaker

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/VoiceChatMicrophoneStateManager.cs
+++ b/Explorer/Assets/DCL/VoiceChat/VoiceChatMicrophoneStateManager.cs
@@ -14,6 +14,7 @@ namespace DCL.VoiceChat
         private VoiceChatStatus currentCallStatus;
         private bool isRoomConnected;
         private bool disposed;
+        private bool microphoneEnabledForCurrentSession;
 
         public VoiceChatMicrophoneStateManager(
             VoiceChatMicrophoneHandler microphoneHandler,
@@ -61,8 +62,19 @@ namespace DCL.VoiceChat
                                            (!isRoomConnected && currentCallStatus != VoiceChatStatus.VOICE_CHAT_STARTING_CALL &&
                                             currentCallStatus != VoiceChatStatus.VOICE_CHAT_STARTED_CALL);
 
-            if (shouldEnableMicrophone) { microphoneHandler.EnableMicrophoneForCall(); }
-            else if (shouldDisableMicrophone) { microphoneHandler.DisableMicrophoneForCall(); }
+            // Only auto-enable the mic once per call session. This prevents re-enabling
+            // the mic when a listener is promoted to speaker — promoted users should
+            // join muted and explicitly unmute themselves.
+            if (shouldEnableMicrophone && !microphoneEnabledForCurrentSession)
+            {
+                microphoneEnabledForCurrentSession = true;
+                microphoneHandler.EnableMicrophoneForCall();
+            }
+            else if (shouldDisableMicrophone)
+            {
+                microphoneEnabledForCurrentSession = false;
+                microphoneHandler.DisableMicrophoneForCall();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #6438 — Listener promoted to Speaker joins with microphone unmuted
- Adds a `microphoneEnabledForCurrentSession` flag to `VoiceChatMicrophoneStateManager` that prevents `UpdateMicrophoneState()` from re-enabling the mic after the initial call join
- When a listener is promoted to speaker, the flag is already set from the initial join, so the mic stays muted — promoted speakers must explicitly unmute

## Technical Details
The root cause was that `UpdateMicrophoneState()` unconditionally called `EnableMicrophoneForCall()` whenever `VOICE_CHAT_IN_CALL + isRoomConnected` was true. On promotion, the room reconnects with speaker permissions, re-triggering this path and auto-unmuting the mic.

The fix tracks whether the mic has already been enabled for the current call session. The flag resets when leaving a call, so normal call joins still auto-enable as before.

## Test plan
- [ ] Join a voice chat room as a listener
- [ ] Get promoted to speaker — verify mic stays **muted**
- [ ] Manually unmute — verify mic works normally
- [ ] Leave call and rejoin as speaker — verify mic auto-enables on first join
- [ ] Verify existing voice chat tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)