### PR TITLE
fix: use Y axis for LODGroup size to fix early LOD culling

### DIFF
--- a/Explorer/Assets/DCL/LOD/Components/SceneLODInfo.cs
+++ b/Explorer/Assets/DCL/LOD/Components/SceneLODInfo.cs
@@ -125,8 +125,8 @@ namespace DCL.LOD.Components
             for (int i = 1; i < renderersCount; i++)
                 mergedBounds.Encapsulate(lodRenderers[i].bounds);
 
-            //Object size required to be the largest of the 3 axis
-            metadata.LodGroup.size = Mathf.Max(Mathf.Max(mergedBounds.size.x, mergedBounds.size.y), mergedBounds.size.z);
+            //Object size based on the Y axis, as screen-relative height is what Unity evaluates for LODGroup transitions
+            metadata.LodGroup.size = mergedBounds.size.y;
         }
 
         private void CalculateCullRelativeHeight(float defaultFOV, float defaultLodBias, int loadingDistance)

--- a/Explorer/Assets/DCL/LOD/Systems/LODUtils.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/LODUtils.cs
@@ -42,7 +42,7 @@ namespace DCL.LOD.Systems
                         {
                             if (TEMP_MATERIALS[j].mainTexture.width != TEMP_MATERIALS[j].mainTexture.height)
                             {
-                                ReportHub.LogWarning(ReportCategory.LOD, $"Trying to apply a non square resolution in {sceneID} {baseCoordinate}");
+                                ReportHub.LogWarning(ReportCategory.LOD, $"Trying to apply a non square resolution in {sceneID} {baseCoordinate}. Texture '{TEMP_MATERIALS[j].mainTexture.name}' is {TEMP_MATERIALS[j].mainTexture.width}x{TEMP_MATERIALS[j].mainTexture.height}");
                                 continue;
                             }
 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreiab7g5s2nrkqodf3gizxxcmb3l7ft5wptzb2c5u42zpf4vo4d7fo4_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreiab7g5s2nrkqodf3gizxxcmb3l7ft5wptzb2c5u42zpf4vo4d7fo4_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2518e20ca06785a796766527133765524a7b6467a8548e39ea4d98d0afcc4d28
+size 915930

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreiab7g5s2nrkqodf3gizxxcmb3l7ft5wptzb2c5u42zpf4vo4d7fo4_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreiab7g5s2nrkqodf3gizxxcmb3l7ft5wptzb2c5u42zpf4vo4d7fo4_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d6c8af688a7d94121a9d59a61197f8a9
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreiaszttgzy5hyjzebunida5djcbgb7gnd2lanhno6innchd65pyf6m_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreiaszttgzy5hyjzebunida5djcbgb7gnd2lanhno6innchd65pyf6m_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3726aee0bba56255dd2226e83e23639b9edf637b13c888db3561aceb68918fe4
+size 854762

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreiaszttgzy5hyjzebunida5djcbgb7gnd2lanhno6innchd65pyf6m_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreiaszttgzy5hyjzebunida5djcbgb7gnd2lanhno6innchd65pyf6m_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e16bbc08e6ce0433ea1578820375ba85
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreib6c2rw5k7eqvuslfjjpb5rdbqzfkzuysml7wpmsb53bcmxlf6oze_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreib6c2rw5k7eqvuslfjjpb5rdbqzfkzuysml7wpmsb53bcmxlf6oze_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:632875d6ffff57565161c3543763d5a462a19d7dd94f5f4feacfc541c618eb1d
+size 528468

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreib6c2rw5k7eqvuslfjjpb5rdbqzfkzuysml7wpmsb53bcmxlf6oze_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreib6c2rw5k7eqvuslfjjpb5rdbqzfkzuysml7wpmsb53bcmxlf6oze_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 55f0fc66bc8a14002aaa36eba6bfca3e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreic5dmnp5nifb7arrja4lmzopzgqsnycg56a3vaufo7voog5lblxne_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreic5dmnp5nifb7arrja4lmzopzgqsnycg56a3vaufo7voog5lblxne_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a62aa0fc00fb2e7023474eca39dbd58aa2f77b1075e34ef8a3e305d28e6c2958
+size 1318817

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreic5dmnp5nifb7arrja4lmzopzgqsnycg56a3vaufo7voog5lblxne_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreic5dmnp5nifb7arrja4lmzopzgqsnycg56a3vaufo7voog5lblxne_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4e9ffb3edc66748ca80fd53093c06096
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreidgzk7ycydzmx7xrw2tjhemss54djubvsn5guhrujibh4eeumkix4_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreidgzk7ycydzmx7xrw2tjhemss54djubvsn5guhrujibh4eeumkix4_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfdbbe8f450464547f7ac30e142bef2bd3fa710ca5385819e737ec7fcff0af1e
+size 397572

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreidgzk7ycydzmx7xrw2tjhemss54djubvsn5guhrujibh4eeumkix4_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreidgzk7ycydzmx7xrw2tjhemss54djubvsn5guhrujibh4eeumkix4_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b657d7d0fb2d94ab2b0154f983fe2c27
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreidumi4bps45ui5ny4usm3atsjtj5imnxkgc24jd3wc6uigfmgdnte_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreidumi4bps45ui5ny4usm3atsjtj5imnxkgc24jd3wc6uigfmgdnte_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66b60247bf1ef35b0c4c3f20872e122459afbfdbd499d0a50523b26f7cddfcb0
+size 895123

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreidumi4bps45ui5ny4usm3atsjtj5imnxkgc24jd3wc6uigfmgdnte_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreidumi4bps45ui5ny4usm3atsjtj5imnxkgc24jd3wc6uigfmgdnte_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7c83ad46956eb4e96bd9d9995506eab9
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreie2ethh6vd2nh2yix6gdqfcnkodm46uj5qjea54cjbqb4qowe66sy_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreie2ethh6vd2nh2yix6gdqfcnkodm46uj5qjea54cjbqb4qowe66sy_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07454babade21cdf30b8553887f81dbc12ac1fd3fd523a3377f3029ae6bdbd45
+size 358800

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreie2ethh6vd2nh2yix6gdqfcnkodm46uj5qjea54cjbqb4qowe66sy_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreie2ethh6vd2nh2yix6gdqfcnkodm46uj5qjea54cjbqb4qowe66sy_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8004f688e371e4a9eb82238bee7ff4c7
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreifblpxvraianuh3gte2ohhu5tpatl7dqbbhenefl44uvbmdzkv25m_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreifblpxvraianuh3gte2ohhu5tpatl7dqbbhenefl44uvbmdzkv25m_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ef0f50edeefa3fcd56a5874e186ec91669bcba4c00b0ead43d3ddf10826d131
+size 348266

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreifblpxvraianuh3gte2ohhu5tpatl7dqbbhenefl44uvbmdzkv25m_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreifblpxvraianuh3gte2ohhu5tpatl7dqbbhenefl44uvbmdzkv25m_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8f3daa29c8c284b42b71498be0307bf7
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreifd6ya77mmo7lbdfxyqovpx5msudczk5ipkwqaofukylgzj4ljwa4_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreifd6ya77mmo7lbdfxyqovpx5msudczk5ipkwqaofukylgzj4ljwa4_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b94e4c349604556ae15e81189d16dcdf0282a8a056a314fb3a362abd915251b4
+size 1924268

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreifd6ya77mmo7lbdfxyqovpx5msudczk5ipkwqaofukylgzj4ljwa4_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreifd6ya77mmo7lbdfxyqovpx5msudczk5ipkwqaofukylgzj4ljwa4_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 742734264315442b38b3e0659bdf47bb
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreig4tlkkhmcrjb4ybrz5ylswdbmdnavjbmm76a6qbw5huuthsshgge_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreig4tlkkhmcrjb4ybrz5ylswdbmdnavjbmm76a6qbw5huuthsshgge_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a83e66edefdf9509900678491573f3ed00d0836a4e536e743e1076afa55f18a6
+size 997741

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreig4tlkkhmcrjb4ybrz5ylswdbmdnavjbmm76a6qbw5huuthsshgge_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreig4tlkkhmcrjb4ybrz5ylswdbmdnavjbmm76a6qbw5huuthsshgge_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0d1a817dc5fdc436b88be03cb797b0aa
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreighl6hd5rubetryckqi4rmk7jp46qoy3i2zc6w6t4wimcsbnd3b4i_1_mac
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreighl6hd5rubetryckqi4rmk7jp46qoy3i2zc6w6t4wimcsbnd3b4i_1_mac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4123dff2081d0fb5ecfe9e7988acafbc8d17d623b1366756efe48c906f68dcd
+size 796637

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreighl6hd5rubetryckqi4rmk7jp46qoy3i2zc6w6t4wimcsbnd3b4i_1_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/bafkreighl6hd5rubetryckqi4rmk7jp46qoy3i2zc6w6t4wimcsbnd3b4i_1_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f92953afa22bb479bad82575005b5bab
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/buildlogtep.json
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/buildlogtep.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:091bb5ca32e9cc41096c156eb396d716ee0447209d20f2d35d7b7054ca277b72
+size 8653

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/buildlogtep.json.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/buildlogtep.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 080479d620f2445f3a216e37acc1062d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/StreamingAssets/AssetBundles/lods/dcl/scene_texarray_ignore_mac.meta
+++ b/Explorer/Assets/StreamingAssets/AssetBundles/lods/dcl/scene_texarray_ignore_mac.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d5a7b7fbf345945f3a6c45239046d430
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Use `mergedBounds.size.y` instead of max axis for `LODGroup.size`, reducing inflated `CullRelativeHeightPercentage` on wide/long scenes that caused LODs to disappear too soon
- Improve non-square texture warning to include texture name and dimensions for easier debugging

## Test plan
- [ ] Verify LOD_1 remains visible at expected distances for multi-parcel scenes
- [ ] Check that small single-parcel scenes still cull correctly
- [ ] Confirm non-square texture warnings now show texture name and resolution in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)