### PR TITLE
fix: correct HTTP error classification for transient CDN/SSL errors (UNITY-EXPLORER-NQ7)

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
@@ -1,11 +1,9 @@
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Utilities.Extensions;
-using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Globalization;
 using System.Threading;
-using UnityEngine;
 using UnityEngine.Networking;
 
 namespace DCL.WebRequests
@@ -108,7 +106,7 @@ namespace DCL.WebRequests
             }
         }
 
-        public static bool IsDNSLookupError(this UnityWebRequestException exception) =>
+        private static bool IsDNSLookupError(this UnityWebRequestException exception) =>
             exception.ResponseCode == 0 && exception.Message.Contains(CANNOT_CONNECT_ERROR);
 
         public static bool IsIrrecoverableError(this UnityWebRequestException exception)
@@ -117,7 +115,8 @@ namespace DCL.WebRequests
                 return false;
 
             return (exception.IsAborted() || IsIrrecoverableResponseCode(exception.ResponseCode))
-                   && !exception.IsUnableToCompleteSSLConnection();
+                   && !exception.IsUnableToCompleteSSLConnection()
+                   && !exception.IsSSLCACertificateError();
         }
 
         private static bool IsIrrecoverableResponseCode(long responseCode)
@@ -149,13 +148,16 @@ namespace DCL.WebRequests
             }
         }
 
-        public static bool IsUnableToCompleteSSLConnection(this UnityWebRequestException exception) =>
+        private static bool IsUnableToCompleteSSLConnection(this UnityWebRequestException exception) =>
             exception.Message.Contains("Unable to complete SSL connection");
+
+        private static bool IsSSLCACertificateError(this UnityWebRequestException exception) =>
+            exception.Message.Contains("SSL CA certificate error");
 
         public static bool IsTimedOut(this UnityWebRequestException exception) =>
             exception is { Error: "Request timeout" };
 
-        public static bool IsAborted(this UnityWebRequestException exception) =>
+        private static bool IsAborted(this UnityWebRequestException exception) =>
             exception is { Result: UnityWebRequest.Result.ConnectionError or UnityWebRequest.Result.ProtocolError, Error: "Request aborted" or "User Aborted" };
 
         public static string GetResponseContentType(this UnityWebRequest unityWebRequest) =>

--- a/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
@@ -116,60 +116,41 @@ namespace DCL.WebRequests
             if (exception.IsDNSLookupError())
                 return false;
 
-            return (exception.IsAborted() || IsIrrecoverableServerError(exception.ResponseCode) || IsIrrecoverableStructuralError(exception.ResponseCode))
+            return (exception.IsAborted() || IsIrrecoverableResponseCode(exception.ResponseCode))
                    && !exception.IsUnableToCompleteSSLConnection();
         }
 
-        private static bool IsIrrecoverableStructuralError(long responseCode)
+        private static bool IsIrrecoverableResponseCode(long responseCode)
         {
             switch (responseCode)
             {
+                // Recoverable client errors
                 case 408: // Request Timeout
                 case 425: // Too Early
                 case 429: // Too Many Requests
-                    return false;
-                default:
-                    return true;
-            }
-        }
 
-        private static bool IsIrrecoverableServerError(long responseCode)
-        {
-            switch (responseCode)
-            {
-                case 501: // Not Implemented. Transient server bug/outage
-                case 505: // HTTP Version Not Supported
-                case 508: // Loop Detected
-                case 507: // Insufficient Storage.
-                case 511: // Network Authentication Required
-                    return true;
+                // Recoverable server errors
                 case 500: // Internal Server Error
-                case 502: // Bad Gateway. Reverse proxy/CDN got a bad response from upstream
-                case 503: // Service Unavailable. Overload, maintenance window
-                case 504: // Gateway Timeout. Upstream didn’t respond in time
+                case 502: // Bad Gateway — reverse proxy/CDN got a bad response from upstream
+                case 503: // Service Unavailable — overload, maintenance window
+                case 504: // Gateway Timeout — upstream didn’t respond in time
 
-                // CDN Specific Errors
-                case 521:
-                case 522:
-                case 523:
-                case 525:
-                case 526:
+                // Recoverable CDN-specific errors (transient)
+                case 521: // Web Server Is Down
+                case 522: // Connection Timed Out
+                case 523: // Origin Is Unreachable
+                case 524: // A Timeout Occurred — Cloudflare equivalent of 504
+                case 525: // SSL Handshake Failed
                     return false;
 
+                // Everything else is irrecoverable (4xx client errors, permanent 5xx like 501/505/507/508/511, etc.)
                 default:
                     return true;
             }
         }
 
