### PR TITLE
fix: point event links to whats-on page

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
@@ -72,7 +72,7 @@ namespace DCL.Communities.CommunitiesCard.Events
             this.thumbnailLoader = thumbnailLoader;
             this.decentralandUrlsSource = decentralandUrlsSource;
 
-            createEventFormat = $"{decentralandUrlsSource.Url(DecentralandUrl.EventsWebpage)}?community_id={{0}}&utm_source=explorer&utm_campaign=communities";
+            createEventFormat = $"{decentralandUrlsSource.Url(DecentralandUrl.WhatsOnNewEventLink)}?community_id={{0}}&utm_source=explorer&utm_campaign=communities";
 
             view.InitList(thumbnailLoader, cancellationToken);
 

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
@@ -105,13 +105,13 @@ namespace DCL.Communities.CommunitiesCard.Events
 
         private void OnEventCopyLinkButtonClicked(PlaceAndEventDTO eventData)
         {
-            clipboard.Set(EventUtilities.GetEventCopyLink(eventData.Event));
+            clipboard.Set(EventUtilities.GetEventCopyLink(eventData.Event, decentralandUrlsSource));
 
             NotificationsBusController.Instance.AddNotification(new DefaultSuccessNotification(LINK_COPIED_MESSAGE));
         }
 
         private void OnEventShareButtonClicked(PlaceAndEventDTO eventData) =>
