### PR TITLE
fix: identity cached with no profile

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -150,7 +150,7 @@ namespace DCL.AuthenticationScreenFlow
             fsm.AddStates(
                 new InitAuthState(viewInstance, installSource),
                 new LoginSelectionAuthState(fsm, viewInstance, this, CurrentState, splashScreen, web3Authenticator, webBrowser, enableEmailOTP),
-                new ProfileFetchingAuthState(fsm, viewInstance, this, CurrentState, selfProfile),
+                new ProfileFetchingAuthState(fsm, viewInstance, this, CurrentState, selfProfile, storedIdentityProvider),
                 new IdentityVerificationDappAuthState(fsm, viewInstance, this, CurrentState, web3Authenticator),
                 new LobbyForExistingAccountAuthState(fsm, viewInstance, this, splashScreen, CurrentState, characterPreviewController)
             );

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs
@@ -19,10 +19,13 @@ namespace DCL.AuthenticationScreenFlow
 {
     public class ProfileFetchingAuthState : AuthStateBase, IPayloadedState<ProfileFetchingPayload>
     {
+        private static readonly TimeSpan PROFILE_FETCH_TIMEOUT = TimeSpan.FromSeconds(15);
+
         private readonly MVCStateMachine<AuthStateBase> machine;
         private readonly AuthenticationScreenController controller;
         private readonly ReactiveProperty<AuthStatus> currentState;
         private readonly ISelfProfile selfProfile;
+        private readonly IWeb3IdentityCache identityCache;
         private readonly ProfileFetchingAuthView view;
         private Exception? profileFetchException;
 
@@ -31,13 +34,15 @@ namespace DCL.AuthenticationScreenFlow
             AuthenticationScreenView viewInstance,
             AuthenticationScreenController controller,
             ReactiveProperty<AuthStatus> currentState,
-            ISelfProfile selfProfile) : base(viewInstance)
+            ISelfProfile selfProfile,
+            IWeb3IdentityCache identityCache) : base(viewInstance)
         {
             view = viewInstance.ProfileFetchingAuthView;
             this.machine = machine;
             this.controller = controller;
             this.currentState = currentState;
             this.selfProfile = selfProfile;
+            this.identityCache = identityCache;
         }
 
         public void Enter(ProfileFetchingPayload payload)
@@ -64,6 +69,7 @@ namespace DCL.AuthenticationScreenFlow
                                     OperationCanceledException => new SpanErrorInfo("Login process was cancelled by user"),
                                     ProfileNotFoundException ex => new SpanErrorInfo($"Profile not found during {nameof(ProfileFetchingAuthState)}", ex),
                                     NotAllowedUserException ex => new SpanErrorInfo(ex.Message, ex),
+                                    TimeoutException ex => new SpanErrorInfo($"Profile fetch timed out during {nameof(ProfileFetchingAuthState)}", ex),
                                     Exception ex => new SpanErrorInfo($"Unexpected error during {nameof(ProfileFetchingAuthState)}", ex),
                                 };
 
@@ -103,7 +109,8 @@ namespace DCL.AuthenticationScreenFlow
                         Depth =  STATE_SPAN_DEPTH + 1,
                     });
 
