### PR TITLE
chore: build as IL2CPP master configuration

### DIFF
--- a/Explorer/ProjectSettings/ProjectSettings.asset
+++ b/Explorer/ProjectSettings/ProjectSettings.asset
@@ -41,7 +41,6 @@ PlayerSettings:
     height: 1
   m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
-  m_HolographicTrackingLossScreen: {fileID: 0}
   defaultScreenWidth: 1920
   defaultScreenHeight: 1080
   defaultScreenWidthWeb: 960
@@ -150,12 +149,10 @@ PlayerSettings:
   - {fileID: 11400000, guid: 97cab6ceefd0a524bbfcc0638de8fa08, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
-  m_HolographicPauseOnTrackingLoss: 1
   xboxOneDisableKinectGpuReservation: 1
   xboxOneEnable7thCore: 1
   vrSettings:
     enable360StereoCapture: 0
-  isWsaHolographicRemotingEnabled: 0
   enableFrameTimingStats: 1
   enableOpenGLProfilerGPURecorders: 1
   allowHDRDisplaySupport: 0
@@ -941,7 +938,8 @@ PlayerSettings:
   platformArchitecture: {}
   scriptingBackend:
     Standalone: 1
-  il2cppCompilerConfiguration: {}
+  il2cppCompilerConfiguration:
+    Standalone: 2
   il2cppCodeGeneration:
     Standalone: 1
   il2cppStacktraceInformation:


### PR DESCRIPTION
# Pull Request Description

Enable "master" configuration to squeeze IL2CPP performance.

```Master configuration enables all possible optimizations, squeezing every bit of performance possible. For instance, on platforms that use the MSVC++ compiler, this option enables link-time code generation. Compiling code using this configuration can take significantly longer than it does using the Release configuration. Unity recommends building the shipping version of your game using the Master configuration if the increase in build time is acceptable.```

reference:  https://docs.unity3d.com/ScriptReference/Il2CppCompilerConfiguration.Master.html