### PR TITLE
fix: ensure release PR labels survive API errors

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -28,9 +28,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr create \
-            --base main \
-            --head $BRANCH_NAME \
-            --title "release: $RELEASE_DATE" \
-            --body ":rocket: Automated release PR" \
-            --label release,auto-pr
+          # Create PR if it doesn't already exist
+          if ! gh pr view "$BRANCH_NAME" --json number &>/dev/null; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH_NAME" \
+              --title "release: $RELEASE_DATE" \
+              --body ":rocket: Automated release PR"
+          fi
+
+          # Always ensure labels are applied (handles 502 / retry scenarios)
+          gh pr edit "$BRANCH_NAME" --add-label "release,auto-pr"


### PR DESCRIPTION
## Summary
- The release workflow's `gh pr create` failed with a 502 Bad Gateway on March 30, creating PR #7945 without labels (`release`, `auto-pr`)
- Split label application into a separate `gh pr edit` step that runs after PR creation, so labels are always applied even on retries or transient API errors
- Also handles the case where the PR already exists (re-run scenario) by checking first with `gh pr view`

## Test plan
- [ ] Run the workflow — PR should be created with both `release` and `auto-pr` labels
- [ ] Re-run the workflow for the same date — should not fail, and labels should still be present