### PR TITLE
fix: use raw gltf on remote AB not found during LSD

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/PrepareGltfAssetLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/PrepareGltfAssetLoadingSystem.cs
@@ -10,8 +10,8 @@ using ECS.StreamableLoading.Common.Components;
 using ECS.StreamableLoading.GLTF;
 using ECS.Unity.GLTFContainer.Asset.Cache;
 using ECS.Unity.GLTFContainer.Asset.Components;
+using SceneRunner.Scene;
 using UnityEngine;
-using Utility;
 
 namespace ECS.Unity.GLTFContainer.Asset.Systems
 {
@@ -24,17 +24,22 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
     public partial class PrepareGltfAssetLoadingSystem : BaseUnityLoopSystem
     {
         private readonly IGltfContainerAssetsCache cache;
+        private readonly ISceneData sceneData;
         private readonly Options options;
 
-        internal PrepareGltfAssetLoadingSystem(World world, IGltfContainerAssetsCache cache, Options options) : base(world)
+        internal PrepareGltfAssetLoadingSystem(World world, IGltfContainerAssetsCache cache, ISceneData sceneData, Options options) : base(world)
         {
             this.cache = cache;
+            this.sceneData = sceneData;
             this.options = options;
         }
 
         protected override void Update(float t)
         {
             PrepareQuery(World);
+
+            if (options is {LocalSceneDevelopment: true, UseRemoteAssetBundles: true })
+                FallbackToRawGltfQuery(World);
         }
 
         [Query]
@@ -51,19 +56,32 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
                 return;
             }
 
-            bool loadRawGltf = options.PreviewingBuilderCollection || options is { LocalSceneDevelopment: true, UseRemoveAssetBundles: false };
+            bool loadRawGltf = options.PreviewingBuilderCollection || options is { LocalSceneDevelopment: true, UseRemoteAssetBundles: false };
             if (loadRawGltf)
                 World.Add(entity, GetGLTFIntention.Create(intention.Name, intention.Hash));
             else
                 World.Add(entity, GetAssetBundleIntention.Create(typeof(GameObject), $"{intention.Hash}{PlatformUtils.GetCurrentPlatform()}", intention.Name));
         }
 
+        /// <summary>
+        ///     AB loading failed in LSD mode — fall back to loading raw GLTF from the local content server.
+        /// </summary>
+        [Query]
+        [None(typeof(GetGLTFIntention))]
+        private void FallbackToRawGltf(in Entity entity, ref GetGltfContainerAssetIntention intention, ref StreamableLoadingResult<GltfContainerAsset> result)
+        {
+            if (result.Succeeded) return;
+
+            // Tried to load remotely, the AB is missing, then try to load locally
+            sceneData.SceneContent.SwitchToLocal(intention.Name);
+            World.Remove<StreamableLoadingResult<GltfContainerAsset>>(entity);
+            World.Add(entity, GetGLTFIntention.Create(intention.Name, intention.Hash));
+        }
+
         public struct Options
         {
             public bool LocalSceneDevelopment;
-
-            public bool UseRemoveAssetBundles;
-
+            public bool UseRemoteAssetBundles;
             public bool PreviewingBuilderCollection;
         }
     }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/PrepareGltfAssetLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/PrepareGltfAssetLoadingSystem.cs
@@ -1,4 +1,4 @@
-﻿using Arch.Core;
+using Arch.Core;
 using Arch.System;
 using Arch.SystemGroups;
 using DCL.Diagnostics;
@@ -37,9 +37,6 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
         protected override void Update(float t)
         {
             PrepareQuery(World);
-
-            if (options is {LocalSceneDevelopment: true, UseRemoteAssetBundles: true })
-                FallbackToRawGltfQuery(World);
         }
 
         [Query]
@@ -56,26 +53,20 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
                 return;
             }
 
