### PR TITLE
chore: add dependency security review workflow

### DIFF
--- a/.github/prompts/dependency-security-review.md
+++ b/.github/prompts/dependency-security-review.md
@@ -1,63 +1,138 @@
 You are reviewing a PR that adds or modifies external dependencies in a Unity project.
 This is a SECURITY-FOCUSED review. The project ships as a desktop client to end users.
 
+Your job is to identify dependency changes visible in the PR, assess their supply-chain and runtime risk, and clearly separate:
+1. facts supported by the diff/repo,
+2. reasonable inferences,
+3. unknowns that require manual follow-up.
+
+Do not guess. If something cannot be determined from the PR, mark it as UNKNOWN.
+
 --- STEP 1: IDENTIFY ALL DEPENDENCY CHANGES ---
-List every external dependency change in this PR:
-- New packages added to `Packages/manifest.json` (name, source URL, version/commit)
-- Version changes to existing packages
-- New DLL/binary files added under `Explorer/Assets/Plugins/` or anywhere under `Explorer/`
-- New or modified `.asmdef` files that reference external assemblies
-- Changes to `Packages/packages-lock.json` (transitive dependency changes)
+List every external dependency change visible in this PR:
 
-For each dependency, state: name, version, source, and whether it's a binary (DLL/SO/dylib) or source code.
+- New or changed entries in `Packages/manifest.json`
+  - Include package name, source (registry/git/path), and exact version/tag/commit if present
+- New or changed entries in `Packages/packages-lock.json`
+  - Include direct and notable transitive changes
+- New binary or native plugin files added or modified under:
+  - `Explorer/Assets/Plugins/`
+  - any `Assets/**`
+  - any package contents included in the repo
+- New or modified `.asmdef` files that reference precompiled assemblies or change assembly visibility
+- New editor scripts, build scripts, install hooks, or package setup code that execute automatically
 
---- STEP 2: EVALUATE EACH NEW/CHANGED DEPENDENCY ---
-For each dependency identified, assess:
+For each item, state:
+- name
+- version / commit / file hash if available
+- source
+- type: source code / managed binary / native binary / unknown
+- scope: runtime / editor-only / test-only / unknown
 
-**Source trust:**
-- Is the source a known, reputable publisher? (Unity official, Microsoft, established OSS with >500 stars)
-- Is the version pinned to an immutable reference (commit SHA, exact version)? Flag branch refs or unpinned git URLs.
-- Is there a Decentraland fork, or is it pulled directly from a third party?
-- For DLLs: can the binary be reproduced from publicly available source code? If not, flag as HIGH RISK.
+--- STEP 2: ASSESS EACH NEW OR CHANGED DEPENDENCY ---
+For each dependency, assess the following using only evidence available in the PR or clearly-labeled external metadata if provided.
 
-**Capabilities and attack surface:**
-- Does this library make network requests? To what domains? Can it contact arbitrary endpoints?
-- Does it render UI, web content, popups, or overlays?
-- Does it access the filesystem beyond its own data directory?
-- Does it use reflection, runtime code generation, or load additional assemblies dynamically?
-- Does it have platform-specific or locale/region-specific behavior? (This was the vector in a past incident where a library showed harmful content to users in specific countries.)
-- Does it include native plugins (.dll/.so/.dylib/.bundle) that can't be inspected as C# source?
-- Does it have capabilities disproportionate to its stated purpose? (e.g., a video URL resolver that includes an HTML rendering engine)
+A. Provenance / source trust
+- Is the publisher clearly identifiable and reputable?
+- Is the dependency pinned to an immutable version or commit?
+- Flag branch refs, floating versions, local paths, or unpinned git URLs
+- Is this an internal fork, official upstream, or third-party fork?
+- For binaries: is corresponding source code referenced or vendored? If not, mark provenance as weaker
 
