### PR TITLE
fix: disable Unity Cloud Diagnostics to prevent exit freeze

### DIFF
--- a/Explorer/ProjectSettings/UnityConnectSettings.asset
+++ b/Explorer/ProjectSettings/UnityConnectSettings.asset
@@ -17,7 +17,7 @@ UnityConnectSettings:
   CrashReportingSettings:
     serializedVersion: 2
     m_EventUrl: https://perf-events.cloud.unity3d.com
-    m_EnableCloudDiagnosticsReporting: 1
+    m_EnableCloudDiagnosticsReporting: 0
     m_LogBufferSize: 10
     m_CaptureEditorExceptions: 0
   UnityPurchasingSettings:


### PR DESCRIPTION
## Summary

Disables Unity Cloud Diagnostics in the project to eliminate the multi-second freeze (and occasional OS-level "Not Responding" termination) that happens when exiting a built player (specially from Genesis Plaza).

## Problem

Closing the app via Profile -> EXIT while in Genesis Plaza hangs the process for ~30 s on Windows (reproducible on Mac too). When the freeze exceeds the OS "Not Responding" timeout the process is killed and reported as a crash. The freeze does not reproduce in the Editor.

## Root cause

Unity's built-in `UnityEngine.CrashReportHandler` synchronously uploads every captured exception to `https://perf-events.cloud.unity3d.com` at process termination. Genesis Plaza's teardown cascade throws 2-3 NREs that are effectively false positives (Unity destroying `ParticleSystem`/`Transform`/etc. in parallel with our `IFinalizeWorldSystem` cleanup, plus a re-entrant `MVCManager.ShowPopupAsync` that fires `Focus()` on the Minimap with a destroyed `CharacterTransform`). Each upload waits the full HTTP timeout (~12 s) on the main thread. 2 uploads ≈ 25 s of freeze on top of the regular dispose cost.

The Editor doesn't reproduce because `m_CaptureEditorExceptions: 0` is already off in the same file, and because stopping play mode never terminates the Editor process.

## Why this specific fix

We currently have **two** crash-capture systems running in parallel against the same `Debug.LogException` / `LogError` signal: Sentry (`SentryReportHandler`) and Unity Cloud Diagnostics. We are not actively reviewing Unity Cloud Diagnostics reports — Sentry is the source of truth. Disabling Cloud Diagnostics removes the synchronous drain at quit entirely while preserving all observability through Sentry.

## Investigation summary

The hypothesis was validated via this draft PR: https://github.com/decentraland/unity-explorer/pull/8731

## Test plan

- [ ] Windows build: enter Genesis Plaza, warm up ~60 s in a busy area with peers, click Profile -> EXIT. Verify the process exits within a few seconds (vs ~30 s before).
- [ ] Mac build: same flow, same expectation.
- [ ] Verify `Player.log` no longer contains `Uploading Crash Report` lines around `Application is quitting`.