### PR TITLE
chore: ensure full PDBs available for windows

### DIFF
--- a/Explorer/Assets/Editor/CloudBuild.cs
+++ b/Explorer/Assets/Editor/CloudBuild.cs
@@ -70,6 +70,10 @@ namespace Editor
                 AltBuilder.RemoveAltTesterFromScriptingDefineSymbols(BuildTargetGroup.Standalone);
             }
 
+            // Emit UnityPlayer.pdb into the build output so Sentry can symbolicate engine frames.
+            // Without this, stack traces show raw offsets like "UnityPlayer +0x07d152c".
+            // No-op for macOS builds — dSYM handling there is separate.
+            EditorUserBuildSettings.SetPlatformSettings("Standalone", "CopyPDBFiles", "true");
         }
 
         // Defined in the @T_MacOS/@T_Windows64 configurations in Unity Cloud

--- a/Explorer/Assets/Editor/CloudBuild.cs
+++ b/Explorer/Assets/Editor/CloudBuild.cs
@@ -70,10 +70,7 @@ namespace Editor
                 AltBuilder.RemoveAltTesterFromScriptingDefineSymbols(BuildTargetGroup.Standalone);
             }
 
-            // Emit UnityPlayer.pdb into the build output so Sentry can symbolicate engine frames.
-            // Without this, stack traces show raw offsets like "UnityPlayer +0x07d152c".
-            // No-op for macOS builds — dSYM handling there is separate.
-            EditorUserBuildSettings.SetPlatformSettings("Standalone", "CopyPDBFiles", "true");
+            DesktopStandaloneSettings.CopyPDBFiles = true;
         }
 
         // Defined in the @T_MacOS/@T_Windows64 configurations in Unity Cloud

--- a/Explorer/Assets/Editor/DesktopStandaloneSettings.cs
+++ b/Explorer/Assets/Editor/DesktopStandaloneSettings.cs
@@ -10,7 +10,7 @@ namespace Editor
 
         internal static bool CopyPDBFiles
         {
-            get => EditorUserBuildSettings.GetPlatformSettings(platformName, SETTING_COPY_PDB_FILES).ToLower() == "true";
+            get => EditorUserBuildSettings.GetPlatformSettings(PlatformName, SETTING_COPY_PDB_FILES).ToLower() == "true";
             set => EditorUserBuildSettings.SetPlatformSettings(PlatformName, SETTING_COPY_PDB_FILES, value.ToString().ToLower());
         }
     }

--- a/Explorer/Assets/Editor/DesktopStandaloneSettings.cs
+++ b/Explorer/Assets/Editor/DesktopStandaloneSettings.cs
@@ -6,7 +6,7 @@ namespace Editor
     {
         private static readonly string SETTING_COPY_PDB_FILES = "CopyPDBFiles";
 
-        internal static string platformName => "Standalone";
+        private static string PlatformName => "Standalone";
 
         internal static bool CopyPDBFiles
         {

--- a/Explorer/Assets/Editor/DesktopStandaloneSettings.cs
+++ b/Explorer/Assets/Editor/DesktopStandaloneSettings.cs
@@ -11,7 +11,7 @@ namespace Editor
         internal static bool CopyPDBFiles
         {
             get => EditorUserBuildSettings.GetPlatformSettings(platformName, SETTING_COPY_PDB_FILES).ToLower() == "true";
-            set => EditorUserBuildSettings.SetPlatformSettings(platformName, SETTING_COPY_PDB_FILES, value.ToString().ToLower());
+            set => EditorUserBuildSettings.SetPlatformSettings(PlatformName, SETTING_COPY_PDB_FILES, value.ToString().ToLower());
         }
     }
 }

--- a/Explorer/Assets/Editor/DesktopStandaloneSettings.cs
+++ b/Explorer/Assets/Editor/DesktopStandaloneSettings.cs
@@ -4,7 +4,7 @@ namespace Editor
 {
     internal static class DesktopStandaloneSettings
     {
-        private static readonly string SETTING_COPY_PDB_FILES = "CopyPDBFiles";
+        private const string SETTING_COPY_PDB_FILES = "CopyPDBFiles";
 
         private static string PlatformName => "Standalone";
 

--- a/Explorer/Assets/Editor/DesktopStandaloneSettings.cs
+++ b/Explorer/Assets/Editor/DesktopStandaloneSettings.cs
@@ -1,0 +1,17 @@
+﻿using UnityEditor;
+
+namespace Editor
+{
+    internal static class DesktopStandaloneSettings
+    {
+        private static readonly string SETTING_COPY_PDB_FILES = "CopyPDBFiles";
+
+        internal static string platformName => "Standalone";
+
+        internal static bool CopyPDBFiles
+        {
+            get => EditorUserBuildSettings.GetPlatformSettings(platformName, SETTING_COPY_PDB_FILES).ToLower() == "true";
+            set => EditorUserBuildSettings.SetPlatformSettings(platformName, SETTING_COPY_PDB_FILES, value.ToString().ToLower());
+        }
+    }
+}

--- a/Explorer/Assets/Editor/DesktopStandaloneSettings.cs.meta
+++ b/Explorer/Assets/Editor/DesktopStandaloneSettings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 390a2d54443e449aba050230593f5901
+timeCreated: 1776948711


### PR DESCRIPTION
# Pull Request Description

Ensure PDBs are copied so that sentry can have symbolicated unity crash dumps even when stripped.

`Enable this checkbox to include Microsoft program database (PDB) files in the built Standalone Player. PDB files contain application debugging information that is useful for debugging, but might increase the size of your Player. This setting is disabled by default.`