### PR TITLE
chore: fix broken links and outdated Unity version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Unity Explorer is the official desktop client implementation for Decentraland 2.
 
 ## 📋 Requirements
 
-- Unity 6000.2.6f2
+- Unity 6000.4.0f1
 
 ## 🚀 Installation & Setup
 
@@ -55,15 +55,15 @@ Unity Explorer is the official desktop client implementation for Decentraland 2.
 
 ## 📚 Documentation
 
-For detailed information about the project, please visit our [Wiki](https://github.com/decentraland/unity-explorer/wiki).
+For detailed information about the project, see the [documentation index](docs/README.md).
 
 ### Architecture
 
-The Unity Explorer follows a component-based architecture designed for flexibility and scalability. Learn more in our [Architecture Overview](https://github.com/decentraland/unity-explorer/wiki/Architecture-Overview).
+The Unity Explorer follows a component-based architecture designed for flexibility and scalability. Learn more in our [Architecture Overview](docs/architecture-overview.md).
 
 ### Development Guides
 
-Find specific guidance on development topics in our [How To Guide](https://github.com/decentraland/unity-explorer/wiki/How-To).
+Find specific guidance on development topics in the [Development Guide](docs/development-guide.md).
 
 ## 🔧 Troubleshooting
 
@@ -85,7 +85,7 @@ See our [Whitepaper](https://decentraland.org/blog/announcements/decentralands-w
 
 ## 👥 Contributing
 
-Please follow our coding standards and guidelines outlined in our [How To Guide](https://github.com/decentraland/unity-explorer/wiki/How-To).
+Please follow our [Branch & PR Standards](docs/branch-and-pr-standards.md) and [Code Style Guidelines](docs/code-style-guidelines.md).
 
 ## 🤝 Community and Support
 
@@ -95,4 +95,4 @@ Please follow our coding standards and guidelines outlined in our [How To Guide]
 
 ## 📜 License
 
-This project is licensed under the [Apache 2.0 License](LICENSE.md) - see the LICENSE file for details.
+This project is licensed under the [Apache 2.0 License](LICENSE) - see the LICENSE file for details.


### PR DESCRIPTION
## Summary

- Replace 4 broken GitHub wiki links with local `docs/` paths (wiki does not exist)
- Fix `LICENSE.md` → `LICENSE` (file has no extension)
- Point Contributing section to `docs/branch-and-pr-standards.md` and `docs/code-style-guidelines.md`
- Update Unity version requirement from `6000.2.6f2` to `6000.4.0f1` (matches `ProjectSettings/ProjectVersion.txt`)

## Test plan

- [ ] Verify all links in README.md resolve correctly on GitHub