### PR TITLE
fix: reset feature flags on error to avoid already init exception

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/Bootstraper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/Bootstraper.cs
@@ -214,6 +214,7 @@ namespace Global.Dynamic
             try { await featureFlagsProvider.InitializeAsync(decentralandUrlsSource, identity?.Address, appArgs, ct); }
             catch (Exception e) when (e is not OperationCanceledException)
             {
+                FeatureFlagsConfiguration.Reset();
                 FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(FeatureFlagsResultDto.Empty));
                 ReportHub.LogException(e, new ReportData(ReportCategory.FEATURE_FLAGS));
             }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #8317
This PR avoids the exception "FeatureFlagsConfiguration is already initialized." when there is a failure in the web request or FF parsing
It simply does the same flow of HttpFeatureFlagsProvider

## Test Instructions
Just a simple smoke test that you can enter DCL as always and everything works fine

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
