### PR TITLE
hotfix: avoid network congestion and increase scene admin polling delay

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/SceneAdmins.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/SceneAdmins.cs
@@ -47,8 +47,8 @@ namespace SceneRunner.Admins
             public string parcel;
         }
         // END Copied
-        
-        private static readonly TimeSpan DELAY = TimeSpan.FromMilliseconds(1000);
+
+        private static readonly TimeSpan DELAY = TimeSpan.FromMilliseconds(30000);
 
         private readonly IWebRequestController webRequestController;
         private readonly IDecentralandUrlsSource urls;
@@ -58,7 +58,7 @@ namespace SceneRunner.Admins
         private readonly CancellationTokenSource cts = new ();
         private readonly SemaphoreSlim operationLock = new (initialCount: 1, maxCount: 1);
         private readonly ConcurrentDictionary<string, AdminInfo> wallets = new (StringComparer.OrdinalIgnoreCase);
-        
+
         private bool initialLoadFinished;
 
         public SceneAdmins(

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportCategory.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportCategory.cs
@@ -15,11 +15,6 @@ namespace DCL.Diagnostics
         public const string ANALYTICS = nameof(ANALYTICS);
 
         /// <summary>
-        ///     Everything connected analytics that is not supposed to be reported to Sentry (retries for example)
-        /// </summary>
-        public const string ANALYTICS_INTERNAL = nameof(ANALYTICS_INTERNAL);
-
-        /// <summary>
         ///     Everything connected to raw assets and addressables
         /// </summary>
         public const string ASSETS_PROVISION = nameof(ASSETS_PROVISION);

--- a/Explorer/Assets/Plugins/RustSegment/.native/Cargo.toml
+++ b/Explorer/Assets/Plugins/RustSegment/.native/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 lazy_static = "1.5.0"
-segment = { git = "https://github.com/decentraland/segment", rev = "fbb7ed5cbb3f3ea8b4f2d02a41aa29a2b2a86e2b", default-features = false, features = ["rustls-tls"] }
+segment = { git = "https://github.com/decentraland/segment", rev = "6c97226b10d70f2d1576b529af432209c45415f0", default-features = false, features = ["rustls-tls"] }
 serde = "1.0.210"
 serde_json = "1.0.128"
 tokio = { version = "1.40.0", features = ["full", "parking_lot"] }

--- a/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/Libraries/Windows/segment-server.dll
+++ b/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/Libraries/Windows/segment-server.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c63e8d38e539667c8ae31689adaf4d367b60bf5efe1031cc69d90ab3b7a4e1e
-size 4594176
+oid sha256:d12143afcdb37fc669012d6688d6e0ef419d6fed813c0596af317db715d210e0
+size 4560384

--- a/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
+++ b/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
@@ -228,22 +228,7 @@ namespace Plugins.RustSegment.SegmentServerWrap
             try
             {
                 string marshaled = Marshal.PtrToStringUTF8(msg) ?? "cannot parse message";
-
-                bool isInternal = marshaled.Contains("(will retry)");
-
-                // Required to avoid polluting Sentry with retry messages
-                string reportCategory = isInternal
-                    ? ReportCategory.ANALYTICS_INTERNAL
-                    : ReportCategory.ANALYTICS;
-
-#if UNITY_EDITOR
-                ReportHub.LogException(new Exception($"Segment error: {marshaled}"), reportCategory);
-#else
-                if (isInternal == false) // Avoid logging ANALYTICS_INTERNAL in builds
-                {
-                    ReportHub.LogException(new Exception($"Segment error: {marshaled}"), reportCategory);
-                }
-#endif
+                ReportHub.LogException(new Exception($"Segment error: {marshaled}"), ReportCategory.ANALYTICS);
             }
             catch
             {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Hotfix that includes:
* fix: high network consumption
* increased from 1 second to 30 seconds the polling delay for scene admins

## Test Instructions

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. Follow the steps mentioned in the PR https://github.com/decentraland/unity-explorer/pull/8561 this hotfix has those changes
2. In addition this hotfix reduces the calls for the scene admin filtering from 1 to 30 seconds, verify setting new admins to play videos works, it has a delay of 30 seconds from when you do the action to when the user promoted to admin sees the changes

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
