### PR TITLE
fix: profile persistence after login with new account

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -9,6 +9,7 @@ using DCL.FeatureFlags;
 using DCL.Input;
 using DCL.Input.Component;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.SceneLoadingScreens.SplashScreen;
 using DCL.Settings.Utils;
@@ -64,6 +65,7 @@ namespace DCL.AuthenticationScreenFlow
         private readonly IWearablesProvider wearablesProvider;
         private readonly IWebRequestController webRequestController;
         private readonly IDecentralandUrlsSource decentralandUrlsSource;
+        private readonly ProfileChangesBus profileChangesBus;
 
         private AuthenticationScreenCharacterPreviewController? characterPreviewController;
         private readonly IInputBlock inputBlock;
@@ -100,7 +102,8 @@ namespace DCL.AuthenticationScreenFlow
             AudioClipConfig backgroundMusic,
             IWearablesProvider wearablesProvider,
             IWebRequestController webRequestController,
-            IDecentralandUrlsSource decentralandUrlsSource)
+            IDecentralandUrlsSource decentralandUrlsSource,
+            ProfileChangesBus profileChangesBus)
             : base(viewFactory)
         {
             this.web3Authenticator = web3Authenticator;
@@ -119,6 +122,7 @@ namespace DCL.AuthenticationScreenFlow
             this.wearablesProvider = wearablesProvider;
             this.webRequestController = webRequestController;
             this.decentralandUrlsSource = decentralandUrlsSource;
+            this.profileChangesBus = profileChangesBus;
         }
 
         public override void Dispose()
@@ -163,7 +167,7 @@ namespace DCL.AuthenticationScreenFlow
 
                 fsm.AddStates(
                     otpVerificationState,
-                    new LobbyForNewAccountAuthState(fsm, viewInstance, this, CurrentState, characterPreviewController, selfProfile, wearablesProvider, webBrowser, webRequestController, decentralandUrlsSource)
+                    new LobbyForNewAccountAuthState(fsm, viewInstance, this, CurrentState, characterPreviewController, selfProfile, wearablesProvider, webBrowser, webRequestController, decentralandUrlsSource, profileChangesBus)
                 );
             }
 

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LobbyForNewAccountAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LobbyForNewAccountAuthState.cs
@@ -38,6 +38,7 @@ namespace DCL.AuthenticationScreenFlow
         private readonly IWebBrowser webBrowser;
         private readonly IWebRequestController webRequestController;
         private readonly IDecentralandUrlsSource decentralandUrlsSource;
+        private readonly ProfileChangesBus profileChangesBus;
 
         private Dictionary<string, List<URN>>? maleWearablesByCategory;
         private Dictionary<string, List<URN>>? femaleWearablesByCategory;
@@ -61,7 +62,8 @@ namespace DCL.AuthenticationScreenFlow
             IWearablesProvider wearablesProvider,
             IWebBrowser webBrowser,
             IWebRequestController webRequestController,
-            IDecentralandUrlsSource decentralandUrlsSource) : base(viewInstance)
+            IDecentralandUrlsSource decentralandUrlsSource,
+            ProfileChangesBus profileChangesBus) : base(viewInstance)
         {
             view = viewInstance.LobbyForNewAccountAuthView;
 
@@ -74,6 +76,7 @@ namespace DCL.AuthenticationScreenFlow
             this.webBrowser = webBrowser;
             this.webRequestController = webRequestController;
             this.decentralandUrlsSource = decentralandUrlsSource;
+            this.profileChangesBus = profileChangesBus;
 
             characterPreviewView = viewInstance.CharacterPreviewView;
             characterPreviewOrigPosition = characterPreviewView.transform.localPosition;
@@ -347,6 +350,10 @@ namespace DCL.AuthenticationScreenFlow
                     newUserProfile.Name = view.ProfileNameInputField.Text;
                     Profile? publishedProfile = await selfProfile.UpdateProfileAsync(newUserProfile, ct, updateAvatarInWorld: false);
                     newUserProfile = publishedProfile ?? throw new ProfileNotFoundException();
+
+                    // Notify profile-bus subscribers (sidebar thumbnail, explore panel, chat) that the
+                    // freshly created profile is live
+                    profileChangesBus.PushUpdate(newUserProfile);
 
                     await characterPreviewController.PlayJumpInEmoteAndAwaitItAsync();
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -856,7 +856,6 @@ namespace Global.Dynamic
                     bootstrapContainer.DecentralandUrlsSource,
                     passportBridge,
                     chatEventBus,
-                    eventsApiService,
                     staticContainer.SmartWearableCache),
                 new ErrorPopupPlugin(mvcManager, assetsProvisioner),
                 new PrivateWorldsPlugin(
@@ -1012,7 +1011,7 @@ namespace Global.Dynamic
                     staticContainer.ImageControllerProvider),
                 new CharacterPreviewPlugin(staticContainer.ComponentsContainer.ComponentPoolsRegistry, assetsProvisioner, staticContainer.CacheCleaner),
                 staticContainer.WebRequestsContainer.CreatePlugin(localSceneDevelopment),
-                new Web3AuthenticationPlugin(assetsProvisioner, dynamicWorldDependencies.CompositeWeb3Provider, debugBuilder, mvcManager, selfProfile, webBrowser, staticContainer.RealmData, identityCache, characterPreviewFactory, dynamicWorldDependencies.SplashScreen, audioMixerVolumesController, staticContainer.InputBlock, characterPreviewEventBus, backgroundMusic, globalWorld, bootstrapContainer.AppArgs, wearablesProvider, staticContainer.WebRequestsContainer.WebRequestController, bootstrapContainer.DecentralandUrlsSource),
+                new Web3AuthenticationPlugin(assetsProvisioner, dynamicWorldDependencies.CompositeWeb3Provider, debugBuilder, mvcManager, selfProfile, webBrowser, staticContainer.RealmData, identityCache, characterPreviewFactory, dynamicWorldDependencies.SplashScreen, audioMixerVolumesController, staticContainer.InputBlock, characterPreviewEventBus, backgroundMusic, globalWorld, bootstrapContainer.AppArgs, wearablesProvider, staticContainer.WebRequestsContainer.WebRequestController, bootstrapContainer.DecentralandUrlsSource, profileChangesBus),
                 new SkyboxPlugin(assetsProvisioner, dynamicSettings.DirectionalLight, staticContainer.ScenesCache, staticContainer.SceneRestrictionBusController, staticContainer.RealmData),
                 new LoadingScreenPlugin(assetsProvisioner, mvcManager, audioMixerVolumesController,
                     staticContainer.InputBlock, debugBuilder, staticContainer.LoadingStatus),

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -856,6 +856,7 @@ namespace Global.Dynamic
                     bootstrapContainer.DecentralandUrlsSource,
                     passportBridge,
                     chatEventBus,
+                    eventsApiService,
                     staticContainer.SmartWearableCache),
                 new ErrorPopupPlugin(mvcManager, assetsProvisioner),
                 new PrivateWorldsPlugin(

--- a/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
@@ -6,7 +6,6 @@ using DCL.Backpack;
 using DCL.Browser;
 using DCL.Chat;
 using DCL.Chat.History;
-using DCL.EventsApi;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Notifications;
 using DCL.Notifications.NotificationsMenu;
@@ -63,7 +62,6 @@ namespace DCL.PluginSystem.Global
         private readonly IPassportBridge passportBridge;
         private readonly ChatEventBus chatEventBus;
         private readonly SmartWearableCache smartWearableCache;
-        private readonly HttpEventsApiService eventsApiService;
 
         private SidebarController? sidebarController;
         private NotificationsPanelController? notificationsPanelController;
@@ -100,7 +98,6 @@ namespace DCL.PluginSystem.Global
             IDecentralandUrlsSource decentralandUrls,
             IPassportBridge passportBridge,
             ChatEventBus chatEventBus,
-            HttpEventsApiService eventsApiService,
             SmartWearableCache smartWearableCache)
         {
             this.assetsProvisioner = assetsProvisioner;
@@ -126,7 +123,6 @@ namespace DCL.PluginSystem.Global
             this.passportBridge = passportBridge;
             this.smartWearableCache = smartWearableCache;
             this.chatEventBus = chatEventBus;
-            this.eventsApiService = eventsApiService;
         }
 
         public void Dispose()
@@ -181,8 +177,7 @@ namespace DCL.PluginSystem.Global
                 realmData,
                 decentralandUrls,
                 globalWorld,
-                chatEventBus,
-                eventsApiService
+                chatEventBus
                 );
 
             mvcManager.RegisterController(controlsPanelController);

--- a/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
@@ -6,6 +6,7 @@ using DCL.Backpack;
 using DCL.Browser;
 using DCL.Chat;
 using DCL.Chat.History;
+using DCL.EventsApi;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Notifications;
 using DCL.Notifications.NotificationsMenu;
