### PR TITLE
fix: improve skybox performance by throttling reflections cubemap baking

### DIFF
--- a/Explorer/Assets/Rendering/ForwardRenderer - High.asset
+++ b/Explorer/Assets/Rendering/ForwardRenderer - High.asset
@@ -413,6 +413,7 @@ MonoBehaviour:
     dimensions: 256
     executeInEditMode: 0
     assignAsReflectionProbe: 1
+    updateInterval: 10
 --- !u!114 &8407763759742182732
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -44,7 +44,7 @@
     "com.unity.ugui": "2.0.0",
     "com.unity.visualeffectgraph": "17.4.0",
     "decentraland.grassshader": "git@github.com:decentraland/unity-explorer-packages.git?path=/StylizedGrassShader",
-    "decentraland.renderfeatures": "git@github.com:decentraland/unity-explorer-packages.git?path=/RenderGraphs/RenderFeatures",
+    "decentraland.renderfeatures": "git@github.com:decentraland/unity-explorer-packages.git?path=/RenderGraphs/RenderFeatures#feat/skybox-cubemap-update-interval",
     "io.livekit.unity": "https://github.com/livekit/client-sdk-unity-web.git",
     "io.sentry.unity": "https://github.com/getsentry/unity.git#4.0.0",
     "net.tnrd.nsubstitute": "https://github.com/decentraland/Unity3D-NSubstitute.git",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -505,11 +505,11 @@
       "hash": "c35c10aabe0f919b1a455d28d2a1d18b6bcbe574"
     },
     "decentraland.renderfeatures": {
-      "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/RenderGraphs/RenderFeatures",
+      "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/RenderGraphs/RenderFeatures#feat/skybox-cubemap-update-interval",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "d5e6427e41422d069e8c0b9b4a8d9ab606877b70"
+      "hash": "b4076aff2998b9dcca76ab8f5dd3ac55fd674124"
     },
     "io.livekit.unity": {
       "version": "https://github.com/livekit/client-sdk-unity-web.git",


### PR DESCRIPTION
Skybox pr on shared dependencies: https://github.com/decentraland/unity-explorer-packages/pull/57

## Summary

Adds a configurable `updateInterval` to `SkyboxToCubemapRendererFeature` that throttles how often the IBL reflection cubemap is re-baked. The directly visible sky (`DrawSkybox`) is untouched. Update internal set to `10` (~6 Hz at 60 FPS).

## Motivation

The skybox-to-cubemap pipeline (`InitialRender` + `Remapping` + `Convolution`) executes **103 render events every single frame on the main camera**, regardless of whether anything reflective could perceive a change:

| Subpass | Events / frame | What it does |
|---|---:|---|
| `SkyboxToCubemap_InitialRender` | 6 | Run Genesis sky shader once per cubemap face |
| `SkyboxToCubemap_Remapping` | 48 | 6 faces × 8 mips: roughness-based re-encode |
| `SkyboxToCubemap_Convolution` | 48 | 6 faces × 8 mips: pre-filter for specular IBL |
| `DrawSkybox/Camera.RenderSkybox` | 1 | Directly visible sky (untouched by this PR) |
| **Total bake cost** | **103** | |

Frame Debugger captures across multiple in-game positions, camera angles, and player states all show the cubemap subpasses producing **exactly** 6/48/48 events. The bake doesn't gate on camera, sun position, cloud state, or anything else — it is an unconditional fixed cost per frame.

The pipeline only feeds **indirect** rendering (specular IBL on reflective surfaces and ambient probe tinting). Reflections of slowly-animating clouds and minute-scale TOD transitions don't need 60 Hz updates to look correct — most projects bake this on demand or at low frequencies.

## Change

- New `updateInterval` field (Range 1–60) on `SkyBoxToCubemapSettings`, assigned `10`.
- `AddRenderPasses` increments a frame counter and skips `EnqueuePass(skyboxToCubemapRenderPass)` when `frameCounter % interval != 0`.
- `RenderSettings.customReflectionTexture` is re-asserted **every** frame (outside the gate), so reflective materials always read the persistent cubemap texture even on skip frames. The texture retains the last bake's contents; only the writer is throttled, readers are unaffected.

## Frame Debugger results at `updateInterval = 10`

Captured against the same scene/camera state:

| Frame state | Total events | SkyboxToCubemap events |
|---|---:|---:|
| Baseline (`interval = 1`, every frame is a bake) | 728 | 102 |
| **Skip frame** (`interval = 10`, 9 of 10 frames) | **435** | **0** |
| Bake frame (`interval = 10`, 1 of 10 frames) | 728 | 102 |

Averaged over time at `interval = 10`, the IBL pipeline cost drops from **102 events/frame** to **~10.2 events/frame** — a **90% reduction**.

At 60 FPS:
- **Before:** 6,180 SkyboxToCubemap events/second
- **After (interval=10):** 612 SkyboxToCubemap events/second

The 48 Convolution and 48 Remapping events are fullscreen blits on a 256² HDR cubemap — these are the GPU-expensive ones.

The visible sky (`DrawSkybox/Camera.RenderSkybox`) remains at 1 event/frame across all configurations — the player still sees the sky animate at the full frame rate.

The cubemap drives only **indirect specular reflections** and **ambient probe tinting** — both perceptually tolerant of staleness. Direct view of the sky and direct sunlight are unaffected.

## Test plan

Go through Genesis City or any world. Look for glossy objects, like glasses, metal, shinny things. Check they look OK.
Play with skybox settings, change the time. Observe that lightning reflection works acceptable.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
