### PR TITLE
chore: validate incoming auto login UUID

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/Bootstraper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/Bootstraper.cs
@@ -336,6 +336,7 @@ namespace Global.Dynamic
                     bootstrapContainer.Analytics.Controller.Identify(identity);
             }
             catch (AutoLoginTokenNotFoundException) { } // Exceptions on auto-login should not block the application bootstrap
+            catch (AutoLoginTokenInvalidException e) { ReportHub.LogException(e, ReportCategory.AUTHENTICATION); }
             catch (Exception e) { ReportHub.LogException(e, ReportCategory.AUTHENTICATION); }
 
             await dynamicWorldContainer.UserInAppInAppInitializationFlow.ExecuteAsync(

--- a/Explorer/Assets/DCL/Web3/Authenticators/Exceptions/AutoLoginTokenInvalidException.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Exceptions/AutoLoginTokenInvalidException.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace DCL.Web3.Authenticators
+{
+    public class AutoLoginTokenInvalidException : Exception
+    {
+        public AutoLoginTokenInvalidException(string message) : base(message) { }
+    }
+}

--- a/Explorer/Assets/DCL/Web3/Authenticators/Exceptions/AutoLoginTokenInvalidException.cs.meta
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Exceptions/AutoLoginTokenInvalidException.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a9a1c733f83247c58b1738792d1f6cb0
+timeCreated: 1775134923

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/TokenFileAuthenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/TokenFileAuthenticator.cs
@@ -72,6 +72,9 @@ namespace DCL.Web3.Authenticators
 
             string token = contentResult.Value.Trim();
 
+            if (!Guid.TryParse(token, out _))
+                throw new AutoLoginTokenInvalidException($"Token read from {TOKEN_PATH} is invalid. {token}");
+
             urlBuilder.Clear();
 
             urlBuilder.AppendDomain(URLDomain.FromString(authApiUrl))


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

The `TokenFileAuthenticator` reads a token from a file written by the Decentraland Launcher and uses it directly in an API URL (`identities/{token}`). Previously, no validation was performed on the token content before making the request, meaning a malformed, empty, or malicious string could be forwarded to the auth API.

This PR adds UUID validation on the token read from `auth-token-bridge.txt` before it is used. If the token is not a valid GUID, an `AutoLoginTokenInvalidException` is thrown immediately with a diagnostic message indicating the file path and the invalid value, preventing the malformed token from reaching the network layer.

### Changes

- Added `Guid.TryParse` check in `TokenFileAuthenticator.LoginAsync` to reject non-UUID tokens early
- Added new `AutoLoginTokenInvalidException` for this specific failure case, distinct from the existing `AutoLoginTokenNotFoundException`

## Test Instructions

### Prerequisites

- Windows or macOS build with the Decentraland Launcher Light installed, or ability to manually create the token file at:
  - **Windows:** `%LOCALAPPDATA%\DecentralandLauncherLight\auth-token-bridge.txt`
  - **macOS:** `~/Library/Application Support/DecentralandLauncherLight/auth-token-bridge.txt`

### Test Steps

1. Write a valid UUID (e.g. `550e8400-e29b-41d4-a716-446655440000`) into the token file and launch the Explorer — login should proceed normally
2. Write an invalid string (e.g. `not-a-uuid`, empty string, or random garbage) into the token file and launch the Explorer
3. **Expected:** login fails fast with `AutoLoginTokenInvalidException` and the invalid token value is visible in the error message — no network request is made to the auth API
4. Verify the token file is deleted in both cases (file deletion happens before validation, as before)

### Additional Testing Notes

- Verify that a file containing only whitespace is also rejected (token is trimmed before validation)
- The exception message includes the raw token value — confirm it does not appear in any user-facing UI (it's for diagnostics only)

## Quality Checklist

- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference

Please review our [[code review standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md)](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.