### PR TITLE
chore: improve PR review automation and documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -82,4 +82,4 @@ metaforge explorer test XXXX
 - [ ] For SDK features: Test scene is included
 
 ## Code Review Reference
-Please review our [Code Review Standards](https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md) before submitting.
+Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.

--- a/.github/prompts/review-instructions.md
+++ b/.github/prompts/review-instructions.md
@@ -1,0 +1,78 @@
+Read `CLAUDE.md` and `docs/README.md` before reviewing. Load the relevant subsystem doc for the diff. Cite the specific rule or doc section when flagging a violation.
+
+--- ROOT-CAUSE CHECK ---
+Before listing issues, state in the summary comment: what problem is this PR solving, and does the diff fix the cause or a symptom?
+Flag as FAIL if the diff null-checks a value that shouldn't be null there, swallows an exception without addressing the source, works around a race instead of fixing ordering, or disables a check to make tests pass. Say what the actual fix would be.
+
+--- BLOCKING ISSUES ---
+Report ONLY issues that require fixes:
+1. Code quality violations per CLAUDE.md standards (cite the rule)
+2. Bugs or potential runtime errors
+3. Security vulnerabilities
+4. Performance issues
+5. Missing error handling
+6. Unclear or problematic logic
+
+For each issue found:
+- Location: File and line number
+- Problem: What is wrong (be specific)
+- Fix: Exact change needed
+- Why: Brief explanation of the impact
+
+Use mcp__github_inline_comment__create_inline_comment for specific line issues.
+Use Bash(gh pr comment) for a top-level summary comment.
+Do NOT include praise, style preferences, or nice-to-have suggestions.
+
+--- COMPLEXITY ASSESSMENT ---
+After reviewing the diff, classify the PR complexity as SIMPLE or COMPLEX.
+
+A PR is SIMPLE when ALL of the following are true:
+- Touches 3 or fewer files with under ~150 lines of meaningful changes
+- Changes are straightforward: typo fixes, config tweaks, log/comment changes,
+  dependency bumps, small bug fixes with obvious cause and fix
+- Does not modify ECS systems, components, queries, or system execution order
+- Does not touch entity structural changes (Add/Remove component operations)
+- Does not alter cross-world ECS access, propagation systems, or bridge components
+- Does not modify async/UniTask patterns, cancellation flows, or Result types
+- Does not change plugin registration, containers, dependency injection, or assembly definitions
+- Does not touch the avatar rendering pipeline (GPU skinning, GVB, wearable loading, compute shaders)
+- Does not modify scene runtime, CRDT synchronization, or JS module system
+- Does not affect asset promise lifecycle, memory budgeting, pooling, or cache unloading
+- Does not change networking, LiveKit rooms, movement encoding, or multiplayer sync
+- Does not alter physics, player/camera singletons, or input handling
+- Does not modify auth, web3 signing, or security-sensitive code paths
+
+A PR is COMPLEX when ANY of the following are true:
+- Touches core ECS infrastructure (systems, components, queries, world management)
+- Modifies cross-world access patterns (global ↔ scene propagation, PersistentEntities)
+- Changes component structural operations (ref invalidation risk from Add/Remove)
+- Alters async flow (new UniTask/UniTaskVoid, cancellation, SuppressToResultAsync)
+- Modifies plugin/container wiring, system registration, or assembly structure
+- Touches avatar system, scene runtime, CRDT bridge, or asset loading pipeline
+- Changes networking, multiplayer sync, or movement interpolation
+- Affects memory management, object pooling, or resource cleanup paths
+- Modifies shared interfaces, public APIs, or abstractions used across assemblies
+- Introduces new dependencies or changes dependency injection
+- Risk of silent data corruption or subtle regressions is non-trivial
+- Large diff (4+ files or significant logic changes)
+
+--- QA ASSESSMENT ---
+Determine whether QA (manual testing) is needed for this PR.
+
+QA_REQUIRED: NO when ALL of the following are true:
+- Changes are limited to CI/CD workflows (.github/), scripts, documentation,
+  config files, or other non-runtime code
+- No user-facing behavior is affected (UI, rendering, gameplay, input, audio, etc.)
+- No changes to code that runs in the Unity player at runtime
+
+QA_REQUIRED: YES when ANY of the following are true:
+- Changes could affect what the user sees, hears, or interacts with
+- Modifies runtime code (anything under Explorer/ that ships in the build)
+- Touches UI, rendering, avatars, scenes, networking, or player-facing systems
+- Changes asset loading, authentication, or navigation flows
+
+IMPORTANT: At the very end of your output, emit exactly these four lines (order matters — downstream automation parses them):
+REVIEW_RESULT: PASS ✅  (or FAIL ❌)
+COMPLEXITY: SIMPLE  (or COMPLEX)
+COMPLEXITY_REASON: <one sentence citing which subsystem(s) the diff touches>
+QA_REQUIRED: YES  (or NO)

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -53,6 +53,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
+      - name: Load review instructions
+        if: steps.check-type.outputs.is-auto-review == 'true'
+        id: prompt
+        run: echo "instructions<<PROMPT_EOF" >> "$GITHUB_OUTPUT" && cat .github/prompts/review-instructions.md >> "$GITHUB_OUTPUT" && echo "PROMPT_EOF" >> "$GITHUB_OUTPUT"
+
       - name: Claude Review
         if: steps.check-type.outputs.is-auto-review == 'true'
         id: claude
