### PR TITLE
fix: overlapping login screen on new account

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/IdentityVerificationDappAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/IdentityVerificationDappAuthState.cs
@@ -55,7 +55,14 @@ namespace DCL.AuthenticationScreenFlow
         public override void Exit()
         {
             if (loginException == null)
+            {
                 view.Hide(OUT);
+
+                // Hide login selection view if still visible (social logins skip the verification step,
+                // so ShowVerification is never called and the login selection view remains active)
+                if (viewInstance.LoginSelectionAuthView.gameObject.activeSelf)
+                    viewInstance.LoginSelectionAuthView.Hide();
+            }
             else
             {
                 if (currentState.Value == AuthStatus.VerificationRequested)


### PR DESCRIPTION
# Pull Request Description
Fixes #8167 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes sure that if we hit a proper login which doesn't cross `ShowVerification` (happens with a fresh account, since we are not waiting for matching codes), the login selection view is hidden so it doesn't overlap the jump-in screen


## Test Steps
1. Verify that the whole login flow works as normal
2. While being in the login selection, create a new account on metamask and chose metamask as login method in the client
3. Confirm all auths for the new account
4. Skip customization and confirm the login
5. Verify that the screens now don't overlap (as described in the linked issue) and the flow behaves correctly

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
