### PR TITLE
fix: skip build and test checks for workflow-only PRs

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -246,13 +246,18 @@ jobs:
           echo "should_build=$should_build" >> "$GITHUB_OUTPUT"
           echo "Final decision: should_build=$should_build"
 
-      - name: Skip build checks
+      - name: Skip build and test checks
         if: steps.decide.outputs.should_build == 'false' && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
             const sha = context.payload.pull_request.head.sha;
-            const checks = ['Build (macos)', 'Build (windows64)'];
+            const checks = [
+              'Build (macos)',
+              'Build (windows64)',
+              'Test (editmode)',
+              'Test (playmode)'
+            ];
             for (const check of checks) {
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -738,3 +738,4 @@ jobs:
           ORG_ID: ${{ secrets.UNITY_CLOUD_ORG_ID }}
           PROJECT_ID: ${{ secrets.UNITY_CLOUD_PROJECT_ID }}
         run: python -u scripts/cloudbuild/build.py --cancel
+# Test change

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -34,9 +34,59 @@ jobs:
           fi
           echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
-  comment-success:
+  check-build-ran:
     needs: pre-validation
-    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != ''
+    if: needs.pre-validation.outputs.pr-number != ''
+    runs-on: ubuntu-latest
+    outputs:
+      build-ran: ${{ steps.check.outputs.build-ran }}
+    steps:
+      - name: Check if build jobs actually ran
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          # Check if any build artifacts exist (they only exist when Build jobs ran)
+          ARTIFACT_COUNT=$(gh api "/repos/$OWNER/$REPO/actions/runs/$RUN_ID/artifacts" \
+            --jq '[.artifacts[] | select(.name | startswith("Decentraland_"))] | length')
+          echo "Build artifact count: $ARTIFACT_COUNT"
+          if [ "$ARTIFACT_COUNT" -gt 0 ]; then
+            echo "build-ran=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build-ran=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  comment-skipped:
+    needs: [pre-validation, check-build-ran]
+    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.build-ran == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: find-comment
+        with:
+          issue-number: ${{ needs.pre-validation.outputs.pr-number }}
+          comment-author: 'github-actions[bot]'
+
+      - name: Post skipped comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ needs.pre-validation.outputs.pr-number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |-
+            ![badge]  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">
+
+            Build skipped — no changes detected under `Explorer/`.
+
+            [badge]: https://img.shields.io/badge/Build-Skipped-yellow?logo=github&style=for-the-badge
+
+  comment-success:
+    needs: [pre-validation, check-build-ran]
+    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.build-ran == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Get Artifact and Pull request info
@@ -204,8 +254,8 @@ jobs:
             }
 
   comment-failed:
-    needs: pre-validation
-    if: github.event.workflow_run.conclusion == 'failure' && needs.pre-validation.outputs.pr-number != ''
+    needs: [pre-validation, check-build-ran]
+    if: github.event.workflow_run.conclusion == 'failure' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.build-ran == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -246,6 +246,7 @@ jobs:
           token: ${{ secrets.PERFORMANCE_TESTING_PAT }}
           client-payload: |-
             {
+              "run_name": "${{ github.event.workflow_run.display_title }}",
               "pr_number": "${{ needs.pre-validation.outputs.pr-number }}",
               "win_change_build_url": "${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}/${{ env.ARTIFACT_S3_DESTINATION_PATH }}/Decentraland_windows64.zip",
               "win_base_build_url": "${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}/@dcl/unity-explorer/releases/${{ env.RELEASE_TAG }}/Decentraland_windows64.zip",


### PR DESCRIPTION
## Summary
- When a PR only changes files outside `Explorer/` (e.g., `.github/` workflows, scripts, docs), the build and test checks are no longer needed but were blocking merges as required status checks
- Prebuild now posts success commit statuses for `Build (macos)`, `Build (windows64)`, `Test (editmode)`, and `Test (playmode)` when no `Explorer/` changes are detected, satisfying the required checks without running actual builds or tests
- The PR comment workflow now shows a "Build Skipped" message instead of the misleading "Windows and Mac build successful" when builds didn't run
- Restored accidentally removed `run_name` field in the performance test dispatch payload

## Test plan
- [ ] Push a workflow-only PR → all four required checks should show success with "Skipped — no Explorer/ changes detected"
- [ ] PR comment should say "Build skipped — no changes detected under Explorer/"
- [ ] Push a PR with Explorer/ changes → builds and tests run as normal, comment shows artifact links