-            webBrowser.OpenUrl($"{EventUtilities.GetEventShareLink(eventData.Event)}&utm_source=explorer&utm_campaign=communities");
+            webBrowser.OpenUrl($"{EventUtilities.GetEventShareLink(eventData.Event, decentralandUrlsSource)}&utm_source=explorer&utm_campaign=communities");
 
         private void OnInterestedButtonClicked(PlaceAndEventDTO eventData, EventListItemView eventItemView)
         {

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListController.cs
@@ -72,7 +72,7 @@ namespace DCL.Communities.CommunitiesCard.Events
             this.thumbnailLoader = thumbnailLoader;
             this.decentralandUrlsSource = decentralandUrlsSource;
 
-            createEventFormat = $"{decentralandUrlsSource.Url(DecentralandUrl.EventsWebpage)}/submit?community_id={{0}}&utm_source=explorer&utm_campaign=communities";
+            createEventFormat = $"{decentralandUrlsSource.Url(DecentralandUrl.EventsWebpage)}?community_id={{0}}&utm_source=explorer&utm_campaign=communities";
 
             view.InitList(thumbnailLoader, cancellationToken);
 

--- a/Explorer/Assets/DCL/Events/EventCardActionsController.cs
+++ b/Explorer/Assets/DCL/Events/EventCardActionsController.cs
@@ -74,13 +74,13 @@ namespace DCL.Events
 
         public void AddEventToCalendar(IEventDTO eventData)
         {
-            webBrowser.OpenUrl($"{EventUtilities.GetEventAddToCalendarLink(eventData)}&utm_source=explorer&utm_campaign=discover");
+            webBrowser.OpenUrl($"{EventUtilities.GetEventAddToCalendarLink(eventData, decentralandUrlsSource)}&utm_source=explorer&utm_campaign=discover");
             AddEventToCalendarClicked?.Invoke(eventData);
         }
 
         public void AddEventToCalendar(IEventDTO eventData, DateTime utcStart)
         {
-            webBrowser.OpenUrl($"{EventUtilities.GetEventAddToCalendarLink(eventData, utcStart)}&utm_source=explorer&utm_campaign=discover");
+            webBrowser.OpenUrl($"{EventUtilities.GetEventAddToCalendarLink(eventData, utcStart, decentralandUrlsSource)}&utm_source=explorer&utm_campaign=discover");
             AddEventToCalendarClicked?.Invoke(eventData);
         }
 
@@ -101,13 +101,13 @@ namespace DCL.Events
 
         public void ShareEvent(IEventDTO eventData)
         {
-            webBrowser.OpenUrl($"{EventUtilities.GetEventShareLink(eventData)}&utm_source=explorer&utm_campaign=discover");
+            webBrowser.OpenUrl($"{EventUtilities.GetEventShareLink(eventData, decentralandUrlsSource)}&utm_source=explorer&utm_campaign=discover");
             EventShared?.Invoke(eventData);
         }
 
         public void CopyEventLink(IEventDTO eventData)
         {
-            clipboard.Set(EventUtilities.GetEventCopyLink(eventData));
+            clipboard.Set(EventUtilities.GetEventCopyLink(eventData, decentralandUrlsSource));
             NotificationsBusController.Instance.AddNotification(new DefaultSuccessNotification(LINK_COPIED_MESSAGE));
             EventLinkCopied?.Invoke(eventData);
         }

--- a/Explorer/Assets/DCL/Events/EventUtilities.cs
+++ b/Explorer/Assets/DCL/Events/EventUtilities.cs
@@ -16,7 +16,7 @@ namespace DCL.Communities.EventInfo
         private const string MINUTES_STRING = "min";
         private const string JUMP_IN_GC_LINK = " https://decentraland.org/jump/?position={0},{1}";
         private const string JUMP_IN_WORLD_LINK = " https://decentraland.org/jump/?realm={0}";
-        private const string EVENT_WEBSITE_LINK = "https://decentraland.org/events/event/?id={0}";
+        private const string EVENT_WEBSITE_LINK = "https://decentraland.org/whats-on/?id={0}";
         private const string TWITTER_NEW_POST_LINK = "https://twitter.com/intent/tweet?text={0}&hashtags={1}&url={2}";
         private const string TWITTER_HASHTAG = "DCLPlace";
         private const string ADD_TO_CALENDAR_LINK = "https://calendar.google.com/calendar/r/eventedit?text={0}&details={1}\n\n{2}&dates={3}/{4}";

--- a/Explorer/Assets/DCL/Events/EventUtilities.cs
+++ b/Explorer/Assets/DCL/Events/EventUtilities.cs
@@ -1,4 +1,5 @@
 using DCL.EventsApi;
+using DCL.Multiplayer.Connections.DecentralandUrls;
 using System;
 using System.Globalization;
 using System.Text;
@@ -14,9 +15,6 @@ namespace DCL.Communities.EventInfo
         private const string DAY_STRING = "day";
         private const string HOUR_STRING = "hour";
         private const string MINUTES_STRING = "min";
-        private const string JUMP_IN_GC_LINK = " https://decentraland.org/jump/?position={0},{1}";
-        private const string JUMP_IN_WORLD_LINK = " https://decentraland.org/jump/?realm={0}";
-        private const string EVENT_WEBSITE_LINK = "https://decentraland.org/whats-on/?id={0}";
         private const string TWITTER_NEW_POST_LINK = "https://twitter.com/intent/tweet?text={0}&hashtags={1}&url={2}";
         private const string TWITTER_HASHTAG = "DCLPlace";
         private const string ADD_TO_CALENDAR_LINK = "https://calendar.google.com/calendar/r/eventedit?text={0}&details={1}\n\n{2}&dates={3}/{4}";
@@ -94,21 +92,23 @@ namespace DCL.Communities.EventInfo
             sb.Append(')');
         }
 
-        public static string GetEventCopyLink(IEventDTO eventData) =>
+        public static string GetEventCopyLink(IEventDTO eventData, IDecentralandUrlsSource urls) =>
             eventData.Live
-                ? GetPlaceJumpInLink(eventData)
-                : GetEventWebsiteLink(eventData);
+                ? GetPlaceJumpInLink(eventData, urls)
+                : GetEventWebsiteLink(eventData, urls);
 
