### PR TITLE
fix: unisex scene emotes

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
@@ -3,6 +3,7 @@ using DCL.AvatarRendering.Loading.DTO;
 using DCL.Diagnostics;
 using DCL.Ipfs;
 using ECS.StreamableLoading.Common.Components;
+using System;
 
 namespace DCL.AvatarRendering.Loading.Components
 {
@@ -31,8 +32,26 @@ namespace DCL.AvatarRendering.Loading.Components
         public new string? GetEntityId() =>
             DTO.id;
 
-        public bool IsUnisex() =>
-            DTO.Metadata.AbstractData.representations.Length > 1;
+        public bool IsUnisex()
+        {
+            if (DTO.Metadata.AbstractData.representations.Length == 0) return false;
+            if (DTO.Metadata.AbstractData.representations.Length > 1) return true;
+
+            bool femaleFound = false, maleFound = false;
+
+            foreach (AvatarAttachmentDTO.Representation representation in DTO.Metadata.AbstractData.representations)
+            {
+                foreach (string bodyShape in representation.bodyShapes)
+                {
+                    if (string.Equals(bodyShape, BodyShape.FEMALE, StringComparison.OrdinalIgnoreCase))
+                        femaleFound = true;
+                    else if (string.Equals(bodyShape, BodyShape.MALE, StringComparison.OrdinalIgnoreCase))
+                        maleFound = true;
+                }
+            }
+
+            return femaleFound && maleFound;
+        }
 
         public new URN GetUrn() =>
             DTO.Metadata.id;


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/6772
Fixes https://github.com/decentraland/unity-explorer/issues/7006

We load scene emotes with a different body shape representation than usual (compared to the content server). We were not considering them as unisex emotes. The emote was unisex, but was loading only with the requested body shape. When we needed the same emote again for another gender, the emote was pending forever, because it was already loaded but the gender was not there.

## Test Instructions

Group up with some people at Genesis Plaza. Use the benches and the chairs in the bar. They should be propagated correctly.

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
