### PR TITLE
fix: Scene avatar thumbnails cache key collision

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/GetTextureIntention.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/GetTextureIntention.cs
@@ -30,7 +30,11 @@ namespace ECS.StreamableLoading.Textures
         public readonly bool IsAvatarTexture => !string.IsNullOrEmpty(AvatarTextureUserId);
 
         // Note: Depending on the origin of the texture, it may not have a file hash, so the source URL is used in equality comparisons
-        private readonly string cacheKey => string.IsNullOrEmpty(FileHash) ? CommonArguments.URL.Value : FileHash;
+        // For avatar textures, use the userId as the cache key to ensure each user's avatar is cached separately
+        private readonly string cacheKey => 
+            IsAvatarTexture 
+                ? AvatarTextureUserId! 
+                : (string.IsNullOrEmpty(FileHash) ? CommonArguments.URL.Value : FileHash);
 
         public GetTextureIntention(string url, string fileHash, TextureWrapMode wrapMode, FilterMode filterMode, TextureType textureType,
             string reportSource,
@@ -81,13 +85,14 @@ namespace ECS.StreamableLoading.Textures
             WrapMode == other.WrapMode &&
             FilterMode == other.FilterMode &&
             IsVideoTexture == other.IsVideoTexture &&
-            VideoPlayerEntity.Equals(other.VideoPlayerEntity);
+            VideoPlayerEntity.Equals(other.VideoPlayerEntity) &&
+            AvatarTextureUserId == other.AvatarTextureUserId;
 
         public override bool Equals(object obj) =>
             obj is GetTextureIntention other && Equals(other);
 
         public readonly override int GetHashCode() =>
-            HashCode.Combine((int)WrapMode, (int)FilterMode, cacheKey, IsVideoTexture, VideoPlayerEntity);
+            HashCode.Combine((int)WrapMode, (int)FilterMode, cacheKey, IsVideoTexture, VideoPlayerEntity, AvatarTextureUserId);
 
         public readonly override string ToString() =>
             $"Get Texture by {ReportSource}, {(IsAvatarTexture ? "isAvatarTexture" : string.Empty)} : {(IsVideoTexture ? $"Video {VideoPlayerEntity}" : CommonArguments.URL)}";
@@ -98,8 +103,9 @@ namespace ECS.StreamableLoading.Textures
             /// Number added to the hash, to differentiate between incompatible serialize/deserialize types.
             /// E.g. after adding WrapMode and Filtering mode to meta data, previously downloaded textures could not be
             /// deserialized anymore.
+            /// Incremented to 2 to invalidate avatar texture cache after fixing cache key bug (issue #7443)
             /// </summary>
-            private const int ITERATION_NUMBER = 1;
+            private const int ITERATION_NUMBER = 2;
             public static readonly DiskHashCompute INSTANCE = new ();
 
             private DiskHashCompute() { }
@@ -112,6 +118,7 @@ namespace ECS.StreamableLoading.Textures
                 keyPayload.Put((int)asset.FilterMode);
                 keyPayload.Put(asset.IsVideoTexture);
                 keyPayload.Put(asset.VideoPlayerEntity.Id);
+                keyPayload.Put(asset.AvatarTextureUserId ?? string.Empty);
             }
         }
     }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/Tests/GetTextureIntentionShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/Tests/GetTextureIntentionShould.cs