-**Maintenance and reputation:**
-- When was the library last updated?
-- Does it have known CVEs or security advisories?
-- Is the license compatible with Apache 2.0?
-- Has the author/org published other widely-used packages?
+B. Runtime capability / attack surface
+Check whether the dependency appears to:
+- make network requests or expose network-facing functionality
+- render UI, HTML, webviews, overlays, or external content
+- access filesystem locations beyond normal app data
+- use reflection, dynamic loading, or runtime assembly loading
+- include native plugins (`.dll`, `.so`, `.dylib`, `.bundle`)
+- change behavior by platform, locale, region, or remote config
+- introduce capabilities disproportionate to its stated purpose
 
-**Transitive dependencies:**
-- What transitive dependencies does this library pull in?
-- Do any of them have the above risk factors?
-- Flag any transitive dependency that is not well-known.
+If not provable from the PR, mark UNKNOWN rather than assuming.
 
---- STEP 3: RISK ASSESSMENT ---
-Classify each dependency as:
-- **LOW RISK**: Unity official package, well-known OSS, source-only, no network/UI capabilities
-- **MEDIUM RISK**: Established library with some capabilities (network, filesystem) proportionate to its purpose
-- **HIGH RISK**: Any of: opaque binaries without reproducible build, network + UI capabilities, locale/region-specific behavior, unmaintained (>12 months), low reputation, disproportionate capabilities
+C. Shipping impact
+- Does this ship in the end-user desktop client, or is it editor/dev/test only?
+- Does it affect all platforms or only specific desktop targets?
+
+D. Maintenance / known risk
+If the PR includes evidence, note:
+- maintenance status
+- security advisories / CVEs
+- license
+If not visible from the PR, mark UNKNOWN and recommend manual verification where relevant.
+
+E. Transitive risk
+From lockfile changes, identify notable transitive dependencies that are:
+- new
+- executable/native
+- low-trust / obscure
+- unusually privileged for the parent dependency
+
+--- STEP 3: RISK CLASSIFICATION ---
+Classify each dependency as one of:
+
+LOW RISK
+- official or well-established dependency
+- immutable version pinning
+- source-visible or standard package source
+- capabilities are limited or proportionate
+- no major provenance concerns
+
+MEDIUM RISK
+- some unresolved provenance or maintenance questions
+- network/filesystem/native capability that is proportionate but worth human review
+- notable transitive dependency risk
+- editor/runtime boundary unclear
+- claims require manual validation
+
+HIGH RISK
+- opaque binary or native plugin added for runtime use without trustworthy provenance
+- unpinned or floating external dependency
+- unknown publisher plus privileged capability
+- dynamic code loading / assembly loading / remote executable behavior
+- suspicious mismatch between stated purpose and actual capability
+- region/platform-specific behavior with insufficient reviewability
 
 --- STEP 4: OUTPUT ---
-Post a summary comment with:
+Produce:
 
-1. A table of all dependency changes with risk level
-2. For each MEDIUM/HIGH risk item, a specific explanation of the concern
-3. For HIGH risk items, concrete recommendations (fork it, replace the binary with a source build, use an alternative, add runtime sandboxing)
+1. A concise summary table with:
+- dependency / file
+- version
+- source
+- type
+- scope
+- risk
+- evidence confidence (HIGH / MEDIUM / LOW)
 
-Use mcp__github_inline_comment__create_inline_comment to flag specific files (especially binary additions).
+2. For each MEDIUM or HIGH risk item:
+- specific concern
+- what evidence supports it
+- what remains unknown
 
