### PR TITLE
chore: split queue and build timeouts, reattach on retry

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -394,8 +394,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prebuild
     if: needs.prebuild.outputs.should_build == 'true'
-    # Outer ceiling — must be >= the Execute Unity Cloud build step timeout
-    # (450 min) plus a margin for the surrounding setup/upload/cancel steps.
+    # Safety ceiling around the 450m retry budget + surrounding steps.
     timeout-minutes: 510
     strategy:
       fail-fast: false
@@ -421,9 +420,7 @@ jobs:
       - name: Execute Unity Cloud build
         uses: nick-fields/retry@v3
         with:
-          # Wraps QUEUE_TIMEOUT (240m) + BUILD_TIMEOUT (180m) + 30m buffer so the outer
-          # step timeout only ever fires as a safety net — the Python script enforces
-          # the real per-phase budgets and exits 99 on cleanly-cancelled timeout.
+          # Wraps QUEUE_TIMEOUT (240m) + BUILD_TIMEOUT (180m) + buffer.
           timeout_minutes: 450
           max_attempts: 2
           retry_on_exit_code: 99
@@ -437,11 +434,11 @@ jobs:
           API_KEY: ${{ secrets.UNITY_CLOUD_API_KEY }}
           ORG_ID: ${{ secrets.UNITY_CLOUD_ORG_ID }}
           PROJECT_ID: ${{ secrets.UNITY_CLOUD_PROJECT_ID }}