@@ -62,6 +63,7 @@ namespace DCL.PluginSystem.Global
         private readonly IPassportBridge passportBridge;
         private readonly ChatEventBus chatEventBus;
         private readonly SmartWearableCache smartWearableCache;
+        private readonly HttpEventsApiService eventsApiService;
 
         private SidebarController? sidebarController;
         private NotificationsPanelController? notificationsPanelController;
@@ -98,6 +100,7 @@ namespace DCL.PluginSystem.Global
             IDecentralandUrlsSource decentralandUrls,
             IPassportBridge passportBridge,
             ChatEventBus chatEventBus,
+            HttpEventsApiService eventsApiService,
             SmartWearableCache smartWearableCache)
         {
             this.assetsProvisioner = assetsProvisioner;
@@ -123,6 +126,7 @@ namespace DCL.PluginSystem.Global
             this.passportBridge = passportBridge;
             this.smartWearableCache = smartWearableCache;
             this.chatEventBus = chatEventBus;
+            this.eventsApiService = eventsApiService;
         }
 
         public void Dispose()
@@ -177,7 +181,8 @@ namespace DCL.PluginSystem.Global
                 realmData,
                 decentralandUrls,
                 globalWorld,
-                chatEventBus
+                chatEventBus,
+                eventsApiService
                 );
 
             mvcManager.RegisterController(controlsPanelController);

--- a/Explorer/Assets/DCL/PluginSystem/Global/Web3AuthenticationPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Web3AuthenticationPlugin.cs
@@ -9,6 +9,7 @@ using DCL.CharacterPreview;
 using DCL.DebugUtilities;
 using DCL.Input;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.SceneLoadingScreens.SplashScreen;
 using DCL.Web3.Authenticators;
@@ -45,6 +46,7 @@ namespace DCL.PluginSystem.Global
         private readonly IWearablesProvider wearablesProvider;
         private readonly IWebRequestController webRequestController;
         private readonly IDecentralandUrlsSource decentralandUrlsSource;
+        private readonly ProfileChangesBus profileChangesBus;
 
         private CancellationTokenSource? cancellationTokenSource;
         private AuthenticationScreenController authenticationScreenController = null!;
@@ -69,7 +71,8 @@ namespace DCL.PluginSystem.Global
             IAppArgs appArgs,
             IWearablesProvider wearablesProvider,
             IWebRequestController webRequestController,
-            IDecentralandUrlsSource decentralandUrlsSource
+            IDecentralandUrlsSource decentralandUrlsSource,
+            ProfileChangesBus profileChangesBus
         )
         {
             this.assetsProvisioner = assetsProvisioner;
@@ -91,6 +94,7 @@ namespace DCL.PluginSystem.Global
             this.wearablesProvider = wearablesProvider;
             this.webRequestController = webRequestController;
             this.decentralandUrlsSource = decentralandUrlsSource;
+            this.profileChangesBus = profileChangesBus;
         }
 
         public void Dispose() { }
@@ -116,7 +120,8 @@ namespace DCL.PluginSystem.Global
                 backgroundMusic,
                 wearablesProvider,
                 webRequestController,
-                decentralandUrlsSource);
+                decentralandUrlsSource,
+                profileChangesBus);
 
             mvcManager.RegisterController(authenticationScreenController);
 

--- a/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileSectionPresenter.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/ProfileElements/ProfileSectionPresenter.cs
@@ -62,6 +62,7 @@ namespace DCL.UI.ProfileElements
                 userNameElementPresenter.Setup(profile.Value);
                 walletAddressElementPresenter.Setup(profile.Value);
 
+                profileThumbnail.SetLoading(profile.Value.UserNameColor);
                 await GetProfileThumbnailCommand.Instance.ExecuteAsync(profileThumbnail, null, profile.Value, ct);
             }
         }

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
@@ -58,7 +58,6 @@ namespace DCL.UI.Sidebar
         private readonly bool isNearbyVoiceChatEnabled;
 
         private readonly CancellationTokenSource profileWidgetCts = new ();
-        private readonly CancellationTokenSource checkForLiveEventsCts = new ();
         private CancellationTokenSource checkForMarketplaceCreditsFeatureCts = new ();
         private CancellationTokenSource referralNotificationCts = new ();
         private CancellationTokenSource checkForCommunitiesFeatureCts = new ();
@@ -157,7 +156,6 @@ namespace DCL.UI.Sidebar
             referralNotificationCts.SafeCancelAndDispose();
             checkForCommunitiesFeatureCts.SafeCancelAndDispose();
             openPanelCts.SafeCancelAndDispose();
