### PR TITLE
chore: updated skills + added create-skills skill

### DIFF
--- a/.claude/skills/asset-promise-lifecycle/SKILL.md
+++ b/.claude/skills/asset-promise-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asset-promise-lifecycle
-description: "AssetPromise lifecycle for async ECS asset loading — textures, models, audio, wearables. Use when creating, polling, consuming, or cleaning up asset promises, working with memory budgeting and cache dereferencing, or implementing async loading, texture loading, model loading, streaming, or loading pipeline logic."
+description: "AssetPromise lifecycle for async ECS asset loading — textures, models, audio, wearables. Use when creating, polling, consuming, or cleaning up asset promises, or working with memory budgeting."
 user-invocable: false
 ---
 
@@ -122,109 +122,6 @@ if (promise.TryConsume(World, out StreamableLoadingResult<TextureData> result))
 
 ---
 
-## Code Example — Full Promise Lifecycle
-
-From `MapPinLoaderSystem.cs`:
-
-```csharp
-[UpdateInGroup(typeof(ComponentInstantiationGroup))]
-public partial class MapPinLoaderSystem : BaseUnityLoopSystem, IFinalizeWorldSystem
-{
-    private const int ATTEMPTS_COUNT = 6;
-
-    protected override void Update(float t)
-    {
-        LoadMapPinQuery(World);
-        UpdateMapPinQuery(World);
-        HandleComponentRemovalQuery(World);
-        HandleEntityDestructionQuery(World);
-
-        if (useCustomMapPinIcons)
-            ResolveTexturePromiseQuery(World);
-    }
-
-    // CREATE — Build a texture promise when the map pin has a texture
-    private bool TryCreateGetTexturePromise(in TextureComponent? textureComponent,
-        ref Promise? promise)
-    {
-        if (textureComponent == null)
-            return false;
-
-        TextureComponent textureComponentValue = textureComponent.Value;
-
-        // Skip if same texture already requested
-        if (TextureComponentUtils.Equals(ref textureComponentValue, ref promise))
-            return false;
-
-        // Dereference old promise before creating new one
-        DereferenceTexture(ref promise);
-
-        promise = Promise.Create(
-            World,
-            new GetTextureIntention(
-                textureComponentValue.Src,
-                textureComponentValue.FileHash,
-                textureComponentValue.WrapMode,
-                textureComponentValue.FilterMode,
-                textureComponentValue.TextureType,
-                attemptsCount: ATTEMPTS_COUNT,
-                reportSource: nameof(MapPinLoaderSystem)),
-            partitionComponent);
-
-        return true;
-    }
-
-    // POLL + CONSUME — Check if the loading system has completed
-    [Query]
-    private void ResolveTexturePromise(in Entity entity, ref MapPinComponent mapPinComponent)
-    {
-        if (mapPinComponent.TexturePromise is null ||
-            mapPinComponent.TexturePromise.Value.IsConsumed)
-            return;
-
-        if (mapPinComponent.TexturePromise.Value.TryConsume(World,
-            out StreamableLoadingResult<TextureData> texture))
-        {
-            mapPinComponent.TexturePromise = null;
-            mapPinsEventBus.UpdateMapPinThumbnail(entity, texture.Asset!.EnsureTexture2D());
-        }
-    }
-
-    // CLEANUP — Dereference in all cleanup paths
-    [Query]
-    [None(typeof(PBMapPin), typeof(DeleteEntityIntention))]
-    private void HandleComponentRemoval(in Entity entity, ref MapPinComponent mapPinComponent)
-    {
-        DereferenceTexture(ref mapPinComponent.TexturePromise);
-        World.Remove<MapPinComponent>(entity);
-        mapPinsEventBus.RemoveMapPin(entity);
-    }
-
-    [Query]
-    [All(typeof(DeleteEntityIntention))]
-    private void HandleEntityDestruction(in Entity entity, ref MapPinComponent mapPinComponent)
-    {
-        DereferenceTexture(ref mapPinComponent.TexturePromise);
-        mapPinsEventBus.RemoveMapPin(entity);
-    }
-
-    // DEREFERENCE — Allow memory reclamation
-    private void DereferenceTexture(ref Promise? promise)
-    {
-        if (promise == null)
-            return;
-
-        Promise promiseValue = promise.Value;
-        promiseValue.TryDereference(World);
-    }
-
-    public void FinalizeComponents(in Query query)
-    {
-        CleanupOnFinalizeQuery(World);
-    }
-}
-```
-
 ## Memory Budgeting
 
 ### MemoryBudgetProvider
@@ -244,6 +141,19 @@ Implements `IConcurrentBudgetProvider`. Uses `IProfilingProvider` for current me
 
 Always dereference in cleanup paths to allow the unloading pipeline to reclaim memory:
 
-- `TexturesCache` → `Texture2D`
-- `WearableAssetsCache` → `CachedWearable` → `WearableAsset` → `AssetBundleData`
-- `GltfContainerAssetsCache` → `GltfContainerAsset` → `AssetBundleData`
+- `TexturesCache` -> `Texture2D`
+- `WearableAssetsCache` -> `CachedWearable` -> `WearableAsset` -> `AssetBundleData`
+- `GltfContainerAssetsCache` -> `GltfContainerAsset` -> `AssetBundleData`
+
+---
+
+## Detailed Reference
+
+For detailed code examples, see [reference.md](reference.md).
+
+---
+
+## Cross-References
+
+- **ecs-system-and-component-design** — Component cleanup lifecycle, `IFinalizeWorldSystem`
+- **plugin-architecture** — `IAssetsProvisioner`, `ProvidedAsset<T>`, pool registration via `IComponentPoolsRegistry`

--- a/.claude/skills/asset-promise-lifecycle/reference.md
+++ b/.claude/skills/asset-promise-lifecycle/reference.md
@@ -1,0 +1,102 @@
+# Asset Promise Lifecycle — Detailed Reference
+
+## Full Promise Lifecycle — MapPinLoaderSystem
+
+```csharp
+[UpdateInGroup(typeof(ComponentInstantiationGroup))]
+public partial class MapPinLoaderSystem : BaseUnityLoopSystem, IFinalizeWorldSystem
+{
+    private const int ATTEMPTS_COUNT = 6;
+
+    protected override void Update(float t)
+    {
+        LoadMapPinQuery(World);
+        UpdateMapPinQuery(World);
+        HandleComponentRemovalQuery(World);
+        HandleEntityDestructionQuery(World);
+
+        if (useCustomMapPinIcons)
+            ResolveTexturePromiseQuery(World);
+    }
+
+    // CREATE — Build a texture promise when the map pin has a texture
+    private bool TryCreateGetTexturePromise(in TextureComponent? textureComponent,
+        ref Promise? promise)
+    {
+        if (textureComponent == null)
+            return false;
+
+        TextureComponent textureComponentValue = textureComponent.Value;
+
+        // Skip if same texture already requested
+        if (TextureComponentUtils.Equals(ref textureComponentValue, ref promise))
+            return false;
+
+        // Dereference old promise before creating new one
+        DereferenceTexture(ref promise);
+
+        promise = Promise.Create(
+            World,
+            new GetTextureIntention(
+                textureComponentValue.Src,
+                textureComponentValue.FileHash,
+                textureComponentValue.WrapMode,
+                textureComponentValue.FilterMode,
+                textureComponentValue.TextureType,
+                attemptsCount: ATTEMPTS_COUNT,
+                reportSource: nameof(MapPinLoaderSystem)),
+            partitionComponent);
+
+        return true;
+    }
+
+    // POLL + CONSUME — Check if the loading system has completed
+    [Query]
+    private void ResolveTexturePromise(in Entity entity, ref MapPinComponent mapPinComponent)
+    {
+        if (mapPinComponent.TexturePromise is null ||
+            mapPinComponent.TexturePromise.Value.IsConsumed)
+            return;
+
+        if (mapPinComponent.TexturePromise.Value.TryConsume(World,
+            out StreamableLoadingResult<TextureData> texture))
+        {
+            mapPinComponent.TexturePromise = null;
+            mapPinsEventBus.UpdateMapPinThumbnail(entity, texture.Asset!.EnsureTexture2D());
+        }
+    }
+
+    // CLEANUP — Dereference in all cleanup paths
+    [Query]
+    [None(typeof(PBMapPin), typeof(DeleteEntityIntention))]
+    private void HandleComponentRemoval(in Entity entity, ref MapPinComponent mapPinComponent)
+    {
+        DereferenceTexture(ref mapPinComponent.TexturePromise);
+        World.Remove<MapPinComponent>(entity);
+        mapPinsEventBus.RemoveMapPin(entity);
+    }
+
+    [Query]
+    [All(typeof(DeleteEntityIntention))]
+    private void HandleEntityDestruction(in Entity entity, ref MapPinComponent mapPinComponent)
+    {
+        DereferenceTexture(ref mapPinComponent.TexturePromise);
+        mapPinsEventBus.RemoveMapPin(entity);
+    }
+
+    // DEREFERENCE — Allow memory reclamation
+    private void DereferenceTexture(ref Promise? promise)
+    {
+        if (promise == null)
+            return;
+
+        Promise promiseValue = promise.Value;
+        promiseValue.TryDereference(World);
+    }
+
+    public void FinalizeComponents(in Query query)
+    {
+        CleanupOnFinalizeQuery(World);
+    }
+}
+```

--- a/.claude/skills/avatar-rendering-pipeline/SKILL.md
+++ b/.claude/skills/avatar-rendering-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avatar-rendering-pipeline
-description: "Avatar rendering pipeline — GPU skinning, compute shaders, Global Vertex Buffer, wearable loading, material pooling, and emote system. Use when modifying avatar instantiation, skinning systems, GVB defragmentation, wearable material setup, texture array slots, emote integration, or avatar cleanup lifecycle."
+description: "Avatar rendering -- GPU skinning, compute shaders, GVB, wearable loading, material pooling, emotes. Use when modifying avatar instantiation, skinning, wearable materials, texture arrays, or emote integration."
 user-invocable: false
 ---
 
@@ -8,8 +8,8 @@ user-invocable: false
 
 ## Sources
 
-- `docs/avatar-rendering.md` — GPU skinning, compute shaders, Global Vertex Buffer, AvatarCelShading shader
-- `docs/emotes.md` — Emote loading, Mecanim controllers, EmotePlayer pooling
+- `docs/avatar-rendering.md` -- GPU skinning, compute shaders, Global Vertex Buffer, AvatarCelShading shader
+- `docs/emotes.md` -- Emote loading, Mecanim controllers, EmotePlayer pooling
 
 ---
 
@@ -19,10 +19,10 @@ user-invocable: false
 
 ```
 AvatarGroup (PresentationSystemGroup)
-  1. AvatarLoaderSystem           — creates AvatarShapeComponent + WearablePromise from Profile/PBAvatarShape
-  2. MakeVertsOutBufferDefragmentationSystem  — GVB defrag (runs before instantiation)
-  3. AvatarInstantiatorSystem     — consumes WearablePromise, instantiates wearables, allocates GVB region
-  4. StartAvatarMatricesCalculationSystem     — schedules bone matrix Job (after instantiation)
+  1. AvatarLoaderSystem           -- creates AvatarShapeComponent + WearablePromise from Profile/PBAvatarShape
+  2. MakeVertsOutBufferDefragmentationSystem  -- GVB defrag (runs before instantiation)
+  3. AvatarInstantiatorSystem     -- consumes WearablePromise, instantiates wearables, allocates GVB region
+  4. StartAvatarMatricesCalculationSystem     -- schedules bone matrix Job (after instantiation)
 
 FinishAvatarMatricesCalculationSystem (PreRenderingSystemGroup)
   5. Completes bone Job, dispatches compute shader skinning
@@ -56,42 +56,9 @@ public partial class StartAvatarMatricesCalculationSystem : BaseUnityLoopSystem 
 
 Three-stage pipeline: CPU Job (bone matrices) -> GPU transfer -> Compute Shader (vertex transform).
 
-### Stage 1 — CPU Bone Matrix Job
-
-`StartAvatarMatricesCalculationSystem` schedules a Burst-compiled Job early in the frame:
-
-```csharp
-protected override void Update(float t)
-{
-    ExecuteQuery(World);  // collects avatar bone data
-    avatarTransformMatrixBatchJob.ScheduleBoneMatrixCalculation();
-}
-```
-
-### Stage 2 — Job Completion + GPU Transfer
-
-`FinishAvatarMatricesCalculationSystem` runs in `PreRenderingSystemGroup` to maximize Job parallelism:
-
-```csharp
-protected override void Update(float t)
-{
-    jobWrapper.CompleteBoneMatrixCalculations();
-    currentResult = jobWrapper.job.BonesMatricesResult;  // NativeArray<float4x4>
-    ExecuteQuery(World);
-}
-
-[Query] [All(typeof(AvatarShapeComponent))] [None(typeof(DeleteEntityIntention))]
-private void Execute(ref AvatarTransformMatrixComponent avatarTransformMatrixComponent,
-    ref AvatarCustomSkinningComponent computeShaderSkinning)
-{
-    Result result = computeShaderSkinning.ComputeSkinning(
-        currentResult, avatarTransformMatrixComponent.IndexInGlobalJobArray);
-}
-```
-
-### Stage 3 — Compute Shader
-
-`ComputeSkinning` calls `SetData` to upload bone matrices to GPU, then dispatches the compute shader. The shader calculates positions, normals, and tangents using 4-weight bone skinning. Results are written into the Global Vertex Buffer.
+- **Stage 1 -- CPU Bone Matrix Job:** `StartAvatarMatricesCalculationSystem` schedules a Burst-compiled Job early in the frame via `avatarTransformMatrixBatchJob.ScheduleBoneMatrixCalculation()`.
+- **Stage 2 -- Job Completion + GPU Transfer:** `FinishAvatarMatricesCalculationSystem` runs in `PreRenderingSystemGroup` to maximize Job parallelism. Completes the Job, retrieves `NativeArray<float4x4>`, then calls `ComputeSkinning` per avatar.
+- **Stage 3 -- Compute Shader:** `ComputeSkinning` uploads bone matrices to GPU via `SetData`, dispatches the compute shader for 4-weight bone skinning. Results are written into the Global Vertex Buffer.
 
 ---
 
@@ -99,9 +66,7 @@ private void Execute(ref AvatarTransformMatrixComponent avatarTransformMatrixCom
 
 All avatar vertex data lives in a single `ComputeBuffer` set as a global shader buffer. The `AvatarCelShading` shader indexes into it per-material.
 
-### FixedComputeBufferHandler
-
-Manages rent/release of `Slice` regions within the fixed-size buffer:
+### FixedComputeBufferHandler API
 
 ```csharp
 public class FixedComputeBufferHandler : IDisposable