-          POLL_TIME: 60                # base poll cadence (s) while status is changing
-          QUEUE_POLL_TIME: 120         # throttled poll cadence (s) while queued and unchanged
-          STALE_POLL_THRESHOLD: 600    # status unchanged > this (s) -> throttle
-          QUEUE_TIMEOUT: 14400         # 4h cap for created/queued/sentToBuilder
-          BUILD_TIMEOUT: 10800         # 3h cap for started/restarted (resets at queue->active transition)
+          POLL_TIME: 60
+          QUEUE_POLL_TIME: 120
+          STALE_POLL_THRESHOLD: 600
+          QUEUE_TIMEOUT: 14400
+          BUILD_TIMEOUT: 10800
           TARGET: t_${{ matrix.target }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
           COMMIT_SHA: ${{ needs.prebuild.outputs.commit_sha }}
@@ -744,9 +741,7 @@ jobs:
           path: shader_compilation_report.log
           if-no-files-found: warn
 
-      # Runs on workflow cancel and on step failure (including the outer step timeout
-      # winning the race against the Python timeouts). Best-effort: the script no-ops
-      # if the persisted build is already in a terminal state.
+      # Also runs on failure() so an outer-step timeout doesn't leave a Unity-side build holding a slot.
       - name: Cancel Unity Cloud build
         if: ${{ cancelled() || failure() }}
         env:

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -394,7 +394,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: prebuild
     if: needs.prebuild.outputs.should_build == 'true'
-    timeout-minutes: 360
+    # Outer ceiling — must be >= the Execute Unity Cloud build step timeout
+    # (450 min) plus a margin for the surrounding setup/upload/cancel steps.
+    timeout-minutes: 510
     strategy:
       fail-fast: false
       matrix:
@@ -419,12 +421,15 @@ jobs:
       - name: Execute Unity Cloud build
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 180  # matches your GLOBAL_TIMEOUT = 10800s
+          # Wraps QUEUE_TIMEOUT (240m) + BUILD_TIMEOUT (180m) + 30m buffer so the outer
+          # step timeout only ever fires as a safety net — the Python script enforces
+          # the real per-phase budgets and exits 99 on cleanly-cancelled timeout.
+          timeout_minutes: 450
           max_attempts: 2
           retry_on_exit_code: 99
           retry_wait_seconds: 30
           on_retry_command: |
-            echo "::warning::🔁 Unity Cloud Build retry triggered at $(date '+%Y-%m-%d %H:%M:%S')"
+            echo "::warning::🔁 Unity Cloud Build retry triggered at $(date '+%Y-%m-%d %H:%M:%S'). The next attempt will reattach to the persisted build if it is still in flight."
           command: |
             echo "🔧 Starting Unity Cloud Build attempt at $(date '+%Y-%m-%d %H:%M:%S')"
             python -u scripts/cloudbuild/build.py
@@ -432,8 +437,11 @@ jobs:
           API_KEY: ${{ secrets.UNITY_CLOUD_API_KEY }}
           ORG_ID: ${{ secrets.UNITY_CLOUD_ORG_ID }}
           PROJECT_ID: ${{ secrets.UNITY_CLOUD_PROJECT_ID }}
-          POLL_TIME: 60  # Set the polling time in seconds
-          GLOBAL_TIMEOUT: 10800  # Set the global timeout in seconds (e.g., 3 hours)
+          POLL_TIME: 60                # base poll cadence (s) while status is changing
+          QUEUE_POLL_TIME: 120         # throttled poll cadence (s) while queued and unchanged
+          STALE_POLL_THRESHOLD: 600    # status unchanged > this (s) -> throttle
+          QUEUE_TIMEOUT: 14400         # 4h cap for created/queued/sentToBuilder
+          BUILD_TIMEOUT: 10800         # 3h cap for started/restarted (resets at queue->active transition)
           TARGET: t_${{ matrix.target }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
           COMMIT_SHA: ${{ needs.prebuild.outputs.commit_sha }}
@@ -736,12 +744,14 @@ jobs:
           path: shader_compilation_report.log
           if-no-files-found: warn
 
-      # Will run on cancel or timeout only
+      # Runs on workflow cancel and on step failure (including the outer step timeout
+      # winning the race against the Python timeouts). Best-effort: the script no-ops
+      # if the persisted build is already in a terminal state.
       - name: Cancel Unity Cloud build
-        if: ${{ cancelled() }}
+        if: ${{ cancelled() || failure() }}
         env:
           API_KEY: ${{ secrets.UNITY_CLOUD_API_KEY }}
           ORG_ID: ${{ secrets.UNITY_CLOUD_ORG_ID }}
           PROJECT_ID: ${{ secrets.UNITY_CLOUD_PROJECT_ID }}
-        run: python -u scripts/cloudbuild/build.py --cancel
+        run: python -u scripts/cloudbuild/build.py --cancel || true
 # Test change

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -8,10 +8,14 @@ import zipfile
 import requests
 import datetime
 import argparse
+import collections
 from urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 # Local
 import utils
+
+# Exit code that nick-fields/retry watches for in-step retries
+RETRYABLE_EXIT_CODE = 99
 
 from zipfile import ZipFile, ZipInfo
 
@@ -33,8 +37,22 @@ is_release_workflow = os.getenv('IS_RELEASE_BUILD', 'false').lower() == 'true'
 
 URL = utils.create_base_url(os.getenv('ORG_ID'), os.getenv('PROJECT_ID'))
 HEADERS = utils.create_headers(os.getenv('API_KEY'))
-POLL_TIME = int(os.getenv('POLL_TIME', '60')) # Seconds
-GLOBAL_TIMEOUT = int(os.getenv('GLOBAL_TIMEOUT', '10800')) # Seconds
+
+# Cadence (seconds)
+POLL_TIME = int(os.getenv('POLL_TIME', '60'))                   # base poll cadence
+QUEUE_POLL_TIME = int(os.getenv('QUEUE_POLL_TIME', '120'))      # throttled cadence while queued and unchanged
+STALE_THRESHOLD = int(os.getenv('STALE_POLL_THRESHOLD', '600')) # status unchanged > this -> throttle polling
+
+# Per-phase budgets (seconds). Queue time and active build time are accounted separately
+# so a long Unity Cloud queue does not eat into the actual build window.
+QUEUE_TIMEOUT = int(os.getenv('QUEUE_TIMEOUT', '14400'))        # default 4h in created/queued/sentToBuilder
+BUILD_TIMEOUT = int(os.getenv('BUILD_TIMEOUT', '10800'))        # default 3h once status is started/restarted
+
+# Unity Cloud Build statuses
+# https://docs.unity.com/cloud-build/api.html (buildStatus enum)
+QUEUE_STATUSES = {'created', 'queued', 'sentToBuilder'}
+ACTIVE_STATUSES = {'started', 'restarted'}
+TERMINAL_STATUSES = {'success', 'failure', 'canceled', 'unknown'}
 
 build_healthy = True
 
@@ -267,6 +285,17 @@ def run_build(branch, clean):
     sys.exit(1)
     
 def cancel_build(id):
+    # Best-effort, idempotent: don't fail the cancel path if Unity says the build is already done.
+    try:
+        check = requests.get(f'{URL}/buildtargets/{os.getenv("TARGET")}/builds/{id}', headers=HEADERS, timeout=30)
+        if check.status_code == 200:
+            current_status = check.json().get('buildStatus')
+            if current_status in TERMINAL_STATUSES:
+                print(f'Build {id} already in terminal state ({current_status}). Skipping cancel.')
+                return
+    except requests.exceptions.RequestException as e:
+        print(f'Pre-cancel status check failed ({e}); attempting cancel anyway.')
+
     response = requests.delete(f'{URL}/buildtargets/{os.getenv('TARGET')}/builds/{id}', headers=HEADERS)
 
     if response.status_code == 204:
@@ -274,7 +303,7 @@ def cancel_build(id):
     else:
         print("Build failed to cancel with status code:", response.status_code)
         print("Response body:", response.text)
-        sys.exit(1)
+        # Best-effort; do not abort the cancel step
 
 def poll_build(id):
     if id == -1:
@@ -309,19 +338,17 @@ def poll_build(id):
     status = response_json['buildStatus']
     match status:
         case 'created' | 'queued' | 'sentToBuilder' | 'started' | 'restarted':
-            print(f'Build status: {status}')
-            return True
+            return True, status, response_json
         case 'success':
-            print(f'Build finished successfully! | Elapsed (Unity) time: {datetime.timedelta(seconds=(response_json['totalTimeInSeconds']))}')
-            return False
+            print(f'Build finished successfully! | Elapsed (Unity) time: {datetime.timedelta(seconds=(response_json["totalTimeInSeconds"]))}')
+            return False, status, response_json
         case 'failure' | 'canceled' | 'unknown':
             print(f'Build error! Last known status: "{status}"')
             build_healthy = False
-            return False
+            return False, status, response_json
         case _:
             print(f'Build status is not known!: "{status}"')
             sys.exit(1)
-            return False
             
 def download_artifact(id):
     session = requests.Session()
@@ -487,13 +514,179 @@ def delete_current_target():
     
     sys.exit(0)
 
+def try_resume_build():
+    """If build_info.json points to a still-trackable build, return (target, id, status).
+
+    The persisted record survives across nick-fields/retry attempts within a single
+    GitHub Actions step. Reattaching avoids creating a new Unity Cloud build that
+    would go to the back of the queue — which is exactly the wrong thing under
+    concurrency pressure.
+    """
+    info = utils.read_build_info()
+    if info is None:
+        return None
+
+    persisted_target = info.get('target')
+    persisted_id = info.get('id')
+    if not persisted_target or persisted_id is None:
+        utils.delete_build_info()
+        return None
+
+    try:
+        resp = requests.get(
+            f'{URL}/buildtargets/{persisted_target}/builds/{persisted_id}',
+            headers=HEADERS,
+            timeout=30,
+        )
+    except requests.exceptions.RequestException as e:
+        print(f'Resume probe failed ({e}). Discarding build_info.')
+        utils.delete_build_info()
+        return None
+
+    if resp.status_code != 200:
+        print(f'Resume probe returned status {resp.status_code}. Discarding build_info.')
+        utils.delete_build_info()
+        return None
+
+    current_status = resp.json().get('buildStatus')
+    if current_status in QUEUE_STATUSES or current_status in ACTIVE_STATUSES:
+        print(f'Resuming persisted build: target={persisted_target}, id={persisted_id}, status={current_status}')
+        return persisted_target, persisted_id, current_status
+
+    print(f'Persisted build status={current_status} - not resumable. Discarding build_info.')
+    utils.delete_build_info()
+    return None
+
+
+def write_step_summary(target, build_id, final_status, phase_durations, queue_reasons, queue_elapsed, build_elapsed):
+    """Append a phase breakdown to $GITHUB_STEP_SUMMARY (best-effort)."""
+    summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
+    if not summary_path:
+        return
+
+    def fmt(seconds):
+        if not seconds:
+            return '—'
+        return str(datetime.timedelta(seconds=int(seconds)))
+
+    queue_total = sum(phase_durations.get(s, 0) for s in QUEUE_STATUSES)
+    build_total = sum(phase_durations.get(s, 0) for s in ACTIVE_STATUSES)
+
+    lines = []
+    lines.append('### Unity Cloud Build phase breakdown')
+    lines.append('')
+    lines.append(f'- Target: `{target}`')
+    lines.append(f'- Build ID: `{build_id}`')
+    lines.append(f'- Final outcome: `{final_status}`')
+    if queue_reasons:
+        lines.append(f"- Queue reasons seen: {', '.join(f'`{r}`' for r in sorted(queue_reasons))}")
+    lines.append('')
+    lines.append('| Phase | Duration | Budget |')
+    lines.append('|---|---:|---:|')
+    lines.append(f"| created | {fmt(phase_durations.get('created', 0))} | — |")
+    lines.append(f"| queued | {fmt(phase_durations.get('queued', 0))} | — |")
+    lines.append(f"| sentToBuilder | {fmt(phase_durations.get('sentToBuilder', 0))} | — |")
+    lines.append(f"| **queue subtotal** | **{fmt(queue_total or queue_elapsed)}** | {fmt(QUEUE_TIMEOUT)} |")
+    lines.append(f"| started | {fmt(phase_durations.get('started', 0))} | — |")
+    lines.append(f"| restarted | {fmt(phase_durations.get('restarted', 0))} | — |")
+    lines.append(f"| **build subtotal** | **{fmt(build_total or build_elapsed)}** | {fmt(BUILD_TIMEOUT)} |")
+    lines.append('')
+
+    try:
+        with open(summary_path, 'a') as f:
+            f.write('\n'.join(lines) + '\n')
+    except OSError as e:
+        print(f'Warning: could not write step summary: {e}')
+
+
+def run_poll_loop(id, build_already_active=False):
+    """Polls the build, enforcing queue and build budgets separately.
+
+    Returns (final_outcome: str, phase_durations: dict, queue_reasons: set,
+             queue_elapsed: float, build_elapsed: float).
+    """
+    phase_durations = collections.defaultdict(float)
+    queue_reasons = set()
+
+    now = time.time()
+    queue_start = now
+    build_start = now if build_already_active else None
+    last_status = None
+    last_status_change = now
+    last_poll = now
+
+    while True:
+        now = time.time()
+
+        # Attribute the elapsed slice since the last poll to whichever status we last saw.
+        if last_status is not None:
+            phase_durations[last_status] += now - last_poll
+        last_poll = now
+
+        # Enforce phase budgets before polling so a stuck phase cannot loiter past its cap.
+        if build_start is None:
+            queue_elapsed = now - queue_start
+            if queue_elapsed > QUEUE_TIMEOUT:
+                print(f'Queue timeout exceeded ({datetime.timedelta(seconds=int(queue_elapsed))} > {datetime.timedelta(seconds=QUEUE_TIMEOUT)}). Cancelling build...')
+                cancel_build(id)
+                return 'queue_timeout', phase_durations, queue_reasons, queue_elapsed, 0.0
+        else:
+            build_elapsed = now - build_start
+            if build_elapsed > BUILD_TIMEOUT:
+                print(f'Build timeout exceeded ({datetime.timedelta(seconds=int(build_elapsed))} > {datetime.timedelta(seconds=BUILD_TIMEOUT)}). Cancelling build...')
+                cancel_build(id)
+                queue_elapsed = build_start - queue_start
+                return 'build_timeout', phase_durations, queue_reasons, queue_elapsed, build_elapsed
+
+        keep_polling, status, response_json = poll_build(id)
+
+        queued_reason = response_json.get('queuedReason')
+        if queued_reason and status in QUEUE_STATUSES:
+            queue_reasons.add(queued_reason)
+
+        # Detect queue -> active transition once.
+        if build_start is None and status in ACTIVE_STATUSES:
+            build_start = now
+            queue_total_seen = now - queue_start
+            print(f'Build picked up by builder after {datetime.timedelta(seconds=int(queue_total_seen))} in queue.')
+
+        if status != last_status:
+            queue_elapsed = (build_start or now) - queue_start
+            build_elapsed = (now - build_start) if build_start else 0
+            reason_suffix = f', queuedReason={queued_reason}' if queued_reason and status in QUEUE_STATUSES else ''
+            print(f'Build status: {status} (queue {datetime.timedelta(seconds=int(queue_elapsed))} / build {datetime.timedelta(seconds=int(build_elapsed))}){reason_suffix}')
+            last_status = status
+            last_status_change = now
+        else:
+            print(f'Build status: {status}')
+
+        if not keep_polling:
+            queue_elapsed = (build_start or now) - queue_start
+            build_elapsed = (now - build_start) if build_start else 0
+            return status, phase_durations, queue_reasons, queue_elapsed, build_elapsed
+
+        # Adaptive polling: throttle while sitting in queue with no status change.
+        if status in QUEUE_STATUSES and (now - last_status_change) > STALE_THRESHOLD:
+            poll_interval = QUEUE_POLL_TIME
+        else:
+            poll_interval = POLL_TIME
+
+        queue_elapsed = (build_start or now) - queue_start
+        build_elapsed = (now - build_start) if build_start else 0
+        print(f'Runner elapsed: queue {datetime.timedelta(seconds=int(queue_elapsed))} / build {datetime.timedelta(seconds=int(build_elapsed))} | Polling again in {poll_interval}s [...]')
+        time.sleep(poll_interval)
+
+
 # Entrypoint here ->
 args = parser.parse_args()
+
+# Tracks whether we attached to an existing in-flight build rather than creating a fresh one.
+build_already_active = False
 
 # MODE: Delete
 if args.delete:
     delete_current_target()
-# MODE: Resume
+# MODE: Resume / Cancel — operate on the persisted in-flight build
 elif args.resume or args.cancel:
     build_info = utils.read_build_info()
     if build_info is None:
@@ -502,7 +695,6 @@ elif args.resume or args.cancel:
     os.environ['TARGET'] = build_info["target"]
     id = build_info["id"]
 
-# MODE: Cancel
     if args.cancel:
         cancel_build(id)
 
@@ -513,52 +705,53 @@ else:
     branch_name = os.getenv('BRANCH_NAME')
     validate_branch_name(branch_name)
 
-    # Clone current target
-    # This will clone the current $TARGET and replace the value in $TARGET with it
-    # Also sets the branch to $BRANCH_NAME
-    #
-    # If the target already exists, it will check if it has running builds on it
-    try:
-        clone_current_target(True)
-    except Exception as e:
-        print(f"Operation failed: {e}")
-
-    # Set ENVs (Parameters)
-    # This must run immediately before starting a build
-    # to avoid any race conditions with other concurrent builds*
-    #
-    # *Above warning mostly applies to shared targets, not clones
-    set_parameters(get_param_env_variables())
-
-    def get_clean_build_bool():
-        value = os.getenv('CLEAN_BUILD', 'false').lower() 
-        if value in ['true', '1']:
-            return True
-        elif value in ['false', '0']:
-            return False
-        else:
-            raise ValueError(f"Invalid boolean value for CLEAN_BUILD: {value}")
-    # Run Build
-    id = run_build(os.getenv('BRANCH_NAME'), get_clean_build_bool())
-
-    utils.persist_build_info(os.getenv('TARGET'), id)
-    print(f'For more info and live logs, go to https://cloud.unity.com/ and search for target "{os.getenv('TARGET')}" and build ID "{id}"')
-
-# Poll the build stats every {POLL_TIME}s
-start_time = time.time()
-while True:
-    elapsed_time = time.time() - start_time
-    if elapsed_time > GLOBAL_TIMEOUT:
-        print(f'Global timeout reached: {datetime.timedelta(seconds=elapsed_time)}. Cancelling build...')
-        cancel_build(id)
-        sys.exit(1)
-
-    if poll_build(id):
-        print(f'Runner elapsed time: {datetime.timedelta(seconds=elapsed_time)} | Polling again in {POLL_TIME}s [...]')
-        time.sleep(POLL_TIME)
+    # Auto-resume: if a previous attempt in this step left an in-flight build behind
+    # (typical when nick-fields/retry fires after a queue timeout), reattach to it
+    # instead of POSTing a fresh build that would go to the back of the Unity Cloud queue.
+    resumed = try_resume_build()
+    if resumed is not None:
+        target_name, id, resumed_status = resumed
+        os.environ['TARGET'] = target_name
+        build_already_active = resumed_status in ACTIVE_STATUSES
     else:
-        print(f'Runner FINAL elapsed time: {datetime.timedelta(seconds=elapsed_time)}')
-        break
+        # Clone current target — clones $TARGET, retargets to $BRANCH_NAME, replaces $TARGET.
+        try:
+            clone_current_target(True)
+        except Exception as e:
+            print(f"Operation failed: {e}")
+
+        # Set ENVs (Parameters) immediately before starting the build to avoid race
+        # conditions with other concurrent builds on shared targets.
+        set_parameters(get_param_env_variables())
+
+        def get_clean_build_bool():
+            value = os.getenv('CLEAN_BUILD', 'false').lower()
+            if value in ['true', '1']:
+                return True
+            elif value in ['false', '0']:
+                return False
+            else:
+                raise ValueError(f"Invalid boolean value for CLEAN_BUILD: {value}")
+
+        id = run_build(os.getenv('BRANCH_NAME'), get_clean_build_bool())
+        utils.persist_build_info(os.getenv('TARGET'), id)
+        print(f'For more info and live logs, go to https://cloud.unity.com/ and search for target "{os.getenv('TARGET')}" and build ID "{id}"')
+
+# Poll with separate queue and build budgets
+final_outcome, phase_durations, queue_reasons, queue_elapsed, build_elapsed = run_poll_loop(id, build_already_active=build_already_active)
+write_step_summary(os.getenv('TARGET'), id, final_outcome, phase_durations, queue_reasons, queue_elapsed, build_elapsed)
+
+if final_outcome in ('queue_timeout', 'build_timeout'):
+    # Best-effort: capture whatever Unity has produced so the upload-log step has something to show.
+    try:
+        download_log(id)
+    except Exception as e:
+        print(f'Warning: could not download log after timeout: {e}')
+    # Exit with the retryable code so nick-fields/retry picks us up. The persisted build_info
+    # lets the next attempt reattach via try_resume_build instead of re-queuing.
+    sys.exit(RETRYABLE_EXIT_CODE)
+
+print(f'Runner FINAL elapsed: queue {datetime.timedelta(seconds=int(queue_elapsed))} / build {datetime.timedelta(seconds=int(build_elapsed))}')
 
 # Handle build artifact
 download_artifact(id)

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -14,8 +14,7 @@ from requests.adapters import HTTPAdapter
 # Local
 import utils
 
-# Exit code that nick-fields/retry watches for in-step retries
-RETRYABLE_EXIT_CODE = 99
+RETRYABLE_EXIT_CODE = 99  # nick-fields/retry only retries on this code
 
 from zipfile import ZipFile, ZipInfo
 
@@ -38,18 +37,16 @@ is_release_workflow = os.getenv('IS_RELEASE_BUILD', 'false').lower() == 'true'
 URL = utils.create_base_url(os.getenv('ORG_ID'), os.getenv('PROJECT_ID'))
 HEADERS = utils.create_headers(os.getenv('API_KEY'))
 
-# Cadence (seconds)
-POLL_TIME = int(os.getenv('POLL_TIME', '60'))                   # base poll cadence
-QUEUE_POLL_TIME = int(os.getenv('QUEUE_POLL_TIME', '120'))      # throttled cadence while queued and unchanged
-STALE_THRESHOLD = int(os.getenv('STALE_POLL_THRESHOLD', '600')) # status unchanged > this -> throttle polling
+POLL_TIME = int(os.getenv('POLL_TIME', '60'))
+QUEUE_POLL_TIME = int(os.getenv('QUEUE_POLL_TIME', '120'))
+STALE_THRESHOLD = int(os.getenv('STALE_POLL_THRESHOLD', '600'))
 
-# Per-phase budgets (seconds). Queue time and active build time are accounted separately
-# so a long Unity Cloud queue does not eat into the actual build window.
-QUEUE_TIMEOUT = int(os.getenv('QUEUE_TIMEOUT', '14400'))        # default 4h in created/queued/sentToBuilder
-BUILD_TIMEOUT = int(os.getenv('BUILD_TIMEOUT', '10800'))        # default 3h once status is started/restarted
+# Queue time and active build time use separate budgets so a long Unity Cloud
+# queue does not eat into the actual build window.
+QUEUE_TIMEOUT = int(os.getenv('QUEUE_TIMEOUT', '14400'))
+BUILD_TIMEOUT = int(os.getenv('BUILD_TIMEOUT', '10800'))
 
-# Unity Cloud Build statuses
-# https://docs.unity.com/cloud-build/api.html (buildStatus enum)
+# Unity Cloud Build buildStatus enum: https://docs.unity.com/cloud-build/api.html
 QUEUE_STATUSES = {'created', 'queued', 'sentToBuilder'}
 ACTIVE_STATUSES = {'started', 'restarted'}
 TERMINAL_STATUSES = {'success', 'failure', 'canceled', 'unknown'}
@@ -285,7 +282,7 @@ def run_build(branch, clean):
     sys.exit(1)
     
 def cancel_build(id):
-    # Best-effort, idempotent: don't fail the cancel path if Unity says the build is already done.
+    # Idempotent: Unity 4xx's a DELETE on a terminal build, so skip in that case.
     try:
         check = requests.get(f'{URL}/buildtargets/{os.getenv("TARGET")}/builds/{id}', headers=HEADERS, timeout=30)
         if check.status_code == 200:
@@ -303,7 +300,6 @@ def cancel_build(id):
     else:
         print("Build failed to cancel with status code:", response.status_code)
         print("Response body:", response.text)
-        # Best-effort; do not abort the cancel step
 
 def poll_build(id):
     if id == -1:
@@ -515,12 +511,10 @@ def delete_current_target():
     sys.exit(0)
 
 def try_resume_build():
-    """If build_info.json points to a still-trackable build, return (target, id, status).
+    """Reattach to an in-flight build from build_info.json so the next retry attempt
+    keeps the same Unity Cloud queue position instead of POSTing a fresh build.
 
-    The persisted record survives across nick-fields/retry attempts within a single
-    GitHub Actions step. Reattaching avoids creating a new Unity Cloud build that
-    would go to the back of the queue — which is exactly the wrong thing under
-    concurrency pressure.
+    Returns (target, id, status, elapsed_seconds) or None.
     """
     info = utils.read_build_info()
     if info is None:
@@ -548,10 +542,12 @@ def try_resume_build():
         utils.delete_build_info()
         return None
 
-    current_status = resp.json().get('buildStatus')
+    body = resp.json()
+    current_status = body.get('buildStatus')
     if current_status in QUEUE_STATUSES or current_status in ACTIVE_STATUSES:
-        print(f'Resuming persisted build: target={persisted_target}, id={persisted_id}, status={current_status}')
-        return persisted_target, persisted_id, current_status
+        elapsed = int(body.get('totalTimeInSeconds') or 0)
+        print(f'Resuming persisted build: target={persisted_target}, id={persisted_id}, status={current_status}, elapsed={datetime.timedelta(seconds=elapsed)}')
+        return persisted_target, persisted_id, current_status, elapsed
 
     print(f'Persisted build status={current_status} - not resumable. Discarding build_info.')
     utils.delete_build_info()
@@ -599,18 +595,22 @@ def write_step_summary(target, build_id, final_status, phase_durations, queue_re
         print(f'Warning: could not write step summary: {e}')
 
 
-def run_poll_loop(id, build_already_active=False):
+def run_poll_loop(id, build_already_active=False, resumed_build_elapsed=0):
     """Polls the build, enforcing queue and build budgets separately.
 
-    Returns (final_outcome: str, phase_durations: dict, queue_reasons: set,
-             queue_elapsed: float, build_elapsed: float).
+    On QUEUE_TIMEOUT the runner yields without cancelling so the next retry
+    attempt can reattach via try_resume_build and keep the queue position.
+    BUILD_TIMEOUT still cancels — a runaway active build should not keep
+    holding a Unity Cloud slot.
+
+    Returns (final_outcome, phase_durations, queue_reasons, queue_elapsed, build_elapsed).
     """
     phase_durations = collections.defaultdict(float)
     queue_reasons = set()
 
     now = time.time()
     queue_start = now
-    build_start = now if build_already_active else None
+    build_start = (now - resumed_build_elapsed) if build_already_active else None
     last_status = None
     last_status_change = now
     last_poll = now
@@ -618,17 +618,18 @@ def run_poll_loop(id, build_already_active=False):
     while True:
         now = time.time()
 
-        # Attribute the elapsed slice since the last poll to whichever status we last saw.
         if last_status is not None:
             phase_durations[last_status] += now - last_poll
         last_poll = now
 
-        # Enforce phase budgets before polling so a stuck phase cannot loiter past its cap.
         if build_start is None:
             queue_elapsed = now - queue_start
             if queue_elapsed > QUEUE_TIMEOUT:
-                print(f'Queue timeout exceeded ({datetime.timedelta(seconds=int(queue_elapsed))} > {datetime.timedelta(seconds=QUEUE_TIMEOUT)}). Cancelling build...')
-                cancel_build(id)
+                print(
+                    f'Queue timeout exceeded ({datetime.timedelta(seconds=int(queue_elapsed))} '
+                    f'> {datetime.timedelta(seconds=QUEUE_TIMEOUT)}). '
+                    f'Yielding runner; build stays queued for the next attempt to reattach.'
+                )
                 return 'queue_timeout', phase_durations, queue_reasons, queue_elapsed, 0.0
         else:
             build_elapsed = now - build_start
@@ -644,11 +645,9 @@ def run_poll_loop(id, build_already_active=False):
         if queued_reason and status in QUEUE_STATUSES:
             queue_reasons.add(queued_reason)
 
-        # Detect queue -> active transition once.
         if build_start is None and status in ACTIVE_STATUSES:
             build_start = now
-            queue_total_seen = now - queue_start
-            print(f'Build picked up by builder after {datetime.timedelta(seconds=int(queue_total_seen))} in queue.')
+            print(f'Build picked up by builder after {datetime.timedelta(seconds=int(now - queue_start))} in queue.')
 
         if status != last_status:
             queue_elapsed = (build_start or now) - queue_start
@@ -665,7 +664,6 @@ def run_poll_loop(id, build_already_active=False):
             build_elapsed = (now - build_start) if build_start else 0
             return status, phase_durations, queue_reasons, queue_elapsed, build_elapsed
 
-        # Adaptive polling: throttle while sitting in queue with no status change.
         if status in QUEUE_STATUSES and (now - last_status_change) > STALE_THRESHOLD:
             poll_interval = QUEUE_POLL_TIME
         else:
@@ -677,16 +675,13 @@ def run_poll_loop(id, build_already_active=False):
         time.sleep(poll_interval)
 
 
-# Entrypoint here ->
 args = parser.parse_args()
 
-# Tracks whether we attached to an existing in-flight build rather than creating a fresh one.
 build_already_active = False
+resumed_build_elapsed = 0
 
-# MODE: Delete
 if args.delete:
     delete_current_target()
-# MODE: Resume / Cancel — operate on the persisted in-flight build
 elif args.resume or args.cancel:
     build_info = utils.read_build_info()
     if build_info is None:
@@ -697,31 +692,27 @@ elif args.resume or args.cancel:
 
     if args.cancel:
         cancel_build(id)
+        sys.exit(0)
 
-# MODE: Create (default)
 else:
-
-    # Validate branch name before proceeding
     branch_name = os.getenv('BRANCH_NAME')
     validate_branch_name(branch_name)
 
-    # Auto-resume: if a previous attempt in this step left an in-flight build behind
-    # (typical when nick-fields/retry fires after a queue timeout), reattach to it
-    # instead of POSTing a fresh build that would go to the back of the Unity Cloud queue.
     resumed = try_resume_build()
     if resumed is not None:
-        target_name, id, resumed_status = resumed
+        target_name, id, resumed_status, resumed_elapsed = resumed
         os.environ['TARGET'] = target_name
         build_already_active = resumed_status in ACTIVE_STATUSES
+        if build_already_active:
+            resumed_build_elapsed = resumed_elapsed
     else:
-        # Clone current target — clones $TARGET, retargets to $BRANCH_NAME, replaces $TARGET.
         try:
             clone_current_target(True)
         except Exception as e:
             print(f"Operation failed: {e}")
 
-        # Set ENVs (Parameters) immediately before starting the build to avoid race
-        # conditions with other concurrent builds on shared targets.
+        # Set parameters immediately before run_build to avoid races with concurrent
+        # builds on shared targets.
         set_parameters(get_param_env_variables())
 
         def get_clean_build_bool():
@@ -737,18 +728,19 @@ else:
         utils.persist_build_info(os.getenv('TARGET'), id)
         print(f'For more info and live logs, go to https://cloud.unity.com/ and search for target "{os.getenv('TARGET')}" and build ID "{id}"')
 
-# Poll with separate queue and build budgets
-final_outcome, phase_durations, queue_reasons, queue_elapsed, build_elapsed = run_poll_loop(id, build_already_active=build_already_active)
+final_outcome, phase_durations, queue_reasons, queue_elapsed, build_elapsed = run_poll_loop(
+    id,
+    build_already_active=build_already_active,
+    resumed_build_elapsed=resumed_build_elapsed,
+)
 write_step_summary(os.getenv('TARGET'), id, final_outcome, phase_durations, queue_reasons, queue_elapsed, build_elapsed)
 
 if final_outcome in ('queue_timeout', 'build_timeout'):
-    # Best-effort: capture whatever Unity has produced so the upload-log step has something to show.
-    try:
-        download_log(id)
-    except Exception as e:
-        print(f'Warning: could not download log after timeout: {e}')
-    # Exit with the retryable code so nick-fields/retry picks us up. The persisted build_info
-    # lets the next attempt reattach via try_resume_build instead of re-queuing.
+    if final_outcome == 'build_timeout':
+        try:
+            download_log(id)
+        except Exception as e:
+            print(f'Warning: could not download log after timeout: {e}')
     sys.exit(RETRYABLE_EXIT_CODE)
 
 print(f'Runner FINAL elapsed: queue {datetime.timedelta(seconds=int(queue_elapsed))} / build {datetime.timedelta(seconds=int(build_elapsed))}')

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -692,6 +692,7 @@ elif args.resume or args.cancel:
 
     if args.cancel:
         cancel_build(id)
+        utils.delete_build_info()
         sys.exit(0)
 
 else:
@@ -737,17 +738,19 @@ write_step_summary(os.getenv('TARGET'), id, final_outcome, phase_durations, queu
 
 if final_outcome in ('queue_timeout', 'build_timeout'):
     if final_outcome == 'build_timeout':
+        # Build was cancelled; the persisted info points to a dead build.
+        utils.delete_build_info()
         try:
             download_log(id)
         except Exception as e:
             print(f'Warning: could not download log after timeout: {e}')
     sys.exit(RETRYABLE_EXIT_CODE)
 
+utils.delete_build_info()
+
 print(f'Runner FINAL elapsed: queue {datetime.timedelta(seconds=int(queue_elapsed))} / build {datetime.timedelta(seconds=int(build_elapsed))}')
 
-# Handle build artifact
 download_artifact(id)
-# Handle build log
 download_log(id)
 
 if not build_healthy:

--- a/scripts/cloudbuild/utils.py
+++ b/scripts/cloudbuild/utils.py
@@ -40,6 +40,7 @@ def read_build_info():
 def delete_build_info():
     if not os.path.exists(BUILD_INFO_PATH):
         print('No build_info file found, ignoring delete...')
-    
+        return
+
     os.remove(BUILD_INFO_PATH)
     print('build_info file deleted')


### PR DESCRIPTION
## Why

Unity Cloud Build's reduced concurrency leaves builds queued for hours before a builder picks them up. The old single `GLOBAL_TIMEOUT` charged queue time + build time against the same 3h budget, so a long queue could kill an otherwise-healthy build, and `nick-fields/retry` would POST a fresh build that went to the back of the queue — the worst possible move under concurrency pressure.

This PR splits queue time from build time, makes the retry actually preserve queue position, and cleans up persistent state on every terminal path.

## How it works

- **`QUEUE_TIMEOUT` (4h)** caps how long a single runner attempt waits in `created` / `queued` / `sentToBuilder`. On hit: exit `99` *without* cancelling — the build keeps its Unity Cloud queue slot.
- **`BUILD_TIMEOUT` (3h)** caps active build time (`started` / `restarted`). On hit: cancel and exit `99` — runaway builds shouldn't keep burning a slot.
- **`try_resume_build()`** reads `build_info.json` at the start of each attempt. If the persisted build is still in-flight, the next retry reattaches instead of POSTing a fresh one. `build_start` is seeded from Unity's reported elapsed time so the 3h cap stays real wall-clock across reattaches.
- **`build_info.json` lifecycle** is now deterministic: deleted on any terminal status, on `BUILD_TIMEOUT`, and on `--cancel`; kept only across `QUEUE_TIMEOUT` so reattach can find it.

## Use cases

1. **Healthy build, busy queue (1h queue + 2h build)** — single attempt completes; phase breakdown table shows queue vs build subtotals. No retry.
2. **Build stuck in queue >4h** — attempt 1 yields the runner at 4h, build stays queued in Unity Cloud, retry reattaches and continues polling the *same* build with its preserved queue position. Effective patience = `QUEUE_TIMEOUT × max_attempts = 8h`.
3. **Build picks up but runs >3h** — `BUILD_TIMEOUT` cancels, exits `99`. Retry POSTs a fresh build (the previous one is dead).
4. **Workflow cancelled or outer step timeout** — the `Cancel Unity Cloud build` step now runs on `failure()` too, so a Unity-side build never keeps holding a slot after a step timeout.
5. **Adaptive polling under sustained queue** — poll cadence drops to `120s` after 10 minutes of unchanged status, reducing API noise while waiting.
6. **Visibility** — each status change logs `queue Xh Ym / build Zm`, and the job's Summary tab gets a phase-breakdown table with per-status durations and observed `queuedReason` values.
