### PR TITLE
feat: handled device change for audio streams and audio sources

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
@@ -40,5 +40,12 @@ namespace DCL.VoiceChat.Nearby.Audio
         /// allocation-free so per-frame ECS systems can call it without touching <see cref="LiveKit.Rooms.IRoom"/>.
         /// </summary>
         bool IsActiveSpeaker(string walletId);
+
+        /// <summary>
+        /// Monotonic pull-based freshness signal — bumped on Unity output-device change
+        /// (<see cref="UnityEngine.AudioSettings.OnAudioConfigurationChanged"/>, <c>deviceWasChanged: true</c>).
+        /// A value different from last tick means consumers must reconcile their device-bound state.
+        /// </summary>
+        int RebuildEpoch { get; }
     }
 }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioSourceFactory.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioSourceFactory.cs
@@ -5,7 +5,6 @@ using LiveKit.Rooms.Streaming.Audio;
 using RichTypes;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Audio;
 using Utility;
 
 namespace DCL.VoiceChat.Nearby.Audio
@@ -84,6 +83,22 @@ namespace DCL.VoiceChat.Nearby.Audio
             liveInstances.Clear();
             legacyInstances.Clear();
             liveCount = 0;
+        }
+
+        /// <summary>
+        ///     Discards every instance pinned to the previous Unity audio output device since <see cref="AudioSource"/> binds to the device at creation and stays pinned.
+        ///     Inactive pool entries are destroyed; live instances are reclassified as legacy
+        ///     so their next <see cref="Dispose"/> destroys them instead of returning device-stale objects to the pool.
+        /// </summary>
+        public void InvalidateForDeviceChange()
+        {
+            foreach (LivekitAudioSource live in liveInstances)
+                legacyInstances.Add(live);
+
+            liveInstances.Clear();
+            liveCount = 0;
+
+            pool.Clear();
         }
 
         private LivekitAudioSource CreateFreshInstance()

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
+using UnityEngine;
 
 namespace DCL.VoiceChat.Nearby.Audio
 {
@@ -47,6 +48,11 @@ namespace DCL.VoiceChat.Nearby.Audio
         private ConcurrentDictionary<string, string[]> streamsByIdentity = NewSnapshot();
         private readonly ConcurrentDictionary<string, byte> activeSpeakers = new ();
 
+        // Pull-based freshness signal for output-device changes;
+        private int rebuildEpoch;
+
+        public int RebuildEpoch => Volatile.Read(ref rebuildEpoch);
+
         public NearbyAudioStreamsRegistry(IRoom room)
         {
             this.room = room;
@@ -59,6 +65,8 @@ namespace DCL.VoiceChat.Nearby.Audio
 
             room.Participants.UpdatesFromParticipant += OnParticipantUpdate;
             room.ActiveSpeakers.Updated += PullActiveSpeakers;
+
+            AudioSettings.OnAudioConfigurationChanged += OnAudioConfigurationChanged;
 
             if (room.Info.ConnectionState == LKConnectionState.ConnConnected)
             {
@@ -78,8 +86,16 @@ namespace DCL.VoiceChat.Nearby.Audio
             room.Participants.UpdatesFromParticipant -= OnParticipantUpdate;
             room.ActiveSpeakers.Updated -= PullActiveSpeakers;
 
+            AudioSettings.OnAudioConfigurationChanged -= OnAudioConfigurationChanged;
+
             Interlocked.Exchange(ref streamsByIdentity, NewSnapshot());
             activeSpeakers.Clear();
+        }
+
+        private void OnAudioConfigurationChanged(bool deviceWasChanged)
+        {
+            if (deviceWasChanged)
+                Interlocked.Increment(ref rebuildEpoch);
         }
 
         private static ConcurrentDictionary<string, string[]> NewSnapshot(int capacity = 0) =>

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
@@ -42,6 +42,9 @@ namespace DCL.VoiceChat.Nearby.Systems
         private readonly NearbyVoiceChatStateModel stateModel;
         private readonly NearbyAudioSourceFactory sourceFactory;
 
+        // Mismatch with registry.RebuildEpoch ⇒ output-device changed since last tick.
+        private int lastSeenRebuildEpoch;
+
         internal NearbyAudioCleanupSystem(World world, INearbyAudioStreamRegistry registry, HashSet<StreamKey> bindings, IUserBlockingCache userBlockingCache, NearbyVoiceChatStateModel stateModel, NearbyAudioSourceFactory sourceFactory) : base(world)
         {
             this.registry = registry;
@@ -49,12 +52,23 @@ namespace DCL.VoiceChat.Nearby.Systems
             this.userBlockingCache = userBlockingCache;
             this.stateModel = stateModel;
             this.sourceFactory = sourceFactory;
+
+            lastSeenRebuildEpoch = registry.RebuildEpoch;
         }
 
         protected override void Update(float t)
         {
-            // Listening-gate is one bulk archetype-move; per-entity detection is skipped entirely when closed.
-            if (stateModel.IsListeningDisabled)
+            int currentEpoch = registry.RebuildEpoch;
+
+            bool deviceChanged = currentEpoch != lastSeenRebuildEpoch;
+            if (deviceChanged)
+            {
+                lastSeenRebuildEpoch = currentEpoch;
+                sourceFactory.InvalidateForDeviceChange();
+            }
+
+            // Listening-gate AND device-change are bulk archetype-moves; per-entity detection is skipped in either case.
+            if (stateModel.IsListeningDisabled || deviceChanged)
                 World.Add<DeleteEntityIntention>(in LIVE_AUDIO_QUERY);
             else
                 FlagDoomedAudioEntitiesQuery(World);

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
@@ -519,6 +519,8 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             public bool IsActiveSpeaker(string walletId) => false;
 
+            public int RebuildEpoch => 0;
+
             public void Dispose() { }
         }
     }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
@@ -533,6 +533,8 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             public bool IsActiveSpeaker(string walletId) => false;
 
+            public int RebuildEpoch => 0;
+
             public void Dispose() { }
         }
     }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCycleManualTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCycleManualTest.cs
