### PR TITLE
fix: multiple chat user online status issues

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatConfig/ChatConfig.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatConfig/ChatConfig.cs
@@ -81,6 +81,9 @@ namespace DCL.Chat.ChatConfig
         [Tooltip("Message shown when your own settings prevent you from sending a DM.")]
         public string OnlyFriendsOwnUserMessage = "Add this user as a friend to chat, or update your <b><u>DM settings</b></u> to connect with everyone.";
 
+        [Tooltip("Message shown when a target user is not connected to chat room, preventing you from sending them a DM.")]
+        public string ConnectedFromAnotherClientMessage = "User is not connected to chat. They may be using a client without DM support.";
+
         [Tooltip("Message when status is being checked.")]
         public string CheckingUserStatusMessage = "Checking user status...";
 

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatConfig/Resources_moved/ChatConfig.asset
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatConfig/Resources_moved/ChatConfig.asset
@@ -34,6 +34,8 @@ MonoBehaviour:
   BlockedByOwnUserMessage: To message this user you must first unblock them.
   OnlyFriendsOwnUserMessage: Add this user as a friend to chat, or update your <b><u>DM
     & Call settings</b></u> to connect with everyone.
+  ConnectedFromAnotherClientMessage: User is not connected to chat. They may be using
+    a client without DM support.
   CheckingUserStatusMessage: Checking user status...
   InputUnfocusedMessages: Press Enter to chat
   InputFocusedMessages: Write a message
@@ -42,8 +44,6 @@ MonoBehaviour:
   DefaultLanguage: 1
   <TranslationMaxRetries>k__BackingField: 1
   <TranslationTimeoutSeconds>k__BackingField: 12
-  <ChatReceiveMessageAudio>k__BackingField: {fileID: 11400000, guid: 1c179628ffe816f4c9be1ba12630f97f, type: 2}
-  <ChatReceiveMentionMessageAudio>k__BackingField: {fileID: 11400000, guid: c588f98cfe945864190c601f54ccb4d6, type: 2}
   <FocusedChannelMessageAudioConfig>k__BackingField:
     receiveMessageAudio: {fileID: 11400000, guid: 1c179628ffe816f4c9be1ba12630f97f, type: 2}
     receiveMentionAudio: {fileID: 11400000, guid: c588f98cfe945864190c601f54ccb4d6, type: 2}

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/BlockedChatInputState.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/BlockedChatInputState.cs
@@ -48,6 +48,7 @@ namespace DCL.Chat.ChatInput
                     PrivateConversationUserStateService.ChatUserState.DISCONNECTED => config.UserOfflineMessage,
                     PrivateConversationUserStateService.ChatUserState.PRIVATE_MESSAGES_BLOCKED_BY_OWN_USER => config.OnlyFriendsOwnUserMessage,
                     PrivateConversationUserStateService.ChatUserState.PRIVATE_MESSAGES_BLOCKED => config.OnlyFriendsMessage,
