### PR TITLE
hotfix: prevent shared sprite cache downloads from being cancelled by other consumers

### DIFF
--- a/Explorer/Assets/DCL/Communities/ThumbnailLoader.cs
+++ b/Explorer/Assets/DCL/Communities/ThumbnailLoader.cs
@@ -37,9 +37,10 @@ namespace DCL.Communities
                 if (!string.IsNullOrEmpty(thumbnailUrl))
                     loadedSprite = await Cache!.GetSpriteAsync(thumbnailUrl, useKtx, ct: ct);
             }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException) { return; }
             catch (Exception e) { ReportHub.LogException(e, ReportCategory.COMMUNITIES); }
-            finally { thumbnailView.IsLoading = false; }
+
+            thumbnailView.IsLoading = false;
 
             if (loadedSprite != null)
                 thumbnailView.SetImage(loadedSprite, true);

--- a/Explorer/Assets/DCL/Events/EventCardView.cs
+++ b/Explorer/Assets/DCL/Events/EventCardView.cs
@@ -72,6 +72,7 @@ namespace DCL.Events
         private EventDTO currentEventInfo;
         private PlacesData.PlaceInfo? currentPlaceInfo;
         private GenericContextMenu? contextMenu;
+        private string? lastLoadedThumbnailUrl;
 
         protected CancellationTokenSource? loadingThumbnailCts;
         private CancellationTokenSource? openContextMenuCts;
@@ -125,6 +126,7 @@ namespace DCL.Events
         {
             loadingThumbnailCts.SafeCancelAndDispose();
             openContextMenuCts.SafeCancelAndDispose();
+            lastLoadedThumbnailUrl = null;
         }
 
         private void OnDestroy()
@@ -247,6 +249,10 @@ namespace DCL.Events
             if (eventThumbnail == null)
                 return;
 