-            checkForLiveEventsCts.SafeCancelAndDispose();
         }
 
         private void OnChatStateChanged(ChatEvents.ChatStateChangedEvent eventData) =>

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
@@ -27,10 +27,14 @@ using MVC;
 using System;
 using System.Threading;
 using DCL.CharacterCamera;
+using DCL.EventsApi;
 using DCL.InWorldCamera;
 using DCL.UI.Buttons;
+using DCL.Utilities.Extensions;
+using DCL.Utility.Types;
 using DCL.VoiceChat.UI;
 using ECS.Abstract;
+using System.Collections.Generic;
 using Utility;
 
 namespace DCL.UI.Sidebar
@@ -56,8 +60,10 @@ namespace DCL.UI.Sidebar
         private readonly bool isFriendsFeatureEnabled;
         private readonly bool isDiscoverFeatureEnabled;
         private readonly bool isNearbyVoiceChatEnabled;
+        private readonly HttpEventsApiService eventsApiService;
 
         private readonly CancellationTokenSource profileWidgetCts = new ();
+        private CancellationTokenSource checkForLiveEventsCts = new ();
         private CancellationTokenSource checkForMarketplaceCreditsFeatureCts = new ();
         private CancellationTokenSource referralNotificationCts = new ();
         private CancellationTokenSource checkForCommunitiesFeatureCts = new ();
@@ -83,7 +89,8 @@ namespace DCL.UI.Sidebar
             IRealmData realmData,
             IDecentralandUrlsSource decentralandUrlsSource,
             World globalWorld,
-            ChatEventBus chatEventBus)
+            ChatEventBus chatEventBus,
+            HttpEventsApiService eventsApiService)
             : base(viewFactory)
         {
             this.mvcManager = mvcManager;
@@ -96,6 +103,7 @@ namespace DCL.UI.Sidebar
             this.decentralandUrlsSource = decentralandUrlsSource;
             this.globalWorld = globalWorld;
             this.chatEventBus = chatEventBus;
+            this.eventsApiService = eventsApiService;
             isCameraReelFeatureEnabled = FeaturesRegistry.Instance.IsEnabled(FeatureId.CAMERA_REEL);
             isFriendsFeatureEnabled = FeaturesRegistry.Instance.IsEnabled(FeatureId.FRIENDS);
             isMarketplaceCreditsFeatureEnabled = FeaturesRegistry.Instance.IsEnabled(FeatureId.MARKETPLACE_CREDITS);
@@ -156,6 +164,7 @@ namespace DCL.UI.Sidebar
             referralNotificationCts.SafeCancelAndDispose();
             checkForCommunitiesFeatureCts.SafeCancelAndDispose();
             openPanelCts.SafeCancelAndDispose();
+            checkForLiveEventsCts.SafeCancelAndDispose();
         }
 
         private void OnChatStateChanged(ChatEvents.ChatStateChangedEvent eventData) =>
@@ -307,6 +316,9 @@ namespace DCL.UI.Sidebar
         {
             //We load the data into the profile widget
             profileButtonPresenter.LoadProfile();
+
+            checkForLiveEventsCts = checkForLiveEventsCts.SafeRestart();
+            FillLiveEventsAsync(checkForLiveEventsCts.Token).Forget();
         }
 
         protected override void OnViewClose()
@@ -341,6 +353,21 @@ namespace DCL.UI.Sidebar
             viewInstance?.communitiesButton.gameObject.SetActive(false);
             bool includeCommunities = await CommunitiesFeatureAccess.Instance.IsUserAllowedToUseTheFeatureAsync(ct);
             viewInstance?.communitiesButton.gameObject.SetActive(includeCommunities);
+        }
+
+        private async UniTaskVoid FillLiveEventsAsync(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                Result<IReadOnlyList<EventDTO>> liveEventsResult = await eventsApiService.GetEventsAsync(ct, onlyLiveEvents: true)
+                                                                                         .SuppressToResultAsync(ReportCategory.EVENTS);
+
+                if (ct.IsCancellationRequested)
+                    return;
+
+                viewInstance!.SetLiveEventsCounter(liveEventsResult.Success ? liveEventsResult.Value.Count : 0);
+                await UniTask.Delay(TimeSpan.FromMinutes(3), cancellationToken: ct);
+            }
         }
 
 #region Sidebar button handlers

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
@@ -8,7 +8,6 @@ using DCL.Chat.History;
 using DCL.Communities;
 using DCL.Diagnostics;
 using DCL.EmotesWheel;
-using DCL.EventsApi;
 using DCL.ExplorePanel;
 using DCL.FeatureFlags;
 using DCL.Friends.UI.FriendPanel;