-            bool loadRawGltf = options.PreviewingBuilderCollection || options is { LocalSceneDevelopment: true, UseRemoteAssetBundles: false };
+            bool loadRawGltf = options.PreviewingBuilderCollection;
+
+            if (options.LocalSceneDevelopment)
+            {
+                if (options.UseRemoteAssetBundles)
+                    loadRawGltf |= sceneData.SceneContent.IsRawAsset(intention.Name);
+                else
+                    loadRawGltf = true;
+            }
+
             if (loadRawGltf)
                 World.Add(entity, GetGLTFIntention.Create(intention.Name, intention.Hash));
             else
                 World.Add(entity, GetAssetBundleIntention.Create(typeof(GameObject), $"{intention.Hash}{PlatformUtils.GetCurrentPlatform()}", intention.Name));
-        }
-
-        /// <summary>
-        ///     AB loading failed in LSD mode — fall back to loading raw GLTF from the local content server.
-        /// </summary>
-        [Query]
-        [None(typeof(GetGLTFIntention))]
-        private void FallbackToRawGltf(in Entity entity, ref GetGltfContainerAssetIntention intention, ref StreamableLoadingResult<GltfContainerAsset> result)
-        {
-            if (result.Succeeded) return;
-
-            // Tried to load remotely, the AB is missing, then try to load locally
-            sceneData.SceneContent.SwitchToLocal(intention.Name);
-            World.Remove<StreamableLoadingResult<GltfContainerAsset>>(entity);
-            World.Add(entity, GetGLTFIntention.Create(intention.Name, intention.Hash));
         }
 
         public struct Options

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Tests/PrepareGltfAssetLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Tests/PrepareGltfAssetLoadingSystemShould.cs
@@ -1,5 +1,4 @@
-﻿using Arch.Core;
-using DCL.Diagnostics;
+using Arch.Core;
 using DCL.Utility;
 using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.Common.Components;
@@ -11,7 +10,6 @@ using ECS.Unity.GLTFContainer.Asset.Systems;
 using NSubstitute;
 using NUnit.Framework;
 using SceneRunner.Scene;
-using System;
 using System.Threading;
 using UnityEngine;
 using Utility;
@@ -23,12 +21,15 @@ namespace ECS.Unity.GLTFContainer.Asset.Tests
     {
         private IGltfContainerAssetsCache cache;
         private ISceneData sceneData;
+        private ISceneContent sceneContent;
 
         [SetUp]
         public void SetUp()
         {
             cache = Substitute.For<IGltfContainerAssetsCache>();
             sceneData = Substitute.For<ISceneData>();
+            sceneContent = Substitute.For<ISceneContent>();
+            sceneData.SceneContent.Returns(sceneContent);
             system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, default);
         }
 
