### PR TITLE
fix: use correct image url for nft type result

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/NFTShapes/LoadNFTTypeSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/NFTShapes/LoadNFTTypeSystem.cs
@@ -44,7 +44,7 @@ namespace ECS.StreamableLoading.NFTShapes
             if (!ktxEnabled && contentInfo is { Type: WebContentInfo.ContentType.Image, SizeInBytes: > MAX_PREVIEW_SIZE })
                 return new StreamableLoadingResult<NftTypeResult>(GetReportCategory(), new Exception("Image size is too big"));
 
-            return new StreamableLoadingResult<NftTypeResult>(new NftTypeResult(contentInfo.Type, URLAddress.FromString(convertUrl)));
+            return new StreamableLoadingResult<NftTypeResult>(new NftTypeResult(contentInfo.Type, URLAddress.FromString(imageUrl)));
         }
 
         private async UniTask<string> ImageUrlAsync(CommonArguments commonArguments, CancellationToken ct)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fixes NFT image loading using the wrong URL. The `LoadNFTTypeSystem` was passing `convertUrl` (the MetaMorph URL) into the `NftTypeResult` instead of the original `imageUrl`. This caused a double conversion — the image URL was being morphed through the converter twice, leading to broken NFT image display.

This likely worked until we switched to the CDN setup, when it started throwing a 525 error.

The fix passes the correct `imageUrl` to `NftTypeResult`.

## Test Instructions

### Prerequisites
- [ ] Access to a scene with NFT shapes (NFT picture frames)

### Test Steps
1. Enter a scene containing NFT picture frames
2. Observe that NFT images load and display correctly
3. Verify images are not broken or distorted from double URL conversion

### Additional Testing Notes
- Test with both KTX-enabled and KTX-disabled configurations
- Verify large images (>MAX_PREVIEW_SIZE) still correctly return the size error

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.