### PR TITLE
fix: enable only current scene stream setting

### DIFF
--- a/Explorer/Assets/DCL/Prefs/DCLPrefKeys.cs
+++ b/Explorer/Assets/DCL/Prefs/DCLPrefKeys.cs
@@ -53,6 +53,7 @@ namespace DCL.Prefs
         public const string PS_MAX_SCENE_LIGHTS = "QS_MaxSceneLights";
         public const string PS_SHADOW_QUALITY = "QS_ShadowQuality";
         public const string PS_SHADOW_DISTANCE = "QS_ShadowDistance";
+        public const string PS_PLAY_CURRENT_SCENE_STREAMS_ONLY = "QS_PlayCurrentSceneStreamsOnly";
         public const string PS_RESOLUTION = "QS_Resolution";
 
         public const string SETTINGS_HIDE_BLOCKED_USERS_MESSAGES = "Settings_HideBlockedUsersChatMessages";

--- a/Explorer/Assets/DCL/Quality/Runtime/IQualitySettingsController.cs
+++ b/Explorer/Assets/DCL/Quality/Runtime/IQualitySettingsController.cs
@@ -37,6 +37,9 @@ namespace DCL.Quality.Runtime
         ShadowQualityLevel SceneShadowQuality { get; }
         int ShadowDistance { get; }
 
+        // Other
+        bool PlayCurrentSceneStreamsOnly { get; }
+
         /// <summary>
         ///     Applies a full preset, resetting all individual overrides
         /// </summary>
@@ -73,5 +76,8 @@ namespace DCL.Quality.Runtime
         // General Shadows
         void SetShadowQuality(ShadowQualityLevel level);
         void SetShadowDistance(int distance);
+
+        // Other
+        void SetPlayCurrentSceneStreamsOnly(bool enabled);
     }
 }

--- a/Explorer/Assets/DCL/Quality/Runtime/QualitySettingsController.cs
+++ b/Explorer/Assets/DCL/Quality/Runtime/QualitySettingsController.cs
@@ -33,6 +33,7 @@ namespace DCL.Quality.Runtime
         public int MaxSceneLights { get; private set; }
         public ShadowQualityLevel SceneShadowQuality { get; private set; }
         public int ShadowDistance { get; private set; }
+        public bool PlayCurrentSceneStreamsOnly { get; private set; }
 
         private readonly QualityPresetsAsset presetsAsset;
         private readonly UpscalingController upscalingController;
@@ -102,6 +103,7 @@ namespace DCL.Quality.Runtime
             MaxSceneLights = preset.MaxSceneLights;
             SceneShadowQuality = preset.ShadowsQualityLevel;
             ShadowDistance = preset.ShadowDistance;
+            PlayCurrentSceneStreamsOnly = preset.PlayCurrentSceneStreamsOnly;
 
             ApplyAllSettings();
             OnPresetChanged?.Invoke(level);
@@ -264,6 +266,14 @@ namespace DCL.Quality.Runtime
             TrackQualitySettingsReport();
         }
 
+        public void SetPlayCurrentSceneStreamsOnly(bool enabled)
+        {
+            PlayCurrentSceneStreamsOnly = enabled;
+            DCLPlayerPrefs.SetInt(DCLPrefKeys.PS_PLAY_CURRENT_SCENE_STREAMS_ONLY, enabled ? 1 : 0);
+            SwitchToCustom();
+            TrackQualitySettingsReport();
+        }
+
         private void SwitchToCustom()
         {
             if (CurrentPreset == QualityPresetLevel.Custom)
@@ -292,6 +302,7 @@ namespace DCL.Quality.Runtime
             MaxSceneLights = saved.MaxSceneLights;
             SceneShadowQuality = saved.SceneShadowQuality;
             ShadowDistance = saved.ShadowDistance;
+            PlayCurrentSceneStreamsOnly = saved.PlayCurrentSceneStreamsOnly;
         }
 
         private static void DeleteCustomSettings()
@@ -328,6 +339,7 @@ namespace DCL.Quality.Runtime
                 if (MaxSceneLights != b.MaxSceneLights) properties["max_scene_lights"] = MaxSceneLights;
                 if (SceneShadowQuality != b.ShadowsQualityLevel) properties["shadow_quality"] = SceneShadowQuality.ToString();
                 if (ShadowDistance != b.ShadowDistance) properties["shadow_distance"] = ShadowDistance;
