### PR TITLE
fix: loading spinner issues

### DIFF
--- a/Explorer/Assets/DCL/Backpack/Assets/BackpackItem.prefab
+++ b/Explorer/Assets/DCL/Backpack/Assets/BackpackItem.prefab
@@ -1861,10 +1861,6 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3817016671180041992, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_Maskable
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Explorer/Assets/DCL/Backpack/Assets/ItemInfoPanel.prefab
+++ b/Explorer/Assets/DCL/Backpack/Assets/ItemInfoPanel.prefab
@@ -2556,10 +2556,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: LoadingSpinner
       objectReference: {fileID: 0}
-    - target: {fileID: 3817016671180041992, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_Maskable
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/VisiblePersonEntry.prefab
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/Prefabs/VisiblePersonEntry.prefab
@@ -1179,10 +1179,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: LoadingSpinner
       objectReference: {fileID: 0}
-    - target: {fileID: 3817016671180041992, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_Maskable
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Explorer/Assets/DCL/UI/Assets/TextInput.Email.prefab
+++ b/Explorer/Assets/DCL/UI/Assets/TextInput.Email.prefab
@@ -898,14 +898,6 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3817016671180041992, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_Maskable
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849787312596893835, guid: d565b61885fb1ef41b1582a285e748e9, type: 3}
-      propertyPath: m_Maskable
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Explorer/Assets/DCL/UI/LoadingSpinner/UILoadingSpinner.cs
+++ b/Explorer/Assets/DCL/UI/LoadingSpinner/UILoadingSpinner.cs
@@ -24,15 +24,11 @@ namespace DCL.UI.LoadingSpinner
             UpdateValues();
         }
 
-        private void InitializeMaterial()
-        {
-            // Create per spinner material instance
+        private void InitializeMaterial() =>
             img.material = new Material(img.material);
-        }
 
         private void UpdateValues()
         {
-            // Animate the material instance
             Material rendered = img.materialForRendering;
             if (!rendered) return;
 

--- a/Explorer/Assets/DCL/UI/LoadingSpinner/UILoadingSpinner.cs
+++ b/Explorer/Assets/DCL/UI/LoadingSpinner/UILoadingSpinner.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -15,8 +14,6 @@ namespace DCL.UI.LoadingSpinner
         public float head;
         public float tail;
 
-        private Material material;
-
         private void Awake()
         {
             InitializeMaterial();
@@ -29,18 +26,19 @@ namespace DCL.UI.LoadingSpinner
 
         private void InitializeMaterial()
         {
-            material = img.maskable ? new Material(img.materialForRendering) : new Material(img.material);
-
-            img.material = material;
+            // Create per spinner material instance
+            img.material = new Material(img.material);
         }
 
         private void UpdateValues()
         {
-            if (!material) return;
+            // Animate the material instance
+            Material rendered = img.materialForRendering;
+            if (!rendered) return;
 
-            material.SetColor(COLOR01_SHADER_PROP, color);
-            material.SetFloat(FILL_HEAD_SHADER_PROP, head);
-            material.SetFloat(FILL_TAIL_SHADER_PROP, tail);
+            rendered.SetColor(COLOR01_SHADER_PROP, color);
+            rendered.SetFloat(FILL_HEAD_SHADER_PROP, head);
+            rendered.SetFloat(FILL_TAIL_SHADER_PROP, tail);
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description
Fixes #8437
Fixes #8232
Fixes #8100

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->
This PR makes sure that `UILoadingSpinner` animates the instanced loading spinner's material rather than an unused copy.
On top of that it reverts the workaround of setting the `Maskable` flag to false just to make it work (while also making it unmaskable) in a couple of prefabs.


### Test Steps
1. Verify that the loading spinner across all UIs are working properly like they used to and they animate rather than staying still/display a white box
2. Verify that the spinners are maskable (e.g. when expanding the user's wearable in the photo detail of a reel and then scrolling: the spinner should be properly masked rather than appearing on top of other panels)


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
