### PR TITLE
fix: user context menu opens in an incorrect position on screen

### DIFF
--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
@@ -100,7 +100,7 @@ namespace DCL.UI
 
         protected override void OnBeforeViewShow()
         {
-            Canvas.ForceUpdateCanvases();
+            viewInstance!.gameObject.SetActive(true);
             backgroundWorldRect = GetWorldRect(viewRectTransform);
             internalCloseTask = new UniTaskCompletionSource();
             ConfigureContextMenu(viewInstance!.ControlsContainer, inputData.Config, inputData.AnchorPosition, inputData.OverlapRect);

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
@@ -47,7 +47,6 @@ namespace DCL.UI
         private NativeArray<float3> tempPositionCache;
 
         private RectTransform viewRectTransform;
-        private float4 backgroundWorldRect;
         private UniTaskCompletionSource internalCloseTask;
         private bool isNativeArrayInitialized;
 
@@ -100,7 +99,6 @@ namespace DCL.UI
 
         protected override void OnBeforeViewShow()
         {
-            backgroundWorldRect = GetWorldRect(viewInstance!.BackgroundCloseButton.GetComponent<RectTransform>());
             internalCloseTask = new UniTaskCompletionSource();
             ConfigureContextMenu(viewInstance!.ControlsContainer, inputData.Config, inputData.AnchorPosition, inputData.OverlapRect);
         }
@@ -145,7 +143,7 @@ namespace DCL.UI
                 ConfigureContextMenu(deferredConfig.ParentComponent.container, deferredConfig.Config, Vector2.zero, deferredConfig.OverlapRect);
 
                 // Moves the submenu in case it is crossing any of the borders of the screen
-                float4 boundaryRect = deferredConfig.OverlapRect.HasValue ? BurstRectUtils.RectToFloat4(deferredConfig.OverlapRect.Value) : backgroundWorldRect;
+                float4 boundaryRect = deferredConfig.OverlapRect.HasValue ? BurstRectUtils.RectToFloat4(deferredConfig.OverlapRect.Value) : new float4(0, 0, Screen.width, Screen.height);
                 deferredConfig.ParentComponent.container.transform.position = AdjustSubmenuPositionToFitBounds(deferredConfig.ParentComponent.container, boundaryRect);
             }
             catch (OperationCanceledException) { }
@@ -237,7 +235,7 @@ namespace DCL.UI
                     ConfigureContextMenu(queuedDeferredConfig.ParentComponent.container, queuedDeferredConfig.Config, Vector2.zero, queuedDeferredConfig.OverlapRect);
 
                     // Moves the submenu in case it is crossing any of the borders of the screen
-                    float4 boundaryRect = overlapRect.HasValue ? BurstRectUtils.RectToFloat4(overlapRect.Value) : backgroundWorldRect;
+                    float4 boundaryRect = overlapRect.HasValue ? BurstRectUtils.RectToFloat4(overlapRect.Value) : new float4(0, 0, Screen.width, Screen.height);
                     queuedDeferredConfig.ParentComponent.container.transform.position = AdjustSubmenuPositionToFitBounds(queuedDeferredConfig.ParentComponent.container, boundaryRect);
                 }
             }
@@ -338,7 +336,7 @@ namespace DCL.UI
 
             float3 adjustedInitialPosition = tempPos;
 
-            float4 boundaryRect = overlapRect.HasValue ? BurstRectUtils.RectToFloat4(overlapRect.Value) : backgroundWorldRect;
+            float4 boundaryRect = overlapRect.HasValue ? BurstRectUtils.RectToFloat4(overlapRect.Value) : new float4(0, 0, Screen.width, Screen.height);
 
             float menuWidth = container.controlsContainer.rect.width;
             float menuHeight = container.controlsContainer.rect.height;
@@ -525,7 +523,7 @@ namespace DCL.UI
 
             Vector2 anchorPosition = inputData.AnchorPosition;
 
