### PR TITLE
fix: add shortcut in mute/unmute button tooltip

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/UI/MicrophoneButton.cs
+++ b/Explorer/Assets/DCL/VoiceChat/UI/MicrophoneButton.cs
@@ -6,8 +6,8 @@ namespace DCL.VoiceChat
 {
     public class MicrophoneButton : MonoBehaviour
     {
-        private const string MUTE_TEXT = "Mute";
-        private const string UNMUTE_TEXT = "Unmute";
+        private const string MUTE_TEXT = "Mute <color=#716B7C>[T]</color>";
+        private const string UNMUTE_TEXT = "Unmute <color=#716B7C>[T]</color>";
 
         [field: SerializeField]
         public Button MicButton { get; private set; }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #5882 
This PR adds the T shortcut in the mute unmute button tooltip when hovering the button in a community stream

## Test Instructions

### Test Steps
1. Launch the client
2. Start a community voice stream
3. Verify that when you mouse over the mute button, the tooltip has the T shortcut in the text

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
