### PR TITLE
fix: exit app delay investigation

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -5,6 +5,13 @@ namespace Global.AppArgs
         public const string DEBUG = "debug";
         public const string DCL_EDITOR = "hub";
 
+        // EXIT-DELAY INVESTIGATION (#exit-app-delay): runtime toggles to isolate the
+        // dominant cause of the long freeze/crash when quitting from Genesis Plaza.
+        // Remove once the investigation concludes and a definitive fix is merged.
+        public const string EXIT_TEST_NO_SENTRY_FLUSH = "exit-test-no-sentry-flush";
+        public const string EXIT_TEST_NO_CRASH_UPLOAD = "exit-test-no-crash-upload";
+        public const string EXIT_TEST_SKIP_DISPOSE_QUIT = "exit-test-skip-dispose-quit";
+
         public const string SKIP_VERSION_CHECK = "skip-version-check";
         public const string SIMULATE_VERSION = "simulateVersion";
         public const string FORCE_MINIMUM_SPECS_SCREEN = "forceMinimumSpecsScreen";

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -62,6 +62,7 @@ using System.IO;
 using Plugins.NativeWindowManager;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.CrashReportHandler;
 using UnityEngine.UI;
 using Utility;
 using MinimumSpecsScreenView = DCL.ApplicationMinimumSpecsGuard.MinimumSpecsScreenView;
@@ -163,6 +164,15 @@ namespace Global.Dynamic
                 Environment.GetCommandLineArgs()
 #endif
             );
+
+            // EXIT-DELAY INVESTIGATION (Test B):
+            // When --exit-test-no-crash-upload is passed, stop Unity's CrashReportHandler
+            // from capturing exceptions at runtime so it has nothing to upload to
+            // perf-events.cloud.unity3d.com when the process is quitting. This isolates
+            // whether the Cloud Diagnostics upload pipeline is contributing to the freeze.
+            // Remove once the investigation closes.
+            if (applicationParametersParser.HasFlag(AppArgsFlags.EXIT_TEST_NO_CRASH_UPLOAD))
+                CrashReportHandler.enableCaptureExceptions = false;
 
             FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(FeatureFlagsResultDto.Empty));
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -287,6 +287,17 @@ namespace Global.Dynamic
 
         public void DisposeGlobalWorld()
         {
+            // EXIT-DELAY INVESTIGATION (Test C):
+            // When --exit-test-skip-dispose-quit is passed, skip the synchronous
+            // global-world + scene disposal during process termination. The OS
+            // reclaims memory on quit; avoiding this cascade short-circuits:
+            //  - N synchronous V8 ScriptEngine teardowns (one per loaded scene)
+            //  - IFinalizeWorldSystem NREs (e.g. ParticleSystem.Stop on destroyed instances)
+            //  - re-entrant MVCManager focus calls triggered by synchronous CTS cancellation
+            // Remove once the investigation closes.
+            if (UnityObjectUtils.IsQuitting && appArgs.HasFlag(AppArgsFlags.EXIT_TEST_SKIP_DISPOSE_QUIT))
+                return;
+
             List<ISceneFacade> loadedScenes = allScenes;
 
             if (globalWorld != null)

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
@@ -43,6 +43,14 @@ namespace DCL.Diagnostics.Sentry
             options.Enabled = true;
             options.TracesSampler = sentrySampler.Execute;
 
+            // EXIT-DELAY INVESTIGATION (Test A):
+            // When --exit-test-no-sentry-flush is passed, drop the 2s shutdown flush
+            // to measure how much of the EXIT freeze is due to Sentry draining its
+            // queue at process termination. Flag kept in sync with AppArgsFlags.EXIT_TEST_NO_SENTRY_FLUSH.
+            // Remove once the investigation closes.
+            if (HasExitTestFlag("exit-test-no-sentry-flush"))
+                options.ShutdownTimeout = TimeSpan.Zero;
+
             if (!IsValidConfiguration(options))
             {
 #if !UNITY_EDITOR
@@ -52,6 +60,16 @@ namespace DCL.Diagnostics.Sentry
             }
 
             SentrySdk.Init(options);
+        }
+
+        private static bool HasExitTestFlag(string flag)
+        {
+            string[] args = Environment.GetCommandLineArgs();
+            string dashed = "--" + flag;
+            for (var i = 0; i < args.Length; i++)
+                if (args[i] == dashed)
+                    return true;
+            return false;
         }
 
         public void AddMeetMinimumRequirements(Scope scope, bool meets)

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
@@ -1,6 +1,5 @@
 using DCL.Optimization.Pools;
 using DCL.Optimization.ThreadSafePool;
