### PR TITLE
chore: added sanification of passport fields on save to avoid trailing dirt

### DIFF
--- a/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileConverter.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileConverter.cs
@@ -216,28 +216,28 @@ namespace DCL.Profiles
             writer.WriteValue(profile.HasClaimedName);
 
             writer.WritePropertyName("description");
-            writer.WriteValue(profile.Description);
+            writer.WriteValue(Sanitize(profile.Description));
 
             writer.WritePropertyName("tutorialStep");
             writer.WriteValue(profile.TutorialStep);
 
             writer.WritePropertyName("name");
-            writer.WriteValue(profile.Name);
+            writer.WriteValue(Sanitize(profile.Name));
 
             writer.WritePropertyName("userId");
-            writer.WriteValue(profile.UserId);
+            writer.WriteValue(Sanitize(profile.UserId));
 
             writer.WritePropertyName("email");
-            writer.WriteValue(profile.Email);
+            writer.WriteValue(Sanitize(profile.Email));
 
             writer.WritePropertyName("ethAddress");
-            writer.WriteValue(profile.UserId);
+            writer.WriteValue(Sanitize(profile.UserId));
 
             writer.WritePropertyName("version");
             writer.WriteValue(profile.Version);
 
             writer.WritePropertyName("unclaimedName");
-            writer.WriteValue(profile.UnclaimedName);
+            writer.WriteValue(Sanitize(profile.UnclaimedName));
 
             writer.WritePropertyName("hasConnectedWeb3");
             writer.WriteValue(profile.HasConnectedWeb3);
@@ -246,34 +246,34 @@ namespace DCL.Profiles
             SerializeAvatar(writer, profile);
 
             writer.WritePropertyName("country");
-            writer.WriteValue(profile.Country);
+            writer.WriteValue(Sanitize(profile.Country));
 
             writer.WritePropertyName("gender");
-            writer.WriteValue(profile.Gender);
+            writer.WriteValue(Sanitize(profile.Gender));
 
             writer.WritePropertyName("pronouns");
-            writer.WriteValue(profile.Pronouns);
+            writer.WriteValue(Sanitize(profile.Pronouns));
 
             writer.WritePropertyName("relationshipStatus");
-            writer.WriteValue(profile.RelationshipStatus);
+            writer.WriteValue(Sanitize(profile.RelationshipStatus));
 
             writer.WritePropertyName("sexualOrientation");
-            writer.WriteValue(profile.SexualOrientation);
+            writer.WriteValue(Sanitize(profile.SexualOrientation));
 
             writer.WritePropertyName("language");
-            writer.WriteValue(profile.Language);
+            writer.WriteValue(Sanitize(profile.Language));
 
             writer.WritePropertyName("employmentStatus");
-            writer.WriteValue(profile.EmploymentStatus);
+            writer.WriteValue(Sanitize(profile.EmploymentStatus));
 
             writer.WritePropertyName("profession");
-            writer.WriteValue(profile.Profession);
+            writer.WriteValue(Sanitize(profile.Profession));
 
             writer.WritePropertyName("realName");
-            writer.WriteValue(profile.RealName);
+            writer.WriteValue(Sanitize(profile.RealName));
 
             writer.WritePropertyName("hobbies");
-            writer.WriteValue(profile.Hobbies);
+            writer.WriteValue(Sanitize(profile.Hobbies));
 
             writer.WritePropertyName("birthDate");
             writer.WriteValue(profile.Birthdate != null ? new DateTimeOffset(profile.Birthdate.Value, TimeSpan.Zero).ToUnixTimeSeconds() : 0);
@@ -360,9 +360,9 @@ namespace DCL.Profiles
                 {
                     writer.WriteStartObject();
                     writer.WritePropertyName("title");
-                    writer.WriteValue(link.title);
+                    writer.WriteValue(Sanitize(link.title));
                     writer.WritePropertyName("url");
-                    writer.WriteValue(link.url);
+                    writer.WriteValue(Sanitize(link.url));
                     writer.WriteEndObject();
                 }
             }
@@ -412,5 +412,8 @@ namespace DCL.Profiles
 
             writer.WriteEndArray();
         }
+
+        private static string Sanitize(string? value) =>
+            value?.Trim() ?? "";
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #8548
Sometimes when trailing \n, \r were saved in passport fields, the deploy of the profile was failing

## Test Instructions

### Test Steps
1. Launch the client
2. Open your own passport
3. Edit description/links/additional data
4. Verify that the save works as in production

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
