### PR TITLE
fix: allow force-build label to trigger builds on draft PR synchronize

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -157,7 +157,11 @@ jobs:
               (github.event.action == 'opened' ||
                github.event.action == 'reopened' ||
                github.event.action == 'synchronize') &&
-              !github.event.pull_request.draft
+              (
+                !github.event.pull_request.draft ||
+                contains(github.event.pull_request.labels.*.name, 'force-build') ||
+                contains(github.event.pull_request.labels.*.name, 'clean-build')
+              )
             ) ||
             github.event.action == 'ready_for_review' ||
             (


### PR DESCRIPTION
## Summary
- When a draft PR has the `force-build` or `clean-build` label and new commits are pushed (`synchronize` event), the Unity Cloud Build workflow was skipped because the `prebuild` job's `if` condition required `!github.event.pull_request.draft` for `synchronize` events
- The fix allows `synchronize` events to proceed when the PR carries a `force-build` or `clean-build` label, even if it's still a draft

## Test plan
- [ ] Create a draft PR with no labels → push a commit → build should **not** trigger
- [ ] Add `force-build` label to the draft PR → build should trigger via `labeled` event
- [ ] Push a new commit to the draft PR (with `force-build` label still on) → build should now trigger via `synchronize` event
- [ ] Mark PR as ready for review → build should trigger via `ready_for_review` event