### PR TITLE
fix: flush stored login email on dapp login

### DIFF
--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/CompositeWeb3Provider.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/CompositeWeb3Provider.cs
@@ -66,6 +66,10 @@ namespace DCL.Web3.Authenticators
             IWeb3Identity identity = await currentAuthenticator.LoginAsync(payload, ct);
             identityCache.Identity = identity;
             analytics.Identify(identity);
+
+            if (identity.Source != IWeb3Identity.Web3IdentitySource.OTP)
+                DCLPlayerPrefs.DeleteKey(DCLPrefKeys.LOGGEDIN_EMAIL, save: true);
+
             return identity;
         }
 


### PR DESCRIPTION
# Pull Request Description
Fixes #8592

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes sure that stale stored login emails are flushed when the user successfully logs in via dapps, so that subsequent logins are correctly routed to the proper flow.


### Test Steps
1. Verify that if you login with a method, jump in and then close, on the next client launch the same login has persisted


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
