### PR TITLE
chore: revise issue closure conditions in workflow

### DIFF
--- a/.github/workflows/issue-deduplication.yml
+++ b/.github/workflows/issue-deduplication.yml
@@ -40,9 +40,10 @@ jobs:
             If you find duplicates:
             - Add a comment on the new issue linking to the original issue(s)
             - Apply a "duplicate" label to the new issue
-            - Close the new issue as "not planned" using: gh issue close <number> --repo ${{ github.repository }} --reason "not planned"
             - Be polite and explain why it's a duplicate
             - Suggest the user follow the original issue for updates
+            - IMPORTANT: Only close the new issue if it has the "SENTRY" label. Use: gh issue close <number> --repo ${{ github.repository }} --reason "not planned"
+            - If the issue does NOT have the "SENTRY" label, do NOT close it. Just leave the comment and the "duplicate" label so a maintainer can review.
             If it's NOT a duplicate:
             - Don't add any comments
             - You may apply appropriate topic labels based on the issue content


### PR DESCRIPTION
Updated issue handling instructions to specify that new issues should only be closed if they have the 'SENTRY' label.
