### PR TITLE
chore: upgrade ClearScript to 7.5.1

### DIFF
--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "arch.systemgroups.visualiser": "https://github.com/m3taphysics/Arch.SystemGroups.Visualiser.git?path=/Packages/arch.systemgroups.visualiser",
-    "com.renderheads.avpro.video-ultra": "git@github.com:decentraland/unity-explorer-packages.git?path=/AVProVideo",
     "com.alttester.sdk": "2.3.0",
     "com.arch.systemgroups": "https://github.com/mikhail-dcl/Arch.SystemGroups.git?path=/Arch.SystemGroups",
     "com.atteneder.draco": "4.0.2",
@@ -21,6 +20,7 @@
     "com.mackysoft.serializereference-extensions": "1.3.1",
     "com.nickkhalow.chrome-devtool-protocol-unity": "https://github.com/decentraland/chrome-devtool-protocol-unity.git?path=/Packages",
     "com.nickkhalow.richtypes": "https://github.com/NickKhalow/RichTypesUnity.git?path=/Packages/RichTypes",
+    "com.renderheads.avpro.video-ultra": "git@github.com:decentraland/unity-explorer-packages.git?path=/AVProVideo",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "2.9.1",
     "com.unity.animation.rigging": "1.4.1",
@@ -48,7 +48,7 @@
     "io.livekit.unity": "https://github.com/livekit/client-sdk-unity-web.git",
     "io.sentry.unity": "https://github.com/getsentry/unity.git#4.0.0",
     "net.tnrd.nsubstitute": "https://github.com/decentraland/Unity3D-NSubstitute.git",
-    "org.decentraland.clearscript": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package#v2",
+    "org.decentraland.clearscript": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package#7.5.1.a",
     "superscrollview": "git@github.com:decentraland/unity-explorer-packages.git?path=/SuperScrollView",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.adaptiveperformance": "1.0.0",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -535,13 +535,13 @@
       "hash": "cdd11bb74398afae73e71b6fe01114f597a6ce08"
     },
     "org.decentraland.clearscript": {
-      "version": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package#v2",
+      "version": "https://github.com/decentraland/ClearScript.git?path=/Unity/Package#7.5.1.a",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.nuget.newtonsoft-json": "3.2.1"
       },
-      "hash": "ae0c51ae4a6f2325f9757e9a0253ddbef8713a9b"
+      "hash": "5f385df93c2d1e4a9aed3dd0aad62c247c684a4b"
     },
     "superscrollview": {
       "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/SuperScrollView",


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Upgraded ClearScript to 7.5.1. It should resolve native memory corruption (ephemeron crashes)

## Test Instructions

- Walk through Genesis City scenes where the crashes usually happen
- Try to reproduce them (the rate is really low after mitigations on the JS side)
- Confirm there is no regression on the scenes in comparison with `dev`


## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered

## Code Review Reference

Nothing to review

## After merge

- [ ] Upload new symbols to Sentry
- [ ] Observe crash rate after the release
