### PR TITLE
style: increase resolution for the exit icon texture

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/Prefabs/Authentication.MainScreen.prefab
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/Prefabs/Authentication.MainScreen.prefab
@@ -768,7 +768,6 @@ MonoBehaviour:
   <raycaster>k__BackingField: {fileID: 8454101078806804241}
   <VersionText>k__BackingField: {fileID: 4613417570274952093}
   <CharacterPreviewView>k__BackingField: {fileID: 8185437588405162452}
-  <TransactionFeeConfirmationView>k__BackingField: {fileID: 1263697144875488291}
   <LoginSelectionAuthView>k__BackingField: {fileID: 3626083524348347871}
   <VerificationDappAuthView>k__BackingField: {fileID: 5988428590248281739}
   <VerificationOTPAuthView>k__BackingField: {fileID: 1435686278016238798}
@@ -1128,7 +1127,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -21, y: 0}
-  m_SizeDelta: {x: 22, y: 20}
+  m_SizeDelta: {x: 24, y: 24}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6217521105691194791
 CanvasRenderer:
@@ -1409,17 +1408,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 780e6ed0fdb34194c92f8e560963b8f9, type: 3}
---- !u!114 &1263697144875488291 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1567150198340539680, guid: 780e6ed0fdb34194c92f8e560963b8f9, type: 3}
-  m_PrefabInstance: {fileID: 303481800695464195}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0da9bb98e83027746b40c1f5f43ba19c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: AuthenticationScreenFlow::DCL.AuthenticationScreenFlow.TransactionFeeConfirmationView
 --- !u!224 &3992252487768445545 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3697872467015258986, guid: 780e6ed0fdb34194c92f8e560963b8f9, type: 3}

--- a/Explorer/Assets/DCL/UI/Sidebar/ProfileMenuView.prefab
+++ b/Explorer/Assets/DCL/UI/Sidebar/ProfileMenuView.prefab
@@ -2584,8 +2584,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 7.4000244, y: 0}
-  m_SizeDelta: {x: 20, y: 20}
+  m_AnchoredPosition: {x: 6, y: 0}
+  m_SizeDelta: {x: 22, y: 22}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &221841605973460720
 CanvasRenderer:
@@ -2755,7 +2755,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 7.4000244, y: 0}
+  m_AnchoredPosition: {x: 6, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &2973044070004701940

--- a/Explorer/Assets/Textures/Common/ExitIcn.png
+++ b/Explorer/Assets/Textures/Common/ExitIcn.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7a98fe83f250d46ce3fd566c408890017c4c9660776969a2cae21a026c65f34
-size 293
+oid sha256:37c21a39c77d3329cea3714fb959226207bbd0f7b61955a35bafae3cc6584658
+size 359

--- a/Explorer/Assets/Textures/Common/ExitIcn.png.meta
+++ b/Explorer/Assets/Textures/Common/ExitIcn.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 32
+    maxTextureSize: 64
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 0


### PR DESCRIPTION
## What does this PR change?
This PR updates the ExitIcon.png texture, since the icon currently looks blurry in production. With this update, it now looks crisp.

<img width="191" height="55" alt="Screenshot 2026-03-18 at 14 20 32" src="https://github.com/user-attachments/assets/1eaad309-32d8-4f1b-85ee-82421db6c5a3" />


### Test Steps
1. Launch the explorer.
2. Check that in the auth flow, the exit button's icon looks crips.
3. Sign In. Once in world, open your profile menu by clicking your profile snapshot in the sidebar. Validate that the icon to exit the app looks fine there too.