### PR TITLE
fix: avoid nullref on texture consumption and avoid zombie entity

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/TexturesExtensions.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/TexturesExtensions.cs
@@ -16,7 +16,9 @@ namespace ECS.StreamableLoading.Textures
             new (
                 result.Succeeded
                     ? new SpriteData(result.Asset!,
-                        result.Asset!.Asset.Match(video => fallback, tex2D => Sprite.Create(tex2D, new Rect(0, 0, result.Asset!.Asset.Width, result.Asset.Asset.Height), VectorUtilities.OneHalf, pixelsPerUnit, 0, SpriteMeshType.FullRect, Vector4.one, false)))
+                        result.Asset!.Asset.Match(video => fallback, tex2D => tex2D != null
+                            ? Sprite.Create(tex2D, new Rect(0, 0, tex2D.width, tex2D.height), VectorUtilities.OneHalf, pixelsPerUnit, 0, SpriteMeshType.FullRect, Vector4.one, false)
+                            : fallback))
                     : fallback);
 
         public static StreamableLoadingResult<SpriteData>.WithFallback ToFullRectSpriteData(this StreamableLoadingResult<AssetBundleData> result, SpriteData fallback, int pixelsPerUnit = 50)

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/TexturesExtensions.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Textures/TexturesExtensions.cs
@@ -1,4 +1,5 @@
-﻿using ECS.StreamableLoading.AssetBundles;
+﻿using DCL.Diagnostics;
+using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.Common.Components;
 using UnityEngine;
 using Utility;
@@ -16,9 +17,16 @@ namespace ECS.StreamableLoading.Textures
             new (
                 result.Succeeded
                     ? new SpriteData(result.Asset!,
-                        result.Asset!.Asset.Match(video => fallback, tex2D => tex2D != null
-                            ? Sprite.Create(tex2D, new Rect(0, 0, tex2D.width, tex2D.height), VectorUtilities.OneHalf, pixelsPerUnit, 0, SpriteMeshType.FullRect, Vector4.one, false)
-                            : fallback))
+                        result.Asset!.Asset.Match(video => fallback, tex2D =>
+                        {
+                            if (tex2D == null)
+                            {
+                                ReportHub.LogError(new ReportData(ReportCategory.TEXTURES), "Resolved texture asset has a null Texture2D despite Succeeded == true; using fallback sprite.");
+                                return fallback;
+                            }
+
+                            return Sprite.Create(tex2D, new Rect(0, 0, tex2D.width, tex2D.height), VectorUtilities.OneHalf, pixelsPerUnit, 0, SpriteMeshType.FullRect, Vector4.one, false);
+                        }))
                     : fallback);
 
         public static StreamableLoadingResult<SpriteData>.WithFallback ToFullRectSpriteData(this StreamableLoadingResult<AssetBundleData> result, SpriteData fallback, int pixelsPerUnit = 50)

--- a/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
+++ b/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
@@ -29,7 +29,10 @@ namespace DCL.Profiles
             if (promise.TryConsume(World, out StreamableLoadingResult<TextureData> result))
             {
                 try { profile.ProfilePicture = result.ToFullRectSpriteData(fallback: ProfileUtils.DEFAULT_PROFILE_PIC); }
-                catch (Exception e) { ReportHub.LogException(e, new ReportData(ReportCategory.PROFILE)); }
+                catch (Exception e)
+                {
+                    ReportHub.LogError(ReportCategory.PROFILE, $"Error when processing texture promise for {promise.LoadingIntention.CommonArguments.URL} for profile {profile.UserId} error {e.Message}");
+                }
                 finally { World.Destroy(entity); }
             }
         }

--- a/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
+++ b/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
@@ -27,8 +27,14 @@ namespace DCL.Profiles
         {
             if (promise.TryConsume(World, out StreamableLoadingResult<TextureData> result))
             {
-                profile.ProfilePicture = result.ToFullRectSpriteData(fallback: ProfileUtils.DEFAULT_PROFILE_PIC);
-                World.Destroy(entity);
+                try
+                {
+                    profile.ProfilePicture = result.ToFullRectSpriteData(fallback: ProfileUtils.DEFAULT_PROFILE_PIC);
+                }
+                finally
+                {
+                    World.Destroy(entity);
+                }
             }
         }
     }

--- a/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
+++ b/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
@@ -29,9 +29,7 @@ namespace DCL.Profiles
             if (promise.TryConsume(World, out StreamableLoadingResult<TextureData> result))
             {
                 try { profile.ProfilePicture = result.ToFullRectSpriteData(fallback: ProfileUtils.DEFAULT_PROFILE_PIC); }
-                catch (Exception e) {
                 catch (Exception e) { ReportHub.LogException(e, new ReportData(ReportCategory.PROFILE)); }
-                }
                 finally { World.Destroy(entity); }
             }
         }

