### PR TITLE
fix: allow mentioning short names in chat

### DIFF
--- a/Explorer/Assets/DCL/Chat/History/ChatMessageFactory.cs
+++ b/Explorer/Assets/DCL/Chat/History/ChatMessageFactory.cs
@@ -12,7 +12,7 @@ namespace DCL.Chat.History
     public class ChatMessageFactory
     {
         public const string LOADING_PROFILE_TEXT = "Loading Profile...";
-        private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{3,15}(?:#[A-Za-z0-9]{4})?)(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
+        private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{1,15}(?:#[A-Za-z0-9]{4})?)(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
 
         private readonly IProfileCache profileCache;
         private readonly IWeb3IdentityCache web3IdentityCache;

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
@@ -11,7 +11,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
     public class ChatMessagesBusAnalyticsDecorator : IChatMessagesBus
     {
         private static readonly JArray MENTION_WALLET_IDS = new ();
-        private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{3,15}(?:#[A-Za-z0-9]{4})?)(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
+        private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{1,15}(?:#[A-Za-z0-9]{4})?)(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
 
         private readonly IChatMessagesBus core;
         private readonly IAnalyticsController analytics;

--- a/Explorer/Assets/DCL/UI/TextFormatter/HyperlinkTextFormatter.cs
+++ b/Explorer/Assets/DCL/UI/TextFormatter/HyperlinkTextFormatter.cs
@@ -39,7 +39,7 @@ namespace DCL.UI.InputFieldFormatting
         private static readonly string WORLD_PATTERN =
             $@"(?<{WORLD_GROUP_NAME}>{LEAD}[A-Za-z0-9]+\.dcl\.eth{TRAIL})";
 
-        private static readonly string USERNAME_PATTERN = $@"(?<{USERNAME_FULL_GROUP_NAME}>(?<=^|\s)@(?<{USERNAME_NAME_GROUP_NAME}>[A-Za-z0-9]{{3,15}}(?:#[A-Za-z0-9]{{4}})?)(?=\s|!|\?|\.|,|$))";
+        private static readonly string USERNAME_PATTERN = $@"(?<{USERNAME_FULL_GROUP_NAME}>(?<=^|\s)@(?<{USERNAME_NAME_GROUP_NAME}>[A-Za-z0-9]{{1,15}}(?:#[A-Za-z0-9]{{4}})?)(?=\s|!|\?|\.|,|$))";
         private static readonly string RICH_TEXT_PATTERN = $@"(?<{RICHTEXT_GROUP_NAME}><(?!\/?(b|i)(>|\s))[^>]+>)";
 
         private static readonly Regex COMBINED_LINK_REGEX = new (


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7857
This PR allows mentioning correctly users with 3 chracters or less in their name

## Test Instructions

### Test Steps
1. Create an account with mobile client that allows having names shorter than 3 characters
2. Login with this pr
3. Try to mention that user in the chat
4. Verify that the mention works correctly

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