-                    Profile? profile = await selfProfile.ProfileAsync(ct);
+                    // Timeout surfaces catalyst stalls as CONNECTION_ERROR instead of a frozen spinner.
+                    Profile? profile = await selfProfile.ProfileAsync(ct).Timeout(PROFILE_FETCH_TIMEOUT);
 
                     if (profile != null)
                     {
@@ -112,6 +119,13 @@ namespace DCL.AuthenticationScreenFlow
                         // Catalysts don't manipulate this field, so at this point we assume that the user is connected to web3
                         profile.HasConnectedWeb3 = true;
                         machine.Enter<LobbyForExistingAccountAuthState, (Profile, bool, CancellationToken)>((profile, isCached, ct));
+                    }
+                    else if (isCached)
+                    {
+                        // Auto-login restored an identity that has no deployed profile (abandoned onboarding). Clear it and return to login selection.
+                        identityCache.Clear();
+                        profileFetchException = new ProfileNotFoundException();
+                        machine.Enter<LoginSelectionAuthState, int>(SLIDE);
                     }
                     else
                     {
@@ -128,6 +142,11 @@ namespace DCL.AuthenticationScreenFlow
                 {
                     profileFetchException = e;
                     machine.Enter<LoginSelectionAuthState, int>(SLIDE);
+                }
+                catch (TimeoutException e)
+                {
+                    profileFetchException = e;
+                    machine.Enter<LoginSelectionAuthState, ErrorType>(ErrorType.CONNECTION_ERROR);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes the "I abandoned the profile creation step, closed the app, reopened, and now I'm stuck" regression in the auth/onboarding flow. The symptom differs by provider:

- **Social / MetaMask (Dapp):** DCL logo splash stays up on top of the onboarding UI → perceived as an infinite loading spinner, never recoverable without clearing local cache.
- **OTP:** silently routed back into the new-account onboarding lobby with the stale session, instead of letting the user pick a provider again.

Both paths stem from the same root cause: after a user signs in but *before* their first profile is deployed to the catalyst, the cached AuthIdentity is **orphaned**. On the next launch, auto-login happily restores that identity and pushes the user into a state they had explicitly abandoned.

### Root cause

On auto-login the controller enters `ProfileFetchingAuthState` with `IsCached = true` (see `AuthenticationScreenController.TryAutoLoginAndProceedAsync`). Fresh signin (both OTP and Dapp) enters it with `IsCached = false`. That flag is the unambiguous signal for "we got here via auto-login vs a fresh user action".

Pre-PR #8344 the state had this branching:

```csharp
if (profile != null) { ... }
else if (!string.IsNullOrEmpty(email))
    machine.Enter<LobbyForNewAccountAuthState, ...>(...);
else
    throw new ProfileNotFoundException();
```

The `!string.IsNullOrEmpty(email)` was an accidental proxy for "fresh OTP signin" — auto-login uses a payload constructor that hardcodes `Email = string.Empty`, whereas the fresh OTP path passes the real email. So orphaned-identity auto-logins fell into `else` → `ProfileNotFoundException` → caught in the outer catch → routed to `LoginSelectionAuthState`. Users could recover.

PR #8344 removed that guard so that Dapp/Social users (who never have an email) could also reach `LobbyForNewAccountAuthState` on a legitimate fresh signin. But it also deleted the "I came from auto-login" branch entirely. Now every null-profile case — including orphaned auto-logins — routes into the onboarding lobby.

### Fix

Use the signal that's already in the payload. In `ProfileFetchingAuthState.FetchProfileFlowAsync`, when `ProfileAsync` returns `null`:

- `isCached == true` → auto-login surfaced an identity with no catalyst profile. Orphaned. Clear the identity cache and route to `LoginSelectionAuthState` so the user picks a provider again.
- `isCached == false` → fresh signin, no profile yet. Proceed to `LobbyForNewAccountAuthState` (existing behavior for new accounts).

The identity cache is cleared in-place via the existing `IWeb3IdentityCache` (same instance the controller already holds), so there is no new DI wiring or persistent state. The catalyst remains the single source of truth for "does this identity have a profile".

### Additional fix: splash screen not fading on `LobbyForNewAccountAuthState`

`LobbyForExistingAccountAuthState.Enter` and `LoginSelectionAuthState.Enter` both call `splashScreen.FadeOutAndHide()` on entry. `LobbyForNewAccountAuthState.Enter` did not. Any user who reached that state on reopen (before this PR: the abandoned Dapp/Social scenario; after this PR: any legitimate fresh-signin new account) would see the DCL logo spinner on top of an invisible lobby UI and perceive it as a hang, even though the state machine was actually in the correct state. Fixed by injecting `SplashScreen` into `LobbyForNewAccountAuthState` and fading it on `Enter`, using the same null-check pattern as its siblings (`splashScreen` is nulled out after the first login).

### Secondary safety net: timeout on initial `ProfileAsync`

`selfProfile.ProfileAsync(ct)` in `ProfileFetchingAuthState` is now wrapped in `.Timeout(15s)` with a `catch (TimeoutException)` that routes to `LoginSelectionAuthState` with a `CONNECTION_ERROR`. This ensures that if the catalyst is ever unresponsive (flaky network, partial state, etc.) the user surfaces into a recoverable error screen rather than a frozen spinner. Independent of the main fix.

### Why not a `PROFILE_DEPLOYED` PlayerPrefs marker

An earlier iteration introduced a persistent marker in `CompositeWeb3Provider.TryAutoLoginAsync` that checked whether the cached identity had ever deployed a profile. It was dropped in favor of the `isCached` approach because:

- **Layer bleed:** `CompositeWeb3Provider` (pure auth/crypto) had to know about profile deployment state. Even via a PlayerPref, that's the same coupling with extra indirection.
- **Multiple sync points:** the marker had to be seeded in `LobbyForNewAccountAuthState` (after first deploy) and in `ProfileFetchingAuthState` (for migration of existing users), cleared in `LogoutAsync`, and an auxiliary `LOGGEDIN_EMAIL` cleanup in `LoginAsync` was needed to avoid mis-routing. Any future auth entry point had to remember to seed it.
- **Source-of-truth duplication:** the catalyst is the authoritative answer to "does this identity have a profile". `ProfileFetchingAuthState` calls it anyway. Using that result directly is simpler and stays honest under migration and edge cases.

### Not covered by this PR (known, separate)

If a user abandons OTP onboarding and then logs in with MetaMask in the same cache, `LOGGEDIN_EMAIL` is left behind from the OTP flow. On subsequent launches, `CompositeWeb3Provider.TryAutoLoginAsync` uses the stale email to infer "this is an OTP session" and takes the ThirdWeb branch, which does not match the actually cached Dapp identity. This is a pre-existing bug in how `LOGGEDIN_EMAIL` is used as a provider heuristic and is orthogonal to the abandoned-onboarding recovery path fixed here. To be addressed in a follow-up: either clear `LOGGEDIN_EMAIL` on successful Dapp login, or (better) derive the provider from the identity itself rather than inferring it from a side-channel PlayerPref.

### Files changed

- `Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs` — pass `storedIdentityProvider` into `ProfileFetchingAuthState` and `splashScreen` into `LobbyForNewAccountAuthState` (both already available in the controller).
- `Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs` — inject `IWeb3IdentityCache`, add the `else if (isCached)` branch that clears the identity and routes to `LoginSelection`, wrap `ProfileAsync` in a 15s timeout with a dedicated `TimeoutException` catch.
- `Explorer/Assets/DCL/AuthenticationScreenFlow/States/LobbyForNewAccountAuthState.cs` — inject `SplashScreen`, fade it on `Enter`.

## Test Instructions

**Steps (standard run — validates returning users still auto-login cleanly)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**: existing users with a deployed profile auto-login straight to the existing-account lobby. No regression.

**Steps (fresh account — validates the actual bug fix)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

### Prerequisites
- [ ] Build ships with the 3 changed files
- [ ] Clean local state for the abandoned-flow scenarios. On macOS:
  ```bash
  pkill -9 Explorer 2>/dev/null; sleep 1
  rm -rf "$HOME/Library/Application Support/Decentraland/Explorer"
  defaults delete unity.Decentraland.Explorer 2>/dev/null
  rm -f "$HOME/Library/Preferences/unity.Decentraland.Explorer.plist"
  rm -f "$HOME/Library/Logs/Decentraland/Explorer/Player.log"
  ```

### Test Scenarios

**A. Abandoned Social / MetaMask onboarding**
1. Start with a clean cache.
2. Open the Explorer → login with Social or MetaMask → sign the AuthChain.
3. Reach the new-account lobby (avatar preview + name field + body type + ToS).
4. **Close the Explorer without pressing "GO / Jump In".**
5. Reopen the Explorer.
6. **Expected:** login selection screen is shown.
   Pre-fix: infinite loading spinner; only recoverable by manually clearing local cache.

**B. Abandoned OTP onboarding**
1. Start with a clean cache.
2. Open the Explorer → email + OTP → sign the AuthChain.
3. Reach the new-account lobby.
4. **Close the Explorer without pressing "GO".**
5. Reopen the Explorer.
6. **Expected:** login selection screen is shown.
   Pre-fix (after PR #8344 landed): silently re-enters the new-account lobby with the stale OTP session, without the user being able to change their mind.

**C. Happy path — Social / MetaMask complete onboarding**
1. Start with a clean cache.
2. Login with Social or MetaMask, complete the new-account lobby, press "GO / Jump In".
3. Confirm you land in-world.
4. Close, reopen.
5. **Expected:** auto-login goes directly to the existing-account lobby ("Back, <username>"), no re-authentication.

**D. Happy path — OTP complete onboarding**
1. Start with a clean cache.
2. Login with OTP, complete the new-account lobby, press "GO".
3. Confirm you land in-world.
4. Close, reopen.
5. **Expected:** auto-login goes directly to the existing-account lobby, no re-authentication.

**E. Returning user with already-deployed profile**
1. Start with an account that already has a profile deployed (any previous session).
2. Open this build.
3. **Expected:** auto-login completes normally, straight to the existing-account lobby. No regressions for users who were working fine before the fix.

**F. Fresh new-account splash visibility**
1. Start with a clean cache.
2. Login with any provider → reach the new-account lobby.
3. **Expected:** the DCL logo splash fades out and the onboarding UI (avatar preview, name field, body type, ToS) is visible and interactive.
   Pre-fix: the splash stayed on top of the UI until it was dismissed some other way.

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Additional Testing Notes
- The 15s timeout on `ProfileAsync` is a safety net, not the primary fix. It should not fire in a healthy environment; only if the catalyst stalls.
- Logging out via "Diff Account" continues to work as before — this PR doesn't touch `LogoutAsync`.
- No test harness exists for `Web3` or `AuthenticationScreenFlow` assemblies, so these scenarios are manual-only.
- Known-not-fixed: stale `LOGGEDIN_EMAIL` after switching from an abandoned OTP session to a Dapp login (see "Not covered by this PR" above). To be addressed separately.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