--- a/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
+++ b/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
@@ -7,6 +7,7 @@ using DCL.Profiles.Helpers;
 using ECS.Abstract;
 using ECS.StreamableLoading.Common.Components;
 using ECS.StreamableLoading.Textures;
+using System;
 using Promise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.Textures.TextureData, ECS.StreamableLoading.Textures.GetTextureIntention>;
 
 namespace DCL.Profiles
@@ -27,14 +28,11 @@ namespace DCL.Profiles
         {
             if (promise.TryConsume(World, out StreamableLoadingResult<TextureData> result))
             {
-                try
-                {
-                    profile.ProfilePicture = result.ToFullRectSpriteData(fallback: ProfileUtils.DEFAULT_PROFILE_PIC);
+                try { profile.ProfilePicture = result.ToFullRectSpriteData(fallback: ProfileUtils.DEFAULT_PROFILE_PIC); }
+                catch (Exception e) {
+                    ReportHub.LogError(new ReportData(ReportCategory.PROFILE), $"Error on setting full rect sprite data to profile picture: {e.Message}");
                 }
-                finally
-                {
-                    World.Destroy(entity);
-                }
+                finally { World.Destroy(entity); }
             }
         }
     }

--- a/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
+++ b/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
@@ -30,7 +30,7 @@ namespace DCL.Profiles
             {
                 try { profile.ProfilePicture = result.ToFullRectSpriteData(fallback: ProfileUtils.DEFAULT_PROFILE_PIC); }
                 catch (Exception e) {
-                    ReportHub.LogError(new ReportData(ReportCategory.PROFILE), $"Error on setting full rect sprite data to profile picture: {e.Message}");
+                catch (Exception e) { ReportHub.LogException(e, new ReportData(ReportCategory.PROFILE)); }
                 }
                 finally { World.Destroy(entity); }
             }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7663 

When ResolveProfilePictureSystem.CompleteProfilePictureDownload processes a resolved texture promise, it calls result.ToFullRectSpriteData to build the profile picture sprite. Inside TexturesExtensions.ToFullRectSpriteData, the tex2D => flow of the AnyTexture.Match call accessed result.Asset!.Asset.Width and result.Asset.Asset.Height — routing through AnyTexture.get_Width() → UnityEngine.Texture.GetDataWidth(). When the underlying Texture2D is null or has been destroyed (even though result.Succeeded == true), this throws a NullReferenceException.

Now, I couldn't find when the Texture2D was null or being destroyed and I relied on what Claude suggested as conditions:

```
  1. Successful HTTP response but invalid/undecodable image data                                                                                                                                                                                     
  The most likely cause in this codebase. UnityWebRequest returns HTTP 200 and result.Succeeded = true, but DownloadHandlerTexture.texture returns null when Unity can't decode the body — e.g. a malformed image, a zero-byte response, or a
  content-type mismatch from the CDN. The loading system has no way to distinguish this from a valid texture at the HTTP level.                                                                                                                      
                                                                       
  2. Two promises for the same profile URL (related to the duplicate entity issue)                                                                                                                                                                   
  When UpdateCharacter creates a second promise entity for the same face snapshot URL, LoadSystemBase deduplicates via OngoingRequests — both loading entities await the same UniTaskCompletionSource. When the first promise entity is consumed and
  TryConsume calls DestroyEntity, it calls world.Get<StreamableLoadingState>(Entity).Dispose() on the loading entity. If reference counting in the cache then drops to zero and triggers DisposeAbandonedResult, the Texture2D inside TextureData    
  could be unloaded. The second loading entity still holds a StreamableLoadingResult<TextureData> pointing to it, but the underlying asset is now gone.
                                                                                                                                                                                                                                                     
  3. Memory pressure / asset unloading between load and consumption                                                                                                                                                                                  
  If Unity's memory budgeting triggers Resources.UnloadUnusedAssets() between when the texture is written to the loading entity and when TryConsume reads it, and the texture's reference count is somehow zero at that point, the Texture2D gets
  destroyed. This is less likely given the ref-counting system, but possible if the promise entity sits unconsumed for many frames while memory pressure spikes. 
```

In addition the NullReferenceException was thrown after promise.TryConsume succeeded but before World.Destroy(entity) was called. This left the profile picture entity permanently alive in a broken state: Result.HasValue = true and Entity == Entity.Null.
ResolveProfilePictureSystem's query kept finding this zombie entity, called TryConsume on it again, and hit the already consumed assertion (origin of the spam of events in sentry)

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
  1. Launch the explorer, go where other players are present. Open the logs and confirm there are no EcsSystemException: [ResolveProfilePictureSystem] or already consumed entries.
  2. Verify that remote player profile pictures display correctly in chat, the social panel, and any other UI that shows avatars.
  4. Update a profile for a second user and confirm no exceptions appear and the profile picture updates correctly (remember that this can take up to a few minutes as the backend takes a lot of time to generate the new picture)

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
