### PR TITLE
fix: wrong min max parcels when no parcels

### DIFF
--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -226,7 +226,8 @@ namespace DCL.Landscape
             int2 maxParcel, int padding)
         {
             int absMax = cmax(abs(int4(minParcel, maxParcel)));
-            int textureSize = ceilpow2((absMax * 2) + 2);
+            long requiredSize = ((long)absMax * 2) + 2;
+            int textureSize = ceilpow2((int)min(requiredSize, TERRAIN_SIZE_LIMIT));
             int textureHalfSize = textureSize / 2;
 
             var occupancyMap = new Texture2D(textureSize, textureSize, TextureFormat.R8, false, true);

--- a/Explorer/Assets/DCL/Landscape/Worlds/TerrainModel.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/TerrainModel.cs
@@ -136,6 +136,9 @@ namespace DCL.Landscape
 
         private static (int2 min,int2 max) CalculateMinMaxParcels(NativeHashSet<int2> ownedParcels)
         {
+            if (ownedParcels.IsEmpty)
+                return (int2.zero, int2.zero);
+
             var minParcel = new int2(int.MaxValue, int.MaxValue);
             var maxParcel = new int2(int.MinValue, int.MinValue);
 


### PR DESCRIPTION
# Pull Request Description
This PR fixes both:
- min and max parcels returned with max and min int values respectively when ownedParcels is empty (now both 0,0)
- overflow in texture size calculation when creating occupancy map due to possibly very big absolute values for min / max parcels (now calculation is done with long type)

### Test Steps
1. Run a local scene with base and parcels configured like these in `scene.json`:
`
"scene": {
    "base": "0,0",
    "parcels": [
      "0,0"
    ]
  },
`
2. Launch the build with `--position 88,-13` to override starting position
3. Verify terrain loads

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