@@ -115,79 +80,25 @@ public class FixedComputeBufferHandler : IDisposable
 }
 ```
 
-The buffer is created in `AvatarPlugin.InjectToWorld` and bound globally:
+Buffer is created in `AvatarPlugin.InjectToWorld` (5M vertices) and bound globally via `Shader.SetGlobalBuffer`.
 
-```csharp
-var vertOutBuffer = new FixedComputeBufferHandler(5_000_000, Unsafe.SizeOf<CustomSkinningVertexInfo>());
-Shader.SetGlobalBuffer(GLOBAL_AVATAR_BUFFER, vertOutBuffer.Buffer);
-```
-
-### Defragmentation
-
-`MakeVertsOutBufferDefragmentationSystem` triggers when free regions exceed the threshold. It compacts rented regions and remaps avatar indices:
-
-```csharp
-protected override void Update(float t)
-{
-    IReadOnlyDictionary<int, Slice> defragmentationMap = computeBufferHandler.TryMakeDefragmentation();
-    if (defragmentationMap.Count == 0) return;
-    UpdateIndicesQuery(World, defragmentationMap);
-}
-
-[Query]
-private void UpdateIndices([Data] IReadOnlyDictionary<int, Slice> remapping,
-    ref AvatarCustomSkinningComponent avatarCustomSkinningComponent)
-{
-    if (remapping.TryGetValue(avatarCustomSkinningComponent.VertsOutRegion.StartIndex, out Slice newRegion))
-        avatarCustomSkinningComponent.SetVertOutRegion(newRegion);
-}
-```
+**Defragmentation:** `MakeVertsOutBufferDefragmentationSystem` triggers when free regions exceed the threshold, compacts rented regions, and remaps avatar indices via query.
 
 ---
 
 ## Wearable Loading
 
-### Flow
+### 3-Step Flow
 
 1. `AvatarLoaderSystem` creates a `WearablePromise` from `Profile` or `PBAvatarShape`
 2. Loading systems resolve the promise (Asset Bundle download + wearable resolution)
 3. `AvatarInstantiatorSystem` consumes the promise and instantiates wearables
 
-### SMR to MeshRenderer Conversion
-
-Wearables arrive as `SkinnedMeshRenderer` from Asset Bundles. `ComputeShaderSkinning` converts them to `MeshRenderer` for custom GPU skinning:
-
-```csharp
-private (MeshRenderer, MeshFilter) SetupMesh(SkinnedMeshRenderer skin)
-{
-    GameObject go = skin.gameObject;
-    MeshFilter filter = go.AddComponent<MeshFilter>();
-    filter.mesh = skin.sharedMesh;
-    MeshRenderer meshRenderer = go.AddComponent<MeshRenderer>();
-    meshRenderer.renderingLayerMask = 2;
-    Object.Destroy(skin);
-    return (meshRenderer, filter);
-}
-```
-
-### Facial Features
-
-Facial features (eyes, eyebrows, mouth) use suffix-based matching on the renderer name:
-
-```csharp
-private static readonly (string suffix, string category, int defaultSlotIndexUsed, ...)[] SUFFIX_CATEGORY_MAP =
-{
-    ("Mask_Eyes",     WearableCategories.Categories.EYES,     1, shape => shape.EyesColor),
-    ("Mask_Eyebrows", WearableCategories.Categories.EYEBROWS, 0, shape => shape.HairColor),
-    ("Mask_Mouth",    WearableCategories.Categories.MOUTH,    0, shape => shape.SkinColor),
-};
-```
+Wearables arrive as `SkinnedMeshRenderer` from Asset Bundles; `ComputeShaderSkinning` converts them to `MeshRenderer` for custom GPU skinning. Facial features (eyes, eyebrows, mouth) use suffix-based matching on the renderer name (`Mask_Eyes`, `Mask_Eyebrows`, `Mask_Mouth`).
 
 ---
 
 ## Material Pooling & Shader Conventions
-
-### Shader Categories
 
 Materials are pooled by shader type using `AvatarMaterialPoolHandler`:
 
@@ -196,98 +107,35 @@ Materials are pooled by shader type using `AvatarMaterialPoolHandler`:
 | `SHADERID_DCL_TOON` (2) | `DCL/DCL_Toon` | Regular wearable materials |
 | `SHADERID_DCL_FACIAL_FEATURES` (3) | `DCL/DCL_Avatar_Facial_Features` | Eyes, eyebrows, mouth |
 
-### Color Assignment
-
-Original material names determine avatar color application:
-
-```csharp
-if (name.Contains("skin", StringComparison.OrdinalIgnoreCase))
-    avatarMaterial.SetColor(BASE_COLOR, avatarShapeComponent.SkinColor);
-else if (name.Contains("hair", StringComparison.OrdinalIgnoreCase))
-    avatarMaterial.SetColor(BASE_COLOR, avatarShapeComponent.HairColor);
-```
-
-### Texture Arrays
-
-Textures are copied into shared `Texture2DArray` objects to reduce draw call binding cost. `TextureArrayContainer` manages slots per shader, with resolutions at 256 and 512. Each material gets a `TextureArraySlot?[]` tracking its occupied slots.
-
-```csharp
-TextureArraySlot?[] slots = poolMaterialSetup.TextureArrayContainer
-    .SetTexturesFromOriginalMaterial(originalMaterial, avatarMaterial);
-```
+Color assignment is based on original material names: `skin` -> SkinColor, `hair` -> HairColor. Textures are copied into shared `Texture2DArray` objects (256/512 resolution) to reduce draw call binding cost via `TextureArrayContainer`.
 
 ---
 
 ## Emote System
 
-### EmotePlayer
+`EmotePlayer` manages pooled emote instances. Multiple avatars can share the same emote asset; each gets a pooled `EmoteReferences` instance via `GameObjectPool<EmoteReferences>`.
 
-`EmotePlayer` manages pooled emote instances. Multiple avatars can share the same emote asset; each gets a pooled `EmoteReferences` instance:
-
-```csharp
-public class EmotePlayer
-{
-    private readonly Dictionary<GameObject, GameObjectPool<EmoteReferences>> pools = new();
-    private readonly Dictionary<EmoteReferences, GameObjectPool<EmoteReferences>> emotesInUse = new();
-
-    public bool Play(GameObject mainAsset, AudioClip? audioAsset, bool isLooping,
-        bool isSpatial, in IAvatarView view, ref CharacterEmoteComponent emoteComponent)
-    {
-        // Get or create pool for this emote asset
-        if (!pools.ContainsKey(mainAsset))
-            pools.Add(mainAsset, new GameObjectPool<EmoteReferences>(poolRoot,
-                () => CreateNewEmoteReference(mainAsset), onRelease: releaseEmoteReferences));
-
-        EmoteReferences emoteReferences = pools[mainAsset].Get();
-        // Parent to avatar, play Mecanim or legacy animation
-        // ...
-    }
-
-    public void Stop(EmoteReferences emoteReference)
-    {
-        if (!emotesInUse.Remove(emoteReference, out var pool)) return;
-        pool.Release(emoteReference);
-    }
-}
-```
-
-### Intent-Based Loading
-
-Entities receive a `CharacterEmoteIntent` component. `CharacterEmoteSystem` consumes the intent — if the emote is not yet loaded, the intent persists until the asset resolves.
-
-### Mecanim vs Legacy
-
-Asset Bundle emotes contain an `AnimatorController` with trigger-based transitions. The avatar clip is assigned via `view.ReplaceEmoteAnimation()`. Legacy animations (local scene dev only) use `Animation.Play()`.
-
-Clip extraction follows naming conventions: `_avatar` suffix for avatar clips, `_prop` suffix for prop clips.
+- **Intent-Based Loading:** Entities receive `CharacterEmoteIntent`. `CharacterEmoteSystem` consumes the intent; if the emote is not yet loaded, the intent persists until the asset resolves.
+- **Mecanim vs Legacy:** Asset Bundle emotes use `AnimatorController` with trigger-based transitions. Clip extraction follows naming: `_avatar` suffix for avatar clips, `_prop` suffix for prop clips. Legacy animations (local scene dev only) use `Animation.Play()`.
 
 ---
 
 ## Cleanup
 
-`AvatarCleanUpSystem` handles `DeleteEntityIntention` and world disposal. Cleanup delegates to `ReleaseAvatar.Execute`:
-
-```csharp
-public static void Execute(FixedComputeBufferHandler vertOutBuffer, IAttachmentsAssetsCache wearableAssetsCache,
-    IAvatarMaterialPoolHandler avatarMaterialPoolHandler, IObjectPool<ComputeShader> computeShaderSkinningPool,
-    in AvatarShapeComponent avatarShapeComponent, ref AvatarCustomSkinningComponent skinningComponent,
-    ref AvatarTransformMatrixComponent avatarTransformMatrixComponent, AvatarTransformMatrixJobWrapper jobWrapper)
-{
-    vertOutBuffer.Release(skinningComponent.VertsOutRegion);    // GVB region release
-    skinningComponent.Dispose(avatarMaterialPoolHandler, computeShaderSkinningPool); // material + compute shader pool return
-    jobWrapper.ReleaseAvatar(ref avatarTransformMatrixComponent); // Job array slot release
-    wearableAssetsCache.ReleaseAssets(avatarShapeComponent.InstantiatedWearables); // wearable cache deref
-}
-```
-
-The `AvatarBase` GameObject is returned to its pool separately after `ReleaseAvatar.Execute`.
+`AvatarCleanUpSystem` handles `DeleteEntityIntention` and world disposal. Cleanup delegates to `ReleaseAvatar.Execute` which performs: GVB region release, material + compute shader pool return, Job array slot release, and wearable cache deref. The `AvatarBase` GameObject is returned to its pool separately.
 
 For cleanup patterns (component removed, entity destroyed, world disposed), see the **ecs-system-and-component-design** skill.
 
 ---
 
+## Detailed Reference
+
+For detailed code examples, see [reference.md](reference.md).
+
+---
+
 ## Cross-References
 
-- **ecs-system-and-component-design** — Cleanup lifecycle patterns (component removal, entity destruction, world disposal)
-- **asset-promise-lifecycle** — `WearablePromise` creation, polling, consumption, and dereferencing in `AvatarLoaderSystem`
-- **plugin-architecture** — `AvatarPlugin` as `IDCLGlobalPlugin`, system injection via `InjectToWorld`, pool initialization
+- **ecs-system-and-component-design** -- Cleanup lifecycle patterns (component removal, entity destruction, world disposal)
+- **asset-promise-lifecycle** -- `WearablePromise` creation, polling, consumption, and dereferencing in `AvatarLoaderSystem`
+- **plugin-architecture** -- `AvatarPlugin` as `IDCLGlobalPlugin`, system injection via `InjectToWorld`, pool initialization

--- a/.claude/skills/avatar-rendering-pipeline/reference.md
+++ b/.claude/skills/avatar-rendering-pipeline/reference.md
@@ -1,0 +1,169 @@
+# Avatar Rendering Pipeline -- Detailed Reference
+
+## GPU Skinning Code
+
+### Stage 1 -- CPU Bone Matrix Job
+
+`StartAvatarMatricesCalculationSystem` schedules a Burst-compiled Job early in the frame:
+
+```csharp
+protected override void Update(float t)
+{
+    ExecuteQuery(World);  // collects avatar bone data
+    avatarTransformMatrixBatchJob.ScheduleBoneMatrixCalculation();
+}
+```
+
+### Stage 2 -- Job Completion + GPU Transfer
+
+`FinishAvatarMatricesCalculationSystem` runs in `PreRenderingSystemGroup` to maximize Job parallelism:
+
+```csharp
+protected override void Update(float t)
+{
+    jobWrapper.CompleteBoneMatrixCalculations();
+    currentResult = jobWrapper.job.BonesMatricesResult;  // NativeArray<float4x4>
+    ExecuteQuery(World);
+}
+
+[Query] [All(typeof(AvatarShapeComponent))] [None(typeof(DeleteEntityIntention))]
+private void Execute(ref AvatarTransformMatrixComponent avatarTransformMatrixComponent,
+    ref AvatarCustomSkinningComponent computeShaderSkinning)
+{
+    Result result = computeShaderSkinning.ComputeSkinning(
+        currentResult, avatarTransformMatrixComponent.IndexInGlobalJobArray);
+}
+```
+
+### Stage 3 -- Compute Shader
+
+`ComputeSkinning` calls `SetData` to upload bone matrices to GPU, then dispatches the compute shader. The shader calculates positions, normals, and tangents using 4-weight bone skinning. Results are written into the Global Vertex Buffer.
+
+---
+
+## GVB Defragmentation Code
+
+`MakeVertsOutBufferDefragmentationSystem` triggers when free regions exceed the threshold. It compacts rented regions and remaps avatar indices:
+
+```csharp
+protected override void Update(float t)
+{
+    IReadOnlyDictionary<int, Slice> defragmentationMap = computeBufferHandler.TryMakeDefragmentation();
+    if (defragmentationMap.Count == 0) return;
+    UpdateIndicesQuery(World, defragmentationMap);
+}
+
+[Query]
+private void UpdateIndices([Data] IReadOnlyDictionary<int, Slice> remapping,
+    ref AvatarCustomSkinningComponent avatarCustomSkinningComponent)
+{
+    if (remapping.TryGetValue(avatarCustomSkinningComponent.VertsOutRegion.StartIndex, out Slice newRegion))
+        avatarCustomSkinningComponent.SetVertOutRegion(newRegion);
+}
+```
+
+---
+
+## SMR to MeshRenderer Conversion Code
+
+Wearables arrive as `SkinnedMeshRenderer` from Asset Bundles. `ComputeShaderSkinning` converts them to `MeshRenderer` for custom GPU skinning:
+
+```csharp
+private (MeshRenderer, MeshFilter) SetupMesh(SkinnedMeshRenderer skin)
+{
+    GameObject go = skin.gameObject;
+    MeshFilter filter = go.AddComponent<MeshFilter>();
+    filter.mesh = skin.sharedMesh;
+    MeshRenderer meshRenderer = go.AddComponent<MeshRenderer>();
+    meshRenderer.renderingLayerMask = 2;
+    Object.Destroy(skin);
+    return (meshRenderer, filter);
+}
+```
+
+---
+
+## Facial Features Code
+
+Facial features (eyes, eyebrows, mouth) use suffix-based matching on the renderer name:
+
+```csharp
+private static readonly (string suffix, string category, int defaultSlotIndexUsed, ...)[] SUFFIX_CATEGORY_MAP =
+{
+    ("Mask_Eyes",     WearableCategories.Categories.EYES,     1, shape => shape.EyesColor),
+    ("Mask_Eyebrows", WearableCategories.Categories.EYEBROWS, 0, shape => shape.HairColor),
+    ("Mask_Mouth",    WearableCategories.Categories.MOUTH,    0, shape => shape.SkinColor),
+};
+```
+
+---
+
+## Color Assignment Code
+
+Original material names determine avatar color application:
+
+```csharp
+if (name.Contains("skin", StringComparison.OrdinalIgnoreCase))
+    avatarMaterial.SetColor(BASE_COLOR, avatarShapeComponent.SkinColor);
+else if (name.Contains("hair", StringComparison.OrdinalIgnoreCase))
+    avatarMaterial.SetColor(BASE_COLOR, avatarShapeComponent.HairColor);
+```
+
+---
+
+## Texture Arrays Code
+
+Textures are copied into shared `Texture2DArray` objects to reduce draw call binding cost. `TextureArrayContainer` manages slots per shader, with resolutions at 256 and 512:
+
+```csharp
+TextureArraySlot?[] slots = poolMaterialSetup.TextureArrayContainer
+    .SetTexturesFromOriginalMaterial(originalMaterial, avatarMaterial);
+```
+
+---
+
+## EmotePlayer Code
+
+```csharp
+public class EmotePlayer
+{
+    private readonly Dictionary<GameObject, GameObjectPool<EmoteReferences>> pools = new();
+    private readonly Dictionary<EmoteReferences, GameObjectPool<EmoteReferences>> emotesInUse = new();
+
+    public bool Play(GameObject mainAsset, AudioClip? audioAsset, bool isLooping,
+        bool isSpatial, in IAvatarView view, ref CharacterEmoteComponent emoteComponent)
+    {
+        // Get or create pool for this emote asset
+        if (!pools.ContainsKey(mainAsset))
+            pools.Add(mainAsset, new GameObjectPool<EmoteReferences>(poolRoot,
+                () => CreateNewEmoteReference(mainAsset), onRelease: releaseEmoteReferences));
+
+        EmoteReferences emoteReferences = pools[mainAsset].Get();
+        // Parent to avatar, play Mecanim or legacy animation
+        // ...
+    }
+
+    public void Stop(EmoteReferences emoteReference)
+    {
+        if (!emotesInUse.Remove(emoteReference, out var pool)) return;
+        pool.Release(emoteReference);
+    }
+}
+```
+
+---
+
+## ReleaseAvatar Cleanup Code
+
+```csharp
+public static void Execute(FixedComputeBufferHandler vertOutBuffer, IAttachmentsAssetsCache wearableAssetsCache,
+    IAvatarMaterialPoolHandler avatarMaterialPoolHandler, IObjectPool<ComputeShader> computeShaderSkinningPool,
+    in AvatarShapeComponent avatarShapeComponent, ref AvatarCustomSkinningComponent skinningComponent,
+    ref AvatarTransformMatrixComponent avatarTransformMatrixComponent, AvatarTransformMatrixJobWrapper jobWrapper)
+{
+    vertOutBuffer.Release(skinningComponent.VertsOutRegion);    // GVB region release
+    skinningComponent.Dispose(avatarMaterialPoolHandler, computeShaderSkinningPool); // material + compute shader pool return
+    jobWrapper.ReleaseAvatar(ref avatarTransformMatrixComponent); // Job array slot release
+    wearableAssetsCache.ReleaseAssets(avatarShapeComponent.InstantiatedWearables); // wearable cache deref
+}
+```

--- a/.claude/skills/chat-system/SKILL.md
+++ b/.claude/skills/chat-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chat-system
-description: "Chat system architecture — MVP pattern, message bus decorator chain, commands, auto-translation, encrypted history, and input state machine. Use when adding chat commands, modifying message flow, working with chat services (history, translation), implementing message decorators, or extending chat UI states."
+description: "Chat system — MVP pattern, message bus decorators, commands, auto-translation, encrypted history, state machine. Use when adding chat commands, modifying message flow, or working with chat services."
 user-invocable: false
 ---
 
@@ -50,17 +50,7 @@ The chat system uses **MVP + State Machine + EventBus + Commands**:
 
 ## Message Bus Decorator Chain
 
-`IChatMessagesBus` is wrapped in decorators, each adding a concern. The chain is composed in `DynamicWorldContainer`:
-
-```csharp
-// DynamicWorldContainer.cs — decorator chain composition
-IChatMessagesBus coreChatMessageBus =
-    new MultiplayerChatMessagesBus(messagePipesHub, chatMessageFactory, ...)
-        .WithSelfResend(identityCache, chatMessageFactory)
-        .WithIgnoreSymbols()
-        .WithCommands(chatCommands, loadingStatus)
-        .WithDebugPanel(debugBuilder);
-```
+`IChatMessagesBus` is wrapped in decorators, each adding a concern. The chain is composed in `DynamicWorldContainer`.
 
 ### Decorator Responsibilities
 
@@ -74,7 +64,6 @@ IChatMessagesBus coreChatMessageBus =
 ### Interface
 
 ```csharp