-At the end, emit:
-DEPENDENCY_REVIEW: PASS (no HIGH risk items)
-or
-DEPENDENCY_REVIEW: NEEDS_ATTENTION (has MEDIUM risk items that need human judgment)
-or
-DEPENDENCY_REVIEW: BLOCK (has HIGH risk items that must be addressed before merge)
+3. For each HIGH risk item:
+- concrete recommendation such as:
+  - replace binary with source build
+  - pin to commit/version
+  - fork and vendor reviewed source
+  - restrict to editor-only
+  - add allowlist / sandboxing / network restrictions
+  - require manual security review before merge
+
+Use inline comments to flag:
+- binary additions
+- unpinned dependency declarations
+- suspicious asmdef or build-script changes
+
+Do not claim to have inspected binary internals unless the PR actually contains inspectable source or metadata.
+
+At the end, emit exactly one:
+DEPENDENCY_REVIEW: PASS
+DEPENDENCY_REVIEW: NEEDS_ATTENTION
+DEPENDENCY_REVIEW: BLOCK
+
+Use:
+- PASS only if no meaningful unresolved concerns remain
+- NEEDS_ATTENTION if human review is needed or important unknowns remain
+- BLOCK if there is a clear high-risk issue that should be addressed before merge

--- a/.github/prompts/dependency-security-review.md
+++ b/.github/prompts/dependency-security-review.md
@@ -29,8 +29,27 @@ For each item, state:
 - type: source code / managed binary / native binary / unknown
 - scope: runtime / editor-only / test-only / unknown
 
