### PR TITLE
fix: added double click setting, opt in by default

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/UpdatePointAndClickInputSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/UpdatePointAndClickInputSystem.cs
@@ -8,6 +8,7 @@ using DCL.CharacterMotion.Settings;
 using DCL.CharacterMotion.Utils;
 using DCL.Diagnostics;
 using DCL.Input;
+using DCL.Prefs;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
 using System.Collections.Generic;
@@ -123,6 +124,9 @@ namespace DCL.CharacterMotion.Systems
             normal = Vector3.up;
 
             if (!navigateToAction.WasPerformedThisFrame())
+                return false;
+
+            if (!DCLPlayerPrefs.GetBool(DCLPrefKeys.SETTINGS_DOUBLE_TAP_TO_MOVE, false))
                 return false;
 
             var mouse = Mouse.current;

--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -73,6 +73,7 @@ namespace DCL.FeatureFlags
         public const string REPORT_USER = "alfa-report-user";
         public const string POINT_AT = "alfa-point-at";
         public const string AVATAR_CONTEXT_MENU = "alfa-avatar-context-menu";
+        public const string DOUBLE_CLICK_WALK = "alfa-double-click-walk";
 
         public static class Endpoints
         {

--- a/Explorer/Assets/DCL/FeatureFlags/FeaturesRegistry.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeaturesRegistry.cs
@@ -54,6 +54,7 @@ namespace DCL.FeatureFlags
                 [FeatureId.REPORT_USER] = appArgs.ResolveFeatureFlagArg(AppArgsFlags.REPORT_USER, featureFlags.IsEnabled(FeatureFlagsStrings.REPORT_USER) || Application.isEditor),
                 [FeatureId.POINT_AT] = appArgs.ResolveFeatureFlagArg(AppArgsFlags.POINT_AT, featureFlags.IsEnabled(FeatureFlagsStrings.POINT_AT) || Application.isEditor),
                 [FeatureId.AVATAR_CONTEXT_MENU] = appArgs.ResolveFeatureFlagArg(AppArgsFlags.AVATAR_CONTEXT_MENU, featureFlags.IsEnabled(FeatureFlagsStrings.AVATAR_CONTEXT_MENU) || Application.isEditor),
+                [FeatureId.DOUBLE_CLICK_WALK] = appArgs.ResolveFeatureFlagArg(AppArgsFlags.DOUBLE_CLICK_WALK, featureFlags.IsEnabled(FeatureFlagsStrings.DOUBLE_CLICK_WALK) || Application.isEditor),
                 // Note: COMMUNITIES feature is not cached here because it depends on user identity
             });
 
@@ -172,5 +173,6 @@ namespace DCL.FeatureFlags
         REPORT_USER,
         POINT_AT,
         AVATAR_CONTEXT_MENU,
+        DOUBLE_CLICK_WALK,
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -94,6 +94,7 @@ namespace Global.AppArgs
         public const string REPORT_USER = "report-user";
 
         public const string AVATAR_CONTEXT_MENU = "avatar-context-menu";
+        public const string DOUBLE_CLICK_WALK = "double-click-walk";
 
         public static class Multiplayer
         {

--- a/Explorer/Assets/DCL/PluginSystem/Global/CharacterMotionPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/CharacterMotionPlugin.cs
@@ -121,7 +121,8 @@ namespace DCL.PluginSystem.Global
                 new HandPointAtComponent(),
                 new TorsoIKComponent());
 
-            UpdatePointAndClickInputSystem.InjectToWorld(ref builder, destinationMarkerPrefab);
+            if (FeaturesRegistry.Instance.IsEnabled(FeatureId.DOUBLE_CLICK_WALK))
+                UpdatePointAndClickInputSystem.InjectToWorld(ref builder, destinationMarkerPrefab);
             InterpolateCharacterSystem.InjectToWorld(ref builder, scenesCache);
             TeleportPositionCalculationSystem.InjectToWorld(ref builder, landscape);
             TeleportCharacterSystem.InjectToWorld(ref builder, sceneReadinessReportQueue);

--- a/Explorer/Assets/DCL/Prefs/DCLPrefKeys.cs
+++ b/Explorer/Assets/DCL/Prefs/DCLPrefKeys.cs
@@ -93,6 +93,8 @@ namespace DCL.Prefs
 
         public const string SETTINGS_HEAD_SYNC_ENABLED = "Settings_HeadSync";
 
+        public const string SETTINGS_DOUBLE_TAP_TO_MOVE = "Settings_DoubleTapToMove";
+
         public const string RECENTLY_VISITED_PLACES = "Recently_Visited_Places";
 
         public const string SKYBOX_FIXED_TIME = "Skybox_FixedTime";

--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
@@ -92,6 +92,7 @@ MonoBehaviour:
       - rid: 3126482891795070976
       - rid: 3126482891795070977
       - rid: 5190442991532376251