-// IChatMessagesBus.cs
 public interface IChatMessagesBus : IDisposable
 {
     event Action<ChatChannel.ChannelId, ChatChannel.ChatChannelType, ChatMessage> MessageAdded;
@@ -91,7 +80,6 @@ Each decorator wraps `origin.Send()` and forwards `origin.MessageAdded` events, 
 ### Interface
 
 ```csharp
-// IChatCommand.cs
 public interface IChatCommand
 {
     string Command { get; }
@@ -120,17 +108,6 @@ public interface IChatCommand
 | `/killpx <urn>` | `KillPortableExperienceChatCommand` | Yes |
 | `/appargs` | `AppArgsChatCommand` | Yes |
 
-### Command Dispatch (inside `CommandsHandleChatMessageBus`)
-
-```csharp
-if (message[0] == '/') // User tried running a command
-{
-    HandleChatCommandAsync(ChatChannel.NEARBY_CHANNEL_ID, ChatChannel.ChatChannelType.NEARBY, message).Forget();
-    return;
-}
-this.origin.Send(channel, message, origin, timestamp); // Not a command — pass through
-```
-
 Commands are registered in `DynamicWorldContainer` as `IReadOnlyList<IChatCommand>` and looked up by name in a dictionary.
 
 ---
@@ -155,28 +132,6 @@ Minimized --> Focused (focus requested / minimize toggle)
 Hidden <-- (SharedSpaceManager hides chat when other panels open)
 Hidden --> Default (SharedSpaceManager restores chat)
 ```
-
-### State Example
-
-```csharp
-// FocusedChatState.cs
-public class FocusedChatState : ChatState, IState
-{
-    public void Enter()
-    {
-        mediator.SetupForFocusedState();
-        inputBlocker.Block();       // Block player movement input
-    }
-
-    public override void Exit() => inputBlocker.Unblock();
-
-    public override void OnClickOutside() => stateMachine.Enter<DefaultChatState>();
-    public override void OnCloseRequested() => stateMachine.Enter<MinimizedChatState>();
-    public override void OnToggleMembers() => stateMachine.Enter<MembersChatState>();
-}
-```
-
-### Base Class
 
 All states inherit `ChatState` which provides virtual no-op methods: `OnClickOutside`, `OnClickInside`, `OnCloseRequested`, `OnFocusRequested`, `OnMinimizeRequested`, `OnToggleMembers`, `OnPointerEnter`, `OnPointerExit`. States override only the transitions they handle.
 
@@ -231,25 +186,6 @@ Feature flag: `explorer-alfa-chat-history-local-storage`. Core classes in `Explo
     {Base64(AES(channelId))}              <-- encrypted CSV per conversation
 ```
 
-### Encryption
-
-```csharp
-// ChatHistoryEncryptor.cs
-public void SetNewEncryptionKey(string newEncryptionKey)
-{
-    byte[] hashedKey = shaEncryptor.ComputeHash(Encoding.UTF8.GetBytes(newEncryptionKey));
-    cryptoProvider.Key = hashedKey;
-    cryptoProvider.IV = hashedKey.AsSpan(0, 16).ToArray();
-    cryptoProvider.Mode = CipherMode.ECB;
-    cryptoProvider.Padding = PaddingMode.Zeros;
-}
-
-public string StringToFileName(string str)
-{
-    // AES-encrypt -> Base64 -> replace '/' with '_' for filesystem safety
-}
-```
-
 ### Key Behaviors
 
 - **Per-account isolation**: wallet address is the encryption key; folder name is `Base64(AES(address))`
@@ -257,6 +193,12 @@ public string StringToFileName(string str)
 - **Background processing**: message queue processed on a thread pool via `UniTask.RunOnThreadPool`
 - **Rehydration**: on first DM message, snapshots session messages, loads history from disk, replays session tail to avoid data loss
 - **Nearby excluded**: only `ChatChannelType.USER` conversations are persisted
+
+---
+
+## Detailed Reference
+
+For detailed code examples, see [reference.md](reference.md).
 
 ---
 

--- a/.claude/skills/chat-system/reference.md
+++ b/.claude/skills/chat-system/reference.md
@@ -1,0 +1,67 @@
+# Chat System — Detailed Reference
+
+## DynamicWorldContainer Decorator Composition
+
+```csharp
+// DynamicWorldContainer.cs — decorator chain composition
+IChatMessagesBus coreChatMessageBus =
+    new MultiplayerChatMessagesBus(messagePipesHub, chatMessageFactory, ...)
+        .WithSelfResend(identityCache, chatMessageFactory)
+        .WithIgnoreSymbols()
+        .WithCommands(chatCommands, loadingStatus)
+        .WithDebugPanel(debugBuilder);
+```
+
+---
+
+## CommandsHandleChatMessageBus — Command Dispatch
+
+```csharp
+if (message[0] == '/') // User tried running a command
+{
+    HandleChatCommandAsync(ChatChannel.NEARBY_CHANNEL_ID, ChatChannel.ChatChannelType.NEARBY, message).Forget();
+    return;
+}
+this.origin.Send(channel, message, origin, timestamp); // Not a command — pass through
+```
+
+---
+
+## FocusedChatState — State Example
+
+```csharp
+public class FocusedChatState : ChatState, IState
+{
+    public void Enter()
+    {
+        mediator.SetupForFocusedState();
+        inputBlocker.Block();       // Block player movement input
+    }
+
+    public override void Exit() => inputBlocker.Unblock();
+
+    public override void OnClickOutside() => stateMachine.Enter<DefaultChatState>();
+    public override void OnCloseRequested() => stateMachine.Enter<MinimizedChatState>();
+    public override void OnToggleMembers() => stateMachine.Enter<MembersChatState>();
+}
+```
+
+---
+
+## ChatHistoryEncryptor — Encryption
+
+```csharp
+public void SetNewEncryptionKey(string newEncryptionKey)
+{
+    byte[] hashedKey = shaEncryptor.ComputeHash(Encoding.UTF8.GetBytes(newEncryptionKey));
+    cryptoProvider.Key = hashedKey;
+    cryptoProvider.IV = hashedKey.AsSpan(0, 16).ToArray();
+    cryptoProvider.Mode = CipherMode.ECB;
+    cryptoProvider.Padding = PaddingMode.Zeros;
+}
+
+public string StringToFileName(string str)
+{
+    // AES-encrypt -> Base64 -> replace '/' with '_' for filesystem safety
+}
+```

--- a/.claude/skills/creating-skills/SKILL.md
+++ b/.claude/skills/creating-skills/SKILL.md
@@ -149,8 +149,26 @@ Match specificity to task fragility:
 - **Frequently-triggered skills**: <500 words preferred.
 - **On-demand skills** (`disable-model-invocation`): more generous, but still under 500 lines.
 - **Body word count target**: 1,500-2,000 words ideal, <5,000 words max.
-- Move heavy reference to separate files when SKILL.md approaches 300+ lines.
 - Scripts in `scripts/` are executed, not loaded — only output consumes tokens.
+
+### Progressive Disclosure Split
+
+Even skills under 300 lines benefit from splitting SKILL.md into a lean core + reference.md. The split reduces context consumption by ~46% on average with zero quality loss — Claude reads reference.md on demand only when it needs detailed code examples.
+
+**What stays in SKILL.md** (always loaded when skill triggers):
+- Workflow steps, decision tables, rules, API summaries
+- Minimal code snippets (2-5 lines) showing correct/wrong patterns
+- Checklists, quick-reference tables
+- Cross-references to other skills
+- A "## Detailed Reference" section linking to `[reference.md](reference.md)`
+
+**What moves to reference.md** (loaded only when Claude needs implementation details):
+- Full code examples (>10 lines) from the codebase
+- Complete class/system implementations showing patterns end-to-end
+- Deep-dive explanations of internal mechanisms
+- Test code examples
+
+**When to split:** Always consider splitting if the skill has code examples >10 lines. The question is not "is this skill too long?" but "does Claude need this code block to understand the workflow, or only when implementing?" If the latter, extract it.
 
 ## Description Optimization
 
@@ -270,11 +288,12 @@ What works for Opus may need more detail for Haiku. If a skill will be used acro
 **WRITE Phase:**
 - [ ] Name: lowercase, hyphens, max 64 chars, gerund form preferred
 - [ ] Frontmatter max 1024 chars, description in third person
-- [ ] Description: no workflow summary, includes "Use when..." + keywords
+- [ ] Description: no workflow summary, includes "Use when..." + keywords, under 250 chars
 - [ ] Body under 500 lines. Heavy reference in separate files.
 - [ ] Appropriate degree of freedom for the task type
 - [ ] Only context Claude doesn't already have
 - [ ] References one level deep, files >100 lines have TOC
+- [ ] Progressive disclosure split — code examples >10 lines moved to reference.md
 
 **VERIFY Phase:**
 - [ ] Run WITH skill (Claude B) — verify compliance on all scenarios

--- a/.claude/skills/creating-skills/SKILL.md
+++ b/.claude/skills/creating-skills/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: creating-skills
+disable-model-invocation: true
+description: Skill authoring and optimization. Use when creating new skills, editing existing skills, verifying skill quality, or optimizing trigger descriptions.
+---
+
+# Creating Skills
+
+Skills are eval-driven process documentation. Build evaluations first, write the skill to pass them, then optimize trigger descriptions for activation accuracy.
+
+For comprehensive Anthropic guidelines, see [best-practices-reference.md](best-practices-reference.md).
+
+## Eval-Driven Development
+
+### Why Evals First
+
+A skill without evals is untested code. The eval proves the skill teaches the right thing and activates at the right time.
+
+### The Claude A / Claude B Pattern
+
+Use two separate agent sessions to avoid self-confirmation bias:
+
+1. **Claude A** (author) — writes the skill content
+2. **Claude B** (tester) — runs evaluation scenarios cold, without seeing the authoring process
+
+This separation ensures the skill works for any agent, not just one primed by the authoring context.
+
+### Minimum Evaluation Requirements
+
+Every skill needs at least **3 evaluation scenarios** before writing content:
+
+1. **Baseline (no skill)** — Run scenarios without the skill. Document what the agent did wrong, what rationalizations it used (verbatim), which pressures triggered violations.
+2. **With-skill pass** — Run the same scenarios with the skill loaded. The agent should now comply.
+3. **Adversarial/edge case** — Test boundary conditions, near-misses, and rationalization attempts.
+
+Record concrete outputs, not impressions. Quote agent responses verbatim when documenting failures.
+
+### Eval-Write-Eval Cycle
+
+```
+1. Design 3+ realistic evaluation scenarios
+2. Run baseline WITHOUT skill (Claude B) -> document failures
+3. Write minimal skill addressing those specific failures (Claude A)
+4. Run same scenarios WITH skill (Claude B) -> verify compliance
+5. If new failure modes appear, add counters and re-test
+```
+
+Do not add content for hypothetical cases. Every section should trace back to an observed failure.
+
+## Skill Types
+
+- **Technique** — Concrete method with steps (e.g., root-cause-tracing, condition-based-waiting)
+- **Pattern** — Way of thinking about problems (e.g., flatten-with-flags)
+- **Reference** — API docs, syntax guides, tool documentation
+
+## Directory Structure
+
+```
+skills/
+  skill-name/          # letters, numbers, hyphens only
+    SKILL.md           # required — main instructions, under 500 lines
+    reference.md       # optional — detailed docs, loaded on demand
+    examples.md        # optional — usage examples, loaded on demand
+    scripts/
+      helper.py        # optional — executed via Bash, NOT loaded into context
+    assets/
+      template.pptx    # optional — output files (templates, icons, fonts), NOT loaded into context
+```
+
+**`assets/`** holds files used in skill output (brand logos, slide templates, boilerplate projects). Unlike references, assets are never read into context — they're copied, modified, or embedded in output.
+
+Keep references **one level deep** from SKILL.md. Nested references (SKILL.md → advanced.md → details.md) cause Claude to partially read files. For files over 100 lines, include a table of contents at the top.
+
+## SKILL.md Frontmatter
+
+```yaml
+---
+name: skill-name-with-hyphens
+description: What it does. Use when [specific triggering conditions]
+---
+```
+
+**Hard constraints:**
+- `name`: Max 64 chars. Lowercase letters, numbers, hyphens only. No "anthropic" or "claude".
+- `description`: Max 1024 chars. Non-empty. No XML tags.
+- Prefer gerund form for names: `processing-pdfs`, `analyzing-data`, `testing-code`
+
+**Optional frontmatter fields:**
+- `disable-model-invocation: true` — only user can invoke (not auto-triggered, saves context budget)
+- `user-invocable: false` — only Claude can invoke (background knowledge, hidden from `/` menu)
+- `allowed-tools` — restrict tools when skill is active (e.g., `Read, Grep, Glob`)
+- `context: fork` — run in isolated subagent context
+- `agent` — which subagent type when `context: fork` is set
+- `model` — override model for this skill (e.g., `haiku` for cheap tasks)
+- `effort` — `low`, `medium`, `high`, `max` (Opus 4.6 only)
+- `hooks` — lifecycle hooks scoped to this skill's execution
+- `paths` — glob patterns limiting when skill auto-activates (e.g., `["src/**/*.py"]`)
+- `shell` — `bash` (default) or `powershell`
+- `argument-hint` — shown during autocomplete (e.g., `[issue-number]`)
+
+**Description rules:**
+- **Third-person always.** Description is injected into the system prompt.
+- **CRITICAL: Description = when to use ONLY.** NEVER summarize the skill's process or workflow. Testing shows that when a description summarizes workflow, Claude follows the description instead of reading the skill body.
+- Include **both what the skill does AND when to use it**.
+- Include 5+ keywords from actual user workflows.
+- **Front-load the key use case** — descriptions are truncated at ~250 chars in skill listings.
+- **Be assertive about activation** — include phrases like "Make sure to use this skill whenever the user mentions X, even if they don't explicitly ask for it."
+
+**Context budget:** All skill descriptions share a pool of **~1% of context window (fallback ~8K chars)**. Every character in every description consumes from this shared pool. Skills with `disable-model-invocation: true` are NOT loaded into context at all. Override with `SLASH_COMMAND_TOOL_CHAR_BUDGET` env var.
+
+## SKILL.md Body Structure
+
+```markdown
+# Skill Name
+
+## Overview
+What is this? Core principle in 1-2 sentences.
+
+## Quick Reference
+Table or bullets for scanning common operations
+
+## Core Pattern
+Before/after comparison (for techniques/patterns)
+
+## Implementation
+Inline code for simple patterns, link to file for heavy reference
+
+## Common Mistakes
+What goes wrong + fixes
+```
+
+**Default assumption: Claude is already very smart.** Only add context Claude doesn't already have. Challenge each piece: "Does Claude really need this explanation?"
+
+**Writing style:** Use imperative/infinitive form ("Validate the input", "Configure the server"), not second person ("You should validate..."). Explain *why* behind instructions — LLMs respond better to reasoning than bare ALWAYS/NEVER directives.
+
+## Degrees of Freedom
+
+Match specificity to task fragility:
+
+| Level | When to use | Example |
+|-------|------------|---------|
+| **High** (text instructions) | Multiple valid approaches, context-dependent | Code review guidelines |
+| **Medium** (parameterized scripts) | Preferred pattern exists, some variation ok | Report generation with template |
+| **Low** (exact scripts, no params) | Fragile operations, consistency critical | Database migrations, deployments |
+
+## Token Efficiency
+
+- **Every-session skills** (loaded via hook): absolute minimum tokens. <200 words.
+- **Frequently-triggered skills**: <500 words preferred.
+- **On-demand skills** (`disable-model-invocation`): more generous, but still under 500 lines.
+- **Body word count target**: 1,500-2,000 words ideal, <5,000 words max.
+- Move heavy reference to separate files when SKILL.md approaches 300+ lines.
+- Scripts in `scripts/` are executed, not loaded — only output consumes tokens.
+
+## Description Optimization
+
+The description controls activation rate. Optimize methodically:
+
+### Step 1 — Keyword Coverage
+
+Use words Claude would search for: error messages, symptoms ("flaky", "hanging", "race condition"), tool names, synonyms. Cover the vocabulary space of likely user prompts.
+
+### Step 2 — Build Eval Queries
+
+Create at least 20 evaluation queries:
+- 8-10 should-trigger queries (realistic user prompts with personal context, specific details)
+- 8-10 should-not-trigger queries (near-misses from adjacent domains, not obviously irrelevant)
+
+### Step 3 — Test and Iterate
+
+1. For each query, check if the description would cause activation
+2. Adjust keywords and phrasing to improve precision and recall
+3. Re-test until satisfied with activation accuracy
+
+### Activation Rate Benchmarks
+
+- **Good:** >80% correct activation on eval set
+- **Acceptable:** >70% with no false positives on critical should-not-trigger queries
+- **Needs work:** <70% or any false positive on dangerous near-misses
+
+### Step 4 — Add Concrete Examples
+
+If keyword coverage alone is insufficient, add specific phrases from real user prompts. Concrete examples improve activation from ~50% to 72-90%.
+
+## Workflow Patterns
+
+### Checklist Pattern
+For complex multi-step tasks, provide a copyable checklist Claude can track progress with.
+
+### Feedback Loop Pattern
+Run validator → fix errors → repeat. Greatly improves output quality for document generation, form filling, code review.
+
+### Plan-Validate-Execute Pattern
+Have Claude create an intermediate plan file → validate with script → execute. Catches errors early.
+
+### Conditional Workflow
+Guide Claude through decision points: "Creating new? → Creation workflow. Editing existing? → Editing workflow."
+
+### Template Pattern
+Provide output format templates (strict or flexible) so Claude produces consistent structured output.
+
+### Examples Pattern
+Input/output pairs work like few-shot prompting — show what good output looks like for representative inputs.
+
+## Bulletproofing Discipline Skills
+
+For skills that enforce rules, resistance to rationalization is critical.
+
+**Close every loophole explicitly** — state the rule, then forbid specific workarounds.
+
+**Build a rationalization table** from baseline testing:
+
+```markdown
+| Excuse | Reality |
+|--------|---------|
+| "Too simple to test" | Simple code breaks. Test takes 30 seconds. |
+```
+
+**Red flags list** — makes agent self-checking easy.
+
+## Dynamic Features
+
+### String Substitutions
+
+| Variable | Description |
+|----------|------------|
+| `$ARGUMENTS` / `$N` | Arguments passed when invoking the skill |
+| `${CLAUDE_SKILL_DIR}` | Directory containing the skill's SKILL.md |
+| `${CLAUDE_SESSION_ID}` | Current session ID |
+
+### Dynamic Context Injection
+
+The `` !`command` `` syntax runs shell commands before skill content is sent to Claude:
+```yaml
+## PR context
+- PR diff: !`gh pr diff`
+- Changed files: !`gh pr diff --name-only`
+```
+
+## Anti-Patterns
+
+- **Narrative** — "In session 2025-10-03, we found..." is too specific, not reusable
+- **Multi-language dilution** — One great example beats mediocre examples in 5 languages
+- **Generic labels** — `helper1`, `step3` have no semantic meaning
+- **Skipping evals** — Writing content before observing failures produces bloated skills
+- **Graphviz diagrams** — Rendered as raw text in terminals. Use numbered lists or tables instead.
+- **Workflow summary in description** — Claude follows description shortcut instead of reading body
+- **Vague descriptions** — "Helps with documents" achieves ~20% activation
+- **Over-explaining** — Claude knows what PDFs are and how libraries work
+- **Deeply nested references** — Keep one level deep from SKILL.md
+- **Time-sensitive info** — "Before August 2025, use old API" becomes wrong. Use "Old patterns" section.
+- **Inconsistent terminology** — Pick one term ("endpoint" not "endpoint/URL/route/path")
+- **Too many options** — Provide one default with an escape hatch, not 5 choices
+- **Excessive ALWAYS/NEVER caps** — Explain reasoning instead; LLMs respond better to "why" than bare directives
+
+## Testing Across Models
+
+What works for Opus may need more detail for Haiku. If a skill will be used across models:
+- **Haiku**: May need more explicit guidance and examples
+- **Sonnet**: Balanced — good default target
+- **Opus**: May be over-served by verbose instructions — trim for efficiency
+
+## Checklist
+
+**EVAL Phase:**
+- [ ] Design 3+ realistic evaluation scenarios
+- [ ] Run WITHOUT skill (Claude B) — document exact failures verbatim
+- [ ] Record rationalizations and failure modes
+
+**WRITE Phase:**
+- [ ] Name: lowercase, hyphens, max 64 chars, gerund form preferred
+- [ ] Frontmatter max 1024 chars, description in third person
+- [ ] Description: no workflow summary, includes "Use when..." + keywords
+- [ ] Body under 500 lines. Heavy reference in separate files.
+- [ ] Appropriate degree of freedom for the task type
+- [ ] Only context Claude doesn't already have
+- [ ] References one level deep, files >100 lines have TOC
+
+**VERIFY Phase:**
+- [ ] Run WITH skill (Claude B) — verify compliance on all scenarios
+- [ ] Add rationalization table (if discipline skill)
+- [ ] Re-test until bulletproof
+
+**OPTIMIZE Phase:**
+- [ ] Build 20+ eval queries for description
+- [ ] Test activation accuracy (target >80%)
+- [ ] Add concrete examples if activation <70%
+- [ ] Test with Haiku, Sonnet, and Opus if cross-model use planned

--- a/.claude/skills/creating-skills/best-practices-reference.md
+++ b/.claude/skills/creating-skills/best-practices-reference.md
@@ -1,0 +1,371 @@
+# Anthropic Skill Authoring Best Practices — Reference
+
+Comprehensive reference extracted from Anthropic's official documentation. Load this file when you need detailed guidance beyond what SKILL.md covers.
+
+## Contents
+
+- [Sources](#sources)
+- [Discovery Mechanics](#discovery-mechanics)
+- [Progressive Disclosure — Deep Dive](#progressive-disclosure--deep-dive)
+- [Invocation Control — Full Matrix](#invocation-control--full-matrix)
+- [Description Writing — Detailed Examples](#description-writing--detailed-examples)
+- [Conciseness Guidelines](#conciseness-guidelines)
+- [Workflow Patterns — Detailed](#workflow-patterns--detailed)
+- [Script Guidelines](#script-guidelines)
+- [Iterative Development with Claude](#iterative-development-with-claude)
+- [Skill Locations and Priority](#skill-locations-and-priority)
+- [Quality Checklist (Anthropic Official)](#quality-checklist-anthropic-official)
+
+---
+
+## Sources
+
+- [Skill Authoring Best Practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+- [Skills Overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+- [Claude Code Skills Docs](https://code.claude.com/docs/en/skills)
+- [Equipping Agents for the Real World](https://claude.com/blog/equipping-agents-for-the-real-world-with-agent-skills)
+- [Improving Skill Creator](https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills)
+- [Agent Skills Open Standard](https://agentskills.io/home) — cross-platform (Claude Code, Cursor, VS Code Copilot, Gemini CLI)
+
+---
+
+## Discovery Mechanics
+
+There is no algorithmic routing — pure LLM reasoning via transformer forward pass. All skill metadata (name + description) is formatted into `<available_skills>` tags within the Skill tool's description in the `tools` array of the API request.
+
+At startup, only metadata (~100 tokens per skill) is loaded. Full SKILL.md loads only when Claude selects the skill. Additional bundled files load only on demand.
+
+### Context Budget
+
+- Total character budget for all skill descriptions: **~1% of context window, fallback ~8,000 characters**
+- Override with `SLASH_COMMAND_TOOL_CHAR_BUDGET` environment variable
+- Run `/context` to check for warnings about excluded skills
+- Skills with `disable-model-invocation: true` are NOT loaded into context at all
+- **Descriptions truncated at ~250 chars** in skill listings — front-load the key use case
+
+### Activation Rate Benchmarks (from real-world testing, 200+ prompts)
+
+| Strategy | Activation Rate | Effort |
+|----------|----------------|--------|
+| No optimization | ~20% | None |
+| Optimized description with "USE WHEN" | ~50% | Low |
+| Adding concrete examples | 72-90% | Medium |
+| LLM pre-evaluation hook | ~80% | High |
+| Forced evaluation hook | ~84% | High |
+
+### Three-Tier Activation Strategy
+
+1. **Level 1**: Description optimization (50% success, low effort)
+2. **Level 2**: CLAUDE.md references mentioning the skill (60-70%, medium effort)
+3. **Level 3**: Custom evaluation hooks (84%, high effort)
+
+---
+
+## Progressive Disclosure — Deep Dive
+
+### Three Tiers
+
+1. **Tier 1 (Metadata)**: Name + description loaded at startup (~100 tokens)
+2. **Tier 2 (Core Content)**: Full SKILL.md loaded when skill is triggered
+3. **Tier 3+ (Details)**: Additional bundled files loaded only when needed
+
+### Pattern 1 — High-level guide with references
+
+```markdown
+# PDF Processing
+
+## Quick start
+[inline code example]
+
+## Advanced features
+- Form filling: See [FORMS.md](FORMS.md)
+- API reference: See [REFERENCE.md](REFERENCE.md)
+```
+
+Claude loads FORMS.md or REFERENCE.md only when needed.
+
+### Pattern 2 — Domain-specific organization
+
+For skills with multiple domains, organize by domain:
+
+```
+bigquery-skill/
+  SKILL.md (overview and navigation)
+  reference/
+    finance.md (revenue, billing)
+    sales.md (pipeline, accounts)
+    product.md (API usage, features)
+```
+
+When user asks about revenue, Claude only reads `reference/finance.md`.
+
+### Pattern 3 — Conditional details
+
+```markdown
+## Creating documents
+Use docx-js. See [DOCX-JS.md](DOCX-JS.md).
+
+## Editing documents
+For simple edits, modify XML directly.
+**For tracked changes**: See [REDLINING.md](REDLINING.md)
+```
+
+---
+
+## Invocation Control — Full Matrix
+
+| Frontmatter | User can invoke | Claude can invoke | Context loading |
+|---|---|---|---|
+| (default) | Yes | Yes | Description always in context |
+| `disable-model-invocation: true` | Yes | No | Description NOT in context |
+| `user-invocable: false` | No | Yes | Description always in context |
+
+### Additional frontmatter fields
+
+| Field | Description |
+|---|---|
+| `model` | Override model for this skill (e.g., `haiku` for cheap tasks) |
+| `effort` | `low`, `medium`, `high`, `max` (Opus 4.6 only) |
+| `hooks` | Lifecycle hooks scoped to this skill's execution |
+| `paths` | Glob patterns limiting auto-activation (e.g., `["src/**/*.py"]`) |
+| `shell` | `bash` (default) or `powershell` |
+| `argument-hint` | Shown during autocomplete (e.g., `[issue-number]`) |
+
+### When to use each invocation mode
+
+- **`disable-model-invocation: true`**: Skills with side effects (deploy, commit, send messages) or rarely used skills (saves context budget)
+- **`user-invocable: false`**: Background knowledge that is not actionable as a command (e.g., `legacy-system-context`)
+- **Default**: Most skills — Claude triggers them automatically when relevant
+
+### Permission control
+
+```text
+# Allow specific skills
+Skill(commit)
+Skill(review-pr *)
+
+# Deny specific skills
+Skill(deploy *)
+```
+
+---
+
+## Description Writing — Detailed Examples
+
+### Good descriptions (specific, third person, trigger-focused)
+
+```yaml
+# PDF Processing
+description: Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.
+
+# Git Commit Helper
+description: Generate descriptive commit messages by analyzing git diffs. Use when the user asks for help writing commit messages or reviewing staged changes.
+
+# Excel Analysis
+description: Analyze Excel spreadsheets, create pivot tables, generate charts. Use when analyzing Excel files, spreadsheets, tabular data, or .xlsx files.
+```
+
+### Bad descriptions (vague, wrong person, workflow summary)
+
+```yaml
+# Too vague
+description: Helps with documents
+
+# First person
+description: I can help you process Excel files
+
+# Second person
+description: You can use this to process Excel files
+
+# Workflow summary (CRITICAL VIOLATION)
+description: Use when executing plans - dispatches subagent per task with code review between tasks
+```
+
+### Naming conventions
+
+Prefer **gerund form** (verb + -ing):
+- `processing-pdfs`, `analyzing-spreadsheets`, `managing-databases`
+
+Acceptable alternatives:
+- Noun phrases: `pdf-processing`, `spreadsheet-analysis`
+- Action-oriented: `process-pdfs`, `analyze-spreadsheets`
+
+Avoid: `helper`, `utils`, `tools`, `documents`, `data`, `files`
+
+---
+
+## Conciseness Guidelines
+
+**Default assumption: Claude is already very smart.** Only add context Claude doesn't already have.
+
+**Good (concise, ~50 tokens):**
+```markdown
+## Extract PDF text
+Use pdfplumber for text extraction:
+\```python
+import pdfplumber
+with pdfplumber.open("file.pdf") as pdf:
+    text = pdf.pages[0].extract_text()
+\```
+```
+
+**Bad (verbose, ~150 tokens):**
+```markdown
+## Extract PDF text
+PDF (Portable Document Format) files are a common file format that contains
+text, images, and other content. To extract text from a PDF, you'll need to
+use a library. There are many libraries available...
+```
+
+---
+
+## Workflow Patterns — Detailed
+
+### Checklist pattern
+
+```markdown
+Copy this checklist and track your progress:
+
+Task Progress:
+- [ ] Step 1: Analyze the form (run analyze_form.py)
+- [ ] Step 2: Create field mapping (edit fields.json)
+- [ ] Step 3: Validate mapping (run validate_fields.py)
+- [ ] Step 4: Fill the form (run fill_form.py)
+- [ ] Step 5: Verify output (run verify_output.py)
+```
+
+### Feedback loop pattern
+
+```markdown
+1. Make edits to document.xml
+2. Validate: python scripts/validate.py unpacked_dir/
+3. If validation fails: fix issues, run validation again
+4. Only proceed when validation passes
+5. Rebuild: python scripts/pack.py unpacked_dir/ output.docx
+```
+
+### Plan-validate-execute pattern
+
+For batch operations or destructive changes:
+1. Claude creates intermediate `changes.json`
+2. Script validates the plan: field names exist, no conflicts, no missing required fields
+3. Only after validation passes, apply changes
+4. Verify output
+
+**Benefits:** catches errors early, machine-verifiable, reversible planning, clear debugging.
+
+### Conditional workflow
+
+```markdown
+1. Determine the modification type:
+   **Creating new content?** -> Follow "Creation workflow" below
+   **Editing existing content?** -> Follow "Editing workflow" below
+```
+
+---
+
+## Script Guidelines
+
+### Handle errors explicitly
+
+```python
+def process_file(path):
+    try:
+        with open(path) as f:
+            return f.read()
+    except FileNotFoundError:
+        print(f"File {path} not found, creating default")
+        with open(path, "w") as f:
+            f.write("")
+        return ""
+```
+
+### Document magic numbers
+
+```python
+# HTTP requests typically complete within 30 seconds
+REQUEST_TIMEOUT = 30
+
+# Three retries balances reliability vs speed
+MAX_RETRIES = 3
+```
+
+### Make execution intent clear
+
+- "Run `analyze_form.py` to extract fields" (execute)
+- "See `analyze_form.py` for the extraction algorithm" (read as reference)
+
+---
+
+## Iterative Development with Claude
+
+### Creating a new skill
+
+1. Complete a task without a skill — notice what context you repeatedly provide
+2. Identify the reusable pattern
+3. Ask Claude A to create a skill capturing the pattern
+4. Review for conciseness — remove explanations Claude doesn't need
+5. Ask Claude A to improve information architecture (separate reference files)
+6. Test with Claude B on related use cases
+7. Iterate based on observation
+
+### Iterating on existing skills
+
+1. Use the skill in real workflows with Claude B
+2. Observe behavior — where does it struggle, succeed, or make unexpected choices?
+3. Return to Claude A with specifics: "Claude B forgot to filter test accounts when..."
+4. Review Claude A's suggestions
+5. Apply changes, re-test with Claude B
+6. Repeat as new scenarios emerge
+
+### Watch for navigation patterns
+
+- **Unexpected exploration paths**: Structure may not be intuitive
+- **Missed connections**: Links need to be more explicit
+- **Overreliance on certain sections**: Content should be in main SKILL.md
+- **Ignored content**: May be unnecessary or poorly signaled
+
+---
+
+## Skill Locations and Priority
+
+| Level | Path | Applies to |
+|---|---|---|
+| Enterprise | Managed settings | All org users |
+| Personal | `~/.claude/skills/<name>/SKILL.md` | All your projects |
+| Project | `.claude/skills/<name>/SKILL.md` | This project only |
+| Plugin | `<plugin>/skills/<name>/SKILL.md` | Where plugin enabled |
+
+Priority: enterprise > personal > project. Plugin skills use `plugin-name:skill-name` namespace.
+
+Monorepo support: Nested `.claude/skills/` in subdirectories are auto-discovered.
+
+---
+
+## Quality Checklist (Anthropic Official)
+
+### Core quality
+- [ ] Description is specific, includes key terms, written in third person
+- [ ] Description includes both what the skill does and when to use it
+- [ ] SKILL.md body under 500 lines
+- [ ] Additional details in separate files (if needed)
+- [ ] No time-sensitive information
+- [ ] Consistent terminology throughout
+- [ ] Examples are concrete, not abstract
+- [ ] File references one level deep
+- [ ] Progressive disclosure used appropriately
+- [ ] Workflows have clear steps
+
+### Code and scripts
+- [ ] Scripts handle errors explicitly (don't punt to Claude)
+- [ ] No magic numbers (all values justified)
+- [ ] Required packages listed and verified
+- [ ] No Windows-style paths (all forward slashes)
+- [ ] Validation/verification steps for critical operations
+- [ ] Feedback loops for quality-critical tasks
+
+### Testing
+- [ ] At least 3 evaluations created
+- [ ] Tested with Haiku, Sonnet, and Opus
+- [ ] Tested with real usage scenarios
+- [ ] Team feedback incorporated (if applicable)

--- a/.claude/skills/cross-world-ecs-access/SKILL.md
+++ b/.claude/skills/cross-world-ecs-access/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cross-world-ecs-access
-description: "Cross-world ECS access — global world entities from scene systems, propagation systems, bridge components, PersistentEntities, and ISceneIsCurrentListener. Use when a scene-world system needs to read or modify global-world state (player entity, camera, input, avatar), implementing global-to-scene or scene-to-global propagation, working with PlayerCRDTEntity bridge components, accessing PersistentEntities, or using ISceneIsCurrentListener for scene-current safety guards."
+description: "Cross-world ECS access — global world from scene systems, propagation, bridge components, PersistentEntities. Use when scene systems need global-world state, implementing propagation, or using ISceneIsCurrentListener."
 user-invocable: false
 ---
 
@@ -22,29 +22,6 @@ The global world reaches scene systems through a plugin injection chain:
 3. Plugin stores `globalWorld` as a field
 4. On scene creation, `InjectToWorld` passes `globalWorld` to system constructors
 
-From `InputModifierPlugin.cs` — plugin receives global world + player entity, forwards to system:
-
-```csharp
-public class InputModifierPlugin : IDCLWorldPlugin
-{
-    private readonly Arch.Core.World world;       // global world
-    private readonly Entity playerEntity;          // global player entity
-
-    public InputModifierPlugin(Arch.Core.World world, Entity playerEntity,
-        ISceneRestrictionBusController sceneRestrictionBusController) { ... }
-
-    public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder,
-        in ECSWorldInstanceSharedDependencies sharedDependencies,
-        in PersistentEntities persistentEntities, ...)
-    {
-        var system = InputModifierHandlerSystem.InjectToWorld(
-            ref builder, world, playerEntity, sharedDependencies.SceneStateProvider, ...);
-        sceneIsCurrentListeners.Add(system);
-        finalizeWorldSystems.Add(system);
-    }
-}
-```
-
 > **Note:** `ECSWorldInstanceSharedDependencies` provides scene-specific metadata (scene data, partition, CRDT writer) but does NOT carry the global world reference. The global world must be passed through the plugin constructor.
 
 ---
@@ -53,70 +30,17 @@ public class InputModifierPlugin : IDCLWorldPlugin
 
 ### Pattern A: Direct Global World Access
 
-For O(1) reads/writes on known global entities. The scene system stores `globalWorld` and the target entity, then calls `Get`/`TryGet` directly.
-
-From `InputModifierHandlerSystem.cs`:
-
-```csharp
-public partial class InputModifierHandlerSystem : BaseUnityLoopSystem, ISceneIsCurrentListener
-{
-    private readonly World globalWorld;
-    private readonly Entity playerEntity;
-
-    internal InputModifierHandlerSystem(World world, World globalWorld, Entity playerEntity, ...) : base(world)
-    {
-        this.globalWorld = globalWorld;
-        this.playerEntity = playerEntity;
-    }
-
-    [Query]
-    private void ApplyModifiers([Data] bool skipDirtyCheck, Entity entity,
-        in PBInputModifier pbInputModifier, in CRDTEntity crdtEntity)
-    {
-        // Read scene-world SDK component, write to global-world component
-        ref var inputModifier = ref globalWorld.Get<InputModifierComponent>(playerEntity);
-        inputModifier.DisableAll = pbInputModifier.Standard.DisableAll;
-        // ...
-    }
-}
-```
-
-**When to use:** Fast singleton access — player input, camera state, settings. Best when the target entity is known at construction time.
+For O(1) reads/writes on known global entities. The scene system stores `globalWorld` and the target entity at construction, then calls `Get`/`TryGet` directly in queries. Best when the target entity is known at construction time (player input, camera state, settings).
 
 ### Pattern B: CRDT Bridge
 
-For indirect sync without direct world references. Uses `IECSToCRDTWriter` to serialize data back to the scene runtime.
-
-From `WriteSDKAvatarBaseSystem.cs`:
-
-```csharp
-public partial class WriteSDKAvatarBaseSystem : BaseUnityLoopSystem
-{
-    private readonly IECSToCRDTWriter ecsToCRDTWriter;
-
-    [Query]
-    [None(typeof(DeleteEntityIntention))]
-    private void UpdateAvatarBase(PlayerSceneCRDTEntity playerCRDTEntity, SDKProfile profile)
-    {
-        if (!profile.IsDirty) return;
-        ecsToCRDTWriter.PutMessage<PBAvatarBase, SDKProfile>(static (pb, profile) =>
-        {
-            pb.Name = profile.Name;
-            pb.BodyShapeUrn = profile.Avatar.BodyShape;
-        }, playerCRDTEntity.CRDTEntity, profile);
-    }
-}
-```
-
-**When to use:** Scene-to-runtime communication, CRDT-synchronized data. See the **sdk-component-implementation** skill for `PutMessage`/`AppendMessage`/`DeleteMessage` patterns.
+For indirect sync without direct world references. Uses `IECSToCRDTWriter` to serialize data back to the scene runtime. Best for scene-to-runtime communication and CRDT-synchronized data. See **sdk-component-implementation** skill for `PutMessage`/`AppendMessage`/`DeleteMessage` patterns.
 
 ---
 
 ## PersistentEntities
 
 Well-known entities created once per scene world, guaranteed alive for the world's lifetime. Received via `InjectToWorld`'s `in PersistentEntities persistentEntities` parameter.
-
-From `PersistentEntities.cs`:
 
 ```csharp
 public struct PersistentEntities
@@ -126,17 +50,6 @@ public struct PersistentEntities
     public readonly Entity SceneRoot;       // root entity (modifiable by scene creator)
     public readonly Entity SceneContainer;  // container of root (internal use only)
 }
-```
-
-Use `SingleInstanceEntity` + `WorldExtensions` for cached global-world singletons:
-
-```csharp
-// From WorldExtensions.cs
-public static SingleInstanceEntity CacheCamera(this World world) =>
-    new (in QUERY, world);
-
-public static ref CameraComponent GetCameraComponent(this in SingleInstanceEntity instance, World world) =>
-    ref world.Get<CameraComponent>(instance);
 ```
 
 ---
@@ -177,77 +90,18 @@ public struct PlayerSceneCRDTEntity : IDirtyMarker
 
 ## Propagation Systems
 
-### Global-to-Scene: PlayerTransformPropagationSystem
-
-Runs in the global world, queries global entities, writes into scene worlds via `playerCRDTEntity.SceneFacade.EcsExecutor.World`:
-
-```csharp
-[UpdateInGroup(typeof(PreRenderingSystemGroup))]
-public partial class PlayerTransformPropagationSystem : BaseUnityLoopSystem
-{
-    [Query]
-    [None(typeof(DeleteEntityIntention))]
-    private void PropagateTransformToScene(in CharacterTransform characterTransform,
-        in PlayerCRDTEntity playerCRDTEntity)
-    {
-        if (!characterTransform.Transform.hasChanged || !playerCRDTEntity.AssignedToScene) return;
-        if (playerCRDTEntity.CRDTEntity.Id == SpecialEntitiesID.PLAYER_ENTITY) return;
-
-        World sceneEcsWorld = playerCRDTEntity.SceneFacade!.EcsExecutor.World;
-
-        if (!sceneEcsWorld.TryGet<SDKTransform>(playerCRDTEntity.SceneWorldEntity, out SDKTransform? sdkTransform))
-            sceneEcsWorld.Add(playerCRDTEntity.SceneWorldEntity, sdkTransform = sdkTransformPool.Get());
-
-        sdkTransform!.Position.Value = characterTransform.Transform.position;
-        sdkTransform.Rotation.Value = characterTransform.Transform.rotation;
-        sdkTransform.IsDirty = true;
-    }
-}
-```
-
-### Scene-to-Global: Direct globalWorld Access
-
-Scene systems write to the global world directly using Pattern A (see `InputModifierHandlerSystem` above). The system reads scene-world SDK components and writes the result to `globalWorld.Get<T>(playerEntity)`.
+- **Global-to-Scene (`PlayerTransformPropagationSystem`):** Runs in the global world, queries global entities, writes into scene worlds via `playerCRDTEntity.SceneFacade.EcsExecutor.World`.
+- **Scene-to-Global:** Scene systems write to the global world directly using Pattern A. The system reads scene-world SDK components and writes the result to `globalWorld.Get<T>(playerEntity)`.
 
 ---
 
 ## ISceneIsCurrentListener Safety Pattern
 
-When a scene system modifies global state, it must only do so while the scene is current. Implement `ISceneIsCurrentListener` to apply state when becoming current and reset to defaults when leaving.
-
-From `InputModifierHandlerSystem.cs`:
-
-```csharp
-public partial class InputModifierHandlerSystem : BaseUnityLoopSystem, ISceneIsCurrentListener
-{
-    protected override void Update(float t)
-    {
-        if (!sceneStateProvider.IsCurrent) return;   // guard every frame
-        ApplyModifiersQuery(World, false);
-        HandleComponentRemovalQuery(World);
-    }
-
-    public void OnSceneIsCurrentChanged(bool value)
-    {
-        if (value)
-            ApplyModifiersQuery(World, true);        // re-apply on becoming current
-        else
-            ResetModifiers();                        // reset global state on leaving
-    }
-
-    private void ResetModifiers()
-    {
-        ref InputModifierComponent inputModifier = ref globalWorld.Get<InputModifierComponent>(playerEntity);
-        inputModifier.RemoveAllModifiers();
-    }
-}
-```
-
-Register the system in the plugin:
-
-```csharp
-sceneIsCurrentListeners.Add(system);
-```
+When a scene system modifies global state, it must only do so while the scene is current. Implement `ISceneIsCurrentListener` to:
+- Guard every `Update()` with `sceneStateProvider.IsCurrent`
+- Re-apply state in `OnSceneIsCurrentChanged(true)`
+- Reset to defaults in `OnSceneIsCurrentChanged(false)`
+- Register via `sceneIsCurrentListeners.Add(system)` in the plugin
 
 > `ISceneIsCurrentListener.OnSceneIsCurrentChanged` is called even if the scene has stopped with an error, ensuring global state is always cleaned up.
 
@@ -263,6 +117,12 @@ sceneIsCurrentListeners.Add(system);
 4. **Guard global writes with `IsCurrent` check** — always check `sceneStateProvider.IsCurrent` in `Update()` and implement `ISceneIsCurrentListener` to reset on scene exit
 5. **`ECSWorldInstanceSharedDependencies` provides scene metadata, NOT global world** — the global world must be injected through the plugin constructor
 6. **Register for cleanup** — systems that modify global state should implement `IFinalizeWorldSystem` and be added to `finalizeWorldSystems` so global state is reset on world disposal
+
+---
+
+## Detailed Reference
+
+For detailed code examples, see [reference.md](reference.md).
 
 ---
 

--- a/.claude/skills/cross-world-ecs-access/reference.md
+++ b/.claude/skills/cross-world-ecs-access/reference.md
@@ -1,0 +1,152 @@
+# Cross-World ECS Access — Detailed Reference
+
+## InputModifierPlugin — Plugin Injection Example
+
+```csharp
+public class InputModifierPlugin : IDCLWorldPlugin
+{
+    private readonly Arch.Core.World world;       // global world
+    private readonly Entity playerEntity;          // global player entity
+
+    public InputModifierPlugin(Arch.Core.World world, Entity playerEntity,
+        ISceneRestrictionBusController sceneRestrictionBusController) { ... }
+
+    public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder,
+        in ECSWorldInstanceSharedDependencies sharedDependencies,
+        in PersistentEntities persistentEntities, ...)
+    {
+        var system = InputModifierHandlerSystem.InjectToWorld(
+            ref builder, world, playerEntity, sharedDependencies.SceneStateProvider, ...);
+        sceneIsCurrentListeners.Add(system);
+        finalizeWorldSystems.Add(system);
+    }
+}
+```
+
+---
+
+## Pattern A: Direct Global World Access — InputModifierHandlerSystem
+
+```csharp
+public partial class InputModifierHandlerSystem : BaseUnityLoopSystem, ISceneIsCurrentListener
+{
+    private readonly World globalWorld;
+    private readonly Entity playerEntity;
+
+    internal InputModifierHandlerSystem(World world, World globalWorld, Entity playerEntity, ...) : base(world)
+    {
+        this.globalWorld = globalWorld;
+        this.playerEntity = playerEntity;
+    }
+
+    [Query]
+    private void ApplyModifiers([Data] bool skipDirtyCheck, Entity entity,
+        in PBInputModifier pbInputModifier, in CRDTEntity crdtEntity)
+    {
+        // Read scene-world SDK component, write to global-world component
+        ref var inputModifier = ref globalWorld.Get<InputModifierComponent>(playerEntity);
+        inputModifier.DisableAll = pbInputModifier.Standard.DisableAll;
+        // ...
+    }
+}
+```
+
+---
+
+## Pattern B: CRDT Bridge — WriteSDKAvatarBaseSystem
+
+```csharp
+public partial class WriteSDKAvatarBaseSystem : BaseUnityLoopSystem
+{
+    private readonly IECSToCRDTWriter ecsToCRDTWriter;
+
+    [Query]
+    [None(typeof(DeleteEntityIntention))]
+    private void UpdateAvatarBase(PlayerSceneCRDTEntity playerCRDTEntity, SDKProfile profile)
+    {
+        if (!profile.IsDirty) return;
+        ecsToCRDTWriter.PutMessage<PBAvatarBase, SDKProfile>(static (pb, profile) =>
+        {
+            pb.Name = profile.Name;
+            pb.BodyShapeUrn = profile.Avatar.BodyShape;
+        }, playerCRDTEntity.CRDTEntity, profile);
+    }
+}
+```
+
+---
+
+## SingleInstanceEntity and WorldExtensions
+
+```csharp
+// From WorldExtensions.cs
+public static SingleInstanceEntity CacheCamera(this World world) =>
+    new (in QUERY, world);
+
+public static ref CameraComponent GetCameraComponent(this in SingleInstanceEntity instance, World world) =>
+    ref world.Get<CameraComponent>(instance);
+```
+
+---
+
+## Global-to-Scene Propagation — PlayerTransformPropagationSystem
+
+```csharp
+[UpdateInGroup(typeof(PreRenderingSystemGroup))]
+public partial class PlayerTransformPropagationSystem : BaseUnityLoopSystem
+{
+    [Query]
+    [None(typeof(DeleteEntityIntention))]
+    private void PropagateTransformToScene(in CharacterTransform characterTransform,
+        in PlayerCRDTEntity playerCRDTEntity)
+    {
+        if (!characterTransform.Transform.hasChanged || !playerCRDTEntity.AssignedToScene) return;
+        if (playerCRDTEntity.CRDTEntity.Id == SpecialEntitiesID.PLAYER_ENTITY) return;
+
+        World sceneEcsWorld = playerCRDTEntity.SceneFacade!.EcsExecutor.World;
+
+        if (!sceneEcsWorld.TryGet<SDKTransform>(playerCRDTEntity.SceneWorldEntity, out SDKTransform? sdkTransform))
+            sceneEcsWorld.Add(playerCRDTEntity.SceneWorldEntity, sdkTransform = sdkTransformPool.Get());
+
+        sdkTransform!.Position.Value = characterTransform.Transform.position;
+        sdkTransform.Rotation.Value = characterTransform.Transform.rotation;
+        sdkTransform.IsDirty = true;
+    }
+}
+```
+
+---
+
+## ISceneIsCurrentListener Full Lifecycle
+
+```csharp
+public partial class InputModifierHandlerSystem : BaseUnityLoopSystem, ISceneIsCurrentListener
+{
+    protected override void Update(float t)
+    {
+        if (!sceneStateProvider.IsCurrent) return;   // guard every frame
+        ApplyModifiersQuery(World, false);
+        HandleComponentRemovalQuery(World);
+    }
+
+    public void OnSceneIsCurrentChanged(bool value)
+    {
+        if (value)
+            ApplyModifiersQuery(World, true);        // re-apply on becoming current
+        else
+            ResetModifiers();                        // reset global state on leaving
+    }
+
+    private void ResetModifiers()
+    {
+        ref InputModifierComponent inputModifier = ref globalWorld.Get<InputModifierComponent>(playerEntity);
+        inputModifier.RemoveAllModifiers();
+    }
+}
+```
+
+Register the system in the plugin:
+
+```csharp
+sceneIsCurrentListeners.Add(system);
+```

--- a/.claude/skills/ecs-system-and-component-design/SKILL.md
+++ b/.claude/skills/ecs-system-and-component-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ecs-system-and-component-design
-description: "ECS system and component design patterns using Arch ECS. Use when creating or modifying systems, components, queries, cleanup logic, singletons, or system tests — also when reviewing code that manipulates World, Entity, or component references, even if the user doesn't mention 'ECS' explicitly."
+description: "ECS system and component design using Arch ECS. Use when creating or modifying systems, components, queries, cleanup, singletons, or tests -- also for code reviewing World/Entity/component usage."
 user-invocable: false
 ---
 
@@ -8,97 +8,57 @@ user-invocable: false
 
 ## Sources
 
-- `docs/development-guide.md` — Primary ECS development reference
-- `docs/architecture-overview.md` — High-level ECS architecture and patterns
-- `docs/systems.md` — Scene bounds and rendering system details
-- `CLAUDE.md` — Condensed ECS rules
+- `docs/development-guide.md` -- Primary ECS development reference
+- `docs/architecture-overview.md` -- High-level ECS architecture and patterns
+- `docs/systems.md` -- Scene bounds and rendering system details
+- `CLAUDE.md` -- Condensed ECS rules
 
 ---
 
 ## System Design Rules
 
-> Condensed rules are in CLAUDE.md §1–7. This skill provides expanded examples and patterns not covered there.
+> Condensed rules are in CLAUDE.md sections 1-7. This skill provides expanded patterns and guidance not covered there. For a full clean system code example, see [reference.md](reference.md).
 
-### Code Example — Clean System
+Key reminders:
+- Systems inherit from `BaseUnityLoopSystem`, constructors are `internal`, accept shared dependencies only
+- Systems must not hold persistent entity/component collections or contain state
+- `Update()` must be allocation-free; no LINQ
+- Split systems >200 lines into static counterparts
+- Assign each system to a `SystemGroup`; use `[UpdateBefore]`/`[UpdateAfter]` for ordering
 
-From `BillboardSystem.cs`:
-
-```csharp
-[UpdateInGroup(typeof(SyncedSimulationSystemGroup))]
-[UpdateAfter(typeof(UpdateTransformSystem))]
-public partial class BillboardSystem : BaseUnityLoopSystem
-{
-    private const float MINIMUM_DISTANCE_TO_ROTATE_SQR = 0.25f * 0.25f;
-    private readonly IExposedCameraData exposedCameraData;
-
-    // Internal constructor with shared dependencies only (see CLAUDE.md §1)
-    internal BillboardSystem(World world, IExposedCameraData exposedCameraData) : base(world)
-    {
-        this.exposedCameraData = exposedCameraData;
-    }
-
-    protected override void Update(float t)
-    {
-        Vector3 cameraPosition;
-        Quaternion cameraRotation;
-
-        var activeVirtualCamera = exposedCameraData.CinemachineBrain?.ActiveVirtualCamera;
-        if (activeVirtualCamera != null)
-        {
-            var cameraTransform = activeVirtualCamera.VirtualCameraGameObject.transform;
-            cameraPosition = cameraTransform.position;
-            cameraRotation = cameraTransform.rotation;
-        }
-        else
-        {
-            cameraPosition = exposedCameraData.WorldPosition;
-            cameraRotation = exposedCameraData.WorldRotation.Value;
-        }
-
-        var cameraRotationAxisZ = Quaternion.Euler(0, 0, cameraRotation.eulerAngles.z);
-        UpdateRotationQuery(World, cameraPosition, cameraRotationAxisZ);
-    }
-
-    [Query]
-    private void UpdateRotation(
-        [Data] in Vector3 cameraPosition,
-        [Data] in Quaternion cameraRotationAxisZ,
-        ref TransformComponent transform,
-        in PBBillboard billboard)
-    {
-        // Bitwise billboard-mode filtering, early-exit guards
-        // ...
-    }
-}
-```
+---
 
 ## Querying Best Practices
 
-> See CLAUDE.md §3 for core query rules. This section adds the preference ranking not covered there.
-
 Ranked from most preferred to least:
 
-1. **Source-generated queries** (preferred) — Use `[Query]` attribute with `[Data]` parameters
-2. **`GetChunkIterator()`** — For generic systems
-3. **`World.InlineQuery`** — Outside systems or generic cases; uses `IForEach<T>` struct
-4. **`World.Query`** — Last resort due to delegate/closure overhead
+1. **Source-generated queries** (preferred) -- Use `[Query]` attribute with `[Data]` parameters
+2. **`GetChunkIterator()`** -- For generic systems
+3. **`World.InlineQuery`** -- Outside systems or generic cases; uses `IForEach<T>` struct
+4. **`World.Query`** -- Last resort due to delegate/closure overhead
+
+Always filter out `DeleteEntityIntention`. No nested queries. Use `TryGet` for known entities over queries.
+
+---
 
 ## Safe Component Mutation
 
-> See CLAUDE.md §5 for the full mutation rules. This section adds the code example and component design guidance.
-
 ```csharp
-// CORRECT — ref var modifies the component in-place
+// CORRECT -- ref var modifies the component in-place
 ref var component = ref world.Get<MyComponent>(entity);
 component.Value = 42;
 
-// WRONG — var copies the component; changes are lost
+// WRONG -- var copies the component; changes are lost
 var component = world.Get<MyComponent>(entity);
 component.Value = 42; // This modification is lost!
 ```
 
+- **NEVER perform structural changes (Add/Remove) after obtaining a `ref`, `in`, or `out` reference.** Structural changes relocate entity data in memory, invalidating all outstanding pointers.
 - Components should be data-only (no logic); may have pool, static factory, or non-empty constructor
 - Prefer `struct` for components; use `class` for MonoBehaviors, existing class lifecycle, or cross-world references
+- Clarify `ref` vs `in` intent; use `ref readonly` for immutable refs
+
+---
 
 ## Component Cleanup Patterns
 
@@ -106,33 +66,21 @@ Cleanup must handle three triggers:
 
 ### 1. Component Removed
 
-Query for entities that lost the SDK component but still have the internal component:
-
 ```csharp
-[Query]
-[None(typeof(PBAudioSource), typeof(DeleteEntityIntention))]
+[Query] [None(typeof(PBAudioSource), typeof(DeleteEntityIntention))]
 private void HandleComponentRemoval(ref AudioSourceComponent component)
-{
-    releaseAudioSourceComponent.Update(ref component);
-}
+    => releaseAudioSourceComponent.Update(ref component);
 ```
 
 ### 2. Entity Destroyed
 
-Query for entities marked for deletion:
-
 ```csharp
-[Query]
-[All(typeof(DeleteEntityIntention))]
+[Query] [All(typeof(DeleteEntityIntention))]
 private void HandleEntityDestruction(ref AudioSourceComponent component)
-{
-    releaseAudioSourceComponent.Update(ref component);
-}
+    => releaseAudioSourceComponent.Update(ref component);
 ```
 
 ### 3. World Disposed
-
-Implement `IFinalizeWorldSystem` for cleanup when the world shuts down:
 
 ```csharp
 public void FinalizeComponents(in Query query)
@@ -145,82 +93,37 @@ public void FinalizeComponents(in Query query)
 
 **Cleanup tasks include:** pool returns, promise invalidation/dereferencing, cache dereferencing, custom logic (e.g., avatar teardown).
 
-Prefer `ReleasePoolableComponentSystem<T, TProvider>` for pooled disposals.
+Prefer `ReleasePoolableComponentSystem<T, TProvider>` for pooled disposals. For the full cleanup lifecycle code example with `IForEach<T>` struct pattern, see [reference.md](reference.md).
 
-### Code Example — Full Cleanup Lifecycle
-
-From `CleanUpAudioSourceSystem.cs` — shows all three triggers + `IForEach<T>` struct pattern:
-
-```csharp
-[UpdateInGroup(typeof(CleanUpGroup))]
-[LogCategory(ReportCategory.SDK_AUDIO_SOURCES)]
-[ThrottlingEnabled]
-public partial class CleanUpAudioSourceSystem : BaseUnityLoopSystem, IFinalizeWorldSystem
-{
-    private ReleaseAudioSourceComponent releaseAudioSourceComponent;
-
-    protected override void Update(float t)
-    {
-        HandleEntityDestructionQuery(World);
-        HandleComponentRemovalQuery(World);
-        World.Remove<AudioSourceComponent>(in HandleComponentRemoval_QueryDescription);
-    }
-
-    [Query] [None(typeof(PBAudioSource), typeof(DeleteEntityIntention))]
-    private void HandleComponentRemoval(ref AudioSourceComponent component)
-        => releaseAudioSourceComponent.Update(ref component);
-
-    [Query] [All(typeof(DeleteEntityIntention))]
-    private void HandleEntityDestruction(ref AudioSourceComponent component)
-        => releaseAudioSourceComponent.Update(ref component);
-
-    public void FinalizeComponents(in Query query)
-    {
-        World.InlineQuery<ReleaseAudioSourceComponent, AudioSourceComponent>(
-            in new QueryDescription().WithAll<AudioSourceComponent>(),
-            ref releaseAudioSourceComponent);
-    }
-
-    // IForEach<T> struct — allocation-free callback for InlineQuery
-    private readonly struct ReleaseAudioSourceComponent : IForEach<AudioSourceComponent>
-    {
-        private readonly World world;
-        private readonly IComponentPool componentPool;
-
-        public void Update(ref AudioSourceComponent component)
-        {
-            component.CleanUp(world);
-            if (component.AudioSource != null) componentPool.Release(component.AudioSource);
-            component.Dispose();
-        }
-    }
-}
-```
+---
 
 ## Intention Components (Request-Response Pattern)
 
 The codebase uses "intention" struct components to model async ECS requests. A system creates an entity with an intention; a loading system processes it and adds `StreamableLoadingResult<T>`.
 
-**Base interfaces:**
-- `IAssetIntention` — has `CancellationTokenSource`
-- `ILoadingIntention : IAssetIntention` — adds `CommonLoadingArguments` (URL, source, attempts, etc.)
+**4-step pattern:**
+1. **Create** -- Build an `AssetPromise` entity with the intention component
+2. **Load** -- A `LoadSystemBase<TAsset, TIntention>` picks it up, loads the asset, adds `StreamableLoadingResult<T>`
+3. **Consume** -- The requesting system calls `TryConsume` / `TryGetResult` to retrieve the result
+4. **Cleanup** -- Dereference via `TryDereference`, destroy via `ForgetLoading` or `Consume`
+
+**Base interfaces:** `IAssetIntention` (has `CancellationTokenSource`), `ILoadingIntention : IAssetIntention` (adds `CommonLoadingArguments`).
 
 **Common intention types:** `GetTextureIntention`, `GetAudioClipIntention`, `GetSceneFacadeIntention`, `DeleteEntityIntention`, `GetProfilesBatchIntent`, and 15+ others.
 
-**4-step pattern:**
-1. **Create** — Build an `AssetPromise` entity with the intention component
-2. **Load** — A `LoadSystemBase<TAsset, TIntention>` picks it up, loads the asset, adds `StreamableLoadingResult<T>`
-3. **Consume** — The requesting system calls `TryConsume` / `TryGetResult` to retrieve the result
-4. **Cleanup** — Dereference via `TryDereference`, destroy via `ForgetLoading` or `Consume`
-
 See the **asset-promise-lifecycle** skill for full creation, polling, error handling, and cleanup patterns.
+
+---
 
 ## ECS Singletons
 
-> See CLAUDE.md §8 for core singleton rules. This section adds caching details.
+> See CLAUDE.md section 8 for core singleton rules.
 
 - Cache via `WorldExtensions` (`world.CacheCamera()`, `world.CachePlayer()`)
 - Use `SingleInstanceEntity` struct; cache once, store in system field
+- Use `TryGet` for mutation, `Has` for presence checks, `Query` for grouped access (prefer `TryGet` -- 2x faster)
+
+---
 
 ## Testing Systems
 
@@ -229,50 +132,18 @@ See the **asset-promise-lifecycle** skill for full creation, polling, error hand
 - Use NSubstitute for mocking dependencies
 - Test multiple scenarios: creation, update (dirty flag), cancellation, cleanup
 
-### Code Example — System Test
+See the **testing-infrastructure** skill for full test patterns, utilities, and examples.
 
-From `AvatarLoaderSystemShould.cs`:
+---
 
-```csharp
-public class AvatarLoaderSystemShould : UnitySystemTestBase<AvatarLoaderSystem>
-{
-    [SetUp]
-    public void Setup()
-    {
-        IRealmData realmData = Substitute.For<IRealmData>();
-        system = new AvatarLoaderSystem(world);
-    }
+## Detailed Reference
 
-    [Test]
-    public void StartAvatarLoad()
-    {
-        //Arrange
-        Entity entity = world.Create(pbAvatarShape, PartitionComponent.TOP_PRIORITY);
+For detailed code examples, see [reference.md](reference.md).
 
-        //Act
-        system.Update(0);
+---
 
-        //Assert
-        AvatarShapeComponent comp = world.Get<AvatarShapeComponent>(entity);
-        Assert.AreEqual(comp.BodyShape.Value, BODY_SHAPE_MALE);
-    }
+## Cross-References
 
-    [Test]
-    public void CancelAvatarLoad()
-    {
-        Entity entity = world.Create(pbAvatarShape, PartitionComponent.TOP_PRIORITY);
-        system.Update(0);
-
-        ref AvatarShapeComponent comp = ref world.Get<AvatarShapeComponent>(entity);
-        Entity originalPromise = comp.WearablePromise.Entity;
-
-        pbAvatarShape.BodyShape = BODY_SHAPE_FEMALE;
-        pbAvatarShape.IsDirty = true;
-        system.Update(0);
-
-        // Old promise destroyed, new one created
-        Assert.That(world.IsAlive(originalPromise), Is.False);
-        Assert.AreNotEqual(comp.WearablePromise.Entity, originalPromise);
-    }
-}
-```
+- **testing-infrastructure** -- `UnitySystemTestBase<T>`, test utilities, mocking strategies
+- **asset-promise-lifecycle** -- `AssetPromise` creation, polling, consumption, and cleanup
+- **plugin-architecture** -- System registration via `InjectToWorld`, plugin lifecycle

--- a/.claude/skills/ecs-system-and-component-design/reference.md
+++ b/.claude/skills/ecs-system-and-component-design/reference.md
@@ -1,0 +1,156 @@
+# ECS System & Component Design -- Detailed Reference
+
+## BillboardSystem -- Clean System Example
+
+From `BillboardSystem.cs`:
+
+```csharp
+[UpdateInGroup(typeof(SyncedSimulationSystemGroup))]
+[UpdateAfter(typeof(UpdateTransformSystem))]
+public partial class BillboardSystem : BaseUnityLoopSystem
+{
+    private const float MINIMUM_DISTANCE_TO_ROTATE_SQR = 0.25f * 0.25f;
+    private readonly IExposedCameraData exposedCameraData;
+
+    // Internal constructor with shared dependencies only (see CLAUDE.md section 1)
+    internal BillboardSystem(World world, IExposedCameraData exposedCameraData) : base(world)
+    {
+        this.exposedCameraData = exposedCameraData;
+    }
+
+    protected override void Update(float t)
+    {
+        Vector3 cameraPosition;
+        Quaternion cameraRotation;
+
+        var activeVirtualCamera = exposedCameraData.CinemachineBrain?.ActiveVirtualCamera;
+        if (activeVirtualCamera != null)
+        {
+            var cameraTransform = activeVirtualCamera.VirtualCameraGameObject.transform;
+            cameraPosition = cameraTransform.position;
+            cameraRotation = cameraTransform.rotation;
+        }
+        else
+        {
+            cameraPosition = exposedCameraData.WorldPosition;
+            cameraRotation = exposedCameraData.WorldRotation.Value;
+        }
+
+        var cameraRotationAxisZ = Quaternion.Euler(0, 0, cameraRotation.eulerAngles.z);
+        UpdateRotationQuery(World, cameraPosition, cameraRotationAxisZ);
+    }
+
+    [Query]
+    private void UpdateRotation(
+        [Data] in Vector3 cameraPosition,
+        [Data] in Quaternion cameraRotationAxisZ,
+        ref TransformComponent transform,
+        in PBBillboard billboard)
+    {
+        // Bitwise billboard-mode filtering, early-exit guards
+        // ...
+    }
+}
+```
+
+---
+
+## Full Cleanup Lifecycle -- CleanUpAudioSourceSystem
+
+From `CleanUpAudioSourceSystem.cs` -- shows all three cleanup triggers + `IForEach<T>` struct pattern:
+
+```csharp
+[UpdateInGroup(typeof(CleanUpGroup))]
+[LogCategory(ReportCategory.SDK_AUDIO_SOURCES)]
+[ThrottlingEnabled]
+public partial class CleanUpAudioSourceSystem : BaseUnityLoopSystem, IFinalizeWorldSystem
+{
+    private ReleaseAudioSourceComponent releaseAudioSourceComponent;
+
+    protected override void Update(float t)
+    {
+        HandleEntityDestructionQuery(World);
+        HandleComponentRemovalQuery(World);
+        World.Remove<AudioSourceComponent>(in HandleComponentRemoval_QueryDescription);
+    }
+
+    [Query] [None(typeof(PBAudioSource), typeof(DeleteEntityIntention))]
+    private void HandleComponentRemoval(ref AudioSourceComponent component)
+        => releaseAudioSourceComponent.Update(ref component);
+
+    [Query] [All(typeof(DeleteEntityIntention))]
+    private void HandleEntityDestruction(ref AudioSourceComponent component)
+        => releaseAudioSourceComponent.Update(ref component);
+
+    public void FinalizeComponents(in Query query)
+    {
+        World.InlineQuery<ReleaseAudioSourceComponent, AudioSourceComponent>(
+            in new QueryDescription().WithAll<AudioSourceComponent>(),
+            ref releaseAudioSourceComponent);
+    }
+
+    // IForEach<T> struct -- allocation-free callback for InlineQuery
+    private readonly struct ReleaseAudioSourceComponent : IForEach<AudioSourceComponent>
+    {
+        private readonly World world;
+        private readonly IComponentPool componentPool;
+
+        public void Update(ref AudioSourceComponent component)
+        {
+            component.CleanUp(world);
+            if (component.AudioSource != null) componentPool.Release(component.AudioSource);
+            component.Dispose();
+        }
+    }
+}
+```
+
+---
+
+## AvatarLoaderSystemShould -- System Test Example
+
+From `AvatarLoaderSystemShould.cs`:
+
+```csharp
+public class AvatarLoaderSystemShould : UnitySystemTestBase<AvatarLoaderSystem>
+{
+    [SetUp]
+    public void Setup()
+    {
+        IRealmData realmData = Substitute.For<IRealmData>();
+        system = new AvatarLoaderSystem(world);
+    }
+
+    [Test]
+    public void StartAvatarLoad()
+    {
+        //Arrange
+        Entity entity = world.Create(pbAvatarShape, PartitionComponent.TOP_PRIORITY);
+
+        //Act
+        system.Update(0);
+
+        //Assert
+        AvatarShapeComponent comp = world.Get<AvatarShapeComponent>(entity);
+        Assert.AreEqual(comp.BodyShape.Value, BODY_SHAPE_MALE);
+    }
+
+    [Test]
+    public void CancelAvatarLoad()
+    {
+        Entity entity = world.Create(pbAvatarShape, PartitionComponent.TOP_PRIORITY);
+        system.Update(0);
+
+        ref AvatarShapeComponent comp = ref world.Get<AvatarShapeComponent>(entity);
+        Entity originalPromise = comp.WearablePromise.Entity;
+
+        pbAvatarShape.BodyShape = BODY_SHAPE_FEMALE;
+        pbAvatarShape.IsDirty = true;
+        system.Update(0);
+
+        // Old promise destroyed, new one created
+        Assert.That(world.IsAlive(originalPromise), Is.False);
+        Assert.AreNotEqual(comp.WearablePromise.Entity, originalPromise);
+    }
+}
+```

--- a/.claude/skills/multiplayer-and-network-sync/SKILL.md
+++ b/.claude/skills/multiplayer-and-network-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multiplayer-and-network-sync
-description: "Multiplayer networking and player synchronization — LiveKit rooms, movement encoding, interpolation, profile sync, and entity-participant mapping. Use when working with RoomHub, ConnectiveRoom, movement systems (ParcelEncoder, FloatQuantizer, InterpolationSpline), EntityParticipantTable, remote player profiles, emote propagation, or scene/island room architecture."
+description: "Multiplayer networking -- LiveKit rooms, movement encoding, interpolation, profile sync, entity-participant mapping. Use when working with RoomHub, movement systems, EntityParticipantTable, or remote player sync."
 user-invocable: false
 ---
 
@@ -16,30 +16,7 @@ user-invocable: false
 
 `RoomHub` orchestrates four LiveKit rooms: **Island**, **Scene** (GateKeeper), **Chat**, and **VoiceChat**. Island + Scene are "local rooms" for entity synchronization; Chat + VoiceChat are independent.
 
-From `RoomHub.cs`:
-
-```csharp
-public class RoomHub : IRoomHub
-{
-    private readonly IConnectiveRoom archipelagoIslandRoom;
-    private readonly IGateKeeperSceneRoom gateKeeperSceneRoom;
-    private readonly IConnectiveRoom chatRoom;
-    private readonly VoiceChatActivatableConnectiveRoom voiceChatRoom;
-
-    public async UniTask<bool> StartAsync()
-    {
-        // Starts Island + Scene + Chat in parallel; VoiceChat starts on demand
-        (bool, bool, bool) result = await UniTask.WhenAll(
-            archipelagoIslandRoom.StartIfNotAsync(),
-            gateKeeperSceneRoom.StartIfNotAsync(),
-            chatRoom.StartIfNotAsync());
-        return result is { Item1: true, Item2: true, Item3: true };
-    }
-
-    // Merges participants from Island + Scene (cached per frame)
-    public IReadOnlyCollection<string> AllLocalRoomsRemoteParticipantIdentities() { ... }
-}
-```
+`RoomHub.StartAsync()` starts Island + Scene + Chat in parallel; VoiceChat starts on demand. `AllLocalRoomsRemoteParticipantIdentities()` merges participants from Island + Scene (cached per frame).
 
 ### IConnectiveRoom Lifecycle
 
@@ -67,58 +44,25 @@ public class RoomHub : IRoomHub
 
 ## Movement Encoding & Transmission
 
-### NetworkMovementMessage
+### NetworkMovementMessage Fields
 
-The core message struct carrying position, velocity, rotation, animation state, head IK, and movement kind:
-
-```csharp
-public struct NetworkMovementMessage : IEquatable<NetworkMovementMessage>
-{
-    public float timestamp;
-    public Vector3 position;
-    public Vector3 velocity;
-    public float velocitySqrMagnitude;
-    public float rotationY;
-    public bool headIKYawEnabled, headIKPitchEnabled;
-    public Vector2 headYawAndPitch;
-    public MovementKind movementKind;
-    public AnimationStates animState;
-    public byte velocityTier;
-    public bool isSliding, isStunned, isInstant, isEmoting;
-}
-```
+`timestamp`, `position`, `velocity`, `velocitySqrMagnitude`, `rotationY`, `headIKYawEnabled`, `headIKPitchEnabled`, `headYawAndPitch`, `movementKind`, `animState`, `velocityTier`, `isSliding`, `isStunned`, `isInstant`, `isEmoting`.
 
 ### Encoding Pipeline
 
-- **`FloatQuantizer`** -- Fixed-size quantization via scaled integers. `Compress(value, min, max, bits)` maps a float to an integer with `bits` resolution. `Decompress` reverses.
-- **`ParcelEncoder`** -- Flattens 2D parcel coordinates `(x, y)` into a 1D index: `x - MinX + (y - MinY) * width`. Used for position encoding relative to the Genesis City grid.
-- **`TimestampEncoder`** -- Circular buffer encoding. Timestamps are compressed modulo `2^TIMESTAMP_BITS * TIMESTAMP_QUANTUM` with wraparound detection on decompression.
+- **`FloatQuantizer`** -- Fixed-size quantization via scaled integers. `Compress(value, min, max, bits)` / `Decompress`.
+- **`ParcelEncoder`** -- Flattens 2D parcel coordinates `(x, y)` into a 1D index relative to the Genesis City grid.
+- **`TimestampEncoder`** -- Circular buffer encoding with wraparound detection on decompression.
 
 ### Send Throttling
 
-`PlayerMovementNetSendSystem` caps at **10 messages/sec**. Adaptive send rate: drops to `MoveSendRate` on movement, doubles (up to `StandSendRate`) when idle. Immediate sends on grounded/jump state changes.
-
-```csharp
-// From PlayerMovementNetSendSystem.cs -- adaptive rate
-if (anythingChanged && sendRate > settings.MoveSendRate)
-    sendRate = settings.MoveSendRate;
-if (timeDiff > sendRate)
-{
-    if (!anythingChanged && sendRate < settings.StandSendRate)
-        sendRate = Mathf.Min(2 * sendRate, settings.StandSendRate);
-    SendMessage(...);
-}
-```
-
-Messages are sent to both Island and Scene pipes via `MultiplayerMovementMessageBus.Send()`, supporting both compressed (`MovementCompressed`) and uncompressed (`Decentraland.Kernel.Comms.Rfc4.Movement`) schemas.
+`PlayerMovementNetSendSystem` caps at **10 messages/sec**. Adaptive send rate: drops to `MoveSendRate` on movement, doubles (up to `StandSendRate`) when idle. Immediate sends on grounded/jump state changes. Messages are sent to both Island and Scene pipes via `MultiplayerMovementMessageBus.Send()`, supporting both compressed and uncompressed schemas.
 
 ---
 
 ## Movement Interpolation
 
-### InterpolationSpline
-
-Seven interpolation types in `InterpolationSpline`:
+### InterpolationSpline Types
 
 | Type | Description |
 |------|-------------|
@@ -140,30 +84,7 @@ Runs in `PresentationSystemGroup`. Processes a priority queue of `NetworkMovemen
 4. **Extrapolation** -- when no messages arrive and speed > threshold, `ExtrapolationComponent` continues movement along last velocity for up to `TotalMoveDuration`
 5. **Blend** -- after extrapolation stops, blends back with speed-limited interpolation
 
-```csharp
-// ExtrapolationComponent -- simple velocity continuation
-public struct ExtrapolationComponent
-{
-    public NetworkMovementMessage Start;
-    public Vector3 Velocity;
-    public float Time, TotalMoveDuration;
-    public bool Enabled { get; private set; }
-
-    public void Restart(NetworkMovementMessage from, float moveDuration) { ... }
-    public void Stop() { Enabled = false; }
-}
-```
-
-### Catch-Up Mechanism
-
-When inbox has more messages than `CatchUpMessagesMin`, interpolation duration is shortened:
-
-```csharp
-float correctionTime = inboxMessages * Time.smoothDeltaTime;
-intComp.TotalDuration = Mathf.Max(
-    intComp.TotalDuration - correctionTime,
-    intComp.TotalDuration / settings.InterpolationSettings.MaxSpeedUpTimeDivider);
-```
+**Catch-Up:** When inbox has more messages than `CatchUpMessagesMin`, interpolation duration is shortened proportionally to smooth DeltaTime.
 
 ---
 
@@ -171,113 +92,34 @@ intComp.TotalDuration = Mathf.Max(
 
 ### EntityParticipantTable
 
-Bidirectional mapping between wallet IDs and ECS entities, with room source tracking. NOT thread-safe -- only accessed from the main thread.
+Bidirectional mapping between wallet IDs and ECS entities, with room source tracking (`ISLAND`, `GATEKEEPER`, or both). NOT thread-safe -- only accessed from main thread.
 
-```csharp
-public class EntityParticipantTable : IEntityParticipantTable
-{
-    // walletId <-> Entity, with RoomSource (ISLAND, GATEKEEPER, or both)
-    public void Register(string walletId, Entity entity, RoomSource fromRoom);
-    public bool Release(string walletId, RoomSource fromRoom);  // returns true if fully disconnected
-    public void AddRoomSource(string walletId, RoomSource fromRoom);
-}
-```
+Key API: `Register(walletId, entity, fromRoom)`, `Release(walletId, fromRoom)` (returns true only when `ConnectedTo == RoomSource.NONE`), `AddRoomSource(walletId, fromRoom)`.
 
-`Release` only removes the entity when `ConnectedTo == RoomSource.NONE` (disconnected from all rooms). This allows a player visible via Island to remain alive when they leave the Scene room.
+`Release` only removes the entity when disconnected from all rooms. This allows a player visible via Island to remain alive when they leave the Scene room.
 
-### ThreadSafeRemoveIntentions
+### ThreadSafe Disconnect Buffering
 
-LiveKit participant callbacks fire off the main thread. `ThreadSafeRemoveIntentions` buffers disconnect events using `MutexSync`:
-
-```csharp
-public class ThreadSafeRemoveIntentions : IRemoveIntentions
-{
-    private readonly HashSet<RemoveIntention> list = new ();
-    private readonly MutexSync multithreadSync = new();
-
-    // Subscribed to LiveKit events (off main thread)
-    private void ParticipantsOnUpdatesFromParticipant(Participant participant,
-        UpdateFromParticipant update, RoomSource roomSource)
-    {
-        if (update is UpdateFromParticipant.Disconnected)
-            ThreadSafeAdd(new RemoveIntention(participant.Identity, roomSource));
-    }
-
-    // Main thread consumes via OwnedBunch
-    public OwnedBunch<RemoveIntention> Bunch() => new(multithreadSync, list);
-}
-```
-
-### OwnedBunch -- Thread-Safe Collection Access
-
-`OwnedBunch<T>` acquires a `MutexSync.Scope` on construction, exposes the collection for reading, and clears + releases the mutex on `Dispose()`:
-
-```csharp
-public readonly struct OwnedBunch<T> : IBunch<T> where T : struct
-{
-    public OwnedBunch(MutexSync ownership, HashSet<T> set)
-    {
-        this.ownership = ownership.GetScope();  // acquires lock
-        this.set = set;
-    }
-    public void Dispose() { set.Clear(); ownership.Dispose(); }  // clears + releases
-}
-```
-
-**Usage pattern:** `using var bunch = removeIntentions.Bunch(); foreach (var item in bunch.Collection()) { ... }`
+LiveKit participant callbacks fire off the main thread. `ThreadSafeRemoveIntentions` buffers disconnect events using `MutexSync`. Main thread consumes via `OwnedBunch<RemoveIntention>` which acquires the lock on construction, exposes the collection, and clears + releases on `Dispose()`.
 
 ### ProfileBroadcast
 
-Sends `AnnounceProfileVersion` to both Island and Scene pipes to notify remotes of profile updates. Async: fetches self-profile version before sending via `SendAndDisposeAsync` with `KindReliable`.
+Sends `AnnounceProfileVersion` to both Island and Scene pipes. Async: fetches self-profile version before sending via `SendAndDisposeAsync` with `KindReliable`.
 
 ---
 
 ## SDK Propagation Systems
 
-### PlayerTransformPropagationSystem (Global -> Scene)
+- **`PlayerTransformPropagationSystem`** (Global -> Scene) -- Copies `CharacterTransform` into the scene world's `SDKTransform` when transform has changed and player is assigned to scene.
+- **`WritePlayerTransformSystem`** (Scene -> CRDT) -- Converts `SDKTransform` to scene-relative coordinates and writes via `IECSToCRDTWriter`.
+- **`WritePlayerIdentityDataSystem`** (Scene -> CRDT) -- Writes `PBPlayerIdentityData` (address + isGuest) on dirty, with force-write on `Initialize()`. Uses static lambda to avoid closures.
+- **`PlayerProfileDataPropagationSystem`** (Global -> Scene) -- Copies `Profile` data to scene entities via `CharacterDataPropagationUtility` when profile or CRDT entity assignment is dirty.
 
-Runs in `PreRenderingSystemGroup` on the global world. Copies `CharacterTransform` into the scene world's `SDKTransform`:
+---
 
-```csharp
-[Query] [None(typeof(DeleteEntityIntention))]
-private void PropagateTransformToScene(in CharacterTransform characterTransform,
-    in PlayerCRDTEntity playerCRDTEntity)
-{
-    if (!characterTransform.Transform.hasChanged || !playerCRDTEntity.AssignedToScene) return;
-    if (playerCRDTEntity.CRDTEntity.Id == SpecialEntitiesID.PLAYER_ENTITY) return;
+## Detailed Reference
 
-    World sceneEcsWorld = playerCRDTEntity.SceneFacade!.EcsExecutor.World;
-    if (!sceneEcsWorld.TryGet<SDKTransform>(playerCRDTEntity.SceneWorldEntity, out SDKTransform? sdkTransform))
-        sceneEcsWorld.Add(playerCRDTEntity.SceneWorldEntity, sdkTransform = sdkTransformPool.Get());
-
-    sdkTransform!.Position.Value = characterTransform.Transform.position;
-    sdkTransform.Rotation.Value = characterTransform.Transform.rotation;
-    sdkTransform.IsDirty = true;
-}
-```
-
-### WritePlayerTransformSystem (Scene -> CRDT)
-
-Converts `SDKTransform` to scene-relative coordinates and writes via `IECSToCRDTWriter`:
-
-```csharp
-[Query] [None(typeof(DeleteEntityIntention))]
-private void UpdateSDKTransform(in PlayerSceneCRDTEntity playerCRDTEntity, ref SDKTransform sdkTransform)
-{
-    if (!sdkTransform.IsDirty) return;
-    if (playerCRDTEntity.CRDTEntity.Id == SpecialEntitiesID.PLAYER_ENTITY) return;
-    ExposedTransformUtils.Put(ecsToCRDTWriter, sdkTransform, playerCRDTEntity.CRDTEntity,
-        sceneData.Geometry.BaseParcelPosition, false);
-}
-```
-
-### WritePlayerIdentityDataSystem (Scene -> CRDT)
-
-Writes `PBPlayerIdentityData` (address + isGuest) on dirty, with force-write on `Initialize()`. Uses `ecsToCRDTWriter.PutMessage<PBPlayerIdentityData>` with a static lambda to avoid closures.
-
-### PlayerProfileDataPropagationSystem (Global -> Scene)
-
-Copies `Profile` data to scene entities via `CharacterDataPropagationUtility` when either the profile or the CRDT entity assignment is dirty.
+For detailed code examples, see [reference.md](reference.md).
 
 ---
 

--- a/.claude/skills/multiplayer-and-network-sync/reference.md
+++ b/.claude/skills/multiplayer-and-network-sync/reference.md
@@ -1,0 +1,192 @@
+# Multiplayer & Network Sync -- Detailed Reference
+
+## RoomHub Code
+
+```csharp
+public class RoomHub : IRoomHub
+{
+    private readonly IConnectiveRoom archipelagoIslandRoom;
+    private readonly IGateKeeperSceneRoom gateKeeperSceneRoom;
+    private readonly IConnectiveRoom chatRoom;
+    private readonly VoiceChatActivatableConnectiveRoom voiceChatRoom;
+
+    public async UniTask<bool> StartAsync()
+    {
+        // Starts Island + Scene + Chat in parallel; VoiceChat starts on demand
+        (bool, bool, bool) result = await UniTask.WhenAll(
+            archipelagoIslandRoom.StartIfNotAsync(),
+            gateKeeperSceneRoom.StartIfNotAsync(),
+            chatRoom.StartIfNotAsync());
+        return result is { Item1: true, Item2: true, Item3: true };
+    }
+
+    // Merges participants from Island + Scene (cached per frame)
+    public IReadOnlyCollection<string> AllLocalRoomsRemoteParticipantIdentities() { ... }
+}
+```
+
+---
+
+## NetworkMovementMessage Struct
+
+```csharp
+public struct NetworkMovementMessage : IEquatable<NetworkMovementMessage>
+{
+    public float timestamp;
+    public Vector3 position;
+    public Vector3 velocity;
+    public float velocitySqrMagnitude;
+    public float rotationY;
+    public bool headIKYawEnabled, headIKPitchEnabled;
+    public Vector2 headYawAndPitch;
+    public MovementKind movementKind;
+    public AnimationStates animState;
+    public byte velocityTier;
+    public bool isSliding, isStunned, isInstant, isEmoting;
+}
+```
+
+---
+
+## Send Throttling Code
+
+```csharp
+// From PlayerMovementNetSendSystem.cs -- adaptive rate
+if (anythingChanged && sendRate > settings.MoveSendRate)
+    sendRate = settings.MoveSendRate;
+if (timeDiff > sendRate)
+{
+    if (!anythingChanged && sendRate < settings.StandSendRate)
+        sendRate = Mathf.Min(2 * sendRate, settings.StandSendRate);
+    SendMessage(...);
+}
+```
+
+---
+
+## ExtrapolationComponent Code
+
+```csharp
+// ExtrapolationComponent -- simple velocity continuation
+public struct ExtrapolationComponent
+{
+    public NetworkMovementMessage Start;
+    public Vector3 Velocity;
+    public float Time, TotalMoveDuration;
+    public bool Enabled { get; private set; }
+
+    public void Restart(NetworkMovementMessage from, float moveDuration) { ... }
+    public void Stop() { Enabled = false; }
+}
+```
+
+---
+
+## Catch-Up Mechanism Code
+
+```csharp
+float correctionTime = inboxMessages * Time.smoothDeltaTime;
+intComp.TotalDuration = Mathf.Max(
+    intComp.TotalDuration - correctionTime,
+    intComp.TotalDuration / settings.InterpolationSettings.MaxSpeedUpTimeDivider);
+```
+
+---
+
+## EntityParticipantTable Code
+
+```csharp
+public class EntityParticipantTable : IEntityParticipantTable
+{
+    // walletId <-> Entity, with RoomSource (ISLAND, GATEKEEPER, or both)
+    public void Register(string walletId, Entity entity, RoomSource fromRoom);
+    public bool Release(string walletId, RoomSource fromRoom);  // returns true if fully disconnected
+    public void AddRoomSource(string walletId, RoomSource fromRoom);
+}
+```
+
+---
+
+## ThreadSafeRemoveIntentions Code
+
+```csharp
+public class ThreadSafeRemoveIntentions : IRemoveIntentions
+{
+    private readonly HashSet<RemoveIntention> list = new ();
+    private readonly MutexSync multithreadSync = new();
+
+    // Subscribed to LiveKit events (off main thread)
+    private void ParticipantsOnUpdatesFromParticipant(Participant participant,
+        UpdateFromParticipant update, RoomSource roomSource)
+    {
+        if (update is UpdateFromParticipant.Disconnected)
+            ThreadSafeAdd(new RemoveIntention(participant.Identity, roomSource));
+    }
+
+    // Main thread consumes via OwnedBunch
+    public OwnedBunch<RemoveIntention> Bunch() => new(multithreadSync, list);
+}
+```
+
+---
+
+## OwnedBunch Code
+
+```csharp
+public readonly struct OwnedBunch<T> : IBunch<T> where T : struct
+{
+    public OwnedBunch(MutexSync ownership, HashSet<T> set)
+    {
+        this.ownership = ownership.GetScope();  // acquires lock
+        this.set = set;
+    }
+    public void Dispose() { set.Clear(); ownership.Dispose(); }  // clears + releases
+}
+```
+
+**Usage pattern:** `using var bunch = removeIntentions.Bunch(); foreach (var item in bunch.Collection()) { ... }`
+
+---
+
+## SDK Propagation Code
+
+### PlayerTransformPropagationSystem (Global -> Scene)
+
+```csharp
+[Query] [None(typeof(DeleteEntityIntention))]
+private void PropagateTransformToScene(in CharacterTransform characterTransform,
+    in PlayerCRDTEntity playerCRDTEntity)
+{
+    if (!characterTransform.Transform.hasChanged || !playerCRDTEntity.AssignedToScene) return;
+    if (playerCRDTEntity.CRDTEntity.Id == SpecialEntitiesID.PLAYER_ENTITY) return;
+
+    World sceneEcsWorld = playerCRDTEntity.SceneFacade!.EcsExecutor.World;
+    if (!sceneEcsWorld.TryGet<SDKTransform>(playerCRDTEntity.SceneWorldEntity, out SDKTransform? sdkTransform))
+        sceneEcsWorld.Add(playerCRDTEntity.SceneWorldEntity, sdkTransform = sdkTransformPool.Get());
+
+    sdkTransform!.Position.Value = characterTransform.Transform.position;
+    sdkTransform.Rotation.Value = characterTransform.Transform.rotation;
+    sdkTransform.IsDirty = true;
+}
+```
+
+### WritePlayerTransformSystem (Scene -> CRDT)
+
+```csharp
+[Query] [None(typeof(DeleteEntityIntention))]
+private void UpdateSDKTransform(in PlayerSceneCRDTEntity playerCRDTEntity, ref SDKTransform sdkTransform)
+{
+    if (!sdkTransform.IsDirty) return;
+    if (playerCRDTEntity.CRDTEntity.Id == SpecialEntitiesID.PLAYER_ENTITY) return;
+    ExposedTransformUtils.Put(ecsToCRDTWriter, sdkTransform, playerCRDTEntity.CRDTEntity,
+        sceneData.Geometry.BaseParcelPosition, false);
+}
+```
+
+### WritePlayerIdentityDataSystem (Scene -> CRDT)
+
+Writes `PBPlayerIdentityData` (address + isGuest) on dirty, with force-write on `Initialize()`. Uses `ecsToCRDTWriter.PutMessage<PBPlayerIdentityData>` with a static lambda to avoid closures.
+
+### PlayerProfileDataPropagationSystem (Global -> Scene)
+
+Copies `Profile` data to scene entities via `CharacterDataPropagationUtility` when either the profile or the CRDT entity assignment is dirty.

--- a/.claude/skills/plugin-architecture/SKILL.md
+++ b/.claude/skills/plugin-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-architecture
-description: "Plugin and dependency injection architecture. Use when adding or modifying plugins (IDCLWorldPlugin, IDCLGlobalPlugin), InjectToWorld, system registration, dependency injection, plugin settings, containers (StaticContainer, DynamicWorldContainer), assembly structure (asmdef, asmref, assembly definition), or Addressables asset provisioning."
+description: "Plugin and DI architecture. Use when adding or modifying plugins (IDCLWorldPlugin, IDCLGlobalPlugin), system registration, dependency injection, containers, assembly structure, or Addressables provisioning."
 user-invocable: false
 ---
 
@@ -30,148 +30,11 @@ Created per scene world. Receives world-specific dependencies and injects system
 - `List<IFinalizeWorldSystem> finalizeWorldSystems` — register cleanup systems here
 - `List<ISceneIsCurrentListener> sceneIsCurrentListeners` — register scene-current listeners here
 
-### Code Example — World Plugin
-
-From `LightSourcePlugin.cs`:
-
-```csharp
-public class LightSourcePlugin : IDCLWorldPlugin<LightSourcePlugin.LightSourcePluginSettings>
-{
-    private readonly IComponentPoolsRegistry poolsRegistry;
-    private readonly IAssetsProvisioner assetsProvisioner;
-    private readonly CacheCleaner cacheCleaner;
-    private readonly ICharacterObject characterObject;
-    private readonly Arch.Core.World globalWorld;
-    private readonly bool hasDebugFlag;
-
-    private LightSourceSettings? lightSourceSettings;
-    private IComponentPool<Light>? lightPoolRegistry;
-
-    public LightSourcePlugin(
-        IComponentPoolsRegistry poolsRegistry,
-        IAssetsProvisioner assetsProvisioner,
-        CacheCleaner cacheCleaner,
-        ICharacterObject characterObject,
-        Arch.Core.World globalWorld,
-        bool hasDebugFlag)
-    {
-        this.poolsRegistry = poolsRegistry;
-        this.assetsProvisioner = assetsProvisioner;
-        this.cacheCleaner = cacheCleaner;
-        this.characterObject = characterObject;
-        this.globalWorld = globalWorld;
-        this.hasDebugFlag = hasDebugFlag;
-    }
-
-    public void Dispose() { }
-
-    public void InjectToWorld(
-        ref ArchSystemsWorldBuilder<Arch.Core.World> builder,
-        in ECSWorldInstanceSharedDependencies sharedDependencies,
-        in PersistentEntities persistentEntities,
-        List<IFinalizeWorldSystem> finalizeWorldSystems,
-        List<ISceneIsCurrentListener> sceneIsCurrentListeners)
-    {
-        // Always inject the dirty-flag reset system for SDK components
-        ResetDirtyFlagSystem<PBLightSource>.InjectToWorld(ref builder);
-
-        // Inject feature systems
-        var lifecycleSystem = LightSourceLifecycleSystem.InjectToWorld(
-            ref builder, sharedDependencies.SceneStateProvider, lightPoolRegistry);
-        LightSourceApplyPropertiesSystem.InjectToWorld(
-            ref builder, sharedDependencies.SceneData, sharedDependencies.ScenePartition, lightSourceSettings);
-
-        // Conditional debug system
-        if (hasDebugFlag)
-            LightSourceDebugSystem.InjectToWorld(ref builder, globalWorld);
-
-        // Register cleanup
-        finalizeWorldSystems.Add(lifecycleSystem);
-    }
-
-    public async UniTask InitializeAsync(LightSourcePluginSettings settings, CancellationToken ct)
-    {
-        Light lightSourcePrefab = (await assetsProvisioner.ProvideMainAssetAsync(
-            settings!.LightSourcePrefab, ct)).Value.GetComponent<Light>();
-        lightSourceSettings = (await assetsProvisioner.ProvideMainAssetAsync(
-            settings.LightSourceSettings, ct)).Value;
-
-        // Create and register pool
-        lightPoolRegistry = poolsRegistry.AddGameObjectPool(
-            () => Object.Instantiate(lightSourcePrefab, Vector3.zero, quaternion.identity),
-            onRelease: OnPoolRelease,
-            onGet: OnPoolGet);
-        cacheCleaner.Register(lightPoolRegistry);
-    }
-
-    [Serializable]
-    public class LightSourcePluginSettings : IDCLPluginSettings
-    {
-        public AssetReferenceGameObject LightSourcePrefab;
-        public AssetReferenceT<LightSourceSettings> LightSourceSettings;
-    }
-}
-```
-
-> **Note:** `LightSourcePlugin.cs` actually lives in `PluginSystem/World/` because it predates the current convention. New SDK component plugins should follow the `SDKComponents/<Feature>/Systems/` pattern described in the **sdk-component-implementation** skill.
-
 ### IDCLGlobalPlugin — Application-Scoped
 
-Created once for the application lifetime. Injects systems into the global world only.
+Created once for the application lifetime. Injects systems into the global world only. Same lifecycle as world plugin but with `GlobalPluginArguments` instead of world-specific dependencies.
 
-**Lifecycle:** Same as world plugin but with `GlobalPluginArguments` instead of world-specific dependencies.
-
-### Code Example — Global Plugin
-
-From `AudioPlaybackPlugin.cs`:
-
-```csharp
-public class AudioPlaybackPlugin : IDCLGlobalPlugin<AudioPlaybackPlugin.PluginSettings>
-{
-    private ProvidedInstance<UIAudioPlaybackController> uiAudioPlaybackController;
-    private ProvidedInstance<WorldAudioPlaybackController> worldAudioPlaybackController;
-    private ProvidedAsset<LandscapeAudioSystemSettings> landscapeAudioSettings;
-
-    // ... constructor with shared dependencies ...
-
-    public void Dispose()
-    {
-        // Dispose all provisioned assets
-        uiAudioPlaybackController.Dispose();
-        worldAudioPlaybackController.Dispose();
-        landscapeAudioSettings.Dispose();
-    }
-
-    public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder,
-        in GlobalPluginArguments arguments)
-    {
-        // Conditional injection
-        if (enableLandscape)
-            LandscapeAudioCullingSystem.InjectToWorld(ref builder, terrainGenerator,
-                worldTerrainGenerator, landscapeAudioSettings.Value,
-                worldAudioPlaybackController.Value, realmData);
-    }
-
-    public async UniTask InitializeAsync(PluginSettings settings, CancellationToken ct)
-    {
-        // Use ProvidedInstance for proper disposal tracking
-        uiAudioPlaybackController = await assetsProvisioner.ProvideInstanceAsync(
-            settings.UIAudioPlaybackControllerReference, ct: ct);
-        worldAudioPlaybackController = await assetsProvisioner.ProvideInstanceAsync(
-            settings.WorldAudioPlaybackControllerReference, ct: ct);
-        landscapeAudioSettings = await assetsProvisioner.ProvideMainAssetAsync(
-            settings.LandscapeAudioSettingsReference, ct: ct);
-    }
-
-    [Serializable]
-    public class PluginSettings : IDCLPluginSettings
-    {
-        [field: SerializeField]
-        public LandscapeAudioSettingsReference LandscapeAudioSettingsReference { get; private set; }
-        // ... other asset references ...
-    }
-}
-```
+---
 
 ## Plugin Settings
 
@@ -180,12 +43,13 @@ public class AudioPlaybackPlugin : IDCLGlobalPlugin<AudioPlaybackPlugin.PluginSe
 - Settings are stored in `PluginSettingsContainer` ScriptableObject
 - `IAssetsProvisioner` loads addressable assets; returns `ProvidedAsset<T>` or `ProvidedInstance<T>` for disposal tracking
 
+---
+
 ## Container Architecture
 
 ### StaticContainer
 
 Created first. Produces common dependencies and world plugins.
-
 - Creates `IComponentPoolsRegistry`, `CacheCleaner`, `IAssetsProvisioner`
 - Instantiates world plugins (`IDCLWorldPlugin`) with their dependencies
 - Provides `StaticSettings` (all plugin settings)
@@ -193,7 +57,6 @@ Created first. Produces common dependencies and world plugins.
 ### DynamicWorldContainer
 
 Created after StaticContainer. Holds global plugins and runtime state.
-
 - Instantiates global plugins (`IDCLGlobalPlugin`)
 - Creates `RealmController`, `GlobalWorldFactory`
 - Manages scene lifecycle
@@ -201,6 +64,8 @@ Created after StaticContainer. Holds global plugins and runtime state.
 ### ComponentsContainer
 
 Registers SDK component types for CRDT deserialization. Each SDK component must be registered here.
+
+---
 
 ## Assembly Structure
 
@@ -269,3 +134,17 @@ Assets/DCL/<Feature>/
 - If the plugin has **no ECS systems**, do not create a `Systems/` folder. Place the plugin directly in:
   - `Assets/DCL/PluginSystem/Global/` — for global plugins (`IDCLGlobalPlugin`)
   - `Assets/DCL/PluginSystem/World/` — for world plugins (`IDCLWorldPlugin`)
+
+---
+
+## Detailed Reference
+
+For detailed code examples, see [reference.md](reference.md).
+
+---
+
+## Cross-References
+
+- **cross-world-ecs-access** — Global world injection chain, `InjectToWorld` usage from plugin to system
+- **ecs-system-and-component-design** — System design patterns, `BaseUnityLoopSystem`, query best practices
+- **sdk-component-implementation** — SDK component plugin pattern, `ComponentsContainer` registration

--- a/.claude/skills/plugin-architecture/reference.md
+++ b/.claude/skills/plugin-architecture/reference.md
@@ -1,0 +1,136 @@
+# Plugin & Dependency Architecture — Detailed Reference
+
+## World Plugin Example — LightSourcePlugin
+
+```csharp
+public class LightSourcePlugin : IDCLWorldPlugin<LightSourcePlugin.LightSourcePluginSettings>
+{
+    private readonly IComponentPoolsRegistry poolsRegistry;
+    private readonly IAssetsProvisioner assetsProvisioner;
+    private readonly CacheCleaner cacheCleaner;
+    private readonly ICharacterObject characterObject;
+    private readonly Arch.Core.World globalWorld;
+    private readonly bool hasDebugFlag;
+
+    private LightSourceSettings? lightSourceSettings;
+    private IComponentPool<Light>? lightPoolRegistry;
+
+    public LightSourcePlugin(
+        IComponentPoolsRegistry poolsRegistry,
+        IAssetsProvisioner assetsProvisioner,
+        CacheCleaner cacheCleaner,
+        ICharacterObject characterObject,
+        Arch.Core.World globalWorld,
+        bool hasDebugFlag)
+    {
+        this.poolsRegistry = poolsRegistry;
+        this.assetsProvisioner = assetsProvisioner;
+        this.cacheCleaner = cacheCleaner;
+        this.characterObject = characterObject;
+        this.globalWorld = globalWorld;
+        this.hasDebugFlag = hasDebugFlag;
+    }
+
+    public void Dispose() { }
+
+    public void InjectToWorld(
+        ref ArchSystemsWorldBuilder<Arch.Core.World> builder,
+        in ECSWorldInstanceSharedDependencies sharedDependencies,
+        in PersistentEntities persistentEntities,
+        List<IFinalizeWorldSystem> finalizeWorldSystems,
+        List<ISceneIsCurrentListener> sceneIsCurrentListeners)
+    {
+        // Always inject the dirty-flag reset system for SDK components
+        ResetDirtyFlagSystem<PBLightSource>.InjectToWorld(ref builder);
+
+        // Inject feature systems
+        var lifecycleSystem = LightSourceLifecycleSystem.InjectToWorld(
+            ref builder, sharedDependencies.SceneStateProvider, lightPoolRegistry);
+        LightSourceApplyPropertiesSystem.InjectToWorld(
+            ref builder, sharedDependencies.SceneData, sharedDependencies.ScenePartition, lightSourceSettings);
+
+        // Conditional debug system
+        if (hasDebugFlag)
+            LightSourceDebugSystem.InjectToWorld(ref builder, globalWorld);
+
+        // Register cleanup
+        finalizeWorldSystems.Add(lifecycleSystem);
+    }
+
+    public async UniTask InitializeAsync(LightSourcePluginSettings settings, CancellationToken ct)
+    {
+        Light lightSourcePrefab = (await assetsProvisioner.ProvideMainAssetAsync(
+            settings!.LightSourcePrefab, ct)).Value.GetComponent<Light>();
+        lightSourceSettings = (await assetsProvisioner.ProvideMainAssetAsync(
+            settings.LightSourceSettings, ct)).Value;
+
+        // Create and register pool
+        lightPoolRegistry = poolsRegistry.AddGameObjectPool(
+            () => Object.Instantiate(lightSourcePrefab, Vector3.zero, quaternion.identity),
+            onRelease: OnPoolRelease,
+            onGet: OnPoolGet);
+        cacheCleaner.Register(lightPoolRegistry);
+    }
+
+    [Serializable]
+    public class LightSourcePluginSettings : IDCLPluginSettings
+    {
+        public AssetReferenceGameObject LightSourcePrefab;
+        public AssetReferenceT<LightSourceSettings> LightSourceSettings;
+    }
+}
+```
+
+> **Note:** `LightSourcePlugin.cs` actually lives in `PluginSystem/World/` because it predates the current convention. New SDK component plugins should follow the `SDKComponents/<Feature>/Systems/` pattern described in the **sdk-component-implementation** skill.
+
+---
+
+## Global Plugin Example — AudioPlaybackPlugin
+
+```csharp
+public class AudioPlaybackPlugin : IDCLGlobalPlugin<AudioPlaybackPlugin.PluginSettings>
+{
+    private ProvidedInstance<UIAudioPlaybackController> uiAudioPlaybackController;
+    private ProvidedInstance<WorldAudioPlaybackController> worldAudioPlaybackController;
+    private ProvidedAsset<LandscapeAudioSystemSettings> landscapeAudioSettings;
+
+    // ... constructor with shared dependencies ...
+
+    public void Dispose()
+    {
+        // Dispose all provisioned assets
+        uiAudioPlaybackController.Dispose();
+        worldAudioPlaybackController.Dispose();
+        landscapeAudioSettings.Dispose();
+    }
+
+    public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder,
+        in GlobalPluginArguments arguments)
+    {
+        // Conditional injection
+        if (enableLandscape)
+            LandscapeAudioCullingSystem.InjectToWorld(ref builder, terrainGenerator,
+                worldTerrainGenerator, landscapeAudioSettings.Value,
+                worldAudioPlaybackController.Value, realmData);
+    }
+
+    public async UniTask InitializeAsync(PluginSettings settings, CancellationToken ct)
+    {
+        // Use ProvidedInstance for proper disposal tracking
+        uiAudioPlaybackController = await assetsProvisioner.ProvideInstanceAsync(
+            settings.UIAudioPlaybackControllerReference, ct: ct);
+        worldAudioPlaybackController = await assetsProvisioner.ProvideInstanceAsync(
+            settings.WorldAudioPlaybackControllerReference, ct: ct);
+        landscapeAudioSettings = await assetsProvisioner.ProvideMainAssetAsync(
+            settings.LandscapeAudioSettingsReference, ct: ct);
+    }
+
+    [Serializable]
+    public class PluginSettings : IDCLPluginSettings
+    {
+        [field: SerializeField]
+        public LandscapeAudioSettingsReference LandscapeAudioSettingsReference { get; private set; }
+        // ... other asset references ...
+    }
+}
+```

--- a/.claude/skills/sdk-component-implementation/SKILL.md
+++ b/.claude/skills/sdk-component-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdk-component-implementation
-description: "End-to-end SDK7 component implementation from protocol definition to C# systems. Use when implementing a new SDK component (PB* types, protobuf components, CRDT, protocol buffer), modifying existing SDK component systems, adding result components for scene-to-explorer communication, or registering components in ComponentsContainer."
+description: "End-to-end SDK7 component implementation from protocol to C# systems. Use when implementing new SDK components (PB* types, protobuf, CRDT), modifying SDK component systems, or registering in ComponentsContainer."
 user-invocable: false
 ---
 
@@ -10,11 +10,6 @@ user-invocable: false
 
 - `docs/how-to-implement-new-sdk-components.md` -- Step-by-step implementation guide
 - `docs/scene-runtime.md` -- SDK7 scene execution and CRDT bridge
-- `Explorer/Assets/DCL/Infrastructure/ProtobufPartialClasses/IDirtyMarker.cs` -- IDirtyMarker registration
-- `Explorer/Assets/DCL/Infrastructure/Global/ComponentsContainer.cs` -- Component registration
-- `Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs` -- Plugin instantiation
-- `Explorer/Assets/DCL/Infrastructure/ECS/LifeCycle/Systems/ResetDirtyFlagSystem.cs` -- Dirty flag reset
-- `Explorer/Assets/Protocol/DecentralandProtocol/ComponentID.gen.cs` -- Generated component IDs
 
 ---
 
@@ -58,8 +53,6 @@ Protocol first -> update both `js-sdk-toolchain` and `unity-explorer` -> merge i
 
 **File:** `Explorer/Assets/DCL/Infrastructure/ProtobufPartialClasses/IDirtyMarker.cs`
 
-Add a partial class with a manually implemented `IsDirty` property:
-
 ```csharp
 public partial class PBMyComponent : IDirtyMarker
 {
@@ -71,20 +64,12 @@ public partial class PBMyComponent : IDirtyMarker
 
 **File:** `Explorer/Assets/DCL/Infrastructure/Global/ComponentsContainer.cs`
 
-Register using `SDKComponentBuilder<T>` fluent API. Choose the pattern that fits:
-
 ```csharp
 // Standard protobuf component (most common)
 .Add(SDKComponentBuilder<PBMyComponent>.Create(ComponentID.MY_COMPONENT).AsProtobufComponent())
 
 // Result component (explorer -> scene, LWW)
 .Add(SDKComponentBuilder<PBMyResult>.Create(ComponentID.MY_RESULT).AsProtobufResult())
-
-// Custom pool + serializer (rare, e.g. SDKTransform)
-.Add(SDKComponentBuilder<SDKTransform>.Create(ComponentID.TRANSFORM)
-    .WithPool(t => { t.Clear(); SDKComponentBuilderExtensions.SetAsDirty(t); })
-    .WithCustomSerializer(new SDKTransformSerializer())
-    .Build())
 ```
 
 ### 3. StaticContainer Plugin Instantiation
@@ -121,172 +106,13 @@ Assets/DCL/SDKComponents/<Feature>/
 |   |   +-- EditMode.asmref                // { "reference": "DCL.EditMode.Tests" }
 ```
 
-**Assembly & naming notes:**
-- The `.asmref` for `DCL.Plugins` goes **inside `Systems/`**, named `DCL.<Feature>.Systems.asmref`.
-- Tests: `.asmref` pointing to `DCL.EditMode.Tests` (or `DCL.PlayMode.Tests` for PlayMode).
-- Do not create a standalone `.asmdef` for ECS systems.
-
-See the **plugin-architecture** skill for full assembly, naming, and plugin placement rules.
+**Assembly notes:** `.asmref` for `DCL.Plugins` goes inside `Systems/`. Tests use `DCL.EditMode.Tests`. Do not create standalone `.asmdef` for ECS systems. See **plugin-architecture** skill for full rules.
 
 ---
 
-## Plugin Creation
+## Detailed Reference
 
-Two interfaces exist: `IDCLWorldPlugin<TSettings>` (has `InitializeAsync` + nested `Settings` class) and `IDCLWorldPluginWithoutSettings` (no async init). See `LightSourcePlugin.cs` (in `PluginSystem/World/` — predates the current convention) and `TweenPlugin.cs` for examples of each pattern.
-
-**File:** `Explorer/Assets/DCL/SDKComponents/<Feature>/Systems/<Feature>Plugin.cs`
-
-> Plugins with ECS systems live in the `Systems/` folder alongside those systems. Only plugins **without** ECS systems go into `PluginSystem/Global/` or `PluginSystem/World/`. See the **plugin-architecture** skill § "Plugin file placement".
-
-```csharp
-// With settings (LightSourcePlugin pattern)
-public class MyPlugin : IDCLWorldPlugin<MyPlugin.MySettings>
-{
-    public MyPlugin(IComponentPoolsRegistry poolsRegistry, IAssetsProvisioner assetsProvisioner) { ... }
-
-    public async UniTask InitializeAsync(MySettings settings, CancellationToken ct)
-    {
-        // Load prefabs, create pools, etc.
-    }
-
-    public void InjectToWorld(ref ArchSystemsWorldBuilder<World> builder,
-        in ECSWorldInstanceSharedDependencies sharedDependencies,
-        in PersistentEntities persistentEntities,
-        List<IFinalizeWorldSystem> finalizeWorldSystems,
-        List<ISceneIsCurrentListener> sceneIsCurrentListeners)
-    {
-        ResetDirtyFlagSystem<PBMyComponent>.InjectToWorld(ref builder);
-        var lifecycle = MyLifecycleSystem.InjectToWorld(ref builder, ...);
-        MyApplyPropertiesSystem.InjectToWorld(ref builder, ...);
-        finalizeWorldSystems.Add(lifecycle);
-    }
-
-    [Serializable]
-    public class MySettings : IDCLPluginSettings { public AssetReferenceGameObject Prefab; }
-    public void Dispose() { }
-}
-
-// Without settings (TweenPlugin pattern) -- implement IDCLWorldPluginWithoutSettings instead
-```
-
----
-
-## System Patterns
-
-### Lifecycle System (first-occurrence detection)
-
-From `LightSourceLifecycleSystem.cs` -- `[None]` detects entities with SDK component but no internal component yet:
-
-```csharp
-[Query]
-[None(typeof(LightSourceComponent))]  // Matches only NEW entities
-private void CreateLightSourceComponent(in Entity entity, ref PBLightSource pbLightSource,
-    in TransformComponent transform)
-{
-    Light light = poolRegistry.Get();
-    light.transform.SetParent(transform.Transform, false);
-    World.Add(entity, new LightSourceComponent(light));
-    pbLightSource.IsDirty = true;  // Force downstream update
-}
-```
-
-The system inherits `BaseUnityLoopSystem` and `IFinalizeWorldSystem`, with `[UpdateInGroup(typeof(LightSourcesGroup))]`.
-
-### Apply Properties System (IsDirty guard)
-
-From `LightSourceApplyPropertiesSystem.cs`:
-
-```csharp
-[Query]
-private void UpdateLightSource(in PBLightSource pbLightSource, ref LightSourceComponent component)
-{
-    component.LightSourceInstance.enabled = LightSourceHelper.IsPBLightSourceActive(pbLightSource, ...);
-    if (pbLightSource.IsDirty) ApplyPBLightSource(pbLightSource, ref component);
-}
-```
-
-`ResetDirtyFlagSystem<T>` resets `IsDirty = false` at end of frame -- systems do NOT manually reset it.
-
-### Cleanup System (three scenarios)
-
-Cleanup must handle three triggers — see the **ecs-system-and-component-design** skill for full patterns and the `CleanUpAudioSourceSystem` example:
-
-1. **SDK component removed** — `[None(typeof(PBMyComponent), typeof(DeleteEntityIntention))]`
-2. **Entity destroyed** — `[All(typeof(DeleteEntityIntention))]`
-3. **World disposed** — implement `IFinalizeWorldSystem.FinalizeComponents(in Query)`
-
-Place in `[UpdateInGroup(typeof(CleanUpGroup))]` with `[ThrottlingEnabled]`.
-
-### Custom SystemGroup (only when needed)
-
-Most systems can use existing groups (e.g., `ComponentInstantiationGroup`, `CleanUpGroup`). Only create a custom group when you need fine-grained ordering between multiple systems in the same feature:
-
-```csharp
-[UpdateInGroup(typeof(SyncedSimulationSystemGroup))]
-[UpdateAfter(typeof(ComponentInstantiationGroup))]
-[ThrottlingEnabled]
-public partial class LightSourcesGroup { }
-```
-
----
-
-## CRDT Bridge (Result Components)
-
-Use `IECSToCRDTWriter` (via `sharedDependencies.EcsToCRDTWriter`) to send data back to the scene runtime:
-
-```csharp
-// LWW PUT -- overwrites prior state
-ecsToCRDTWriter.PutMessage<PBAudioAnalysis>(sdkComponent, entity);
-
-// LWW PUT -- with prepare callback (use static lambda to avoid allocation)
-ecsToCRDTWriter.PutMessage<PBRealmInfo, (IRealmData rd, CommsRoomInfo ci)>(
-    static (c, d) => { c.BaseUrl = d.rd.Ipfs.CatalystBaseUrl.Value; },
-    SpecialEntitiesID.SCENE_ROOT_ENTITY, (realmData, commsRoomInfo));
-
-// GOVS APPEND -- accumulates values (events); DELETE -- removes component
-ecsToCRDTWriter.AppendMessage<PBAudioEvent, ...>(static (e, d) => { ... }, sdkEntity, tickNumber, data);
-ecsToCRDTWriter.DeleteMessage<PBTweenState>(sdkEntity);
-```
-
----
-
-## LWW vs GOVS Components
-
-- **LWW (Last Write Wins):** Standard for most components. Uses `PutMessage`. The latest value overwrites previous. Registered with `.AsProtobufComponent()` or `.AsProtobufResult()`.
-- **GOVS (Grow-Only Value Set):** For components that accumulate values (e.g., events). Uses `AppendMessage`. Must be listed in `generateIndex.ts` in the protocol repo.
-
----
-
-## Test Pattern
-
-From `TweenUpdaterSystemShould.cs`:
-
-```csharp
-[TestFixture]
-public class TweenUpdaterSystemShould : UnitySystemTestBase<TweenUpdaterSystem>
-{
-    [SetUp]
-    public void SetUp()
-    {
-        var sceneStateProvider = Substitute.For<ISceneStateProvider>();
-        sceneStateProvider.IsCurrent.Returns(true);
-        system = new TweenUpdaterSystem(world, Substitute.For<IECSToCRDTWriter>(),
-            new TweenerPool(), sceneStateProvider);
-    }
-
-    [Test]
-    public void ChangingPBTweenUpdatesState()
-    {
-        Entity entity = world.Create(new PBTween { ... }, new SDKTweenComponent { ... });
-        system!.Update(0);
-        Assert.IsTrue(world.Get<SDKTweenComponent>(entity).TweenStateStatus == TweenStateStatus.TsActive);
-    }
-}
-```
-
-`UnitySystemTestBase<T>` provides `world` and `system` fields. Mock with `Substitute.For<T>()`. Constructors are `internal` + `[InternalsVisibleTo]`.
-
-Prefer **EditMode** tests -- they are faster and sufficient for most system logic. Only use **PlayMode** tests when you need Unity lifecycle callbacks (Awake, Start, coroutines) or real frame timing that EditMode cannot provide.
+For plugin code examples, system patterns (lifecycle, apply-properties, cleanup, groups), CRDT bridge usage (`IECSToCRDTWriter`, LWW vs GOVS), and test patterns, see [reference.md](reference.md).
 
 ---
 

--- a/.claude/skills/sdk-component-implementation/reference.md
+++ b/.claude/skills/sdk-component-implementation/reference.md
@@ -1,0 +1,157 @@
+# SDK Component Implementation — Detailed Reference
+
+## Plugin Creation
+
+Two interfaces exist: `IDCLWorldPlugin<TSettings>` (has `InitializeAsync` + nested `Settings` class) and `IDCLWorldPluginWithoutSettings` (no async init). See `LightSourcePlugin.cs` and `TweenPlugin.cs` for examples.
+
+**File:** `Explorer/Assets/DCL/SDKComponents/<Feature>/Systems/<Feature>Plugin.cs`
+
+> Plugins with ECS systems live in the `Systems/` folder alongside those systems. Only plugins **without** ECS systems go into `PluginSystem/Global/` or `PluginSystem/World/`. See the **plugin-architecture** skill for rules.
+
+```csharp
+// With settings (LightSourcePlugin pattern)
+public class MyPlugin : IDCLWorldPlugin<MyPlugin.MySettings>
+{
+    public MyPlugin(IComponentPoolsRegistry poolsRegistry, IAssetsProvisioner assetsProvisioner) { ... }
+
+    public async UniTask InitializeAsync(MySettings settings, CancellationToken ct)
+    {
+        // Load prefabs, create pools, etc.
+    }
+
+    public void InjectToWorld(ref ArchSystemsWorldBuilder<World> builder,
+        in ECSWorldInstanceSharedDependencies sharedDependencies,
+        in PersistentEntities persistentEntities,
+        List<IFinalizeWorldSystem> finalizeWorldSystems,
+        List<ISceneIsCurrentListener> sceneIsCurrentListeners)
+    {
+        ResetDirtyFlagSystem<PBMyComponent>.InjectToWorld(ref builder);
+        var lifecycle = MyLifecycleSystem.InjectToWorld(ref builder, ...);
+        MyApplyPropertiesSystem.InjectToWorld(ref builder, ...);
+        finalizeWorldSystems.Add(lifecycle);
+    }
+
+    [Serializable]
+    public class MySettings : IDCLPluginSettings { public AssetReferenceGameObject Prefab; }
+    public void Dispose() { }
+}
+
+// Without settings (TweenPlugin pattern) -- implement IDCLWorldPluginWithoutSettings instead
+```
+
+---
+
+## System Patterns
+
+### Lifecycle System (first-occurrence detection)
+
+From `LightSourceLifecycleSystem.cs` -- `[None]` detects entities with SDK component but no internal component yet:
+
+```csharp
+[Query]
+[None(typeof(LightSourceComponent))]  // Matches only NEW entities
+private void CreateLightSourceComponent(in Entity entity, ref PBLightSource pbLightSource,
+    in TransformComponent transform)
+{
+    Light light = poolRegistry.Get();
+    light.transform.SetParent(transform.Transform, false);
+    World.Add(entity, new LightSourceComponent(light));
+    pbLightSource.IsDirty = true;  // Force downstream update
+}
+```
+
+The system inherits `BaseUnityLoopSystem` and `IFinalizeWorldSystem`, with `[UpdateInGroup(typeof(LightSourcesGroup))]`.
+
+### Apply Properties System (IsDirty guard)
+
+From `LightSourceApplyPropertiesSystem.cs`:
+
+```csharp
+[Query]
+private void UpdateLightSource(in PBLightSource pbLightSource, ref LightSourceComponent component)
+{
+    component.LightSourceInstance.enabled = LightSourceHelper.IsPBLightSourceActive(pbLightSource, ...);
+    if (pbLightSource.IsDirty) ApplyPBLightSource(pbLightSource, ref component);
+}
+```
+
+`ResetDirtyFlagSystem<T>` resets `IsDirty = false` at end of frame -- systems do NOT manually reset it.
+
+### Cleanup System (three scenarios)
+
+Cleanup must handle three triggers — see the **ecs-system-and-component-design** skill for full patterns and the `CleanUpAudioSourceSystem` example:
+
+1. **SDK component removed** — `[None(typeof(PBMyComponent), typeof(DeleteEntityIntention))]`
+2. **Entity destroyed** — `[All(typeof(DeleteEntityIntention))]`
+3. **World disposed** — implement `IFinalizeWorldSystem.FinalizeComponents(in Query)`
+
+Place in `[UpdateInGroup(typeof(CleanUpGroup))]` with `[ThrottlingEnabled]`.
+
+### Custom SystemGroup (only when needed)
+
+Most systems can use existing groups. Only create a custom group when you need fine-grained ordering between multiple systems in the same feature:
+
+```csharp
+[UpdateInGroup(typeof(SyncedSimulationSystemGroup))]
+[UpdateAfter(typeof(ComponentInstantiationGroup))]
+[ThrottlingEnabled]
+public partial class LightSourcesGroup { }
+```
+
+---
+
+## CRDT Bridge (Result Components)
+
+Use `IECSToCRDTWriter` (via `sharedDependencies.EcsToCRDTWriter`) to send data back to the scene runtime:
+
+```csharp
+// LWW PUT -- overwrites prior state
+ecsToCRDTWriter.PutMessage<PBAudioAnalysis>(sdkComponent, entity);
+
+// LWW PUT -- with prepare callback (use static lambda to avoid allocation)
+ecsToCRDTWriter.PutMessage<PBRealmInfo, (IRealmData rd, CommsRoomInfo ci)>(
+    static (c, d) => { c.BaseUrl = d.rd.Ipfs.CatalystBaseUrl.Value; },
+    SpecialEntitiesID.SCENE_ROOT_ENTITY, (realmData, commsRoomInfo));
+
+// GOVS APPEND -- accumulates values (events); DELETE -- removes component
+ecsToCRDTWriter.AppendMessage<PBAudioEvent, ...>(static (e, d) => { ... }, sdkEntity, tickNumber, data);
+ecsToCRDTWriter.DeleteMessage<PBTweenState>(sdkEntity);
+```
+
+### LWW vs GOVS Components
+
+- **LWW (Last Write Wins):** Standard for most components. Uses `PutMessage`. The latest value overwrites previous. Registered with `.AsProtobufComponent()` or `.AsProtobufResult()`.
+- **GOVS (Grow-Only Value Set):** For components that accumulate values (e.g., events). Uses `AppendMessage`. Must be listed in `generateIndex.ts` in the protocol repo.
+
+---
+
+## Test Pattern
+
+From `TweenUpdaterSystemShould.cs`:
+
+```csharp
+[TestFixture]
+public class TweenUpdaterSystemShould : UnitySystemTestBase<TweenUpdaterSystem>
+{
+    [SetUp]
+    public void SetUp()
+    {
+        var sceneStateProvider = Substitute.For<ISceneStateProvider>();
+        sceneStateProvider.IsCurrent.Returns(true);
+        system = new TweenUpdaterSystem(world, Substitute.For<IECSToCRDTWriter>(),
+            new TweenerPool(), sceneStateProvider);
+    }
+
+    [Test]
+    public void ChangingPBTweenUpdatesState()
+    {
+        Entity entity = world.Create(new PBTween { ... }, new SDKTweenComponent { ... });
+        system!.Update(0);
+        Assert.IsTrue(world.Get<SDKTweenComponent>(entity).TweenStateStatus == TweenStateStatus.TsActive);
+    }
+}
+```
+
+`UnitySystemTestBase<T>` provides `world` and `system` fields. Mock with `Substitute.For<T>()`. Constructors are `internal` + `[InternalsVisibleTo]`.
+
+Prefer **EditMode** tests -- they are faster and sufficient for most system logic. Only use **PlayMode** tests when you need Unity lifecycle callbacks (Awake, Start, coroutines) or real frame timing that EditMode cannot provide.

--- a/.claude/skills/testing-infrastructure/SKILL.md
+++ b/.claude/skills/testing-infrastructure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-infrastructure
-description: "Testing patterns and infrastructure — UnitySystemTestBase, ECS test utilities, mocking strategies, EditMode vs PlayMode tests. Use when writing tests for ECS systems, controllers, or async code, setting up test worlds, mocking ECS dependencies with NSubstitute, creating test entities, or choosing between EditMode and PlayMode test types."
+description: "Testing patterns -- UnitySystemTestBase, ECS test utilities, mocking, EditMode vs PlayMode. Use when writing tests for ECS systems, controllers, or async code, or choosing test types."
 user-invocable: false
 ---
 
@@ -13,101 +13,60 @@ user-invocable: false
 
 ---
 
-## Test Base Classes
+## UnitySystemTestBase<TSystem>
 
-### `UnitySystemTestBase<TSystem>`
+Located at `Explorer/Assets/DCL/Infrastructure/ECS/TestSuite/UnitySystemTestBase.cs`. Provides world lifecycle for ECS system tests.
 
-Located at `Explorer/Assets/DCL/Infrastructure/ECS/TestSuite/UnitySystemTestBase.cs`. Provides world lifecycle for ECS system tests:
-
-```csharp
-public abstract class UnitySystemTestBase<TSystem> where TSystem : BaseUnityLoopSystem
-{
-    protected TSystem? system;
-    protected World world { get; } // Lazy-created; includes SceneShortInfo entity
-
-    [TearDown] public void DestroyWorld() { OnTearDown(); system?.Dispose(); world?.Dispose(); }
-    protected virtual void OnTearDown() { }
-
-    // Convenience helpers (delegate to EcsTestsUtils)
-    protected TransformComponent AddTransformToEntity(in Entity entity, bool isDirty = false, World world = null);
-    protected MaterialComponent AddMaterialToEntity(in Entity entity, bool isDirty = false, World world = null);
-    protected UITransformComponent AddUITransformToEntity(in Entity entity, bool isDirty = false);
-}
-```
+**Key API:**
+- `protected TSystem? system` -- assign in `[SetUp]`
+- `protected World world` -- lazily created with a default `SceneShortInfo(Vector2Int.zero, "TEST")` entity
+- `AddTransformToEntity(entity, isDirty, world)`, `AddMaterialToEntity(entity, isDirty, world)`, `AddUITransformToEntity(entity, isDirty)` -- convenience helpers delegating to `EcsTestsUtils`
 
 **Key behaviors:**
-- World is lazily created on first access with a default `SceneShortInfo(Vector2Int.zero, "TEST")` entity.
-- `[TearDown]` disposes system and world automatically. Override `OnTearDown()` for custom cleanup.
-- Assign `system` in `[SetUp]` by calling the system constructor directly.
+- World is lazily created on first access with a default scene info entity
+- `[TearDown]` disposes system and world automatically; override `OnTearDown()` for custom cleanup
+- Assign `system` in `[SetUp]` by calling the system constructor directly
 
 ---
 
 ## Test Utilities
 
-### `EcsTestsUtils` (static helpers)
+### EcsTestsUtils (static helpers in TestSuite)
 
 Located at `Explorer/Assets/DCL/Infrastructure/ECS/TestSuite/EcsTestsUtils.cs`:
 
 | Method | Purpose |
 |--------|---------|
 | `AddTransformToEntity(world, entity, isDirty)` | Creates a GameObject, adds `TransformComponent` + `SDKTransform` |
-| `AddMaterialToEntity(world, entity)` | Creates a GameObject, adds `MaterialComponent` with a default URP Lit material |
+| `AddMaterialToEntity(world, entity)` | Creates a GameObject, adds `MaterialComponent` with default URP Lit material |
 | `SetUpFeaturesRegistry(params string[] flags)` | Initializes `FeatureFlagsConfiguration` and `FeaturesRegistry` for tests |
 | `TearDownFeaturesRegistry()` | Resets feature flags singletons |
 
-### `ECSTestUtils` (mocking helpers)
+### ECSTestUtils (mocking helpers in Tests/Editor)
 
-Located at `Explorer/Assets/DCL/Tests/Editor/ECSTestUtils.cs`:
+Located at `Explorer/Assets/DCL/Tests/Editor/ECSTestUtils.cs`. Use `ECSTestUtils.SceneDataSub()` whenever a system requires `ISceneData` -- it maps any content path to a `URLAddress`.
 
-```csharp
-public static ISceneData SceneDataSub()
-{
-    ISceneData sceneData = Substitute.For<ISceneData>();
-    sceneData.TryGetContentUrl(Arg.Any<string>(), out Arg.Any<URLAddress>())
-             .Returns(args =>
-             {
-                 args[1] = URLAddress.FromString(args.ArgAt<string>(0));
-                 return true;
-             });
-    return sceneData;
-}
-```
-
-Use `ECSTestUtils.SceneDataSub()` whenever a system requires `ISceneData` -- it maps any content path to a `URLAddress`.
+> **Note:** `EcsTestsUtils` = static helpers in TestSuite; `ECSTestUtils` = mocking helpers in Tests/Editor. Different classes despite near-identical names.
 
 ---
 
 ## EditMode vs PlayMode Tests
-
-### When to use each
 
 | Type | Use when | Requires |
 |------|----------|----------|
 | **EditMode** | Pure logic, ECS systems, serialization, utilities -- no scene or coroutines needed | Editor only |
 | **PlayMode** | Integration tests needing MonoBehaviours, scene loading, `UniTask.Yield`, or full containers | Runtime player loop |
 
-### Assembly structure
-
-Two root test assemblies exist:
+### Assembly Structure
 
 - `DCL.EditMode.Tests` -- `Explorer/Assets/DCL/Tests/Editor/DCL.EditMode.Tests.asmdef` (platform: Editor only)
 - `DCL.PlayMode.Tests` -- `Explorer/Assets/DCL/Tests/PlayMode/DCL.PlayMode.Tests.asmdef` (all platforms)
 
 Both require `UNITY_INCLUDE_TESTS` define constraint and reference `nunit.framework.dll` and `NSubstitute.dll`.
 
-### `.asmref` pattern
+Feature-local test folders reference the root assembly via `.asmref` files. Naming convention: `{Feature}.Tests.asmref` for EditMode (most common), `{Feature}.EditMode.Tests.asmref` or `{Feature}.PlayMode.Tests.asmref` when both types exist.
 
-Feature-local test folders reference the root assembly via `.asmref` files:
-
-```json
-{
-    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
-}
-```
-
-Naming convention: `{Feature}.Tests.asmref` for EditMode (most common), `{Feature}.EditMode.Tests.asmref` or `{Feature}.PlayMode.Tests.asmref` when both types exist for the same feature.
-
-### `[InternalsVisibleTo]` pattern
+### [InternalsVisibleTo] Pattern
 
 System constructors are `internal`. Expose them to tests via an `AssemblyInfo.cs` in the production assembly:
 
@@ -118,9 +77,7 @@ System constructors are `internal`. Expose them to tests via an `AssemblyInfo.cs
 
 ---
 
-## Mocking with NSubstitute
-
-### Common mocks
+## Common Mocks
 
 | Interface | Typical setup |
 |-----------|---------------|
@@ -132,128 +89,22 @@ System constructors are `internal`. Expose them to tests via an `AssemblyInfo.cs
 | `IFinalizeWorldSystem` | `Substitute.For<IFinalizeWorldSystem>()` then verify `FinalizeComponents` called |
 | `IRealmData` | `Substitute.For<IRealmData>()` |
 
-### Verification example
-
-```csharp
-// Verify a mock was called
-ecsToCRDTWriter.Received(1).PutMessage(...);
-
-// Verify pool release count
-pool.Received(100).Release(Arg.Is<object>(o => o.GetType() == typeof(TestComponent1)));
-```
-
 ---
 
 ## System Test Patterns
 
-> See CLAUDE.md sections 1 and 10 for condensed testing rules.
-
-### Lifecycle testing pattern
-
-Test creation, update, dirty-flag re-processing, cancellation, and cleanup:
-
-```csharp
-public class StartAudioClipLoadingSystemShould : UnitySystemTestBase<StartAudioSourceLoadingSystem>
-{
-    [SetUp]
-    public void SetUp()
-    {
-        system = CreateSystem(world);
-        entity = world.Create(pbAudioSource, PartitionComponent.TOP_PRIORITY);
-    }
-
-    [Test]
-    public void CreateAudioSourceComponentForPBAudioSource()
-    {
-        // Act
-        system.Update(0);
-
-        // Assert
-        Assert.That(world.TryGet(entity, out AudioSourceComponent comp), Is.True);
-        Assert.That(comp.AudioClipUrl, Is.EqualTo(pbAudioSource.AudioClipUrl));
-    }
-}
-```
-
-### Multi-frame simulation
-
-Call `system.Update(0)` repeatedly to simulate multiple frames:
-
-```csharp
-system.Update(0); // Frame 1: creates component
-pbAudioSource.IsDirty = true;
-system.Update(0); // Frame 2: processes dirty flag
-```
-
-### `DeleteEntityIntention` testing
-
-Add `DeleteEntityIntention` to trigger entity destruction cleanup:
-
-```csharp
-Entity e = world.Create(scene, new DeleteEntityIntention(), new SceneDefinitionComponent());
-system.Update(0f);
-scene.Received(1).DisposeAsync();
-```
-
-### `IFinalizeWorldSystem` testing
-
-Mock the interface and verify `FinalizeComponents` is called on dispose:
-
-```csharp
-var finalizeSystem = Substitute.For<IFinalizeWorldSystem>();
-// ... wire into ECSWorldFacade ...
-ecsWorldFacade.Dispose();
-finalizeSystem.Received(1).FinalizeComponents(Arg.Any<Query>());
-```
+- **Lifecycle testing:** Test creation, update, dirty-flag re-processing, cancellation, and cleanup
+- **Multi-frame simulation:** Call `system.Update(0)` repeatedly to simulate multiple frames; set `IsDirty = true` between calls
+- **DeleteEntityIntention:** Add `DeleteEntityIntention` to trigger entity destruction cleanup, verify disposal calls via `.Received()`
+- **IFinalizeWorldSystem:** Mock the interface, wire into `ECSWorldFacade`, call `Dispose()`, verify `FinalizeComponents` called
 
 ---
 
 ## Async Test Patterns
 
-### UniTask in tests
-
-Use `async Task` (not `async void`) with `[Test]`:
-
-```csharp
-[Test]
-public async Task RestoreCameraDataOnFailureAsync(
-    [Values(UniTaskStatus.Faulted, UniTaskStatus.Canceled)] UniTaskStatus status)
-{
-    var loadReport = AsyncLoadProcessReport.Create(CancellationToken.None);
-    Entity e = world.Create(characterController, new CharacterRigidTransform(), teleportIntent);
-
-    if (status == UniTaskStatus.Faulted)
-    {
-        loadReport.SetException(new Exception("test"));
-        LogAssert.Expect(LogType.Exception, new Regex(".*test.*"));
-    }
-    else
-        loadReport.SetCancelled();
-
-    await loadReport.WaitUntilFinishedAsync();
-    system!.Update(0);
-
-    Assert.That(cameraSamplingData.IsDirty, Is.True);
-}
-```
-
-### `AssetPromise` consumption in tests
-
-Simulate promise resolution by adding `StreamableLoadingResult<T>` to the promise entity:
-
-```csharp
-// Create promise during SetUp or first Update
-system.Update(0);
-
-// Simulate asset loaded
-world.Add(component.ClipPromise.Entity, new StreamableLoadingResult<AudioClipData>(data));
-
-// Process the resolved promise
-system.Update(0);
-
-// Assert consumption
-Assert.That(world.Get<AudioSourceComponent>(entity).AudioSource, Is.Not.Null);
-```
+- Use `async Task` (not `async void`) with `[Test]`
+- Simulate `AssetPromise` resolution by adding `StreamableLoadingResult<T>` to the promise entity, then call `system.Update(0)` to consume
+- For `UniTask` failures: use `AsyncLoadProcessReport.Create`, set exception/cancelled, then `await WaitUntilFinishedAsync()`
 
 ---
 
@@ -265,7 +116,7 @@ Assert.That(world.Get<AudioSourceComponent>(entity).AudioSource, Is.Not.Null);
 - **Methods:** Describe expected behavior -- `CreateAudioSourceFromResolvedPromise`, `DisposeLoadedScene`
 - **Body:** Split with `// Arrange`, `// Act`, `// Assert` comments
 
-### Folder structure
+### Folder Structure
 
 ```
 Feature/
@@ -278,9 +129,13 @@ Feature/
     {Feature}.PlayMode.Tests.asmref
 ```
 
-### PlayMode integration tests
+For full integration tests, use `IntegrationTestsSuite.CreateStaticContainer()` to spin up the full dependency container.
 
-For full integration tests, use `IntegrationTestsSuite.CreateStaticContainer()` to spin up the full dependency container. See `Explorer/Assets/DCL/Infrastructure/Global/Tests/PlayMode/IntegrationTestsSuite.cs`.
+---
+
+## Detailed Reference
+
+For detailed code examples, see [reference.md](reference.md).
 
 ---
 

--- a/.claude/skills/testing-infrastructure/reference.md
+++ b/.claude/skills/testing-infrastructure/reference.md
@@ -1,0 +1,162 @@
+# Testing Infrastructure -- Detailed Reference
+
+## UnitySystemTestBase Full API
+
+```csharp
+public abstract class UnitySystemTestBase<TSystem> where TSystem : BaseUnityLoopSystem
+{
+    protected TSystem? system;
+    protected World world { get; } // Lazy-created; includes SceneShortInfo entity
+
+    [TearDown] public void DestroyWorld() { OnTearDown(); system?.Dispose(); world?.Dispose(); }
+    protected virtual void OnTearDown() { }
+
+    // Convenience helpers (delegate to EcsTestsUtils)
+    protected TransformComponent AddTransformToEntity(in Entity entity, bool isDirty = false, World world = null);
+    protected MaterialComponent AddMaterialToEntity(in Entity entity, bool isDirty = false, World world = null);
+    protected UITransformComponent AddUITransformToEntity(in Entity entity, bool isDirty = false);
+}
+```
+
+---
+
+## ECSTestUtils.SceneDataSub Code
+
+```csharp
+public static ISceneData SceneDataSub()
+{
+    ISceneData sceneData = Substitute.For<ISceneData>();
+    sceneData.TryGetContentUrl(Arg.Any<string>(), out Arg.Any<URLAddress>())
+             .Returns(args =>
+             {
+                 args[1] = URLAddress.FromString(args.ArgAt<string>(0));
+                 return true;
+             });
+    return sceneData;
+}
+```
+
+---
+
+## .asmref File Format
+
+```json
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}
+```
+
+---
+
+## Lifecycle Testing Pattern
+
+```csharp
+public class StartAudioClipLoadingSystemShould : UnitySystemTestBase<StartAudioSourceLoadingSystem>
+{
+    [SetUp]
+    public void SetUp()
+    {
+        system = CreateSystem(world);
+        entity = world.Create(pbAudioSource, PartitionComponent.TOP_PRIORITY);
+    }
+
+    [Test]
+    public void CreateAudioSourceComponentForPBAudioSource()
+    {
+        // Act
+        system.Update(0);
+
+        // Assert
+        Assert.That(world.TryGet(entity, out AudioSourceComponent comp), Is.True);
+        Assert.That(comp.AudioClipUrl, Is.EqualTo(pbAudioSource.AudioClipUrl));
+    }
+}
+```
+
+---
+
+## Multi-Frame Simulation
+
+```csharp
+system.Update(0); // Frame 1: creates component
+pbAudioSource.IsDirty = true;
+system.Update(0); // Frame 2: processes dirty flag
+```
+
+---
+
+## DeleteEntityIntention Testing
+
+```csharp
+Entity e = world.Create(scene, new DeleteEntityIntention(), new SceneDefinitionComponent());
+system.Update(0f);
+scene.Received(1).DisposeAsync();
+```
+
+---
+
+## IFinalizeWorldSystem Testing
+
+```csharp
+var finalizeSystem = Substitute.For<IFinalizeWorldSystem>();
+// ... wire into ECSWorldFacade ...
+ecsWorldFacade.Dispose();
+finalizeSystem.Received(1).FinalizeComponents(Arg.Any<Query>());
+```
+
+---
+
+## Verification Example
+
+```csharp
+// Verify a mock was called
+ecsToCRDTWriter.Received(1).PutMessage(...);
+
+// Verify pool release count
+pool.Received(100).Release(Arg.Is<object>(o => o.GetType() == typeof(TestComponent1)));
+```
+
+---
+
+## Async Test -- UniTask Pattern
+
+```csharp
+[Test]
+public async Task RestoreCameraDataOnFailureAsync(
+    [Values(UniTaskStatus.Faulted, UniTaskStatus.Canceled)] UniTaskStatus status)
+{
+    var loadReport = AsyncLoadProcessReport.Create(CancellationToken.None);
+    Entity e = world.Create(characterController, new CharacterRigidTransform(), teleportIntent);
+
+    if (status == UniTaskStatus.Faulted)
+    {
+        loadReport.SetException(new Exception("test"));
+        LogAssert.Expect(LogType.Exception, new Regex(".*test.*"));
+    }
+    else
+        loadReport.SetCancelled();
+
+    await loadReport.WaitUntilFinishedAsync();
+    system!.Update(0);
+
+    Assert.That(cameraSamplingData.IsDirty, Is.True);
+}
+```
+
+---
+
+## AssetPromise Consumption in Tests
+
+```csharp
+// Create promise during SetUp or first Update
+system.Update(0);
+
+// Simulate asset loaded
+world.Add(component.ClipPromise.Entity, new StreamableLoadingResult<AudioClipData>(data));
+
+// Process the resolved promise
+system.Update(0);
+
+// Assert consumption
+Assert.That(world.Get<AudioSourceComponent>(entity).AudioSource, Is.Not.Null);
+```


### PR DESCRIPTION
## Summary

This all starts with me wanting to optimize skills creation and use, for this I researched and made Claude research many papers related to best practices for skill creation, as well as context limitations, impact, performance, etc.
This resulted in a skill called create-skills which I have used repeatedly to not only create new skills, but to review and improve existing ones.
So I decided to apply it to our own skills and run some tests.
These are the changes applied:
| Skill | Before | After | Reduction |
|-------|--------|-------|-----------|
| sdk-component-implementation | 307 lines | 133 lines | **56%** |
| multiplayer-and-network-sync | 289 lines | 131 lines | **54%** |
| avatar-rendering-pipeline | 293 lines | 141 lines | **51%** |
| cross-world-ecs-access | 273 lines | 133 lines | **51%** |
| testing-infrastructure | 290 lines | 145 lines | **50%** |
| ecs-system-and-component-design | 278 lines | 149 lines | **46%** |
| plugin-architecture | 271 lines | 150 lines | **44%** |
| asset-promise-lifecycle | 249 lines | 159 lines | **36%** |
| chat-system | 267 lines | 209 lines | **21%** |
| **Total** | **2,517 lines** | **1,350 lines** | **46%** |

with the tests run by the LLM finding no reduction on answer quality.
This is achieved not by removing information (although some had to be restructured) but by applying a progressive disclosure pattern, extracting detailed code examples into separate `reference.md` files that are only loaded on demand. This makes it so only when the LLM really needs to know some specific reference it will check it, otherwise its context wont get populated by unneeded information.
Then, trimmed all 9 skill descriptions to under 250 characters to ensure very low context impact.
Also deleted 6 empty gitnexus stub directories that were causing clutter


Now some Claude info dump for those interested on why:

## Why this works

Claude Code skills use a three-tier loading system:
1. **Metadata** (name + description) — always in context (~100 tokens per skill)
2. **SKILL.md body** — loaded when the skill triggers
3. **Bundled files** (reference.md) — loaded only when Claude determines it needs detailed examples

Previously, all 9 skills put everything in SKILL.md, meaning every time a skill triggered, Claude loaded ~250-300 lines of content including detailed code examples it might not need. By moving code examples to `reference.md`, the SKILL.md now loads only the core workflow, rules, and API summaries. Claude reads `reference.md` on demand — only when it actually needs to write code following those patterns.

This reduces context window consumption per skill activation by ~46% on average, leaving more room for the actual task at hand.

## Quality validation

Agent-based evaluations were run on 4 skills using realistic implementation prompts. Each eval tested whether the lean SKILL.md provided sufficient information to guide correct implementation without needing to read reference.md for the core workflow:

| Skill | Test prompt | Score |
|-------|-----------|-------|
| sdk-component-implementation | "Implement PBAudioAnalysis result component" | **8/8 PASS** |
| multiplayer-and-network-sync | "Add facial expression sync global→scene" | **6/6 PASS** |
| avatar-rendering-pipeline | "Add wings wearable with custom shader" | **6/6 PASS** |
| cross-world-ecs-access | "Read camera FOV from global world in scene system" | **5.5/6 PASS** |

No quality regressions were found. In all cases, the lean SKILL.md contained the essential workflow, rules, and API references needed to guide implementation. The reference.md was correctly pointed to for detailed code examples.

## New skill: `creating-skills`

Added a comprehensive skill authoring guide so any developer on the team can create, improve, and optimize  skills for this project. The skill covers:

- **Eval-driven development** — the Claude A / Claude B pattern for testing skills without self-confirmation bias. Every skill should have at least 3 evaluation scenarios before writing content.
- **Skill structure** — directory layout (`SKILL.md`, `reference.md`, `scripts/`, `assets/`), frontmatter fields (including newer fields like `model`, `effort`, `paths`, `hooks`, `shell`, `argument-hint`), and body structure templates.
- **Description optimization** — how to write descriptions that activate reliably (front-load key use case, stay under 250 chars, be assertive about triggers). Includes a methodology for building 20+ eval queries and testing activation accuracy.
- **Token efficiency** — progressive disclosure tiers, word count targets (1,500-2,000 words ideal), when to extract reference files, and context budget awareness (~1% of context window shared across all skill descriptions).
- **Workflow patterns** — checklist, feedback loop, plan-validate-execute, conditional, template, and examples patterns.
- **Bulletproofing discipline skills** — rationalization tables, red flags lists, and loophole-closing techniques for skills that enforce rules.
- **Anti-patterns** — narrative style, multi-language dilution, workflow summaries in descriptions, excessive ALWAYS/NEVER caps, deeply nested references, and more.

The skill includes a `best-practices-reference.md` with detailed Anthropic guidelines, activation rate benchmarks from real-world testing (200+ prompts), invocation control matrix, and cross-platform notes (Agent Skills is now an open standard at agentskills.io, working across Claude Code, Cursor, VS Code Copilot, and Gemini CLI).

This is the same methodology used to perform the progressive disclosure extraction in this PR.