@@ -371,6 +371,8 @@ namespace DCL.VoiceChat.Nearby
             public bool IsActiveSpeaker(string walletId) =>
                 throw new NotImplementedException();
 
+            public int RebuildEpoch => 0;
+
             public void Dispose() { }
         }
     }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCyclePerformanceTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCyclePerformanceTest.cs
@@ -573,6 +573,8 @@ namespace DCL.VoiceChat.Nearby
 
             public bool IsActiveSpeaker(string walletId) => activeSpeakers.Contains(walletId);
 
+            public int RebuildEpoch => 0;
+
             public void Dispose() { }
         }
     }


### PR DESCRIPTION
# Pull Request Description

## What Does This PR Change?

Companion fix to #8458 for the **Nearby (proximity) voice chat** path. PR #8458 fixed the same Bluetooth-reconnect class of bug for community/private calls; that fix does not cover Nearby because Nearby owns a parallel audio pipeline.

After a runtime audio output device change (typical Bluetooth disconnect/reconnect cycle, manual switch in OS settings, AirPods take-off/put-on), incoming Nearby voice from other avatars goes silent. The remote LiveKit streams are alive, but the Unity `AudioSource` instances spatializing them stay bound to the previous output device and never route to the new one.

Outgoing mic is **not** affected here — Nearby already republishes the mic track via `NearbyVoiceChatManager.RepublishIfNeeded` on `MicrophoneChanged`, which is the symmetric path #8458 added to community/private.

## Root Cause

Unity binds an `AudioSource` to the active output device at creation. When the OS audio output changes, Unity fires `AudioSettings.OnAudioConfigurationChanged(deviceWasChanged: true)` and resets the engine — but **existing** `AudioSource` instances remain pinned to the old device and become silent. Only newly created sources route to the new device.

