### PR TITLE
fix: profile name change and segment fixes

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/DiagnosticInfoUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/DiagnosticInfoUtils.cs
@@ -57,6 +57,7 @@ namespace DCL.Diagnostics
                 Screen.currentResolution.height,
                 Screen.currentResolution.refreshRateRatio
             );
+            stringBuilder.AppendFormat("Window Mode: {0}\n", Screen.fullScreenMode.ToString());
             AppendFooter(stringBuilder);
 
 

--- a/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
@@ -202,6 +202,7 @@ namespace DCL.UI.ProfileNames
                     // which would cause UpdateProfileAsync to see an identical "previous" snapshot
                     Profile newProfile = new ProfileBuilder().From(profile).Build();
                     newProfile.Name = config.nameInputField.Text;
+                    newProfile.ClaimedNameColor = null;
                     newProfile.HasClaimedName = false;
 
                     try

--- a/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
@@ -198,12 +198,15 @@ namespace DCL.UI.ProfileNames
 
                 if (profile != null)
                 {
-                    profile.Name = config.nameInputField.Text;
-                    profile.HasClaimedName = false;
+                    // Create a copy to avoid mutating the cached profile directly,
+                    // which would cause UpdateProfileAsync to see an identical "previous" snapshot
+                    Profile newProfile = new ProfileBuilder().From(profile).Build();
+                    newProfile.Name = config.nameInputField.Text;
+                    newProfile.HasClaimedName = false;
 
                     try
                     {
-                        Profile? updatedProfile = await selfProfile.UpdateProfileAsync(profile, ct);
+                        Profile? updatedProfile = await selfProfile.UpdateProfileAsync(newProfile, ct);
                         NameChanged?.Invoke();
 
                         if (updatedProfile != null)
@@ -235,12 +238,15 @@ namespace DCL.UI.ProfileNames
 
                 if (profile != null)
                 {
-                    profile.Name = config.claimedNameDropdown.options[config.claimedNameDropdown.value].text;
-                    profile.HasClaimedName = true;
+                    // Create a copy to avoid mutating the cached profile directly,
+                    // which would cause UpdateProfileAsync to see an identical "previous" snapshot
+                    Profile newProfile = new ProfileBuilder().From(profile).Build();
+                    newProfile.Name = config.claimedNameDropdown.options[config.claimedNameDropdown.value].text;
+                    newProfile.HasClaimedName = true;
 
                     try
                     {
-                        Profile? updatedProfile = await selfProfile.UpdateProfileAsync(profile, ct);
+                        Profile? updatedProfile = await selfProfile.UpdateProfileAsync(newProfile, ct);
                         NameChanged?.Invoke();
 
                         if (updatedProfile != null)

--- a/Explorer/Assets/Plugins/NativeWindowManager/DCL.NativeWindowManager.asmdef
+++ b/Explorer/Assets/Plugins/NativeWindowManager/DCL.NativeWindowManager.asmdef
@@ -2,7 +2,8 @@
     "name": "DCL.NativeWindowManager",
     "rootNamespace": "",
     "references": [
-        "GUID:8614faad1014549c88b57654b0fb41bd"
+        "GUID:8614faad1014549c88b57654b0fb41bd",
+        "GUID:fa7b3fdbb04d67549916da7bd2af58ab"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/Plugins/NativeWindowManager/NativeWindowManager.cs
+++ b/Explorer/Assets/Plugins/NativeWindowManager/NativeWindowManager.cs
@@ -1,3 +1,4 @@
+using DCL.Diagnostics;
 using DCL.Prefs;
 using System;
 using System.Collections.Generic;
@@ -10,6 +11,8 @@ namespace Plugins.NativeWindowManager
     /// Handles switching between fullscreen and windowed mode,
     /// and changing resolutions.
     /// </summary>
+
+    [LogCategory(ReportCategory.ENGINE)]
     public static class NativeWindowManager
     {
         private const float WINDOWED_RESOLUTION_RESIZE_COEFFICIENT = .75f;
@@ -47,7 +50,7 @@ namespace Plugins.NativeWindowManager
             set
             {
                 if (Screen.fullScreenMode == FullScreenMode.Windowed)
-                    throw new NotSupportedException("Trying to set fullscreen resolution while in windowed mode.");
+                    ReportHub.LogWarning(ReportCategory.ENGINE, "Trying to set fullscreen resolution while in windowed mode.");
 
                 DCLPlayerPrefs.SetVector2Int(DCLPrefKeys.PS_RESOLUTION, value);
                 Screen.SetResolution(value.x, value.y, FullScreenMode.FullScreenWindow);

--- a/Explorer/Assets/Plugins/RustSegment/.native/Cargo.toml
+++ b/Explorer/Assets/Plugins/RustSegment/.native/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 lazy_static = "1.5.0"
-segment = { git = "https://github.com/decentraland/segment", branch = "main", default-features = false, features = ["rustls-tls"] }
+segment = { git = "https://github.com/decentraland/segment", rev = "fbb7ed5cbb3f3ea8b4f2d02a41aa29a2b2a86e2b", default-features = false, features = ["rustls-tls"] }
 serde = "1.0.210"
 serde_json = "1.0.128"
 tokio = { version = "1.40.0", features = ["full", "parking_lot"] }

--- a/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/Libraries/Windows/segment-server.dll
+++ b/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/Libraries/Windows/segment-server.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:adabf8d92ed161df8a2ac0ba5cd378c97a86231839da9c981c3b04348fe2e68f
-size 4688384
+oid sha256:2c63e8d38e539667c8ae31689adaf4d367b60bf5efe1031cc69d90ab3b7a4e1e
+size 4594176

--- a/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
+++ b/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
@@ -62,7 +62,14 @@ namespace Plugins.RustSegment.SegmentServerWrap
 
             this.anonId = anonId ?? SystemInfo.deviceUniqueIdentifier!;
 
-            string path = Path.Combine(Application.persistentDataPath!, "analytics_queue.sqlite3");
+            // Drop legacy version if exists
+            string legacyPath = Path.Combine(Application.persistentDataPath!, "analytics_queue.sqlite3");
+            if (File.Exists(legacyPath))
+            {
+                File.Delete(legacyPath);
+            }
+
+            string path = Path.Combine(Application.persistentDataPath!, "analytics_queue_v1.sqlite3");
             const int DEFAULT_LIMIT = 500;
             using var mQueuePath = new MarshaledString(path);
             using var mWriterKey = new MarshaledString(writerKey);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

The hotfix contains fixes for three issues:

* #7992 - We copy the profile before updating it, so we are not modifying the cached instance. The ClaimedNameColor also needs to be reset when changing from a claimed name to a non-unique name
* Fixes high traffic utilization issues with Segment : https://github.com/decentraland/unity-explorer/pull/7982
* Fixes full screen exception that happened when starting a local scene in windowed mode.

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

* Verify that name changing works (NAME -> non-uniquie, non-unique -> NAME, non-unique -> non-unique)
* Verify that Segment traffic is stabilized
* Verify that starting a local scene does not produce a black screen / crash

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