+            if (eventInfo.image == lastLoadedThumbnailUrl)
+                return;
+
+            lastLoadedThumbnailUrl = eventInfo.image;
             loadingThumbnailCts = loadingThumbnailCts.SafeRestart();
             thumbnailLoader.LoadCommunityThumbnailFromUrlAsync(
                 eventInfo.image,

--- a/Explorer/Assets/DCL/UI/SpriteCache.cs
+++ b/Explorer/Assets/DCL/UI/SpriteCache.cs
@@ -69,7 +69,19 @@ namespace DCL.UI
 
             // Avoid multiple requests for the same thumbnail
             if (currentSpriteTasks.TryGetValue(imageUrl, out UniTaskCompletionSource<Sprite?> thumbnailTask))
-                return await thumbnailTask.Task;
+            {
+                // Waits for the shared download but doesn't let our cancellation token affect it.
+                // If the download succeeds, return the sprite.
+                // If it was canceled by the original requester and resolved with null, retry.
+                Sprite? result = await thumbnailTask.Task;
+                if (result != null || ct.IsCancellationRequested)
+                    return result;
+
+                // The shared download was canceled by another consumer, but we're still active — check if it landed in cache, otherwise start a new download
+                sprite = GetCachedSprite(imageUrl);
+                if (sprite != null)
+                    return sprite;
+            }
 
             UniTaskCompletionSource<Sprite?> spriteTaskCompletionSource = new UniTaskCompletionSource<Sprite?>();
 

--- a/Explorer/Assets/DCL/UI/SpriteCache.cs
+++ b/Explorer/Assets/DCL/UI/SpriteCache.cs
@@ -70,14 +70,11 @@ namespace DCL.UI
             // Avoid multiple requests for the same thumbnail
             if (currentSpriteTasks.TryGetValue(imageUrl, out UniTaskCompletionSource<Sprite?> thumbnailTask))
             {
-                // Waits for the shared download but doesn't let our cancellation token affect it.
-                // If the download succeeds, return the sprite.
-                // If it was canceled by the original requester and resolved with null, retry.
                 Sprite? result = await thumbnailTask.Task;
                 if (result != null || ct.IsCancellationRequested)
                     return result;
 
-                // The shared download was canceled by another consumer, but we're still active — check if it landed in cache, otherwise start a new download
+                // The shared download was canceled by another consumer, but we're still active — check cache, otherwise fall through to start a new download
                 sprite = GetCachedSprite(imageUrl);
                 if (sprite != null)
                     return sprite;
@@ -86,9 +83,17 @@ namespace DCL.UI
             UniTaskCompletionSource<Sprite?> spriteTaskCompletionSource = new UniTaskCompletionSource<Sprite?>();
 
             if (currentSpriteTasks.TryAdd(imageUrl, spriteTaskCompletionSource))
+            {
                 DownloadSpriteAsync(imageUrl, useKtx, retryPolicy, spriteTaskCompletionSource, ct).Forget();
+                return await spriteTaskCompletionSource.Task;
+            }
 
-            return await spriteTaskCompletionSource.Task;
+            // Another consumer already registered a new download — await theirs instead of our local TCS that nobody would resolve
+            if (currentSpriteTasks.TryGetValue(imageUrl, out UniTaskCompletionSource<Sprite?> retryTask))
+                return await retryTask.Task;
+
+            // Edge case: download registered and completed between TryAdd and TryGetValue
+            return GetCachedSprite(imageUrl);
         }
 
         public void AddOrReplaceCachedSprite(string? imageUrl, Sprite imageContent)

--- a/Explorer/Assets/DCL/UI/SpriteCache.cs
+++ b/Explorer/Assets/DCL/UI/SpriteCache.cs
@@ -62,38 +62,37 @@ namespace DCL.UI
 
         public async UniTask<Sprite?> GetSpriteAsync(string imageUrl, bool useKtx, RetryPolicy? retryPolicy, CancellationToken ct)
         {
-            Sprite? sprite = GetCachedSprite(imageUrl);
-
-            if (sprite != null)
-                return sprite;
-
-            // Avoid multiple requests for the same thumbnail
-            if (currentSpriteTasks.TryGetValue(imageUrl, out UniTaskCompletionSource<Sprite?> thumbnailTask))
+            while (!ct.IsCancellationRequested)
             {
-                Sprite? result = await thumbnailTask.Task;
-                if (result != null || ct.IsCancellationRequested)
-                    return result;
-
-                // The shared download was canceled by another consumer, but we're still active — check cache, otherwise fall through to start a new download
-                sprite = GetCachedSprite(imageUrl);
+                Sprite? sprite = GetCachedSprite(imageUrl);
                 if (sprite != null)
                     return sprite;
+
+                // Avoid multiple requests for the same thumbnail
+                if (currentSpriteTasks.TryGetValue(imageUrl, out UniTaskCompletionSource<Sprite?> existingTask))
+                {
+                    Sprite? result = await existingTask.Task;
+                    if (result != null || ct.IsCancellationRequested)
+                        return result;
+
+                    // The shared download was canceled by another consumer, but we're still active.
+                    // Yield to let the final block in DownloadSpriteAsync clean up the entry from currentSpriteTasks before retrying.
+                    await UniTask.Yield(ct);
+                    continue;
+                }
+
+                UniTaskCompletionSource<Sprite?> tcs = new UniTaskCompletionSource<Sprite?>();
+                if (currentSpriteTasks.TryAdd(imageUrl, tcs))
+                {
+                    DownloadSpriteAsync(imageUrl, useKtx, retryPolicy, tcs, ct).Forget();
+                    return await tcs.Task;
+                }
+
+                // Another consumer registered between TryGetValue and TryAdd — yield and retry
+                await UniTask.Yield(ct);
             }
 
-            UniTaskCompletionSource<Sprite?> spriteTaskCompletionSource = new UniTaskCompletionSource<Sprite?>();
-
-            if (currentSpriteTasks.TryAdd(imageUrl, spriteTaskCompletionSource))
-            {
-                DownloadSpriteAsync(imageUrl, useKtx, retryPolicy, spriteTaskCompletionSource, ct).Forget();
-                return await spriteTaskCompletionSource.Task;
-            }
-
-            // Another consumer already registered a new download — await theirs instead of our local TCS that nobody would resolve
-            if (currentSpriteTasks.TryGetValue(imageUrl, out UniTaskCompletionSource<Sprite?> retryTask))
-                return await retryTask.Task;
-
-            // Edge case: download registered and completed between TryAdd and TryGetValue
-            return GetCachedSprite(imageUrl);
+            return null;
         }
 
         public void AddOrReplaceCachedSprite(string? imageUrl, Sprite imageContent)


### PR DESCRIPTION
# Pull Request Description

## Summary

- Fixes a bug where event card thumbnails appeared blank (white) in the Events Calendar section
- The root cause was in `SpriteCache.GetSpriteAsync`: when multiple consumers requested the same image URL simultaneously, the download was shared via a single `UniTaskCompletionSource`. If the first requester's `CancellationToken` was cancelled, the download was aborted and all other consumers received `null` — even if they were still active
- This race condition was exposed by the parallelization introduced in #7860, where event cards could be rebuilt (`RefreshAllShownItem`) while their thumbnails were still downloading. The rebuild created new cards that requested the same URLs, but the original cards' cancellation killed the shared downloads

## Fix

Three complementary changes:

1. **`SpriteCache.GetSpriteAsync`** — When a shared download resolves with `null` due to another consumer's cancellation, the consumer now yields a frame (to let the `finally` block clean up `currentSpriteTasks`) and retries with a new download. Handles the N > 1 consumer case where `TryAdd` fails by yielding and retrying in a loop.

2. **`ThumbnailLoader.LoadCommunityThumbnailFromUrlAsync`** — On `OperationCanceledException`, returns immediately without modifying the `ImageView`. This prevents the cancelled load's continuation from hiding the loading spinner or showing a white rectangle while the retry is in progress.

3. **`EventCardView.LoadThumbnail`** — Skips reloading when the thumbnail URL hasn't changed (`lastLoadedThumbnailUrl` check). This prevents `RefreshAllShownItem` from unnecessarily clearing and reloading thumbnails that are already loaded or in progress for the same event. The field is cleared in `OnDisable` so cards recycled by scroll always reload correctly.

## Test plan

- [ ] Open Events Calendar section — all thumbnails should load correctly
- [ ] Verify thumbnails remain visible when community data arrives and cards change from small to big
- [ ] Verify thumbnails load correctly on scroll (recycled cards)
- [ ] Verify Places section thumbnails are unaffected