@@ -23,12 +22,9 @@ using DCL.UI.Controls;
 using DCL.UI.ProfileElements;
 using DCL.UI.Profiles;
 using DCL.UI.Skybox;
-using DCL.Utilities.Extensions;
-using DCL.Utility.Types;
 using ECS;
 using MVC;
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using DCL.CharacterCamera;
 using DCL.InWorldCamera;
@@ -61,7 +57,6 @@ namespace DCL.UI.Sidebar
         private readonly bool isDiscoverFeatureEnabled;
         private readonly bool isNearbyVoiceChatEnabled;
 
-        private readonly HttpEventsApiService eventsApiService;
         private readonly CancellationTokenSource profileWidgetCts = new ();
         private readonly CancellationTokenSource checkForLiveEventsCts = new ();
         private CancellationTokenSource checkForMarketplaceCreditsFeatureCts = new ();
@@ -89,8 +84,7 @@ namespace DCL.UI.Sidebar
             IRealmData realmData,
             IDecentralandUrlsSource decentralandUrlsSource,
             World globalWorld,
-            ChatEventBus chatEventBus,
-            HttpEventsApiService eventsApiService)
+            ChatEventBus chatEventBus)
             : base(viewFactory)
         {
             this.mvcManager = mvcManager;
@@ -108,7 +102,6 @@ namespace DCL.UI.Sidebar
             isMarketplaceCreditsFeatureEnabled = FeaturesRegistry.Instance.IsEnabled(FeatureId.MARKETPLACE_CREDITS);
             isDiscoverFeatureEnabled = FeaturesRegistry.Instance.IsEnabled(FeatureId.DISCOVER);
             isNearbyVoiceChatEnabled = FeaturesRegistry.Instance.IsEnabled(FeatureId.NEARBY_VOICE_CHAT);
-            this.eventsApiService = eventsApiService;
 
             chatEventBusSubscription = chatEventBus.Subscribe<ChatEvents.ChatStateChangedEvent>(OnChatStateChanged);
         }
@@ -350,21 +343,6 @@ namespace DCL.UI.Sidebar
             viewInstance?.communitiesButton.gameObject.SetActive(false);
             bool includeCommunities = await CommunitiesFeatureAccess.Instance.IsUserAllowedToUseTheFeatureAsync(ct);
             viewInstance?.communitiesButton.gameObject.SetActive(includeCommunities);
-        }
-
-        private async UniTaskVoid FillLiveEventsAsync(CancellationToken ct)
-        {
-            while (!ct.IsCancellationRequested)
-            {
-                Result<IReadOnlyList<EventsApi.EventDTO>> liveEventsResult = await eventsApiService.GetEventsAsync(ct, onlyLiveEvents: true)
-                                                                                                   .SuppressToResultAsync(ReportCategory.EVENTS);
-
-                if (ct.IsCancellationRequested)
-                    return;
-
-                viewInstance!.SetLiveEventsCounter(liveEventsResult.Success ? liveEventsResult.Value.Count : 0);
-                await UniTask.Delay(TimeSpan.FromMinutes(3), cancellationToken: ct);
-            }
         }
 
 #region Sidebar button handlers

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadPlayerAvatarStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadPlayerAvatarStartupOperation.cs
@@ -39,7 +39,11 @@ namespace DCL.UserInAppInitializationFlow
             Entity playerEntity = args.FlowParameters.PlayerEntity;
 
             if (world.Has<Profile>(playerEntity))
-                world.Set(playerEntity, profile!);
+            {
+                // Make all systems update again since the previous profile was already stored and processed, but we now updated it
+                profile!.IsDirty = true;
+                world.Set(playerEntity, profile);
+            }
             else
                 world.Add(playerEntity, profile!);
 


### PR DESCRIPTION
# Pull Request Description
Fixes #7748 
Fixes #6930 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes sure that everything profile-related to the previous session is updated with the newly created account after login.
- `isDirty` flag reset so that the in-world avatar is the new one rather than the previous session's one
- profile update propagated after the new profile creation so that other UIs can react (e.g. sidebar profile widget and panel)


### Test Steps
1. Login with an existing account
2. Enter in world and logout
3. Login with a brand new account (very fast with email+otp using the `+` trick -> test@mail.com becomes test+123@mail.com and is treated as a new account but the otp is sent to the original)
4. Verify that the shown avatar is the new one and not the previous session's

### Additional Testing Notes
- Check the repro steps in the 2 linked issues if I have missed any other test cases

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