+                    PrivateConversationUserStateService.ChatUserState.OTHER_CLIENT => config.ConnectedFromAnotherClientMessage,
                     _ => string.Empty
                 };
             }

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/ChatMemberListService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/ChatMemberListService.cs
@@ -33,6 +33,7 @@ namespace DCL.Chat.ChatServices
         private readonly List<ChatMemberListData> membersBuffer = new ();
 
         private readonly HashSet<string> lastKnownMemberIds = new (StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> participantsBuffer = new ();
 
         private int lastKnownTitleBarCount = -1;
 
@@ -163,8 +164,11 @@ namespace DCL.Chat.ChatServices
         ///     Performs a single, fresh fetch of the full member list.
         ///     This should be called by the UI when the member list panel is first opened.
         /// </summary>
-        public UniTask RequestInitialMemberListAsync() =>
-            RefreshFullListAsync(currentChannelService.UserStateService!.OnlineParticipants, liveUpdateCts!.Token);
+        public UniTask RequestInitialMemberListAsync()
+        {
+            currentChannelService.UserStateService!.CopyOnlineParticipantsTo(participantsBuffer);
+            return RefreshFullListAsync(participantsBuffer, liveUpdateCts!.Token);
+        }
 
         private void OnChannelSelected(ChatEvents.ChannelSelectedEvent @event)
         {
@@ -186,14 +190,14 @@ namespace DCL.Chat.ChatServices
 
         private UniTask RefreshFullListIfNeededAsync(CancellationToken ct)
         {
-            IReadOnlyCollection<string> participants = currentChannelService.UserStateService!.OnlineParticipants;
+            currentChannelService.UserStateService!.CopyOnlineParticipantsTo(participantsBuffer);
 
-            if (lastKnownMemberIds.SetEquals(participants))
+            if (lastKnownMemberIds.SetEquals(participantsBuffer))
                 return UniTask.CompletedTask;
 
             lastKnownMemberIds.Clear();
 
-            foreach (string participant in participants)
+            foreach (string participant in participantsBuffer)
                 lastKnownMemberIds.Add(participant);
 
             return RefreshFullListAsync(lastKnownMemberIds, ct);

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/CommunityUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/CommunityUserStateService.cs
@@ -118,6 +118,14 @@ namespace DCL.Chat.ChatServices
                 eventBus.Publish(new ChatEvents.ChannelUsersStatusUpdated(communityChannelId, ChatChannel.ChatChannelType.COMMUNITY, onlineParticipants.normal));
         }
 
+        public void CopyOnlineParticipantsTo(HashSet<string> destination)
+        {
+            destination.Clear();
+
+            foreach (string participant in OnlineParticipants)
+                destination.Add(participant);
+        }
+
         public void Deactivate()
         {
             OnlineParticipants = Array.Empty<string>();

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/ICurrentChannelUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/ICurrentChannelUserStateService.cs
@@ -6,6 +6,11 @@ namespace DCL.Chat.ChatServices
     {
         IReadOnlyCollection<string> OnlineParticipants { get; }
 
+        /// <summary>
+        ///     Copies the current online participants into the provided destination set, safe from concurrent modification.
+        /// </summary>
+        void CopyOnlineParticipantsTo(HashSet<string> destination);
+
         void Deactivate();
     }
 }

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/NearbyUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/NearbyUserStateService.cs
@@ -23,6 +23,7 @@ namespace DCL.Chat.ChatServices
 
         private readonly HashSet<string> onlineParticipants = new (PoolConstants.AVATARS_COUNT);
         private readonly HashSet<string> blockedOnlineParticipants = new (PoolConstants.AVATARS_COUNT);
+        private readonly HashSet<string> snapshotBuffer = new (PoolConstants.AVATARS_COUNT);
 
         public IReadOnlyCollection<string> OnlineParticipants
         {
@@ -59,6 +60,25 @@ namespace DCL.Chat.ChatServices
             userBlockingCache.StrictObject.UserBlocksYou += BlockedSetOffline;
             userBlockingCache.StrictObject.UserUnblocked += UnblockedSetOnline;
             userBlockingCache.StrictObject.UserUnblocksYou += UnblockedSetOnline;
+        }
+
+        public void CopyOnlineParticipantsTo(HashSet<string> destination)
+        {
+            destination.Clear();
+
+            lock (onlineParticipants)
+            {
+                foreach (string participant in onlineParticipants)
+                    destination.Add(participant);
+            }
+        }
+
+        private void CopyToSnapshotBuffer()
+        {
+            snapshotBuffer.Clear();
+
+            foreach (string participant in onlineParticipants)
+                snapshotBuffer.Add(participant);
         }
 
         public void Deactivate()
@@ -141,6 +161,8 @@ namespace DCL.Chat.ChatServices
         /// <param name="connectionState"></param>
         private void OnRoomConnectionStateChange(ConnectionState connectionState)
         {
+            bool shouldNotify = false;
+
             lock (onlineParticipants)
             {
                 switch (connectionState)
@@ -148,10 +170,14 @@ namespace DCL.Chat.ChatServices
                     case ConnectionState.ConnDisconnected:
                     case ConnectionState.ConnConnected:
                         RefreshAllOnlineParticipants(roomHub.AllLocalRoomsRemoteParticipantIdentities());
-                        eventBus.Publish(new ChatEvents.ChannelUsersStatusUpdated(ChatChannel.NEARBY_CHANNEL_ID, ChatChannel.ChatChannelType.NEARBY, OnlineParticipants));
+                        CopyToSnapshotBuffer();
+                        shouldNotify = true;
                         break;
                 }
             }
+
+            if (shouldNotify)
+                eventBus.Publish(new ChatEvents.ChannelUsersStatusUpdated(ChatChannel.NEARBY_CHANNEL_ID, ChatChannel.ChatChannelType.NEARBY, snapshotBuffer));
         }
 
         private void SetOnline(string userId)

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -61,8 +61,6 @@ namespace DCL.Chat.ChatServices
         private readonly IEventBus eventBus;
         private readonly CurrentChannelService currentChannelService;
 
-        private readonly HashSet<string> friendIds = new();
-
         /// <summary>
         ///     Contains the list of all participants in all private conversations as they share the same LiveKit room
         /// </summary>
@@ -72,8 +70,15 @@ namespace DCL.Chat.ChatServices
 
         public IReadOnlyCollection<string> OnlineParticipants { get; }
 
-        public PrivateConversationUserStateService(CurrentChannelService currentChannelService, IEventBus eventBus, ObjectProxy<IUserBlockingCache> userBlockingCacheProxy, ObjectProxy<IFriendsService> friendsService,
-            ChatSettingsAsset settingsAsset, RPCChatPrivacyService rpcChatPrivacyService, IFriendsEventBus friendsEventBus, IRoom chatRoom)
+        public PrivateConversationUserStateService(
+            CurrentChannelService currentChannelService,
+            IEventBus eventBus,
+            ObjectProxy<IUserBlockingCache> userBlockingCacheProxy,
+            ObjectProxy<IFriendsService> friendsService,
+            ChatSettingsAsset settingsAsset,
+            RPCChatPrivacyService rpcChatPrivacyService,
+            IFriendsEventBus friendsEventBus,
+            IRoom chatRoom)
         {
             this.currentChannelService = currentChannelService;
             this.eventBus = eventBus;
@@ -103,8 +108,7 @@ namespace DCL.Chat.ChatServices
             try
             {
                 await UniTask.WhenAll(
-                    rpcChatPrivacyService.GetOwnSocialSettingsAsync(cts.Token),
-                    InitializeFriendshipCacheAsync(cts.Token)
+                    rpcChatPrivacyService.GetOwnSocialSettingsAsync(cts.Token)
                 );
 
                 await UniTask.WaitUntil(() =>
@@ -147,65 +151,6 @@ namespace DCL.Chat.ChatServices
             friendsEventBus.OnOtherUserRemovedTheFriendship -= OnFriendRemoved;
             friendsEventBus.OnYouAcceptedFriendRequestReceivedFromOtherUser -= OnNewFriendAdded;
             friendsEventBus.OnYouRemovedFriend -= OnFriendRemoved;
-        }
-
-        private async UniTask InitializeFriendshipCacheAsync(CancellationToken ct)
-        {
-            // Implementation requires calling GetFriendsAsync in a loop until all pages are fetched
-            // (See the previous detailed answer for the full pagination logic)
-
-            // Example of updating the cache once friends are fetched:
-            var allFriends = await GetAllFriendsAsync(ct); // A helper method that handles pagination
-
-            lock (friendIds)
-            {
-                friendIds.Clear();
-                foreach (var friend in allFriends)
-                {
-                    friendIds.Add(friend.UserId);
-                }
-            }
-        }
-
-        private async UniTask<List<Profile.CompactInfo>> GetAllFriendsAsync(CancellationToken ct)
-        {
-            var allFriends = new List<Profile.CompactInfo>();
-            if (!friendsService.Configured) return allFriends;
-
-            int pageNum = 0;
-            const int pageSize = 100;
-
-            try
-            {
-                while (true)
-                {
-                    using var result =
-                        await friendsService.StrictObject.GetFriendsAsync(pageNum, pageSize, ct);
-
-                    if (ct.IsCancellationRequested) break;
-                    if (result.Friends.Count == 0) break;
-
-                    allFriends.AddRange(result.Friends);
-
-                    if (allFriends.Count >= result.TotalAmount)
-                        break;
-
-                    pageNum++;
-                }
-            }
-            // Gracefully handle cancellation on exit without logging it as an error.
-            catch (OperationCanceledException)
-            {
-                // This is expected when the application closes.
-            }
-            // Catch any other exception, which indicates a real problem.
-            catch (Exception ex)
-            {
-                ReportHub.LogError(ReportCategory.FRIENDS, $"Failed to fetch all friends due to: {ex.Message}");
-            }
-
-
-            return allFriends;
         }
 
         private void OnPrivacySettingsSet(ChatPrivacySettings privacySettings)
@@ -256,6 +201,7 @@ namespace DCL.Chat.ChatServices
                 switch (connectionUpdate)
                 {
                     case ConnectionUpdate.Connected:
+                    case ConnectionUpdate.Reconnected:
                         onlineParticipants.Clear();
 
                         foreach ((string remoteParticipantIdentity, _) in chatRoom.Participants.RemoteParticipantIdentities())
@@ -288,8 +234,6 @@ namespace DCL.Chat.ChatServices
 
         private void OnFriendRemoved(string userId)
         {
-            lock (friendIds) { friendIds.Remove(userId); }
-
             if (!UserIsConnectedToRoom(userId)) return;
 
             CheckOnlineStatusAndNotify(userId);
@@ -297,8 +241,6 @@ namespace DCL.Chat.ChatServices
 
         private void OnNewFriendAdded(string userId)
         {
-            lock (friendIds) { friendIds.Add(userId); }
-
             CheckOnlineStatusAndNotify(userId);
         }
 
@@ -393,11 +335,6 @@ namespace DCL.Chat.ChatServices
         {
             cts.SafeCancelAndDispose();
             UnsubscribeFromEvents();
-
-            lock (friendIds)
-            {
-                friendIds.Clear();
-            }
 
             lock (onlineParticipants)
             {

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -35,7 +35,7 @@ namespace DCL.Chat.ChatServices
             PRIVATE_MESSAGES_BLOCKED_BY_OWN_USER, //Own user has privacy settings set to ONLY FRIENDS
             PRIVATE_MESSAGES_BLOCKED, //The other user has its privacy settings set to ONLY FRIENDS
             DISCONNECTED, //The other user is either offline or has blocked the own user.
-            OTHER_CLIENT, //The other user is either offline or has blocked the own user.
+            OTHER_CLIENT, //The other user is connected with a client that doesn't support DMs
         }
 
         public readonly struct UserState

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -65,6 +65,7 @@ namespace DCL.Chat.ChatServices
         ///     Contains the list of all participants in all private conversations as they share the same LiveKit room
         /// </summary>
         private readonly HashSet<string> onlineParticipants = new (PoolConstants.AVATARS_COUNT);
+        private readonly HashSet<string> snapshotBuffer = new (PoolConstants.AVATARS_COUNT);
 
         private CancellationTokenSource cts = new ();
 
@@ -116,8 +117,11 @@ namespace DCL.Chat.ChatServices
                     userBlockingCacheProxy.Configured, cancellationToken: cts.Token)
                              .Timeout(TimeSpan.FromMinutes(TIMEOUT_FRIENDS_CONTAINER_MINUTES));
 
-                foreach ((string remoteParticipantIdentity, _) in chatRoom.Participants.RemoteParticipantIdentities().Where(rp => UserIsConsideredAsOnline(rp.Key)))
-                    onlineParticipants.Add(remoteParticipantIdentity);
+                lock (onlineParticipants)
+                {
+                    foreach ((string remoteParticipantIdentity, _) in chatRoom.Participants.RemoteParticipantIdentities().Where(rp => UserIsConsideredAsOnline(rp.Key)))
+                        onlineParticipants.Add(remoteParticipantIdentity);
+                }
             }
             catch (TimeoutException) { ReportHub.LogError(ReportCategory.CHAT_MESSAGES, "Friend service and user blocking cache are not available. Ignore this if you are in LSD"); }
             catch (Exception e) when (e is not OperationCanceledException) { ReportHub.LogError(ReportCategory.CHAT_MESSAGES, $"Error during initialization: {e.Message}"); }
@@ -196,6 +200,8 @@ namespace DCL.Chat.ChatServices
 
         private void OnRoomConnectionStateChanged(IRoom room, ConnectionUpdate connectionUpdate, DisconnectReason? disconnectReason)
         {
+            bool shouldNotify = false;
+
             lock (onlineParticipants)
             {
                 switch (connectionUpdate)
@@ -205,20 +211,23 @@ namespace DCL.Chat.ChatServices
                         onlineParticipants.Clear();
 
                         foreach ((string remoteParticipantIdentity, _) in chatRoom.Participants.RemoteParticipantIdentities())
-                        {
                             if (UserIsConsideredAsOnline(remoteParticipantIdentity))
                                 onlineParticipants.Add(remoteParticipantIdentity);
-                        }
 
-                        NotifyChannelUsersStateUpdated();
-
+                        shouldNotify = true;
                         break;
                     case ConnectionUpdate.Disconnected:
                         onlineParticipants.Clear();
-                        NotifyChannelUsersStateUpdated();
+                        shouldNotify = true;
                         break;
                 }
+
+                if (shouldNotify)
+                    CopyToSnapshotBuffer();
             }
+
+            if (shouldNotify)
+                eventBus.Publish(new ChatEvents.ChannelUsersStatusUpdated(ChatChannel.EMPTY_CHANNEL_ID, ChatChannel.ChatChannelType.USER, snapshotBuffer));
         }
 
         private void OnUpdatesFromParticipant(Participant participant, UpdateFromParticipant update)
@@ -227,7 +236,10 @@ namespace DCL.Chat.ChatServices
             string userId = participant.Identity;
 
             if (update == UpdateFromParticipant.Disconnected)
-                onlineParticipants.Remove(userId);
+                lock (onlineParticipants)
+                {
+                    onlineParticipants.Remove(userId);
+                }
 
             CheckOnlineStatusAndNotify(userId);
         }
@@ -282,19 +294,17 @@ namespace DCL.Chat.ChatServices
         private bool UserIsConnectedToRoom(string userId) =>
             chatRoom.Participants.RemoteParticipant(userId) != null;
 
-        private void NotifyChannelUsersStateUpdated()
-        {
-            eventBus.Publish(new ChatEvents.ChannelUsersStatusUpdated(ChatChannel.EMPTY_CHANNEL_ID, ChatChannel.ChatChannelType.USER, OnlineParticipants));
-        }
-
         private void CheckOnlineStatusAndNotify(string userId)
         {
             bool consideredAsOnline = UserIsConsideredAsOnline(userId);
 
-            if (consideredAsOnline)
-                onlineParticipants.Add(userId);
-            else
-                onlineParticipants.Remove(userId);
+            lock (onlineParticipants)
+            {
+                if (consideredAsOnline)
+                    onlineParticipants.Add(userId);
+                else
+                    onlineParticipants.Remove(userId);
+            }
 
             NotifyUserStateUpdated(userId, consideredAsOnline);
         }
@@ -308,6 +318,25 @@ namespace DCL.Chat.ChatServices
 
             if (currentChannelService.CurrentChannelId.Id == userId)
                 eventBus.Publish(new ChatEvents.CurrentChannelStateUpdatedEvent());
+        }
+
+        public void CopyOnlineParticipantsTo(HashSet<string> destination)
+        {
+            destination.Clear();
+
+            lock (onlineParticipants)
+            {
+                foreach (string participant in onlineParticipants)
+                    destination.Add(participant);
+            }
+        }
+
+        private void CopyToSnapshotBuffer()
+        {
+            snapshotBuffer.Clear();
+
+            foreach (string participant in onlineParticipants)
+                snapshotBuffer.Add(participant);
         }
 
         void ICurrentChannelUserStateService.Deactivate()

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -114,9 +114,7 @@ namespace DCL.Chat.ChatServices
 
             try
             {
-                await UniTask.WhenAll(
-                    rpcChatPrivacyService.GetOwnSocialSettingsAsync(cts.Token)
-                );
+                await rpcChatPrivacyService.GetOwnSocialSettingsAsync(cts.Token);
 
                 await UniTask.WaitUntil(() =>
                     chatRoom.Info.ConnectionState == ConnectionState.ConnConnected &&

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -3,6 +3,8 @@ using DCL.Chat.History;
 using DCL.Diagnostics;
 using DCL.Friends;
 using DCL.Friends.UserBlocking;
+using DCL.Multiplayer.Connections.RoomHubs;
+using DCL.Multiplayer.Profiles.Poses;
 using DCL.Optimization.Pools;
 using DCL.Profiles;
 using DCL.Settings.Settings;
@@ -33,6 +35,7 @@ namespace DCL.Chat.ChatServices
             PRIVATE_MESSAGES_BLOCKED_BY_OWN_USER, //Own user has privacy settings set to ONLY FRIENDS
             PRIVATE_MESSAGES_BLOCKED, //The other user has its privacy settings set to ONLY FRIENDS
             DISCONNECTED, //The other user is either offline or has blocked the own user.
+            OTHER_CLIENT, //The other user is either offline or has blocked the own user.
         }
 
         public readonly struct UserState
@@ -57,6 +60,7 @@ namespace DCL.Chat.ChatServices
         private readonly RPCChatPrivacyService rpcChatPrivacyService;
         private readonly IFriendsEventBus friendsEventBus;
         private readonly IRoom chatRoom;
+        private readonly IRoomHub roomHub;
 
         private readonly IEventBus eventBus;
         private readonly CurrentChannelService currentChannelService;
@@ -79,7 +83,7 @@ namespace DCL.Chat.ChatServices
             ChatSettingsAsset settingsAsset,
             RPCChatPrivacyService rpcChatPrivacyService,
             IFriendsEventBus friendsEventBus,
-            IRoom chatRoom)
+            IRoomHub roomHub)
         {
             this.currentChannelService = currentChannelService;
             this.eventBus = eventBus;
@@ -88,7 +92,9 @@ namespace DCL.Chat.ChatServices
             this.settingsAsset = settingsAsset;
             this.rpcChatPrivacyService = rpcChatPrivacyService;
             this.friendsEventBus = friendsEventBus;
-            this.chatRoom = chatRoom;
+            this.chatRoom = roomHub.ChatRoom();
+            this.roomHub = roomHub;
+
             OnlineParticipants = new ReadOnlyHashSet<string>(onlineParticipants);
         }
 
