### PR TITLE
fix: avoid showing black event counter on no live events

### DIFF
--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarUI.prefab
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarUI.prefab
@@ -74,6 +74,7 @@ MonoBehaviour:
   <placesButton>k__BackingField: {fileID: 5769488305435868274}
   <eventsButton>k__BackingField: {fileID: 7889445956358821651}
   <liveEventsCounterText>k__BackingField: {fileID: 5871320542459693597}
+  <liveEventsCounterContainer>k__BackingField: {fileID: 5821736173644323423}
   <communitiesButton>k__BackingField: {fileID: 9067792495595083366}
   <mapButton>k__BackingField: {fileID: 8108662634941636583}
   <backpackButton>k__BackingField: {fileID: 7310006030576766240}
@@ -2587,6 +2588,11 @@ PrefabInstance:
 --- !u!224 &213922546199920864 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7344965737709528038, guid: a6d5885fdf7854743861ea324687f23f, type: 3}
+  m_PrefabInstance: {fileID: 7428280767322972934}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5821736173644323423 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4025224332538706265, guid: a6d5885fdf7854743861ea324687f23f, type: 3}
   m_PrefabInstance: {fileID: 7428280767322972934}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &5871320542459693597 stripped

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarView.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarView.cs
@@ -29,6 +29,7 @@ namespace DCL.UI.Sidebar
         [field: SerializeField] internal Button placesButton { get; private set; }
         [field: SerializeField] internal Button eventsButton { get; private set; }
         [field: SerializeField] internal TMP_Text liveEventsCounterText { get; private set; }
+        [field: SerializeField] internal GameObject liveEventsCounterContainer { get; private set; }
         [field: SerializeField] internal Button communitiesButton { get; private set; }
         [field: SerializeField] internal Button mapButton { get; private set; }
         [field: SerializeField] internal Button backpackButton { get; private set; }
@@ -98,7 +99,7 @@ namespace DCL.UI.Sidebar
         public void SetLiveEventsCounter(int count)
         {
             liveEventsCounterText.text = count.ToString();
-            liveEventsCounterText.transform.parent.gameObject.SetActive(count > 0);
+            liveEventsCounterContainer.SetActive(count > 0);
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7597 
Disables the correct gameobject when no events are live

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. Open app
2. Check the events panel on the side bar
3. Check that the notification circle is not appearing black, either hidden or appearing with the counter of live events

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
