### PR TITLE
fix: slightly increase min shadowmap distance to avoid own shadow blurriness

### DIFF
--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
@@ -391,9 +391,9 @@ MonoBehaviour:
         <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 39458b71e0ed84549b1b280c4fb1f105
-          m_SubObjectName:
-          m_SubObjectType:
-          m_SubObjectGUID:
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_SubObjectGUID: 
           m_EditorAssetChanged: 0
         <Config>k__BackingField:
           <ModuleName>k__BackingField: Sun Shadows
@@ -403,23 +403,6 @@ MonoBehaviour:
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
         <Feature>k__BackingField: 7
-    - rid: 2404945524685013200
-      type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
-      data:
-        <FeatureId>k__BackingField: 0
-        <View>k__BackingField:
-          m_AssetGUID: 39458b71e0ed84549b1b280c4fb1f105
-          m_SubObjectName:
-          m_SubObjectType:
-          m_SubObjectGUID:
-          m_EditorAssetChanged: 0
-        <Config>k__BackingField:
-          <ModuleName>k__BackingField: Sun Lens Flare
-          <Description>k__BackingField: Enables a lens flare effect on the sun light.
-            Disable this to remove the effect and gain a minor performance improvement.
-          <IsEnabled>k__BackingField: 1
-          defaultIsOn: 1
-        <Feature>k__BackingField: 11
     - rid: 2404945524685013118
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
@@ -478,7 +461,7 @@ MonoBehaviour:
             for nearby objects, improving close-up shadow detail and performance.
           <IsEnabled>k__BackingField: 1
           sliderType: 0
-          minValue: 30
+          minValue: 40
           maxValue: 100
           wholeNumbers: 1
           defaultValue: 60
@@ -501,6 +484,23 @@ MonoBehaviour:
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
         <Feature>k__BackingField: 9
+    - rid: 2404945524685013200
+      type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
+      data:
+        <FeatureId>k__BackingField: 0
+        <View>k__BackingField:
+          m_AssetGUID: 39458b71e0ed84549b1b280c4fb1f105
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_SubObjectGUID: 
+          m_EditorAssetChanged: 0
+        <Config>k__BackingField:
+          <ModuleName>k__BackingField: Sun Lens Flare
+          <Description>k__BackingField: Enables a lens flare effect on the sun light.
+            Disable this to remove the effect and gain a minor performance improvement.
+          <IsEnabled>k__BackingField: 1
+          defaultIsOn: 1
+        <Feature>k__BackingField: 11
     - rid: 2659808844961546333
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:

--- a/Explorer/Assets/DCL/Settings/Settings/QualityPresetLow.asset
+++ b/Explorer/Assets/DCL/Settings/Settings/QualityPresetLow.asset
@@ -22,9 +22,10 @@ MonoBehaviour:
   sceneDistance: 10
   landscapeDistance: 500
   sunShadows: 0
+  sunLensFlare: 0
   sceneLightsEnabled: 0
   sceneLightShadowsEnabled: 1
   maxSceneLights: 0
   shadowsQualityLevel: 0
-  shadowDistance: 30
+  shadowDistance: 40
   playCurrentSceneStreamsOnly: 1

--- a/Explorer/Assets/Rendering/UniversalRenderPipeline - High.asset
+++ b/Explorer/Assets/Rendering/UniversalRenderPipeline - High.asset
@@ -28,7 +28,7 @@ MonoBehaviour:
   m_HDRColorBufferPrecision: 0
   m_MSAA: 8
   m_RenderScale: 1
-  m_UpscalingFilter: 0
+  m_UpscalingFilter: 3
   m_FsrOverrideSharpness: 0
   m_FsrSharpness: 0.92
   m_EnableLODCrossFade: 1
@@ -55,12 +55,12 @@ MonoBehaviour:
   m_ReflectionProbeBlending: 0
   m_ReflectionProbeBoxProjection: 0
   m_ReflectionProbeAtlas: 0
-  m_ShadowDistance: 56
+  m_ShadowDistance: 100
   m_ShadowCascadeCount: 4
   m_Cascade2Split: 0.25
   m_Cascade3Split: {x: 0.1, y: 0.3}
-  m_Cascade4Split: {x: 0.049999997, y: 0.14999999, z: 0.29999998}
-  m_CascadeBorder: 0.42857143
+  m_Cascade4Split: {x: 0.102, y: 0.282, z: 0.474}
+  m_CascadeBorder: 0.7053232
   m_ShadowDepthBias: 1.56
   m_ShadowNormalBias: 0
   m_AnyShadowsSupported: 1


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #8282
The min value of shadow map distance was a bit too low and it was blurring the own player shadow when moving the 3rd person camera up and down. The min value was slightly increased

## Test Instructions

### Test Steps
1. Open app
2. Be in third person view
3. Lower the shadow distance to minimum
4. Move the camera up and down and observe the shadow of the avatar
5. It should stay consistent and now get half blurred
(you can check the video in the issue if not clear)

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
