### PR TITLE
fix: handle profile version mismatches as failure during central profile requests

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Profiles/RemoteProfiles/RemoteProfiles.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/RemoteProfiles/RemoteProfiles.cs
@@ -101,7 +101,8 @@ namespace DCL.Multiplayer.Profiles.RemoteProfiles
             try
             {
                 // Delay the profile resolution in case it's not found, as otherwise it will be re-requested every frame - it's not the desired behaviour
-                Profile? profile = await profileRepository.GetAsync(remoteAnnouncement.WalletId, remoteAnnouncement.Version, lambdasEndpoint, cts.Token, batchBehaviour: IProfileRepository.FetchBehaviour.DELAY_UNTIL_RESOLVED);
+                Profile? profile = await profileRepository.GetAsync(remoteAnnouncement.WalletId, remoteAnnouncement.Version, lambdasEndpoint, cts.Token,
+                    batchBehaviour: IProfileRepository.FetchBehaviour.DELAY_UNTIL_RESOLVED);
 
                 if (profile is null)
                     return;

--- a/Explorer/Assets/DCL/Profiles/Repository/RealmProfileRepository.cs
+++ b/Explorer/Assets/DCL/Profiles/Repository/RealmProfileRepository.cs
@@ -290,10 +290,11 @@ namespace DCL.Profiles
                         // Batching is allowed
                         result = await AddToBatch(id, fromCatalyst, pendingBatches, tier, partition).Task.AttachExternalCancellation(ct);
 
-                        // Not found profiles (Catalyst replication delays) will be processed individually by GET
+                        // Not found profiles or version mismatches (Catalyst replication delays) will be processed individually by GET
                         // ⚠️ The following produces potentially a very long-living task ⚠️
                         // ⚠️ One request gives birth to many => potential distribution error, but it's a workaround for catalysts anyway ⚠️
-                        return result == null && delayBatchResolution ? await EnforceSingleGetAsync() : result;
+                        bool versionMismatch = versionSpecified && result != null && result.Value.Version < version;
+                        return (result == null || versionMismatch) && delayBatchResolution ? await EnforceSingleGetAsync() : result;
                     }
                 }
                 finally


### PR DESCRIPTION
## What does this PR change?
This PR updates the logic for handling profile version mismatches during centralized profile requests. If there is a mismatch in profile versions, it will now be treated as a failure to ensure better consistency and error reporting.

## Test Instructions

Group up with another user in an area. Change wearables. Check the changes are propagated to peers.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.