### PR TITLE
fix: player pref shutdown exception

### DIFF
--- a/Explorer/Assets/DCL/Prefs/DCL.Prefs.asmdef
+++ b/Explorer/Assets/DCL/Prefs/DCL.Prefs.asmdef
@@ -2,7 +2,6 @@
     "name": "DCL.Prefs",
     "rootNamespace": "",
     "references": [
-        "GUID:767f25efd20d4339a8b1683f8dc1d7d8",
         "GUID:75edf6fa50ff464395ca31529ea14d25"
     ],
     "includePlatforms": [],

--- a/Explorer/Assets/DCL/Prefs/DCLPlayerPrefs.cs
+++ b/Explorer/Assets/DCL/Prefs/DCLPlayerPrefs.cs
@@ -15,6 +15,33 @@ namespace DCL.Prefs
     /// </summary>
     public static class DCLPlayerPrefs
     {
+        /// <summary>
+        /// A stub to ensure graceful shutdown
+        /// </summary>
+        private sealed class DisposedDCLPlayerPrefs : IDCLPrefs
+        {
+            public void SetString(string key, string value) => Warn();
+            public void SetInt(string key, int value) => Warn();
+            public void SetFloat(string key, float value) => Warn();
+            public void SetBool(string key, bool value) => Warn();
+            public string GetString(string key, string def) { Warn(); return def; }
+            public int GetInt(string key, int def) { Warn(); return def; }
+            public float GetFloat(string key, float def) { Warn(); return def; }
+            public bool GetBool(string key, bool def) { Warn(); return def; }
+            public bool HasKey(string key) { Warn(); return false; }
+            public void DeleteKey(string key) => Warn();
+            public void DeleteAll() => Warn();
+            public void Save() { }
+            public void SaveSync() { }
+
+            [System.Diagnostics.Conditional("UNITY_EDITOR")]
+            private static void Warn([System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+            {
+                // TODO: Use ReportHub when it properly lives in its own dependency.
+                Debug.LogWarning( $"[DCLPlayerPrefs] {caller} called after shutdown — ignored.");
+            }
+        }
+
         private const string VECTOR2_KEY_FORMAT = "{0}_{1}";
 
         private static IDCLPrefs dclPrefs;
@@ -135,7 +162,8 @@ namespace DCL.Prefs
 
             System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
             (dclPrefs as IDisposable)?.Dispose();
-            dclPrefs = null;
+            // Avoid any shutdown exceptions, just throw warnings.
+            dclPrefs = new DisposedDCLPlayerPrefs();
             Debug.Log($"[ExitUtils] [DCLPlayerPrefs] cleanup took {stopwatch.ElapsedMilliseconds}ms");
         }
 

--- a/Explorer/Assets/DCL/Prefs/DCLPlayerPrefs.cs
+++ b/Explorer/Assets/DCL/Prefs/DCLPlayerPrefs.cs
@@ -31,8 +31,8 @@ namespace DCL.Prefs
             public bool HasKey(string key) { Warn(); return false; }
             public void DeleteKey(string key) => Warn();
             public void DeleteAll() => Warn();
-            public void Save() { }
-            public void SaveSync() { }
+            public void Save() => Warn();
+            public void SaveSync() => Warn();
 
             [System.Diagnostics.Conditional("UNITY_EDITOR")]
             private static void Warn([System.Runtime.CompilerServices.CallerMemberName] string caller = "")


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes `NullReferenceException`s that could occur during application shutdown when systems still call into `DCLPlayerPrefs` after `OnQuitting` has disposed the underlying provider.

Previously, `OnQuitting` set `dclPrefs = null` after disposing it, so any subsequent `Get*`/`Set*`/`HasKey`/`Save` call from a still-tearing-down system would throw an NRE and pollute the shutdown logs (and in some cases mask the real exit error).

This PR introduces a `DisposedDCLPlayerPrefs` stub that implements `IDCLPrefs` with no-op writes and default-returning reads. On shutdown the static now swaps to this stub instead of nulling the field, so late callers get safe defaults plus an editor-only warning naming the offending API (via `[CallerMemberName]`). The unused `GUID:767f25ef…` reference is also dropped from `DCL.Prefs.asmdef` since it's no longer needed.

Notes:
- Warnings are gated behind `[Conditional("UNITY_EDITOR")]` so production builds stay silent.
- A `TODO` is left to switch the warning to `ReportHub` once it can be referenced from `DCL.Prefs` without a circular dependency.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 8809
```

**Expected result**:
- Application starts and runs normally; `DCLPlayerPrefs` behaviour is unchanged during the session.

**Expected result**:
- Same as above, with a freshly created prefs file. Confirm settings persist across a normal restart (i.e. the stub only takes over after quit, not during runtime).

### Test Steps
1. Launch the explorer via `metaforge explorer run 8809`.
2. Interact with anything that reads/writes prefs (settings panel, chat, audio sliders, etc.).
3. Quit the application (close the window or use the in-game exit flow).
4. Ensure prefs persist on the next reload


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered (shutdown-only path, single allocation of stub)
- [ ] For SDK features: Test scene is included (n/a)

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
