### PR TITLE
fix: UNITY-EXPLORER-NQG

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/SceneAdmins.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/SceneAdmins.cs
@@ -47,7 +47,7 @@ namespace SceneRunner.Admins
             public string parcel;
         }
         // END Copied
-        
+
         private static readonly TimeSpan DELAY = TimeSpan.FromMilliseconds(1000);
 
         private readonly IWebRequestController webRequestController;
@@ -58,7 +58,7 @@ namespace SceneRunner.Admins
         private readonly CancellationTokenSource cts = new ();
         private readonly SemaphoreSlim operationLock = new (initialCount: 1, maxCount: 1);
         private readonly ConcurrentDictionary<string, AdminInfo> wallets = new (StringComparer.OrdinalIgnoreCase);
-        
+
         private bool initialLoadFinished;
 
         public SceneAdmins(
@@ -91,6 +91,7 @@ namespace SceneRunner.Admins
             while (cts.IsCancellationRequested == false)
             {
                 await FireRequestAsync(cts.Token);
+                if (cts.IsCancellationRequested) return;
                 await UniTask.Delay(DELAY, cancellationToken: cts.Token).SuppressCancellationThrow();
             }
         }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/SceneAdmins.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/SceneAdmins.cs
@@ -88,11 +88,12 @@ namespace SceneRunner.Admins
 
         public async UniTaskVoid StartRequestPollingAsync()
         {
-            while (cts.IsCancellationRequested == false)
+            CancellationToken token = cts.Token;
+            while (token.IsCancellationRequested == false)
             {
-                await FireRequestAsync(cts.Token);
+                await FireRequestAsync(token);
                 if (cts.IsCancellationRequested) return;
-                await UniTask.Delay(DELAY, cancellationToken: cts.Token).SuppressCancellationThrow();
+                await UniTask.Delay(DELAY, cancellationToken: token).SuppressCancellationThrow();
             }
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/SceneAdmins.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/SceneAdmins.cs
@@ -92,7 +92,7 @@ namespace SceneRunner.Admins
             while (token.IsCancellationRequested == false)
             {
                 await FireRequestAsync(token);
-                if (cts.IsCancellationRequested) return;
+                if (token.IsCancellationRequested) return;
                 await UniTask.Delay(DELAY, cancellationToken: token).SuppressCancellationThrow();
             }
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes the `System.ObjectDisposedException: The CancellationTokenSource has been disposed.` crash in `SceneAdmins.StartRequestPollingAsync` (Sentry: **UNITY-EXPLORER-NQG**, ~7.2k occurrences over the last month).

**The race**

`SceneAdmins.StartRequestPollingAsync` is a detached `UniTaskVoid` polling loop:

```csharp
while (cts.IsCancellationRequested == false)
{
    await FireRequestAsync(cts.Token);                                                       // line 93
    await UniTask.Delay(DELAY, cancellationToken: cts.Token).SuppressCancellationThrow();    // line 94
}
```

When the scene tears down during an in-flight admin fetch:
1. `Dispose()` runs and calls `cts.SafeCancelAndDispose()`.
2. The web request fails with `OperationCanceledException`, which `FireRequestAsync`'s `catch (OperationCanceledException)` swallows, so it returns normally.
3. Control resumes at line 94 and evaluates `cts.Token` on the now-disposed source — `CancellationTokenSource.get_Token` calls `ThrowIfDisposed()` and throws.

**The fix**

Cache the token once, before the loop, and add a cancellation guard between the two awaits. After this change, `cts.Token` is read exactly once while the source is guaranteed alive; the rest of the loop only touches the `CancellationToken` struct, whose `IsCancellationRequested` getter does not throw on a disposed source. Matches the project's async cancellation pattern (CLAUDE.md §9 / async-programming skill).

```csharp
public async UniTaskVoid StartRequestPollingAsync()
{
    CancellationToken token = cts.Token;
    while (!token.IsCancellationRequested)
    {
        await FireRequestAsync(token);
        if (token.IsCancellationRequested) return;
        await UniTask.Delay(DELAY, cancellationToken: token).SuppressCancellationThrow();
    }
}
```

Sentry issue: https://decentraland.sentry.io/issues/7364595635/

## Test Instructions

This is a timing-sensitive race against scene teardown — the reviewer should verify that fast scene transitions no longer produce `ObjectDisposedException` from `SceneAdmins.StartRequestPollingAsync` in the logs or in Sentry.

**Steps (standard run)**:
```bash
metaforge explorer run 8536 # ← replace with this PR number
```

**Expected result**:
- Walk into a scene, then quickly teleport / change realm / unload while the admin fetch is in flight. Repeat 5-10 times across different scenes (Genesis Plaza, a populated scene, an empty parcel).
- No `System.ObjectDisposedException: The CancellationTokenSource has been disposed.` exceptions originating from `SceneAdmins.StartRequestPollingAsync` should appear in the Console or in tailed logs.
- Admin-gated functionality inside scenes (where applicable) continues to work normally — the fix only changes the cancellation path, not the polling behaviour.

### Prerequisites
- [ ] Network access (admin fetch hits `DecentralandUrl.SceneAdmins`)
- [ ] No special configuration required

### Test Steps
1. Run the PR build and sign in.
2. Teleport to a populated scene (e.g. Genesis Plaza).
3. Within ~1s of arrival (while the admin fetch is in flight), teleport to a different scene.
4. Repeat across 5-10 scenes; include at least one rapid back-to-back unload.
5. Confirm no `ObjectDisposedException` from `SceneAdmins` in logs

### Additional Testing Notes
- The race is most reproducible on slow networks where the admin fetch takes longer, widening the window between the two awaits.
- The behavioural surface of `SceneAdmins` is otherwise unchanged — no need to re-test admin-list correctness beyond a smoke check.
- Only `StartRequestPollingAsync` is touched; `FireRequestAsync` and `Dispose` are untouched.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required) — N/A
- [x] Performance impact has been considered — single extra local variable, negligible
- [ ] For SDK features: Test scene is included — N/A

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
