### PR TITLE
fix: allow workflow-only PRs to merge without blocking on build checks

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -172,6 +172,7 @@ jobs:
         )
       )
     outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
       commit_sha: ${{ steps.get_commit_sha.outputs.commit_sha }}
       options: ${{ steps.get_options.outputs.options }}
       version: ${{ github.event.inputs.version || inputs.version || steps.get_version.outputs.full_version }}
@@ -200,45 +201,72 @@ jobs:
         run: |
           set -euo pipefail
 
+          should_build=false
+
           # Non-PR triggers that reached prebuild => build
           echo "[check non-PR] event_name='${{ github.event_name }}' != 'pull_request'"
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "[non-PR] TRUE -> should_build=true -> exiting 0"
-            exit 0
+            echo "[non-PR] TRUE -> should_build=true"
+            should_build=true
           fi
 
-          labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
-          echo "labels='$labels'"
+          if [ "$should_build" = "false" ]; then
+            labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
+            echo "labels='$labels'"
 
-          has_override=false
-          echo "[check override] searching for 'force-build|clean-build' in labels"
-          echo "$labels" | grep -qwE 'force-build|clean-build' && has_override=true
+            has_override=false
+            echo "[check override] searching for 'force-build|clean-build' in labels"
+            echo "$labels" | grep -qwE 'force-build|clean-build' && has_override=true
 
-          echo "has_override='$has_override'"
-          if [ "$has_override" = "true" ]; then
-            echo "[override] TRUE -> should_build=true -> exiting 0"
-            exit 0
+            echo "has_override='$has_override'"
+            if [ "$has_override" = "true" ]; then
+              echo "[override] TRUE -> should_build=true"
+              should_build=true
+            fi
           fi
 
-          # If still draft and no override => do not build
-          is_draft="${{ github.event.pull_request.draft }}"
-          echo "[check draft] is_draft='$is_draft'"
-          if [ "$is_draft" = "true" ]; then
-            echo "[draft] TRUE -> should_build=false -> exiting 1"
-            exit 1
+          if [ "$should_build" = "false" ]; then
+            # If still draft and no override => do not build
+            is_draft="${{ github.event.pull_request.draft }}"
+            echo "[check draft] is_draft='$is_draft'"
+            if [ "$is_draft" = "true" ]; then
+              echo "[draft] TRUE -> should_build=false"
+            else
+              explorer_changed="${{ steps.changed_explorer.outputs.any_changed }}"
+              echo "[check explorer_changed] explorer_changed='$explorer_changed'"
+              if [ "$explorer_changed" = "true" ]; then
+                echo "[explorer_changed] TRUE -> should_build=true"
+                should_build=true
+              else
+                echo "[explorer_changed] FALSE -> should_build=false"
+              fi
+            fi
           fi
 
-          explorer_changed="${{ steps.changed_explorer.outputs.any_changed }}"
-          echo "[check explorer_changed] explorer_changed='$explorer_changed'"
-          if [ "$explorer_changed" = "true" ]; then
-            echo "[explorer_changed] TRUE -> should_build=true -> exiting 0"
-            exit 0
-          fi
+          echo "should_build=$should_build" >> "$GITHUB_OUTPUT"
+          echo "Final decision: should_build=$should_build"
 
-          echo "[explorer_changed] FALSE -> should_build=false -> exiting 1"
-          exit 1
+      - name: Skip build checks
+        if: steps.decide.outputs.should_build == 'false' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            const checks = ['Build (macos)', 'Build (windows64)'];
+            for (const check of checks) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'success',
+                context: check,
+                description: 'Skipped — no Explorer/ changes detected'
+              });
+            }
+            console.log(`Posted success statuses for: ${checks.join(', ')}`);
 
       - name: Get commit SHA
+        if: steps.decide.outputs.should_build == 'true'
         id: get_commit_sha
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
@@ -248,6 +276,7 @@ jobs:
           fi
 
       - name: Debug Commit SHA
