### PR TITLE
fix: use full screen prefs in lsd

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -182,8 +182,7 @@ namespace Global.Dynamic
 
             NativeWindowManager.Initialize(
                 applicationParametersParser.HasFlag(AppArgsFlags.DISABLE_WINDOW_RESTRICTIONS),
-                applicationParametersParser.HasFlag(AppArgsFlags.WINDOWED_MODE),
-                applicationParametersParser.HasFlag(AppArgsFlags.LOCAL_SCENE));
+                applicationParametersParser.HasFlag(AppArgsFlags.WINDOWED_MODE));
 
             World world = World.Create();
 

--- a/Explorer/Assets/Plugins/NativeWindowManager/NativeWindowManager.cs
+++ b/Explorer/Assets/Plugins/NativeWindowManager/NativeWindowManager.cs
@@ -88,21 +88,20 @@ namespace Plugins.NativeWindowManager
         /// </summary>
         /// <param name="disableConstraints">If constraints should be disabled in window mode.</param>
         /// <param name="windowedModeRequested">If window mode was specifically requested via app args.</param>
-        /// <param name="isLocalScene">If we're running a local scene.</param>
-        public static void Initialize(bool disableConstraints, bool windowedModeRequested, bool isLocalScene)
+        public static void Initialize(bool disableConstraints, bool windowedModeRequested)
         {
             disableWindowConstraints = disableConstraints;
 
-            if (windowedModeRequested || isLocalScene)
-                EnableFullscreen(false, false);
-            else if (!FullScreenEnabled)
+            bool desiredFullscreen = !windowedModeRequested
+                                     && DCLPlayerPrefs.GetBool(DCLPrefKeys.SETTINGS_FULLSCREEN, true);
+
+            if (desiredFullscreen != FullScreenEnabled)
+                EnableFullscreen(desiredFullscreen, store: false);
+            else if (!desiredFullscreen)
                 ApplyConstraints(true);
 
             var resolutionListenerGO = new GameObject("ResolutionListener");
             resolutionListener = resolutionListenerGO.AddComponent<ResolutionListener>();
-
-            if (isLocalScene)
-                FullScreenResolution = ResolutionUtils.GetDefaultResolution();
         }
 
         /// <summary>


### PR DESCRIPTION
# Pull Request Description
Fixes #8490

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR addresses the annoying fact of running a client for a local scene preview that always goes to fullscreen (also overriding prefs).

`NativeWindowManager.Initialize()` never read the persisted SETTINGS_FULLSCREEN pref at startup. The other issue was that `FullScreenResolution` setter always sets `FullScreenMode.FullScreenWindow` and that was always running in LSD.

 Changes:
  - Read SETTINGS_FULLSCREEN at boot and apply it to Screen.fullScreenMode.
  - --windowed-mode is now the only override; isLocalScene no longer forces windowed.                                              
  - Removed the local-scene FullScreenResolution = ... line that had the fullscreen side-effect.

### Test Steps
1. Run the client with `--local-scene true` arg and verify it no longer goes to full screen but mirrors whatever setting you have saved
2. Verify that only `--windows-mode` arg overrides whatever setting you have and always starts windowed
3. Verify that settings work as usual


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