@@ -67,6 +68,8 @@ namespace ECS.Unity.GLTFContainer.Asset.Tests
         [Test]
         public void CreateAssetBundleIntentionWhenLsdWithRemoteAb()
         {
+            sceneContent.IsRawAsset("TEST").Returns(false);
+
             system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, new PrepareGltfAssetLoadingSystem.Options
             {
                 LocalSceneDevelopment = true,
@@ -83,10 +86,9 @@ namespace ECS.Unity.GLTFContainer.Asset.Tests
         }
 
         [Test]
-        public void FallbackToRawGltfWhenAbFailsInLsdWithRemoteAb()
+        public void CreateGltfIntentionForRawAssetWhenLsdWithRemoteAb()
         {
-            var sceneContent = Substitute.For<ISceneContent>();
-            sceneData.SceneContent.Returns(sceneContent);
+            sceneContent.IsRawAsset("models/local_only.glb").Returns(true);
 
             system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, new PrepareGltfAssetLoadingSystem.Options
             {
@@ -94,53 +96,13 @@ namespace ECS.Unity.GLTFContainer.Asset.Tests
                 UseRemoteAssetBundles = true,
             });
 
-            var intent = new GetGltfContainerAssetIntention("models/tree.glb", "TEST_HASH", new CancellationTokenSource());
-            Entity e = world.Create(intent,
-                new StreamableLoadingResult<GltfContainerAsset>(new ReportData(ReportCategory.GLTF_CONTAINER), new Exception("AB not found")));
+            var intent = new GetGltfContainerAssetIntention("models/local_only.glb", "TEST_HASH", new CancellationTokenSource());
+            Entity e = world.Create(intent);
 
             system.Update(0);
 
-            sceneContent.Received(1).SwitchToLocal("models/tree.glb");
-            Assert.That(world.Has<StreamableLoadingResult<GltfContainerAsset>>(e), Is.False);
+            Assert.That(world.Has<GetAssetBundleIntention>(e), Is.False);
             Assert.That(world.Has<GetGLTFIntention>(e), Is.True);
-        }
-
-        [Test]
-        public void NotFallbackToRawGltfInPlayMode()
-        {
-            system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, default);
-
-            var intent = new GetGltfContainerAssetIntention("TEST", "TEST_HASH", new CancellationTokenSource());
-            Entity e = world.Create(intent,
-                new StreamableLoadingResult<GltfContainerAsset>(new ReportData(ReportCategory.GLTF_CONTAINER), new Exception("AB not found")));
-
-            system.Update(0);
-
-            // Failed result should remain — no fallback in play mode
-            Assert.That(world.Has<StreamableLoadingResult<GltfContainerAsset>>(e), Is.True);
-            Assert.That(world.Has<GetGLTFIntention>(e), Is.False);
-        }
-
-        [Test]
-        public void NotFallbackWhenResultSucceeded()
-        {
-            var asset = GltfContainerAsset.Create(new GameObject("GLTF_ROOT"), assetData: null);
-
-            system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, new PrepareGltfAssetLoadingSystem.Options
-            {
-                LocalSceneDevelopment = true,
-                UseRemoteAssetBundles = true,
-            });
-
-            var intent = new GetGltfContainerAssetIntention("TEST", "TEST_HASH", new CancellationTokenSource());
-            Entity e = world.Create(intent, new StreamableLoadingResult<GltfContainerAsset>(asset));
-
-            system.Update(0);
-
-            // Successful result should not trigger fallback
-            Assert.That(world.TryGet(e, out StreamableLoadingResult<GltfContainerAsset> result), Is.True);
-            Assert.That(result.Succeeded, Is.True);
-            Assert.That(world.Has<GetGLTFIntention>(e), Is.False);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Tests/PrepareGltfAssetLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Tests/PrepareGltfAssetLoadingSystemShould.cs
@@ -1,13 +1,17 @@
 ﻿using Arch.Core;
+using DCL.Diagnostics;
 using DCL.Utility;
 using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.Common.Components;
+using ECS.StreamableLoading.GLTF;
 using ECS.TestSuite;
 using ECS.Unity.GLTFContainer.Asset.Cache;
 using ECS.Unity.GLTFContainer.Asset.Components;
 using ECS.Unity.GLTFContainer.Asset.Systems;
 using NSubstitute;
 using NUnit.Framework;
+using SceneRunner.Scene;
+using System;
 using System.Threading;
 using UnityEngine;
 using Utility;
@@ -17,13 +21,16 @@ namespace ECS.Unity.GLTFContainer.Asset.Tests
     [TestFixture]
     public class PrepareGltfAssetLoadingSystemShould : UnitySystemTestBase<PrepareGltfAssetLoadingSystem>
     {
+        private IGltfContainerAssetsCache cache;
+        private ISceneData sceneData;
+
         [SetUp]
         public void SetUp()
         {
-            system = new PrepareGltfAssetLoadingSystem(world, cache = Substitute.For<IGltfContainerAssetsCache>(), default);
+            cache = Substitute.For<IGltfContainerAssetsCache>();
+            sceneData = Substitute.For<ISceneData>();
+            system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, default);
         }
-
-        private IGltfContainerAssetsCache cache;
 
         [Test]
         public void CreateAssetBundleIntention()
@@ -36,6 +43,104 @@ namespace ECS.Unity.GLTFContainer.Asset.Tests
             Assert.That(world.Has<StreamableLoadingResult<GltfContainerAsset>>(e), Is.False);
             Assert.That(world.TryGet(e, out GetAssetBundleIntention result), Is.True);
             Assert.That(result.Hash, Is.EqualTo($"TEST_HASH{PlatformUtils.GetCurrentPlatform()}"));