#8458 fixed this for community/private by subscribing inside `RemoteTrackListener` and rebuilding entries in `PlaybackSourcesHub`. **Nearby does not use `PlaybackSourcesHub`**: its incoming audio is materialized through an ECS pipeline:

- `NearbyAudioStreamsRegistry` — Island-room subscription, copy-on-write sid index.
- `NearbyLivekitBridgeSystem` — pull-mirrors registry into `NearbyAudioStreamerComponent` on avatars.
- `NearbyAudioBindingSystem` — for each `(walletId, sid)` in audible range, creates a spatial audio entity holding a `LivekitAudioSource` from `NearbyAudioSourceFactory` (a pooled factory).
- `NearbyAudioCleanupSystem` — tears down audio entities on the ECS-side triggers (avatar gone, stream gone, blocked, listening-gate).

Nothing in this pipeline reacts to `OnAudioConfigurationChanged`, so live `LivekitAudioSource` instances and pooled-but-released ones stay device-stale across a reconnect.

## The Fix

A pull-based freshness signal in the **Registry**, plus an explicit invalidation hook on the **Factory**, orchestrated by the **Cleanup** system. No new classes, no events leaking into ECS.

### `NearbyAudioStreamsRegistry` — single subscriber to `AudioSettings.OnAudioConfigurationChanged`

- New `int RebuildEpoch { get; }` (interface), backed by `Interlocked.Increment` on the device-changed event.
- Symmetric `+=` / `-=` next to existing LiveKit room subscriptions, in `Dispose`.
- Mirrors the existing pattern of the registry — it is already the single source of truth for "stream state went stale" (track-subscribed/unsubscribed, connection-updated, participant-disconnected). Output-device change is the same class of source, so it lives here. No public mutation on the API; consumers only read `RebuildEpoch`.

### `NearbyAudioCleanupSystem` — orchestrator

- Tracks `lastSeenRebuildEpoch`. Mismatch with `registry.RebuildEpoch` ⇒ output device changed since last tick.
- On mismatch, performs the bulk teardown via the same `LIVE_AUDIO_QUERY` archetype-move already used by the listening-gate path: `World.Add<DeleteEntityIntention>(in LIVE_AUDIO_QUERY)`. The existing `TearDownMarkedAudioEntitiesQuery` then disposes every `LivekitAudioSource` and clears `bindings`. On the next tick, `NearbyAudioBindingSystem` recreates fresh audio entities for the same `(walletId, sid)` set against the new device.
- Calls `sourceFactory.InvalidateForDeviceChange()` **before** the bulk-add so the upcoming `Dispose` calls take the destroy path instead of returning device-stale instances to the pool. Order is documented inline.

### `NearbyAudioSourceFactory` — pool/live invariant

- New `InvalidateForDeviceChange()` reclassifies every live pool-managed instance as `legacy` (their next `Dispose` destroys instead of releasing — the existing legacy/overflow path) and drains the inactive pool via `pool.Clear()`. Next `Create` allocates a fresh `LivekitAudioSource` against the new device.
- The factory is **not** a subscriber on `AudioSettings`; the single subscription stays in the registry and the factory exposes a domain method that the cleanup system calls. One source of truth for "what counts as a device change".

### Why this layering

The audio pipeline already has a clean separation: **Registry** owns "what changed about streams", **Factory** owns the pool invariant, **Cleanup** orchestrates teardown of ECS audio entities. Putting the subscription in the manager would have spread "what counts as device change" across two places and required exposing an `Invalidate()` setter on the registry interface (a shallower module). Putting the subscription on the factory would have duplicated the subscription on the same Unity event in two classes. The chosen layering keeps each fact in one place.

### Files touched

- `Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs`
- `Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs`
- `Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioSourceFactory.cs`
- `Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs`
- Test fakes (`FakeStreamRegistry` in 4 test files) — `RebuildEpoch => 0`.

## Test Instructions

