### PR TITLE
fix: discard unknown fields on comms packet parse

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Connections/Messaging/Pipe/MessagePipe.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Messaging/Pipe/MessagePipe.cs
@@ -42,7 +42,7 @@ namespace DCL.Multiplayer.Connections.Messaging.Pipe
                 var packet = multiPool.Get<Packet>();
                 packet.ClearProtobufComponent();
                 return packet;
-            }),
+            }).WithDiscardUnknownFields(true),
             100, roomId) { }
 
         public MessagePipe(IDataPipe dataPipe, IMultiPool multiPool, IMemoryPool memoryPool, MessageParser<Packet> messageParser, uint supportedVersion,


### PR DESCRIPTION
## What does this PR change?

`MessagePipe` parses incoming `rfc4.Packet` using a factory that draws from the shared `DCLMultiPool`. The same pool serves the *outbound* send path (`MessageWrap<T>` gets its `Payload` from `multiPool.Get<T>()`, and `ReceivedMessage.Dispose` releases the inbound payload back into it).

Google.Protobuf's C# runtime preserves **unknown fields** on parse by default — they land in the generated message's private `_unknownFields` set and are re-serialized on the next `WriteTo`. `ClearProtobufComponent` only iterates the declared `FieldDescriptor` list, so it never touches `_unknownFields`. The net effect: once a peer sends us a packet carrying a tag we don't recognise, the pooled protobuf instance retains those bytes and the *next* outbound send emits them under our own identity.

We observed this in the wild: a bevy-explorer peer that locally extends `rfc4.Movement` with a nested message at tag 10000 saw Unity start echoing that peer's exact scene-animation hashes in Unity's own outbound `Movement` packets — stable across position/velocity changes, for a player that clearly had no source of those values. Before the peer broadcast anything, Unity's Movement packets were ~50 bytes with no unknown fields; the moment the peer sent tag 10000 once, Unity's packets grew to ~190 bytes and carried the peer's hashes verbatim.

Calling `WithDiscardUnknownFields(true)` on the `MessageParser<Packet>` tells the parser to drop unknown fields during decode. The flag propagates through nested-message parsing, so it covers `Packet`, the `Movement` inside its oneof, and any future nested types. Pooled instances stay round-trip clean; we no longer leak bytes we never intended to send.

## Test Instructions

**Steps**:
1. Run any two Decentraland clients in the same realm/scene.
2. Have one of them broadcast a `Packet` that contains fields Unity doesn't know about (e.g. a custom protobuf extension at a high tag number, such as a nested sub-message at tag 10000 inside `Movement`).
3. Capture Unity's outbound `Movement` packets on the wire.

**Expected result**:
- Before this fix: Unity's outbound packet size grows after receiving the extended packet, and the wire bytes contain the foreign tag echoed back.
- After this fix: Unity's outbound packet size stays constant (~50 bytes for a standard Movement) regardless of what foreign tags appear in inbound traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)