### PR TITLE
fix: comms fail to recover after network disconnect

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ChatConnectiveRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ChatConnectiveRoom.cs
@@ -54,7 +54,7 @@ namespace DCL.Multiplayer.Connections.Archipelago.Rooms.Chat
         protected override async UniTask CycleStepAsync(CancellationToken token)
         {
             if (CurrentState() is not IConnectiveRoom.State.Running // CurrentState will be != Running at start, so we need to connect
-                || Room().Info.ConnectionState == LKConnectionState.ConnDisconnected) // If the room was running but our connection was lost at some point, we need to reconnect
+                || Room().Info.ConnectionState != LKConnectionState.ConnConnected) // If the room was running but our connection was lost (or stuck reconnecting), we need to reconnect
             {
                 string connectionString = await ConnectionStringAsync(token);
                 await TryConnectToRoomAsync(connectionString, token);

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/SceneRoomMetaDataSource.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/SceneRoomMetaDataSource.cs
@@ -94,7 +94,12 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
 
             StreamableLoadingResult<SceneDefinitions> result = promise.Result!.Value;
 
-            if (result.Succeeded && entityDefinitionList.Count > 0)
+            // Don't collapse a network failure into "no scene at this position":
+            // that path parks the room until the player changes parcel.
+            if (!result.Succeeded)
+                return Result<MetaData>.ErrorResult(result.Exception?.Message ?? "Failed to fetch scene definition");
+
+            if (entityDefinitionList.Count > 0)
             {
                 SceneEntityDefinition? sceneDefinition = entityDefinitionList[0];
                 string? id = sceneDefinition.id;

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/GateKeeperSceneRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/GateKeeperSceneRoom.cs
@@ -155,11 +155,11 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
                 }
                 else
                 {
-                    if (!meta.Equals(currentMetaData.GetValueOrDefault()) || Room().Info.ConnectionState == LKConnectionState.ConnDisconnected)
+                    if (!meta.Equals(currentMetaData.GetValueOrDefault()) || Room().Info.ConnectionState != LKConnectionState.ConnConnected)
                     {
                         string connectionString = await ConnectionStringAsync(meta, token);
 
-                        if (Room().Info.ConnectionState == LKConnectionState.ConnDisconnected)
+                        if (Room().Info.ConnectionState != LKConnectionState.ConnConnected)
                             currentMetaData = null;
 
                         // if the player returns to the previous scene but the new room has been connected, the previous connection should be preserved


### PR DESCRIPTION
# Pull Request Description
Fix #8782 

## Summary

After a network drop longer than ~1 minute, the user's avatar stayed disconnected from the scene comms room (no avatar updates, chat or emotes from nearby players) until they teleported or walked into another parcel. This PR makes the room reconnect on its own as soon as the network is back, no movement required.

## Why it happened

Two independent code paths could leave the scene room stuck after recovering from a long disconnect:

1. The LiveKit connection state could end up frozen mid-recovery, and the reconnect loop only reacted to the fully-disconnected state.
2. While the network was still unstable, a failed HTTP call to fetch the current scene was mistaken for "there is no scene here", and the room parked itself until the player changed parcel.

Both paths produce the same user-visible symptom, which is why QA hit it 100% of the time.

## Fix

- Reconnect on any non-connected state, not only on fully disconnected.
- When the scene lookup fails because of a transient network error, surface the error and retry on the next cycle instead of pretending "no scene here".

## Test plan

- [ ] Join Genesis Plaza near other avatars.
- [ ] Disable the network for >60 s (`Disable-NetAdapter -Name "Ethernet" -Confirm:$false` on Windows, or `netsh wlan disconnect` for Wi-Fi).
- [ ] Re-enable the network.
- [ ] Without moving, verify within ~5 s that other avatars resume moving, chat and emotes sync. The "ROOM: SCENE" debug panel should return to `Room State: Running`, `Attempt to Connect: Success`, `Connection State: ConnConnected`.
- [ ] Repeat the drop several times to exercise both recovery paths.
- [ ] Walk into an empty parcel (no scene assigned) and confirm the room still disconnects normally — the "no scene here" case must keep working.
- [ ] Normal teleport between scenes still works.
- [ ] Repeat the same tests in a world.