@@ -1,0 +1,167 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace ECS.StreamableLoading.Textures.Tests
+{
+    [TestFixture]
+    public class GetTextureIntentionShould
+    {
+        [Test]
+        public void AvatarTextures_WithDifferentUserIds_AreNotEqual()
+        {
+            var intention1 = new GetTextureIntention(
+                userId: "user-123",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            var intention2 = new GetTextureIntention(
+                userId: "user-456",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            Assert.AreNotEqual(intention1, intention2);
+            Assert.IsFalse(intention1.Equals(intention2));
+        }
+
+        [Test]
+        public void AvatarTextures_WithSameUserId_AreEqual()
+        {
+            var intention1 = new GetTextureIntention(
+                userId: "user-123",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            var intention2 = new GetTextureIntention(
+                userId: "user-123",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            Assert.AreEqual(intention1, intention2);
+            Assert.IsTrue(intention1.Equals(intention2));
+        }
+
+        [Test]
+        public void AvatarTextures_WithDifferentUserIds_HaveDifferentHashCodes()
+        {
+            var intention1 = new GetTextureIntention(
+                userId: "user-123",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            var intention2 = new GetTextureIntention(
+                userId: "user-456",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            Assert.AreNotEqual(intention1.GetHashCode(), intention2.GetHashCode());
+        }
+
+        [Test]
+        public void AvatarTextures_WithSameUserId_HaveSameHashCodes()
+        {
+            var intention1 = new GetTextureIntention(
+                userId: "user-123",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            var intention2 = new GetTextureIntention(
+                userId: "user-123",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            Assert.AreEqual(intention1.GetHashCode(), intention2.GetHashCode());
+        }
+
+        [Test]
+        public void RegularTextures_WithSameUrl_AreEqual()
+        {
+            var intention1 = new GetTextureIntention(
+                url: "https://example.com/texture.png",
+                fileHash: "hash123",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            var intention2 = new GetTextureIntention(
+                url: "https://example.com/texture.png",
+                fileHash: "hash123",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            Assert.AreEqual(intention1, intention2);
+            Assert.AreEqual(intention1.GetHashCode(), intention2.GetHashCode());
+        }
+
+        [Test]
+        public void AvatarTexture_IsRecognizedAsAvatarTexture()
+        {
+            var intention = new GetTextureIntention(
+                userId: "user-123",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            Assert.IsTrue(intention.IsAvatarTexture);
+            Assert.AreEqual("user-123", intention.AvatarTextureUserId);
+        }
+
+        [Test]
+        public void RegularTexture_IsNotRecognizedAsAvatarTexture()
+        {
+            var intention = new GetTextureIntention(
+                url: "https://example.com/texture.png",
+                fileHash: "hash123",
+                TextureWrapMode.Clamp,
+                FilterMode.Bilinear,
+                TextureType.Albedo,
+                reportSource: "test",
+                attemptsCount: 1
+            );
+            
+            Assert.IsFalse(intention.IsAvatarTexture);
+            Assert.IsNull(intention.AvatarTextureUserId);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/Tests/GetTextureIntentionShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/Tests/GetTextureIntentionShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7c3e52fb91a4e2fa9d7f3c481892a4b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Fixes avatar thumbnail display bug where all players' avatars showed the same random face in production (issue #7443).

**Root Cause:** `GetTextureIntention` used an empty string as the cache key for ALL avatar textures, causing cache collisions. When multiple avatar textures were requested (e.g., leaderboard with many players), they all returned the same cached texture.

**Solution:** Use `AvatarTextureUserId` as the cache key for avatar textures, ensuring each user's avatar is cached separately.

## Changes

- Updated `cacheKey` property to use `AvatarTextureUserId` for avatar textures
- Updated `Equals()` method to compare `AvatarTextureUserId`
- Updated `GetHashCode()` to include `AvatarTextureUserId`  
- Updated `DiskHashCompute.FillPayload()` to include `AvatarTextureUserId`
- Incremented `ITERATION_NUMBER` from 1 to 2 to invalidate old incorrectly cached avatars
- Added comprehensive unit tests for avatar texture equality and hash code behavior

## Testing

### Unit Tests Added
- ✅ Avatar textures with different userIds are not equal
- ✅ Avatar textures with same userId are equal
- ✅ Avatar textures with different userIds have different hash codes
- ✅ Avatar textures with same userId have same hash codes
- ✅ Regular textures continue to work correctly
- ✅ Avatar texture detection works correctly

### CI Tests
All existing tests will run via Unity test runner in CI.

### Manual Testing
After deployment, verify in production:
1. Create scene with multiple player avatars (like Game Arena leaderboard)
2. Each player's correct avatar should display
3. Different users should see the same correct avatars

## Closes

https://github.com/decentraland/unity-explorer/issues/7443

---
🤖 Created via Slack with Claude