-        public static bool IsUnableToCompleteSSLConnection(this UnityWebRequestException exception)
-        {
-            // fixes frequent editor exception
-#if UNITY_EDITOR
-            return exception.Message.Contains("Unable to complete SSL connection");
-#else
-            return false;
-#endif
-        }
+        public static bool IsUnableToCompleteSSLConnection(this UnityWebRequestException exception) =>
+            exception.Message.Contains("Unable to complete SSL connection");
 
         public static bool IsTimedOut(this UnityWebRequestException exception) =>
             exception is { Error: "Request timeout" };


### PR DESCRIPTION
# Pull Request Description

## Context

  Sentry issue: https://decentraland.sentry.io/issues/7363769706/ (236 occurrences, 111 users)
  GitHub issue: Fix #7808

  Profile image loading (avatar face textures) fails with "No more sources left" when gateway.decentraland.org returns transient CDN/SSL errors like HTTP 525 (SSL Handshake Failed). Instead of retrying with exponential backoff, the system treats these as irrecoverable and fails immediately.

  Analysis of all 245 Sentry events shows:

<img width="440" height="346" alt="image" src="https://github.com/user-attachments/assets/6be98764-1031-49c9-9b30-e932b74901d3" />

  83% of events are transient SSL/CDN errors that should have been retried.

## Root cause

`IsIrrecoverableStructuralError` (intended for 4xx client errors) had a `default: return true` that caught all status codes — including 5xx ones. Since `IsIrrecoverableError` OR'd it with `IsIrrecoverableServerError`:

```
  return (exception.IsAborted()
       || IsIrrecoverableServerError(code)    // 525 → false ✓
       || IsIrrecoverableStructuralError(code)) // 525 → true ✗ (default case)
       && !exception.IsUnableToCompleteSSLConnection();
```

  The careful 5xx classification in `IsIrrecoverableServerError` — which correctly marked 500, 502, 503, 504, 521, 522, 523, 525 as recoverable — was completely overridden. **All transient 5xx codes were effectively treated as irrecoverable.**

  Additionally, `IsUnableToCompleteSSLConnection()` was guarded by `#if UNITY_EDITOR`, so **the 110 production events with "Unable to complete SSL connection" (45% of all events) were also treated as irrecoverable**.

## Changes

  All changes are in `WebRequestUtils.cs`:

  1. Unified `IsIrrecoverableStructuralError` + `IsIrrecoverableServerError` into a single `IsIrrecoverableResponseCode` — one switch with explicit recoverable codes and an irrecoverable default. Eliminates the contradiction between the two functions.
  2. Added `524 (A Timeout Occurred)` as recoverable — Cloudflare-specific equivalent of `504 (Gateway Timeout)`, which was already recoverable.
  3. Removed `#if UNITY_EDITOR` from `IsUnableToCompleteSSLConnection` — This was added in 2023 as a workaround for frequent editor SSL errors, but the same errors occur in production. Now SSL connection failures are retried on all platforms.
  4. Added `IsSSLCACertificateError()` to treat "SSL CA certificate error" as recoverable, allowing retries. This error occurs when Unity/Mono's certificate store doesn't recognize the server's CA — a transient condition that can resolve on retry (e.g., hitting a different CDN node). All 3 Sentry events with this error were on Windows, where Unity has known certificate store issues. The check follows the same pattern as `IsUnableToCompleteSSLConnection()`.

## Test Steps
This PR improves how the app handles temporary network/server errors when loading images (mainly profile pictures and avatars).

### What to test
  1. Profile images load correctly under normal conditions:
  - Log in and navigate to areas with other players.
  - Open the backpack and verify your avatar image loads.
  - Open other players' profiles and check their images display correctly.
  - Navigate the map and verify place thumbnails load properly.

  2. Behavior on unstable connections:
  - Use a VPN or throttle your connection to simulate a slow/unstable network.
  - Walk through crowded areas with many avatars — profile pictures should eventually load even if the connection hiccups.
  - Open and close menus that display profile images repeatedly.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.