### PR TITLE
fix: multiple LSD and asset load issues

### DIFF
--- a/Explorer/Assets/DCL/ECS/GlobalPartitioning/GlobalDeferredLoadingSystem.cs
+++ b/Explorer/Assets/DCL/ECS/GlobalPartitioning/GlobalDeferredLoadingSystem.cs
@@ -53,7 +53,6 @@ namespace DCL.GlobalPartitioning
                 CreateQuery<GetEmotesDTOByPointersFromRealmIntention, EmotesDTOList>(),
                 CreateQuery<GetTrimmedEmotesByParamIntention, TrimmedEmotesResponse>(),
                 CreateQuery<GetAudioClipIntention, AudioClipData>(),
-                CreateQuery<GetGLTFIntention, GLTFData>(),
                 CreateQuery<GetProfilesBatchIntent, ProfilesBatchResult>(),
             };
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
@@ -18,6 +18,7 @@ using ECS.StreamableLoading.Common.Systems;
 using Newtonsoft.Json;
 using SceneRunner.Scene;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Text;
@@ -25,6 +26,7 @@ using System.Threading;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Mathematics;
 using Unity.Profiling;
+using UnityEngine.Pool;
 using UnityEngine.Scripting;
 
 namespace ECS.SceneLifeCycle.SceneDefinition
@@ -112,6 +114,8 @@ namespace ECS.SceneLifeCycle.SceneDefinition
                 }
             }
 
+            RemoveDuplicates(intention.TargetCollection);
+
             analytics.OnRequestFinished(intention.TargetCollection.Count);
 
             foreach (SceneEntityDefinition sceneEntityDefinition in intention.TargetCollection)
@@ -123,6 +127,30 @@ namespace ECS.SceneLifeCycle.SceneDefinition
 
             return new StreamableLoadingResult<SceneDefinitions>(
                 new SceneDefinitions(intention.TargetCollection));
+        }
+
+        private void RemoveDuplicates(List<SceneEntityDefinition> list)
+        {
+            if (list.Count <= 1)
+                return;
+
+            var seenIds = HashSetPool<string>.Get();
+            seenIds.EnsureCapacity(list.Count);
+
+            int write = 0;
+
+            for (int read = 0; read < list.Count; read++)
+            {
+                var item = list[read];
+
+                if (seenIds.Add(item.id))
+                    list[write++] = item;
+            }
+
+            if (write < list.Count)
+                list.RemoveRange(write, list.Count - write);
+
+            HashSetPool<string>.Release(seenIds);
         }
 
         [Preserve]

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/UnloadSceneSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/UnloadSceneSystem.cs
@@ -104,9 +104,10 @@ namespace ECS.SceneLifeCycle.Systems
             ReportHub.LogProductionInfo($"Scene '{definitionComponent.Definition?.GetLogSceneName()}' disposed");
             ReportHub.Log(ReportCategory.SCENE_LOADING, $"UnloadSceneSystem: UnloadLoadedScene '{definitionComponent.Definition?.GetLogSceneName()}'");
 
+            World.Remove<DeleteEntityIntention>(entity);
             // Keep definition so it won't be downloaded again = Cache in ECS itself
             if (!localSceneDevelopment)
-                World.Remove<ISceneFacade, AssetPromise<ISceneFacade, GetSceneFacadeIntention>, DeleteEntityIntention>(entity);
+                World.Remove<ISceneFacade, AssetPromise<ISceneFacade, GetSceneFacadeIntention>>(entity);
         }
 
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/CleanUpGltfContainerSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/CleanUpGltfContainerSystem.cs
@@ -63,13 +63,14 @@ namespace ECS.Unity.GLTFContainer.Systems
         {
             if (component.Promise.TryGetResult(World, out StreamableLoadingResult<GltfContainerAsset> result) && result.Succeeded)
             {
-                //TODO (JUANI) : Newly instantiated asset will remain in the bridge
-                cache.Dereference(component.Hash, result.Asset, putInBridge && result.Asset.IsISS);
                 entityCollidersSceneCache.Remove(result.Asset);
 
-                // Since NoCache is used for Raw GLTFs, we have to manually dispose of the Data
+                // Raw GLTFs use NoCache so the underlying data is not shared — dispose directly
+                // instead of returning to the cache (which would later double-dispose)
                 if (result.Asset.AssetData is GLTFData)
                     result.Asset.Dispose();
+                else
+                    cache.Dereference(component.Hash, result.Asset, putInBridge && result.Asset.IsISS);
             }
 
             component.RootGameObject = null;

--- a/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
@@ -238,8 +238,6 @@ namespace Global
             container.ImageControllerProvider = new ImageControllerProvider(globalWorld);
 
             container.FeatureFlagsProvider = new HttpFeatureFlagsProvider(container.WebRequestsContainer.WebRequestController);
-            container.GltfContainerAssetsCache = new GltfContainerAssetsCache(componentsContainer.ComponentPoolsRegistry);
-
 
             ArrayPool<byte> buffersPool = ArrayPool<byte>.Create(1024 * 1024 * 50, 50);
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR addresses multiple problems in LSD (right now it is mostly broken)
- addresses a deduplication of the scene definition introduced by the scene pointers usage (introduced [here](https://github.com/decentraland/unity-explorer/pull/7952))
- fixes reload logic in LSD that was preventing a scene to be reloaded
- fixes a double dispose for raw gltfs (they were firstly dereferenced and then manually disposed but dereferencing made them susceptible of another dispose caused by cache cleaning) 
- GltfContainerAssetsCache was instantiated twice
- there was a double sub in `GlobalDeferredLoadingSystem` for the same <intention, result>


### Test Steps
1. Smoke test for LSD
2. Smoke test for genesis city scenes loading


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
