### PR TITLE
fix: avoid skipping all online community users at channel creation

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/CommunityUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/CommunityUserStateService.cs
@@ -103,7 +103,7 @@ namespace DCL.Chat.ChatServices
 
             foreach (ICommunityMemberData memberData in response.data.results)
             {
-                if (web3IdentityCache.Identity?.Address == localPlayerAddress)
+                if (memberData.Address == localPlayerAddress)
                     continue;
 
                 if (userBlockingCache.Configured && userBlockingCache.StrictObject.UserIsBlocked(memberData.Address))


### PR DESCRIPTION
# Pull Request Description
Fixes #7681 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Caused by an oversight, we were skipping all online community users when the chat channel was created. Making the client only rely on connection/disconnection events -> most users appeared as offline.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Verify that community online users are correctly reported in the chat channel (both messages online status and participant counter)
2. Verify with another user that connecting and disconnecting increases/lowers the counter (both users must be members of said community)


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
