### PR TITLE
fix: add retry and logging for failed wearable fetches

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/ECSWearablesProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/ECSWearablesProvider.cs
@@ -6,11 +6,13 @@ using DCL.AvatarRendering.Loading.Components;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.AvatarRendering.Wearables.Components.Intentions;
 using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Diagnostics;
 using DCL.Web3.Identities;
 using ECS.Prioritization.Components;
 using ECS.StreamableLoading.Common;
 using ECS.StreamableLoading.Common.Components;
 using Runtime.Wearables;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -97,9 +99,24 @@ namespace DCL.AvatarRendering.Wearables
 
             ct.ThrowIfCancellationRequested();
 
-            if (wearablesPromise.Result == null) return (results, 0);
-            if (!wearablesPromise.Result.HasValue) return (results, 0);
-            if (!wearablesPromise.Result!.Value.Succeeded) return (results, 0);
+            if (wearablesPromise.Result == null)
+            {
+                ReportHub.LogWarning(ReportCategory.WEARABLE, "Wearable fetch returned null result");
+                return (results, 0);
+            }
+
+            if (!wearablesPromise.Result.HasValue)
+            {
+                ReportHub.LogWarning(ReportCategory.WEARABLE, "Wearable fetch returned no value");
+                return (results, 0);
+            }
+
+            if (!wearablesPromise.Result!.Value.Succeeded)
+            {
+                string errorMessage = $"Wearable fetch failed: {wearablesPromise.Result.Value.Exception?.Message}";
+                ReportHub.LogWarning(ReportCategory.WEARABLE, errorMessage);
+                throw new WearableFetchException(errorMessage, wearablesPromise.Result.Value.Exception);
+            }
 
             // Should be the same assigned in the intention as `results`
             return (wearablesPromise.Result.Value.Asset.Wearables,
@@ -145,5 +162,14 @@ namespace DCL.AvatarRendering.Wearables
             }
         }
 
+    }
+
+    /// <summary>
+    /// Thrown when a wearable fetch request fails at the ECS promise level.
+    /// </summary>
+    public class WearableFetchException : Exception
+    {
+        public WearableFetchException(string message, Exception? innerException = null)
+            : base(message, innerException) { }
     }
 }

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -5,11 +5,11 @@ using DCL.AvatarRendering.Wearables;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.AvatarRendering.Wearables.Equipped;
 using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Diagnostics;
 using DCL.Backpack.BackpackBus;
 using DCL.Backpack.Breadcrumb;
 using DCL.Browser;
 using DCL.CharacterPreview;
-using DCL.Diagnostics;
 using DCL.UI;
 using MVC;
 using Runtime.Wearables;
@@ -365,18 +365,7 @@ namespace DCL.Backpack
 
             try
             {
-                (var wearables, int totalAmount) = await wearablesProvider.GetTrimmedByParamsAsync(
-                    new IWearablesProvider.Params(CURRENT_PAGE_SIZE, pageNumber)
-                    {
-                        SortingField = currentSort.OrderByOperation.ToSortingField(),
-                        OrderBy = currentSort.SortAscending ? IWearablesProvider.OrderBy.Ascending : IWearablesProvider.OrderBy.Descending,
-                        Category = currentCategory,
-                        CollectionType = collectionType,
-                        SmartWearablesOnly = currentSmartWearablesOnly,
-                        Name = currentSearch,
-                    },
-                    ct,
-                    results);
+                (var wearables, int totalAmount) = await FetchWearablesWithRetryAsync(pageNumber, collectionType, ct);
 
                 if (refreshPageSelector)
                     pageSelectorController.Configure(totalAmount, CURRENT_PAGE_SIZE);
@@ -400,6 +389,30 @@ namespace DCL.Backpack
             }
             catch (OperationCanceledException) { }
             catch (Exception e) { ReportHub.LogException(e, new ReportData(ReportCategory.BACKPACK)); }
+        }
+
+        private async UniTask<(IReadOnlyList<ITrimmedWearable> wearables, int totalAmount)> FetchWearablesWithRetryAsync(
+            int pageNumber, IWearablesProvider.CollectionType collectionType, CancellationToken ct)
+        {
+            var requestParams = new IWearablesProvider.Params(CURRENT_PAGE_SIZE, pageNumber)
+            {
+                SortingField = currentSort.OrderByOperation.ToSortingField(),
+                OrderBy = currentSort.SortAscending ? IWearablesProvider.OrderBy.Ascending : IWearablesProvider.OrderBy.Descending,
+                Category = currentCategory,
+                CollectionType = collectionType,
+                SmartWearablesOnly = currentSmartWearablesOnly,
+                Name = currentSearch,
+            };
+
+            try { return await wearablesProvider.GetTrimmedByParamsAsync(requestParams, ct, results); }
+            catch (OperationCanceledException) { throw; }
+            catch (WearableFetchException e)
+            {
+                ReportHub.Log(ReportCategory.BACKPACK, $"Wearable fetch failed, retrying once: {e.Message}");
+                results.Clear();
+                await UniTask.Delay(1000, cancellationToken: ct);
+                return await wearablesProvider.GetTrimmedByParamsAsync(requestParams, ct, results);
+            }
         }
 
         private async UniTaskVoid InitializeItemViewAsync(ITrimmedWearable itemWearable, BackpackItemView itemView, CancellationToken ct)


### PR DESCRIPTION
## Summary
- Fixes #6264 — Intermittent loading & missing linked wearables in Backpack
- `ECSWearablesProvider` now throws `WearableFetchException` on promise failure instead of silently returning empty results, and logs warnings for all failure modes
- `BackpackGridController` retries once after a 1-second delay when a wearable fetch fails

## Technical Details
The root cause was that `ECSWearablesProvider.GetTrimmedByParamsAsync()` silently returned empty results `(results, 0)` when the ECS promise failed. The caller (`BackpackGridController`) had no way to distinguish between "no wearables match the filter" and "the fetch failed". Failed fetches for linked/third-party wearables would appear as an empty backpack with no error.

Changes:
1. **`ECSWearablesProvider`**: Added `DCL.Diagnostics` import and warning logs for null result, no value, and failed states. The failed state now throws `WearableFetchException` so callers can handle it
2. **`BackpackGridController`**: Extracted `FetchWearablesWithRetryAsync()` that catches `WearableFetchException`, logs it, waits 1s, and retries once before propagating
3. Added `WearableFetchException` class in the `DCL.AvatarRendering.Wearables` namespace

## Test plan
- [ ] Open backpack — verify wearables load normally (including linked/third-party)
- [ ] Simulate a transient network failure — verify retry succeeds and wearables appear
- [ ] Verify the "Wearable fetch failed, retrying once" log appears on transient failures
- [ ] Filter by collectibles only — verify third-party wearables appear
- [ ] Verify existing backpack tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)