### PR TITLE
chore: fix UNITY-EXPLORER-NH7 disposed request in debug window & add tests

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Declarations/DebugOngoingWebRequestDef.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Declarations/DebugOngoingWebRequestDef.cs
@@ -20,6 +20,8 @@ namespace DCL.DebugUtilities
 
             public DateTime StartTime;
             public string ShortenedUrl;
+            public string FullUrl;
+            public string Method;
 
             // Nanoseconds
             public ulong Duration;

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugOngoingWebRequestWidget.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugOngoingWebRequestWidget.cs
@@ -75,7 +75,7 @@ namespace DCL.DebugUtilities.Views
             url.text = data.ShortenedUrl;
             url.RegisterCallback(onHyperlinkClicked, index);
 
-            method.text = data.Request.method;
+            method.text = data.Method;
             duration.text = DebugLongMarkerElement.FormatValue(data.Duration, DebugLongMarkerDef.Unit.TimeNanoseconds);
 
             switch (data.Duration)
@@ -94,7 +94,7 @@ namespace DCL.DebugUtilities.Views
         private void HyperlinkOnPointerUp(PointerUpEvent evt, int index)
         {
             DebugOngoingWebRequestDef.DebugWebRequestInfo data = dataSource.Requests[index];
-            Application.OpenURL(data.Request.url);
+            Application.OpenURL(data.FullUrl);
         }
 
         void INotifyValueChanged<DebugOngoingWebRequestDef.DataSource>.SetValueWithoutNotify(DebugOngoingWebRequestDef.DataSource newValue) =>

--- a/Explorer/Assets/DCL/WebRequests/Analytics/Metrics/ActiveCounter.cs
+++ b/Explorer/Assets/DCL/WebRequests/Analytics/Metrics/ActiveCounter.cs
@@ -94,6 +94,8 @@ namespace DCL.WebRequests.Analytics.Metrics
                 Request = request.UnityWebRequest,
                 StartTime = startTime,
                 ShortenedUrl = shortenedURL,
+                FullUrl = fullURL,
+                Method = request.UnityWebRequest.method,
                 Duration = 0,
             });
         }