@@ -169,6 +175,8 @@ namespace DCL.Chat.ChatServices
 
         public async UniTask<UserState> GetChatUserStateAsync(string userId, CancellationToken ct)
         {
+            string lowerUserId = userId.ToLower();
+
             FriendshipStatus friendshipStatus = await friendsService.StrictObject.GetFriendshipStatusAsync(userId, ct);
             bool isUserConnected = UserIsConsideredAsOnline(userId);
 
@@ -180,20 +188,29 @@ namespace DCL.Chat.ChatServices
             if (friendshipStatus == FriendshipStatus.BLOCKED)
                 return new UserState(isUserConnected, ChatUserState.BLOCKED_BY_OWN_USER);
 
-            if (friendshipStatus == FriendshipStatus.BLOCKED_BY || !isUserConnected)
-                return new UserState(isUserConnected, ChatUserState.DISCONNECTED);
-
-            //At this point we know the user is connected
+            // If we are being blocked by them, show them as offline
+            if (friendshipStatus == FriendshipStatus.BLOCKED_BY)
+                return new UserState(false, ChatUserState.DISCONNECTED);
 
             //If the user is connected we need to check our settings and then theirs.
             if (settingsAsset.chatPrivacySettings == ChatPrivacySettings.ONLY_FRIENDS)
                 return new UserState(isUserConnected, ChatUserState.PRIVATE_MESSAGES_BLOCKED_BY_OWN_USER);
 
-            //If we allow ALL messages, we need to know their settings.
-            ParticipantPrivacyMetadata message = JsonUtility.FromJson<ParticipantPrivacyMetadata>(chatRoom.Participants.RemoteParticipant(userId)!.Metadata);
+            // This is done because other clients don't connect to chat livekit room, so they are not found in the participant list.
+            // If we are able to find them through either island or scene room, it means we cannot chat with them
+            if (!isUserConnected && (roomHub.TryGetUser(userId, out _, out _) || roomHub.TryGetUser(lowerUserId, out _, out _)))
+                return new UserState(isUserConnected, ChatUserState.OTHER_CLIENT);
 
-            if (message.private_messages_privacy != PRIVACY_SETTING_ALL)
-                return new UserState(isUserConnected, ChatUserState.PRIVATE_MESSAGES_BLOCKED);
+            if (isUserConnected)
+            {
+                Participant? participant = chatRoom.Participants.RemoteParticipant(userId) ?? chatRoom.Participants.RemoteParticipant(lowerUserId);
+
+                //If we allow ALL messages, we need to know their settings.
+                ParticipantPrivacyMetadata message = JsonUtility.FromJson<ParticipantPrivacyMetadata>(participant!.Metadata);
+
+                if (message.private_messages_privacy != PRIVACY_SETTING_ALL)
+                    return new UserState(isUserConnected, ChatUserState.PRIVATE_MESSAGES_BLOCKED);
+            }
 
             return new UserState(isUserConnected, isUserConnected ? ChatUserState.CONNECTED : ChatUserState.DISCONNECTED);
         }
