### PR TITLE
fix: use thread-safe pool for profile deserialization collections (UNITY-EXPLORER-N98)

### DIFF
--- a/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
@@ -98,9 +98,23 @@ namespace DCL.Profiles
             GetCompact().Dispose();
             compact = new CompactInfo();
 
-            blocked = null;
-            interests = null;
-            links = null;
+            if (blocked != null)
+            {
+                ThreadSafeCollectionPool<HashSet<string>, string>.SHARED.Release(blocked);
+                blocked = null;
+            }
+
+            if (interests != null)
+            {
+                ThreadSafeCollectionPool<List<string>, string>.SHARED.Release(interests);
+                interests = null;
+            }
+
+            if (links != null)
+            {
+                ThreadSafeCollectionPool<List<LinkJsonDto>, LinkJsonDto>.SHARED.Release(links);
+                links = null;
+            }
             Birthdate = null;
 
             // Avatars on the pool should always have an empty avatar for reusage.

--- a/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
@@ -165,10 +165,10 @@ namespace DCL.Profiles
 
         public void ClearLinks()
         {
-            if (Links == null)
-                Links = new List<LinkJsonDto>();
+            if (links == null)
+                links = ThreadSafeCollectionPool<List<LinkJsonDto>, LinkJsonDto>.SHARED.Get();
             else
-                Links.Clear();
+                links.Clear();
         }
 
         public bool IsSameProfile(Profile profile)

--- a/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileConverter.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileConverter.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Pool;
+using DCL.Optimization.ThreadSafePool;
 using UnityEngine.Scripting;
 
 namespace DCL.Profiles
