### PR TITLE
fix: direct call banner sometimes not shown during calls

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/Core/VoiceChatOrchestrator.cs
+++ b/Explorer/Assets/DCL/VoiceChat/Core/VoiceChatOrchestrator.cs
@@ -313,11 +313,11 @@ namespace DCL.VoiceChat
                     ChangePanelState(VoiceChatPanelState.NONE);
                     break;
                 case VoiceChatType.PRIVATE:
-                    ChangePanelState(VoiceChatPanelState.SELECTED);
+                    ChangePanelState(VoiceChatPanelState.SELECTED, force: true);
                     activeCallStatusService = privateVoiceChatCallStatusService;
                     break;
                 case VoiceChatType.COMMUNITY:
-                    ChangePanelState(VoiceChatPanelState.SELECTED);
+                    ChangePanelState(VoiceChatPanelState.SELECTED, force: true);
                     activeCallStatusService = communityVoiceChatCallStatusService;
                     break;
             }

--- a/Explorer/Assets/DCL/VoiceChat/PrivateVoiceChat/PrivateVoiceChatView.cs
+++ b/Explorer/Assets/DCL/VoiceChat/PrivateVoiceChat/PrivateVoiceChatView.cs
@@ -58,6 +58,7 @@ namespace DCL.VoiceChat
 
         public void Show()
         {
+            VoiceChatCanvasGroup.DOKill();
             VoiceChatContainer.SetActive(true);
             VoiceChatCanvasGroup.alpha = 0;
             VoiceChatCanvasGroup
@@ -72,6 +73,7 @@ namespace DCL.VoiceChat
 
         public void Hide()
         {
+            VoiceChatCanvasGroup.DOKill();
             VoiceChatCanvasGroup.alpha = 1;
             VoiceChatCanvasGroup
                 .DOFade(0, SHOW_HIDE_ANIMATION_DURATION)

--- a/Explorer/Assets/DCL/VoiceChat/UI/VoiceChatPanelPresenter.cs
+++ b/Explorer/Assets/DCL/VoiceChat/UI/VoiceChatPanelPresenter.cs
@@ -21,7 +21,7 @@ namespace DCL.VoiceChat
         private readonly EventSubscriptionScope presenterScope = new();
         private readonly ChatClickDetectionHandler clickDetectionHandler;
 
-        private bool wasVisibleBeforeFullscreen;
+        private VoiceChatPanelState? stateBeforeFullscreen;
 
         public VoiceChatPanelPresenter(VoiceChatPanelView view,
             ProfileRepositoryWrapper profileDataProvider,
@@ -69,7 +69,7 @@ namespace DCL.VoiceChat
         {
             if (evt.ViewSortingLayer is not CanvasOrdering.SortingLayer.FULLSCREEN) return;
 
-            wasVisibleBeforeFullscreen = voiceChatPanelState.Value is not (VoiceChatPanelState.HIDDEN or VoiceChatPanelState.NONE);
+            stateBeforeFullscreen ??= voiceChatPanelState.Value;
 
             voiceChatOrchestrator.ChangePanelState(VoiceChatPanelState.HIDDEN, force: true);
             clickDetectionHandler.Pause();
@@ -78,11 +78,17 @@ namespace DCL.VoiceChat
         private void OnMVCViewClosed(ChatSharedAreaEvents.MVCViewClosedEvent evt)
         {
             if (evt.ViewSortingLayer is not CanvasOrdering.SortingLayer.FULLSCREEN) return;
-            if (!wasVisibleBeforeFullscreen) return;
+            if (stateBeforeFullscreen is null) return;
 
-            wasVisibleBeforeFullscreen = false;
+            VoiceChatPanelState previous = stateBeforeFullscreen.Value;
+            stateBeforeFullscreen = null;
 
-            voiceChatOrchestrator.ChangePanelState(VoiceChatPanelState.UNFOCUSED, force: true);
+            // Always leave HIDDEN — NONE re-activates the panel container without focus side effects
+            VoiceChatPanelState restoreTo = previous is VoiceChatPanelState.NONE or VoiceChatPanelState.HIDDEN
+                ? VoiceChatPanelState.NONE
+                : VoiceChatPanelState.UNFOCUSED;
+
+            voiceChatOrchestrator.ChangePanelState(restoreTo, force: true);
             clickDetectionHandler.Resume();
         }
 

--- a/Explorer/Assets/DCL/VoiceChat/UI/VoiceChatPanelPresenter.cs
+++ b/Explorer/Assets/DCL/VoiceChat/UI/VoiceChatPanelPresenter.cs
@@ -83,7 +83,7 @@ namespace DCL.VoiceChat
             VoiceChatPanelState previous = stateBeforeFullscreen.Value;
             stateBeforeFullscreen = null;
 
-            // Always leave HIDDEN — NONE re-activates the panel container without focus side effects
+            // Never restore to HIDDEN; NONE re-activates the panel container without focus side-effects
             VoiceChatPanelState restoreTo = previous is VoiceChatPanelState.NONE or VoiceChatPanelState.HIDDEN
                 ? VoiceChatPanelState.NONE
                 : VoiceChatPanelState.UNFOCUSED;


### PR DESCRIPTION
## Summary

Fix #8388

Under certain UI navigation sequences, the private voice chat banner failed to appear even though the ringtone played, leaving the user unable to accept, reject or hang up calls.

## Root cause

The `VoiceChatPanelView` is a child of the `VoiceChatPanelResizeView` GameObject. When `VoiceChatPanelState` becomes `HIDDEN`, `VoiceChatPanelResizePresenter.OnUpdateVoiceChatPanelState` deactivates that parent GameObject, so any child (including the private call banner) stays invisible no matter how many times its own `Show()` is called.

The state could get stuck in `HIDDEN` through this sequence:

1. Initial state is `VoiceChatPanelState.NONE` (fresh session, no prior calls).
2. User opens any `FULLSCREEN` MVC view (Friends panel, Explore panel, Controls, Authentication).
3. `VoiceChatPanelPresenter.OnMVCViewOpened` forces the state to `HIDDEN` and records `wasVisibleBeforeFullscreen = (state is not HIDDEN or NONE)` — which is `false` because the previous state was `NONE`.
4. User closes the fullscreen view. `OnMVCViewClosed` early-returns because `wasVisibleBeforeFullscreen == false`, so the state stays `HIDDEN` forever.
5. A call arrives. `VoiceChatOrchestrator.SetActiveCallService` calls `ChangePanelState(SELECTED)` without `force`. `ChangePanelState` ignores the change when the current state is `HIDDEN`, so the parent GameObject stays inactive.
6. `PrivateVoiceChatPresenter` calls `view.Show()` and the audio bus plays the ringtone, but because the parent GameObject is inactive the banner never renders — audio without UI.

## Changes

**`VoiceChatPanelPresenter.cs`** — replace the `wasVisibleBeforeFullscreen` boolean with a nullable `stateBeforeFullscreen` snapshot of the real state:
- `OnMVCViewOpened` snapshots the pre-fullscreen state only on the first open (using `??=`) so nested/stacked fullscreens do not overwrite the original snapshot.
- `OnMVCViewClosed` always restores the state. If the previous state was `NONE`/`HIDDEN`, it restores to `NONE` (reactivates the container without focus side-effects); otherwise it restores to `UNFOCUSED` as before.

**`VoiceChatOrchestrator.cs`** — `SetActiveCallService` now calls `ChangePanelState(SELECTED, force: true)` for `PRIVATE` and `COMMUNITY`. Defensive safety net: an active call must always reveal the panel, regardless of any other code path that may have left it in `HIDDEN`.

**`PrivateVoiceChatView.cs`** — `Show()` and `Hide()` now call `VoiceChatCanvasGroup.DOKill()` before starting a new fade. Without this, a `Hide` in flight could complete after a subsequent `Show` and deactivate `VoiceChatContainer` via its `OnComplete` callback (secondary race that could surface in rapid state transitions).

## How to test it?

1. Login with your user and don't do anything.
2. Simply press [L] shortcut to open the friends panel.
3. Click out of the friends panel UI to make it dissapears.
4. Click on another avatar a click on the call option.
5. Notice that the call banner above the chat always appears.

Also, test the whole private call feature to check that everything works as expected in all scenarios 👍 

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
