### PR TITLE
fix: avoid disposed ct exception on exit in loading screen

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
@@ -12,6 +12,7 @@ namespace MVC
         private readonly Dictionary<Type, IController> controllers;
         private readonly IWindowsStackManager windowsStackManager;
         private readonly CancellationTokenSource destructionCancellationTokenSource;
+        private readonly CancellationToken destructionToken;
         private readonly IPopupCloserView popupCloser;
         public IReadOnlyDictionary<Type, IController> Controllers => controllers;
 
@@ -25,6 +26,7 @@ namespace MVC
         {
             this.windowsStackManager = windowsStackManager;
             this.destructionCancellationTokenSource = destructionCancellationTokenSource;
+            destructionToken = destructionCancellationTokenSource.Token;
 
             controllers = new Dictionary<Type, IController>(200);
             popupCloser = popupCloserView;
@@ -35,6 +37,7 @@ namespace MVC
             foreach (IController controllersValue in controllers.Values)
                 controllersValue.Dispose();
 
+            destructionCancellationTokenSource?.Cancel();
             destructionCancellationTokenSource?.Dispose();
             windowsStackManager.Dispose();
         }
@@ -74,8 +77,8 @@ namespace MVC
                 return;
 
             ct = ct.Equals(default(CancellationToken))
-                ? destructionCancellationTokenSource.Token
-                : CancellationTokenSource.CreateLinkedTokenSource(ct, destructionCancellationTokenSource.Token).Token;
+                ? destructionToken
+                : CancellationTokenSource.CreateLinkedTokenSource(ct, destructionToken).Token;
 
             try
             {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7816 
This PR fixes
System.ObjectDisposedException
[Events (total)](https://decentraland.sentry.io/issues/7364595635/events/?project=4506075736047616&query=is%3Aunresolved&referrer=issue-stream&sort=user)
[Users (90d)](https://decentraland.sentry.io/issues/7364595635/distributions/user/?project=4506075736047616&query=is%3Aunresolved&referrer=issue-stream&sort=user)
Level: Error
The CancellationTokenSource has been disposed.

By avoiding accessing a dispose token when exiting from the loading screen.
This was happening due to a race condition between disposal and async show of a controller, accessing internally a disposed token.

## Test Instructions

### Test Steps
1. Test the loading screen that it works as always, no changes should be noticed

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
