### PR TITLE
fix: Release semaphore on scene disposal in CRDTWorldSynchronizer

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/CrdtEcsSynchronizer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/CrdtEcsSynchronizer.cs
@@ -68,15 +68,15 @@ namespace CrdtEcsBridge.WorldSynchronizer
 
         public void ApplySyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer)
         {
-            if (disposed)
+            try
             {
-                // If the scene was disposed before just dispose the sync buffer
-                syncCommandBuffer.Dispose();
-                return;
+                if (disposed)
+                    // If the scene was disposed before just dispose the sync buffer
+                    syncCommandBuffer.Dispose();
+                else
+                    syncCommandBuffer.Apply(world, reusableCommandBuffer, entitiesMap);
             }
-
-            syncCommandBuffer.Apply(world, reusableCommandBuffer, entitiesMap);
-            semaphore.Release();
+            finally { semaphore.Release(); }
         }
     }
 }


### PR DESCRIPTION
### What does this PR change?

CRDTWorldSynchronizer.ApplySyncCommandBuffer uses a SemaphoreSlim to serialize access to the ECS world between the JS scene thread and the main thread. The semaphore is acquired in GetSyncCommandBuffer and must always be released in ApplySyncCommandBuffer.

Previously, the disposed early-return path disposed the sync buffer but returned without releasing the semaphore. This caused the semaphore to leak: any subsequent call to GetSyncCommandBuffer would block for the full 5-second timeout before throwing System.TimeoutException: Rent Wait Timeout: Couldn't rent command buffer.

Sentry issue https://decentraland.sentry.io/issues/UNITY-EXPLORER-KZP (1120 occurrences, 109 users) shows this happening in production — strongly correlated with meets_minimum_requirements: False and integrated Intel GPUs, where slower main-thread processing makes it more likely the scene is disposed while a sync buffer is still in-flight.

  The fix wraps the method body in a try/finally to unconditionally release the semaphore regardless of the disposal path or any exception thrown by Apply.

##  Test Instructions
  
### Test Steps

  1. Enter a scene in the Explorer
  2. While the scene is loading or actively running, teleport away or trigger a scene reload to force disposal mid-flight
  3. Enter another scene immediately after
  4. Verify the new scene loads and runs correctly with no Rent Wait Timeout exception in logs or Sentry
  5. Repeat several times in quick succession to stress the disposal timing