### PR TITLE
fix: prevent repeated "already consumed" exception in ResolveProfilePictureSystem (UNITY-EXPLORER-NNJ)

### DIFF
--- a/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
+++ b/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
@@ -45,6 +45,7 @@ namespace DCL.Profiles
             }
             catch (Exception e)
             {
+                result.Asset?.Dispose();
                 ReportHub.LogException(e, ReportCategory.PROFILE);
             }
             finally

--- a/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
+++ b/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
@@ -26,32 +26,33 @@ namespace DCL.Profiles
         [Query]
         private void CompleteProfilePictureDownload(in Entity entity, ref ProfileTier profile, ref Promise promise)
         {
-            if (promise.IsCancellationRequested(World))
+            // Try to consume first: if the load already completed, we must dispose the asset
+            // even when cancellation was requested (late-cancel race)
+            if (promise.TryConsume(World, out StreamableLoadingResult<TextureData> result))
             {
-                World.Destroy(entity);
-                return;
-            }
-
-            if (!promise.TryConsume(World, out StreamableLoadingResult<TextureData> result))
-                return;
-
-            try
-            {
-                // Guard: the Profile object may have been returned to the pool and reused for a different user
-                if (profile.UserId == promise.LoadingIntention.AvatarTextureUserId)
-                    profile.ProfilePicture = result.ToFullRectSpriteData(fallback: ProfileUtils.DEFAULT_PROFILE_PIC);
-                else
+                try
+                {
+                    // Guard: the Profile object may have been returned to the pool and reused for a different user
+                    if (profile.UserId == promise.LoadingIntention.AvatarTextureUserId)
+                        profile.ProfilePicture = result.ToFullRectSpriteData(fallback: ProfileUtils.DEFAULT_PROFILE_PIC);
+                    else
+                        result.Asset?.Dispose();
+                }
+                catch (Exception e)
+                {
                     result.Asset?.Dispose();
+                    ReportHub.LogException(e, ReportCategory.PROFILE);
+                }
+                finally
+                {
+                    World.Destroy(entity);
+                }
+
+                return;
             }
-            catch (Exception e)
-            {
-                result.Asset?.Dispose();
-                ReportHub.LogException(e, ReportCategory.PROFILE);
-            }
-            finally
-            {
+
+            if (promise.IsCancellationRequested(World))
                 World.Destroy(entity);
-            }
         }
     }
 }

--- a/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
+++ b/Explorer/Assets/DCL/Profiles/Systems/ResolveProfilePictureSystem.cs
@@ -7,6 +7,7 @@ using DCL.Profiles.Helpers;
 using ECS.Abstract;
 using ECS.StreamableLoading.Common.Components;
 using ECS.StreamableLoading.Textures;
+using System;
 using Promise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.Textures.TextureData, ECS.StreamableLoading.Textures.GetTextureIntention>;
 
 namespace DCL.Profiles
@@ -25,14 +26,29 @@ namespace DCL.Profiles
         [Query]
         private void CompleteProfilePictureDownload(in Entity entity, ref ProfileTier profile, ref Promise promise)
         {
-            if (promise.TryConsume(World, out StreamableLoadingResult<TextureData> result))
+            if (promise.IsCancellationRequested(World))
+            {
+                World.Destroy(entity);
+                return;
+            }
+
+            if (!promise.TryConsume(World, out StreamableLoadingResult<TextureData> result))
+                return;
+
+            try
             {
                 // Guard: the Profile object may have been returned to the pool and reused for a different user
                 if (profile.UserId == promise.LoadingIntention.AvatarTextureUserId)
                     profile.ProfilePicture = result.ToFullRectSpriteData(fallback: ProfileUtils.DEFAULT_PROFILE_PIC);
                 else
                     result.Asset?.Dispose();
-
+            }
+            catch (Exception e)
+            {
+                ReportHub.LogException(e, ReportCategory.PROFILE);
+            }
+            finally
+            {
                 World.Destroy(entity);
             }
         }


### PR DESCRIPTION
# Pull Request Description

Fix #7663

## Summary

Fixes [UNITY-EXPLORER-NNJ](https://decentraland.sentry.io/issues/7345176669/) — `EcsSystemException: [ResolveProfilePictureSystem]` with inner exception `AssetPromise is already consumed`. **7,284 occurrences** across 27 users since 2026-03-18, firing every frame once triggered.

## Root Cause

In the system `ResolveProfilePictureSystem`, when `TryConsume` succeeds, the promise struct transitions to `Result.HasValue = true, Entity = Null`. If anything between `TryConsume` and `World.Destroy(entity)` throws (e.g. `Sprite.Create` on a destroyed `Texture2D`, or the REnum `ProfilePicture` setter), the profile entity is **never destroyed**. On the next frame the query re-enters the same entity, `TryConsume` sees `Result.HasValue && Entity == Null`, and throws `"is already consumed"`. This repeats every frame indefinitely, explaining the high occurrence count.

### Contributing factors

- **Destroyed texture**: `ToFullRectSpriteData` calls `Sprite.Create(tex2D, ...)` without checking if the `Texture2D` is still alive. On low-spec devices (Sentry event: M1 Mac, `meets_minimum_requirements=False`), textures can be unloaded by memory pressure while promises are still in flight.
- **Missing cancellation handling**: Unlike `ResolveAvatarAttachmentThumbnailSystem`, this system did not handle cancelled loads — cancelled promises could leave entities in an inconsistent state.

## Fix

- **`try/catch/finally` around post-consume body**: guarantees `World.Destroy(entity)` executes even if the body throws. The original exception is reported once via `ReportHub.LogException` instead of looping every frame.
- **`result.Asset?.Dispose()` in `catch`**: ensures the loaded texture asset is released on error, preventing GPU memory leaks when `ToFullRectSpriteData` throws after the asset was successfully loaded.
- **`TryConsume` before `IsCancellationRequested`**: consume-first ordering ensures that if a texture load completed right before cancellation was requested (late-cancel race), the loaded asset is properly consumed and disposed instead of being silently leaked by `ForgetLoading`.
- **`IsCancellationRequested` as fallback**: only reached when the load has not yet completed. Destroys the profile entity and cancels the in-flight load cleanly.

## How to test

1. Enter a high-density scene (Genesis Plaza / event) — verify profile pictures load normally.
2. Rapidly teleport between scenes with many remote players — verify profile pictures load normally.

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
