### PR TITLE
fix: safely destroy ghost material on cleanup

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarGhostCleanupSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarGhostCleanupSystem.cs
@@ -9,6 +9,7 @@ using ECS.Abstract;
 using ECS.Groups;
 using ECS.LifeCycle.Components;
 using UnityEngine;
+using Utility;
 
 namespace DCL.AvatarRendering.AvatarShape
 {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Safely cleanup ghosts on exit. Because we dont control how Unity destroys GO on exit, we may have a NRE

## Test Instructions


### Test Steps
1. Open the app on a palce with lots of avatars, then close it. You shouldnt get crashes, or NRE int he Player.log




## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