@@ -64,78 +69,9 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            This is an automatic review for a bug fix / chore PR. Review the full PR diff.
+            This is an automatic review for a fix / chore PR. Review the full PR diff.
 
-            Review Focus — report ONLY issues that require fixes:
-            1. Code quality violations per CLAUDE.md standards
-            2. Bugs or potential runtime errors
-            3. Security vulnerabilities
-            4. Performance issues
-            5. Missing error handling
-            6. Unclear or problematic logic
-
-            For each issue found:
-            - Location: File and line number
-            - Problem: What is wrong (be specific)
-            - Fix: Exact change needed
-            - Why: Brief explanation of the impact
-
-            Use mcp__github_inline_comment__create_inline_comment for specific line issues.
-            Use Bash(gh pr comment) for a top-level summary comment.
-            Do NOT include praise, style preferences, or nice-to-have suggestions.
-
-            --- COMPLEXITY ASSESSMENT ---
-            After reviewing the diff, classify the PR complexity as SIMPLE or COMPLEX.
-
-            A PR is SIMPLE when ALL of the following are true:
-            - Touches 3 or fewer files with under ~150 lines of meaningful changes
-            - Changes are straightforward: typo fixes, config tweaks, log/comment changes,
-              dependency bumps, small bug fixes with obvious cause and fix
-            - Does not modify ECS systems, components, queries, or system execution order
-            - Does not touch entity structural changes (Add/Remove component operations)
-            - Does not alter cross-world ECS access, propagation systems, or bridge components
-            - Does not modify async/UniTask patterns, cancellation flows, or Result types
-            - Does not change plugin registration, containers, dependency injection, or assembly definitions
-            - Does not touch the avatar rendering pipeline (GPU skinning, GVB, wearable loading, compute shaders)
-            - Does not modify scene runtime, CRDT synchronization, or JS module system
-            - Does not affect asset promise lifecycle, memory budgeting, pooling, or cache unloading
-            - Does not change networking, LiveKit rooms, movement encoding, or multiplayer sync
-            - Does not alter physics, player/camera singletons, or input handling
-            - Does not modify auth, web3 signing, or security-sensitive code paths
-
-            A PR is COMPLEX when ANY of the following are true:
-            - Touches core ECS infrastructure (systems, components, queries, world management)
-            - Modifies cross-world access patterns (global ↔ scene propagation, PersistentEntities)
-            - Changes component structural operations (ref invalidation risk from Add/Remove)
-            - Alters async flow (new UniTask/UniTaskVoid, cancellation, SuppressToResultAsync)
-            - Modifies plugin/container wiring, system registration, or assembly structure
-            - Touches avatar system, scene runtime, CRDT bridge, or asset loading pipeline
-            - Changes networking, multiplayer sync, or movement interpolation
-            - Affects memory management, object pooling, or resource cleanup paths
-            - Modifies shared interfaces, public APIs, or abstractions used across assemblies
-            - Introduces new dependencies or changes dependency injection
-            - Risk of silent data corruption or subtle regressions is non-trivial
-            - Large diff (4+ files or significant logic changes)
-
-            --- QA ASSESSMENT ---
-            Determine whether QA (manual testing) is needed for this PR.
-
-            QA_REQUIRED: NO when ALL of the following are true:
-            - Changes are limited to CI/CD workflows (.github/), scripts, documentation,
-              config files, or other non-runtime code
-            - No user-facing behavior is affected (UI, rendering, gameplay, input, audio, etc.)
-            - No changes to code that runs in the Unity player at runtime
-
-            QA_REQUIRED: YES when ANY of the following are true:
-            - Changes could affect what the user sees, hears, or interacts with
-            - Modifies runtime code (anything under Explorer/ that ships in the build)
-            - Touches UI, rendering, avatars, scenes, networking, or player-facing systems
-            - Changes asset loading, authentication, or navigation flows
-
-            IMPORTANT: At the very end of your output, emit exactly these three lines:
-            REVIEW_RESULT: PASS ✅  (or FAIL ❌)
-            COMPLEXITY: SIMPLE  (or COMPLEX)
-            QA_REQUIRED: YES  (or NO)
+            ${{ steps.prompt.outputs.instructions }}
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
             --max-turns 40
@@ -165,15 +101,14 @@ jobs:
             const errored = '${{ steps.claude.outcome }}' === 'failure';
             const isSimple = output.includes('COMPLEXITY: SIMPLE');
             const qaRequired = !output.includes('QA_REQUIRED: NO');
+            const hasReviewResult = output.includes('REVIEW_RESULT:');
             const passed = !failed && !errored;
 
             if (passed && isSimple) {
-              // Determine approval message based on QA need
               const approvalBody = qaRequired
                 ? 'Auto-approved by Claude — simple fix/chore with no blocking issues. QA approval is still required.'
                 : 'Auto-approved by Claude — simple fix/chore with no blocking issues. No QA needed (non-runtime changes only).';
 
-              // Simple fix/chore with no issues — auto-approve
               await github.rest.pulls.createReview({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -182,7 +117,6 @@ jobs:
                 body: approvalBody
               });
 
-              // Add label so enforce-group-approvals knows to skip DEV requirement
               const labels = ['claude-approved'];
               if (!qaRequired) {
                 labels.push('no QA needed');
@@ -194,7 +128,6 @@ jobs:
                 labels
               });
             } else if (passed && !isSimple) {
-              // Complex but no issues — flag for human review
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -203,14 +136,21 @@ jobs:
               });
             }
 
+            let description;
+            if (errored && !output) {
+              description = 'Claude review failed — credit balance too low or API error';
+            } else if (errored && output && !hasReviewResult) {
+              description = 'Claude review failed — reached maximum number of turns';
+            } else if (errored) {
+              description = 'Claude review encountered an error';
+            } else if (failed) {
+              description = 'Claude found issues that must be resolved';
+            } else if (isSimple) {
+              description = 'No blocking issues found — PR auto-approved';
+            } else {
+              description = 'No blocking issues — complex change, DEV review required';
+            }
             const state = (failed || errored) ? 'failure' : 'success';
-            const description = errored
-              ? 'Claude review encountered an error'
-              : failed
-              ? 'Claude found issues that must be resolved'
-              : isSimple
-              ? 'No blocking issues found — PR auto-approved'
-              : 'No blocking issues — complex change, DEV review required';
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -301,6 +241,10 @@ jobs:
           ref: ${{ steps.pr.outputs.sha }}
           fetch-depth: 1
 
+      - name: Load review instructions
+        id: prompt
+        run: echo "instructions<<PROMPT_EOF" >> "$GITHUB_OUTPUT" && cat .github/prompts/review-instructions.md >> "$GITHUB_OUTPUT" && echo "PROMPT_EOF" >> "$GITHUB_OUTPUT"
+
       - name: Claude Review
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -316,29 +260,7 @@ jobs:
                 'A re-review has been requested. Focus on whether previously raised issues have been addressed. Check prior review comments on this PR before assessing the diff.' ||
                 'A review has been requested. Review the full PR diff.' }}
 
-            Review Focus — report ONLY issues that require fixes:
-            1. Code quality violations per CLAUDE.md standards
-            2. Bugs or potential runtime errors
-            3. Security vulnerabilities
-            4. Performance issues
-            5. Missing error handling
-            6. Unclear or problematic logic
-
-            For each issue found:
-            - Location: File and line number
-            - Problem: What is wrong (be specific)
-            - Fix: Exact change needed
-            - Why: Brief explanation of the impact
-
-            Use mcp__github_inline_comment__create_inline_comment for specific line issues.
-            Use Bash(gh pr comment) for a top-level summary comment.
-            Do NOT include praise, style preferences, or nice-to-have suggestions.
-
-            IMPORTANT: At the very end, output a single line in this exact format:
-            REVIEW_RESULT: PASS ✅
-            or
-            REVIEW_RESULT: FAIL ❌
-            PASS means no blocking issues found. FAIL means there are issues that must be fixed before merging.
+            ${{ steps.prompt.outputs.instructions }}
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
             --max-turns 40
@@ -348,31 +270,38 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Find Claude's comment on this PR
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: ${{ github.event.issue.number }},
               per_page: 100
             });
-      
-            // Find the most recent comment from claude[bot]
+
             const claudeComment = comments.data
               .reverse()
               .find(c => c.user?.login === 'claude[bot]');
-      
+
             const output = claudeComment?.body ?? '';
             console.log('Claude comment preview:', output.slice(0, 200));
-      
+
             const failed = output.includes('REVIEW_RESULT: FAIL');
             const errored = '${{ steps.claude.outcome }}' === 'failure';
+            const hasReviewResult = output.includes('REVIEW_RESULT:');
+
+            let description;
+            if (errored && !output) {
+              description = 'Claude review failed — credit balance too low or API error';
+            } else if (errored && output && !hasReviewResult) {
+              description = 'Claude review failed — reached maximum number of turns';
+            } else if (errored) {
+              description = 'Claude review encountered an error';
+            } else if (failed) {
+              description = 'Claude found issues that must be resolved';
+            } else {
+              description = 'No blocking issues found';
+            }
             const state = (failed || errored) ? 'failure' : 'success';
-            const description = errored
-              ? 'Claude review encountered an error'
-              : failed
-              ? 'Claude found issues that must be resolved'
-              : 'No blocking issues found';
-      
+
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/enforce-group-approvals.yml
+++ b/.github/workflows/enforce-group-approvals.yml
@@ -133,11 +133,31 @@ jobs:
             MISSING_MSG=$(IFS=", "; echo "${MISSING[*]}")
             echo "❌ PR must have at least 1: $MISSING_MSG."
             echo "APPROVAL_CHECK=failed" >> $GITHUB_ENV
+            echo "MISSING_MSG=Waiting on: $MISSING_MSG" >> $GITHUB_ENV
             exit 1
           fi
 
           echo "✅ PR has the required approvals."
           echo "APPROVAL_CHECK=passed" >> $GITHUB_ENV
+          echo "MISSING_MSG=" >> $GITHUB_ENV
+
+      - name: Set approval status on commit
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
+        run: |
+          if [ "$APPROVAL_CHECK" == "passed" ]; then
+            STATE="success"
+            DESC="QA and DEV approvals satisfied"
+          else
+            STATE="failure"
+            DESC="${MISSING_MSG:-Waiting on: QA approval, DEV approval}"
+          fi
+
+          gh api "repos/$REPO_OWNER/$REPO_NAME/statuses/$HEAD_SHA" \
+            -f state="$STATE" \
+            -f context="QA and DEV Approvals" \
+            -f description="$DESC"
 
       - name: Search Failed "Enforce QA and DEV Approvals" Run
         env:

--- a/.github/workflows/welcome-external-contributor.yml
+++ b/.github/workflows/welcome-external-contributor.yml
@@ -1,0 +1,52 @@
+name: Welcome External Contributor
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  welcome:
+    if: |
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'auto-pr')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Check author team membership and post welcome
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const title = context.payload.pull_request.title || '';
+
+            // Skip if author is in explorer-devs or qa teams
+            for (const team of ['explorer-devs', 'qa']) {
+              try {
+                await github.rest.teams.getMembershipForUserInOrg({
+                  org: context.repo.owner,
+                  team_slug: team,
+                  username: author
+                });
+                return; // internal — no welcome needed
+              } catch (e) { /* 404 = not a member, keep checking */ }
+            }
+
+            const isAutoReview = /^(fix|chore)(\(.*?\))?!?:/i.test(title);
+            const body = [
+              `Thanks for opening this PR! Here's how the review process works:`,
+              '',
+              isAutoReview
+                ? '**Auto-review is running** — this is a `fix:`/`chore:` PR, so Claude will review it automatically. A QA reviewer and a DEV reviewer have been auto-assigned.'
+                : '**This is a `feat:`/`opti:` PR** — automatic AI review does not run for these. Comment `@claude review` to request a review, or `@claude re-review` after addressing feedback.',
+              '',
+              'For the full review process, labels, and merge requirements, see [Branch & PR Standards](../docs/branch-and-pr-standards.md).'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body
+            });

--- a/docs/branch-and-pr-standards.md
+++ b/docs/branch-and-pr-standards.md
@@ -1,56 +1,165 @@
 # Branch & PR Standards
 
+This document describes how code reaches `dev` and `main` — branching, PR metadata, the automated review/approval flow, and the labels that drive it. External contributors and team members should both be able to open a PR using only this page.
+
+---
+
 ## Branches
 
-The unity explorer codebase is held in 2 main branches:
-* dev: where all the branches are merged
-* main: the branch used to create new releases
+Two long-lived branches:
+- **`dev`** — integration branch. All feature and fix branches merge here.
+- **`main`** — release branch. Only release-cut commits land here.
 
-When working on a bug or a new functionality, it's important that the code is committed in a separate branch based on the dev branch.
+Work branches are created off `dev` using these prefixes:
 
-We are using the following naming convention:
-* `feat/...` - for branches about new functionalities
-* `fix/...` - for branches about bugfixing
-* `chore/...` - for chores such as code cleanup, minor tweaks
-* `opti/...` - for optimization related things
+| Prefix | Purpose |
+|---|---|
+| `feat/` | New functionality |
+| `fix/` | Bug fix |
+| `chore/` | Cleanup, tooling, non-runtime tweaks |
+| `opti/` | Optimization |
 
-It is allowed to create feature-related sublevel there - `feat/analytics/...`, `fix/sdk-scene/...`
+Feature-scoped sub-prefixes are allowed: `feat/analytics/...`, `fix/sdk-scene/...`.
 
-## Pull requests
+---
 
-In order to merge the changes made in a branch, a pull request has to be created in GitHub.
+## PR title
 
-The PR name can mimic the branch name with the following LOWERCASE convention:
-* feat:
-* fix:
-* chore:
-* opti:
+The PR title must start with one of the same prefixes, **lowercase**, followed by a colon:
 
-If the PR solves an issue it is important that the description contains the following text:
-`Fix #IssueNumber`
-So that the issue will be automatically linked with the PR and closed once the PR is merged.
+- `feat: add emote wheel quick-select`
+- `fix: null ref when scene unloads mid-animation`
+- `chore: bump UniTask to 2.5.10`
+- `opti: skip avatar skinning for offscreen players`
 
-As the PR template will suggest, the description needs to contain a few important sections:
-* A generic description of what the PR achieves
-* A technical description to help guide technical reviews
-* A step by step guide to help QA test the results
+The prefix matters — it drives automation (see below). `fix:` and `chore:` PRs receive automatic AI review; `feat:` and `opti:` do not.
 
-To merge the PR multiple steps have to be completed:
-* The PR needs to be reviewed and approved by QA
-* The PR needs to be reviewed and approved by developers
-* The build and tests need to be successful
+If the PR closes an issue, include `Fix #NNNN` in the description so GitHub links and auto-closes it.
 
-Once all the steps have been reached the PR can be merged with the 'squash and merge' button
+---
+
+## PR description
+
+The PR template has three sections. All three must be filled in:
+
+1. **What does this PR change?** — what and *why*. For optimizations, include before/after numbers. For SDK features, include or link a test scene.
+2. **Test Instructions** — copy-pasteable steps. This is what QA will run.
+3. **Quality Checklist** — self-check before marking ready for review.
+
+A PR with empty sections will typically be sent back before review starts.
+
+---
+
+## What happens after you open the PR
+
+The flow below is entirely automated — you usually don't need to assign anyone by hand.
+
+### 1. Reviewers are auto-assigned
+- **1 QA reviewer** is picked from the `qa` team ([`.github/auto_assign_config_qa.yml`](../.github/auto_assign_config_qa.yml)).
+- **1 developer reviewer** is picked from the `devs` or `techleads` group ([`.github/auto_assign_config_dev.yml`](../.github/auto_assign_config_dev.yml)).
+
+Skip auto-assign by adding the `no review` or `no QA needed` label (see [Labels](#labels) for when that's legitimate).
+
+### 2. AI pre-review
+
+The `Claude Review` workflow ([`.github/workflows/claude-pr-review.yml`](../.github/workflows/claude-pr-review.yml)) reviews the diff against the project's architecture docs and code standards.
+
+**Automatic** for `fix:` and `chore:` PRs — runs on open and on every push.
+
+**Manual** for `feat:` and `opti:` PRs — comment `@claude review` on the PR to trigger it. External contributors will see a welcome comment with these instructions when they open a PR.
+
+The review:
+- Reads the diff, [`CLAUDE.md`](../CLAUDE.md), and the relevant subsystem docs.
+- Checks whether the PR addresses the root cause or patches a symptom.
+- Posts inline comments for blocking issues (bugs, standards violations, missing error handling, perf regressions).
+- Classifies the PR as **SIMPLE** or **COMPLEX** (with a one-line justification).
+- Decides whether QA is needed (`QA_REQUIRED: YES/NO`).
+- Emits a `Claude Review` commit status (pass/fail).
+
+**Outcomes (for auto-reviewed `fix:`/`chore:` PRs):**
+
+| AI verdict | Complexity | Effect |
+|---|---|---|
+| PASS | SIMPLE | Auto-approves the PR, adds `claude-approved` label, DEV approval no longer required. |
+| PASS | COMPLEX | Posts a comment: "no blocking issues, but complex — human DEV review still required." |
+| FAIL | any | Blocks merge until issues are addressed. |
+
+For `feat:`/`opti:` PRs, the AI review provides feedback but does **not** auto-approve — human DEV review is always required.
+
+**AI review has real limits.** It checks standards, bugs, and obvious issues. It cannot judge architectural fit, cross-system impact, or whether the PR fixes the *root cause* vs. a symptom. A green Claude status is not a substitute for a human reviewer on a complex change.
+
+You can invoke or re-invoke it at any time with a PR comment:
+- `@claude review` — fresh review (required for `feat:`/`opti:` PRs)
+- `@claude re-review` — focus on whether prior feedback was addressed
+
+### 3. QA review
+QA runs the **Test Instructions** from the PR description against a build of the branch (typically via `metaforge explorer run <PR>`). If steps are missing or unclear, QA will send the PR back — they should not have to reverse-engineer the test plan from the diff.
+
+### 4. DEV review
+A developer reviewer evaluates architecture, correctness, and whether the PR fits the broader system. If the AI auto-approved a SIMPLE PR, this step is waived — but any human reviewer may still override and request changes.
+
+### 5. Merge gate
+The `Enforce QA and DEV Approvals` workflow ([`.github/workflows/enforce-group-approvals.yml`](../.github/workflows/enforce-group-approvals.yml)) blocks merge until all of the following hold:
+
+- ≥1 approval from the `qa` team (unless `no QA needed`).
+- ≥1 approval from the `explorer-devs` team (unless `claude-approved`).
+- All CI checks green.
+- PR is not a draft.
+
+When all conditions are met, **use "Squash and merge"**. Write a clear squash message — title + bulleted list of changes + test steps. Most of this can be copied from the PR description.
+
+---
+
+## Labels
+
+Labels drive policy decisions. Only apply them when the criteria below are genuinely met.
+
+| Label | Effect | When to apply |
+|---|---|---|
+| `claude-approved` | DEV approval no longer required. | Applied **automatically** by AI review on SIMPLE+PASS. Don't apply by hand. |
+| `no QA needed` | QA approval no longer required. | Changes limited to CI/CD, scripts, docs, or other non-runtime code. **No** user-facing or runtime Unity code touched. Applied automatically when AI review determines this, or manually with justification in the PR. |
+| `no review` | Suppresses AI review and reviewer auto-assignment. | Rare — reserved for trivial maintenance where the author has coordinated review separately. |
+| `auto-pr` | Skips both AI review and the approval gate entirely. | Bot-generated PRs only (dependency bumps, auto-sync). Humans should not apply this. |
+
+If in doubt, **do not apply the label.** Let the default flow run.
+
+---
+
+## External contributors
+
+You don't need to be on the `qa` or `explorer-devs` teams to open a PR. Follow this page and the PR template and the automation will route reviewers to you.
+
+When you open a PR, you'll receive a **welcome comment** that explains the review process for your specific PR type — whether AI review runs automatically or needs to be triggered manually with `@claude review`.
+
+A few things to know:
+
+- The auto-assigned reviewers will handle the QA/DEV approvals the merge gate requires — you don't need to pin anyone yourself.
+- For `feat:` and `opti:` PRs, AI review is **not automatic**. Comment `@claude review` to request it, or `@claude re-review` after addressing feedback.
+- If you're unsure whether a change is "simple" or "complex," lean toward **complex**: write a richer technical description and don't worry if the AI classifies it as COMPLEX. That just means a human dev will look at it, which is the right outcome for anything non-trivial.
+- You **cannot** apply `claude-approved`, `no QA needed`, `no review`, or `auto-pr` yourself, and you should not request them. Let the automation or a maintainer decide.
+- If AI review raises a concern you think is wrong, reply on the inline comment with reasoning rather than silently dismissing it. A maintainer will adjudicate.
+
+---
 
 ## Commits
 
-When adding commits to your branch there is no need of following any guidelines. Since approved PR will be squashed before merging into `dev` (see below), it is allowed to use any amount of commits. It is suggested to commit often (considering it as saving points of your progress)
+Commits inside a feature branch have **no format requirements** — the branch will be squashed on merge, so commit as often as you like (think of them as save points).
 
-## Merging approved PR into `dev`
+The squash commit message that lands on `dev` is what matters:
+- Self-explanatory title (mirrors the PR title).
+- Bulleted list of changes.
+- Test steps copied from the PR description.
 
-In this case **squash merge** option should be used. Also, it is important to provide a descriptive message, following the standard:
-* a self explanatory title
-* a list of all changes in the description
-* test steps
+GitHub pre-fills most of this from the PR; tidy it before clicking the final merge button.
 
-This will generally be auto generated by GitHub when clicking on squash and merge, but it is better to copy main part of your description including test steps
+---
+
+## Quick reference for common situations
+
+| Situation | What to do |
+|---|---|
+| Opened a `fix:` PR, Claude approved it, but you want a human to look anyway | Leave it — the `claude-approved` label only waives the DEV *requirement*. Any human can still approve or request changes. |
+| QA reviewer isn't responding | Ping in `#qa-team` on Slack. Don't reassign QA — the auto-assign picked the right rotation. |
+| Your PR touches only GitHub workflows | It's still a real PR. The AI should mark it `QA_REQUIRED: NO`; if it doesn't, add `no QA needed` manually and note why. |
+| You disagree with an AI inline comment | Reply with your reasoning on the thread. A maintainer will resolve it. Don't silently resolve/dismiss AI comments without engaging. |
+| You want a faster turnaround on a hotfix | See [Incident Management & Hotfix Policy](incident-management-and-hotfix-policy.md) — there is a separate fast-track process for SEV-1/SEV-2. |


### PR DESCRIPTION
## Summary

Improves the PR review automation flow and documents it for both team members and external contributors. All changes are CI/docs only — no runtime code touched.

### Workflow changes

- **Shared review prompt** — extracted the Claude review instructions to ` .github/prompts/review-instructions.md`, loaded by both the `fix:`/`chore:` auto-review job and the `@claude review` comment-triggered job. Removes ~90 lines of near-duplicated prompt text.
- **Better review quality** — prompt now instructs Claude to (1) read `CLAUDE.md` and relevant subsystem docs before reviewing and cite the rule when flagging a violation, (2) perform a root-cause check that flags symptom-patching (null-guards where nulls shouldn't happen, swallowed exceptions, etc.), and (3) justify the SIMPLE/COMPLEX classification via a new `COMPLEXITY_REASON` line.
- **Clearer failure statuses** — when Claude's step fails, the commit status now distinguishes credit exhaustion (no Claude comment posted) from max-turn failures (partial comment, no `REVIEW_RESULT`) instead of the generic "encountered an error".
- **Welcome external contributors** — new `welcome-external-contributor.yml` that posts a PR-type-aware guide when someone outside the `explorer-devs`/`qa` teams opens a PR. Explains whether auto-review will run (`fix:`/`chore:`) or how to request one (`feat:`/`opti:` → `@claude review`).
- **Approval status with specifics** — `enforce-group-approvals` now posts a `QA and DEV Approvals` commit status saying exactly what's missing (`Waiting on: QA approval` / `Waiting on: DEV approval` / both / satisfied).

### Documentation

- **`docs/branch-and-pr-standards.md`** — rewritten. Old doc predated all the automation. New doc walks through the entire lifecycle (auto-assign → AI review → QA → DEV → merge gate), documents every label, and has a dedicated section for external contributors.
- **PR template** — fixed broken link pointing to the old `unity-renderer` repo; now points to the local Branch & PR Standards doc.