### PR TITLE
fix: validate spawn point of scenes

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/TeleportUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/TeleportUtils.cs
@@ -79,14 +79,15 @@ namespace ECS.SceneLifeCycle
             Vector3 parcelBaseWorldPosition = ParcelMathHelper.GetPositionByParcelPosition(parcel).WithErrorCompensation();
             Vector3 targetWorldPosition = parcelBaseWorldPosition;
 
-            List<SceneMetadata.SpawnPoint>? spawnPoints = sceneDef.metadata.spawnPoints;
+            List<SceneMetadata.SpawnPoint>? spawnPoints = sceneDef?.metadata.spawnPoints;
 
-            if (spawnPoints is { Count: > 0 })
+            if (sceneDef != null && spawnPoints is { Count: > 0 })
             {
-                SceneMetadata.SpawnPoint spawnPoint = PickSpawnPoint(spawnPoints, targetWorldPosition, parcelBaseWorldPosition);
+                LocalBounds bounds = CalculateLocalBounds(sceneDef.metadata.scene.DecodedParcels, parcel);
 
-                // TODO validate offset position is within bounds of one of scene parcels
-                targetWorldPosition += GetSpawnPositionOffset(spawnPoint);
+                SceneMetadata.SpawnPoint spawnPoint = PickSpawnPoint(spawnPoints, targetWorldPosition, parcelBaseWorldPosition, in bounds);
+
+                targetWorldPosition += GetSpawnPositionOffset(spawnPoint, in bounds);
 
                 if (spawnPoint.cameraTarget != null)
                     cameraTarget = spawnPoint.cameraTarget!.Value.ToVector3() + parcelBaseWorldPosition;
@@ -95,7 +96,7 @@ namespace ECS.SceneLifeCycle
             return (targetWorldPosition, cameraTarget);
         }
 
-        private static SceneMetadata.SpawnPoint PickSpawnPoint(IReadOnlyList<SceneMetadata.SpawnPoint> spawnPoints, Vector3 targetWorldPosition, Vector3 parcelBaseWorldPosition)
+        private static SceneMetadata.SpawnPoint PickSpawnPoint(IReadOnlyList<SceneMetadata.SpawnPoint> spawnPoints, Vector3 targetWorldPosition, Vector3 parcelBaseWorldPosition, in LocalBounds bounds)
         {
             List<SceneMetadata.SpawnPoint> defaults = ListPool<SceneMetadata.SpawnPoint>.Get();
             defaults.AddRange(spawnPoints.Where(sp => sp.@default));
@@ -110,7 +111,7 @@ namespace ECS.SceneLifeCycle
                 for (var i = 0; i < elegibleSpawnPoints.Count; i++)
                 {
                     SceneMetadata.SpawnPoint sp = elegibleSpawnPoints[i];
-                    Vector3 spawnWorldPosition = GetSpawnPositionOffset(sp) + parcelBaseWorldPosition;
+                    Vector3 spawnWorldPosition = GetSpawnPositionOffset(sp, in bounds) + parcelBaseWorldPosition;
                     float distance = Vector3.Distance(targetWorldPosition, spawnWorldPosition);
 
                     if (distance < closestDistance)
@@ -128,51 +129,90 @@ namespace ECS.SceneLifeCycle
             return spawnPoint;
         }
 
-        private static Vector3 GetSpawnPositionOffset(SceneMetadata.SpawnPoint spawnPoint)
+        private static Vector3 GetSpawnPositionOffset(SceneMetadata.SpawnPoint spawnPoint, in LocalBounds bounds)
         {
-            static float GetRandomPoint(float[] coordArray)
+            static float GetRandomPointClamped(float[] coordArray, float axisMin, float axisMax)
             {
-                float randomPoint = 0;
-
                 switch (coordArray.Length)
                 {
                     case 1:
-                        randomPoint = coordArray[0];
-                        break;
+                        return Mathf.Clamp(coordArray[0], axisMin, axisMax);
                     case >= 2:
                     {
                         float min = coordArray[0];
                         float max = coordArray[1];
 
-                        if (Mathf.Approximately(min, max))
-                            return max;
-
                         if (min > max)
                             (min, max) = (max, min);
 
-                        randomPoint = (float)((RANDOM.NextDouble() * (max - min)) + min);
-                        break;
-                    }
-                }
+                        min = Mathf.Clamp(min, axisMin, axisMax);
+                        max = Mathf.Clamp(max, axisMin, axisMax);
 
-                return randomPoint;
+                        if (Mathf.Approximately(min, max))
+                            return max;
+
+                        return (float)((RANDOM.NextDouble() * (max - min)) + min);
+                    }
+                    default:
+                        return 0;
+                }
             }
 
-            static float? GetSpawnComponent(SceneMetadata.SpawnPoint.Coordinate coordinate)
+            static float? GetSpawnComponentClamped(SceneMetadata.SpawnPoint.Coordinate coordinate, float axisMin, float axisMax)
             {
                 if (coordinate.SingleValue != null)
-                    return coordinate.SingleValue.Value;
+                    return Mathf.Clamp(coordinate.SingleValue.Value, axisMin, axisMax);
 
                 if (coordinate.MultiValue != null)
-                    return GetRandomPoint(coordinate.MultiValue);
+                    return GetRandomPointClamped(coordinate.MultiValue, axisMin, axisMax);
 
                 return null;
             }
 
             return new Vector3(
-                GetSpawnComponent(spawnPoint.position.x) ?? ParcelMathHelper.PARCEL_SIZE / 2f,
-                GetSpawnComponent(spawnPoint.position.y) ?? 0,
-                GetSpawnComponent(spawnPoint.position.z) ?? ParcelMathHelper.PARCEL_SIZE / 2f);
+                GetSpawnComponentClamped(spawnPoint.position.x, bounds.MinX, bounds.MaxX) ?? ParcelMathHelper.PARCEL_SIZE / 2f,
+                GetSpawnComponentClamped(spawnPoint.position.y, 0f, float.PositiveInfinity) ?? 0,
+                GetSpawnComponentClamped(spawnPoint.position.z, bounds.MinZ, bounds.MaxZ) ?? ParcelMathHelper.PARCEL_SIZE / 2f);
+        }
+
+        private static LocalBounds CalculateLocalBounds(IReadOnlyList<Vector2Int> sceneParcels, Vector2Int referenceParcel)
+        {
+            if (sceneParcels == null || sceneParcels.Count == 0)
+                return new LocalBounds(0, ParcelMathHelper.PARCEL_SIZE, 0, ParcelMathHelper.PARCEL_SIZE);
+
+            int minParcelX = int.MaxValue, maxParcelX = int.MinValue;
+            int minParcelY = int.MaxValue, maxParcelY = int.MinValue;
+
+            for (var i = 0; i < sceneParcels.Count; i++)
+            {
+                Vector2Int p = sceneParcels[i];
+                if (p.x < minParcelX) minParcelX = p.x;
+                if (p.x > maxParcelX) maxParcelX = p.x;
+                if (p.y < minParcelY) minParcelY = p.y;
+                if (p.y > maxParcelY) maxParcelY = p.y;
+            }
+
+            return new LocalBounds(
+                (minParcelX - referenceParcel.x) * ParcelMathHelper.PARCEL_SIZE,
+                (maxParcelX - referenceParcel.x + 1) * ParcelMathHelper.PARCEL_SIZE,
+                (minParcelY - referenceParcel.y) * ParcelMathHelper.PARCEL_SIZE,
+                (maxParcelY - referenceParcel.y + 1) * ParcelMathHelper.PARCEL_SIZE);
+        }
+
+        private readonly struct LocalBounds
+        {
+            public readonly float MinX;
+            public readonly float MaxX;
+            public readonly float MinZ;
+            public readonly float MaxZ;
+
+            public LocalBounds(float minX, float maxX, float minZ, float maxZ)
+            {
+                MinX = minX;
+                MaxX = maxX;
+                MinZ = minZ;
+                MaxZ = maxZ;
+            }
         }
 
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/TeleportUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/TeleportUtils.cs
@@ -177,11 +177,13 @@ namespace ECS.SceneLifeCycle
 
         private static LocalBounds CalculateLocalBounds(IReadOnlyList<Vector2Int> sceneParcels, Vector2Int referenceParcel)
         {
-            if (sceneParcels == null || sceneParcels.Count == 0)
+            if (sceneParcels.Count == 0)
                 return new LocalBounds(0, ParcelMathHelper.PARCEL_SIZE, 0, ParcelMathHelper.PARCEL_SIZE);
 
-            int minParcelX = int.MaxValue, maxParcelX = int.MinValue;
-            int minParcelY = int.MaxValue, maxParcelY = int.MinValue;
+            int minParcelX = int.MaxValue;
+            int maxParcelX = int.MinValue;
+            int minParcelY = int.MaxValue;
+            int maxParcelY = int.MinValue;
 
             for (var i = 0; i < sceneParcels.Count; i++)
             {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Tests/TeleportUtilsShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Tests/TeleportUtilsShould.cs
@@ -1,0 +1,174 @@
+using DCL.Ipfs;
+using NUnit.Framework;
+using System.Collections.Generic;
+using UnityEngine;
+using Utility;
+
+namespace ECS.SceneLifeCycle.Tests
+{
+    public class TeleportUtilsShould
+    {
+        private const int PARCEL = ParcelMathHelper.PARCEL_SIZE;
+        private const float EPSILON = 0.001f;
+
+        [Test]
+        public void ClampOutOfBoundsRangeToParcelOnSingleParcelScene()
+        {
+            var baseParcel = new Vector2Int(17, 59);
+
+            SceneEntityDefinition sceneDef = BuildSceneDef(
+                baseParcel,
+                new[] { baseParcel },
+                MakeSpawnPoint(
+                    xRange: new[] { -117f, 71f },
+                    yRange: new[] { 0f, 0f },
+                    zRange: new[] { -23f, 165f },
+                    cameraTarget: new Vector3(8f, 1f, 8f),
+                    isDefault: true));
+
+            float minWorldX = baseParcel.x * PARCEL;
+            float maxWorldX = (baseParcel.x + 1) * PARCEL;
+            float minWorldZ = baseParcel.y * PARCEL;
+            float maxWorldZ = (baseParcel.y + 1) * PARCEL;
+
+            for (var i = 0; i < 200; i++)
+            {
+                (Vector3 worldPos, Vector3? cameraTarget) = TeleportUtils.PickTargetWithOffset(sceneDef, baseParcel);
+
+                Assert.GreaterOrEqual(worldPos.x, minWorldX);
+                Assert.LessOrEqual(worldPos.x, maxWorldX + EPSILON);
+                Assert.GreaterOrEqual(worldPos.z, minWorldZ);
+                Assert.LessOrEqual(worldPos.z, maxWorldZ + EPSILON);
+                Assert.GreaterOrEqual(worldPos.y, 0f);
+
+                Assert.NotNull(cameraTarget);
+                Assert.AreEqual(minWorldX + 8f, cameraTarget!.Value.x, EPSILON);
+                Assert.AreEqual(1f, cameraTarget.Value.y, EPSILON);
+                Assert.AreEqual(minWorldZ + 8f, cameraTarget.Value.z, EPSILON);
+            }
+        }
+
+        [Test]
+        public void ClampOutOfBoundsSingleValueToParcelEdge()
+        {
+            var baseParcel = new Vector2Int(17, 59);
+
+            SceneEntityDefinition sceneDef = BuildSceneDef(
+                baseParcel,
+                new[] { baseParcel },
+                MakeSpawnPoint(
+                    xSingle: -50f,
+                    ySingle: 0f,
+                    zSingle: 8f,
+                    isDefault: true));
+
+            (Vector3 worldPos, _) = TeleportUtils.PickTargetWithOffset(sceneDef, baseParcel);
+
+            Assert.AreEqual(baseParcel.x * PARCEL, worldPos.x, EPSILON);
+            Assert.AreEqual(baseParcel.y * PARCEL + 8f, worldPos.z, EPSILON);
+        }
+
+        [Test]
+        public void NotClampWhenRangeIsInsideMultiParcelScene()
+        {
+            var baseParcel = new Vector2Int(0, 0);
+            var parcels = new[] { new Vector2Int(0, 0), new Vector2Int(1, 0) };
+
+            SceneEntityDefinition sceneDef = BuildSceneDef(
+                baseParcel,
+                parcels,
+                MakeSpawnPoint(
+                    xRange: new[] { 4f, 20f },
+                    ySingle: 0f,
+                    zSingle: 8f,
+                    isDefault: true));
+
+            for (var i = 0; i < 100; i++)
+            {
+                (Vector3 worldPos, _) = TeleportUtils.PickTargetWithOffset(sceneDef, baseParcel);
+
+                Assert.GreaterOrEqual(worldPos.x, 4f);
+                Assert.LessOrEqual(worldPos.x, 20f + EPSILON);
+                Assert.AreEqual(8f, worldPos.z, EPSILON);
+            }
+        }
+
+        [Test]
+        public void ClampNegativeYToZero()
+        {
+            var baseParcel = new Vector2Int(0, 0);
+
+            SceneEntityDefinition sceneDef = BuildSceneDef(
+                baseParcel,
+                new[] { baseParcel },
+                MakeSpawnPoint(
+                    xSingle: 8f,
+                    yRange: new[] { -50f, -10f },
+                    zSingle: 8f,
+                    isDefault: true));
+
+            (Vector3 worldPos, _) = TeleportUtils.PickTargetWithOffset(sceneDef, baseParcel);
+
+            Assert.AreEqual(0f, worldPos.y, EPSILON);
+        }
+
+        private static SceneEntityDefinition BuildSceneDef(Vector2Int baseParcel, IReadOnlyList<Vector2Int> parcels, SceneMetadata.SpawnPoint spawnPoint)
+        {
+            var sceneSection = new SceneMetadataScene
+            {
+                DecodedBase = baseParcel,
+                DecodedParcels = parcels,
+            };
+
+            var metadata = new SceneMetadata
+            {
+                scene = sceneSection,
+                spawnPoints = new List<SceneMetadata.SpawnPoint> { spawnPoint },
+            };
+
+            return new SceneEntityDefinition("test-scene", metadata);
+        }
+
+        private static SceneMetadata.SpawnPoint MakeSpawnPoint(
+            float[]? xRange = null, float[]? yRange = null, float[]? zRange = null,
+            float? xSingle = null, float? ySingle = null, float? zSingle = null,
+            Vector3? cameraTarget = null, bool isDefault = false)
+        {
+            var sp = new SceneMetadata.SpawnPoint
+            {
+                name = "TestSpawn",
+                @default = isDefault,
+                position = new SceneMetadata.SpawnPoint.Position
+                {
+                    x = MakeCoordinate(xRange, xSingle),
+                    y = MakeCoordinate(yRange, ySingle),
+                    z = MakeCoordinate(zRange, zSingle),
+                },
+            };
+
+            if (cameraTarget.HasValue)
+            {
+                Vector3 target = cameraTarget.Value;
+                sp.cameraTarget = new SceneMetadata.SpawnPoint.Position
+                {
+                    x = new SceneMetadata.SpawnPoint.Coordinate { SingleValue = target.x },
+                    y = new SceneMetadata.SpawnPoint.Coordinate { SingleValue = target.y },
+                    z = new SceneMetadata.SpawnPoint.Coordinate { SingleValue = target.z },
+                };
+            }
+
+            return sp;
+        }
+
+        private static SceneMetadata.SpawnPoint.Coordinate MakeCoordinate(float[]? range, float? single)
+        {
+            if (range != null)
+                return new SceneMetadata.SpawnPoint.Coordinate { MultiValue = range };
+
+            if (single.HasValue)
+                return new SceneMetadata.SpawnPoint.Coordinate { SingleValue = single.Value };
+
+            return default(SceneMetadata.SpawnPoint.Coordinate);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Tests/TeleportUtilsShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Tests/TeleportUtilsShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a178d1a5e868452b9c3858376c89d124
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7271 
This PR adds a validation on the spawn point of a scene, to verify it doesn't exit the scene bounds, if it does it clamps it to the scene valid coordinates.

Note to the reviewer, the added tests were completely generated by AI

## Test Instructions

### Test Steps
1. Launch the client
2. Teleport to various scenes/worlds
3. Verify that the spawn point works fine
4. Verify that it also works fine with the /reload command
5. Go to 17,59
6. Verify that the spawn point is random inside the scene
7. Verify that by doing /reload it doesn't teleport you out of the scene

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