-        private static string GetPlaceJumpInLink(IEventDTO eventData) =>
-            eventData.World ? string.Format(JUMP_IN_WORLD_LINK, eventData.Server) : string.Format(JUMP_IN_GC_LINK, eventData.X, eventData.Y);
+        private static string GetPlaceJumpInLink(IEventDTO eventData, IDecentralandUrlsSource urls) =>
+            eventData.World
+                ? string.Format(urls.Url(DecentralandUrl.JumpInWorldLink), eventData.Server)
+                : string.Format(urls.Url(DecentralandUrl.JumpInGenesisCityLink), eventData.X, eventData.Y);
 
-        private static string GetEventWebsiteLink(IEventDTO eventData) =>
-            string.Format(EVENT_WEBSITE_LINK, eventData.Id);
+        private static string GetEventWebsiteLink(IEventDTO eventData, IDecentralandUrlsSource urls) =>
+            string.Format(urls.Url(DecentralandUrl.WhatsOnEventLink), eventData.Id);
 
-        public static string GetEventShareLink(IEventDTO eventData) =>
-            string.Format(TWITTER_NEW_POST_LINK, eventData.Name, TWITTER_HASHTAG, GetEventCopyLink(eventData));
+        public static string GetEventShareLink(IEventDTO eventData, IDecentralandUrlsSource urls) =>
+            string.Format(TWITTER_NEW_POST_LINK, eventData.Name, TWITTER_HASHTAG, GetEventCopyLink(eventData, urls));
 
-        public static string GetEventAddToCalendarLink(IEventDTO eventData)
+        public static string GetEventAddToCalendarLink(IEventDTO eventData, IDecentralandUrlsSource urls)
         {
             DateTime nextStartAtDate = DateTime.Parse(
                 eventData.Next_start_at,
@@ -125,12 +125,12 @@ namespace DCL.Communities.EventInfo
             return string.Format(ADD_TO_CALENDAR_LINK,
                 eventData.Name,
                 eventData.Description,
-                $"jump in: {GetPlaceJumpInLink(eventData)}",
+                $"jump in: {GetPlaceJumpInLink(eventData, urls)}",
                 nextStartAtDate.ToString("yyyyMMdd'T'HHmmss'Z'"),
                 nextFinishAtDate.ToString("yyyyMMdd'T'HHmmss'Z'"));
         }
 
-        public static string GetEventAddToCalendarLink(IEventDTO eventData, DateTime utcStart)
+        public static string GetEventAddToCalendarLink(IEventDTO eventData, DateTime utcStart, IDecentralandUrlsSource urls)
         {
             TimeSpan duration = TimeSpan.FromMilliseconds(eventData.Duration);
             DateTime utcEnd = utcStart.Add(duration);
@@ -142,7 +142,7 @@ namespace DCL.Communities.EventInfo
             return string.Format(ADD_TO_CALENDAR_LINK,
                 eventData.Name,
                 eventData.Description,
-                $"jump in: {GetPlaceJumpInLink(eventData)}",
+                $"jump in: {GetPlaceJumpInLink(eventData, urls)}",
                 utcStart.ToString("yyyyMMdd'T'HHmmss'Z'"),
                 utcEnd.ToString("yyyyMMdd'T'HHmmss'Z'"));
         }

--- a/Explorer/Assets/DCL/Events/EventsController.cs
+++ b/Explorer/Assets/DCL/Events/EventsController.cs
@@ -200,7 +200,7 @@ namespace DCL.Events
 
         public void GoToCreateEventPage(bool fromHeader)
         {
-            webBrowser.OpenUrl($"{decentralandUrlsSource.Url(DecentralandUrl.EventsWebpage)}/submit?utm_source=explorer&utm_campaign=discover");
+            webBrowser.OpenUrl($"{decentralandUrlsSource.Url(DecentralandUrl.EventsWebpage)}?utm_source=explorer&utm_campaign=discover");
             CreateEventButtonClicked?.Invoke(fromHeader);
         }
     }

--- a/Explorer/Assets/DCL/Events/EventsController.cs
+++ b/Explorer/Assets/DCL/Events/EventsController.cs
@@ -200,7 +200,7 @@ namespace DCL.Events
 
         public void GoToCreateEventPage(bool fromHeader)
         {
-            webBrowser.OpenUrl($"{decentralandUrlsSource.Url(DecentralandUrl.EventsWebpage)}?utm_source=explorer&utm_campaign=discover");
+            webBrowser.OpenUrl($"{decentralandUrlsSource.Url(DecentralandUrl.WhatsOnNewEventLink)}?utm_source=explorer&utm_campaign=discover");
             CreateEventButtonClicked?.Invoke(fromHeader);
         }
     }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/DecentralandUrl.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/DecentralandUrl.cs
@@ -146,5 +146,7 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
         SceneAdmins = 88,
 
         Gatekeeper = 89,
+
+        WhatsOnEventLink = 90,
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/DecentralandUrl.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/DecentralandUrl.cs
@@ -37,7 +37,7 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
         ContentModerationReport = 21,
 
         ApiEvents = 22,
-        EventsWebpage = 23,
+        WhatsOnNewEventLink = 23,
 
         ApiAuth = 24,
         AuthSignatureWebApp = 25,

--- a/Explorer/Assets/DCL/Navmap/EventInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/EventInfoPanelController.cs
@@ -4,6 +4,7 @@ using DCL.Chat.Commands;
 using DCL.Chat.History;
 using DCL.Chat.MessageBus;
 using DCL.EventsApi;
+using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.PlacesAPIService;
 using DCL.UI;
 using DCL.UI.Utilities;
@@ -26,6 +27,7 @@ namespace DCL.Navmap
         private readonly GoogleUserCalendar userCalendar;
         private readonly SharePlacesAndEventsContextMenuController shareContextMenu;
         private readonly IWebBrowser webBrowser;
+        private readonly IDecentralandUrlsSource decentralandUrlsSource;
         private readonly ImageController thumbnailController;
         private readonly MultiStateButtonController interestedButtonController;
         private readonly List<EventScheduleElementView> scheduleElements = new ();
@@ -42,6 +44,7 @@ namespace DCL.Navmap
             GoogleUserCalendar userCalendar,
             SharePlacesAndEventsContextMenuController shareContextMenu,
             IWebBrowser webBrowser,
