### PR TITLE
chore: prevent merge without reducing total warnings

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -358,8 +358,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: prebuild
     timeout-minutes: 360
-    permissions:
-      variables: write  # needed to update the WARNINGS_BASELINE repository variable
     strategy:
       fail-fast: false
       matrix:
@@ -747,7 +745,7 @@ jobs:
         env:
           COUNT: ${{ steps.count_warnings.outputs.warning_count }}
           BASELINE: ${{ vars.WARNINGS_BASELINE }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_PAT }}
         run: |
           if [ -n "$BASELINE" ] && [ "$COUNT" -ge "$BASELINE" ]; then
             echo "No update: current count ($COUNT) is not less than existing baseline ($BASELINE)"


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Adds a ratchet-style compilation warning check to the existing Cloud Build workflow. A PR can only merge if it reduces the C# warning count below the current baseline. Every merge to dev that lowers the count automatically becomes the new baseline.

## How it works
Three steps are added to the build job (windows64 target only, since it's the same C# code):

  1. Count — greps the already-downloaded unity_cloud_log.log for *.cs(line,col): warning CSxxx lines. No second build is triggered.
  2. Enforce — on PRs, fails the job if count >= baseline. On dev pushes, reports the count informationally.
  3. Update baseline — on dev push (or manually via dispatch), calls gh variable set WARNINGS_BASELINE to lower the baseline. The baseline only ever goes down.

  The baseline is stored as the repository variable WARNINGS_BASELINE (Settings → Secrets and variables → Actions → Variables). No files are committed on merge.
