### PR TITLE
fix: skip null/empty DisplayName in chat @-mention suggestions

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/SuggestionPanelChatInputState.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/SuggestionPanelChatInputState.cs
@@ -148,6 +148,9 @@ namespace DCL.Chat.ChatInput
             //We add or update the remaining participants
             foreach (Profile.CompactInfo profile in participantProfiles)
             {
+                if (string.IsNullOrEmpty(profile.DisplayName))
+                    continue;
+
                 if (profileSuggestionsDictionary.TryGetValue(profile.DisplayName, out ProfileInputSuggestionData profileSuggestionData))
                 {
                     if (!profileSuggestionData.ProfileData.Equals(profile))


### PR DESCRIPTION
# Pull Request Description
 Closes #8056 

## What does this PR change?
`SuggestionPanelChatInputState.UpdateProfileNameMap` iterates the participant
  list and uses `Profile.CompactInfo.DisplayName` as a `Dictionary<string, V>` key.
  When `DisplayName` is `null`, `TryGetValue` / `TryAdd` throw
  `ArgumentNullException` ("Value cannot be null. Parameter name: key") and
  crash the chat input on the next keystroke or focus loss.

  This PR adds a one-line guard that skips participants whose `DisplayName`
  is null or empty — they cannot be `@`-mentioned anyway.

### Quick reference

# Run this PR (with cache)
metaforge explorer run <this-PR-number>

# Run this PR (without cache — clears Explorer data)
metaforge explorer run <this-PR-number> --clear

# Run this PR (fresh account — clears everything and creates a new account)
metaforge account create --clear
metaforge explorer run <this-PR-number>

# Tail logs while testing
metaforge explorer logs tail --filter "<relevant text>"

# Run automation tests against this PR
metaforge explorer test <this-PR-number>
-->

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Test Steps
1. Start mentioning people 
2. Notice error doesn't appear
```System.ArgumentNullException: Value cannot be null.
Parameter name: key
  File "C:/workspace/workspace/p/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/SuggestionPanelChatInputState.cs", line 151, in UpdateProfileNameMap
  File "C:/workspace/workspace/p/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/SuggestionPanelChatInputState.cs", line 84, in TryFindMatchAsync
  File "C:/workspace/workspace/p/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/SuggestionPanelChatInputState.cs", line 65, in Dispose
  File "C:/workspace/workspace/p/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/TypingEnabledChatInputState.cs", line 136, in MoveNext
  File "C:/workspace/workspace/p/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/States/TypingEnabledChatInputState.cs", line 242, in OnInputDeselected
```

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
