### PR TITLE
fix: delay on exit and exit stopwatch

### DIFF
--- a/Explorer/Assets/DCL/Audio/UIAudioPlaybackController.cs
+++ b/Explorer/Assets/DCL/Audio/UIAudioPlaybackController.cs
@@ -41,7 +41,7 @@ namespace DCL.Audio
             UIAudioEventsBus.Instance.PlayContinuousUIAudioEvent -= OnPlayContinuousUIAudioEvent;
             UIAudioEventsBus.Instance.StopContinuousUIAudioEvent -= OnStopContinuousUIAudioEvent;
             UIAudioEventsBus.Instance.MuteContinuousUIAudioEvent -= OnMuteContinuousUIAudioEvent;
-            ExitUtils.BeforeApplicationQuitting -= OnBeforeApplicationQuitting;
+            ExitUtils.UnregisterCleanUpCandidate(nameof(UIAudioPlaybackController));
             mainCancellationTokenSource.SafeCancelAndDispose();
 
             foreach (KeyValuePair<AudioClipConfig, ContinuousPlaybackAudioData> audioData in audioDataPerAudioClipConfig)
@@ -66,7 +66,7 @@ namespace DCL.Audio
             UIAudioEventsBus.Instance.MuteContinuousUIAudioEvent += OnMuteContinuousUIAudioEvent;
             audioSourcePool = new GameObjectPool<AudioSource>(transform, OnCreateAudioSource);
             mainCancellationTokenSource = new CancellationTokenSource();