+                if (PlayCurrentSceneStreamsOnly != b.PlayCurrentSceneStreamsOnly) properties["play_current_scene_streams_only"] = PlayCurrentSceneStreamsOnly;
             }
 
             analytics.Track(AnalyticsEvents.Settings.QUALITY_SETTINGS_REPORT, properties);

--- a/Explorer/Assets/DCL/Quality/Runtime/SavedQualitySettingsApplier.cs
+++ b/Explorer/Assets/DCL/Quality/Runtime/SavedQualitySettingsApplier.cs
@@ -25,6 +25,7 @@ namespace DCL.Quality.Runtime
             public int MaxSceneLights;
             public ShadowQualityLevel SceneShadowQuality;
             public int ShadowDistance;
+            public bool PlayCurrentSceneStreamsOnly;
         }
 
         public static QualityPresetLevel ReadSavedPreset() =>
@@ -56,6 +57,7 @@ namespace DCL.Quality.Runtime
                 MaxSceneLights = DCLPlayerPrefs.GetInt(DCLPrefKeys.PS_MAX_SCENE_LIGHTS, basePresetData.MaxSceneLights),
                 SceneShadowQuality = EnumUtils.FromInt<ShadowQualityLevel>(DCLPlayerPrefs.GetInt(DCLPrefKeys.PS_SHADOW_QUALITY, EnumUtils.ToInt(basePresetData.ShadowsQualityLevel))),
                 ShadowDistance = DCLPlayerPrefs.GetInt(DCLPrefKeys.PS_SHADOW_DISTANCE, basePresetData.ShadowDistance),
+                PlayCurrentSceneStreamsOnly = DCLPlayerPrefs.GetInt(DCLPrefKeys.PS_PLAY_CURRENT_SCENE_STREAMS_ONLY, basePresetData.PlayCurrentSceneStreamsOnly ? 1 : 0) == 1
             };
         }
 
@@ -81,6 +83,7 @@ namespace DCL.Quality.Runtime
             DCLPlayerPrefs.DeleteKey(DCLPrefKeys.PS_MAX_SCENE_LIGHTS);
             DCLPlayerPrefs.DeleteKey(DCLPrefKeys.PS_SHADOW_QUALITY);
             DCLPlayerPrefs.DeleteKey(DCLPrefKeys.PS_SHADOW_DISTANCE);
+            DCLPlayerPrefs.DeleteKey(DCLPrefKeys.PS_PLAY_CURRENT_SCENE_STREAMS_ONLY);
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/Quality/Settings/QualityPresetData.cs
+++ b/Explorer/Assets/DCL/Quality/Settings/QualityPresetData.cs
@@ -34,6 +34,9 @@ namespace DCL.Quality
         [SerializeField] internal ShadowQualityLevel shadowsQualityLevel;
         [SerializeField] internal int shadowDistance;
 
+        [Header("Other")]
+        [SerializeField] internal bool playCurrentSceneStreamsOnly;
+
         public int FpsLimit => fpsLimit;
         public bool VSyncEnabled => vSyncEnabled;
         public float ResolutionScale => resolutionScale;
@@ -49,6 +52,7 @@ namespace DCL.Quality
         public int MaxSceneLights => maxSceneLights;
         public ShadowQualityLevel ShadowsQualityLevel => shadowsQualityLevel;
         public int ShadowDistance => shadowDistance;
+        public bool PlayCurrentSceneStreamsOnly => playCurrentSceneStreamsOnly;
     }
 
     [Serializable]

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Settings/VideoPrioritizationSettings.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Settings/VideoPrioritizationSettings.cs
@@ -40,7 +40,7 @@ namespace DCL.SDKComponents.MediaStream.Settings
 
         [Tooltip("A value that determines if only streams of the current scene will play or even in the nearby scenes.")]
         [SerializeField]
-        public bool PlayCurrentSceneStreamOnly = true;
+        private bool playCurrentSceneStreamOnly = true;
 
         /// <summary>
         ///     Gets or sets the amount of videos that will be playing at the same time, at most, on camera.
