### PR TITLE
fix: prevent notifications polling from stopping on transient server errors (UNITY-EXPLORER-N0Y)

### DIFF
--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -70,7 +70,7 @@ namespace DCL.Notifications
             urlBuilder.AppendDomain(URLDomain.FromString($"{urlsSource.Url(DecentralandUrl.Notifications)}/notifications"))
                       .AppendParameter(limitParameter);
 
-            commonArguments = new CommonArguments(urlBuilder.Build());
+            commonArguments = new CommonArguments(urlBuilder.Build(), RetryPolicy.Enforce());
             unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
             List<INotification> notifications =
@@ -89,50 +89,57 @@ namespace DCL.Notifications
         {
             do
             {
-                await UniTask.Delay(NOTIFICATIONS_DELAY, DelayType.Realtime, cancellationToken: ct);
+                try
+                {
+                    await UniTask.Delay(NOTIFICATIONS_DELAY, DelayType.Realtime, cancellationToken: ct);
 
-                if (web3IdentityCache.Identity == null || web3IdentityCache.Identity.IsExpired)
-                    continue;
+                    if (web3IdentityCache.Identity == null || web3IdentityCache.Identity.IsExpired)
+                        continue;
 
-                urlBuilder.Clear();
+                    urlBuilder.Clear();
 
-                urlBuilder.AppendDomain(URLDomain.FromString($"{urlsSource.Url(DecentralandUrl.Notifications)}/notifications"))
-                          .AppendParameter(onlyUnreadParameter)
-                          .AppendParameter(new URLParameter("from", lastPolledTimestamp.ToString()));
+                    urlBuilder.AppendDomain(URLDomain.FromString($"{urlsSource.Url(DecentralandUrl.Notifications)}/notifications"))
+                              .AppendParameter(onlyUnreadParameter)
+                              .AppendParameter(new URLParameter("from", lastPolledTimestamp.ToString()));
 
-                commonArguments = new CommonArguments(urlBuilder.Build());
+                    commonArguments = new CommonArguments(urlBuilder.Build(), RetryPolicy.Enforce());
 
-                unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
+                    unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
-                // TODO remove allocation of List on serialization
-                List<INotification> notifications =
-                    await webRequestController.GetAsync(
-                                                   commonArguments,
-                                                   ct,
-                                                   ReportCategory.UI,
-                                                   signInfo: WebRequestSignInfo.NewFromUrl(urlsSource.GetOriginalUrl(commonArguments.URL), unixTimestamp, "get"),
-                                                   headersInfo: new WebRequestHeadersInfo().WithSign(string.Empty, unixTimestamp))
-                                              .CreateFromNewtonsoftJsonAsync<List<INotification>>(serializerSettings: serializerSettings);
+                    // TODO remove allocation of List on serialization
+                    List<INotification> notifications =
+                        await webRequestController.GetAsync(
+                                                       commonArguments,
+                                                       ct,
+                                                       ReportCategory.UI,
+                                                       signInfo: WebRequestSignInfo.NewFromUrl(urlsSource.GetOriginalUrl(commonArguments.URL), unixTimestamp, "get"),
+                                                       headersInfo: new WebRequestHeadersInfo().WithSign(string.Empty, unixTimestamp))
+                                                  .CreateFromNewtonsoftJsonAsync<List<INotification>>(serializerSettings: serializerSettings);
 
-                if (notifications.Count == 0)
-                    continue;
+                    if (notifications.Count == 0)
+                        continue;
 
-                lastPolledTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
+                    lastPolledTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
+                    using var scope = ThreadSafeListPool<string>.SHARED.Get(out var list);
+                    foreach (INotification notification in notifications)
+                        try
+                        {
+                            NotificationsBusController.Instance.AddNotification(notification);
+                            list.Add(notification.Id);
+                        }
+                        catch (Exception e)
+                        {
+                            ReportHub.LogException(e, ReportCategory.UI);
+                        }
 
-                using var scope = ThreadSafeListPool<string>.SHARED.Get(out var list);
-                foreach (INotification notification in notifications)
-                    try
-                    {
-                        NotificationsBusController.Instance.AddNotification(notification);
-                        list.Add(notification.Id);
-                    }
-                    catch (Exception e)
-                    {
-                        ReportHub.LogException(e, ReportCategory.UI);
-                    }
-
-                await SetNotificationAsReadAsync(list, ct);
+                    await SetNotificationAsReadAsync(list, ct);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception e)
+                {
+                    ReportHub.LogException(e, ReportCategory.UI);
+                }
             }
             while (ct.IsCancellationRequested == false);
         }

--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -135,7 +135,7 @@ namespace DCL.Notifications
 
                     await SetNotificationAsReadAsync(list, ct);
                 }
-                catch (OperationCanceledException) { throw; }
+                catch (OperationCanceledException) { return; }
                 catch (Exception e)
                 {
                     ReportHub.LogException(e, ReportCategory.UI);


### PR DESCRIPTION
# Pull Request Description
Fix #7618 

## Summary
Fixes the notifications polling loop dying permanently when the server returns transient errors (500, 502, DNS failures, timeouts, etc.).

### Root cause
Two combined issues:

1. **Signed GET requests were never retried** — `signInfo` marks requests as non-idempotent, and the default `RetryPolicy` skips retries for non-idempotent requests. Even though 500/502/503/504 are classified as recoverable, the idempotency check short-circuits before reaching that logic.

2. **No exception handling in the polling loop** — `StartGettingNewNotificationsOverTimeAsync` had no try/catch, so any unhandled exception killed the loop permanently. `SuppressCancellationThrow()` at the call site only suppresses `OperationCanceledException`, not web request errors.

### Changes

- Use `RetryPolicy.Enforce()` for notification GET requests so they are retried on transient errors (up to 2 retries with exponential backoff)
- Wrap the polling loop body in try/catch to survive any exception after retries are exhausted, logging via `ReportHub` and continuing on the next 5s cycle

### Error breakdown from Sentry (all 220 events)

| Error | Count | Covered |
|---|---|---|
| 502 Bad Gateway | 75 | Retry + catch |
| Cannot resolve destination host | 34 | Retry + catch |
| Unknown Error | 32 | Catch |
| Failed to transmit data | 30 | Catch |
| 401 Unauthorized | 22 | Catch (loop survives, next cycle uses fresh signature) |
| Cannot connect to destination host | 9 | Retry + catch |
| Request timeout | 7 | Retry + catch |
| SSL connection errors | 7 | Retry + catch |
| 500 Internal Server Error | 1 | Retry + catch |
| Other (400, receive errors) | 3 | Catch |

### Test Steps
The notification system should keep working normally and recover automatically from any transient
server issues.

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.