+        }
+
+        [Test]
+        public void CreateGltfIntentionInLocalSceneDevelopment()
+        {
+            system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, new PrepareGltfAssetLoadingSystem.Options
+            {
+                LocalSceneDevelopment = true,
+                UseRemoteAssetBundles = false,
+            });
+
+            var intent = new GetGltfContainerAssetIntention("TEST", "TEST_HASH", new CancellationTokenSource());
+            Entity e = world.Create(intent);
+
+            system.Update(0);
+
+            Assert.That(world.Has<StreamableLoadingResult<GltfContainerAsset>>(e), Is.False);
+            Assert.That(world.Has<GetAssetBundleIntention>(e), Is.False);
+            Assert.That(world.Has<GetGLTFIntention>(e), Is.True);
+        }
+
+        [Test]
+        public void CreateAssetBundleIntentionWhenLsdWithRemoteAb()
+        {
+            system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, new PrepareGltfAssetLoadingSystem.Options
+            {
+                LocalSceneDevelopment = true,
+                UseRemoteAssetBundles = true,
+            });
+
+            var intent = new GetGltfContainerAssetIntention("TEST", "TEST_HASH", new CancellationTokenSource());
+            Entity e = world.Create(intent);
+
+            system.Update(0);
+
+            Assert.That(world.TryGet(e, out GetAssetBundleIntention result), Is.True);
+            Assert.That(result.Hash, Is.EqualTo($"TEST_HASH{PlatformUtils.GetCurrentPlatform()}"));
+        }
+
+        [Test]
+        public void FallbackToRawGltfWhenAbFailsInLsdWithRemoteAb()
+        {
+            var sceneContent = Substitute.For<ISceneContent>();
+            sceneData.SceneContent.Returns(sceneContent);
+
+            system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, new PrepareGltfAssetLoadingSystem.Options
+            {
+                LocalSceneDevelopment = true,
+                UseRemoteAssetBundles = true,
+            });
+
+            var intent = new GetGltfContainerAssetIntention("models/tree.glb", "TEST_HASH", new CancellationTokenSource());
+            Entity e = world.Create(intent,
+                new StreamableLoadingResult<GltfContainerAsset>(new ReportData(ReportCategory.GLTF_CONTAINER), new Exception("AB not found")));
+
+            system.Update(0);
+
+            sceneContent.Received(1).SwitchToLocal("models/tree.glb");
+            Assert.That(world.Has<StreamableLoadingResult<GltfContainerAsset>>(e), Is.False);
+            Assert.That(world.Has<GetGLTFIntention>(e), Is.True);
+        }
+
+        [Test]
+        public void NotFallbackToRawGltfInPlayMode()
+        {
+            system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, default);
+
+            var intent = new GetGltfContainerAssetIntention("TEST", "TEST_HASH", new CancellationTokenSource());
+            Entity e = world.Create(intent,
+                new StreamableLoadingResult<GltfContainerAsset>(new ReportData(ReportCategory.GLTF_CONTAINER), new Exception("AB not found")));
+
+            system.Update(0);
+
+            // Failed result should remain — no fallback in play mode
+            Assert.That(world.Has<StreamableLoadingResult<GltfContainerAsset>>(e), Is.True);
+            Assert.That(world.Has<GetGLTFIntention>(e), Is.False);
+        }
+
+        [Test]
+        public void NotFallbackWhenResultSucceeded()
+        {
+            var asset = GltfContainerAsset.Create(new GameObject("GLTF_ROOT"), assetData: null);
+
+            system = new PrepareGltfAssetLoadingSystem(world, cache, sceneData, new PrepareGltfAssetLoadingSystem.Options
+            {
+                LocalSceneDevelopment = true,
+                UseRemoteAssetBundles = true,
+            });
+
+            var intent = new GetGltfContainerAssetIntention("TEST", "TEST_HASH", new CancellationTokenSource());
+            Entity e = world.Create(intent, new StreamableLoadingResult<GltfContainerAsset>(asset));
+
+            system.Update(0);
+
+            // Successful result should not trigger fallback
+            Assert.That(world.TryGet(e, out StreamableLoadingResult<GltfContainerAsset> result), Is.True);
+            Assert.That(result.Succeeded, Is.True);
+            Assert.That(world.Has<GetGLTFIntention>(e), Is.False);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/HybridSceneHashedContent.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/HybridSceneHashedContent.cs
@@ -92,7 +92,7 @@ namespace SceneRunner.Scene
                 var sceneEntityDefinition = await webRequestController.GetAsync(new CommonArguments(url), ct, reportCategory)
                                                                       .CreateFromJson<SceneEntityDefinition>(WRJsonParser.Unity, WRThreadFlags.SwitchToThreadPool);
 
-                HashSet<string> remoteFiles = HashSetPool<string>.Get();
+                var remoteFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var contentDefinition in sceneEntityDefinition.content)
                 {

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/HybridSceneHashedContent.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/HybridSceneHashedContent.cs
@@ -25,7 +25,7 @@ namespace SceneRunner.Scene
 
         private readonly URLDomain abDomain;
 
-        private readonly HashSet<string> filesToGetFromLocalHost = new ()
+        private readonly HashSet<string> filesToGetFromLocalHost = new (StringComparer.OrdinalIgnoreCase)
         {
             "scene.json", "main.crdt"
         };

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/HybridSceneHashedContent.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/HybridSceneHashedContent.cs
@@ -7,6 +7,7 @@ using DCL.Diagnostics;
 using DCL.Ipfs;
 using DCL.WebRequests;
 using UnityEngine;
+using UnityEngine.Pool;
 
 namespace SceneRunner.Scene
 {
@@ -24,7 +25,7 @@ namespace SceneRunner.Scene
 
         private readonly URLDomain abDomain;
 
-        private readonly List<string> filesToGetFromLocalHost = new ()
+        private readonly HashSet<string> filesToGetFromLocalHost = new ()
         {
             "scene.json", "main.crdt"
         };
@@ -76,11 +77,8 @@ namespace SceneRunner.Scene
         public bool TryGetHash(string name, out string hash) =>
             fileToHash.TryGetValue(name, out hash);
 
-        public void SwitchToLocal(string contentPath)
-        {
-            filesToGetFromLocalHost.Add(contentPath);
-            resolvedContentURLs.Remove(contentPath);
-        }
+        public bool IsRawAsset(string contentPath) =>
+            filesToGetFromLocalHost.Contains(contentPath) || IsNonConvertedAsset(contentPath);
 
         public async UniTask GetRemoteSceneDefinitionAsync(URLDomain remoteContentDomain, ReportData reportCategory, CancellationToken ct)
         {
@@ -94,11 +92,24 @@ namespace SceneRunner.Scene
                 var sceneEntityDefinition = await webRequestController.GetAsync(new CommonArguments(url), ct, reportCategory)
                                                                       .CreateFromJson<SceneEntityDefinition>(WRJsonParser.Unity, WRThreadFlags.SwitchToThreadPool);
 
+                HashSet<string> remoteFiles = HashSetPool<string>.Get();
+
                 foreach (var contentDefinition in sceneEntityDefinition.content)
                 {
-                    if (fileToHash.ContainsKey(contentDefinition.file) && !filesToGetFromLocalHost.Contains(contentDefinition.file) && !IsNonConvertedAsset(contentDefinition.file))
+                    remoteFiles.Add(contentDefinition.file);
+
+                    if (fileToHash.ContainsKey(contentDefinition.file)
+                        && !filesToGetFromLocalHost.Contains(contentDefinition.file)
+                        && !IsNonConvertedAsset(contentDefinition.file))
                         fileToHash[contentDefinition.file] = contentDefinition.hash;
                 }
+
+                // Files that exist locally but not in the remote definition have no AB on the CDN — load from localhost
+                foreach (string localFile in fileToHash.Keys)
+                    if (!remoteFiles.Contains(localFile))
+                        filesToGetFromLocalHost.Add(localFile);
+
+                HashSetPool<string>.Release(remoteFiles);
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception) { ReportHub.LogError(reportCategory, $"Trying to load hybrid scene with id {remoteSceneID} failed. You wont get the asset bundles"); }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/HybridSceneHashedContent.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/HybridSceneHashedContent.cs
@@ -73,9 +73,13 @@ namespace SceneRunner.Scene
             return false;
         }
 
-        public bool TryGetHash(string name, out string hash)
+        public bool TryGetHash(string name, out string hash) =>
+            fileToHash.TryGetValue(name, out hash);
+
+        public void SwitchToLocal(string contentPath)
         {
-            return fileToHash.TryGetValue(name, out hash);
+            filesToGetFromLocalHost.Add(contentPath);
+            resolvedContentURLs.Remove(contentPath);
         }
 
         public async UniTask GetRemoteSceneDefinitionAsync(URLDomain remoteContentDomain, ReportData reportCategory, CancellationToken ct)

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/HybridSceneHashedContent.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/HybridSceneHashedContent.cs
@@ -108,8 +108,6 @@ namespace SceneRunner.Scene
                 foreach (string localFile in fileToHash.Keys)
                     if (!remoteFiles.Contains(localFile))
                         filesToGetFromLocalHost.Add(localFile);
-
-                HashSetPool<string>.Release(remoteFiles);
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception) { ReportHub.LogError(reportCategory, $"Trying to load hybrid scene with id {remoteSceneID} failed. You wont get the asset bundles"); }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/ISceneContent.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/ISceneContent.cs
@@ -9,5 +9,7 @@ namespace SceneRunner.Scene
         bool TryGetContentUrl(string contentPath, out URLAddress result);
 
         bool TryGetHash(string name, out string hash);
