### PR TITLE
fix: smart wearable metadata is null

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/LoadSmartWearableSceneSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/LoadSmartWearableSceneSystem.cs
@@ -55,7 +55,7 @@ namespace ECS.SceneLifeCycle.Systems
 
             if (sceneContent == null)
             {
-                return new  StreamableLoadingResult<GetSmartWearableSceneIntention.Result>(
+                return new StreamableLoadingResult<GetSmartWearableSceneIntention.Result>(
                     ReportCategory.WEARABLE,
                     new Exception($"sceneContent of {wearable.GetName()} is null"));
             }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/LoadSmartWearableSceneSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/LoadSmartWearableSceneSystem.cs
@@ -53,6 +53,20 @@ namespace ECS.SceneLifeCycle.Systems
             (ISceneContent? sceneContent, SceneMetadata? sceneMetadata) = await smartWearableCache.GetCachedSceneInfoAsync(wearable, ct);
             if (ct.IsCancellationRequested) return new StreamableLoadingResult<GetSmartWearableSceneIntention.Result>();
 
+            if (sceneContent == null)
+            {
+                return new  StreamableLoadingResult<GetSmartWearableSceneIntention.Result>(
+                    ReportCategory.WEARABLE,
+                    new Exception($"sceneContent of {wearable.GetName()} is null"));
+            }
+
+            if (sceneMetadata == null)
+            {
+                return new StreamableLoadingResult<GetSmartWearableSceneIntention.Result>(
+                    ReportCategory.WEARABLE,
+                    new Exception($"sceneMetadata of {wearable.GetName()} is null"));
+            }
+
             AssetBundleManifestVersion manifestVersion = wearable.DTO.assetBundleManifestVersion!;
             SceneEntityDefinition sceneDefinition = new SceneEntityDefinition(wearable.DTO.id!, sceneMetadata, manifestVersion);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

This change adds code to handle smart wearables the metadata of which could not be downloaded. This hopefully solves #7726.

## Test Instructions

Test some smart wearables.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
