### PR TITLE
chore: add workflow_dispatch to PR workflows for manual testing

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,6 +1,7 @@
 name: 'Auto Assign Reviewers'
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, ready_for_review]
 

--- a/.github/workflows/claude-pr-review-require.yml
+++ b/.github/workflows/claude-pr-review-require.yml
@@ -1,5 +1,6 @@
 name: Require Claude Review
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,5 +1,6 @@
 name: Claude Review
 on:
+  workflow_dispatch:
   issue_comment:
     types: [created]
   pull_request_review_comment:

--- a/.github/workflows/enforce-group-approvals.yml
+++ b/.github/workflows/enforce-group-approvals.yml
@@ -1,6 +1,7 @@
 name: Enforce QA and DEV Approvals
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [dev]
     types:


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Adds `workflow_dispatch` trigger to four PR-related workflow files so they can be manually triggered from the Actions tab for testing purposes.

**Files changed:**
- `claude-pr-review.yml`
- `claude-pr-review-require.yml`
- `enforce-group-approvals.yml`
- `auto-assign.yml`

This is a prerequisite for testing #7856 (Claude auto-approve for fix/chore PRs). Once that PR is validated, the `workflow_dispatch` triggers can be kept or removed.

## Test Instructions

### Prerequisites
- [ ] Access to the repository's Actions tab

### Test Steps
1. Merge this PR to dev
2. Go to the Actions tab and verify all four workflows show a "Run workflow" button
3. Use it to manually trigger the workflows against the `chore/claude-auto-approve-fix-chore-prs` branch

### Additional Testing Notes
- No functional changes — only adds a trigger type to each workflow
- Existing PR-based triggers are unchanged

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.