### PR TITLE
fix: supress errors for headers call in open media

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/OpenMediaPromise.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/OpenMediaPromise.cs
@@ -41,7 +41,7 @@ namespace DCL.SDKComponents.MediaStream
 
             mediaAddress.IsUrlMediaAddress(out var urlMediaAddress);
             string url = urlMediaAddress!.Url;
-            isReachable = await webRequestController.IsHeadReachableAsync(reportData, URLAddress.FromString(url), ct, 5, false);
+            isReachable = await webRequestController.IsHeadReachableAsync(reportData, URLAddress.FromString(url), ct, 5, true);
             //This is needed because some servers might not handle HEAD requests correctly and return 404 errors, even thou they are perfectly
             if (!isReachable)
                 isReachable = await IsGetReachableAsync(url, ct);

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/OpenMediaPromise.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/OpenMediaPromise.cs
@@ -41,8 +41,7 @@ namespace DCL.SDKComponents.MediaStream
 
             mediaAddress.IsUrlMediaAddress(out var urlMediaAddress);
             string url = urlMediaAddress!.Url;
-
-            isReachable = await webRequestController.IsHeadReachableAsync(reportData, URLAddress.FromString(url), ct, 5);
+            isReachable = await webRequestController.IsHeadReachableAsync(reportData, URLAddress.FromString(url), ct, 5, false);
             //This is needed because some servers might not handle HEAD requests correctly and return 404 errors, even thou they are perfectly
             if (!isReachable)
                 isReachable = await IsGetReachableAsync(url, ct);

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/OpenMediaPromise.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/OpenMediaPromise.cs
@@ -60,10 +60,12 @@ namespace DCL.SDKComponents.MediaStream
         private async UniTask<bool> IsGetReachableAsync(string url, CancellationToken ct)
         {
             UnityWebRequest isGetReachableRequest = UnityWebRequest.Get(url);
-            isGetReachableRequest.SendWebRequest().ToUniTask(cancellationToken: ct);
+            isGetReachableRequest.SendWebRequest();
 
             while (isGetReachableRequest.downloadedBytes == 0)
             {
+                ct.ThrowIfCancellationRequested();
+
                 if (!string.IsNullOrEmpty(isGetReachableRequest.error))
                     return false;
 

--- a/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
@@ -69,8 +69,9 @@ namespace DCL.WebRequests
             CancellationToken ct,
             ReportData reportData,
             WebRequestHeadersInfo? headersInfo = null,
-            WebRequestSignInfo? signInfo = null) =>
-            new (controller, commonArguments, default(GenericHeadArguments), ct, reportData, headersInfo, signInfo, null, false);
+            WebRequestSignInfo? signInfo = null,
+            bool suppressErrors = false) =>
+            new (controller, commonArguments, default(GenericHeadArguments), ct, reportData, headersInfo, signInfo, null, suppressErrors);
 
         /// <summary>
         ///     Adapts existing calls to the required-op flow

--- a/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestControllerExtensions.cs
@@ -136,14 +136,15 @@ namespace DCL.WebRequests
             CancellationToken ct,
             ReportData reportCategory,
             WebRequestHeadersInfo? headersInfo = null,
-            WebRequestSignInfo? signInfo = null) where TOp: struct, IWebRequestOp<GenericHeadRequest, TResult> =>
-            controller.SendAsync<GenericHeadRequest, GenericHeadArguments, TOp, TResult>(commonArguments, arguments, webRequestOp, ct, reportCategory, headersInfo, signInfo);
+            WebRequestSignInfo? signInfo = null,
+            bool suppressErrors = false) where TOp: struct, IWebRequestOp<GenericHeadRequest, TResult> =>
+            controller.SendAsync<GenericHeadRequest, GenericHeadArguments, TOp, TResult>(commonArguments, arguments, webRequestOp, ct, reportCategory, headersInfo, signInfo, suppressErrors: suppressErrors);
 
-        public static async UniTask<bool> IsHeadReachableAsync(this IWebRequestController controller, ReportData reportData, URLAddress url, CancellationToken ct, int timeout = 0)
+        public static async UniTask<bool> IsHeadReachableAsync(this IWebRequestController controller, ReportData reportData, URLAddress url, CancellationToken ct, int timeout = 0, bool suppressErrors = false)
         {
             await UniTask.SwitchToMainThread();
 
-            try { await HeadAsync<WebRequestUtils.NoOp<GenericHeadRequest>, WebRequestUtils.NoResult>(controller, new CommonArguments(url, RetryPolicy.NONE, timeout: timeout), new WebRequestUtils.NoOp<GenericHeadRequest>(), default(GenericHeadArguments), ct, reportData); }
+            try { await HeadAsync<WebRequestUtils.NoOp<GenericHeadRequest>, WebRequestUtils.NoResult>(controller, new CommonArguments(url, RetryPolicy.NONE, timeout: timeout), new WebRequestUtils.NoOp<GenericHeadRequest>(), default(GenericHeadArguments), ct, reportData, suppressErrors: suppressErrors); }
             catch (UnityWebRequestException unityWebRequestException)
             {
                 // Endpoint was unreacheable


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
https://decentraland.sentry.io/issues/6428116480/
Suppresses error logging for HEAD reachability checks in OpenMediaPromise when validating media stream URLs

## Test Instructions
  1. Enter a scene that uses video streaming.
  2. Verify the media plays correctly.
  3. Check the logs, no 404 specifically in 40,54

Given how important video streaming is, please check as many scenes and examples as possible.

## Quality Checklist
- [X] Changes have been tested locally
- [X] Documentation has been updated (if required)
- [X] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