@@ -83,6 +83,12 @@ namespace DCL.SDKComponents.MediaStream.Settings
         ///     Gets a value that determines which videos will be paused, without being prioritized, when their distance to the camera is above it.
         /// </summary>
         public float MaximumDistanceLimit => maximumDistanceLimit;
+
+        public bool PlayCurrentSceneStreamOnly
+        {
+            get => playCurrentSceneStreamOnly;
+            set => playCurrentSceneStreamOnly = value;
+        }
 
         /// <summary>
         ///     Raised when the maximum simultaneous videos property changes.

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Settings/VideoPrioritizationSettings.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Settings/VideoPrioritizationSettings.cs
@@ -38,6 +38,10 @@ namespace DCL.SDKComponents.MediaStream.Settings
         [SerializeField]
         private float maximumDistanceLimit = 100.0f;
 
+        [Tooltip("A value that determines if only streams of the current scene will play or even in the nearby scenes.")]
+        [SerializeField]
+        public bool PlayCurrentSceneStreamOnly = true;
+
         /// <summary>
         ///     Gets or sets the amount of videos that will be playing at the same time, at most, on camera.
         /// </summary>

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/MediaPlayerPluginWrapper.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/MediaPlayerPluginWrapper.cs
@@ -47,7 +47,7 @@ namespace DCL.SDKComponents.MediaStream
             MediaFactory mediaFactory = this.mediaFactory.CreateForScene(builder.World, sceneDeps);
 
             CreateMediaPlayerSystem.InjectToWorld(ref builder, sceneDeps.SceneStateProvider, mediaFactory);
-            sceneIsCurrentListeners.Add(UpdateMediaPlayerSystem.InjectToWorld(ref builder, sceneDeps.SceneData, sceneDeps.SceneStateProvider, frameTimeBudget, mediaFactory, audioFadeSpeed, flipMaterial));
+            sceneIsCurrentListeners.Add(UpdateMediaPlayerSystem.InjectToWorld(ref builder, sceneDeps.SceneData, sceneDeps.SceneStateProvider, frameTimeBudget, mediaFactory, audioFadeSpeed, flipMaterial, videoPrioritizationSettings));
 
             if (FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.VIDEO_PRIORITIZATION))
                 UpdateMediaPlayerPrioritizationSystem.InjectToWorld(ref builder, exposedCameraData, videoPrioritizationSettings);

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -5,6 +5,7 @@ using Arch.SystemGroups.Throttling;
 using DCL.Diagnostics;
 using DCL.ECSComponents;
 using DCL.Optimization.PerformanceBudgeting;
+using DCL.SDKComponents.MediaStream.Settings;
 using DCL.Utilities.Extensions;
 using ECS.Abstract;
 using ECS.Groups;
@@ -28,6 +29,7 @@ namespace DCL.SDKComponents.MediaStream
         private readonly MediaFactory mediaFactory;
         private readonly float audioFadeSpeed;
         private readonly Material flipMaterial;
+        private readonly VideoPrioritizationSettings videoPrioritizationSettings;
 
         private static float lastOpenMediaTime;
         private const float MIN_OPEN_MEDIA_INTERVAL_SECONDS = 0.5f;
@@ -39,7 +41,8 @@ namespace DCL.SDKComponents.MediaStream
             IPerformanceBudget frameTimeBudget,
             MediaFactory mediaFactory,
             float audioFadeSpeed,
-            Material flipMaterial
+            Material flipMaterial,
+            VideoPrioritizationSettings videoPrioritizationSettings
         ) : base(world)
         {
             this.sceneData = sceneData;
@@ -48,6 +51,7 @@ namespace DCL.SDKComponents.MediaStream
             this.mediaFactory = mediaFactory;
             this.audioFadeSpeed = audioFadeSpeed;
             this.flipMaterial = flipMaterial;
+            this.videoPrioritizationSettings = videoPrioritizationSettings;
         }
 
         protected override void Update(float t)
@@ -108,7 +112,8 @@ namespace DCL.SDKComponents.MediaStream
                         sdkComponent.HasSpatialMaxDistance ? sdkComponent.SpatialMaxDistance : null);
             }
 
