### PR TITLE
fix: release userdata file lock when exiting Editor Play mode

### DIFF
--- a/Explorer/Assets/DCL/Prefs/DCLPlayerPrefs.cs
+++ b/Explorer/Assets/DCL/Prefs/DCLPlayerPrefs.cs
@@ -127,7 +127,30 @@ namespace DCL.Prefs
             dclPrefs = inMemory ? new InMemoryDCLPlayerPrefs() : new FileDCLPlayerPrefs();
         }
 
+        private static void Cleanup()
+        {
+            if (dclPrefs == null)
+                return;
+
+            dclPrefs.SaveSync();
+            (dclPrefs as IDisposable)?.Dispose();
+            dclPrefs = null;
+        }
+
 #if UNITY_EDITOR
+        [InitializeOnLoadMethod]
+        private static void RegisterPlayModeCleanup()
+        {
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            if (state == PlayModeStateChange.ExitingPlayMode)
+                Cleanup();
+        }
+
         [MenuItem("Edit/Clear All DCLPlayerPrefs", priority = 280)]
         private static void ClearDCLPlayerPrefs()
         {

--- a/Explorer/Assets/DCL/Prefs/FileDCLPlayerPrefs.cs
+++ b/Explorer/Assets/DCL/Prefs/FileDCLPlayerPrefs.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace DCL.Prefs
 {
-    public class FileDCLPlayerPrefs : IDCLPrefs
+    public class FileDCLPlayerPrefs : IDCLPrefs, IDisposable
     {
         private const int CONCURRENT_CLIENTS = 16;
         private const string PREFS_FILENAME = "userdata_{0}.json";
@@ -172,6 +172,15 @@ namespace DCL.Prefs
             dataChanged = false;
 
             WriteToDisk();
+        }
+
+        public void Dispose()
+        {
+            try { fileStream.Unlock(0, 0); }
+            catch (IOException) { }
+
+            fileStream.Dispose();
+            PrefsInstanceNumber = -1;
         }
 
         private void WriteToDisk()

--- a/Explorer/Assets/DCL/Prefs/FileDCLPlayerPrefs.cs
+++ b/Explorer/Assets/DCL/Prefs/FileDCLPlayerPrefs.cs
@@ -19,6 +19,7 @@ namespace DCL.Prefs
         private readonly UnityDCLPlayerPrefs unityPrefs;
 
         private bool dataChanged;
+        private Task _writeTask = Task.CompletedTask;
 
         public static int PrefsInstanceNumber { get; private set; }
 
@@ -162,7 +163,7 @@ namespace DCL.Prefs
             dataChanged = false;
 
             // Run save on a background thread
-            Task.Run(WriteToDisk);
+            _writeTask = Task.Run(WriteToDisk);
         }
 
         public void SaveSync()
@@ -176,6 +177,9 @@ namespace DCL.Prefs
 
         public void Dispose()
         {
+            try { _writeTask.Wait(); }
+            catch (AggregateException) { }
+
             try { fileStream.Unlock(0, 0); }
             catch (IOException) { }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

`FileDCLPlayerPrefs` acquires an exclusive file lock on `userdata_N.json` via `FileShare.None` + `.Lock(0, 0)` when entering Play mode, but never releases it when exiting. Since the Unity Editor process stays alive, external tools (e.g., `metaforge account login`) cannot modify the prefs file until the Editor is fully restarted.

**Fix:**
- Added `IDisposable` to `FileDCLPlayerPrefs` that unlocks and disposes the `FileStream`
- Registered an `EditorApplication.playModeStateChanged` handler in `DCLPlayerPrefs` that saves, disposes, and nulls the prefs instance on `ExitingPlayMode`

## Test Instructions

### Prerequisites
- [ ] Unity Editor open with the project
- [ ] MetaForge CLI installed

### Test Steps
1. Enter Play mode in Unity Editor
2. Verify `userdata_0.json` is locked (e.g., try opening it exclusively from another process)
3. Exit Play mode
4. Run `metaforge account login <account>` — should succeed without "file in use" errors
5. Re-enter Play mode — should initialize without `InvalidOperationException`

### Additional Testing Notes
- Verify on macOS specifically, since the `.Lock(0, 0)` call is the macOS-specific locking mechanism
- Confirm the file is properly saved before the lock is released (no data loss on exit)

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)