### PR TITLE
fix: avoid picking microphone logic when no microphone are connected

### DIFF
--- a/Explorer/Assets/DCL/Settings/ModuleControllers/InputDeviceController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/InputDeviceController.cs
@@ -95,6 +95,9 @@ namespace DCL.Settings.ModuleControllers
 
         private void SetSelection(string[] devices)
         {
+            if (devices.Length == 0)
+                return;
+
             if (DCLPlayerPrefs.HasKey(DCLPrefKeys.SETTINGS_MICROPHONE_DEVICE_NAME))
             {
                 string microphoneName = DCLPlayerPrefs.GetString(DCLPrefKeys.SETTINGS_MICROPHONE_DEVICE_NAME);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7622 
If no microphones are plugged in, avoid the logic for picking a microphone to avoid the https://decentraland.sentry.io/issues/7207908873/?project=4506075736047616 issue

## Test Instructions

### Test Steps
1. Start a voice stream
2. Verify that the speaker can be heard when unmuted

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