-            ConsumePromise(ref component, sdkComponent.HasPlaying && sdkComponent.Playing);
+            if (!videoPrioritizationSettings.PlayCurrentSceneStreamOnly || sceneStateProvider.IsCurrent)
+                ConsumePromise(ref component, sdkComponent.HasPlaying && sdkComponent.Playing);
 
             // Need to re-update state in case an update was needed from the sdk component or promise
             component.UpdateState();
@@ -159,7 +164,7 @@ namespace DCL.SDKComponents.MediaStream
                         sdkComponent.HasSpatialMaxDistance ? sdkComponent.SpatialMaxDistance : null);
             }
 
-            if (ConsumePromise(ref component, false))
+            if ((!videoPrioritizationSettings.PlayCurrentSceneStreamOnly || sceneStateProvider.IsCurrent) && ConsumePromise(ref component, false))
                 component.MediaPlayer.SetPlaybackPropertiesAsync(sdkComponent).Forget();
 
             // Need to re-update state in case an update was needed from the sdk component or promise
@@ -176,7 +181,7 @@ namespace DCL.SDKComponents.MediaStream
 
             FadeVolume(ref mediaPlayer, customMediaStream.Volume, dt);
 
-            if (ConsumePromise(ref mediaPlayer, true))
+            if ((!videoPrioritizationSettings.PlayCurrentSceneStreamOnly || sceneStateProvider.IsCurrent) && ConsumePromise(ref mediaPlayer, true))
                 mediaPlayer.MediaPlayer.SetPlaybackProperties(customMediaStream);
         }
 
