### PR TITLE
hotfix: constantly visible splashscreen

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/IdentityVerificationDappAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/IdentityVerificationDappAuthState.cs
@@ -58,10 +58,13 @@ namespace DCL.AuthenticationScreenFlow
             {
                 view.Hide(OUT);
 
-                // Hide login selection view if still visible (social logins skip the verification step,
-                // so ShowVerification is never called and the login selection view remains active)
+                // Instantly deactivate login selection view if still visible (social logins skip the verification step,
+                // so ShowVerification is never called and the login selection view remains active).
+                // Using SetActive directly instead of Hide() to avoid launching an uncancellable HideAsync animation
+                // that can race with ShowAsync started by subsequent LoginSelectionAuthState.Enter(), causing a zombie
+                // WaitUntil(ct=None) on a deactivated Animator that loops forever and leaves the auth screen non-functional.
                 if (viewInstance.LoginSelectionAuthView.gameObject.activeSelf)
-                    viewInstance.LoginSelectionAuthView.Hide();
+                    viewInstance.LoginSelectionAuthView.gameObject.SetActive(false);
             }
             else
             {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Possible hotfix for the always visible splashscreen

## Test Instructions
<!--
Provide clear, copy-pasteable steps for testing these changes.

### Quick reference

# Run this PR (with cache)
metaforge explorer run <this-PR-number>

# Run this PR (without cache — clears Explorer data)
metaforge explorer run <this-PR-number> --clear

# Run this PR (fresh account — clears everything and creates a new account)
metaforge account create --clear
metaforge explorer run <this-PR-number>

# Tail logs while testing
metaforge explorer logs tail --filter "<relevant text>"

# Run automation tests against this PR
metaforge explorer test <this-PR-number>
-->

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
