### PR TITLE
fix: concurrent backpack requests

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/EcsEmoteProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/EcsEmoteProvider.cs
@@ -65,7 +65,8 @@ namespace DCL.AvatarRendering.Emotes
 
             results ??= new List<ITrimmedEmote>();
 
-            var intention = new GetTrimmedEmotesByParamIntention(requestParameters, web3IdentityCache.Identity!.Address, results, 0, needsBuilderAPISigning);
+            var intentionResults = new List<ITrimmedEmote>();
+            var intention = new GetTrimmedEmotesByParamIntention(requestParameters, web3IdentityCache.Identity!.Address, intentionResults, 0, needsBuilderAPISigning);
             if (loadingArguments.HasValue)
                 intention.CommonArguments = loadingArguments.Value;
 
@@ -77,8 +78,8 @@ namespace DCL.AvatarRendering.Emotes
             if (!promise.Result.HasValue) return (results, 0);
             if (!promise.Result!.Value.Succeeded) return (results, 0);
 
-            return (promise.Result.Value.Asset.Emotes,
-                promise.Result.Value.Asset.TotalAmount);
+            results.AddRange(promise.Result.Value.Asset.Emotes);
+            return (results, promise.Result.Value.Asset.TotalAmount);
         }
 
         public async UniTask<IReadOnlyCollection<IEmote>?> GetByPointersAsync(

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/ECSWearablesProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/ECSWearablesProvider.cs
@@ -85,7 +85,8 @@ namespace DCL.AvatarRendering.Wearables
 
             results ??= new List<ITrimmedWearable>();
 
-            var intention = new GetTrimmedWearableByParamIntention(requestParameters, web3IdentityCache.Identity!.Address, results, 0, needsBuilderAPISigning);
+            var intentionResults = new List<ITrimmedWearable>();
+            var intention = new GetTrimmedWearableByParamIntention(requestParameters, web3IdentityCache.Identity!.Address, intentionResults, 0, needsBuilderAPISigning);
             if (loadingArguments.HasValue)
                 intention.CommonArguments = loadingArguments.Value;
 
@@ -101,9 +102,8 @@ namespace DCL.AvatarRendering.Wearables
             if (!wearablesPromise.Result.HasValue) return (results, 0);
             if (!wearablesPromise.Result!.Value.Succeeded) return (results, 0);
 
-            // Should be the same assigned in the intention as `results`
-            return (wearablesPromise.Result.Value.Asset.Wearables,
-                wearablesPromise.Result.Value.Asset.TotalAmount);
+            results.AddRange(wearablesPromise.Result.Value.Asset.Wearables);
+            return (results, wearablesPromise.Result.Value.Asset.TotalAmount);
         }
 
         public async UniTask<IReadOnlyCollection<IWearable>?> GetByPointersAsync(IReadOnlyCollection<URN> pointers,

--- a/Explorer/Assets/DCL/Backpack/BackpackController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackController.cs
@@ -246,7 +246,6 @@ namespace DCL.Backpack
             var avatarShapeComponent = world.Get<AvatarShapeComponent>(playerEntity);
 
             Avatar avatar = world.Get<Profile>(playerEntity).Avatar;
-            backpackGridController.RequestPage(1, true);
             backpackCharacterPreviewController.Initialize(avatar, CharacterPreviewUtils.BACKPACK_PREVIEW_POSITION);
 
             while (!avatarShapeComponent.WearablePromise.IsConsumed)

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -126,10 +126,12 @@ namespace DCL.Backpack
             backpackSortController.OnSortChanged += OnSortChanged;
             backpackSortController.OnCollectiblesOnlyChanged += OnCollectiblesOnlyChanged;
             backpackSortController.OnSmartWearablesOnlyChanged += OnSmartWearablesOnlyChanged;
+            RequestPage(1, true);
         }
 
         public void Deactivate()
         {
+            pageFetchCancellationToken.SafeCancelAndDispose();
             eventBus.FilterEvent -= OnFilterChanged;
             backpackSortController.OnSortChanged -= OnSortChanged;
             backpackSortController.OnCollectiblesOnlyChanged -= OnCollectiblesOnlyChanged;

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -396,6 +396,8 @@ namespace DCL.Backpack
                     view.RegularResults.SetActive(true);
                 }
 