--- a/Explorer/Assets/DCL/WebRequests/Tests/DebugWebRequestInfoShould.cs
+++ b/Explorer/Assets/DCL/WebRequests/Tests/DebugWebRequestInfoShould.cs
@@ -1,0 +1,77 @@
+using DCL.DebugUtilities;
+using NUnit.Framework;
+using System;
+using UnityEngine.Networking;
+
+namespace DCL.WebRequests.Tests
+{
+    // Regression coverage for UNITY-EXPLORER-NH7: BindItem threw NRE when
+    // ListView rebound a row whose UnityWebRequest had already been disposed
+    // by a sibling OnRequestFinished in the same frame.
+    public class DebugWebRequestInfoShould
+    {
+        [Test]
+        public void ThrowNullReferenceException_WhenUnityWebRequestMethodIsReadAfterDispose()
+        {
+            var uwr = new UnityWebRequest("https://example.com", "GET");
+            uwr.Dispose();
+
+            Assert.Throws<NullReferenceException>(() => { _ = uwr.method; });
+        }
+
+        [Test]
+        public void ThrowNullReferenceException_WhenUnityWebRequestUrlIsReadAfterDispose()
+        {
+            var uwr = new UnityWebRequest("https://example.com", "GET");
+            uwr.Dispose();
+
+            Assert.Throws<NullReferenceException>(() => { _ = uwr.url; });
+        }
+
+        [Test]
+        public void PreserveCachedMethodAndUrl_AfterRequestIsDisposed()
+        {
+            const string URL = "https://example.com/resource";
+            var uwr = new UnityWebRequest(URL, "POST");
+
+            var info = new DebugOngoingWebRequestDef.DebugWebRequestInfo
+            {
+                Request = uwr,
+                StartTime = DateTime.UtcNow,
+                ShortenedUrl = "<u>/resource</u>",
+                FullUrl = URL,
+                Method = uwr.method,
+                Duration = 0,
+            };
+
+            uwr.Dispose();
+
+            Assert.That(info.Method, Is.EqualTo("POST"));
+            Assert.That(info.FullUrl, Is.EqualTo(URL));
+        }
+
+        [Test]
+        public void AllowRemovalByReferenceEquality_AfterRequestIsDisposed()
+        {
+            var uwr = new UnityWebRequest("https://example.com", "GET");
+            var dataSource = new DebugOngoingWebRequestDef.DataSource();
+
+            dataSource.Add(new DebugOngoingWebRequestDef.DebugWebRequestInfo
+            {
+                Request = uwr,
+                StartTime = DateTime.UtcNow,
+                ShortenedUrl = "<u>/</u>",
+                FullUrl = "https://example.com",
+                Method = "GET",
+                Duration = 0,
+            });
+
+            Assert.That(dataSource.Requests.Count, Is.EqualTo(1));
+
+            uwr.Dispose();
+            dataSource.Remove(uwr);
+
+            Assert.That(dataSource.Requests.Count, Is.EqualTo(0));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/WebRequests/Tests/DebugWebRequestInfoShould.cs.meta
+++ b/Explorer/Assets/DCL/WebRequests/Tests/DebugWebRequestInfoShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f64e999ec97705042bead384614105a2


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes [Sentry UNITY-EXPLORER-NH7](https://decentraland.sentry.io/issues/7316691370/) — `System.NullReferenceException` thrown from `DebugOngoingWebRequestWidget.BindItem` (370 events, first seen 2026-03-06, still ongoing as of 2026-04-20).

**Root cause.** The "Ongoing Web Requests" debug widget stores a live `UnityWebRequest` reference per row and, on every `RefreshItems`, reads `data.Request.method` (and `data.Request.url` from the hyperlink handler). When multiple requests finish in the same frame, this sequence races:

1. Request **A** finishes → `DebugMetricsAnalyticsHandler.OnRequestFinished` → `ActiveCounter.OnRequestEnded` → `DataSource.Remove(A)` → `Updated` → `ListView.RefreshItems()`.
2. `RefreshItems` rebinds the *remaining* rows, including one for request **B**.
3. Request **B**'s own finalization ran a moment earlier and its `UnityWebRequest` has already been `Dispose()`d — but `ActiveCounter.OnRequestEnded` hasn't reached the list for **B** yet.
4. `data.Request.method` on **B** hits `UnityWebRequest.get_method` on a torn-down native handle → `ThrowHelper.ThrowNullReferenceException`.

Stack from Sentry:
```
UnityEngine.Bindings.ThrowHelper.ThrowNullReferenceException
UnityEngine.Networking.UnityWebRequest.get_method
DebugOngoingWebRequestWidget.BindItem         <-- Views/DebugOngoingWebRequestWidget.cs:78
UnityEngine.UIElements.ListViewController.BindItem
UnityEngine.UIElements.BaseVerticalCollectionView.RefreshItems
DebugOngoingWebRequestDef+DataSource.get_Updated  <-- Declarations/DebugOngoingWebRequestDef.cs:30
DebugOngoingWebRequestDef+DataSource.Remove       <-- Declarations/DebugOngoingWebRequestDef.cs:63
ActiveCounter.OnRequestEnded                      <-- Analytics/Metrics/ActiveCounter.cs:104
DebugMetricsAnalyticsHandler.OnRequestFinished    <-- Analytics/Metrics/DebugMetricsAnalyticsHandler.cs:166
```

**Fix.** Capture `method` and the full URL at `ActiveCounter.OnRequestStarted` (same place we already cache `ShortenedUrl`) and read those cached strings in the widget. The stored `UnityWebRequest` is kept only as a reference-equality key for `DataSource.Remove` — managed reference equality survives native disposal, so removal continues to work.

Changes:

- `Declarations/DebugOngoingWebRequestDef.cs` — add `FullUrl` and `Method` to `DebugWebRequestInfo`.
- `Analytics/Metrics/ActiveCounter.cs` — populate both at `OnRequestStarted`.
- `Views/DebugOngoingWebRequestWidget.cs` — `BindItem` reads `data.Method`; `HyperlinkOnPointerUp` reads `data.FullUrl`.

**Regression coverage.** Added `Tests/DebugWebRequestInfoShould.cs` (4 EditMode tests under `DCL.EditMode.Tests`):

| Test | Role |
|---|---|
| `ThrowNullReferenceException_WhenUnityWebRequestMethodIsReadAfterDispose` | Pins the root cause — matches Sentry's `get_method` → `ThrowNullReferenceException` frame. |
| `ThrowNullReferenceException_WhenUnityWebRequestUrlIsReadAfterDispose` | Same for `.url` (hyperlink path). |
| `PreserveCachedMethodAndUrl_AfterRequestIsDisposed` | Proves the cached strings survive `Dispose()`. |
| `AllowRemovalByReferenceEquality_AfterRequestIsDisposed` | Guards that keeping `Request` as a removal key still works post-dispose. |

**Scope.** Changes are confined to the editor-only debug panel path — no product/runtime behavior changes. Commit message will include `UNITY-EXPLORER-NH7` so Sentry auto-resolves on the next release.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 8370
```

### Prerequisites

- [ ] None beyond a standard Explorer checkout.

### Test Steps

1. (This is Editor Only) -> Just a Sanity Check Required

## Quality Checklist

- [x] Changes have been tested locally (EditMode suite).
- [x] Documentation has been updated (if required) — N/A, internal debug widget only.
- [x] Performance impact has been considered — two extra string refs per in-flight request (already bounded to ~50 entries by the list capacity); `method` is read once at start instead of every `BindItem` rebind, so it's a net reduction in native interop calls.
- [x] For SDK features: Test scene is included — N/A, not an SDK feature.

## Code Review Reference

Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting.
