### PR TITLE
fix: skybox menu becomes unresponsive when clicking out of its slider/toggle

### DIFF
--- a/Explorer/Assets/DCL/UI/Skybox/SkyboxMenuView.cs
+++ b/Explorer/Assets/DCL/UI/Skybox/SkyboxMenuView.cs
@@ -15,6 +15,8 @@ namespace DCL.UI.Skybox
         [field: SerializeField] public CanvasGroup TopSliderGroup { get; private set; } = null!;
         [field: SerializeField] public CanvasGroup TextSliderGroup { get; private set; } = null!;
 
+        // Stops pointer-click events from bubbling up to the SidebarSkyboxButton ancestor,
+        // whose Button would otherwise re-trigger OpenSkyboxSettingsPanel and freeze the view.
         public void OnPointerClick(PointerEventData eventData) { }
     }
 }

--- a/Explorer/Assets/DCL/UI/Skybox/SkyboxMenuView.cs
+++ b/Explorer/Assets/DCL/UI/Skybox/SkyboxMenuView.cs
@@ -1,11 +1,12 @@
 using MVC;
 using TMPro;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace DCL.UI.Skybox
 {
-    public class SkyboxMenuView: ViewBaseWithAnimationElement, IView
+    public class SkyboxMenuView: ViewBaseWithAnimationElement, IView, IPointerClickHandler
     {
         [field: SerializeField] public Toggle TimeProgressionToggle { get; private set; } = null!;
         [field: SerializeField] public Slider TimeSlider { get; private set; } = null!;
@@ -13,5 +14,7 @@ namespace DCL.UI.Skybox
         [field: SerializeField] public CanvasGroup TimeProgressionGroup { get; private set; } = null!;
         [field: SerializeField] public CanvasGroup TopSliderGroup { get; private set; } = null!;
         [field: SerializeField] public CanvasGroup TextSliderGroup { get; private set; } = null!;
+
+        public void OnPointerClick(PointerEventData eventData) { }
     }
 }


### PR DESCRIPTION
# Pull Request Description
Fix #8307 

## What does this PR change?
The skybox menu UI became freezed when we clicked in something that was not its own controls like the slider or the toggle inside the modal. This PR fixes it.

### Test Steps
1. Open the skybox menu clicking on the corresponding button in the sidebar.
2. Click on any part of the UI and check that it works correctly.
3. Click out of the Ui and check the the modal closes.
4. Repeat the process several times.

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.