+                ct.ThrowIfCancellationRequested();
+
                 SetGridElements(currentPageWearables);
             }
             catch (OperationCanceledException) { }

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -396,7 +396,8 @@ namespace DCL.Backpack
                     view.RegularResults.SetActive(true);
                 }
 
-                ct.ThrowIfCancellationRequested();
+                if (ct.IsCancellationRequested)
+                    return;
 
                 SetGridElements(currentPageWearables);
             }

--- a/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using DCL.Backpack.AvatarSection.Outfits.Commands;
+using DCL.Diagnostics;
 using UnityEngine;
 using UnityEngine.Pool;
 using Utility;
@@ -103,6 +104,7 @@ namespace DCL.Backpack.EmotesSection
 
         public void Deactivate()
         {
+            loadElementsCancellationToken.SafeCancelAndDispose();
             eventBus.FilterEvent -= OnFilterEvent;
             backpackSortController.OnSortChanged -= OnSortChanged;
             backpackSortController.OnCollectiblesOnlyChanged -= OnCollectiblesOnlyChanged;
@@ -148,93 +150,105 @@ namespace DCL.Backpack.EmotesSection
 
             async UniTaskVoid RequestPageAsync(CancellationToken ct)
             {
-                IReadOnlyList<ITrimmedEmote> emotes;
+                List<ITrimmedEmote> customOwnedEmotes = ListPool<ITrimmedEmote>.Get();
 
-                using var _ = ListPool<ITrimmedEmote>.Get(out var customOwnedEmotes);
-                customOwnedEmotes = customOwnedEmotes.EnsureNotNull();
-
-                var result = await emoteProvider.GetTrimmedByParamsAsync(
-                    new IEmoteProvider.OwnedEmotesRequestOptions(
-                        pageNum: pageNumber,
-                        pageSize: CURRENT_PAGE_SIZE,
-                        collectionId: null,
-                        orderOperation: currentOrder,
-                        name: currentSearch
-                    ),
-                    ct,
-                    customOwnedEmotes
-                );
-
-                int totalAmount = result.totalAmount;
-
-                // TODO: request base emotes collection instead of pointers:
-                // https://peer-ec1.decentraland.org/content/entities/active/collections/urn:decentraland:off-chain:base-avatars
-                if (onChainEmotesOnly)
-                    emotes = customOwnedEmotes;
-                else
+                try
                 {
-                    using var scope = ListPool<IEmote>.Get(out var baseEmotes);
-                    baseEmotes = baseEmotes.EnsureNotNull();
+                    var result = await emoteProvider.GetTrimmedByParamsAsync(
+                        new IEmoteProvider.OwnedEmotesRequestOptions(
+                            pageNum: pageNumber,
+                            pageSize: CURRENT_PAGE_SIZE,
+                            collectionId: null,
+                            orderOperation: currentOrder,
+                            name: currentSearch
+                        ),
+                        ct,
+                        customOwnedEmotes
+                    );
 
-                    await emoteProvider.GetByPointersAsync(emoteStorage.BaseEmotesUrns, currentBodyShape, ct, baseEmotes);
+                    int totalAmount = result.totalAmount;
+                    IReadOnlyList<ITrimmedEmote> emotes;
 
-                    IEnumerable<IEmote> filteredEmotes = baseEmotes;
+                    // TODO: request base emotes collection instead of pointers:
+                    // https://peer-ec1.decentraland.org/content/entities/active/collections/urn:decentraland:off-chain:base-avatars
+                    if (onChainEmotesOnly)
+                        emotes = customOwnedEmotes;
+                    else
+                    {
+                        using var scope = ListPool<IEmote>.Get(out var baseEmotes);
+                        baseEmotes = baseEmotes.EnsureNotNull();
 
-                    if (!string.IsNullOrEmpty(currentSearch!))
-                        filteredEmotes = baseEmotes.Where(emote => emote.GetName().Contains(currentSearch, StringComparison.OrdinalIgnoreCase));
+                        await emoteProvider.GetByPointersAsync(emoteStorage.BaseEmotesUrns, currentBodyShape, ct, baseEmotes);
 
-                    if (!string.IsNullOrEmpty(currentCategory!))
-                        filteredEmotes = baseEmotes.Where(emote => emote.GetCategory() == currentCategory);
+                        IEnumerable<IEmote> filteredEmotes = baseEmotes;
 
-                    filteredEmotes = currentOrder.By switch
-                                     {
-                                         "name" => currentOrder.IsAscending
-                                             ? filteredEmotes.OrderBy(emote => emote.GetName())
-                                             : filteredEmotes.OrderByDescending(emote => emote.GetName()),
-                                         _ => filteredEmotes,
-                                     };
+                        if (!string.IsNullOrEmpty(currentSearch!))
+                            filteredEmotes = baseEmotes.Where(emote => emote.GetName().Contains(currentSearch, StringComparison.OrdinalIgnoreCase));
 
-                    baseEmotes = filteredEmotes.ToList();
+                        if (!string.IsNullOrEmpty(currentCategory!))
+                            filteredEmotes = baseEmotes.Where(emote => emote.GetCategory() == currentCategory);
 
-                    int customOwnedEmotesAmount = result.totalAmount;
-                    totalAmount += baseEmotes.Count;
+                        filteredEmotes = currentOrder.By switch
+                                         {
+                                             "name" => currentOrder.IsAscending
+                                                 ? filteredEmotes.OrderBy(emote => emote.GetName())
+                                                 : filteredEmotes.OrderByDescending(emote => emote.GetName()),
+                                             _ => filteredEmotes,
+                                         };
 
-                    var baseEmotesToSkip = 0;
-                    int emotesPageIndex = (pageNumber - 1) * CURRENT_PAGE_SIZE;
+                        baseEmotes = filteredEmotes.ToList();
 
-                    if (emotesPageIndex > customOwnedEmotesAmount)
-                        baseEmotesToSkip = emotesPageIndex - customOwnedEmotesAmount;
+                        int customOwnedEmotesAmount = result.totalAmount;
+                        totalAmount += baseEmotes.Count;
 
-                    // We always need to concat embedded emotes at the end, no matter the filter & sorting
-                    // otherwise the pagination in the realm provider get inconsistent with the union of the embedded emotes
-                    // The only way of getting to work properly is by the realm providing also off-chain emotes or request all emotes at once
-                    // For example:
-                    // 1. Set sort by name
-                    // 2. Page 1 will contain some embedded emotes & owned emotes
-                    // 3. Request page 2, the realm will not provide any of the owned emotes since they are part of page 1
-                    // 4. We will probably skip most of the owned emotes in the grid becoming inconsistent
-                    emotes = customOwnedEmotes.Concat(baseEmotes.Skip(baseEmotesToSkip))
-                                              .Take(CURRENT_PAGE_SIZE)
-                                              .ToArray();
+                        var baseEmotesToSkip = 0;
+                        int emotesPageIndex = (pageNumber - 1) * CURRENT_PAGE_SIZE;
+
+                        if (emotesPageIndex > customOwnedEmotesAmount)
+                            baseEmotesToSkip = emotesPageIndex - customOwnedEmotesAmount;
+
+                        // We always need to concat embedded emotes at the end, no matter the filter & sorting
+                        // otherwise the pagination in the realm provider get inconsistent with the union of the embedded emotes
+                        // The only way of getting to work properly is by the realm providing also off-chain emotes or request all emotes at once
+                        // For example:
+                        // 1. Set sort by name
+                        // 2. Page 1 will contain some embedded emotes & owned emotes
+                        // 3. Request page 2, the realm will not provide any of the owned emotes since they are part of page 1
+                        // 4. We will probably skip most of the owned emotes in the grid becoming inconsistent
+                        emotes = customOwnedEmotes.Concat(baseEmotes.Skip(baseEmotesToSkip))
+                                                  .Take(CURRENT_PAGE_SIZE)
+                                                  .ToArray();
+                    }
+
+                    if (emotes.Count == 0)
+                    {
+                        view.NoSearchResults.SetActive(!string.IsNullOrEmpty(currentSearch));
+                        view.NoCategoryResults.SetActive(!string.IsNullOrEmpty(currentCategory));
+                        view.RegularResults.SetActive(string.IsNullOrEmpty(currentSearch) && string.IsNullOrEmpty(currentCategory));
+                    }
+                    else
+                    {
+                        view.NoSearchResults.SetActive(false);
+                        view.NoCategoryResults.SetActive(false);
+                        view.RegularResults.SetActive(true);
+                    }
+
+                    ct.ThrowIfCancellationRequested();
+
+                    SetGridElements(emotes);
+
+                    if (reconfigurePageSelector)
+                        pageSelectorController.Configure(totalAmount, CURRENT_PAGE_SIZE);
                 }
-
-                if (emotes.Count == 0)
+                catch (OperationCanceledException)
                 {
-                    view.NoSearchResults.SetActive(!string.IsNullOrEmpty(currentSearch));
-                    view.NoCategoryResults.SetActive(!string.IsNullOrEmpty(currentCategory));
-                    view.RegularResults.SetActive(string.IsNullOrEmpty(currentSearch) && string.IsNullOrEmpty(currentCategory));
+                    //No need to do anything if the operation was canceled
                 }
-                else
+                catch (Exception e) { ReportHub.LogException(e, ReportCategory.BACKPACK); }
+                finally
                 {
-                    view.NoSearchResults.SetActive(false);
-                    view.NoCategoryResults.SetActive(false);
-                    view.RegularResults.SetActive(true);
+                    ListPool<ITrimmedEmote>.Release(customOwnedEmotes);
                 }
-
-                SetGridElements(emotes);
-
-                if (reconfigurePageSelector)
-                    pageSelectorController.Configure(totalAmount, CURRENT_PAGE_SIZE);
             }
         }
 

