### PR TITLE
fix: add id-token write permission to dependency security review

### DIFF
--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -19,6 +19,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Summary
- The Dependency Security Review workflow was failing all runs on `Failed to get OIDC token: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`.
- `anthropics/claude-code-action@v1` calls `core.getIDToken()` unconditionally; without `id-token: write` in the job's `permissions:` block, GitHub does not inject `ACTIONS_ID_TOKEN_REQUEST_URL` and the action fails after three retries.
- Added `id-token: write` to the `detect-and-review` job. Matches the permission set already granted to the same action in `claude-pr-review.yml`.

## Test plan
- [ ] Open / synchronize a PR that touches `Explorer/Packages/manifest.json`, `Explorer/Packages/packages-lock.json`, `Explorer/Assets/Plugins/**`, or any `*.dll`/`*.so`/`*.dylib`/`*.bundle`/`*.aar`/`*.jar` and confirm the `Dependency Security Review` job no longer errors on OIDC token retrieval.
- [ ] Confirm the `Dependency Security Review` commit status is set (PASS / NEEDS_ATTENTION / BLOCK) instead of failing the job.