@@ -292,7 +309,7 @@ namespace DCL.Chat.ChatServices
 
 
         private bool UserIsConnectedToRoom(string userId) =>
-            chatRoom.Participants.RemoteParticipant(userId) != null;
+            chatRoom.Participants.RemoteParticipant(userId) != null || chatRoom.Participants.RemoteParticipant(userId.ToLower()) != null;
 
         private void CheckOnlineStatusAndNotify(string userId)
         {

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -195,6 +195,10 @@ namespace DCL.Chat.ChatServices
             if (!isUserConnected && (roomHub.TryGetUser(userId, out _, out _) || roomHub.TryGetUser(lowerUserId, out _, out _)))
                 return new UserState(isUserConnected, ChatUserState.OTHER_CLIENT);
 
+            // If the user is not reachable by any means, they are simply offline
+            if (!isUserConnected)
+                return new UserState(false, ChatUserState.DISCONNECTED);
+
             //If the user is connected we need to check our settings and then theirs.
             if (settingsAsset.chatPrivacySettings == ChatPrivacySettings.ONLY_FRIENDS)
                 return new UserState(isUserConnected, ChatUserState.PRIVATE_MESSAGES_BLOCKED_BY_OWN_USER);

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -190,23 +190,25 @@ namespace DCL.Chat.ChatServices
             if (friendshipStatus == FriendshipStatus.BLOCKED_BY)
                 return new UserState(false, ChatUserState.DISCONNECTED);
 
-            //If the user is connected we need to check our settings and then theirs.
-            if (settingsAsset.chatPrivacySettings == ChatPrivacySettings.ONLY_FRIENDS)
-                return new UserState(isUserConnected, ChatUserState.PRIVATE_MESSAGES_BLOCKED_BY_OWN_USER);
-
             // This is done because other clients don't connect to chat livekit room, so they are not found in the participant list.
             // If we are able to find them through either island or scene room, it means we cannot chat with them
             if (!isUserConnected && (roomHub.TryGetUser(userId, out _, out _) || roomHub.TryGetUser(lowerUserId, out _, out _)))
                 return new UserState(isUserConnected, ChatUserState.OTHER_CLIENT);
 
-            if (isUserConnected)
+            //If the user is connected we need to check our settings and then theirs.
+            if (settingsAsset.chatPrivacySettings == ChatPrivacySettings.ONLY_FRIENDS)
+                return new UserState(isUserConnected, ChatUserState.PRIVATE_MESSAGES_BLOCKED_BY_OWN_USER);
+
+            // User should be online, but check if they disconnected while processing this data + ensure we have metadata
+            Participant? participant = chatRoom.Participants.RemoteParticipant(userId)
+                                       ?? chatRoom.Participants.RemoteParticipant(lowerUserId);
+
+            if (participant != null && !string.IsNullOrEmpty(participant.Metadata))
             {
-                Participant? participant = chatRoom.Participants.RemoteParticipant(userId) ?? chatRoom.Participants.RemoteParticipant(lowerUserId);
-
                 //If we allow ALL messages, we need to know their settings.
-                ParticipantPrivacyMetadata message = JsonUtility.FromJson<ParticipantPrivacyMetadata>(participant!.Metadata);
+                ParticipantPrivacyMetadata userMetadata = JsonUtility.FromJson<ParticipantPrivacyMetadata>(participant.Metadata);
 
-                if (message.private_messages_privacy != PRIVACY_SETTING_ALL)
+                if (userMetadata.private_messages_privacy != PRIVACY_SETTING_ALL)
                     return new UserState(isUserConnected, ChatUserState.PRIVATE_MESSAGES_BLOCKED);
             }
 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ChatConnectiveRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ChatConnectiveRoom.cs
@@ -1,5 +1,6 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.Rooms;
 using DCL.Multiplayer.Connections.Rooms.Connective;
 using DCL.WebRequests;
@@ -63,8 +64,16 @@ namespace DCL.Multiplayer.Connections.Archipelago.Rooms.Chat
         {
             while (ct.IsCancellationRequested == false)
             {
-                if (CurrentState() == IConnectiveRoom.State.Running)
-                    ((InteriorRoom)Room()).SimulateConnectionStateChanged();
+                try
+                {
+                    if (CurrentState() == IConnectiveRoom.State.Running)
+                        ((InteriorRoom)Room()).SimulateConnectionStateChanged();
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception e)
+                {
+                    ReportHub.LogException(e, ReportCategory.LIVEKIT);
+                }
 
                 await UniTask.Delay(CONNECTION_UPDATE_INTERVAL, cancellationToken: ct);
             }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/IRoomHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/IRoomHub.cs
@@ -1,9 +1,9 @@
 using Cysharp.Threading.Tasks;
 using DCL.Multiplayer.Connections.Archipelago.Rooms.Chat;
 using DCL.Multiplayer.Connections.GateKeeper.Rooms;
-using DCL.Multiplayer.Connections.Rooms.Connective;
 using LiveKit.Proto;
 using LiveKit.Rooms;
+using LiveKit.Rooms.Participants;
 using System.Collections.Generic;
 
 namespace DCL.Multiplayer.Connections.RoomHubs
@@ -14,6 +14,8 @@ namespace DCL.Multiplayer.Connections.RoomHubs
         IGateKeeperSceneRoom SceneRoom();
         IRoom ChatRoom();
         VoiceChatActivatableConnectiveRoom VoiceChatRoom();
+
+        bool TryGetUser(string wallet, out Participant? participant, out IRoom? room);
 
         UniTask<bool> StartAsync();
         UniTask StopAsync();

--- a/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/NullRoomHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/NullRoomHub.cs
@@ -4,6 +4,7 @@ using DCL.Multiplayer.Connections.GateKeeper.Rooms;
 using DCL.Multiplayer.Connections.Rooms;
 using DCL.Multiplayer.Connections.Rooms.Connective;
 using LiveKit.Rooms;
+using LiveKit.Rooms.Participants;
 using System;
 using System.Collections.Generic;
 
@@ -23,6 +24,13 @@ namespace DCL.Multiplayer.Connections.RoomHubs
 
         public VoiceChatActivatableConnectiveRoom VoiceChatRoom() =>
             VoiceChatActivatableConnectiveRoom.Null.INSTANCE;
+
+        public bool TryGetUser(string wallet, out Participant? participant, out IRoom? room)
+        {
+            participant = null;
+            room = null;
+            return false;
+        }
 
         public UniTask StopLocalRoomsAsync() =>
             UniTask.CompletedTask;

--- a/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/RoomHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/RoomHub.cs
@@ -4,6 +4,7 @@ using DCL.Multiplayer.Connections.GateKeeper.Rooms;
 using DCL.Multiplayer.Connections.Rooms.Connective;
 using LiveKit.Rooms;
 using LiveKit.Rooms.Participants;
+using System;
 using System.Collections.Generic;
 using Utility.Multithreading;
 
@@ -20,6 +21,9 @@ namespace DCL.Multiplayer.Connections.RoomHubs
         private readonly IParticipantsHub sceneParticipantsHub;
 
         private readonly HashSet<string> identityHashCache = new (32);
+
+        private IReadOnlyDictionary<string, Participant> islandIdentities;
+        private IReadOnlyDictionary<string, Participant> sceneIdentities;
 
         private long participantsUpdateLastFrame = -1;
 
@@ -47,6 +51,25 @@ namespace DCL.Multiplayer.Connections.RoomHubs
 
         public VoiceChatActivatableConnectiveRoom VoiceChatRoom() =>
             voiceChatRoom;
+
+        public bool TryGetUser(string wallet, out Participant? participant, out IRoom? room)
+        {
+            if (islandIdentities.TryGetValue(wallet, out participant))
+            {
+                room = IslandRoom();
+                return true;
+            }
+
+            if (sceneIdentities.TryGetValue(wallet, out participant))
+            {
+                room = SceneRoom().Room();
+                return true;
+            }
+
+            participant = null;
+            room = null;
+            return false;
+        }
 
         /// <summary>
         ///     Starts all rooms except the Voice Chat, as this one only starts when there is a live voice chat going
@@ -89,8 +112,8 @@ namespace DCL.Multiplayer.Connections.RoomHubs
 
             identityHashCache.Clear();
 
-            IReadOnlyDictionary<string, Participant> islandIdentities = islandParticipantsHub.RemoteParticipantIdentities();
-            IReadOnlyDictionary<string, Participant> sceneIdentities = sceneParticipantsHub.RemoteParticipantIdentities();
+            islandIdentities = islandParticipantsHub.RemoteParticipantIdentities();
+            sceneIdentities = sceneParticipantsHub.RemoteParticipantIdentities();
 
             identityHashCache.EnsureCapacity(islandIdentities.Count + sceneIdentities.Count);
 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/RoomHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/RoomHub.cs
@@ -54,6 +54,9 @@ namespace DCL.Multiplayer.Connections.RoomHubs
 
         public bool TryGetUser(string wallet, out Participant? participant, out IRoom? room)
         {
+            // Ensure latest data
+            AllLocalRoomsRemoteParticipantIdentities();
+
             if (islandIdentities.TryGetValue(wallet, out participant))
             {
                 room = IslandRoom();

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
@@ -41,6 +41,7 @@ using DCL.Clipboard;
 using DCL.Diagnostics;
 using DCL.ExplorePanel;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Multiplayer.Profiles.Poses;
 using DCL.Settings;
 using DCL.Translation;
 using DCL.Translation.Processors;
@@ -254,7 +255,7 @@ namespace DCL.PluginSystem.Global
                 settings.ChatSettingsAsset,
                 privacySettings,
                 friendsEventBus,
-                roomHub.ChatRoom());
+                roomHub);
 
             pluginScope.Add(chatUserStateService);
 


### PR DESCRIPTION
# Pull Request Description
Fixes #7947
Fixes #8104

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->
This PR fixes multiple things related to DMs and chat online status:
- Fixed incorrect online status in private chat conversations by making sure that lookups to participant lists are case-insensitive + added a new case of a user connected to island/scene room while not being connected to chat room (other clients)
- Added OTHER_CLIENT chat user state to handle the case where a user is connected from a non-DM-capable client, showing a specific message instead of incorrectly reporting them as offline
- Fixed concurrent modification crashes in participant lists (onlineParticipants) by adding lock synchronization and a snapshotBuffer for safe iteration (Sentry UNITY-EXPLORER-KM1)
- Removed unused `InitializeFriendshipCacheAsync` and the paginated friends fetch

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Test Steps
1. Test that DMs and chat overall works as before
2. Check that online statuses are reported correctly
3. Check that users connected with other clients are correctly identified


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
