### PR TITLE
fix: avoid full failure of notification polling on webrequest error

### DIFF
--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -104,35 +104,41 @@ namespace DCL.Notifications
 
                 unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
-                // TODO remove allocation of List on serialization
-                List<INotification> notifications =
-                    await webRequestController.GetAsync(
-                                                   commonArguments,
-                                                   ct,
-                                                   ReportCategory.UI,
-                                                   signInfo: WebRequestSignInfo.NewFromUrl(urlsSource.GetOriginalUrl(commonArguments.URL), unixTimestamp, "get"),
-                                                   headersInfo: new WebRequestHeadersInfo().WithSign(string.Empty, unixTimestamp))
-                                              .CreateFromNewtonsoftJsonAsync<List<INotification>>(serializerSettings: serializerSettings);
+                try
+                {
+                    List<INotification> notifications = await webRequestController.GetAsync(
+                                                                                       commonArguments,
+                                                                                       ct,
+                                                                                       ReportCategory.UI,
+                                                                                       signInfo: WebRequestSignInfo.NewFromUrl(urlsSource.GetOriginalUrl(commonArguments.URL), unixTimestamp, "get"),
+                                                                                       headersInfo: new WebRequestHeadersInfo().WithSign(string.Empty, unixTimestamp))
+                                                                                  .CreateFromNewtonsoftJsonAsync<List<INotification>>(serializerSettings: serializerSettings);
 
-                if (notifications.Count == 0)
-                    continue;
+                    if (notifications.Count == 0)
+                        continue;
 
-                lastPolledTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
+                    lastPolledTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
+                    using var scope = ThreadSafeListPool<string>.SHARED.Get(out var list);
 
-                using var scope = ThreadSafeListPool<string>.SHARED.Get(out var list);
-                foreach (INotification notification in notifications)
-                    try
-                    {
-                        NotificationsBusController.Instance.AddNotification(notification);
-                        list.Add(notification.Id);
-                    }
-                    catch (Exception e)
-                    {
-                        ReportHub.LogException(e, ReportCategory.UI);
-                    }
+                    foreach (INotification notification in notifications)
+                        try
+                        {
+                            NotificationsBusController.Instance.AddNotification(notification);
+                            list.Add(notification.Id);
+                        }
+                        catch (Exception e)
+                        {
+                            ReportHub.LogException(e, ReportCategory.UI);
+                        }
 
-                await SetNotificationAsReadAsync(list, ct);
+                    await SetNotificationAsReadAsync(list, ct);
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception e)
+                {
+                    ReportHub.LogWarning(ReportCategory.UI, "Notifications request failed, retrying on next polling");
+                }
             }
             while (ct.IsCancellationRequested == false);
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, specific steps for testing these changes. Remember:
- QA team members may not have the same technical context
- Be explicit about test requirements and expected outcomes
- Include any specific configuration needed
-->

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
