### PR TITLE
feat: enforce conventional commits PR titles

### DIFF
--- a/.github/workflows/enforce-pr-title.yml
+++ b/.github/workflows/enforce-pr-title.yml
@@ -1,0 +1,18 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+    branches:
+      - dev
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Adds a GitHub Actions workflow (`.github/workflows/enforce-pr-title.yml`) that enforces conventional commit format on PR titles targeting `dev`.

- Uses `amannn/action-semantic-pull-request@v5` to validate titles on PR open, edit, and synchronize events
- Ensures consistent PR title formatting across the project (e.g. `feat:`, `fix:`, `chore:`)

We will also need to tick the option "Default to PR title for squash merge commits" in repository settings, if it's not already.

## Test Instructions

### Prerequisites
- [ ] PR needs to be merged before workflow can be checked

### Test Steps
1. Open a PR targeting `dev` with a non-conventional title (e.g. "my changes")
2. Verify the `PR Title` check fails
3. Edit the PR title to a valid conventional format (e.g. `feat: my changes`)
4. Verify the check passes

## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included — N/A