### PR TITLE
fix: enable ci tests with rg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,6 +175,22 @@ jobs:
           docker push $ghcr
           echo "Seeded GHCR: $ghcr"
 
+      - name: Install ripgrep for edit mode tests
+        if: matrix.testMode == 'editmode'
+        id: rg-img
+        run: |
+          base="${{ steps.img.outputs.ghcr }}"
+          derived="${base}-rg"
+          cat > /tmp/Dockerfile.rg <<EOF
+          FROM $base
+          RUN apt-get update \
+              && apt-get install -y --no-install-recommends ripgrep \
+              && rm -rf /var/lib/apt/lists/*
+          EOF
+          docker build -t "$derived" -f /tmp/Dockerfile.rg /tmp
+          echo "image=$derived" >> $GITHUB_OUTPUT
+          echo "Built derived image with ripgrep: $derived"
+
       # Configure test runner
       - uses: game-ci/unity-test-runner@v4.3.1
         id: testRunner
@@ -186,7 +202,7 @@ jobs:
           projectPath: Explorer
           testMode: ${{ matrix.testMode }}
           sshAgent: ${{ env.SSH_AUTH_SOCK }}
-          customImage: ${{ steps.img.outputs.ghcr }}
+          customImage: ${{ matrix.testMode == 'editmode' && steps.rg-img.outputs.image || steps.img.outputs.ghcr }}
           customParameters: -buildTarget StandaloneLinux64 -testCategory "!Performance" -burst-disable-compilation -accept-apiupdate
           githubToken: ${{ env.GITHUB_TOKEN }}
 

--- a/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
@@ -172,6 +172,7 @@ namespace DCL.Tests
         public void VerifyShouldNotUseConcurrentCollection()
         {
             const string pattern = @"System\.Collections\.Concurrent";
+            // must be used only for the infrastructural types, don't abuse the skipping
             string[] ignorePaths = new []
             {
                 "Assets/DCL/Infrastructure/Utility/Multithreading/DCLConcurrentDictionary.cs",

--- a/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
@@ -222,10 +222,18 @@ namespace DCL.Tests
             using var p = Process.Start(finder);
             p.WaitForExit();
             string output = p!.StandardOutput.ReadToEnd();
-            
-            // Skip rg-based checks when ripgrep isn't installed on the host (common locally; CI has it).
+
+            // In CI (batch mode) ripgrep is required: fail loudly if missing.
+            // Locally we ignore so devs without rg installed can still run the test suite.
             if (p.ExitCode == 1 || string.IsNullOrWhiteSpace(output))
-                Assert.Ignore($"ripgrep (rg) not found on PATH. Install it to run this convention check (e.g. `brew install ripgrep`). which-output: '{output}', err: '{p.StandardError.ReadToEnd()}'.");
+            {
+                string message = $"ripgrep (rg) not found on PATH. Install it to run this convention check (e.g. `brew install ripgrep`). which-output: '{output}', err: '{p.StandardError.ReadToEnd()}'.";
+
+                if (UnityEngine.Application.isBatchMode)
+                    Assert.Fail(message);
+                else
+                    Assert.Ignore(message);
+            }
 
             return output.Trim();
         }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioStreamRegistryShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioStreamRegistryShould.cs
@@ -10,7 +10,6 @@ using LiveKit.Rooms.Tracks.Hub;
 using NSubstitute;
 using NUnit.Framework;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
@@ -541,7 +540,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             LKParticipant participant = NewParticipant(identity);
 
             FieldInfo tracksField = typeof(LKParticipant).GetField("tracks", BindingFlags.Instance | BindingFlags.NonPublic)!;
-            var tracksDict = (ConcurrentDictionary<string, TrackPublication>)tracksField.GetValue(participant)!;
+            var tracksDict = (IDictionary<string, TrackPublication>)tracksField.GetValue(participant)!;
             foreach ((string sid, TrackKind kind, TrackSource source) in tracks)
                 tracksDict[sid] = NewPublication(sid, kind, source);
 

--- a/Explorer/Assets/DCL/VoiceChat/VoiceChatTrackManager.cs.meta
+++ b/Explorer/Assets/DCL/VoiceChat/VoiceChatTrackManager.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 031acb060025b4924b725c4710025694

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,20 @@
-## Makefile for protocol generation
+## Makefile for protocol generation and Unity test runs.
 ## Must be executed from project root.
 ## Commands run inside ./scripts directory.
 
 SCRIPTS_DIR := ./scripts
 
-.PHONY: upgrade-protocol-by-url regenerate-protocol upgrade-protocol clean
+## Unity test configuration. Override on the command line, e.g.:
+##   make test-editmode TEST_FILTER=DCL.Tests.CodeConventionsTests
+##   make test-playmode UNITY=/path/to/Unity
+PROJECT_DIR      := ./Explorer
+UNITY_VERSION    := $(shell grep -o 'm_EditorVersion: [0-9a-f.]*' $(PROJECT_DIR)/ProjectSettings/ProjectVersion.txt | cut -d' ' -f2)
+UNITY            ?= /Applications/Unity/Hub/Editor/$(UNITY_VERSION)/Unity.app/Contents/MacOS/Unity
+TEST_RESULTS_DIR ?= ./test-results
+TEST_CATEGORY    ?= !Performance
+TEST_FILTER      ?=
+
+.PHONY: upgrade-protocol-by-url regenerate-protocol upgrade-protocol clean test-editmode test-playmode
 
 ## Generate C# code from protobuf definitions
 regenerate-protocol:
@@ -49,4 +59,34 @@ clean:
 	@echo "Removing node_modules..."
 	rm -rf $(SCRIPTS_DIR)/node_modules
 	@echo "Clean complete."
+
+## Run Unity EditMode tests in batch mode (matches CI flags).
+test-editmode: TEST_MODE := editmode
+test-editmode: _run-unity-tests
+
+## Run Unity PlayMode tests in batch mode (matches CI flags).
+test-playmode: TEST_MODE := playmode
+test-playmode: _run-unity-tests
+
+.PHONY: _run-unity-tests
+_run-unity-tests:
+	@mkdir -p $(TEST_RESULTS_DIR)
+	@echo "Unity:         $(UNITY)"
+	@echo "Project:       $(PROJECT_DIR)"
+	@echo "Test mode:     $(TEST_MODE)"
+	@echo "Test category: $(TEST_CATEGORY)"
+	@echo "Test filter:   $(if $(TEST_FILTER),$(TEST_FILTER),(none))"
+	@echo "Results:       $(TEST_RESULTS_DIR)/$(TEST_MODE).xml"
+	"$(UNITY)" \
+	  -batchmode \
+	  -nographics \
+	  -projectPath "$(PROJECT_DIR)" \
+	  -runTests \
+	  -testPlatform $(TEST_MODE) \
+	  -testCategory "$(TEST_CATEGORY)" \
+	  -burst-disable-compilation \
+	  -accept-apiupdate \
+	  $(if $(TEST_FILTER),-testFilter "$(TEST_FILTER)") \
+	  -testResults "$(TEST_RESULTS_DIR)/$(TEST_MODE).xml" \
+	  -logFile "$(TEST_RESULTS_DIR)/$(TEST_MODE).log"
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

- **Enforce ripgrep (`rg`) in CI:** The `ResolvedRgPathViaShell()` helper in `CodeConventionTests.cs` previously used `Assert.Ignore` when ripgrep was missing, silently skipping convention checks in both CI and local environments. Now, when running in batch mode (CI), the test calls `Assert.Fail` instead — ensuring CI never silently skips ripgrep-based convention checks. Local (interactive) runs still use `Assert.Ignore` so devs without `rg` installed can run the test suite without friction.
- **Fix concurrent-collection convention violation:** `NearbyAudioStreamRegistryShould.cs` was importing `System.Collections.Concurrent` and casting to `ConcurrentDictionary`, which violates the convention test that bans direct use of concurrent collections outside infrastructure types. Changed the cast to `IDictionary<string, TrackPublication>` and removed the unused import.
- **Add Makefile test targets:** New `test-editmode` and `test-playmode` Make targets that mirror CI Unity batch-mode flags, making it easy to run the same test suite locally with `make test-editmode` / `make test-playmode`. Supports overrides for `UNITY`, `TEST_FILTER`, and `TEST_CATEGORY`.
- **Remove empty file:** Deletes the unused, empty `VoiceChatTrackManager.cs` and its `.meta` file.

## Test Instructions

No QA needed — CI hardening, convention compliance fix, build tooling, and dead-file cleanup with no runtime impact.

Requested by Nikita Khalov via Slack