### PR TITLE
fix: flaky test for binding in nearby voice chat test suite

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioSourceFactory.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioSourceFactory.cs
@@ -1,0 +1,22 @@
+using LiveKit.Rooms.Streaming;
+using LiveKit.Rooms.Streaming.Audio;
+using RichTypes;
+
+namespace DCL.VoiceChat.Nearby.Audio
+{
+    /// <summary>
+    ///     Boundary between Nearby audio systems and the concrete <see cref="LivekitAudioSource"/> pool.
+    ///     Lets EditMode tests substitute a fake that skips <see cref="LivekitAudioSource.Construct"/> /
+    ///     <see cref="LivekitAudioSource.Play"/>, keeping Unity's audio thread out of test runs.
+    /// </summary>
+    public interface INearbyAudioSourceFactory
+    {
+        LivekitAudioSource Create(StreamKey key, Weak<AudioStream> stream);
+
+        void Dispose(LivekitAudioSource? source);
+
+        void DisposeRoot();
+
+        void InvalidateForDeviceChange();
+    }
+}

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioSourceFactory.cs.meta
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioSourceFactory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8c4b3a9f2e5d4b6f0d1c9e3a7b2f8d4c

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioSourceFactory.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioSourceFactory.cs
@@ -17,7 +17,7 @@ namespace DCL.VoiceChat.Nearby.Audio
     ///     as the feature's hierarchy root (renamed to "VoiceChatSources_Nearby") so live and pooled
     ///     instances are siblings under one parent — no factory-side wrapper transform.
     /// </summary>
