### PR TITLE
fix: lsd error spam on server unreachable

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/LocalSceneDevelopmentSceneRoomMetaDataSource.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/LocalSceneDevelopmentSceneRoomMetaDataSource.cs
@@ -7,6 +7,7 @@ using ECS.SceneLifeCycle.Realm;
 using System;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.Networking;
 
 namespace DCL.Multiplayer.Connections.GateKeeper.Meta
 {
@@ -32,13 +33,23 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
             URLAddress sceneDefinitionEndpoint = baseUrl.Append(URLSubdirectory.FromString("scene.json"));
             URLAddress idEndpoint = baseUrl.Append(URLSubdirectory.FromString("content/entities/active"));
 
-            SceneDefinition sceneDefinition =
-                await webRequestController.GetAsync(
-                                               new CommonArguments(sceneDefinitionEndpoint),
-                                               token,
-                                               ReportCategory.LIVEKIT
-                                           )
-                                          .CreateFromJson<SceneDefinition>(WRJsonParser.Unity);
+            SceneDefinition sceneDefinition;
+
+            try
+            {
+                sceneDefinition =
+                    await webRequestController.GetAsync(
+                                                   new CommonArguments(sceneDefinitionEndpoint),
+                                                   token,
+                                                   ReportCategory.LIVEKIT,
+                                                   suppressErrors: true
+                                               )
+                                              .CreateFromJson<SceneDefinition>(WRJsonParser.Unity);
+            }
+            catch (UnityWebRequestException e) when (e.Result == UnityWebRequest.Result.ConnectionError)
+            {
+                return Result<MetaData>.ErrorResult($"Local scene server unreachable at {baseUrl}: {e.Message}");
+            }
 
             var baseResult = sceneDefinition.scene.BaseParcel();
 


### PR DESCRIPTION
# Pull Request Description
Fixes #7609

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR suppresses every retry error on `localhost/scene.json` request, allowing logging only on last attempt (`suppressErrors: true`).
Once the exception is thrown, detects if it's a connection error meaning that the local server is unreachable and if so, returns a proper error so that it is handled. All other error types bubble up.


### Test Steps
1. Launch a local scene (close the prod explorer and use this PR build instead)
2. Launch this PR build with args `--realm http://127.0.0.1:8000 --local-scene true`
3. After pressing the jump in button, immediately shut down the scene local server
4. Verify in the logs that the reported error is no longer spamming (as described in the linked issue)
5. Smoke test on LSD: everything should operate as normal

### Additional Testing Notes
- You can compare the behaviour with the actual live build (there, it should spam constantly)

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
