### PR TITLE
fix: safe social rpc disconnect

### DIFF
--- a/Explorer/Assets/DCL/Communities/RPCCommunitiesService.cs
+++ b/Explorer/Assets/DCL/Communities/RPCCommunitiesService.cs
@@ -20,7 +20,6 @@ namespace DCL.Communities
         private readonly ISocialServiceEventBus socialServiceEventBus;
         private readonly IWeb3IdentityCache identityCache;
         private CancellationTokenSource subscriptionCts = new ();
-        private bool isListeningToUpdatesFromServer;
 
         public RPCCommunitiesService(
             IRPCSocialServices socialServiceRPC,
@@ -69,14 +68,7 @@ namespace DCL.Communities
 
         public async UniTask TrySubscribeToConnectivityStatusAsync(CancellationToken ct)
         {
-            if (isListeningToUpdatesFromServer) return;
-
-            try
-            {
-                isListeningToUpdatesFromServer = true;
-                await KeepServerStreamOpenAsync(OpenStreamAndProcessUpdatesAsync, ct);
-            }
-            finally { isListeningToUpdatesFromServer = false; }
+            await KeepServerStreamOpenAsync(OpenStreamAndProcessUpdatesAsync, ct);
 
             return;
 
@@ -90,6 +82,8 @@ namespace DCL.Communities
                 {
                     try
                     {
+                        if (socialServiceRPC.IsDisconnecting) continue;
+
                         switch (response.Status)
                         {
                             case ConnectivityStatus.Offline:

--- a/Explorer/Assets/DCL/Communities/RPCCommunitiesService.cs
+++ b/Explorer/Assets/DCL/Communities/RPCCommunitiesService.cs
@@ -82,6 +82,8 @@ namespace DCL.Communities
                 {
                     try
                     {
+                        //If we are disconnecting from the social service rpc, avoid processing events
+                        //that would cause exception later down the flow
                         if (socialServiceRPC.IsDisconnecting) continue;
 
                         switch (response.Status)

--- a/Explorer/Assets/DCL/Social/RPCSocialServices.cs
+++ b/Explorer/Assets/DCL/Social/RPCSocialServices.cs
@@ -19,6 +19,8 @@ namespace DCL.SocialService
 
         public RpcClient? Client { get; }
 
+        bool IsDisconnecting { get; }
+
         RpcClientModule Module();
 
         /// <summary>
@@ -63,6 +65,7 @@ namespace DCL.SocialService
         private RpcClientModule? module;
         private RpcClientPort? port;
         private WebSocketRpcTransport? transport;
+        private bool isDisconnecting;
 
         private bool isConnectionReady => transport?.State == WebSocketState.Open
                                           && module != null
@@ -81,6 +84,8 @@ namespace DCL.SocialService
 
         public RpcClient? Client { get; private set; }
 
+        public bool IsDisconnecting => isDisconnecting;
+
         public void Dispose()
         {
             transport?.Dispose();
@@ -96,6 +101,7 @@ namespace DCL.SocialService
         {
             try
             {
+                isDisconnecting = true;
                 await handshakeMutex.WaitAsync(ct);
 
                 port?.Close();
@@ -114,7 +120,10 @@ namespace DCL.SocialService
                 Client?.Dispose();
                 Client = null;
             }
-            finally { handshakeMutex.Release(); }
+            finally {
+                handshakeMutex.Release();
+                isDisconnecting = false;
+            }
         }
 
         public async UniTask EnsureRpcConnectionAsync(int connectionRetries, CancellationToken ct)

--- a/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceTestSocialService.cs
+++ b/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceTestSocialService.cs
@@ -20,6 +20,7 @@ namespace DCL.Tests.PlayMode.PerformanceTests
         private readonly ConcurrentDictionary<uint, long> requests = new ();
 
         public RpcClient? Client => core.Client;
+        public bool IsDisconnecting { get; }
 
         public bool WarmingUp { private get; set; }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #8085
Avoid processing social service RPC events while disconnecting from it on profile change as they could throw an error on the check for own identity id.

This PR adds a flag to avoid processing the events when in disconnecting phase, it also removes the previous flag added to disallow multiple subscription as it is not needed considering the ct safe restart for each disconnect/reconnect action.
The previous flag was causing dead connections as (flow described by claude):
  1. Old subscription is running → isListeningToUpdatesFromServer = true
  2. OnTransportConnected fires → subscriptionCts.SafeRestart() cancels the old ct → calls TrySubscribeToConnectivityStatusAsync(new token)
  3. TrySubscribeToConnectivityStatusAsync sees flag is still true → returns early, skips the new subscription
  4. Old subscription eventually processes the OperationCanceledException from AttachExternalCancellation (next Unity PlayerLoop tick) → sets flag false
  5. No caller left to restart the subscription → dead forever

## Test Instructions

### Test Steps
1. Login and log out with the same avatar (it might happen that when re-authenticating with the user you are sent back to the auth screen, it's a separate bug happening in prod as well)
2. With another account verify that when the first avatar connect/disconnect you see them appearing and disappearing in the list of online users in the chat of a community you are both part of

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