+--- STEP 1.5: LOOK UP PACKAGE REGISTRY METADATA ---
+For each new or changed dependency identified above, check its public registry listing.
+
+For NuGet packages (.dll from NuGet.org): fetch the NuGet page (e.g. https://www.nuget.org/packages/{PackageName}/{Version})
+For Unity packages (com.* in manifest.json): check the Unity package registry or the linked git repo
+For GitHub-sourced packages: check the repository page
+
+Extract and record (label all findings as **[Registry metadata]** to distinguish from PR-visible facts):
+- **Description and stated purpose** — does it match what the PR uses it for?
+- **Download count / popularity** — is this widely used or obscure?
+- **Listed dependencies** — do they match what's committed in the PR? Are there unexpected transitive dependencies?
+- **Notices, warnings, or restrictions** — any regional restrictions, political notices, usage conditions beyond the license, or availability limitations stated on the listing page
+- **Last published date** — is the version current or abandoned?
+- **License** — compatible with Apache 2.0?
+- **Known vulnerabilities** — any advisories listed on the registry page?
+- **Publisher / author** — same as claimed in the PR? Any other notable packages by this publisher?
+
+If a registry page is unreachable or does not exist, note that and move on.
+
 --- STEP 2: ASSESS EACH NEW OR CHANGED DEPENDENCY ---
-For each dependency, assess the following using only evidence available in the PR or clearly-labeled external metadata if provided.
+For each dependency, assess the following using evidence from the PR diff AND the registry metadata gathered above. Always label the source of each finding: **[PR]**, **[Registry metadata]**, **[Inference]**, or **[UNKNOWN]**.
 
 A. Provenance / source trust
 - Is the publisher clearly identifiable and reputable?

--- a/.github/prompts/dependency-security-review.md
+++ b/.github/prompts/dependency-security-review.md
@@ -1,0 +1,63 @@
+You are reviewing a PR that adds or modifies external dependencies in a Unity project.
+This is a SECURITY-FOCUSED review. The project ships as a desktop client to end users.
+
+--- STEP 1: IDENTIFY ALL DEPENDENCY CHANGES ---
+List every external dependency change in this PR:
+- New packages added to `Packages/manifest.json` (name, source URL, version/commit)
+- Version changes to existing packages
+- New DLL/binary files added under `Explorer/Assets/Plugins/` or anywhere under `Explorer/`
+- New or modified `.asmdef` files that reference external assemblies
+- Changes to `Packages/packages-lock.json` (transitive dependency changes)
+
+For each dependency, state: name, version, source, and whether it's a binary (DLL/SO/dylib) or source code.
+
+--- STEP 2: EVALUATE EACH NEW/CHANGED DEPENDENCY ---
+For each dependency identified, assess:
+
+**Source trust:**
+- Is the source a known, reputable publisher? (Unity official, Microsoft, established OSS with >500 stars)
+- Is the version pinned to an immutable reference (commit SHA, exact version)? Flag branch refs or unpinned git URLs.
+- Is there a Decentraland fork, or is it pulled directly from a third party?
+- For DLLs: can the binary be reproduced from publicly available source code? If not, flag as HIGH RISK.
+
+**Capabilities and attack surface:**
+- Does this library make network requests? To what domains? Can it contact arbitrary endpoints?
+- Does it render UI, web content, popups, or overlays?
+- Does it access the filesystem beyond its own data directory?
+- Does it use reflection, runtime code generation, or load additional assemblies dynamically?
+- Does it have platform-specific or locale/region-specific behavior? (This was the vector in a past incident where a library showed harmful content to users in specific countries.)
+- Does it include native plugins (.dll/.so/.dylib/.bundle) that can't be inspected as C# source?
+- Does it have capabilities disproportionate to its stated purpose? (e.g., a video URL resolver that includes an HTML rendering engine)
+
+**Maintenance and reputation:**
+- When was the library last updated?
+- Does it have known CVEs or security advisories?
+- Is the license compatible with Apache 2.0?
+- Has the author/org published other widely-used packages?
+
+**Transitive dependencies:**
+- What transitive dependencies does this library pull in?
+- Do any of them have the above risk factors?
+- Flag any transitive dependency that is not well-known.
+
+--- STEP 3: RISK ASSESSMENT ---
+Classify each dependency as:
+- **LOW RISK**: Unity official package, well-known OSS, source-only, no network/UI capabilities
+- **MEDIUM RISK**: Established library with some capabilities (network, filesystem) proportionate to its purpose
+- **HIGH RISK**: Any of: opaque binaries without reproducible build, network + UI capabilities, locale/region-specific behavior, unmaintained (>12 months), low reputation, disproportionate capabilities
+
+--- STEP 4: OUTPUT ---
+Post a summary comment with:
+
+1. A table of all dependency changes with risk level
+2. For each MEDIUM/HIGH risk item, a specific explanation of the concern
+3. For HIGH risk items, concrete recommendations (fork it, replace the binary with a source build, use an alternative, add runtime sandboxing)
+
+Use mcp__github_inline_comment__create_inline_comment to flag specific files (especially binary additions).
+
+At the end, emit:
+DEPENDENCY_REVIEW: PASS (no HIGH risk items)
+or
+DEPENDENCY_REVIEW: NEEDS_ATTENTION (has MEDIUM risk items that need human judgment)
+or
+DEPENDENCY_REVIEW: BLOCK (has HIGH risk items that must be addressed before merge)

--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -58,6 +58,9 @@ jobs:
           # List new binaries specifically
           NEW_BINARIES=$(git diff --name-only --diff-filter=A "$BASE_SHA" -- \
             '*.dll' '*.so' '*.dylib' '*.bundle' '*.aar' '*.jar' || true)
+          echo "new-binaries<<BINARIES_EOF" >> "$GITHUB_OUTPUT"
+          echo "$NEW_BINARIES" >> "$GITHUB_OUTPUT"
+          echo "BINARIES_EOF" >> "$GITHUB_OUTPUT"
           if [ -n "$NEW_BINARIES" ]; then
             echo ""
             echo "⚠️ New binary files added:"
@@ -107,6 +110,9 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number }}
 
             This PR modifies external dependencies. Perform a security-focused review.
+
+            The following new binary files were added in this PR (pre-computed from the diff — these may not appear in `gh pr diff` output for large binaries):
+            ${{ steps.detect.outputs.new-binaries || 'None' }}
 
             ${{ steps.prompt.outputs.instructions }}
           claude_args: |

--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -19,7 +19,6 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
       pull-requests: write
       issues: write
