### PR TITLE
fix: catalog emote audio 404 and GPUI shader InvalidKeyException in LSD

### DIFF
--- a/Explorer/Assets/AddressableAssetsData/AssetGroups/Landscape.asset
+++ b/Explorer/Assets/AddressableAssetsData/AssetGroups/Landscape.asset
@@ -165,6 +165,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 7835c6b3cbd1dd24bb8cf791f83b3ec9
+    m_Address: GPUInstancerPro/Standard
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 7c45d7279c9840b40bf9cf08795bcb8f
     m_Address: Fork_A
     m_ReadOnly: 0

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -271,8 +271,6 @@ namespace DCL.AvatarRendering.Emotes.Load
                 if (audioType == AudioType.UNKNOWN)
                     continue;
 
-                // In LSD the realm content URL points at the local preview server, which doesn't host catalog
-                // emote audio — fall back to the production catalyst for the active environment.
                 string contentBaseUrl = localSceneDevelopment
                     ? urlsSource.Url(DecentralandUrl.PeerContent)
                     : urlsSource.Url(DecentralandUrl.Content);

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -271,6 +271,8 @@ namespace DCL.AvatarRendering.Emotes.Load
                 if (audioType == AudioType.UNKNOWN)
                     continue;
 
+                // In LSD the realm content URL points at the local preview server, so i.e. audio clips requests cannot succeed,
+                // use the production catalyst instead.
                 string contentBaseUrl = localSceneDevelopment
                     ? urlsSource.Url(DecentralandUrl.PeerContent)
                     : urlsSource.Url(DecentralandUrl.Content);

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -34,6 +34,7 @@ namespace DCL.AvatarRendering.Emotes.Load
         private readonly IEmoteStorage emoteStorage;
         private readonly IDecentralandUrlsSource urlsSource;
         private readonly URLSubdirectory customStreamingSubdirectory;
+        private readonly bool localSceneDevelopment;
         private readonly URLBuilder urlBuilder = new ();
 
         internal LoadEmotesByPointersSystem(
@@ -43,13 +44,15 @@ namespace DCL.AvatarRendering.Emotes.Load
             IEmoteStorage emoteStorage,
             IDecentralandUrlsSource urlsSource,
             URLSubdirectory customStreamingSubdirectory,
-            EntitiesAnalytics entitiesAnalytics
+            EntitiesAnalytics entitiesAnalytics,
+            bool localSceneDevelopment
         )
             : base(world, cache, webRequestController, entitiesAnalytics)
         {
             this.emoteStorage = emoteStorage;
             this.urlsSource = urlsSource;
             this.customStreamingSubdirectory = customStreamingSubdirectory;
+            this.localSceneDevelopment = localSceneDevelopment;
         }
 
         protected override EmotesDTOList CreateAssetFromListOfDTOs(RepoolableList<EmoteDTO> list) =>
@@ -268,8 +271,14 @@ namespace DCL.AvatarRendering.Emotes.Load
                 if (audioType == AudioType.UNKNOWN)
                     continue;
 
+                // In LSD the realm content URL points at the local preview server, which doesn't host catalog
+                // emote audio — fall back to the production catalyst for the active environment.
+                string contentBaseUrl = localSceneDevelopment
+                    ? urlsSource.Url(DecentralandUrl.PeerContent)
+                    : urlsSource.Url(DecentralandUrl.Content);
+
                 urlBuilder.Clear();
-                urlBuilder.AppendDomain(URLDomain.FromString(urlsSource.Url(DecentralandUrl.Content))).AppendPath(new URLPath(item.hash));
+                urlBuilder.AppendDomain(URLDomain.FromString(contentBaseUrl)).AppendPath(new URLPath(item.hash));
                 URLAddress url = urlBuilder.Build();
 
                 // The resolution of the audio promise will be finalized by FinalizeEmoteAssetBundleSystem

--- a/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/DecentralandUrl.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/DecentralandUrl.cs
@@ -148,5 +148,7 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
         Gatekeeper = 89,
 
         WhatsOnEventLink = 90,
+
+        PeerContent = 91,
     }
 }

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -186,6 +186,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.Host => $"https://decentraland.{ENV}",
                 DecentralandUrl.ApiChunks => $"https://api.decentraland.{ENV}/v1/map.png",
                 DecentralandUrl.PeerAbout => $"https://peer.decentraland.{ENV}/about",
+                DecentralandUrl.PeerContent => $"https://peer.decentraland.{ENV}/content/contents",
                 DecentralandUrl.RemotePeers => $"https://archipelago-ea-stats.decentraland.{ENV}/comms/peers",
                 DecentralandUrl.RemotePeersWorld => $"https://worlds-content-server.decentraland.{ENV}/wallet/[USER-ID]/connected-world",
                 DecentralandUrl.DAO => $"https://decentraland.{ENV}/dao/",

--- a/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
@@ -138,7 +138,7 @@ namespace DCL.PluginSystem.Global
 
             LoadEmotesByPointersSystem.InjectToWorld(ref builder, webRequestController,
                 new NoCache<EmotesDTOList, GetEmotesDTOByPointersFromRealmIntention>(false, false),
-                emoteStorage, decentralandUrlsSource, EMOTES_EMBEDDED_SUBDIRECTORY, entitiesAnalytics);
+                emoteStorage, decentralandUrlsSource, EMOTES_EMBEDDED_SUBDIRECTORY, entitiesAnalytics, localSceneDevelopment);
 
             BatchEmotesDTOSystem.InjectToWorld(ref builder, decentralandUrlsSource, batchHeartbeat);
 


### PR DESCRIPTION
# Pull Request Description
Fix #8457 

## What does this PR change?
 1. Catalog emote audio 404. LoadEmotesByPointersSystem.TryCreateAudioClipPromises                                                                                                                                                                                                                                       
     built the audio URL from DecentralandUrl.Content, which in LSD resolves to                                                                                                                                                                                                                                         
     the local preview server. The local server doesn't host catalog emote audio, so every default-loaded                                                                                                                                                                                                                                           
     emote with audio 404'd. Added DecentralandUrl.PeerContent, an env-aware static                                                                                                                                                                                                                                         
     URL pointing at peer.decentraland.{ENV}/content/contents, and the system                                                                                                                                                                                                                                            
     now uses it instead of the realm-dependent URL when localSceneDevelopment is                                                                                                                                                                                                                                         
     true. Production behavior is unchanged.                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                          
  2. InvalidKeyException for shader key "GPUInstancerPro/Standard". GPUI's                                                                                                                                                                                                                                                
     FindShader falls back to Addressables.LoadAssetAsync when Shader.Find                                                                                                                                                                                                                                                
     returns null, which it does in client builds because the shader had no                                                                                                                                                                                                                                               
     build-time references. Registered Standard_GPUIPro.shader in the Landscape                                                                                                                                                                                                                                         
     addressables group at address GPUInstancerPro/Standard (mirroring the                                                                                                                                                                                                                                                
     pattern already used for SpeedTree8_PBRLit_GPUIPro and Rock_GPUIPro).  

## Test Instructions
Before testing verify that you have at least one emote with audio clip equipped in the emotes wheel (i.e. "Funny Proposal")

### Test Steps
1. Deploy a local scene
2. Check out the console log
3. Verify no exception is shown in the console log (check issue #8457 for a screenshot of the exceptions)

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