-            float4 boundaryRect = inputData.OverlapRect.HasValue ? BurstRectUtils.RectToFloat4(inputData.OverlapRect.Value) : backgroundWorldRect;
+            float4 boundaryRect = inputData.OverlapRect.HasValue ? BurstRectUtils.RectToFloat4(inputData.OverlapRect.Value) : new float4(0, 0, Screen.width, Screen.height);
 
             var transformedPosition = new float3(
                 viewRectTransform.InverseTransformPoint(anchorPosition).x,
@@ -887,7 +885,7 @@ namespace DCL.UI
         protected override UniTask WaitForCloseIntentAsync(CancellationToken ct)
         {
             UniTask inputCloseTask = inputData.CloseTask ?? UniTask.Never(ct);
-            return UniTask.WhenAny(internalCloseTask.Task, inputCloseTask, viewInstance!.BackgroundCloseButton.Button.OnClickAsync(ct));
+            return UniTask.WhenAny(internalCloseTask.Task, inputCloseTask);
         }
 
         [BurstCompile]

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
@@ -100,6 +100,7 @@ namespace DCL.UI
 
         protected override void OnBeforeViewShow()
         {
+            Canvas.ForceUpdateCanvases();
             backgroundWorldRect = GetWorldRect(viewRectTransform);
             internalCloseTask = new UniTaskCompletionSource();
             ConfigureContextMenu(viewInstance!.ControlsContainer, inputData.Config, inputData.AnchorPosition, inputData.OverlapRect);

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
@@ -95,14 +95,12 @@ namespace DCL.UI
             isNativeArrayInitialized = false;
         }
 
-        protected override void OnViewInstantiated()
-        {
+        protected override void OnViewInstantiated() =>
             viewRectTransform = viewInstance!.GetComponent<RectTransform>();
-            backgroundWorldRect = GetWorldRect(viewInstance!.BackgroundCloseButton.GetComponent<RectTransform>());
-        }
 
         protected override void OnBeforeViewShow()
         {
+            backgroundWorldRect = GetWorldRect(viewInstance!.BackgroundCloseButton.GetComponent<RectTransform>());
             internalCloseTask = new UniTaskCompletionSource();
             ConfigureContextMenu(viewInstance!.ControlsContainer, inputData.Config, inputData.AnchorPosition, inputData.OverlapRect);
         }

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
@@ -47,6 +47,7 @@ namespace DCL.UI
         private NativeArray<float3> tempPositionCache;
 
         private RectTransform viewRectTransform;
+        private float4 backgroundWorldRect;
         private UniTaskCompletionSource internalCloseTask;
         private bool isNativeArrayInitialized;
 
@@ -99,6 +100,7 @@ namespace DCL.UI
 
         protected override void OnBeforeViewShow()
         {
+            backgroundWorldRect = GetWorldRect(viewRectTransform);
             internalCloseTask = new UniTaskCompletionSource();
             ConfigureContextMenu(viewInstance!.ControlsContainer, inputData.Config, inputData.AnchorPosition, inputData.OverlapRect);
         }
@@ -143,7 +145,7 @@ namespace DCL.UI
                 ConfigureContextMenu(deferredConfig.ParentComponent.container, deferredConfig.Config, Vector2.zero, deferredConfig.OverlapRect);
 
                 // Moves the submenu in case it is crossing any of the borders of the screen
-                float4 boundaryRect = deferredConfig.OverlapRect.HasValue ? BurstRectUtils.RectToFloat4(deferredConfig.OverlapRect.Value) : new float4(0, 0, Screen.width, Screen.height);
+                float4 boundaryRect = deferredConfig.OverlapRect.HasValue ? BurstRectUtils.RectToFloat4(deferredConfig.OverlapRect.Value) : backgroundWorldRect;
                 deferredConfig.ParentComponent.container.transform.position = AdjustSubmenuPositionToFitBounds(deferredConfig.ParentComponent.container, boundaryRect);
             }
             catch (OperationCanceledException) { }
@@ -235,7 +237,7 @@ namespace DCL.UI
                     ConfigureContextMenu(queuedDeferredConfig.ParentComponent.container, queuedDeferredConfig.Config, Vector2.zero, queuedDeferredConfig.OverlapRect);
 
                     // Moves the submenu in case it is crossing any of the borders of the screen
-                    float4 boundaryRect = overlapRect.HasValue ? BurstRectUtils.RectToFloat4(overlapRect.Value) : new float4(0, 0, Screen.width, Screen.height);
+                    float4 boundaryRect = overlapRect.HasValue ? BurstRectUtils.RectToFloat4(overlapRect.Value) : backgroundWorldRect;
                     queuedDeferredConfig.ParentComponent.container.transform.position = AdjustSubmenuPositionToFitBounds(queuedDeferredConfig.ParentComponent.container, boundaryRect);
                 }
             }