@@ -121,7 +121,7 @@ namespace DCL.Profiles
 
             if (root is { Type: JTokenType.Array })
             {
-                list ??= ListPool<LinkJsonDto>.Get();
+                list ??= ThreadSafeCollectionPool<List<LinkJsonDto>, LinkJsonDto>.SHARED.Get();
 
                 foreach (JToken? item in root.Children())
                     list.Add(DeserializeLink(item, new LinkJsonDto()));
@@ -196,7 +196,7 @@ namespace DCL.Profiles
 
             if (token is { Type: JTokenType.Array })
             {
-                list ??= CollectionPool<TCollection, T>.Get();
+                list ??= ThreadSafeCollectionPool<TCollection, T>.SHARED.Get();
 
                 foreach (JToken? item in token.Children())
                 {

--- a/Explorer/Assets/DCL/Profiles/Tests/ProfileClearShould.cs
+++ b/Explorer/Assets/DCL/Profiles/Tests/ProfileClearShould.cs
@@ -1,8 +1,9 @@
 using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Components;
+using DCL.Optimization.ThreadSafePool;
 using ECS.TestSuite;
-using NUnit.Framework;
 using Newtonsoft.Json;
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -101,9 +102,12 @@ namespace DCL.Profiles.Tests
             profile.Birthdate = new DateTime(1990, 1, 1);
             profile.Version = 7;
             profile.IsDirty = true;
-            profile.Links = new List<LinkJsonDto> { new () { title = "test", url = "https://test.com" } };
-            profile.blocked = new HashSet<string> { "0xblocked1" };
-            profile.interests = new List<string> { "gaming" };
+            profile.Links = ThreadSafeCollectionPool<List<LinkJsonDto>, LinkJsonDto>.SHARED.Get();
+            profile.Links.Add(new LinkJsonDto { title = "test", url = "https://test.com" });
+            profile.blocked = ThreadSafeCollectionPool<HashSet<string>, string>.SHARED.Get();
+            profile.blocked.Add("0xblocked1");
+            profile.interests = ThreadSafeCollectionPool<List<string>, string>.SHARED.Get();
+            profile.interests.Add("gaming");
 
             profile.Avatar = new Avatar();
             profile.Avatar.BodyShape = BodyShape.FEMALE;

--- a/Explorer/Assets/DCL/Profiles/Tests/ProfileClearShould.cs
+++ b/Explorer/Assets/DCL/Profiles/Tests/ProfileClearShould.cs
@@ -2,8 +2,10 @@ using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Components;
 using ECS.TestSuite;
 using NUnit.Framework;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace DCL.Profiles.Tests
@@ -21,22 +23,55 @@ namespace DCL.Profiles.Tests
         [Test]
         public void ResetAllFieldsWhenReturnedToPool()
         {
-            int initialInactive = Profile.POOL.CountInactive;
-
             var profile = Profile.Create();
             var clean = Profile.Create();
+            int countAfterCreates = Profile.POOL.CountInactive;
+
             PopulateAllFields(profile);
 
             profile.Dispose();
             var recycled = Profile.Create();
 
-            Assert.AreEqual(initialInactive, Profile.POOL.CountInactive);
+            // Dispose+Create = net zero change from countAfterCreates
+            Assert.AreEqual(countAfterCreates, Profile.POOL.CountInactive);
             Assert.IsTrue(clean.IsSameProfile(recycled));
+            Assert.IsNull(recycled.blocked);
+            Assert.IsNull(recycled.interests);
+            Assert.IsNull(recycled.Links);
 
             recycled.Dispose();
             clean.Dispose();
 
-            Assert.AreEqual(initialInactive + 2, Profile.POOL.CountInactive);
+            Assert.AreEqual(countAfterCreates + 2, Profile.POOL.CountInactive);
+        }
+
+        [Test]
+        public void DeserializeProfilesConcurrently()
+        {
+            const string JSON = @"{""avatars"":[{""name"":""test"",""userId"":""0x123"",
+                ""hasClaimedName"":false,""description"":"""",""tutorialStep"":0,
+                ""version"":1,""hasConnectedWeb3"":false,
+                ""blocked"":[""0xa"",""0xb""],""interests"":[""gaming"",""art""],
+                ""avatar"":{""bodyShape"":"""",""wearables"":[],""forceRender"":[],""emotes"":[],
+                    ""eyes"":{""color"":{""r"":0,""g"":0,""b"":0,""a"":1}},
+                    ""hair"":{""color"":{""r"":0,""g"":0,""b"":0,""a"":1}},
+                    ""skin"":{""color"":{""r"":0,""g"":0,""b"":0,""a"":1}}},
+                ""links"":[{""title"":""web"",""url"":""https://test.com""}]}]}";
+
+            var tasks = new Task[50];
+
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    Profile? profile = JsonConvert.DeserializeObject<Profile>(JSON,
+                        RealmProfileRepository.SERIALIZER_SETTINGS);
+
+                    profile?.Dispose();
+                });
+            }
+
+            Assert.DoesNotThrow(() => Task.WaitAll(tasks));
         }
 
         private static void PopulateAllFields(Profile profile)
@@ -67,6 +102,8 @@ namespace DCL.Profiles.Tests
             profile.Version = 7;
             profile.IsDirty = true;
             profile.Links = new List<LinkJsonDto> { new () { title = "test", url = "https://test.com" } };
+            profile.blocked = new HashSet<string> { "0xblocked1" };
+            profile.interests = new List<string> { "gaming" };
 
             profile.Avatar = new Avatar();
             profile.Avatar.BodyShape = BodyShape.FEMALE;


### PR DESCRIPTION
# Pull Request Description
Fixes #7714

## Summary
- Profile JSON deserialization runs on thread pool threads (`WRThreadFlags.SwitchToThreadPool`) but was using non-thread-safe `CollectionPool`/`ListPool` from `UnityEngine.Pool`. Concurrent access corrupted the pool's internal state, causing `ArgumentOutOfRangeException` (112 occurrences, 59 users).
- Replaced with `ThreadSafeCollectionPool.SHARED` which uses internal locks.
- Added `Release()` calls in `Profile.Clear()` for `blocked`, `interests`, and `links` — these were obtained from the pool but never returned (memory leak).
- Added concurrent deserialization stress test (`ProfileClearShould.DeserializeProfilesConcurrently`) and improved pool-related test stability (`ProfileClearShould.ResetAllFieldsWhenReturnedToPool`).


## Test Steps
Basically, check that the process of loading profiles is working correctly.

Here some detailed steps:

1. **HIGH CONCURRENCY SCENARIO (main test)**
   - Launch the explorer and log in
   - Teleport to a highly populated area (Genesis Plaza, active events, or any
     scene with 20+ players nearby)
   - Verify that all avatars load correctly — names, wearables, profile pictures
   - Repeat the teleport 3-4 times to different crowded locations
   - Expected: no crashes, no freezes, no missing profiles

2. **PROFILE DETAILS CHECK**
   - Click on several players to open their profile cards
   - Expected: they loads correctly

3. **OWN PROFILE EDITING**
   - Open your own profile and edit some fields (description, links, interests)
   - Save changes
   - Close and reopen the profile panel
   - Expected: changes persist correctly

4. **RAPID SCENE SWITCHING**
   - Quickly jump between 3-4 different scenes with players
   - While profiles are still loading, jump to another scene
   - Expected: no crashes, profiles in the new scene load normally

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.