+      - rid: 3126482891795070978
     - <GroupTitle>k__BackingField: Point At
       <FeatureFlagName>k__BackingField: 0
       <FeatureId>k__BackingField: 53
@@ -735,3 +736,19 @@ MonoBehaviour:
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
         <Feature>k__BackingField: 10
+    - rid: 3126482891795070978
+      type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
+      data:
+        <FeatureId>k__BackingField: 0
+        <View>k__BackingField:
+          m_AssetGUID: 39458b71e0ed84549b1b280c4fb1f105
+          m_SubObjectName:
+          m_SubObjectType:
+          m_SubObjectGUID:
+          m_EditorAssetChanged: 0
+        <Config>k__BackingField:
+          <ModuleName>k__BackingField: Double tap to move
+          <Description>k__BackingField: Double-click on any surface to walk there automatically.
+          <IsEnabled>k__BackingField: 1
+          defaultIsOn: 0
+        <Feature>k__BackingField: 11

--- a/Explorer/Assets/DCL/Settings/Configuration/ToggleModuleBinding.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/ToggleModuleBinding.cs
@@ -39,6 +39,7 @@ namespace DCL.Settings.Configuration
             SCENE_SHADOWS_FEATURE,
             SCENE_LIGHTS_FEATURE,
             FULLSCREEN_FEATURE,
+            DOUBLE_TAP_TO_MOVE,
             // add other features...
         }
 
@@ -80,6 +81,7 @@ namespace DCL.Settings.Configuration
                 ToggleFeatures.SCENE_SHADOWS_FEATURE => CreateSimpleToggle(viewInstance, qualitySettingsController, qualitySettingsController.SetSceneLightShadows, x => x.SceneLightShadows),
                 ToggleFeatures.SCENE_LIGHTS_FEATURE => CreateSimpleToggle(viewInstance, qualitySettingsController, qualitySettingsController.SetSceneLights, x => x.SceneLights),
                 ToggleFeatures.FULLSCREEN_FEATURE => new FullscreenSettingsController(viewInstance),
+                ToggleFeatures.DOUBLE_TAP_TO_MOVE => new DoubleTapToMoveSettingsController(viewInstance),
                 // add other cases...
                 _ => throw new ArgumentOutOfRangeException(nameof(viewInstance))
             };

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/DoubleTapToMoveSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/DoubleTapToMoveSettingsController.cs
@@ -1,0 +1,25 @@
+using DCL.Prefs;
+using DCL.Settings.ModuleViews;
+
+namespace DCL.Settings.ModuleControllers
+{
+    public class DoubleTapToMoveSettingsController : SettingsFeatureController
+    {
+        private readonly SettingsToggleModuleView view;
+
+        public DoubleTapToMoveSettingsController(SettingsToggleModuleView view)
+        {
+            this.view = view;
+
+            bool value = DCLPlayerPrefs.GetBool(DCLPrefKeys.SETTINGS_DOUBLE_TAP_TO_MOVE, false);
+            view.ToggleView.Toggle.SetIsOnWithoutNotify(value);
+            view.ToggleView.Toggle.onValueChanged.AddListener(OnToggleValueChanged);
+        }
+
+        public override void Dispose() =>
+            view.ToggleView.Toggle.onValueChanged.RemoveAllListeners();
+
+        private static void OnToggleValueChanged(bool isOn) =>
+            DCLPlayerPrefs.SetBool(DCLPrefKeys.SETTINGS_DOUBLE_TAP_TO_MOVE, isOn, true);
+    }
+}

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/DoubleTapToMoveSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/DoubleTapToMoveSettingsController.cs
@@ -1,3 +1,4 @@
+using DCL.FeatureFlags;
 using DCL.Prefs;
 using DCL.Settings.ModuleViews;
 
@@ -10,6 +11,12 @@ namespace DCL.Settings.ModuleControllers
         public DoubleTapToMoveSettingsController(SettingsToggleModuleView view)
         {
             this.view = view;
+
+            if (!FeaturesRegistry.Instance.IsEnabled(FeatureId.DOUBLE_CLICK_WALK))
+            {
+                view.SetActive(false);
+                return;
+            }
 
             bool value = DCLPlayerPrefs.GetBool(DCLPrefKeys.SETTINGS_DOUBLE_TAP_TO_MOVE, false);
             view.ToggleView.Toggle.SetIsOnWithoutNotify(value);

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/DoubleTapToMoveSettingsController.cs.meta
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/DoubleTapToMoveSettingsController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 431c3e36d26fba74ba2635b3915233d4


### PR DESCRIPTION
Double click to walk feature is causing some issues with Scenes UIs, its going to be behind a feature flag for the next release.
Even when active, it will disabled by default, and behind a toggle in Settings > Controls > Mouse > Doubel tap to walk

Added feature flag --double-click-walk

Testing
----
Open the build with --double-click-walk 
Double click to walk should be disable by default
Open settings > Controls> Mouse > Enable Double tap to walk
Double click anywhere to walk