-using Global.AppArgs;
 using Sentry;
 using Sentry.Extensibility;
 using Sentry.Unity;
@@ -47,8 +46,9 @@ namespace DCL.Diagnostics.Sentry
             // EXIT-DELAY INVESTIGATION (Test A):
             // When --exit-test-no-sentry-flush is passed, drop the 2s shutdown flush
             // to measure how much of the EXIT freeze is due to Sentry draining its
-            // queue at process termination. Remove once the investigation closes.
-            if (HasExitTestFlag(AppArgsFlags.EXIT_TEST_NO_SENTRY_FLUSH))
+            // queue at process termination. Flag kept in sync with AppArgsFlags.EXIT_TEST_NO_SENTRY_FLUSH.
+            // Remove once the investigation closes.
+            if (HasExitTestFlag("exit-test-no-sentry-flush"))
                 options.ShutdownTimeout = TimeSpan.Zero;
 
             if (!IsValidConfiguration(options))

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
@@ -1,5 +1,6 @@
 using DCL.Optimization.Pools;
 using DCL.Optimization.ThreadSafePool;
+using Global.AppArgs;
 using Sentry;
 using Sentry.Extensibility;
 using Sentry.Unity;
@@ -46,9 +47,8 @@ namespace DCL.Diagnostics.Sentry
             // EXIT-DELAY INVESTIGATION (Test A):
             // When --exit-test-no-sentry-flush is passed, drop the 2s shutdown flush
             // to measure how much of the EXIT freeze is due to Sentry draining its
-            // queue at process termination. Flag kept in sync with AppArgsFlags.EXIT_TEST_NO_SENTRY_FLUSH.
-            // Remove once the investigation closes.
-            if (HasExitTestFlag("exit-test-no-sentry-flush"))
+            // queue at process termination. Remove once the investigation closes.
+            if (HasExitTestFlag(AppArgsFlags.EXIT_TEST_NO_SENTRY_FLUSH))
                 options.ShutdownTimeout = TimeSpan.Zero;
 
             if (!IsValidConfiguration(options))


### PR DESCRIPTION
## Summary

Adds three command-line toggles to attribute the long EXIT freeze (sometimes ending in process crash) that reproduces only when quitting from Genesis Plaza in built standalone players. The freeze is not reproducible from the Unity Editor.

This is investigation tooling: one build, five runs, each with a different combination of `--exit-test-*` flags. Once we identify the dominant factor, the toggles and their three `if` blocks are removed and replaced by the definitive fix.

All toggles are gated behind the corresponding flag. A run without flags behaves exactly like `dev` does today.

## Flags added

| Flag | Effect | Hypothesis isolated |
|---|---|---|
| `--exit-test-no-sentry-flush` | Sets `SentryUnityOptions.ShutdownTimeout = 0` before `SentrySdk.Init`, so Sentry does not wait to drain its queued events when the process terminates. | Sentry shutdown flush (2s default × N queued events) blocking quit. |
| `--exit-test-no-crash-upload` | Sets `UnityEngine.CrashReportHandler.enableCaptureExceptions = false` very early in `MainSceneLoader.InitializeFlowAsync`, so Unity does not capture exceptions for upload to `perf-events.cloud.unity3d.com`. | Cloud Diagnostics synchronous upload during quit. |
| `--exit-test-skip-dispose-quit` | Early-returns in `RealmController.DisposeGlobalWorld()` when `UnityObjectUtils.IsQuitting == true`, skipping V8 ScriptEngine disposal and `IFinalizeWorldSystem.FinalizeComponents` iteration. The OS reclaims memory when the process exits. | Synchronous scene cleanup cost (N V8 engines + N finalize systems + NRE cascade). |

