### PR TITLE
fix: duplicated hash in private chat title bar for unclaimed names

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatViewModels/ChatTitleBarViewModel.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatViewModels/ChatTitleBarViewModel.cs
@@ -35,7 +35,7 @@ namespace DCL.Chat.ChatViewModels
             WalletId = profile.WalletId!;
             HasClaimedName = profile.HasClaimedName;
             Thumbnail = new ReactiveProperty<ProfileThumbnailViewModel>(ProfileThumbnailViewModel.ReadyToLoad(profile.UserNameColor));
-            Username = profile.DisplayName;
+            Username = profile.ValidatedName;
         }
 
         public static ChatTitlebarViewModel CreateLoading(TitlebarViewMode viewMode)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes #8272 — the private chat title bar shows the wallet hash twice for users without a claimed name (e.g. `name#abcd#abcd`). The duplication only happens in the chat header; passport, context menus, mentions and friend modals are unaffected.

<img width="613" height="1014" alt="image" src="https://github.com/user-attachments/assets/fd2f1391-86f9-4b59-91e0-7feebb4b075e" />

## How to test it?
1. Start a private conversation with any user without a claimed name.
2. Check that the name + its hash appear correctly.
3. Start a private conversation with any user with a claimed name.
4. Check that the name + its hash appear correctly.

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.