### PR TITLE
fix: toggle settings feature alignment

### DIFF
--- a/Explorer/Assets/DCL/Settings/Configuration/DropdownModuleBinding.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/DropdownModuleBinding.cs
@@ -31,26 +31,26 @@ namespace DCL.Settings.Configuration
         private static readonly MsaaLevel[] MSAA_LEVELS = { MsaaLevel.Off, MsaaLevel.X2, MsaaLevel.X4, MsaaLevel.X8 };
         private static readonly ShadowQualityLevel[] SHADOW_QUALITY_LEVELS = { ShadowQualityLevel.Low, ShadowQualityLevel.Medium, ShadowQualityLevel.High };
 
+        // Values are persisted as ints in SettingsMenuConfiguration.asset.
+        // Never renumber or reuse a value; new entries must pick the next unused integer.
         public enum DropdownFeatures
         {
-            GRAPHICS_QUALITY_FEATURE,
-            CAMERA_LOCK_FEATURE,
-            CAMERA_SHOULDER_FEATURE,
-            RESOLUTION_FEATURE,
-            WINDOW_MODE_FEATURE,
-            FPS_LIMIT_FEATURE,
-            MEMORY_LIMIT_FEATURE,
-            CHAT_NEARBY_AUDIO_MODES_FEATURE,
-            CHAT_DMS_AUDIO_MODES_FEATURE,
-            CHAT_DMS_MODES_FEATURE,
-            CHAT_BUBBLES_MODES_FEATURE,
-            VOICECHAT_INPUT_DEVICE,
-            CHAT_TRANSLATE_FEATURE,
-            MSAA_FEATURE,
-            SHADOWS_QUALITY_FEATURE,
-            POINT_AT_MARKER_FEATURE,
-
-            // add other features...
+            GRAPHICS_QUALITY_FEATURE = 0,
+            CAMERA_LOCK_FEATURE = 1,
+            CAMERA_SHOULDER_FEATURE = 2,
+            RESOLUTION_FEATURE = 3,
+            WINDOW_MODE_FEATURE = 4,
+            FPS_LIMIT_FEATURE = 5,
+            MEMORY_LIMIT_FEATURE = 6,
+            CHAT_NEARBY_AUDIO_MODES_FEATURE = 7,
+            CHAT_DMS_AUDIO_MODES_FEATURE = 8,
+            CHAT_DMS_MODES_FEATURE = 9,
+            CHAT_BUBBLES_MODES_FEATURE = 10,
+            VOICECHAT_INPUT_DEVICE = 11,
+            CHAT_TRANSLATE_FEATURE = 12,
+            MSAA_FEATURE = 13,
+            SHADOWS_QUALITY_FEATURE = 14,
+            POINT_AT_MARKER_FEATURE = 15,
         }
 
         public override async UniTask<SettingsFeatureController> CreateModuleAsync(

--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
@@ -266,7 +266,7 @@ MonoBehaviour:
             performance.
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
-        <Feature>k__BackingField: 4
+        <Feature>k__BackingField: 5
     - rid: 2404945502817747083
       type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
@@ -285,7 +285,7 @@ MonoBehaviour:
             performance on weaker devices.
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
-        <Feature>k__BackingField: 5
+        <Feature>k__BackingField: 6
     - rid: 2404945502817747084
       type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
@@ -303,7 +303,7 @@ MonoBehaviour:
             performance gain.
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
-        <Feature>k__BackingField: 6
+        <Feature>k__BackingField: 7
     - rid: 2404945502817747108
       type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
@@ -403,7 +403,7 @@ MonoBehaviour:
             improve performance.
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
-        <Feature>k__BackingField: 7
+        <Feature>k__BackingField: 8
     - rid: 2404945524685013118
       type: {class: SliderModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
@@ -484,7 +484,7 @@ MonoBehaviour:
             can significantly improve performance in light-heavy scenes.
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
-        <Feature>k__BackingField: 9
+        <Feature>k__BackingField: 10
     - rid: 2404945524685013200
       type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
@@ -501,7 +501,7 @@ MonoBehaviour:
             Disable this to remove the effect and gain a minor performance improvement.
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 1
-        <Feature>k__BackingField: 11
+        <Feature>k__BackingField: 13
     - rid: 2659808844961546333
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
@@ -586,7 +586,7 @@ MonoBehaviour:
             automatically.
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
-        <Feature>k__BackingField: 11
+        <Feature>k__BackingField: 14
     - rid: 3511243270148325473
       type: {class: DropdownModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
@@ -792,7 +792,7 @@ MonoBehaviour:
             or windowed.
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
-        <Feature>k__BackingField: 10
+        <Feature>k__BackingField: 11
     - rid: 7533463652475600993
       type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
@@ -809,4 +809,4 @@ MonoBehaviour:
             play or even the closeby scenes will
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
-        <Feature>k__BackingField: 11
+        <Feature>k__BackingField: 12

--- a/Explorer/Assets/DCL/Settings/Configuration/SliderModuleBinding.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/SliderModuleBinding.cs
@@ -26,23 +26,24 @@ namespace DCL.Settings.Configuration
     [Serializable]
     public class SliderModuleBinding : SettingsModuleBinding<SettingsSliderModuleView, SettingsSliderModuleView.Config, SliderModuleBinding.SliderFeatures>
     {
+        // Values are persisted as ints in SettingsMenuConfiguration.asset.
+        // Never renumber or reuse a value; new entries must pick the next unused integer.
         public enum SliderFeatures
         {
-            SCENE_DISTANCE_FEATURE,
-            ENVIRONMENT_DISTANCE_FEATURE,
-            MOUSE_VERTICAL_SENSITIVITY_FEATURE,
-            MOUSE_HORIZONTAL_SENSITIVITY_FEATURE,
-            MASTER_VOLUME_FEATURE,
-            WORLD_SOUNDS_VOLUME_FEATURE,
-            MUSIC_VOLUME_FEATURE,
-            UI_SOUNDS_VOLUME_FEATURE,
-            AVATAR_SOUNDS_VOLUME_FEATURE,
-            VOICE_CHAT_VOLUME_FEATURE,
-            UPSCALER_FEATURE,
-            MUSIC_SFX_SOUND_VOLUME_FEATURE,
-            MAX_SCENE_LIGHTS_FEATURE,
-            SHADOW_DISTANCE_FEATURE,
-            // add other features...
+            SCENE_DISTANCE_FEATURE = 0,
+            ENVIRONMENT_DISTANCE_FEATURE = 1,
+            MOUSE_VERTICAL_SENSITIVITY_FEATURE = 2,
+            MOUSE_HORIZONTAL_SENSITIVITY_FEATURE = 3,
+            MASTER_VOLUME_FEATURE = 4,
+            WORLD_SOUNDS_VOLUME_FEATURE = 5,
+            MUSIC_VOLUME_FEATURE = 6,
+            UI_SOUNDS_VOLUME_FEATURE = 7,
+            AVATAR_SOUNDS_VOLUME_FEATURE = 8,
+            VOICE_CHAT_VOLUME_FEATURE = 9,
+            UPSCALER_FEATURE = 10,
+            MUSIC_SFX_SOUND_VOLUME_FEATURE = 11,
+            MAX_SCENE_LIGHTS_FEATURE = 12,
+            SHADOW_DISTANCE_FEATURE = 13,
         }
 
         public override async UniTask<SettingsFeatureController> CreateModuleAsync(

--- a/Explorer/Assets/DCL/Settings/Configuration/ToggleModuleBinding.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/ToggleModuleBinding.cs
@@ -27,24 +27,25 @@ namespace DCL.Settings.Configuration
     [Serializable]
     public class ToggleModuleBinding : SettingsModuleBinding<SettingsToggleModuleView, SettingsToggleModuleView.Config, ToggleModuleBinding.ToggleFeatures>
     {
+        // Values are persisted as ints in SettingsMenuConfiguration.asset.
+        // Never renumber or reuse a value; new entries must pick the next unused integer.
         public enum ToggleFeatures
         {
-            CHAT_SOUNDS_FEATURE,
-            GRAPHICS_VSYNC_TOGGLE_FEATURE,
-            HIDE_BLOCKED_USER_CHAT_MESSAGES_FEATURE,
-            HEAD_SYNC_FEATURE,
-            CHAT_REACTIONS_ENABLED_FEATURE,
-            HDR_FEATURE,
-            BLOOM_FEATURE,
-            AVATAR_OUTLINE_FEATURE,
-            SUN_SHADOWS_FEATURE,
-            SCENE_SHADOWS_FEATURE,
-            SCENE_LIGHTS_FEATURE,
-            FULLSCREEN_FEATURE,
-            PLAY_CURRENT_SCENE_STREAM_ONLY_FEATURE,
-            SUN_LENS_FLARE_FEATURE,
-            DOUBLE_TAP_TO_MOVE
-            // add other features...
+            CHAT_SOUNDS_FEATURE = 0,
+            GRAPHICS_VSYNC_TOGGLE_FEATURE = 1,
+            HIDE_BLOCKED_USER_CHAT_MESSAGES_FEATURE = 2,
+            HEAD_SYNC_FEATURE = 3,
+            CHAT_REACTIONS_ENABLED_FEATURE = 4,
+            HDR_FEATURE = 5,
+            BLOOM_FEATURE = 6,
+            AVATAR_OUTLINE_FEATURE = 7,
+            SUN_SHADOWS_FEATURE = 8,
+            SCENE_SHADOWS_FEATURE = 9,
+            SCENE_LIGHTS_FEATURE = 10,
+            FULLSCREEN_FEATURE = 11,
+            PLAY_CURRENT_SCENE_STREAM_ONLY_FEATURE = 12,
+            SUN_LENS_FLARE_FEATURE = 13,
+            DOUBLE_TAP_TO_MOVE = 14,
         }
 
         public override async UniTask<SettingsFeatureController> CreateModuleAsync(


### PR DESCRIPTION
# Pull Request Description
Fixes #8424

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->
This PR re-aligns all the toggle feature values to the proper configuration (every toggle was shifted by 1 by the improperly ordering of `CHAT_REACTIONS_ENABLED_FEATURE` on its creation).

Now all features (toggle, slider and dropdown) have a fixed index enum value so that every new addition can't affect the previous ones.

### Test Steps
1. Verify the steps in the linked issue
2. Verify that all possible settings (especially toggles) modify the proper feature (e.g. v-sync toggle modify the v-sync behaviour, Sun Lens Flare enables/disables the sun lens flare and so on...)


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
