### PR TITLE
fix: auto-upload to Epic Store when a new release is published

### DIFF
--- a/.github/workflows/upload-build-epic-store.yml
+++ b/.github/workflows/upload-build-epic-store.yml
@@ -1,6 +1,8 @@
 name: Upload Latest Build to Epic Store
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       platform:
@@ -25,7 +27,7 @@ jobs:
     - name: Set platform flags
       id: platforms
       run: |
-        $p = "${{ github.event.inputs.platform }}"
+        $p = "${{ github.event.inputs.platform || 'both' }}"
         echo "build_windows=$($p -eq 'windows' -or $p -eq 'both')" >> $env:GITHUB_OUTPUT
         echo "build_mac=$($p -eq 'mac' -or $p -eq 'both')" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/upload-build-epic-store.yml
+++ b/.github/workflows/upload-build-epic-store.yml
@@ -34,7 +34,9 @@ jobs:
     - name: Get the latest release info
       id: get_release
       run: |
-        $releaseData = Invoke-RestMethod -Uri "https://api.github.com/repos/decentraland/unity-explorer/releases/latest"
+        $releaseTag = "${{ github.event.release.tag_name }}"
+        $apiUrl = if ($releaseTag -ne "") { "https://api.github.com/repos/decentraland/unity-explorer/releases/tags/$releaseTag" } else { "https://api.github.com/repos/decentraland/unity-explorer/releases/latest" }
+        $releaseData = Invoke-RestMethod -Uri $apiUrl -Headers @{ Authorization = "token $env:GITHUB_TOKEN" }
         $version = $releaseData.tag_name
         $windowsUrl = ($releaseData.assets | Where-Object { $_.name -eq "Decentraland_windows64_epic.zip" }).browser_download_url
         $macosUrl = ($releaseData.assets | Where-Object { $_.name -eq "Decentraland_macos_epic.zip" }).browser_download_url
@@ -130,8 +132,10 @@ jobs:
 
     - name: Upload Windows artifact
       if: steps.platforms.outputs.build_windows == 'True'
+      id: upload_windows
       run: |
-        BuildPatchTool.exe `
+        $exitCode = 0
+        & BuildPatchTool.exe `
         -OrganizationId="${{ secrets.EPIC_STORE_ORG_ID }}" `
         -ProductId="${{ secrets.EPIC_STORE_PRODUCT_ID }}" `
         -ArtifactId="${{ secrets.EPIC_STORE_ARTIFACT_ID }}" `
@@ -142,12 +146,26 @@ jobs:
         -CloudDir="$env:RUNNER_TEMP\BuildPatchTool\CloudDir_Windows" `
         -BuildVersion="${{ steps.get_release.outputs.version }}-win" `
         -AppLaunch="Decentraland.exe" `
-        -AppArgs="--skip-version-check"
+        -AppArgs="--skip-version-check" 2>&1 | Tee-Object -Variable bptOutput
+        $exitCode = $LASTEXITCODE
+
+        if ($exitCode -ne 0) {
+          $outputStr = $bptOutput -join "`n"
+          if ($outputStr -match "Build already exists") {
+            Write-Host "::warning::Windows build version already uploaded to Epic — skipping."
+            echo "skipped=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Error "BuildPatchTool failed with exit code $exitCode"
+            exit $exitCode
+          }
+        }
 
     - name: Upload macOS artifact
       if: steps.platforms.outputs.build_mac == 'True'
+      id: upload_mac
       run: |
-        BuildPatchTool.exe `
+        $exitCode = 0
+        & BuildPatchTool.exe `
         -OrganizationId="${{ secrets.EPIC_STORE_ORG_ID }}" `
         -ProductId="${{ secrets.EPIC_STORE_PRODUCT_ID }}" `
         -ArtifactId="${{ secrets.EPIC_STORE_ARTIFACT_ID }}" `
@@ -159,7 +177,19 @@ jobs:
         -BuildVersion="${{ steps.get_release.outputs.version }}-mac" `
         -AppLaunch="Decentraland.app/Contents/MacOS/Explorer" `
         -AppArgs="--skip-version-check" `
-        -Platform="Mac"
+        -Platform="Mac" 2>&1 | Tee-Object -Variable bptOutput
+        $exitCode = $LASTEXITCODE
+
+        if ($exitCode -ne 0) {
+          $outputStr = $bptOutput -join "`n"
+          if ($outputStr -match "Build already exists") {
+            Write-Host "::warning::macOS build version already uploaded to Epic — skipping."
+            echo "skipped=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Error "BuildPatchTool failed with exit code $exitCode"
+            exit $exitCode
+          }
+        }
 
     - name: Post-upload instructions
       if: steps.platforms.outputs.build_windows == 'True' || steps.platforms.outputs.build_mac == 'True'

--- a/.github/workflows/upload-build-epic-store.yml
+++ b/.github/workflows/upload-build-epic-store.yml
@@ -43,7 +43,7 @@ jobs:
         Write-Host "Windows download URL: $windowsUrl"
         Write-Host "macOS download URL: $macosUrl"
 
-        $platform = "${{ github.event.inputs.platform }}"
+        $platform = "${{ github.event.inputs.platform || 'both' }}"
         if (-not $windowsUrl -and ($platform -eq "windows" -or $platform -eq "both")) {
           Write-Error "Windows asset (Decentraland_windows64_epic.zip) not found in latest release $version"
           exit 1


### PR DESCRIPTION
## Summary
- Added `release: [published]` trigger so the Epic Store upload runs automatically when a new release is created
- The platform defaults to `both` (Windows + macOS) for release-triggered runs
- Manual `workflow_dispatch` still works as before with platform selection

## Test plan
- [ ] Publish a new release → verify the Epic upload workflow triggers automatically and uploads both platforms
- [ ] Run manually via workflow_dispatch with a specific platform → verify it still respects the selection