### PR TITLE
hotfix: restore login UI when cancelling before verification

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LoginSelectionAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LoginSelectionAuthState.cs
@@ -195,11 +195,8 @@ namespace DCL.AuthenticationScreenFlow
             machine.Enter<LoginSelectionAuthState>(true);
         }
 
-        private void OnCancelBeforeVerification()
-        {
+        private void OnCancelBeforeVerification() =>
             controller.CancelLoginProcess();
-            machine.Enter<LoginSelectionAuthState>(true);
-        }
 
         private void CloseErrorPopup() =>
             view.ErrorPopupRoot.SetActive(false);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Hotfix for a regression introduced in #8233 ("fix: overlapping login screen on new account"): pressing `CancelLoginButton` on the login selection screen while a login was in progress (for example, after clicking Metamask or a social login but before the verification step completes) caused the entire authentication screen UI to disappear, leaving the user locked out with no way to interact.

### Root cause

`OnCancelBeforeVerification` was calling `machine.Enter<LoginSelectionAuthState>(true)` (the payload-less overload), which invokes the parameter-less `Enter()` and **does not** call `view.Show()`. The failing sequence was:

1. The user presses Cancel while in `IdentityVerificationDappAuthState` (before `ShowVerification` is called).
2. The FSM runs `IdentityVerificationDappAuthState.Exit()`. Because `loginException` is still `null` at that point (the async `AuthenticateAsync` hasn't observed the cancellation yet), execution enters the branch added in #8233 that calls `viewInstance.LoginSelectionAuthView.Hide()`, starting the hide animation.
3. `LoginSelectionAuthState.Enter()` (parameter-less) runs without calling `view.Show()`, so the view is never shown again.
4. Later, `AuthenticateAsync` catches `OperationCanceledException` and calls `machine.Enter<LoginSelectionAuthState, int>(SLIDE)`. With the default `allowReEnterSameState = false`, the FSM detects the same state and discards the call (`MVCStateMachine.cs:67-72`).
5. The `HideAsync` animation completes and runs `gameObject.SetActive(false)`. The entire UI disappears.

### Fix

`OnCancelBeforeVerification` now only calls `controller.CancelLoginProcess()`. The transition back to `LoginSelectionAuthState` is handled entirely by the `catch (OperationCanceledException)` block inside `AuthenticateAsync`. By the time the transition happens there, `loginException` is already set, so `Exit()` takes the `else` branch and **does not** hide the `LoginSelectionAuthView`. Finally, `Enter(SLIDE)` calls `view.Show(SLIDE, …)` and the entrance animation plays without any race condition.

This pattern is consistent with how the `BackButton` on `VerificationDappAuthView` (`IdentityVerificationDappAuthState.cs:153`) and the one on `VerificationOTPAuthView` (`IdentityVerificationOTPAuthState.cs:145`) already cancel the login without manually driving the FSM.