## Test plan

Run all five cases against the same build. Reproduction conditions must be identical between cases for the measurements to be comparable:

- Realm: Genesis Plaza via the launcher (no custom `--realm`).
- Spawn point: a busy plaza area with peers.
- Warm-up wait: ~60-90 seconds after load so neighboring scenes and peers are fully resolved.
- Exit gesture: click the profile picture (top-left) -> EXIT.
- Stopwatch: start when EXIT is clicked, stop when the process disappears from Task Manager / Activity Monitor.
- Save `Player.log` after every run with a distinct filename before relaunching, because Unity overwrites it.

### Case 0 - Control (baseline)

```
Decentraland.exe
```

Captures the unmodified behavior. Note total time-to-close and number of `Uploading Crash Report` / `Failed to upload Crash Report to Cloud Diagnostics` lines in `Player.log`.

### Case 1 - Test A only (Sentry shutdown flush disabled)

```
Decentraland.exe --exit-test-no-sentry-flush
```

If the total time drops significantly versus Case 0, Sentry's shutdown drain is the dominant factor.

### Case 2 - Test B only (Cloud Diagnostics capture disabled)

```
Decentraland.exe --exit-test-no-crash-upload
```

If the total time drops significantly versus Case 0, Unity's Cloud Diagnostics upload pipeline is the dominant factor. Note: this disables runtime capture, not the build-time module. If the result is inconclusive, a follow-up build with `m_EnableCloudDiagnosticsReporting: 0` in `UnityConnectSettings.asset` would close the loop.

### Case 3 - Test C only (skip dispose on quit)

```
Decentraland.exe --exit-test-skip-dispose-quit
```

If the total time drops significantly versus Case 0, the synchronous cleanup is the dominant factor (V8 disposal, `IFinalizeWorldSystem` iteration, and the cascade of NREs they emit because Unity destroys backing GameObjects in parallel).

### Case 4 - A + B + C combined

```
Decentraland.exe --exit-test-no-sentry-flush --exit-test-no-crash-upload --exit-test-skip-dispose-quit
```

If the freeze persists with all three flags enabled, there is a fifth factor outside this PR's scope (most likely native V8/ClearScript teardown at process exit, or a scene thread loop still alive when the main thread requests shutdown). Follow-up: capture a Unity profiler trace in a development build.

## What to capture for each case

- Total time from EXIT click to process termination (Windows: Task Manager; macOS: Activity Monitor).
- The `Player.log` after each run, renamed (`Player_case0.log`, `Player_case1.log`, ...).
- Counts of these patterns in each log:
  - `Uploading Crash Report`
  - `Failed to upload Crash Report to Cloud Diagnostics`
  - `NullReferenceException` from `ParticleSystemCleanupSystem.ReleaseParticleSystem`
  - `NullReferenceException` from `MinimapController.QueryPlayerPosition`
  - `NullReferenceException` from `EmojiPanelPresenter.Dispose`
  - `NullReferenceException` from `AuthenticationScreenController.Dispose`

## Notes for reviewers

- Test C is intentionally destructive. It is not a candidate to merge as-is: it skips the entire global-world + scene disposal during quit. It only exists to measure the cost of that path.
- Test B is not 100% equivalent to disabling Cloud Diagnostics at build time, since the native module is still initialized. It is the best runtime-only approximation available.
- Once the investigation closes, all three `if` blocks and the three constants in `AppArgsFlags.cs` are removed in the fix PR. Each block is tagged with the comment `EXIT-DELAY INVESTIGATION` to make the cleanup grep trivial.