-    public class NearbyAudioSourceFactory
+    public class NearbyAudioSourceFactory : INearbyAudioSourceFactory
     {
         private const string ROOT_NAME = "VoiceChatSources_Nearby";
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioBindingSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioBindingSystem.cs
@@ -31,10 +31,10 @@ namespace DCL.VoiceChat.Nearby.Systems
         private readonly HashSet<StreamKey> bindings;
         private readonly IUserBlockingCache userBlockingCache;
         private readonly NearbyVoiceChatStateModel stateModel;
-        private readonly NearbyAudioSourceFactory sourceFactory;
+        private readonly INearbyAudioSourceFactory sourceFactory;
 
 
-        internal NearbyAudioBindingSystem(World world, INearbyAudioStreamRegistry registry, HashSet<StreamKey> bindings, IUserBlockingCache userBlockingCache, NearbyVoiceChatStateModel stateModel, NearbyAudioSourceFactory sourceFactory) : base(world)
+        internal NearbyAudioBindingSystem(World world, INearbyAudioStreamRegistry registry, HashSet<StreamKey> bindings, IUserBlockingCache userBlockingCache, NearbyVoiceChatStateModel stateModel, INearbyAudioSourceFactory sourceFactory) : base(world)
         {
             this.registry = registry;
             this.bindings = bindings;

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
@@ -40,12 +40,12 @@ namespace DCL.VoiceChat.Nearby.Systems
         private readonly HashSet<StreamKey> bindings;
         private readonly IUserBlockingCache userBlockingCache;
         private readonly NearbyVoiceChatStateModel stateModel;
-        private readonly NearbyAudioSourceFactory sourceFactory;
+        private readonly INearbyAudioSourceFactory sourceFactory;
 
         // Mismatch with registry.RebuildEpoch ⇒ output-device changed since last tick.
         private int lastSeenRebuildEpoch;
 
-        internal NearbyAudioCleanupSystem(World world, INearbyAudioStreamRegistry registry, HashSet<StreamKey> bindings, IUserBlockingCache userBlockingCache, NearbyVoiceChatStateModel stateModel, NearbyAudioSourceFactory sourceFactory) : base(world)
+        internal NearbyAudioCleanupSystem(World world, INearbyAudioStreamRegistry registry, HashSet<StreamKey> bindings, IUserBlockingCache userBlockingCache, NearbyVoiceChatStateModel stateModel, INearbyAudioSourceFactory sourceFactory) : base(world)
         {
             this.registry = registry;
             this.bindings = bindings;

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
@@ -15,7 +15,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
-using UnityEngine.TestTools;
 using Avatar = DCL.Profiles.Avatar;
 using Object = UnityEngine.Object;
 
@@ -43,44 +42,27 @@ namespace DCL.VoiceChat.Nearby.Tests
         private IUserBlockingCache userBlockingCache;
         private NearbyVoiceChatStateModel stateModel;
 
-        private VoiceChatConfiguration configuration;
-        private NearbyAudioSourceFactory sourceFactory;
+        private FakeNearbyAudioSourceFactory sourceFactory;
 
         private readonly List<GameObject> gameObjects = new (32);
 
         [SetUp]
         public void SetUp()
         {
-            // FakeStreamRegistry seeds a null AudioStream; once Play() fires, OnAudioFilterRead NREs on
-            // the audio thread on a schedule the teardown can't beat. Proper fix lives in package code.
-            LogAssert.ignoreFailingMessages = true;
-
             EcsTestsUtils.SetUpFeaturesRegistry();
 
             registry = new FakeStreamRegistry();
             bindings = new HashSet<StreamKey>();
             userBlockingCache = Substitute.For<IUserBlockingCache>();
             stateModel = new NearbyVoiceChatStateModel(NearbyVoiceChatState.IDLE);
-            configuration = ScriptableObject.CreateInstance<VoiceChatConfiguration>();
-            sourceFactory = new NearbyAudioSourceFactory(configuration);
+            sourceFactory = new FakeNearbyAudioSourceFactory();
 
             system = new NearbyAudioBindingSystem(world, registry, bindings, userBlockingCache, stateModel, sourceFactory);
         }
 
         protected override void OnTearDown()
         {
-            // Reap LivekitAudioSource instances spawned inside the system itself (parented to its private
-            // sourcesRoot, not tracked in our gameObjects list). Leaving them alive across tests is fatal:
-            // Unity keeps invoking OnAudioFilterRead on the audio thread, and by then the underlying world,
-            // stream, and registry have been torn down — producing NREs on a foreign thread.
-            foreach (LivekitAudioSource src in Object.FindObjectsByType<LivekitAudioSource>(FindObjectsInactive.Include, FindObjectsSortMode.None))
-            {
-                if (src == null) continue;
-
-                src.Stop();
-                src.Free();
-                Object.DestroyImmediate(src.gameObject);
-            }
+            sourceFactory.DisposeRoot();
 
             foreach (GameObject go in gameObjects)
                 if (go != null) Object.DestroyImmediate(go);
@@ -89,8 +71,6 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             bindings.Clear();
             stateModel.Dispose();
-
-            if (configuration != null) Object.DestroyImmediate(configuration);
 
             EcsTestsUtils.TearDownFeaturesRegistry();
         }
@@ -389,10 +369,9 @@ namespace DCL.VoiceChat.Nearby.Tests
             // Replace registry with the mock for the lifetime of this test.
             var localBindings = new HashSet<StreamKey>();
             using var localStateModel = new NearbyVoiceChatStateModel(NearbyVoiceChatState.IDLE);
-            VoiceChatConfiguration localConfig = ScriptableObject.CreateInstance<VoiceChatConfiguration>();
+            var localFactory = new FakeNearbyAudioSourceFactory();
             try
             {
-                var localFactory = new NearbyAudioSourceFactory(localConfig);
                 var localSystem = new NearbyAudioBindingSystem(world, mock, localBindings, userBlockingCache, localStateModel, localFactory);
 
                 const string WALLET = "wallet-alice";
@@ -412,7 +391,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             }
             finally
             {
-                if (localConfig != null) Object.DestroyImmediate(localConfig);
+                localFactory.DisposeRoot();
             }
         }
 
@@ -506,6 +485,55 @@ namespace DCL.VoiceChat.Nearby.Tests
             public int RebuildEpoch => 0;
 
             public void Dispose() { }
+        }
+
+        // ── Fake audio source factory ───────────────────────────────
+
+        // Production NearbyAudioSourceFactory unconditionally invokes Construct(stream) + Play() on every
+        // Create. Construct copies the supplied Weak<AudioStream> into the source, and Play() turns Unity's
+        // audio thread loose on OnAudioFilterRead. With FakeStreamRegistry's contract-breached null payload,
+        // OnAudioFilterRead would dereference a null AudioStream and NRE asynchronously — a race the test
+        // tear-down cannot win. Tests assert bookkeeping (entity count, component fields, AudioSource flags),
+        // not DSP behaviour, so this fake builds a real LivekitAudioSource MonoBehaviour, calls Play() (so
+        // isPlaying assertions still hold), sets mute=true, and DELIBERATELY skips Construct(...). The
+        // source's stream field stays at its default Weak<AudioStream>.Null (Disposed=true), and
+        // OnAudioFilterRead short-circuits via Resource.Has=false on every audio-thread tick.
+        private sealed class FakeNearbyAudioSourceFactory : INearbyAudioSourceFactory
+        {
+            private readonly List<LivekitAudioSource> instances = new (16);
+
+            public LivekitAudioSource Create(StreamKey key, Weak<AudioStream> stream)
+            {
+                LivekitAudioSource lkSource = LivekitAudioSource.New(explicitName: true, isSpatial: true);
+                lkSource.AudioSource.mute = true;
+                lkSource.Play();
+                instances.Add(lkSource);
+                return lkSource;
+            }
+
+            public void Dispose(LivekitAudioSource? source)
+            {
+                if (source == null) return;
+                if (!instances.Remove(source)) return;
+
+                source.Stop();
+                Object.DestroyImmediate(source.gameObject);
+            }
+
+            public void DisposeRoot()
+            {
+                foreach (LivekitAudioSource src in instances)
+                {
+                    if (src == null) continue;
+
+                    src.Stop();
+                    Object.DestroyImmediate(src.gameObject);
+                }
+
+                instances.Clear();
+            }
+
+            public void InvalidateForDeviceChange() { }
         }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fixes flaky `NearbyAudioBindingSystemShould` failures on CI caused by an audio-thread race between `LivekitAudioSource.OnAudioFilterRead` and test tear-down.

### Root cause

`FakeStreamRegistry.SeedActiveStream` does:

```csharp
streamsByKey[key] = new Owned<AudioStream>(null!);
```

`Weak<AudioStream>.Resource` then reports `Has=true, Value=null` (an undisposed Owned wrapping a null reference). The binding system's gate `if (!stream.Resource.Has) continue;` lets the call through, and `NearbyAudioSourceFactory.Create` runs `Construct(stream)` + `Play()`. Unity's audio thread starts invoking `OnAudioFilterRead`, which calls `resource.Value.ReadAudio(...)` — NRE on null `AudioStream`, on a schedule the test tear-down can't beat.

`LogAssert.ignoreFailingMessages = true` masks the NRE *within* the offending test, but the audio-thread NRE pumped between tests lands in the next test's log scope after the flag is reset → `Unhandled log message` gets attributed to the wrong test, randomly.

Editor passes locally because EditMode tests run without an `AudioListener` → `OnAudioFilterRead` is never invoked. The headless CI backend (`-batchmode -nographics`) does invoke it.

### Why not patch RichTypes / livekit-sdk?

`Owned<T> where T : class` is a non-nullable contract. `Owned<AudioStream>(null!)` uses the null-forgiving operator to lie to the type system — that's the breach, not a package bug. Patching `Weak.Resource` to null-check would weaken the contract for every consumer to accommodate a test shortcut, and would make the existing `Weak<T>.Null` (Disposed-as-absence) idiom redundant. Producer-side breach, fix at the producer.

### Production impact

None. `Owned<AudioStream>` is only constructed in production via `Streams.cs:92` → `new AudioStream(streamKey, track)`, which never returns null.

## What changed

- **`Core/INearbyAudioSourceFactory.cs`** (new) — 4-method boundary: `Create`, `Dispose`, `DisposeRoot`, `InvalidateForDeviceChange`.
- **`NearbyAudioSourceFactory`** — implements the interface; behaviour unchanged.
- **`NearbyAudioBindingSystem`**, **`NearbyAudioCleanupSystem`** — depend on the interface.
- **`NearbyAudioBindingSystemShould`** — nested `FakeNearbyAudioSourceFactory` that creates a real `LivekitAudioSource` MonoBehaviour, sets `mute=true`, calls `Play()`, but **deliberately skips `Construct(stream)`**. The source's stream stays at its default `Weak<AudioStream>.Null`, so `OnAudioFilterRead` short-circuits via `Resource.Has=false` on every audio-thread tick. Drops the `LogAssert.ignoreFailingMessages` workaround and the `FindObjectsByType<LivekitAudioSource>` tear-down sweep.
- `VoiceChatPlugin`, `NearbyAudioCleanupSystemShould`, `NearbyAudioSourceFactoryShould`, performance tests — untouched (concrete factory automatically satisfies the new interface).

## Test Instructions

1. Open `NearbyAudioBindingSystemShould` in the Test Runner (EditMode).
2. Run the suite — should be green.
3. Run it ~10× back-to-back to confirm no flap; same for `NearbyAudioCleanupSystemShould` and `NearbyAudioSourceFactoryShould`.
4. (Optional baseline) Reproduce the original flap on `dev` with the same command CI uses, then on this branch to confirm it's gone:

   ```bash
   Unity.exe -batchmode -nographics -runTests \
     -projectPath Explorer \
     -testPlatform EditMode \
     -testFilter "DCL.VoiceChat.Nearby.Tests.NearbyAudioBindingSystemShould" \
     -testResults result.xml -logFile -
   ```

## Quality Checklist
- [x] Changes tested locally
- [x] No production behaviour change (interface extracted, concrete factory unchanged)
- [x] Performance impact: interface dispatch on factory call sites only, not on the per-frame DSP path

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting.