### PR TITLE
fix: name color change not applied in world

### DIFF
--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -554,10 +554,13 @@ namespace DCL.Passport
                 Profile? profile = await selfProfile.ProfileAsync(ct);
                 if (profile != null)
                 {
-                    profile.ClaimedNameColor = colorPickerController.CurrentColor;
+                    // Create a copy to avoid mutating the cached profile in-place,
+                    // which would cause UpdateProfileAsync to see no changes (IdenticalProfileUpdateException)
+                    Profile newProfile = new ProfileBuilder().From(profile).Build();
+                    newProfile.ClaimedNameColor = colorPickerController.CurrentColor;
                     try
                     {
-                        Profile? updatedProfile = await selfProfile.UpdateProfileAsync(profile, ct);
+                        Profile? updatedProfile = await selfProfile.UpdateProfileAsync(newProfile, ct);
 
                         if (updatedProfile != null)
                             profileChangesBus.PushUpdate(updatedProfile);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fixes name color changes not being applied in-world after editing via the Passport.

`ProfileAsync` returns the cached profile by reference. Mutating `ClaimedNameColor` directly on it before calling `UpdateProfileAsync` causes the previous-profile snapshot to already contain the new color, so `IsSameProfile` returns `true` and the update is silently skipped via `IdenticalProfileUpdateException`.

Fix: create a copy via `ProfileBuilder` before setting the color, so the cache stays untouched and the change is correctly detected.

Relates to #7541

## Test Instructions

### Prerequisites
- [ ] Have a claimed name with a customizable name color

### Test Steps
1. Enter the world and note the current nametag color above the avatar
2. Open the Passport and change the name color using the color picker
3. Close the Passport
4. Verify the new color is visible on the nametag in-world immediately
5. Reload the client and verify the color persists

### Additional Testing Notes
- Test changing the color multiple times in a row without reloading. Remember about the 3 seconds mark that stops you from udapting your porifle quickly
- Verify that reverting to the original color also works correctly

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included