### PR TITLE
fix: add -- prefix to skip-version-check arg in Epic upload

### DIFF
--- a/.github/workflows/upload-build-epic-store.yml
+++ b/.github/workflows/upload-build-epic-store.yml
@@ -140,7 +140,7 @@ jobs:
         -CloudDir="$env:RUNNER_TEMP\BuildPatchTool\CloudDir_Windows" `
         -BuildVersion="${{ steps.get_release.outputs.version }}-win" `
         -AppLaunch="Decentraland.exe" `
-        -AppArgs="skip-version-check"
+        -AppArgs="--skip-version-check"
 
     - name: Upload macOS artifact
       if: steps.platforms.outputs.build_mac == 'True'
@@ -156,7 +156,7 @@ jobs:
         -CloudDir="$env:RUNNER_TEMP\BuildPatchTool\CloudDir_Mac" `
         -BuildVersion="${{ steps.get_release.outputs.version }}-mac" `
         -AppLaunch="Decentraland.app/Contents/MacOS/Explorer" `
-        -AppArgs="skip-version-check" `
+        -AppArgs="--skip-version-check" `
         -Platform="Mac"
 
     - name: Post-upload instructions


### PR DESCRIPTION
## Summary
- The Epic Store upload workflow was passing `skip-version-check` without the `--` prefix
- The app's argument parser (`ApplicationParametersParser`) requires args to start with `--` to be recognized as flags
- Without the prefix, `HasFlag("skip-version-check")` returned false and the version check popup still appeared for Epic users

## Test plan
- [ ] Run the Epic upload workflow → verify the uploaded build no longer shows the version check popup on launch