### PR TITLE
fix: phantom private call in community voice chat

### DIFF
--- a/Explorer/Assets/DCL/VoiceChat/PrivateVoiceChat/PrivateVoiceChatPresenter.cs
+++ b/Explorer/Assets/DCL/VoiceChat/PrivateVoiceChat/PrivateVoiceChatPresenter.cs
@@ -137,6 +137,7 @@ namespace DCL.VoiceChat
             statusSubscription?.Dispose();
             this.voiceChatRoom.Participants.UpdatesFromParticipant -= OnParticipantUpdated;
             this.voiceChatRoom.ActiveSpeakers.Updated -= OnActiveSpeakersUpdated;
+            this.voiceChatRoom.ConnectionUpdated -= OnConnectionUpdated;
             micController.Dispose();
         }
     }

--- a/Explorer/Assets/DCL/VoiceChat/PrivateVoiceChat/PrivateVoiceChatPresenter.cs
+++ b/Explorer/Assets/DCL/VoiceChat/PrivateVoiceChat/PrivateVoiceChatPresenter.cs
@@ -5,7 +5,6 @@ using DCL.UI.Profiles.Helpers;
 using DCL.Utilities;
 using DCL.Utilities.Extensions;
 using DCL.LiveKit.Public;
-using LiveKit.Proto;
 using LiveKit.Rooms;
 using LiveKit.Rooms.Participants;
 using System;
@@ -60,8 +59,12 @@ namespace DCL.VoiceChat
 
         private void OnConnectionUpdated(IRoom room, ConnectionUpdate connectionUpdate, LKDisconnectReason? disconnectReason = null)
         {
-            if (connectionUpdate == ConnectionUpdate.Connected)
-                view.SetInCallSection();
+            if (connectionUpdate != ConnectionUpdate.Connected) return;
+
+            // The LiveKit room is shared between private and community calls
+            if (privateCallOrchestrator.CurrentVoiceChatType.Value != VoiceChatType.PRIVATE) return;
+
+            view.SetInCallSection();
         }
 
         private void OnActiveSpeakersUpdated()


### PR DESCRIPTION
# Pull Request Description
Fixes #8378

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR addresses the issue of the private call banner being visible after a failed attempt (other user was already in call) and after starting a community stream.
This was caused by the fact that `PrivateVoiceChatPresenter` reacts to the livekit connection event to show the banner but the livekit room is shared between private and community voice chats, hence it was firing in that case.


### Test Steps
1. Use the repro steps in the linked issue and verify the error is no longer present
2. General test for various voice chats: they should behave as normal


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
