### PR TITLE
fix: avoid opening passport for users that no longer exist in screenshot participants

### DIFF
--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -915,7 +915,7 @@ namespace DCL.Passport
 
             if (targetProfile == null)
             {
-                ReportHub.Log(LogType.Warning, new ReportData(ReportCategory.FRIENDS), $"Failed to show context menu button for user {inputData.UserId}. Profile is null.");
+                ReportHub.Log(LogType.Error, new ReportData(ReportCategory.FRIENDS), $"Failed to show context menu button for user {inputData.UserId}. Profile is null.");
                 return;
             }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7923 
Avoid opening passport for users that no longer exist in screenshot participants

## Test Instructions

### Test Steps
1. Open gallery
2. Go to old screenshots
3. Verify that the participants are correctly shown
4. Verify that if a participant appears with the empty picture and no arrow for wearables like the below screenshot (for user nick#52ee), clicking on them doesn't open the passport

<img width="1509" height="835" alt="Screenshot 2026-03-30 at 10 34 49" src="https://github.com/user-attachments/assets/2cbca541-38d6-45ee-8edf-bf4197bb343d" />

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