+        if: steps.decide.outputs.should_build == 'true'
         run: |
           echo "Ref from Pull Request: ${{ github.event.pull_request.head.sha }}"
           echo "Full Commit from git rev-parse: $(git rev-parse $GITHUB_SHA)"
@@ -255,12 +284,13 @@ jobs:
 
       - name: Get version
         id: get_version
-        if: ${{ github.event.inputs.version == '' && inputs.version == '' }}
+        if: steps.decide.outputs.should_build == 'true' && github.event.inputs.version == '' && inputs.version == ''
         uses: ./.github/actions/version
         with:
           commit_sha: ${{ steps.get_commit_sha.outputs.commit_sha }}
 
       - name: Get Sentry parameters
+        if: steps.decide.outputs.should_build == 'true'
         id: get_sentry
         run: |
           #!/bin/bash
@@ -281,6 +311,7 @@ jobs:
           fi
 
       - name: Set default values
+        if: steps.decide.outputs.should_build == 'true'
         id: set_defaults
         run: |
           # Clean build logic
@@ -320,6 +351,7 @@ jobs:
           echo "install_source=${install_source}" >> $GITHUB_OUTPUT
 
       - name: Get BuildOptions
+        if: steps.decide.outputs.should_build == 'true'
         id: get_options
         run: |
           #!/bin/bash
@@ -356,6 +388,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: prebuild
+    if: needs.prebuild.outputs.should_build == 'true'
     timeout-minutes: 360
     strategy:
       fail-fast: false

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -221,6 +221,36 @@ jobs:
               description
             });
 
+      - name: Re-run failed enforce-approvals check
+        if: steps.check-type.outputs.is-auto-review == 'true' && always()
+        env:
+          GH_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
+        run: |
+          SHA="${{ github.event.pull_request.head.sha }}"
+          echo "Searching for failed enforce-approvals run for SHA $SHA..."
+
+          WORKFLOW_RUN_ID=$(gh run list \
+            --workflow="Enforce QA and DEV Approvals" \
+            --limit 100 \
+            --repo "${{ github.repository }}" \
+            --json databaseId,event,headSha,conclusion \
+            | jq -r --arg SHA "$SHA" '
+                .[] |
+                select(.event == "pull_request") |
+                select(.headSha == $SHA) |
+                select(.conclusion == "failure") |
+                .databaseId
+            ' | head -n 1)
+
+          if [ -z "$WORKFLOW_RUN_ID" ]; then
+            echo "No failed enforce-approvals run found for this commit."
+            exit 0
+          fi
+
+          echo "Re-running failed enforce-approvals workflow: $WORKFLOW_RUN_ID"
+          gh run rerun "$WORKFLOW_RUN_ID" --repo "${{ github.repository }}"
+          echo "Re-run triggered successfully."
+
   review:
     if: |
       github.event.issue.pull_request != null &&


### PR DESCRIPTION
## Summary
- **Build workflow**: Prebuild now uses an output flag (`should_build`) instead of `exit 1` when no `Explorer/` files are changed. When skipping the build, it posts success commit statuses for `Build (macos)` and `Build (windows64)` so the required checks are satisfied without running actual builds. Build checks remain mandatory for PRs that touch runtime code.
- **Claude review workflow**: After auto-approving a PR, the workflow now re-runs any failed `enforce-approvals` check using `ORG_ACCESS_TOKEN`. This is needed because events from `GITHUB_TOKEN` don't trigger other workflows, so the `enforce-group-approvals` workflow never re-ran after Claude added labels/approvals.

## Context
PR #7963 (workflow-only change) was blocked from merging because:
1. `Build (macos/windows64)` were skipped (no Explorer/ changes) but are required checks
2. `enforce-approvals` failed before Claude finished reviewing and was never re-triggered

## Test plan
- [ ] Push a workflow-only PR → Prebuild should succeed, Build checks should show "Skipped — no Explorer/ changes detected" as success
- [ ] Push a PR with Explorer/ changes → Build should run as normal
- [ ] Claude auto-review should re-run failed enforce-approvals after approval