### PR TITLE
fix: promote to speaker sets as muted by default

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/VoiceChatMicrophoneStateManager.cs
+++ b/Explorer/Assets/DCL/VoiceChat/VoiceChatMicrophoneStateManager.cs
@@ -42,6 +42,19 @@ namespace DCL.VoiceChat
             UpdateMicrophoneState();
         }
 
+        public void OnRoomConnectionChangedMuted(bool connected)
+        {
+            if (isRoomConnected == connected) return;
+
+            ReportHub.Log(ReportCategory.VOICE_CHAT, $"{TAG} Room connection changed (muted): {isRoomConnected} -> {connected}");
+            isRoomConnected = connected;
+
+            if (!connected)
+                UpdateMicrophoneState();
+            else
+                microphoneHandler.DisableMicrophoneForCall();
+        }
+
         private void OnCallStatusChanged(VoiceChatStatus newStatus)
         {
             if (newStatus == currentCallStatus) return;

--- a/Explorer/Assets/DCL/VoiceChat/VoiceChatRoomManager.cs
+++ b/Explorer/Assets/DCL/VoiceChat/VoiceChatRoomManager.cs
@@ -122,7 +122,7 @@ namespace DCL.VoiceChat
         {
             if (isSpeaker && voiceChatOrchestrator.CurrentCallStatus.Value == VoiceChatStatus.VOICE_CHAT_IN_CALL && roomHub.VoiceChatRoom().Activated)
             {
-                voiceChatMicrophoneStateManager.OnRoomConnectionChanged(true);
+                voiceChatMicrophoneStateManager.OnRoomConnectionChangedMuted(true);
                 trackManager.PublishLocalTrackAsync(CancellationToken.None).Forget();
             }
             else

--- a/Explorer/Assets/DCL/VoiceChat/VoiceChatTrackManager.cs
+++ b/Explorer/Assets/DCL/VoiceChat/VoiceChatTrackManager.cs
@@ -129,7 +129,9 @@ namespace DCL.VoiceChat
                 if (!result.Success) throw new Exception($"Couldn't create RTCAudioSource: {result.ErrorMessage}");
 
                 MicrophoneRtcAudioSource rtcAudioSource = result.Value;
-                rtcAudioSource.Start();
+
+                if (microphoneHandler.IsMicrophoneEnabled.Value)
+                    rtcAudioSource.Start();
 
                 ITrack livekitMicrophoneTrack = voiceChatRoom.LocalTracks.CreateAudioTrack(
                     voiceChatRoom.Participants.LocalParticipant().Name,


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #6438
This PR allows users to join a voice chat as speaker as muted by default

## Test Instructions

### Prerequisites
- [ ] Have 2 accounts in the same community to test community voice chat

### Test Steps
1. Start a stream
2. Join as speaker with the second account
3. Verify that when you join as speaker the microphone is always muted by default
4. Unmute and check everything works as expected

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