@@ -235,10 +240,15 @@ namespace DCL.SDKComponents.MediaStream
         [Query]
         private void ToggleCurrentStreamsState(Entity entity, MediaPlayerComponent mediaPlayerComponent, [Data] bool enteredScene)
         {
-            if (mediaPlayerComponent.MediaPlayer.IsLivekitPlayer(out LivekitPlayer livekitPlayer) && !enteredScene)
+            if (enteredScene) return;
+
+            bool isLivekit = mediaPlayerComponent.MediaPlayer.IsLivekitPlayer(out _);
+
+            // Livekit streams rely on the livekit room being active for the current scene only.
+            // Non-livekit streams are also stopped when PlayCurrentSceneStreamOnly is on so they can be
+            // recreated fresh by CreateMediaPlayerSystem when the player re-enters the scene.
+            if (isLivekit || videoPrioritizationSettings.PlayCurrentSceneStreamOnly)
             {
-                //Streams rely on livekit room being active; which can only be in we are on the same scene. Next time we enter the scene, it will be recreate by
-                //the regular CreateMediaPlayerSystem
                 mediaPlayerComponent.Dispose();
                 World.Remove<MediaPlayerComponent>(entity);
             }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -29,10 +29,8 @@ namespace DCL.SDKComponents.MediaStream
         private readonly float audioFadeSpeed;
         private readonly Material flipMaterial;
 
-#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
         private static float lastOpenMediaTime;
         private const float MIN_OPEN_MEDIA_INTERVAL_SECONDS = 0.5f;
-#endif
 
         public UpdateMediaPlayerSystem(
             World world,
@@ -277,25 +275,22 @@ namespace DCL.SDKComponents.MediaStream
             if (!component.OpenMediaPromise.IsResolved) return false;
             if (component.OpenMediaPromise.IsConsumed) return false;
 
-#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
             // On macOS, enforce minimum gap between HLS stream opens to prevent
             // AVFoundation crashes when opening multiple streams simultaneously.
             // If too soon since last open, defer the opening.
+            // On windows deferr to avoid frame drops when opening multiple streams simultaneously, as the media player can consume a lot of resources while opening a stream.
             float currentTime = UnityEngine.Time.realtimeSinceStartup;
             float timeSinceLastOpen = currentTime - lastOpenMediaTime;
 
             if (timeSinceLastOpen < MIN_OPEN_MEDIA_INTERVAL_SECONDS)
                 return false;
-#endif
 
             if (component.OpenMediaPromise.IsReachableConsume(component.MediaAddress))
             {
-#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
                 lastOpenMediaTime = currentTime;
 
                 ReportHub.Log(ReportCategory.MEDIA_STREAM,
                     $"[OpenMedia] Opening media: {component.MediaAddress}, Time: {currentTime:F3}, TimeSinceLastOpen: {timeSinceLastOpen:F3}s");
-#endif
 
                 Profiler.BeginSample(component.MediaPlayer.HasControl
                     ? "MediaPlayer.OpenMedia"

--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
@@ -67,6 +67,11 @@ MonoBehaviour:
       <Modules>k__BackingField:
       - rid: 2404945524685013121
       - rid: 2404945524685013122
+    - <GroupTitle>k__BackingField: Other
+      <FeatureFlagName>k__BackingField: 0
+      <FeatureId>k__BackingField: 0
+      <Modules>k__BackingField:
+      - rid: 7533463582823415905
   <SoundSectionConfig>k__BackingField:
     <SettingsGroups>k__BackingField:
     - <GroupTitle>k__BackingField: Volume
@@ -735,3 +740,20 @@ MonoBehaviour:
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
         <Feature>k__BackingField: 10
+    - rid: 7533463582823415905
+      type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
+      data:
+        <FeatureId>k__BackingField: 0
+        <View>k__BackingField:
+          m_AssetGUID: 39458b71e0ed84549b1b280c4fb1f105
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_SubObjectGUID: 
+          m_EditorAssetChanged: 0
+        <Config>k__BackingField:
+          <ModuleName>k__BackingField: Play current scene streams only
+          <Description>k__BackingField: Controls if the video streams are played
+            only for the current scene you are in or for all
+          <IsEnabled>k__BackingField: 1
+          defaultIsOn: 0
+        <Feature>k__BackingField: 11

--- a/Explorer/Assets/DCL/Settings/Configuration/ToggleModuleBinding.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/ToggleModuleBinding.cs
@@ -39,6 +39,7 @@ namespace DCL.Settings.Configuration
             SCENE_SHADOWS_FEATURE,
             SCENE_LIGHTS_FEATURE,
             FULLSCREEN_FEATURE,
+            PLAY_CURRENT_SCENE_STREAM_ONLY_FEATURE,
             // add other features...
         }
 
@@ -80,6 +81,7 @@ namespace DCL.Settings.Configuration
                 ToggleFeatures.SCENE_SHADOWS_FEATURE => CreateSimpleToggle(viewInstance, qualitySettingsController, qualitySettingsController.SetSceneLightShadows, x => x.SceneLightShadows),
                 ToggleFeatures.SCENE_LIGHTS_FEATURE => CreateSimpleToggle(viewInstance, qualitySettingsController, qualitySettingsController.SetSceneLights, x => x.SceneLights),
                 ToggleFeatures.FULLSCREEN_FEATURE => new FullscreenSettingsController(viewInstance),
+                ToggleFeatures.PLAY_CURRENT_SCENE_STREAM_ONLY_FEATURE => new PlayCurrentSceneStreamSettingsController(viewInstance, videoPrioritizationSettings, qualitySettingsController),
                 // add other cases...
                 _ => throw new ArgumentOutOfRangeException(nameof(viewInstance))
             };

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/PlayCurrentSceneStreamSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/PlayCurrentSceneStreamSettingsController.cs
@@ -1,0 +1,46 @@
+using DCL.Prefs;
+using DCL.Quality;
+using DCL.Quality.Runtime;
+using DCL.SDKComponents.MediaStream.Settings;
+using DCL.Settings.ModuleViews;
+using System;
+
+namespace DCL.Settings.ModuleControllers
+{
+    public class PlayCurrentSceneStreamSettingsController : BaseQualitySettingsFeatureController
+    {
+        private readonly SettingsToggleModuleView view;
+        private readonly VideoPrioritizationSettings videoPrioritizationSettings;
+
+        public PlayCurrentSceneStreamSettingsController(SettingsToggleModuleView view, VideoPrioritizationSettings videoPrioritizationSettings, IQualitySettingsController qualitySettingsController) : base(qualitySettingsController)
+        {
+            this.view = view;
+            this.videoPrioritizationSettings = videoPrioritizationSettings;
+
+            view.ToggleView.Toggle.onValueChanged.AddListener(SetPlayCurrentSceneStream);
+        }
+
+        protected override void OnPresetChanged(QualityPresetLevel _)
+        {
+            ManualUpdate(qualitySettingsController.VSync);
+        }
+
+        private void SetPlayCurrentSceneStream(bool enabled)
+        {
+            qualitySettingsController.SetPlayCurrentSceneStreamsOnly(enabled);
+            videoPrioritizationSettings.PlayCurrentSceneStreamOnly = enabled;
+        }
+
+        private void ManualUpdate(bool active)
+        {
+            view.ConfigureWithoutNotify(active);
+            videoPrioritizationSettings.PlayCurrentSceneStreamOnly = active;
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            view.ToggleView.Toggle.onValueChanged.RemoveAllListeners();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/PlayCurrentSceneStreamSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/PlayCurrentSceneStreamSettingsController.cs
@@ -31,7 +31,7 @@ namespace DCL.Settings.ModuleControllers
             qualitySettingsController.SetPlayCurrentSceneStreamsOnly(enabled);
             videoPrioritizationSettings.PlayCurrentSceneStreamOnly = enabled;
         }
-        
+
         public override void OnAllControllersInstantiated(List<SettingsFeatureController> controllers)
         {
             ManualUpdate(qualitySettingsController.PlayCurrentSceneStreamsOnly);

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/PlayCurrentSceneStreamSettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/PlayCurrentSceneStreamSettingsController.cs
@@ -4,6 +4,7 @@ using DCL.Quality.Runtime;
 using DCL.SDKComponents.MediaStream.Settings;
 using DCL.Settings.ModuleViews;
 using System;
+using System.Collections.Generic;
 
 namespace DCL.Settings.ModuleControllers
 {
@@ -22,13 +23,18 @@ namespace DCL.Settings.ModuleControllers
 
         protected override void OnPresetChanged(QualityPresetLevel _)
         {
-            ManualUpdate(qualitySettingsController.VSync);
+            ManualUpdate(qualitySettingsController.PlayCurrentSceneStreamsOnly);
         }
 
         private void SetPlayCurrentSceneStream(bool enabled)
         {
             qualitySettingsController.SetPlayCurrentSceneStreamsOnly(enabled);
             videoPrioritizationSettings.PlayCurrentSceneStreamOnly = enabled;
+        }
+        
+        public override void OnAllControllersInstantiated(List<SettingsFeatureController> controllers)
+        {
+            ManualUpdate(qualitySettingsController.PlayCurrentSceneStreamsOnly);
         }
 
         private void ManualUpdate(bool active)

--- a/Explorer/Assets/DCL/Settings/ModuleControllers/PlayCurrentSceneStreamSettingsController.cs.meta
+++ b/Explorer/Assets/DCL/Settings/ModuleControllers/PlayCurrentSceneStreamSettingsController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0cf53fa527e24e219db50ef507f193a9
+timeCreated: 1776075547

--- a/Explorer/Assets/DCL/Settings/Settings/QualityPresetLow.asset
+++ b/Explorer/Assets/DCL/Settings/Settings/QualityPresetLow.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
   maxSceneLights: 0
   shadowsQualityLevel: 0
   shadowDistance: 30
+  playCurrentSceneStreamsOnly: 1

--- a/Explorer/Assets/DCL/Settings/Settings/QualityPresetMedium.asset
+++ b/Explorer/Assets/DCL/Settings/Settings/QualityPresetMedium.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
   maxSceneLights: 6
   shadowsQualityLevel: 1
   shadowDistance: 60
+  playCurrentSceneStreamsOnly: 1


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7864
Some scenes have multiple streams running, as a consequence they create frame drops to nearby scenes, to avoid this, a new setting has been added that will allow disabling streams of nearby scenes.
This setting is on by default for low and medium settings, off for high settings.

## Test Instructions
To test this you need a parcel or a world (i.e. you can use the dafu world) with a screen that can play videos

### Test Steps
* check in the settings panel that by setting the different quality options this last setting that has been added behave as described above
* check that when you are outside of a scene bounds with a video and the setting is on the video doesn't play
* check that when you enter the scene the video plays
* check that when the setting is disabled all videos work fine (remember that livekit streams work only when you are inside the scene, no matter the configuration of this new setting)

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