--- a/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
@@ -233,7 +233,8 @@ namespace DCL.Backpack.EmotesSection
                         view.RegularResults.SetActive(true);
                     }
 
-                    ct.ThrowIfCancellationRequested();
+                    if (ct.IsCancellationRequested)
+                        return;
 
                     SetGridElements(emotes);
 


### PR DESCRIPTION
# Pull Request Description
Fixes #7886 
Fixes #7375 

Rapidly opening/closing the backpack at the right time (both wearables and emotes), was causing a duplicate key exception.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR adds a proper cancellation flow in the backpack page request + there was a problem with the element provider:
- it accepts a result list
- which was passed to the ecs intention
- When the request was cancelled (backpack close) the list gets recycled but the promise still runs with it
- If another backpack cycle (close/open) gets the same list from the pool (100% repro if you ONLY open/close the backpack), a new promise is created which also points to the same list as the other promise
- results are duplicated
- exception when adding to the `usedPoolItems` dictionary

This fix consists in making the provider use a different list for the promise. The results are then copied into the caller's list.
This list cannot be pooled or the same issue will show up but on the provider level instead as both promises could take the same list from the pool (the first one returns on cancellation but the second one takes the same. Both promises will use the same actual list)

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->


### Test Steps
1. Open and close the backpack (both wearables and emote sections) multiple times
2. Wait for a different amount of times between cycles (e.g. open - close immediately - open wait 1sec - close - open wait 3sec - close .....)
3. Verify that logs don't report any duplicate key exception `ArgumentException: An item with the same key has already been added`
4. Verify that backpack works as normal

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
