### PR TITLE
fix: drain scene comms message buffer regardless of Comms subscription

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/EngineApi/SDKObservableEvents/SDKObservableEventsEngineApiWrapper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/EngineApi/SDKObservableEvents/SDKObservableEventsEngineApiWrapper.cs
@@ -58,15 +58,17 @@ namespace SceneRuntime.Apis.Modules.EngineApi.SDKObservableEvents
 
         private void DetectSceneMessageBusCommsObservableEvent()
         {
-            if (!engineApi.HasSubscription(SDKObservableEventIds.Comms))
-                return;
-
+            // Always drain the buffer to prevent unbounded growth when the scene
+            // subscribes to observables other than Comms. Only emit events when subscribed.
             lock (commsApi.SceneCommsMessages)
             {
                 if (commsApi.SceneCommsMessages.Count == 0) return;
 
-                foreach (CommsPayload currentPayload in commsApi.SceneCommsMessages)
-                    engineApi.AddSDKObservableEvent(SDKObservableUtils.NewSDKObservableEventFromData(SDKObservableEventIds.Comms, currentPayload));
+                if (engineApi.HasSubscription(SDKObservableEventIds.Comms))
+                {
+                    foreach (CommsPayload currentPayload in commsApi.SceneCommsMessages)
+                        engineApi.AddSDKObservableEvent(SDKObservableUtils.NewSDKObservableEventFromData(SDKObservableEventIds.Comms, currentPayload));
+                }
 
                 commsApi.ClearMessages();
             }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes #8558 — Genesis Plaza scene interactions become progressively unresponsive over time.

## What was happening

Scenes can subscribe to engine "observables" — things like _player connected_, _entered scene_, _profile changed_, and _comms_ (messages other players send through the scene's own MessageBus).

The explorer collected incoming MessageBus messages in a per-scene buffer, waiting to deliver them as `comms` observable events. But the code that emptied that buffer only ran in two cases:

1. The scene had **no** subscriptions at all → buffer cleared.
2. The scene was subscribed specifically to `comms` → messages emitted as events, buffer cleared.

If the scene was subscribed to anything else (`playerConnected`, `onEnterScene`, etc.) but **not** to `comms`, the buffer was never cleared. Every message that arrived stayed there forever.

## Test plan

Confirm that the original issue no longer occurs.

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