**Setup**
- Two accounts (A = listener, B = speaker). They must be on the same parcel and within Nearby audible range.
- Account A is the device under test. Account B can be on any second machine / second account on the same machine.
- Account A needs a runtime-switchable output device. Easiest: a Bluetooth headset (AirPods, any BT headphones). Alternatively: an external USB audio device that can be unplugged/plugged, or use the OS sound panel to switch the default output device.

**Run the build**

```bash
metaforge explorer run 8590
```

### Scenario 1 — Bluetooth disconnect / reconnect cycle (the primary bug)

1. On account A, connect Bluetooth headphones and select them as the system output. Enter the world.
2. Account B walks up to A and starts speaking continuously into nearby chat.
3. Confirm A hears B clearly through the Bluetooth headphones.
4. On A: turn off the Bluetooth headphones (or take AirPods off / disconnect from OS Bluetooth panel). Audio routing falls back to laptop speakers / built-in output.
5. Confirm A still hears B through the fallback output (this already worked before this PR — Unity routes new defaults).
6. On A: turn the Bluetooth headphones back on (or put AirPods on / reconnect). System output returns to Bluetooth.
7. **Expected (with fix):** A hears B again, through the Bluetooth headphones, within ~1 second of reconnect. Audio is positional/spatialized like before.
8. **Without fix (regression check on `dev`):** A does **not** hear B anymore through the Bluetooth headphones. Audio stays silent until A leaves and re-enters audible range, or until both accounts disconnect and reconnect.

### Scenario 2 — Manual output device switch via OS sound panel

1. Same setup. A starts on built-in speakers, B is speaking nearby.
2. On A, open the OS sound panel and switch default output to a different device (USB headset, monitor speakers, AirPods, anything — even back and forth between two built-in outputs if available).
3. **Expected:** Audio from B follows the new output device within ~1 second. Switch a few times rapidly (3-4 switches A→B→C→A) — final routing should match the latest selected device.

### Scenario 3 — Multiple speakers nearby

1. Three or more accounts on the same parcel within audible range, two or more of them speaking simultaneously.
2. On A, run the BT disconnect/reconnect cycle from Scenario 1.
3. **Expected:** After reconnect, A hears **every** previously-audible speaker again, not just one. Spatial positioning is preserved (audio comes from each avatar's direction).

### Scenario 4 — Move out of range and back after a device switch

1. Run Scenario 1 fully (BT disconnect → reconnect, audio recovers).
2. A walks far enough away that B is out of nearby audible range. Audio cuts off (expected — out of range).
3. A walks back into range.
4. **Expected:** A hears B again normally. This verifies that the post-device-change audio entities are healthy long-term, not just for one cycle.

### Scenario 5 — Repeated cycles

1. Repeat Scenario 1 four or five times in a row (BT off → BT on → BT off → BT on → ...).
2. **Expected:** Audio recovers every cycle, not just the first one. No audible glitches/clicks beyond the natural ~1s gap. The application stays stable (no crash, no hang, no growing memory).

### Scenario 6 — Outgoing mic regression check

This PR does **not** change the outgoing mic path for Nearby (already handled separately by `RepublishIfNeeded` on `MicrophoneChanged`), but verify it stays intact:

1. A is the speaker; B is the listener.
2. A switches microphone in the settings panel mid-call.
3. **Expected:** B keeps hearing A after the mic switch (this is the `MicrophoneChanged` flow, unchanged here).

### Platform coverage

Test on **Windows** and **macOS** if possible. The original report behind #8458 was macOS-specific for community/private; the underlying Unity behavior (`AudioSource` pinned to device at creation) is cross-platform, so macOS is the highest-priority target for Nearby too. Windows reproduction is also expected on at least Bluetooth (channel layout switches between mono/stereo are common there).

## Quality Checklist
- [ ] Changes have been tested locally on macOS with Bluetooth headphones (disconnect/reconnect cycle)
- [ ] Changes have been tested locally on Windows with Bluetooth headphones or USB audio swap
- [ ] No regressions in outgoing mic switch (Scenario 6)
- [ ] No regressions in normal Nearby flow (entering/leaving audible range, blocking users, suppressing nearby)

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