+            IDecentralandUrlsSource decentralandUrlsSource,
             ImageControllerProvider imageControllerProvider)
         {
             this.view = view;
@@ -52,6 +55,7 @@ namespace DCL.Navmap
             this.userCalendar = userCalendar;
             this.shareContextMenu = shareContextMenu;
             this.webBrowser = webBrowser;
+            this.decentralandUrlsSource = decentralandUrlsSource;
             thumbnailController = imageControllerProvider.Create(view.Thumbnail);
             interestedButtonController = new MultiStateButtonController(view.InterestedButton, true);
             interestedButtonController.OnButtonClicked += SetInterested;
@@ -147,8 +151,8 @@ namespace DCL.Navmap
 
         private void AddRecurrentEventToCalendar(DateTime startAt)
         {
-            // Same link as https://decentraland.org/whats-on?id=... website
-            var description = $"jump in: https://decentraland.org/jump/?position={@event?.x},{@event?.y}";
+            string jumpInLink = string.Format(decentralandUrlsSource.Url(DecentralandUrl.JumpInGenesisCityLink), @event?.x, @event?.y);
+            var description = $"jump in: {jumpInLink}";
 
             DateTime nextStartAt = DateTime.Parse(@event?.next_start_at, null, DateTimeStyles.RoundtripKind);
             DateTime nextFinishAt = DateTime.Parse(@event?.next_finish_at, null, DateTimeStyles.RoundtripKind);

--- a/Explorer/Assets/DCL/Navmap/EventInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/EventInfoPanelController.cs
@@ -147,7 +147,7 @@ namespace DCL.Navmap
 
         private void AddRecurrentEventToCalendar(DateTime startAt)
         {
-            // Same link as https://decentraland.org/events/event?id=... website
+            // Same link as https://decentraland.org/whats-on?id=... website
             var description = $"jump in: https://decentraland.org/jump/?position={@event?.x},{@event?.y}";
 
             DateTime nextStartAt = DateTime.Parse(@event?.next_start_at, null, DateTimeStyles.RoundtripKind);

--- a/Explorer/Assets/DCL/Navmap/SharePlacesAndEventsContextMenuController.cs
+++ b/Explorer/Assets/DCL/Navmap/SharePlacesAndEventsContextMenuController.cs
@@ -13,7 +13,7 @@ namespace DCL.Navmap
     public class SharePlacesAndEventsContextMenuController
     {
         private const string JUMP_IN_LINK = " https://decentraland.org/jump/?position={0},{1}";
-        private const string EVENT_WEBSITE_LINK = "https://decentraland.org/events/event/?id={0}";
+        private const string EVENT_WEBSITE_LINK = "https://decentraland.org/whats-on/?id={0}";
         private const string TWITTER_NEW_POST_LINK = "https://twitter.com/intent/tweet?text={0}&hashtags={1}&url={2}";
         private const string TWITTER_PLACE_DESCRIPTION = "Check out {0}, a cool place I found in Decentraland!";
 

--- a/Explorer/Assets/DCL/Navmap/SharePlacesAndEventsContextMenuController.cs
+++ b/Explorer/Assets/DCL/Navmap/SharePlacesAndEventsContextMenuController.cs
@@ -2,6 +2,7 @@ using Cysharp.Threading.Tasks;
 using DCL.Browser;
 using DCL.Clipboard;
 using DCL.EventsApi;
+using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.PlacesAPIService;
 using DCL.UI;
 using System.Threading;
@@ -12,8 +13,6 @@ namespace DCL.Navmap
 {
     public class SharePlacesAndEventsContextMenuController
     {
-        private const string JUMP_IN_LINK = " https://decentraland.org/jump/?position={0},{1}";
-        private const string EVENT_WEBSITE_LINK = "https://decentraland.org/whats-on/?id={0}";
         private const string TWITTER_NEW_POST_LINK = "https://twitter.com/intent/tweet?text={0}&hashtags={1}&url={2}";
         private const string TWITTER_PLACE_DESCRIPTION = "Check out {0}, a cool place I found in Decentraland!";
 
@@ -21,6 +20,7 @@ namespace DCL.Navmap
         private readonly WarningNotificationView warningNotificationView;
         private readonly ISystemClipboard clipboard;
         private readonly IWebBrowser webBrowser;
+        private readonly IDecentralandUrlsSource decentralandUrlsSource;
         private string? twitterLink;
         private string? copyLink;
         private CancellationTokenSource? showCopyLinkToastCancellationToken;
@@ -28,12 +28,14 @@ namespace DCL.Navmap
         public SharePlacesAndEventsContextMenuController(SharePlacesAndEventsContextMenuView view,
             WarningNotificationView warningNotificationView,
             ISystemClipboard clipboard,
-            IWebBrowser webBrowser)
+            IWebBrowser webBrowser,
+            IDecentralandUrlsSource decentralandUrlsSource)
         {
             this.view = view;
             this.warningNotificationView = warningNotificationView;
             this.clipboard = clipboard;
             this.webBrowser = webBrowser;
+            this.decentralandUrlsSource = decentralandUrlsSource;
             view.ShareOnTwitterButton.onClick.AddListener(ShareOnTwitter);
             view.CopyLinkButton.onClick.AddListener(CopyLink);
             view.CloseButton.onClick.AddListener(Hide);
@@ -53,7 +55,7 @@ namespace DCL.Navmap
         public void Set(PlacesData.PlaceInfo place)
         {
             VectorUtilities.TryParseVector2Int(place.base_position, out var coordinates);
-            copyLink = string.Format(JUMP_IN_LINK, coordinates.x, coordinates.y);
+            copyLink = string.Format(decentralandUrlsSource.Url(DecentralandUrl.JumpInGenesisCityLink), coordinates.x, coordinates.y);
             var description = string.Format(TWITTER_PLACE_DESCRIPTION, place.title);
             twitterLink = string.Format(TWITTER_NEW_POST_LINK, description, "DCLPlace", copyLink);
         }
@@ -63,8 +65,8 @@ namespace DCL.Navmap
             string description = @event.name;
 
             copyLink = @event.live
-                ? string.Format(JUMP_IN_LINK, @event.x, @event.y)
-                : string.Format(EVENT_WEBSITE_LINK, @event.id);
+                ? string.Format(decentralandUrlsSource.Url(DecentralandUrl.JumpInGenesisCityLink), @event.x, @event.y)
+                : string.Format(decentralandUrlsSource.Url(DecentralandUrl.WhatsOnEventLink), @event.id);
 
             twitterLink = string.Format(TWITTER_NEW_POST_LINK, description, "DCLPlace", copyLink);
         }

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -180,7 +180,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.LocalGateKeeperSceneAdapter => "https://comms-gatekeeper-local.decentraland.org/get-scene-adapter",
                 DecentralandUrl.ChatAdapter => $"{Url(DecentralandUrl.Gatekeeper)}/private-messages/token",
                 DecentralandUrl.ApiEvents => $"https://events.decentraland.{ENV}/api/events",
-                DecentralandUrl.EventsWebpage => $"https://decentraland.{ENV}/whats-on",
+                DecentralandUrl.EventsWebpage => $"https://decentraland.{ENV}/whats-on/new-event",
                 DecentralandUrl.WhatsOnEventLink => $"https://decentraland.{ENV}/whats-on/?id={{0}}",
                 DecentralandUrl.OpenSea => $"https://opensea.decentraland.{ENV}",
                 DecentralandUrl.Host => $"https://decentraland.{ENV}",

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -180,7 +180,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.LocalGateKeeperSceneAdapter => "https://comms-gatekeeper-local.decentraland.org/get-scene-adapter",
                 DecentralandUrl.ChatAdapter => $"{Url(DecentralandUrl.Gatekeeper)}/private-messages/token",
                 DecentralandUrl.ApiEvents => $"https://events.decentraland.{ENV}/api/events",
-                DecentralandUrl.EventsWebpage => $"https://decentraland.{ENV}/events",
+                DecentralandUrl.EventsWebpage => $"https://decentraland.{ENV}/whats-on",
                 DecentralandUrl.WhatsOnEventLink => $"https://decentraland.{ENV}/whats-on/?id={{0}}",
                 DecentralandUrl.OpenSea => $"https://opensea.decentraland.{ENV}",
                 DecentralandUrl.Host => $"https://decentraland.{ENV}",

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -180,7 +180,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.LocalGateKeeperSceneAdapter => "https://comms-gatekeeper-local.decentraland.org/get-scene-adapter",
                 DecentralandUrl.ChatAdapter => $"{Url(DecentralandUrl.Gatekeeper)}/private-messages/token",
                 DecentralandUrl.ApiEvents => $"https://events.decentraland.{ENV}/api/events",
-                DecentralandUrl.EventsWebpage => $"https://decentraland.{ENV}/whats-on/new-event",
+                DecentralandUrl.WhatsOnNewEventLink => $"https://decentraland.{ENV}/whats-on/new-event",
                 DecentralandUrl.WhatsOnEventLink => $"https://decentraland.{ENV}/whats-on/?id={{0}}",
                 DecentralandUrl.OpenSea => $"https://opensea.decentraland.{ENV}",
                 DecentralandUrl.Host => $"https://decentraland.{ENV}",

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -181,6 +181,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.ChatAdapter => $"{Url(DecentralandUrl.Gatekeeper)}/private-messages/token",
                 DecentralandUrl.ApiEvents => $"https://events.decentraland.{ENV}/api/events",
                 DecentralandUrl.EventsWebpage => $"https://decentraland.{ENV}/events",
+                DecentralandUrl.WhatsOnEventLink => $"https://decentraland.{ENV}/whats-on/?id={{0}}",
                 DecentralandUrl.OpenSea => $"https://opensea.decentraland.{ENV}",
                 DecentralandUrl.Host => $"https://decentraland.{ENV}",
                 DecentralandUrl.ApiChunks => $"https://api.decentraland.{ENV}/v1/map.png",

--- a/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ExplorePanelPlugin.cs
@@ -419,7 +419,7 @@ namespace DCL.PluginSystem.Global
                 inputBlock, navmapBus, categoryMappingSO.Value);
 
             SharePlacesAndEventsContextMenuController shareContextMenu = new (navmapView.ShareContextMenuView,
-                navmapView.WorldsWarningNotificationView, clipboard, webBrowser);
+                navmapView.WorldsWarningNotificationView, clipboard, webBrowser, decentralandUrlsSource);
 
             placeInfoPanelController = new PlaceInfoPanelController(navmapView.PlacesAndEventsPanelView.PlaceInfoPanelView,
                 imageControllerProvider, placesAPIService, mapPathEventBus, navmapBus, chatMessagesBus, eventsApiService,
@@ -435,7 +435,7 @@ namespace DCL.PluginSystem.Global
 
             eventInfoPanelController = new EventInfoPanelController(navmapView.PlacesAndEventsPanelView.EventInfoPanelView,
                 navmapBus, chatMessagesBus, eventsApiService, eventScheduleElementsPool,
-                userCalendar, shareContextMenu, webBrowser, imageControllerProvider);
+                userCalendar, shareContextMenu, webBrowser, decentralandUrlsSource, imageControllerProvider);
 
             placesAndEventsPanelController = new PlacesAndEventsPanelController(navmapView.PlacesAndEventsPanelView,
                 searchBarController, searchResultPanelController, placeInfoPanelController, eventInfoPanelController,


### PR DESCRIPTION
The Events frontend at `decentraland.org/events/event/?id=...` is being retired in favor of the new What's On section. Replaces the per-event link with `/whats-on/?id=...` and routes it through `IDecentralandUrlsSource` so it follows the active environment (org/zone/today) — needed to test the new page on zone before the prod release.

Changes:
- New `DecentralandUrl.WhatsOnEventLink` enum value resolving to `https://decentraland.{ENV}/whats-on/?id={id}`.
- `EventUtilities` (static) drops the hardcoded `EVENT_WEBSITE_LINK`/`JUMP_IN_GC_LINK`/`JUMP_IN_WORLD_LINK` constants and now takes `IDecentralandUrlsSource`. `EventCardActionsController` and `EventListController` (which already inject the source) pass it through.
- `SharePlacesAndEventsContextMenuController` and `EventInfoPanelController` now inject `IDecentralandUrlsSource`; their hardcoded `decentraland.org` jump-in / event-website URLs are replaced with `JumpInGenesisCityLink` / `WhatsOnEventLink` lookups.
- `ExplorePanelPlugin` passes `decentralandUrlsSource` through to the two new constructor signatures.

Side effect: a stray leading space in the old jump-in URL constants ("` https://...`") is gone, so the calendar event description goes from "jump in:  https://..." to "jump in: https://..." (single space).

Out of scope (other hardcoded `decentraland.org` URLs found in the repo, left alone): `OutfitsPresenter` marketplace claim link, `MarketplaceCreditsMenuController` blog link, and the blog link inside `DecentralandUrlsSource.DecentralandWorlds` itself — those point at content that only lives on .org.