### PR TITLE
fix: sentry UNITY-EXPLORER-KZS

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserController.cs
@@ -447,8 +447,8 @@ namespace DCL.Communities.CommunitiesBrowser
 
             async UniTaskVoid RefreshInvitesCounterAsync(CancellationToken ct)
             {
-                int invitesCount = await LoadInvitesAsync(updateInvitesGrid: false, updateInvitesCounterCts.Token);
-                int receivedRequestsCount = await LoadRequestsReceivedAsync(updateRequestsReceivedGrid: false, updateInvitesCounterCts.Token);
+                int invitesCount = await LoadInvitesAsync(updateInvitesGrid: false, ct);
+                int receivedRequestsCount = await LoadRequestsReceivedAsync(updateRequestsReceivedGrid: false, ct);
                 view.InvitesAndRequestsView.SetInvitesAndRequestsCounter(invitesCount + receivedRequestsCount);
             }
         }


### PR DESCRIPTION
## What does this PR change?

Fixes an `ObjectDisposedException` crash in `CommunitiesBrowserController.RefreshInvitesAndRequestsCounter`.

The local async function `RefreshInvitesCounterAsync` accepted a `CancellationToken ct` parameter but ignored it, instead re-reading `updateInvitesCounterCts.Token` directly from the captured field on every access. This created a race condition: if `RefreshInvitesAndRequestsCounter` was called a third time while the first async task was suspended between its two awaits, `SafeRestart` would cancel and dispose the CTS the field pointed to. When the first task resumed and attempted to read `.Token` on the now-disposed instance, it threw `ObjectDisposedException`.

The fix is to use the `ct` parameter throughout the local function body instead of re-reading the field. The token is safely snapshotted at call time before the field can be overwritten, and `SafeRestart`'s `.Cancel()` call ensures the token transitions to a cancelled state before disposal — so the awaits throw the expected `OperationCanceledException` rather than crashing.

## Test Instructions

### Prerequisites

- Have an account that has pending community invites or join requests

### Test Steps

1. Open the Communities browser
2. Rapidly open and close the invites & requests panel multiple times in quick succession to trigger concurrent refreshes
3. Observe the logs — no `ObjectDisposedException` should appear
4. Verify the invites/requests counter displays the correct value after the panel settles