### PR TITLE
fix: error when removing members from a community

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListView.cs
@@ -183,8 +183,8 @@ namespace DCL.Communities.CommunitiesCard.Members
             // Owner can kick / ban either members and moderators,
             // moderators can only kick / ban members
             bool viewerCanKickOrBan = communityData?.role is CommunityMemberRole.owner
-                ? profile.Role is CommunityMemberRole.member or CommunityMemberRole.moderator
-                : communityData?.role is CommunityMemberRole.moderator && profile.Role is CommunityMemberRole.member;
+                ? profile.Role is not CommunityMemberRole.owner
+                : communityData?.role is CommunityMemberRole.moderator && profile.Role is not CommunityMemberRole.owner && profile.Role is not CommunityMemberRole.moderator;
 
             kickUserContextMenuElement!.Enabled = viewerCanKickOrBan && currentSection == MemberListSections.MEMBERS;
             banUserContextMenuElement!.Enabled = viewerCanKickOrBan && currentSection == MemberListSections.MEMBERS;

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Members/MembersListView.cs
@@ -30,7 +30,7 @@ namespace DCL.Communities.CommunitiesCard.Members
             MEMBERS,
             BANNED,
             REQUESTS,
-            INVITES
+            INVITES,
         }
 
         private const int ELEMENT_MISSING_THRESHOLD = 5;
@@ -104,7 +104,6 @@ namespace DCL.Communities.CommunitiesCard.Members
         private GetCommunityResponse.CommunityData? communityData;
         private CancellationTokenSource contextMenuCts = new ();
         private UniTask panelTask;
-        private bool viewerCanEdit => communityData?.role is CommunityMemberRole.moderator or CommunityMemberRole.owner;
 
         private CommunityInvitationContextMenuButtonHandler? invitationButtonHandler;
         private CommunitiesDataProvider.CommunitiesDataProvider? communitiesDataProvider;
@@ -181,8 +180,14 @@ namespace DCL.Communities.CommunitiesCard.Members
             if (!transferOwnershipContextMenuElement!.Interactable)
                 transferOwnershipContextMenuElement!.NonInteractableFeedback = TRANSFER_OWNERSHIP_NON_INTERACTABLE_FEEDBACK;
 
-            kickUserContextMenuElement!.Enabled = profile.Role != CommunityMemberRole.owner && viewerCanEdit && currentSection == MemberListSections.MEMBERS;
-            banUserContextMenuElement!.Enabled = profile.Role != CommunityMemberRole.owner && viewerCanEdit && currentSection == MemberListSections.MEMBERS;
+            // Owner can kick / ban either members and moderators,
+            // moderators can only kick / ban members
+            bool viewerCanKickOrBan = communityData?.role is CommunityMemberRole.owner
+                ? profile.Role is CommunityMemberRole.member or CommunityMemberRole.moderator
+                : communityData?.role is CommunityMemberRole.moderator && profile.Role is CommunityMemberRole.member;
+
+            kickUserContextMenuElement!.Enabled = viewerCanKickOrBan && currentSection == MemberListSections.MEMBERS;
+            banUserContextMenuElement!.Enabled = viewerCanKickOrBan && currentSection == MemberListSections.MEMBERS;
 
             communityOptionsSeparatorContextMenuElement!.Enabled = removeModeratorContextMenuElement.Enabled ||
                                                                    addModeratorContextMenuElement.Enabled ||


### PR DESCRIPTION
# Pull Request Description
Fix #8166

## What does this PR change?
The kick/ban context menu options in the community members list now respect role hierarchy:

- **Owners** can kick/ban members and moderators (but not other owners)
- **Moderators** can only kick/ban members (not other moderators or owners)
- `none` / `unknown` roles are treated as non-privileged and can be kicked/banned by both owners and moderators

Previously, the `viewerCanEdit` check only verified that the viewer was an owner or moderator, without distinguishing target roles — allowing moderators to kick/ban other moderators.

## Test Instructions

**Steps:**
```bash
metaforge explorer run 8217
```

1. Login with an account which is an **owner** of a community
2. Open said community
3. Open the members list, open the context menu of a **member** → kick/ban options should be **visible**
4. Open the context menu of a **moderator** → kick/ban options should be **visible**
5. Open the context menu of another **owner** → kick/ban options should be **hidden**
6. Switch to an account which is a **moderator** of a community (if needed)
7. Open said community
8. Open the members list, open the context menu of a **member** → kick/ban options should be **visible**
9. Open the context menu of a  **moderator** → kick/ban options should be **hidden**
10. Open the context menu of a **owner** → kick/ban options should be **hidden**

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included