@@ -336,7 +338,7 @@ namespace DCL.UI
 
             float3 adjustedInitialPosition = tempPos;
 
-            float4 boundaryRect = overlapRect.HasValue ? BurstRectUtils.RectToFloat4(overlapRect.Value) : new float4(0, 0, Screen.width, Screen.height);
+            float4 boundaryRect = overlapRect.HasValue ? BurstRectUtils.RectToFloat4(overlapRect.Value) : backgroundWorldRect;
 
             float menuWidth = container.controlsContainer.rect.width;
             float menuHeight = container.controlsContainer.rect.height;
@@ -523,7 +525,7 @@ namespace DCL.UI
 
             Vector2 anchorPosition = inputData.AnchorPosition;
 
-            float4 boundaryRect = inputData.OverlapRect.HasValue ? BurstRectUtils.RectToFloat4(inputData.OverlapRect.Value) : new float4(0, 0, Screen.width, Screen.height);
+            float4 boundaryRect = inputData.OverlapRect.HasValue ? BurstRectUtils.RectToFloat4(inputData.OverlapRect.Value) : backgroundWorldRect;
 
             var transformedPosition = new float3(
                 viewRectTransform.InverseTransformPoint(anchorPosition).x,

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuView.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuView.cs
@@ -1,16 +1,11 @@
 using DCL.UI.Controls;
 using MVC;
-using System;
 using UnityEngine;
 
 namespace DCL.UI
 {
-    public class GenericContextMenuView : ViewBase, IView, IDisposable
+    public class GenericContextMenuView : ViewBase, IView
     {
         [field: SerializeField] public ControlsContainerView ControlsContainer { get; private set; }
-        [field: SerializeField] public ButtonWithRightClickHandler BackgroundCloseButton { get; private set; }
-
-        public void Dispose() =>
-            BackgroundCloseButton?.Button.onClick.RemoveAllListeners();
     }
 }

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Prefabs/GenericContextMenu.prefab
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Prefabs/GenericContextMenu.prefab
@@ -32,7 +32,6 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 503480967888987234}
   - {fileID: 2901786360230773271}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -59,6 +58,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 0
+  m_UseReflectionProbes: 0
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
@@ -119,141 +119,6 @@ MonoBehaviour:
   <canvas>k__BackingField: {fileID: 6591100080399325240}
   <raycaster>k__BackingField: {fileID: 8522526520946479007}
   <ControlsContainer>k__BackingField: {fileID: 3053066410332558912}
-  <BackgroundCloseButton>k__BackingField: {fileID: 4391696262981364702}
---- !u!1 &8356711805427779659
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 503480967888987234}
-  - component: {fileID: 7636819472055252989}
-  - component: {fileID: 5113297092000709205}
-  - component: {fileID: 3243245791156245727}
-  - component: {fileID: 4391696262981364702}
-  m_Layer: 5
-  m_Name: BackgroundCloseButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &503480967888987234
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8356711805427779659}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 197116971752332369}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &7636819472055252989
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8356711805427779659}
-  m_CullTransparentMesh: 1
---- !u!114 &5113297092000709205
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8356711805427779659}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &3243245791156245727
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8356711805427779659}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 5113297092000709205}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &4391696262981364702
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8356711805427779659}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 412440416f2849bd887c7fdb02e92cb9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <Button>k__BackingField: {fileID: 3243245791156245727}
 --- !u!1001 &6389194604828421119
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# Pull Request Description
Fix #8768 and #8767 

## What does this PR change?
Moved backgroundWorldRect calculation from OnViewInstantiated() to OnBeforeViewShow() in GenericContextMenuController

## Test Instructions
These steps need to be verified in both **windowed** and **fullscreen** mode, and on **different resolutions** as well.

### Test Steps
1. Open the minimap context menu
2. Verify the menu opens in the correct place (directly right of the three-dots button)
3. Close the minimap context menu
4. Open a user's context menu (right-click on their avatar) 
5. Verify the menu opens in the correct position (close to the cursor / avatar and on the left or right depending on how close the avatar is to the screen borders)

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