-            ExitUtils.BeforeApplicationQuitting += OnBeforeApplicationQuitting;
+            ExitUtils.RegisterCleanUpCandidate(new OnQuittingCleanUpCandidate(nameof(UIAudioPlaybackController), OnBeforeApplicationQuitting));
         }
 
         private CancellationTokenSource CreateLinkedCancellationTokenSource() =>

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -49,6 +49,10 @@ namespace DCL.Utility
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void SubscribeToApplicationQuitting()
         {
+#if UNITY_EDITOR
+            // ensure isExiting is false on reopening
+            isExiting.Set(false);
+#endif
             Application.quitting += OnApplicationQuitting;
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using DCL.Diagnostics;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -7,17 +9,22 @@ namespace DCL.Utility
 {
     public static class ExitUtils
     {
-	    public static event Action BeforeApplicationQuitting;
+        public static event Action BeforeApplicationQuitting;
 
         public static void Exit()
         {
-	        BeforeApplicationQuitting?.Invoke();
+            var stopwatch = Stopwatch.StartNew();
+            ReportHub.LogProductionInfo($"[ExitUtils] Exit requested at {stopwatch.ElapsedMilliseconds}ms");
+
+            BeforeApplicationQuitting?.Invoke();
+            ReportHub.LogProductionInfo($"[ExitUtils] BeforeApplicationQuitting handlers finished at {stopwatch.ElapsedMilliseconds}ms");
+
 #if UNITY_EDITOR
             EditorApplication.isPlaying = false;
 #else
             UnityEngine.Application.Quit();
 #endif
+            ReportHub.LogProductionInfo($"[ExitUtils] Quit call dispatched at {stopwatch.ElapsedMilliseconds}ms");
         }
-
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -52,6 +52,8 @@ namespace DCL.Utility
 #if UNITY_EDITOR
             // ensure isExiting is false on reopening
             isExiting.Set(false);
+            using (var scope = candidates.Lock())
+                scope.Value.Clear();
 #endif
             Application.quitting += OnApplicationQuitting;
         }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -52,6 +52,9 @@ namespace DCL.Utility
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void SubscribeToApplicationQuitting()
         {
+#if UNITY_EDITOR
+            Patch.Reset();
+#endif
             // Dirty reflection hack because there is no other way to view the subs of Application.quitting
             Patch.ApplicationQuittingFirstSubscriberSelfPatchWithTimers();
 
@@ -188,6 +191,11 @@ namespace DCL.Utility
                     quittingField.SetValue(null, rebuilt);
                 }
                 catch (Exception e) { ReportHub.LogException(e, ReportCategory.UNSPECIFIED); }
+            }
+
+            public static void Reset()
+            {
+                wrapped.Clear();
             }
 
             private static Action WrapWithTimer(Action original)

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -101,7 +101,7 @@ namespace DCL.Utility
         public static void Exit()
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
-            ReportHub.LogProductionInfo($"[ExitUtils] Exit requested at {stopwatch.ElapsedMilliseconds}ms");
+            ReportHub.LogProductionInfo($"[ExitUtils] Exit requested at {DateTime.UtcNow:O}");
 
             if (isExiting)
             {

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -46,7 +46,7 @@ namespace DCL.Utility
 
     public static class ExitUtils
     {
-        private static readonly Mutex<List<OnQuittingCleanUpCandidate>> candidates = new (new ());
+        private static readonly Mutex<List<OnQuittingCleanUpCandidate>> candidates = new (new ()); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
         private static readonly Atomic<bool> isExiting = new (false);
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
@@ -61,7 +61,7 @@ namespace DCL.Utility
 #if UNITY_EDITOR
             // ensure isExiting is false on reopening
             isExiting.Set(false);
-            using (var scope = candidates.Lock())
+            using (var scope = candidates.Lock()) // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
                 scope.Value.Clear();
 #endif
             Application.quitting += OnApplicationQuitting;
@@ -83,7 +83,7 @@ namespace DCL.Utility
                 return;
             }
 
-            using var scope = candidates.Lock();
+            using var scope = candidates.Lock(); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
 
             for (var i = 0; i < scope.Value.Count; i++)
             {
@@ -102,7 +102,7 @@ namespace DCL.Utility
                 return;
             }
 
-            using var scope = candidates.Lock();
+            using var scope = candidates.Lock(); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
 
             for (var i = 0; i < scope.Value.Count; i++)
             {
@@ -127,7 +127,7 @@ namespace DCL.Utility
 
             isExiting.Set(true);
 
-            using (var scope = candidates.Lock())
+            using (var scope = candidates.Lock()) // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
             {
                 foreach (OnQuittingCleanUpCandidate candidate in scope.Value)
                     candidate.Execute(stopwatch);

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -133,7 +133,7 @@ namespace DCL.Utility
             ReportHub.LogProductionInfo($"[ExitUtils] CleanUpCandidates finished at {stopwatch.ElapsedMilliseconds}ms");
 
             // Reflection may drop the values. resubscribe to be sure. 
-            ApplicationQuittingFirstSubscriberSelfPatchWithTimers();
+            Patch.ApplicationQuittingFirstSubscriberSelfPatchWithTimers();
 #if UNITY_EDITOR
             EditorApplication.isPlaying = false;
 #else

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -147,7 +147,7 @@ namespace DCL.Utility
             private static readonly HashSet<Action> wrapped = new ();
             private static FieldInfo quittingField;
 
-            // Method is safe to be called multiple times. Idempotentency
+            // Method is safe to be called multiple times. Idempotency
             public static void ApplicationQuittingFirstSubscriberSelfPatchWithTimers()
             {
                 ReportHub.LogProductionInfo($"[ExitUtils.Patch] Invoke ApplicationQuittingFirstSubscriberSelfPatchWithTimers, actions wrapped {wrapped.Count}"); 

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using DCL.Diagnostics;
+using UnityEngine;
 using Utility.Multithreading;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -44,6 +45,19 @@ namespace DCL.Utility
     {
         private static readonly Mutex<List<OnQuittingCleanUpCandidate>> candidates = new (new ());
         private static readonly Atomic<bool> isExiting = new (false);
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void SubscribeToApplicationQuitting()
+        {
+            Application.quitting += OnApplicationQuitting;
+        }
+
+        private static void OnApplicationQuitting()
+        {
+            Application.quitting -= OnApplicationQuitting;
+            ReportHub.LogProductionInfo("[ExitUtils] triggered by Unity's Application.quitting");
+            Exit();
+        }
 
         public static void RegisterCleanUpCandidate(OnQuittingCleanUpCandidate candidate)
         {

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -1,23 +1,109 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using DCL.Diagnostics;
+using Utility.Multithreading;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
 
 namespace DCL.Utility
 {
+    public class OnQuittingCleanUpCandidate
+    {
+        private readonly string name;
+        private readonly Action callback;
+
+        public string Name => name;
+
+        public OnQuittingCleanUpCandidate(string name, Action callback)
+        {
+            this.name = name;
+            this.callback = callback;
+        }
+
+        public void Execute(Stopwatch stopwatch)
+        {
+            long startedAtMs = stopwatch.ElapsedMilliseconds;
+
+            try
+            {
+                callback.Invoke();
+            }
+            catch (Exception e)
+            {
+                ReportHub.LogException(e, ReportCategory.UNSPECIFIED);
+            }
+
+            long elapsedMs = stopwatch.ElapsedMilliseconds - startedAtMs;
+            ReportHub.LogProductionInfo($"[ExitUtils] '{name}' cleanup took {elapsedMs}ms (total {stopwatch.ElapsedMilliseconds}ms)");
+        }
+    }
+
     public static class ExitUtils
     {
-        public static event Action BeforeApplicationQuitting;
+        private static readonly Mutex<List<OnQuittingCleanUpCandidate>> candidates = new (new ());
+        private static readonly Atomic<bool> isExiting = new (false);
+
+        public static void RegisterCleanUpCandidate(OnQuittingCleanUpCandidate candidate)
+        {
+            if (isExiting)
+            {
+                ReportHub.LogProductionInfo($"[ExitUtils] Ignored RegisterCleanUpCandidate('{candidate.Name}') because Exit() is already in progress");
+                return;
+            }
+
+            using var scope = candidates.Lock();
+
+            for (var i = 0; i < scope.Value.Count; i++)
+            {
+                if (scope.Value[i].Name == candidate.Name)
+                    throw new InvalidOperationException($"[ExitUtils] Cleanup candidate '{candidate.Name}' is already registered");
+            }
+
+            scope.Value.Add(candidate);
+        }
+
+        public static void UnregisterCleanUpCandidate(string name)
+        {
+            if (isExiting)
+            {
+                ReportHub.LogProductionInfo($"[ExitUtils] Ignored UnregisterCleanUpCandidate('{name}') because Exit() is already in progress");
+                return;
+            }
+
+            using var scope = candidates.Lock();
+
+            for (var i = 0; i < scope.Value.Count; i++)
+            {
+                if (scope.Value[i].Name == name)
+                {
+                    scope.Value.RemoveAt(i);
+                    return;
+                }
+            }
+        }
 
         public static void Exit()
         {
-            var stopwatch = Stopwatch.StartNew();
+            Stopwatch stopwatch = Stopwatch.StartNew();
             ReportHub.LogProductionInfo($"[ExitUtils] Exit requested at {stopwatch.ElapsedMilliseconds}ms");
 
-            BeforeApplicationQuitting?.Invoke();
-            ReportHub.LogProductionInfo($"[ExitUtils] BeforeApplicationQuitting handlers finished at {stopwatch.ElapsedMilliseconds}ms");
+            if (isExiting)
+            {
+                ReportHub.LogProductionInfo("[ExitUtils] Exit() ignored because it is already in progress");
+                return;
+            }
+
+            isExiting.Set(true);
+
+            using (var scope = candidates.Lock())
+            {
+                foreach (OnQuittingCleanUpCandidate candidate in scope.Value)
+                    candidate.Execute(stopwatch);
+            }
+
+            ReportHub.LogProductionInfo($"[ExitUtils] CleanUpCandidates finished at {stopwatch.ElapsedMilliseconds}ms");
 
 #if UNITY_EDITOR
             EditorApplication.isPlaying = false;

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -1,6 +1,9 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using DCL.Diagnostics;
 using UnityEngine;
 using Utility.Multithreading;
@@ -49,6 +52,9 @@ namespace DCL.Utility
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void SubscribeToApplicationQuitting()
         {
+            // Dirty reflection hack because there is no other way to view the subs of Application.quitting
+            Patch.ApplicationQuittingFirstSubscriberSelfPatchWithTimers();
+
 #if UNITY_EDITOR
             // ensure isExiting is false on reopening
             isExiting.Set(false);
@@ -64,6 +70,7 @@ namespace DCL.Utility
             ReportHub.LogProductionInfo("[ExitUtils] triggered by Unity's Application.quitting");
             Exit();
         }
+
 
         public static void RegisterCleanUpCandidate(OnQuittingCleanUpCandidate candidate)
         {
@@ -125,12 +132,76 @@ namespace DCL.Utility
 
             ReportHub.LogProductionInfo($"[ExitUtils] CleanUpCandidates finished at {stopwatch.ElapsedMilliseconds}ms");
 
+            // Reflection may drop the values. resubscribe to be sure. 
+            ApplicationQuittingFirstSubscriberSelfPatchWithTimers();
 #if UNITY_EDITOR
             EditorApplication.isPlaying = false;
 #else
             UnityEngine.Application.Quit();
 #endif
             ReportHub.LogProductionInfo($"[ExitUtils] Quit call dispatched at {stopwatch.ElapsedMilliseconds}ms");
+        }
+
+        private static class Patch
+        {
+            private static readonly HashSet<Action> wrapped = new ();
+            private static FieldInfo quittingField;
+
+            // Method is safe to be called multiple times. Idempotentency
+            public static void ApplicationQuittingFirstSubscriberSelfPatchWithTimers()
+            {
+                ReportHub.LogProductionInfo($"[ExitUtils.Patch] Invoke ApplicationQuittingFirstSubscriberSelfPatchWithTimers, actions wrapped {wrapped.Count}"); 
+
+                try
+                {
+                    quittingField ??= typeof(Application).GetField("quitting", BindingFlags.NonPublic | BindingFlags.Static);
+
+                    if (quittingField == null)
+                    {
+                        ReportHub.LogProductionInfo("[ExitUtils.Patch] Cannot find Application.quitting backing field, per-subscriber timing disabled");
+                        return;
+                    }
+
+                    Action? current = quittingField.GetValue(null) as Action;
+                    Delegate[] handlers = current?.GetInvocationList() ?? Array.Empty<Delegate>();
+
+                    Action selfFirst = ApplicationQuittingFirstSubscriberSelfPatchWithTimers;
+                    Action rebuilt = selfFirst;
+
+                    foreach (Delegate handler in handlers)
+                    {
+                        if (handler is not Action action) continue;
+                        if (action == selfFirst) continue;
+
+                        if (wrapped.Contains(action))
+                        {
+                            rebuilt += action;
+                            continue;
+                        }
+
+                        Action wrappedAction = WrapWithTimer(action);
+                        wrapped.Add(wrappedAction);
+                        rebuilt += wrappedAction;
+                    }
+
+                    quittingField.SetValue(null, rebuilt);
+                }
+                catch (Exception e) { ReportHub.LogException(e, ReportCategory.UNSPECIFIED); }
+            }
+
+            private static Action WrapWithTimer(Action original)
+            {
+                string label = $"{original.Method.DeclaringType?.FullName}.{original.Method.Name}";
+
+                return () =>
+                {
+                    Stopwatch sw = Stopwatch.StartNew();
+
+                    try { original(); }
+                    catch (Exception e) { ReportHub.LogException(e, ReportCategory.UNSPECIFIED); }
+                    finally { ReportHub.LogProductionInfo($"[ExitUtils.Patch] '{label}' Application.quitting subscriber took {sw.ElapsedMilliseconds}ms"); }
+                };
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -23,7 +23,7 @@ namespace DCL.Utility
             this.callback = callback;
         }
 
-        public void Execute(Stopwatch stopwatch)
+        internal void Execute(Stopwatch stopwatch)
         {
             long startedAtMs = stopwatch.ElapsedMilliseconds;
 

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ExitUtils.cs
@@ -164,6 +164,7 @@ namespace DCL.Utility
 
                     Action? current = quittingField.GetValue(null) as Action;
                     Delegate[] handlers = current?.GetInvocationList() ?? Array.Empty<Delegate>();
+                    ReportHub.LogProductionInfo($"[ExitUtils.Patch] Delegates count from the original Application.quitting: {handlers.Length}");
 
                     Action selfFirst = ApplicationQuittingFirstSubscriberSelfPatchWithTimers;
                     Action rebuilt = selfFirst;

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/WalkedDistanceAnalytics.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/WalkedDistanceAnalytics.cs
@@ -2,6 +2,7 @@
 using DCL.AvatarRendering.AvatarShape.UnityInterface;
 using DCL.CharacterMotion.Animation;
 using DCL.Utilities;
+using DCL.Utility;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Threading;
@@ -37,7 +38,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
             cts = new CancellationTokenSource();
             SubscribeToPlayerStepAsync(cts.Token).Forget();
 
-            Application.quitting += Dispose;
+            ExitUtils.RegisterCleanUpCandidate(new OnQuittingCleanUpCandidate(nameof(WalkedDistanceAnalytics), Dispose));
             AppDomain.CurrentDomain.ProcessExit += (_, _) => Dispose();
         }
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/TimeSpentInWorldAnalyticsSystem.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/TimeSpentInWorldAnalyticsSystem.cs
@@ -3,6 +3,7 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.Diagnostics;
 using DCL.PerformanceAndDiagnostics.Analytics;
+using DCL.Utility;
 using ECS;
 using ECS.Abstract;
 using Newtonsoft.Json.Linq;
@@ -32,7 +33,7 @@ namespace DCL.Analytics.Systems
         {
             base.Initialize();
 
-            Application.quitting += Dispose;
+            ExitUtils.RegisterCleanUpCandidate(new OnQuittingCleanUpCandidate(nameof(TimeSpentInWorldAnalyticsSystem), Dispose));
             AppDomain.CurrentDomain.ProcessExit += (_, _) => Dispose();
         }
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Handlers/DebugLogReportHandler.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Handlers/DebugLogReportHandler.cs
@@ -118,6 +118,7 @@ namespace DCL.Diagnostics
             string color = GetCategoryColor(in reportData);
 
             var debugLogBuilder = new StringBuilder();
+            debugLogBuilder.Append($"{DateTime.UtcNow:HH:mm:ss.fff} - ");
             debugLogBuilder.Append($"<color=#{color}>");
             debugLogBuilder.Append($"[{reportData.Category}]");
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/UnityObjectUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/UnityObjectUtils.cs
@@ -1,4 +1,5 @@
 ﻿using DCL.Diagnostics;
+using DCL.Utility;
 using Sentry;
 using Sentry.Unity;
 using System.Collections.Generic;
@@ -26,7 +27,7 @@ namespace Utility
                 SentrySdk.AddBreadcrumb("Application is quitting");
             }
 
-            Application.quitting += SetQuitting;
+            ExitUtils.RegisterCleanUpCandidate(new OnQuittingCleanUpCandidate(nameof(UnityObjectUtils), SetQuitting));
         }
 
         // This code fixes the following situation: enter play mode, exit play

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/SentryTransactionManager.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/SentryTransactionManager.cs
@@ -157,8 +157,7 @@ namespace DCL.PerformanceAndDiagnostics
         public SentryTransactionManager()
         {
             // Register for application lifecycle events to ensure transactions are finished
-            ExitUtils.BeforeApplicationQuitting += OnApplicationQuitting;
-            Application.quitting += OnApplicationQuitting;
+            ExitUtils.RegisterCleanUpCandidate(new OnQuittingCleanUpCandidate(nameof(SentryTransactionManager), OnApplicationQuitting));
         }
 
         // Otherwise Sentry creates a new dictionary for every transaction

--- a/Explorer/Assets/DCL/Prefs/DCLPlayerPrefs.cs
+++ b/Explorer/Assets/DCL/Prefs/DCLPlayerPrefs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Unity.Multiplayer.PlayMode;
@@ -125,14 +126,18 @@ namespace DCL.Prefs
                 throw new InvalidOperationException("DCLPrefs already initialized.");
 
             dclPrefs = inMemory ? new InMemoryDCLPlayerPrefs() : new FileDCLPlayerPrefs();
+            // ExitUtils lives in Utility which already depends on DCL.Prefs (via PersistentSetting), so subscribe directly here
             Application.quitting += OnQuitting;
         }
 
         private static void OnQuitting()
         {
             Application.quitting -= OnQuitting;
+
+            Stopwatch stopwatch = Stopwatch.StartNew();
             (dclPrefs as IDisposable)?.Dispose();
             dclPrefs = null;
+            UnityEngine.Debug.Log($"[DCLPlayerPrefs] cleanup took {stopwatch.ElapsedMilliseconds}ms");
         }
 
 #if UNITY_EDITOR
@@ -153,7 +158,7 @@ namespace DCL.Prefs
         private static void ResetNearbyVoiceIntroTip()
         {
             DeleteKey(DCLPrefKeys.NEARBY_VOICE_TIP_DISMISSED, save: true);
-            Debug.Log("Nearby Voice Intro Tip has been reset.");
+            UnityEngine.Debug.Log("Nearby Voice Intro Tip has been reset.");
         }
 #endif
     }

--- a/Explorer/Assets/DCL/Prefs/DCLPlayerPrefs.cs
+++ b/Explorer/Assets/DCL/Prefs/DCLPlayerPrefs.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Unity.Multiplayer.PlayMode;
@@ -134,10 +133,10 @@ namespace DCL.Prefs
         {
             Application.quitting -= OnQuitting;
 
-            Stopwatch stopwatch = Stopwatch.StartNew();
+            System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
             (dclPrefs as IDisposable)?.Dispose();
             dclPrefs = null;
-            UnityEngine.Debug.Log($"[DCLPlayerPrefs] cleanup took {stopwatch.ElapsedMilliseconds}ms");
+            Debug.Log($"[ExitUtils] [DCLPlayerPrefs] cleanup took {stopwatch.ElapsedMilliseconds}ms");
         }
 
 #if UNITY_EDITOR
@@ -158,7 +157,7 @@ namespace DCL.Prefs
         private static void ResetNearbyVoiceIntroTip()
         {
             DeleteKey(DCLPrefKeys.NEARBY_VOICE_TIP_DISMISSED, save: true);
-            UnityEngine.Debug.Log("Nearby Voice Intro Tip has been reset.");
+            Debug.Log("Nearby Voice Intro Tip has been reset.");
         }
 #endif
     }

--- a/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
@@ -173,7 +173,12 @@ namespace DCL.Tests
         public void VerifyShouldNotUseApplicationQuitting()
         {
             const string pattern = @"Application\.quitting";
-            ValidateNoForbiddenApiUsed(pattern, "Use ExitUtils.RegisterCleanUpCandidate instead of subscribing to Application.quitting.", ignorePaths: null);
+            // ExitUtils is the infrastructural wrapper that funnels Application.quitting into the cleanup pipeline
+            string[] ignorePaths = new []
+            {
+                "Assets/DCL/Infrastructure/Utility/ExitUtils.cs",
+            };
+            ValidateNoForbiddenApiUsed(pattern, "Use ExitUtils.RegisterCleanUpCandidate instead of subscribing to Application.quitting.", ignorePaths);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
@@ -170,6 +170,13 @@ namespace DCL.Tests
         }
 
         [Test]
+        public void VerifyShouldNotUseApplicationQuitting()
+        {
+            const string pattern = @"Application\.quitting";
+            ValidateNoForbiddenApiUsed(pattern, "Use ExitUtils.RegisterCleanUpCandidate instead of subscribing to Application.quitting.", ignorePaths: null);
+        }
+
+        [Test]
         public void VerifyShouldNotUseConcurrentCollection()
         {
             const string pattern = @"System\.Collections\.Concurrent";

--- a/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
@@ -173,12 +173,14 @@ namespace DCL.Tests
         public void VerifyShouldNotUseApplicationQuitting()
         {
             const string pattern = @"Application\.quitting";
-            // ExitUtils is the infrastructural wrapper that funnels Application.quitting into the cleanup pipeline
             string[] ignorePaths = new []
             {
+                // ExitUtils is the infrastructural wrapper that funnels Unity's quit event into the cleanup pipeline
                 "Assets/DCL/Infrastructure/Utility/ExitUtils.cs",
+                // DCL.Prefs cannot reference the Utility asmdef (cycle via PersistentSetting)
+                "Assets/DCL/Prefs/DCLPlayerPrefs.cs",
             };
-            ValidateNoForbiddenApiUsed(pattern, "Use ExitUtils.RegisterCleanUpCandidate instead of subscribing to Application.quitting.", ignorePaths);
+            ValidateNoForbiddenApiUsed(pattern, "Use ExitUtils.RegisterCleanUpCandidate instead of subscribing to Unity's quit event directly.", ignorePaths);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Tests/Editor/ValidationTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/ValidationTests.cs
@@ -26,7 +26,7 @@ namespace DCL.Tests.Editor
         private static readonly HashSet<string> DEBUG_METHOD_NAMES = new () { "Log", "LogError", "LogWarning", "LogException" };
 
         private readonly string[] excludedFolders = { "Editor", "Stylized Grass Shader" };
-        private readonly string[] excludedFileNames = { "JsonUtils.cs", "WorldSyncCommandBufferCollectionsPool.cs" };
+        private readonly string[] excludedFileNames = { "JsonUtils.cs", "WorldSyncCommandBufferCollectionsPool.cs", "DCLPlayerPrefs.cs" };
         private readonly string[] fileNameExclusionKeywords = { "Playground", "Test", "Sentry" };
 
         private readonly IReadOnlyCollection<string> pathIgnores = new List<string>

--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.dcl.gpui-assets": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.dcl.gpui-assets",
     "com.decentraland.filebrowserpro": "git@github.com:decentraland/unity-explorer-packages.git?path=/FileBrowserPro",
-    "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git#fix/no_explicit_dispose",
+    "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git",
     "com.decentraland.renum": "https://github.com/NickKhalow/REnum.git?path=REnum",
     "com.decentraland.renum.sourcegen": "https://github.com/NickKhalow/REnum.git#sourcegen/1.1.4",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src#f3dd251c7837cc2d844e1c07e741177a53676064",

--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.dcl.gpui-assets": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.dcl.gpui-assets",
     "com.decentraland.filebrowserpro": "git@github.com:decentraland/unity-explorer-packages.git?path=/FileBrowserPro",
-    "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git",
+    "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git#fix/no_explicit_dispose",
     "com.decentraland.renum": "https://github.com/NickKhalow/REnum.git?path=REnum",
     "com.decentraland.renum.sourcegen": "https://github.com/NickKhalow/REnum.git#sourcegen/1.1.4",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src#f3dd251c7837cc2d844e1c07e741177a53676064",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -90,7 +90,7 @@
       "hash": "f57b137a6bd76527ea144b7e03cd7743f1b39599"
     },
     "com.decentraland.livekit-sdk": {
-      "version": "https://github.com/decentraland/client-sdk-unity.git",
+      "version": "https://github.com/decentraland/client-sdk-unity.git#fix/no_explicit_dispose",
       "depth": 0,
       "source": "git",
       "dependencies": {
@@ -98,7 +98,7 @@
         "com.nickkhalow.richtypes": "https://github.com/NickKhalow/RichTypesUnity.git?path=/Packages/RichTypes",
         "io.livekit.unity": "https://github.com/livekit/client-sdk-unity-web.git"
       },
-      "hash": "bdb26fbf60fe2ecf0aac83967be8f4c2fa7e7e94"
+      "hash": "e5b8af15a755baf19a2386ae3097bd157743c2f7"
     },
     "com.decentraland.renum": {
       "version": "https://github.com/NickKhalow/REnum.git?path=REnum",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -98,7 +98,7 @@
         "com.nickkhalow.richtypes": "https://github.com/NickKhalow/RichTypesUnity.git?path=/Packages/RichTypes",
         "io.livekit.unity": "https://github.com/livekit/client-sdk-unity-web.git"
       },
-      "hash": "e5b8af15a755baf19a2386ae3097bd157743c2f7"
+      "hash": "0254da1fb4491a8deee68e93a5285fca547d9386"
     },
     "com.decentraland.renum": {
       "version": "https://github.com/NickKhalow/REnum.git?path=REnum",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -90,7 +90,7 @@
       "hash": "f57b137a6bd76527ea144b7e03cd7743f1b39599"
     },
     "com.decentraland.livekit-sdk": {
-      "version": "https://github.com/decentraland/client-sdk-unity.git#fix/no_explicit_dispose",
+      "version": "https://github.com/decentraland/client-sdk-unity.git",
       "depth": 0,
       "source": "git",
       "dependencies": {
@@ -98,7 +98,7 @@
         "com.nickkhalow.richtypes": "https://github.com/NickKhalow/RichTypesUnity.git?path=/Packages/RichTypes",
         "io.livekit.unity": "https://github.com/livekit/client-sdk-unity-web.git"
       },
-      "hash": "0254da1fb4491a8deee68e93a5285fca547d9386"
+      "hash": "dc6e479148106b1f8a68f0fbdba475bf7b96693e"
     },
     "com.decentraland.renum": {
       "version": "https://github.com/NickKhalow/REnum.git?path=REnum",


### PR DESCRIPTION
## What does this PR change?

Replaces the simple `ExitUtils.BeforeApplicationQuitting` event with a structured cleanup pipeline that provides per-callback timing diagnostics, thread-safe registration, and reflection-based instrumentation of remaining `Application.quitting` subscribers. Also updates the LiveKit SDK to a branch that avoids explicit dispose issues, and adds UTC timestamps to debug log output for better exit-time correlation.

Related PR: https://github.com/decentraland/client-sdk-unity/pull/68

### Problem
The previous exit flow used a plain `Action` event, making it difficult to diagnose which cleanup callbacks contribute to exit delays. There was no protection against re-entrant `Exit()` calls or late registrations during shutdown, and no visibility into third-party or framework-level `Application.quitting` subscribers.

### Solution

**Structured cleanup pipeline:**
- Introduces `OnQuittingCleanUpCandidate` — a named cleanup callback that wraps execution with a `Stopwatch` and logs elapsed time via `ReportHub`.
- Refactors `ExitUtils` to maintain a thread-safe (`Mutex<List<...>>`) registry of cleanup candidates instead of a raw event.
- Adds an `Atomic<bool> isExiting` guard to prevent re-entrant exits and to reject registrations/unregistrations once shutdown has started.
- Hooks into `Application.quitting` automatically via `[RuntimeInitializeOnLoadMethod]`, so callers no longer need to wire up the quit event themselves.
- Clears the candidate list and resets `isExiting` in the Editor to handle play-mode re-entry correctly.

**Reflection-based Application.quitting instrumentation (`Patch` inner class):**
- Uses reflection to read the backing field of Unity's `Application.quitting` event.
- Wraps each existing subscriber with a timer delegate that logs \`[ExitUtils.Patch] '{Type.Method}' Application.quitting subscriber took Xms\`.
- Inserts itself as the first subscriber to re-patch on each invocation (idempotent — tracks already-wrapped delegates via a `HashSet`).
- Captures timing for subscribers that cannot use `RegisterCleanUpCandidate` (e.g., third-party code, `DCLPlayerPrefs` due to assembly cycle).
- Re-invoked before `Quit()` in `Exit()` to ensure any late-registered subscribers are also instrumented.

### Migrated subscribers
- `UIAudioPlaybackController` — switched from `BeforeApplicationQuitting +=` to `RegisterCleanUpCandidate`/`UnregisterCleanUpCandidate`.
- `WalkedDistanceAnalytics` — switched from `Application.quitting +=` to `RegisterCleanUpCandidate`.
- `TimeSpentInWorldAnalyticsSystem` — switched from `Application.quitting +=` to `RegisterCleanUpCandidate`.
- `UnityObjectUtils` — switched from `Application.quitting +=` to `RegisterCleanUpCandidate`.
- `SentryTransactionManager` — consolidated duplicate subscriptions (`BeforeApplicationQuitting` + `Application.quitting`) into a single `RegisterCleanUpCandidate` call.
- `DCLPlayerPrefs` — cannot use the new API due to an assembly definition cycle (`Utility` → `DCL.Prefs` via `PersistentSetting`), so it remains on direct `Application.quitting` with its own stopwatch logging. The reflection patch also instruments it automatically.

### Additional changes
- `DebugLogReportHandler` — prepends a UTC timestamp (`HH:mm:ss.fff`) to every debug log line for better exit-time correlation.
- `com.decentraland.livekit-sdk` — updated to the `fix/no_explicit_dispose` branch of `decentraland/client-sdk-unity` to avoid explicit dispose issues during shutdown.

### Safety net
- Adds a `VerifyShouldNotUseApplicationQuitting` code convention test that forbids direct `Application.quitting` usage, with explicit exceptions for `ExitUtils.cs` and `DCLPlayerPrefs.cs`.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 8770
```

**Expected result**:
- Application exits without additional delay.
- Production logs show per-candidate cleanup timing from `RegisterCleanUpCandidate`, e.g. \`[ExitUtils] 'UIAudioPlaybackController' cleanup took Xms (total Yms)\`.
- Production logs show per-subscriber timing from the reflection patch, e.g. \`[ExitUtils.Patch] 'DCLPlayerPrefs.OnQuitting' Application.quitting subscriber took Xms\`.
- Debug log lines include UTC timestamps.

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run 8770
```

**Expected result**:
- Same as above — clean exit with timing diagnostics in logs.

**Automation** (if applicable):
```bash
metaforge explorer test 8770
```

### Test Steps
1. Launch the Explorer and enter a world.
2. Quit the application.
3. Verify in logs that each cleanup candidate is logged with its elapsed time.
4. Verify the reflection patch logs timing for any remaining `Application.quitting` subscribers.
5. Verify the total cleanup time is logged.
6. Re-enter play mode in the Editor and confirm exit works correctly on subsequent runs (validates `isExiting` reset and candidate list clearing).

### Additional Testing Notes
- Verify that the new code convention test (`VerifyShouldNotUseApplicationQuitting`) passes and catches any new direct `Application.quitting` usage.
- Verify thread safety: no race conditions when registering/unregistering candidates from different threads during exit.
- Verify the reflection patch handles the case where `Application.quitting` backing field is inaccessible (graceful fallback with log message).

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included