@@ -33,9 +32,12 @@ jobs:
 
       - name: Detect dependency changes
         id: detect
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          BASE_SHA=$(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }})
+          BASE_SHA=$(git merge-base "origin/$BASE_REF" "$HEAD_SHA")
 
           CHANGES=$(git diff --name-only "$BASE_SHA" -- \
             'Explorer/Packages/manifest.json' \
@@ -112,42 +114,53 @@ jobs:
             --max-turns 40
 
       - name: Set final status
-        if: steps.detect.outputs.has-changes == 'true' && always()
+        if: always()
         uses: actions/github-script@v7
         with:
           script: |
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ github.event.pull_request.number }},
-              per_page: 100
-            });
+            const hasChanges = '${{ steps.detect.outputs.has-changes }}' === 'true';
+            const detectFailed = '${{ steps.detect.outcome }}' === 'failure';
 
-            const claudeComment = comments.data
-              .reverse()
-              .find(c => c.user?.login === 'claude[bot]');
-
-            const output = claudeComment?.body ?? '';
-            const errored = '${{ steps.claude.outcome }}' === 'failure';
-            const isBlock = output.includes('DEPENDENCY_REVIEW: BLOCK');
-            const needsAttention = output.includes('DEPENDENCY_REVIEW: NEEDS_ATTENTION');
+            // No dependency changes and detect didn't crash — nothing to report
+            if (!hasChanges && !detectFailed) return;
 
             let state, description;
-            if (errored && !output) {
+
+            if (detectFailed) {
               state = 'failure';
-              description = 'Dependency review failed — credit balance too low or API error';
-            } else if (errored) {
-              state = 'failure';
-              description = 'Dependency review encountered an error';
-            } else if (isBlock) {
-              state = 'failure';
-              description = 'HIGH RISK dependencies found — must be addressed before merge';
-            } else if (needsAttention) {
-              state = 'pending';
-              description = 'MEDIUM RISK dependencies — human review required';
+              description = 'Dependency detection step failed — check workflow logs';
             } else {
-              state = 'success';
-              description = 'No high-risk dependency changes found';
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ github.event.pull_request.number }},
+              });
+
+              const claudeComment = comments
+                .reverse()
+                .find(c => c.user?.login === 'claude[bot]');
+
+              const output = claudeComment?.body ?? '';
+              const errored = '${{ steps.claude.outcome }}' === 'failure';
+              const isBlock = output.includes('DEPENDENCY_REVIEW: BLOCK');
+              const needsAttention = output.includes('DEPENDENCY_REVIEW: NEEDS_ATTENTION');
+
+              if (errored && !output) {
+                state = 'failure';
+                description = 'Dependency review failed — credit balance too low or API error';
+              } else if (errored) {
+                state = 'failure';
+                description = 'Dependency review encountered an error';
+              } else if (isBlock) {
+                state = 'failure';
+                description = 'HIGH RISK dependencies found — must be addressed before merge';
+              } else if (needsAttention) {
+                state = 'pending';
+                description = 'MEDIUM RISK dependencies — human review required';
+              } else {
+                state = 'success';
+                description = 'No high-risk dependency changes found';
+              }
             }
 
             await github.rest.repos.createCommitStatus({

--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -108,8 +108,8 @@ jobs:
 
             ${{ steps.prompt.outputs.instructions }}
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --max-turns 30
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),WebFetch,Bash(curl:*)"
+            --max-turns 40
 
       - name: Set final status
         if: steps.detect.outputs.has-changes == 'true' && always()

--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -1,0 +1,160 @@
+name: Dependency Security Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    paths:
+      - 'Explorer/Packages/manifest.json'
+      - 'Explorer/Packages/packages-lock.json'
+      - 'Explorer/Assets/Plugins/**'
+      - '**/*.dll'
+      - '**/*.so'
+      - '**/*.dylib'
+      - '**/*.bundle'
+      - '**/*.aar'
+      - '**/*.jar'
+
+jobs:
+  detect-and-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: write
+      statuses: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Detect dependency changes
+        id: detect
+        run: |
+          set -euo pipefail
+          BASE_SHA=$(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }})
+
+          CHANGES=$(git diff --name-only "$BASE_SHA" -- \
+            'Explorer/Packages/manifest.json' \
+            'Explorer/Packages/packages-lock.json' \
+            'Explorer/Assets/Plugins/' \
+            '*.dll' '*.so' '*.dylib' '*.bundle' '*.aar' '*.jar')
+
+          if [ -z "$CHANGES" ]; then
+            echo "No dependency changes detected."
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Dependency changes detected:"
+          echo "$CHANGES"
+          echo "has-changes=true" >> "$GITHUB_OUTPUT"
+
+          # List new binaries specifically
+          NEW_BINARIES=$(git diff --name-only --diff-filter=A "$BASE_SHA" -- \
+            '*.dll' '*.so' '*.dylib' '*.bundle' '*.aar' '*.jar' || true)
+          if [ -n "$NEW_BINARIES" ]; then
+            echo ""
+            echo "⚠️ New binary files added:"
+            echo "$NEW_BINARIES"
+          fi
+
+      - name: Add label
+        if: steps.detect.outputs.has-changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.pull_request.number }},
+              labels: ['new-dependency']
+            });
+
+      - name: Set status to pending
+        if: steps.detect.outputs.has-changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.pull_request.head.sha }}',
+              state: 'pending',
+              context: 'Dependency Security Review',
+              description: 'Reviewing external dependency changes...'
+            });
+
+      - name: Load review prompt
+        if: steps.detect.outputs.has-changes == 'true'
+        id: prompt
+        run: echo "instructions<<PROMPT_EOF" >> "$GITHUB_OUTPUT" && cat .github/prompts/dependency-security-review.md >> "$GITHUB_OUTPUT" && echo "PROMPT_EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Claude Dependency Review
+        if: steps.detect.outputs.has-changes == 'true'
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            This PR modifies external dependencies. Perform a security-focused review.
+
+            ${{ steps.prompt.outputs.instructions }}
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns 30
+
+      - name: Set final status
+        if: steps.detect.outputs.has-changes == 'true' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.pull_request.number }},
+              per_page: 100
+            });
+
+            const claudeComment = comments.data
+              .reverse()
+              .find(c => c.user?.login === 'claude[bot]');
+
+            const output = claudeComment?.body ?? '';
+            const errored = '${{ steps.claude.outcome }}' === 'failure';
+            const isBlock = output.includes('DEPENDENCY_REVIEW: BLOCK');
+            const needsAttention = output.includes('DEPENDENCY_REVIEW: NEEDS_ATTENTION');
+
+            let state, description;
+            if (errored && !output) {
+              state = 'failure';
+              description = 'Dependency review failed — credit balance too low or API error';
+            } else if (errored) {
+              state = 'failure';
+              description = 'Dependency review encountered an error';
+            } else if (isBlock) {
+              state = 'failure';
+              description = 'HIGH RISK dependencies found — must be addressed before merge';
+            } else if (needsAttention) {
+              state = 'pending';
+              description = 'MEDIUM RISK dependencies — human review required';
+            } else {
+              state = 'success';
+              description = 'No high-risk dependency changes found';
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.pull_request.head.sha }}',
+              state,
+              context: 'Dependency Security Review',
+              description
+            });


### PR DESCRIPTION
## Summary

Adds an automated security review that triggers when a PR modifies external dependencies.

### What it does

**Trigger**: any PR that touches `Packages/manifest.json`, `packages-lock.json`, `Explorer/Assets/Plugins/**`, or binary files.

**Actions**:
1. Detects all dependency changes and lists new binaries
2. Adds `new-dependency` label to the PR
3. Runs Claude security review using `.github/prompts/dependency-security-review.md`
4. Sets a `Dependency Security Review` commit status (PASS / NEEDS_ATTENTION / BLOCK)

**Review criteria**: provenance, runtime capabilities, shipping scope, maintenance, transitive risk. Clearly separates facts, inferences, and unknowns.

## Test plan

- [ ] PR adding a DLL to Plugins/ triggers the workflow
- [ ] PR modifying manifest.json triggers the workflow
- [ ] PR touching only .cs files does NOT trigger
- [ ] Commit status appears with correct description