### PR TITLE
fix: sentry issue for empty participant in screenshot

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/ScreenshotMetadataBuilder.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/ScreenshotMetadataBuilder.cs
@@ -15,8 +15,8 @@ namespace DCL.InWorldCamera
     public class ScreenshotMetadataBuilder
     {
         private const string UNKNOWN_USER = "Unknown";
+        private const string UNKNOWN_USER_WALLET = "0x000000000000000000000000000000000000000";
         private const string UNKNOWN_PLACE = "Unknown place";
-        private const string WORLD_PLACE_ID = "not applicable";
 
         private readonly SelfProfile selfProfile;
         private readonly CharacterController characterObjectController;
@@ -65,7 +65,7 @@ namespace DCL.InWorldCamera
                 visiblePeople.Add(new VisiblePerson
                 {
                     userName = profile?.Name ?? UNKNOWN_USER,
-                    userAddress = profile?.UserId ?? UNKNOWN_USER,
+                    userAddress = string.IsNullOrEmpty(profile?.UserId) ? UNKNOWN_USER_WALLET : profile!.UserId,
                     isGuest = false,
                     isEmoting = isEmoting,
                     wearables = FilterNonBaseWearables(profile?.Avatar.Wearables ?? Array.Empty<URN>()),
@@ -112,7 +112,7 @@ namespace DCL.InWorldCamera
                 metadata = new ScreenshotMetadata
                 {
                     userName = profile?.Name ?? UNKNOWN_USER,
-                    userAddress = profile?.UserId ?? UNKNOWN_USER,
+                    userAddress = string.IsNullOrEmpty(profile?.UserId) ? UNKNOWN_USER_WALLET : profile!.UserId,
                     dateTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(),
                     realm = realm?.RealmName,
                     placeId = placeId,
@@ -126,7 +126,7 @@ namespace DCL.InWorldCamera
             else
             {
                 metadata.userName = profile?.Name ?? UNKNOWN_USER;
-                metadata.userAddress = profile?.UserId ?? UNKNOWN_USER;
+                metadata.userAddress = string.IsNullOrEmpty(profile?.UserId) ? UNKNOWN_USER_WALLET : profile!.UserId;
                 metadata.dateTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
                 metadata.realm = realm?.RealmName;
                 metadata.placeId = placeId;

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/VisiblePersonController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/VisiblePersonController.cs
@@ -78,7 +78,8 @@ namespace DCL.InWorldCamera.PhotoDetail
 
             view.userName.text = visiblePerson.userName;
             view.userName.color = userColor;
-            view.userNameTag.text = $"#{visiblePerson.userAddress[^4..]}";
+            string address = visiblePerson.userAddress;
+            view.userNameTag.text = $"#{address[^Math.Min(4, address.Length)..]}";
             view.profilePictureView.SetBackgroundColor(userColor);
             view.profilePictureView.SetLoadingState(true);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7496 
It was reported in sentry that a user had some photos taken with a visible person with no wallet Id, this threw an error in the client, we don't know exactly what caused this bug, but to prevent it in the future we added 2 safe guards, one for the retrieval that doesn't break on an empty/null wallet id and one for the screenshot metadata generation, that in case of an empty wallet sets a default one.

## Test Instructions

### Test Steps
1. Open the gallery
2. Open a screenshot
3. Verify users in the screenshot are correctly shown
4. Take a new screenshot
5. Verify it works correctly

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
