### PR TITLE
hotfix: avoid getting stuck on endless splash screen

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -598,7 +598,7 @@ namespace DCL.PluginSystem.Global
 
             mvcManager.RegisterController(explorePanelController);
 
-            bool isCommunitiesFeatureEnabled = await CommunitiesFeatureAccess.Instance.IsUserAllowedToUseTheFeatureAsync(ct);
+            bool isCommunitiesFeatureEnabled = await CommunitiesFeatureAccess.Instance.IsUserAllowedToUseTheFeatureAsync(ct, ignoreAllowedList: true);
 
             if (isCommunitiesFeatureEnabled)
                 dclInput.Shortcuts.Communities.performed += OnInputShortcutsCommunitiesPerformed;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR avoids getting stuck in and endless splash screen when no cached identity was found.
It was stuck in the explore panel plugin as no identity was set and it was endlesly waiting for the identity to check communities status, I just skipped the check with a ignoreAllowedList true as the feature is still gated in the other code paths

## Test Instructions


### Test Steps
1. login
2. in the auth screen select change account
3. close the game
4. reopen the game
5. verify that it loads fine and you are not stuck in the splash screen

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
