### PR TITLE
fix: thread safe dictionary for web request analytics container

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsAnalyticsContainer.cs
+++ b/Explorer/Assets/DCL/WebRequests/Analytics/WebRequestsAnalyticsContainer.cs
@@ -1,5 +1,6 @@
 ﻿using Cysharp.Threading.Tasks;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.Networking;
@@ -8,7 +9,7 @@ namespace DCL.WebRequests.Analytics
 {
     public class WebRequestsAnalyticsContainer : IWebRequestsAnalyticsContainer
     {
-        private readonly Dictionary<UnityWebRequest, DateTime> pendingRequests = new (10);
+        private readonly ConcurrentDictionary<UnityWebRequest, DateTime> pendingRequests = new ();
         private readonly List<IWebRequestAnalyticsHandler> handlers;
 
         public WebRequestsAnalyticsContainer(params IWebRequestAnalyticsHandler?[] handlers)
@@ -18,7 +19,7 @@ namespace DCL.WebRequests.Analytics
 
         void IWebRequestsAnalyticsContainer.OnBeforeBudgeting<T, TWebRequestArgs>(in RequestEnvelope<T, TWebRequestArgs> envelope, T request)
         {
-            pendingRequests.Add(request.UnityWebRequest, DateTime.MinValue);
+            pendingRequests.TryAdd(request.UnityWebRequest, DateTime.MinValue);
 
             foreach (IWebRequestAnalyticsHandler? handler in handlers)
                 handler.OnBeforeBudgeting(in envelope, request);
@@ -50,7 +51,7 @@ namespace DCL.WebRequests.Analytics
 
         void IWebRequestsAnalyticsContainer.OnProcessDataFinished<T>(T request)
         {
-            if (!pendingRequests.Remove(request.UnityWebRequest))
+            if (!pendingRequests.TryRemove(request.UnityWebRequest, out _))
                 return;
 
             foreach (IWebRequestAnalyticsHandler? handler in handlers)
@@ -59,7 +60,7 @@ namespace DCL.WebRequests.Analytics
 
         void IWebRequestsAnalyticsContainer.OnException<T>(T request, Exception exception)
         {
-            if (!pendingRequests.Remove(request.UnityWebRequest, out DateTime startTime))
+            if (!pendingRequests.TryRemove(request.UnityWebRequest, out DateTime startTime))
                 return;
 
             DateTime now = DateTime.Now;
@@ -71,7 +72,7 @@ namespace DCL.WebRequests.Analytics
 
         void IWebRequestsAnalyticsContainer.OnException<T>(T request, UnityWebRequestException exception)
         {
-            if (!pendingRequests.Remove(request.UnityWebRequest, out DateTime startTime))
+            if (!pendingRequests.TryRemove(request.UnityWebRequest, out DateTime startTime))
                 return;
 
             DateTime now = DateTime.Now;

--- a/Explorer/Assets/DCL/WebRequests/WebRequestController.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestController.cs
@@ -95,15 +95,12 @@ namespace DCL.WebRequests
                         return default(TResult);
 
                     if (!envelope.SuppressErrors)
-
                         // Print verbose
                         ReportHub.LogError(
                             envelope.ReportData,
                             $"Exception (code {exception.ResponseCode}) occured on loading {typeof(TWebRequest).Name} from {envelope.CommonArguments.URL} with {envelope}\n"
                             + $"Attempt: {attemptNumber}/{retryPolicy.maxRetriesCount + 1}"
                         );
-
-                    analyticsContainer.OnException(request, exception);
 
                     (bool canBeRepeated, TimeSpan retryDelay) = WebRequestUtils.CanBeRepeated(attemptNumber, retryPolicy, idempotent, exception);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #8009
This PR:
* removes a no op `analyticsContainer.OnException(request, exception);` as it is done a few lines before.
* makes the pendingRequests dictionary of WebRequestsAnalyticsContainer a ConcurrentDictionary
the second change is needed to avoid possibly corrupting the dictionary by accessing it via main thread and thread pool.

When could this happen? It can happen when a WebRequestController.SendAsync starts from the main thread, in the meanwhile a post op contains for example a json serialisation and forces in op.ExecuteAsync (for the CreateFromJsonOp i.e.) a switch to thread pool.

## Test Instructions

### Test Steps
1. Launch the client
2. Verify that everything loads as in production

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