+
+        void SwitchToLocal(string contentPath) { }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/ISceneContent.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/ISceneContent.cs
@@ -10,6 +10,6 @@ namespace SceneRunner.Scene
 
         bool TryGetHash(string name, out string hash);
 
-        void SwitchToLocal(string contentPath) { }
+        bool IsRawAsset(string contentPath) => false;
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/World/GltfContainerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/GltfContainerPlugin.cs
@@ -88,10 +88,11 @@ namespace DCL.PluginSystem.World
             PrepareGltfAssetLoadingSystem.InjectToWorld(
                 ref builder,
                 assetsCache,
+                sharedDependencies.SceneData,
                 new PrepareGltfAssetLoadingSystem.Options
                 {
                     LocalSceneDevelopment = localSceneDevelopment,
-                    UseRemoveAssetBundles = useRemoteAssetBundles,
+                    UseRemoteAssetBundles = useRemoteAssetBundles,
                     PreviewingBuilderCollection = appArgs.HasFlag(AppArgsFlags.SELF_PREVIEW_BUILDER_COLLECTIONS)
                 });
 


### PR DESCRIPTION
## What does this PR change?

Detects which content files are the one missing on the remote ABs and load them locally to allow creators to use a mix of both: remote asset bundles and local files for performance & workflow improvements.

## Test Instructions

Go through different scenes and worlds. Check they load normally.
Try to run any local scene, check that loads normally.

If you have access download this repo: https://github.com/decentraland-scenes/Genesis-Plaza-2025/tree/main/central-plaza
Add a new model in the `centra-plaza` project. For example:
```
const boardEntity = engine.addEntity();
Transform.create(boardEntity, {parent: plazaCenterEntity, position: Vector3.create(0, 2, 0)})
GltfContainer.create(boardEntity, {
  src: 'assets/board.glb',
});
```
(You can duplicate any glb in the project and copy into `assets/board.glb`).

Run the `central-plaza` scene with args:
```
--realm http://127.0.0.1:8000/ --position 0,0 --local-scene true --debug --skip-version-check true --lsd-use-remote-ab --lsd-remote-ab-world dclexperience.dcl.eth
```

Check that the scene loads normally and you can also see the new model you added at the firepit.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
