### PR TITLE
fix: suppress NullRoomInfo metadata parse errors on startup

### DIFF
--- a/Explorer/Assets/DCL/CurrentSceneRoomMetadata/RoomMetadataCurrentScene.cs
+++ b/Explorer/Assets/DCL/CurrentSceneRoomMetadata/RoomMetadataCurrentScene.cs
@@ -2,6 +2,7 @@
 
 using CodeLess.Attributes;
 using DCL.Diagnostics;
+using DCL.Multiplayer.Connections.Rooms.Nulls;
 using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.LiveKit.Public;
 using ECS;
@@ -76,7 +77,8 @@ namespace DCL.SceneBannedUsers
 
         private void UpdateBannedList(string metadata)
         {
-            if (string.IsNullOrEmpty(metadata)) return;
+            // 'metadata == NullRoomInfo.METADATA_SENTINEL' is intendent to avoid Sentry noise. tradeoff: A bit leaks the internal implementation.
+            if (string.IsNullOrEmpty(metadata) || metadata == NullRoomInfo.METADATA_SENTINEL) return;
 
             Result<SceneRoomMetadata> result = SceneRoomMetadata.FromJson(metadata);
 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullRoomInfo.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullRoomInfo.cs
@@ -6,10 +6,12 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
 {
     public class NullRoomInfo : IRoomInfo
     {
+        public const string METADATA_SENTINEL = "NullRoom: Metadata null";
+
         public LKConnectionState ConnectionState => LKConnectionState.ConnDisconnected;
         public string Sid => "NullRoom: Sid null";
         public string Name => "NullRoom: Name null";
-        public string Metadata => "NullRoom: Metadata null";
+        public string Metadata => METADATA_SENTINEL;
 
         public static readonly NullRoomInfo INSTANCE = new ();
     }


### PR DESCRIPTION
## What does this PR change?

Fixes noisy `[ENGINE]: Failed to parse scene room metadata` error logs that appear on every startup after the recent banned/admin changes.

**Root cause:** During initialization, `BannedUsersPlugin` triggers `RoomMetadataCurrentScene`, which subscribes to room metadata changes. The `NullRoomInfo` (used before any real room connection) returns the sentinel string `"NullRoom: Metadata null"` as its metadata. The existing guard `string.IsNullOrEmpty(metadata)` does not catch this non-empty string, so it falls through to JSON parsing — which fails and logs an error with a full stack trace.

**Fix:**
1. Extracts the hardcoded `"NullRoom: Metadata null"` string in `NullRoomInfo` into a `public const string METADATA_SENTINEL` so it can be referenced elsewhere.
2. Adds a sentinel check in `RoomMetadataCurrentScene.UpdateBannedList()` to early-return when the metadata matches the null-room sentinel, preventing the parse attempt entirely.

**Files changed:**
- `NullRoomInfo.cs` — extract `METADATA_SENTINEL` constant from the inline string
- `RoomMetadataCurrentScene.cs` — add sentinel check alongside the existing `IsNullOrEmpty` guard

## Test Instructions

```bash
metaforge explorer run 8745
```

**Expected result:**
- No `Failed to parse scene room metadata` errors on startup
- Banned user functionality works normally once connected to a real room

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered