### PR TITLE
fix: avoid re processing empty pointers

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/IncreasingRadius/LoadPointersByIncreasingRadiusSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/IncreasingRadius/LoadPointersByIncreasingRadiusSystem.cs
@@ -168,6 +168,12 @@ namespace ECS.SceneLifeCycle.IncreasingRadius
 
                     TryCreateSceneEntity(scene, new IpfsPath(scene.id, URLDomain.FromString(urlsSource.Url(DecentralandUrl.Content))), processedScenePointers.Value);
                 }
+
+                //If an empty list for these pointers, mark them as processed anyway
+                //to prevent infinite re-requesting when there is no scene at those coordinates
+                if (definitions.Count == 0)
+                    for (var i = 0; i < requestedList.Count; i++)
+                        processedScenePointers.Value.Add(requestedList[i]);
             }
             else
             {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
While investigating another bug I found out that empty pointers were always re-processed, this PR just sets them as processed if an empty response is returned

## Test Instructions

### Test Steps
1. Launch the client
2. Verify that when walking around scenes load fine like in prod

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
