### PR TITLE
feat: disable user different account button for new users

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LobbyForExistingAccountAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LobbyForExistingAccountAuthState.cs
@@ -73,7 +73,6 @@ namespace DCL.AuthenticationScreenFlow
 
             view.Show(IsNewUser() ? profile.Name : "back " + profile.Name);
 
-            if (IsNewUser() && !payload.isCached)
             view.DiffAccountButton.gameObject.SetActive(true);
             if (IsNewUser() && !payload.isCached)
                 view.DiffAccountButton.gameObject.SetActive(false);


### PR DESCRIPTION
# Pull Request Description

This PR disables the "USE A DIFFERENT ACCOUNT" button on the authentication screen for new users.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] [MetaForge](https://github.com/decentraland/MetaForge) installed

### Test Steps
1. Create a new user with `metaforge account create` - this sets up the auto-login token
2. Start explorer with `metaforge explorer run 7774`
3. Verify that the button is not there
4. Enter world
5. Exit Explorer
6. Start Explorer again - button should now be visible.

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
