### PR TITLE
fix: improve abrupt websocket close on archipelago stream flow

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/ConnectionClosedException.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/ConnectionClosedException.cs
@@ -16,10 +16,10 @@ namespace DCL.Multiplayer.Connections.Archipelago.LiveConnections
             this.webSocket = webSocket;
         }
 
-        public static EnumResult<MemoryWrap, IArchipelagoLiveConnection.ResponseError> NewErrorResult(WebSocket webSocket) =>
+        public static EnumResult<MemoryWrap, IArchipelagoLiveConnection.ResponseError> NewErrorResult(WebSocket webSocket, Exception? inner = null) =>
             EnumResult<MemoryWrap, IArchipelagoLiveConnection.ResponseError>.ErrorResult(
                 IArchipelagoLiveConnection.ResponseError.ConnectionClosed,
-                $"WebSocket closed with state: {webSocket.State} with status: {webSocket.CloseStatus} with description: {webSocket.CloseStatusDescription} - Connection closed"
+                $"WebSocket closed with state: {webSocket.State} with status: {webSocket.CloseStatus} with description: {webSocket.CloseStatusDescription} - Connection closed{(inner is null ? string.Empty : $" ({inner.GetType().Name}: {inner.Message})")}"
             );
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/WebSocketArchipelagoLiveConnection.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/WebSocketArchipelagoLiveConnection.cs
@@ -4,6 +4,7 @@ using DCL.Utility.Types;
 using LiveKit.Internal.FFIClients.Pools.Memory;
 using System;
 using System.Buffers;
+using System.IO;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
@@ -115,6 +116,9 @@ namespace DCL.Multiplayer.Connections.Archipelago.LiveConnections
                            ),
                        };
             }
+            catch (WebSocketException e) { return ConnectionClosedException.NewErrorResult(current!.Value.WebSocket, e); }
+            catch (IOException e) { return ConnectionClosedException.NewErrorResult(current!.Value.WebSocket, e); }
+            catch (ObjectDisposedException e) { return ConnectionClosedException.NewErrorResult(current!.Value.WebSocket, e); }
             catch (Exception e)
             {
                 return EnumResult<MemoryWrap, IArchipelagoLiveConnection.ResponseError>.ErrorResult(

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/WebSocketArchipelagoLiveConnection.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/WebSocketArchipelagoLiveConnection.cs
@@ -116,7 +116,18 @@ namespace DCL.Multiplayer.Connections.Archipelago.LiveConnections
                            ),
                        };
             }
-            catch (WebSocketException e) { return ConnectionClosedException.NewErrorResult(current!.Value.WebSocket, e); }
+            catch (WebSocketException e)
+            {
+                ClientWebSocket socket = current!.Value.WebSocket;
+
+                if (IndicatesConnectionClosed(e.WebSocketErrorCode, socket.State))
+                    return ConnectionClosedException.NewErrorResult(socket, e);
+
+                return EnumResult<MemoryWrap, IArchipelagoLiveConnection.ResponseError>.ErrorResult(
+                    IArchipelagoLiveConnection.ResponseError.MessageError,
+                    $"WebSocket protocol error: {e.WebSocketErrorCode} (state: {socket.State}) - {e.Message}"
+                );
+            }
             catch (IOException e) { return ConnectionClosedException.NewErrorResult(current!.Value.WebSocket, e); }
             catch (ObjectDisposedException e)
             {
@@ -174,6 +185,23 @@ namespace DCL.Multiplayer.Connections.Archipelago.LiveConnections
 
         private bool IsWebSocketInvalid() =>
             current?.WebSocket is not { State: WebSocketState.Open };
+
+        /// <summary>
+        ///     A <see cref="WebSocketException" /> can mean either a connection-level failure or a
+        ///     protocol/format issue on an otherwise live socket. We classify by the reported error
+        ///     code, falling back to the socket state because Mono/IL2CPP commonly reports everything
+        ///     as <see cref="WebSocketError.Faulted" />.
+        /// </summary>
+        private static bool IndicatesConnectionClosed(WebSocketError error, WebSocketState state)
+        {
+            if (state != WebSocketState.Open)
+                return true;
+
+            return error is WebSocketError.Faulted
+                or WebSocketError.NativeError
+                or WebSocketError.ConnectionClosedPrematurely
+                or WebSocketError.InvalidState;
+        }
 
         private readonly struct Current : IDisposable
         {

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/WebSocketArchipelagoLiveConnection.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/WebSocketArchipelagoLiveConnection.cs
@@ -118,7 +118,15 @@ namespace DCL.Multiplayer.Connections.Archipelago.LiveConnections
             }
             catch (WebSocketException e) { return ConnectionClosedException.NewErrorResult(current!.Value.WebSocket, e); }
             catch (IOException e) { return ConnectionClosedException.NewErrorResult(current!.Value.WebSocket, e); }
-            catch (ObjectDisposedException e) { return ConnectionClosedException.NewErrorResult(current!.Value.WebSocket, e); }
+            catch (ObjectDisposedException e)
+            {
+                // Don't probe the websocket here — it's the disposed object. Property access on a disposed
+                // ClientWebSocket is not contractually safe across runtimes (Mono/IL2CPP/.NET differ).
+                return EnumResult<MemoryWrap, IArchipelagoLiveConnection.ResponseError>.ErrorResult(
+                    IArchipelagoLiveConnection.ResponseError.ConnectionClosed,
+                    $"WebSocket disposed: {e}"
+                );
+            }
             catch (Exception e)
             {
                 return EnumResult<MemoryWrap, IArchipelagoLiveConnection.ResponseError>.ErrorResult(


### PR DESCRIPTION
# Pull Request Description

## Summary

Fixes https://github.com/decentraland/unity-explorer/issues/7804

#### Problem

- The Archipelago receive loop was logging _Cannot listen for connection string: ... WebSocketException_ to Sentry on every abrupt websocket disconnect (no close handshake).
 - Root cause: `WebSocketArchipelagoLiveConnection.ReceiveAsync` mapped every caught exception to `ResponseError.MessageError`. The auto-reconnect decorator (`ArchipelagoSignedConnection.ReceiveAsync`) only  
  reconnects on `ResponseError.ConnectionClosed`, so connection-loss exceptions bypassed reconnection and bubbled up as errors.                                    

#### Solution
                                          
  - Fix: route `WebSocketException`, `IOException`, and `ObjectDisposedException` through the existing `ConnectionClosedException.NewErrorResult` factory, which tags the result with `ConnectionClosed`.
  - The decorator now reconnects transparently for these cases.                                                                                                                                                  
  - `ConnectionClosedException.NewErrorResult` gained an optional Exception? inner parameter so the original exception type and message are preserved in the log line.

## Test Instructions

Go through the world, group with other people, check that you can play multiplayer normally.
Drop the connection to archipelago in mid-session. Check that you eventually reconnect to multiplayer.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
