### PR TITLE
chore: nearby voice chat | audio stream deduplication

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Interior/InteriorVideoStreams.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Interior/InteriorVideoStreams.cs
@@ -74,9 +74,6 @@ namespace DCL.Multiplayer.Connections.Rooms.Interior
             assigned.AssignRoom(room);
         }
 
-        public int GetLastFrameReceivedAt(StreamKey streamKey) =>
-            assigned.GetLastFrameReceivedAt(streamKey);
-
         public void Assign(IAudioStreams value, out IAudioStreams? previous)
         {
             previous = assigned;

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Interior/InteriorVideoStreams.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Interior/InteriorVideoStreams.cs
@@ -6,7 +6,6 @@ using LiveKit.Rooms.Streaming;
 using LiveKit.Rooms.Streaming.Audio;
 using LiveKit.Rooms.VideoStreaming;
 using RichTypes;
-using System;
 using System.Collections.Generic;
 
 namespace DCL.Multiplayer.Connections.Rooms.Interior
@@ -74,6 +73,9 @@ namespace DCL.Multiplayer.Connections.Rooms.Interior
         {
             assigned.AssignRoom(room);
         }
+
+        public int GetLastFrameReceivedAt(StreamKey streamKey) =>
+            assigned.GetLastFrameReceivedAt(streamKey);
 
         public void Assign(IAudioStreams value, out IAudioStreams? previous)
         {

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogVideoStreams.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogVideoStreams.cs
@@ -71,12 +71,5 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
         {
             this.origin = origin;
         }
-
-        public int GetLastFrameReceivedAt(StreamKey streamKey)
-        {
-            int tick = origin.GetLastFrameReceivedAt(streamKey);
-            ReportHub.Log(ReportCategory.LIVEKIT, $"{nameof(LogAudioStreams)}: {nameof(GetLastFrameReceivedAt)}: {streamKey.identity}, {streamKey.sid} -> {tick};");
-            return tick;
-        }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogVideoStreams.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogVideoStreams.cs
@@ -65,11 +65,6 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
 
     public class LogAudioStreams : LogStreams<AudioStream, AudioStreamInfo>, IAudioStreams
     {
-        private readonly IAudioStreams origin;
-
-        public LogAudioStreams(IAudioStreams origin) : base(origin, nameof(LogAudioStreams))
-        {
-            this.origin = origin;
-        }
+        public LogAudioStreams(IAudioStreams origin) : base(origin, nameof(LogAudioStreams)) { }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogVideoStreams.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Logs/LogVideoStreams.cs
@@ -4,7 +4,6 @@ using LiveKit.Rooms.Streaming;
 using LiveKit.Rooms.Streaming.Audio;
 using LiveKit.Rooms.VideoStreaming;
 using RichTypes;
-using System;
 using System.Collections.Generic;
 
 namespace DCL.Multiplayer.Connections.Rooms.Logs
@@ -66,6 +65,18 @@ namespace DCL.Multiplayer.Connections.Rooms.Logs
 
     public class LogAudioStreams : LogStreams<AudioStream, AudioStreamInfo>, IAudioStreams
     {
-        public LogAudioStreams(IStreams<AudioStream, AudioStreamInfo> origin) : base(origin, nameof(LogVideoStreams)) { }
+        private readonly IAudioStreams origin;
+
+        public LogAudioStreams(IAudioStreams origin) : base(origin, nameof(LogAudioStreams))
+        {
+            this.origin = origin;
+        }
+
+        public int GetLastFrameReceivedAt(StreamKey streamKey)
+        {
+            int tick = origin.GetLastFrameReceivedAt(streamKey);
+            ReportHub.Log(ReportCategory.LIVEKIT, $"{nameof(LogAudioStreams)}: {nameof(GetLastFrameReceivedAt)}: {streamKey.identity}, {streamKey.sid} -> {tick};");
+            return tick;
+        }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullVideoStreams.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullVideoStreams.cs
@@ -3,7 +3,6 @@ using LiveKit.Rooms.Streaming;
 using LiveKit.Rooms.Streaming.Audio;
 using LiveKit.Rooms.VideoStreaming;
 using RichTypes;
-using System;
 using System.Collections.Generic;
 
 namespace DCL.Multiplayer.Connections.Rooms.Nulls
@@ -44,5 +43,8 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
     public class NullAudioStreams : NullStreams<AudioStream, AudioStreamInfo>, IAudioStreams
     {
         public static readonly NullAudioStreams INSTANCE = new ();
+
+        // -1 is the resolver's sentinel for "stream missing / never decoded a frame"
+        public int GetLastFrameReceivedAt(StreamKey streamKey) => -1;
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullVideoStreams.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullVideoStreams.cs
@@ -43,8 +43,5 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
     public class NullAudioStreams : NullStreams<AudioStream, AudioStreamInfo>, IAudioStreams
     {
         public static readonly NullAudioStreams INSTANCE = new ();
-
-        // -1 is the resolver's sentinel for "stream missing / never decoded a frame"
-        public int GetLastFrameReceivedAt(StreamKey streamKey) => -1;
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/Global/VoiceChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/VoiceChatPlugin.cs
@@ -18,11 +18,8 @@ using DCL.VoiceChat.CommunityVoiceChat;
 using DCL.VoiceChat.Nearby;
 using DCL.VoiceChat.Nearby.Audio;
 using DCL.VoiceChat.Nearby.Systems;
-using LiveKit.Rooms.Streaming;
-using LiveKit.Rooms.Streaming.Audio;
 using LiveKit.Rooms;
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using DCL.UI;
 using DCL.Utilities;
@@ -78,7 +75,6 @@ namespace DCL.PluginSystem.Global
         private VoiceChatPanelPresenter? voiceChatPanelPresenter;
         private VoiceChatDebugContainer? voiceChatDebugContainer;
         private NearbyAudioStreamsRegistry? nearbyAudioStreamRegistry;
-        private HashSet<StreamKey>? nearbyAudioBindings;
         private NearbyAudioSourceFactory? nearbyAudioSourceFactory;
         private NearbyVoiceChatSuppressor? nearbyVoiceChatSuppressor;
         private NearbyMicrophoneHandler? nearbyMicrophoneHandler;
@@ -156,9 +152,9 @@ namespace DCL.PluginSystem.Global
 
                 NearbyLivekitBridgeSystem.InjectToWorld(ref builder, nearbyAudioStreamRegistry!);
                 NearbyAudibleRangeSystem.InjectToWorld(ref builder, voiceChatConfiguration, listenerState);
-                NearbyAudioBindingSystem.InjectToWorld(ref builder, nearbyAudioStreamRegistry!, nearbyAudioBindings!, userBlockingCache, nearbyStateModel!, nearbyAudioSourceFactory!, RoomMetadataCurrentScene.Instance);
+                NearbyAudioBindingSystem.InjectToWorld(ref builder, nearbyAudioStreamRegistry!, userBlockingCache, nearbyStateModel!, nearbyAudioSourceFactory!, RoomMetadataCurrentScene.Instance);
                 NearbyAudioPositionSystem.InjectToWorld(ref builder, nearbyMuteService!, listenerState);
-                NearbyAudioCleanupSystem.InjectToWorld(ref builder, nearbyAudioStreamRegistry!, nearbyAudioBindings!, userBlockingCache, nearbyStateModel!, nearbyAudioSourceFactory!, RoomMetadataCurrentScene.Instance);
+                NearbyAudioCleanupSystem.InjectToWorld(ref builder, nearbyAudioStreamRegistry!, userBlockingCache, nearbyStateModel!, nearbyAudioSourceFactory!, RoomMetadataCurrentScene.Instance);
                 NearbyVoiceChatNametagSystem.InjectToWorld(ref builder, playerEntity, nearbyAudioStreamRegistry!, nearbyStateModel!, nearbyMuteService!);
 
                 NearbyVoiceChatDebugSystem.InjectToWorld(ref builder, voiceChatConfiguration, debugContainer, roomHub.IslandRoom(), nearbyStateModel!, nearbyAudioStreamRegistry!, entityParticipantTable);
@@ -221,7 +217,6 @@ namespace DCL.PluginSystem.Global
                 nearbyAudioStreamRegistry = new NearbyAudioStreamsRegistry(islandRoom);
                 pluginScope.Add(nearbyAudioStreamRegistry);
 
-                nearbyAudioBindings = new HashSet<StreamKey>(32);
                 nearbyAudioSourceFactory = new NearbyAudioSourceFactory(voiceChatConfiguration);
 
                 // State model is created in DynamicWorldContainer so analytics can subscribe to it.

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Components/NearbyAudioSourceComponent.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Components/NearbyAudioSourceComponent.cs
@@ -1,17 +1,12 @@
-using Arch.Core;
 using LiveKit.Rooms.Streaming;
 using LiveKit.Rooms.Streaming.Audio;
 using UnityEngine;
 
 namespace DCL.VoiceChat
 {
-    /// <summary>
-    /// Lives on a dedicated audio-source entity. Bound 1:1 to a (participant, sid) pair.
-    /// </summary>
     public struct NearbyAudioSourceComponent
     {
         public readonly StreamKey Key;
-        public readonly Entity AvatarEntity;
         public readonly LivekitAudioSource LivekitAudioSource;
 
         public uint LastSeenMuteVersion;
@@ -19,10 +14,9 @@ namespace DCL.VoiceChat
         public bool LastInactive;
         public Vector3 LastWrittenPos;
 
-        public NearbyAudioSourceComponent(StreamKey key, Entity avatarEntity, LivekitAudioSource livekitAudioSource)
+        public NearbyAudioSourceComponent(StreamKey key, LivekitAudioSource livekitAudioSource)
         {
             Key = key;
-            AvatarEntity = avatarEntity;
             LivekitAudioSource = livekitAudioSource;
 
             LastSeenMuteVersion = 0;

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Components/NearbyAudioStreamerComponent.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Components/NearbyAudioStreamerComponent.cs
@@ -1,27 +1,25 @@
-using DCL.VoiceChat.Nearby.Audio;
-
 namespace DCL.VoiceChat.Nearby
 {
     /// <summary>
-    ///     Per-avatar mirror of the registry's audio sids for the avatar's walletId.
+    ///     Per-avatar mirror of the registry's single active audio sid for the avatar's walletId.
     ///     <para>
-    ///         <see cref="StreamSidsSnapshot"/> is a reference to a registry-owned copy-on-write <c>string[]</c>.
-    ///         Reference identity is the version signal: a different reference  ↔ content changed.
-    ///         <b>Never mutate.</b>
-    ///         Never retain across frames longer than the COW guarantees in <see cref="NearbyAudioStreamsRegistry"/>.
+    ///         <see cref="CurrentSid"/> is the resolver's pick (most-recent-frame winner). Never <c>null</c>
+    ///         while the component is attached — <see cref="NearbyLivekitBridgeSystem"/> guarantees the invariant
+    ///         by only attaching on a non-null resolver result and ref-mutating on flips.
     ///     </para>
     ///     <para>
     ///         Remote-only: the local participant (user) is never present in the registry's streaming snapshot.
-    ///         LiveKit does not raise <c>TrackSubscribed</c> for locally-published tracks, so this component is never attached to the local player avatar.
+    ///         LiveKit does not raise <c>TrackSubscribed</c> for locally-published tracks, so this component is never
+    ///         attached to the local player avatar.
     ///     </para>
     /// </summary>
     public struct NearbyAudioStreamerComponent
     {
-        public string[] StreamSidsSnapshot;
+        public string CurrentSid;
 
-        public NearbyAudioStreamerComponent(string[] streamSidsSnapshot)
+        public NearbyAudioStreamerComponent(string currentSid)
         {
-            StreamSidsSnapshot = streamSidsSnapshot;
+            CurrentSid = currentSid;
         }
     }
 }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
@@ -25,6 +25,7 @@ namespace DCL.VoiceChat.Nearby.Audio
         Weak<AudioStream> GetActiveStream(StreamKey key);
 
         /// <summary>
+        /// <b>Call-site discipline.</b> Main-thread only — the multi-candidate branch performs one FFI hop per sid.
         /// The single active sid for an identity. Returns <c>null</c> if the identity has no sids.
         /// Single-candidate fast path: returned eagerly without consulting the frame oracle (a lone candidate is active by definition).
         /// Multi-candidate: picks the sid that most recently emitted a media frame; returns <c>null</c> if none of the candidates has
@@ -36,6 +37,7 @@ namespace DCL.VoiceChat.Nearby.Audio
         /// <c>true</c> when <paramref name="key"/>.sid is the resolver's current pick for <paramref name="key"/>.identity.
         /// Cleanup uses this in place of "sid disappeared from snapshot" — it also reaps demoted ghost sids that
         /// still exist in the registry but lost to a fresher candidate.
+        /// Shares the cost profile and main-thread discipline of <see cref="GetActiveSid"/>: same resolver call underneath.
         /// </summary>
         bool IsActiveSid(StreamKey key);
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
@@ -32,11 +32,11 @@ namespace DCL.VoiceChat.Nearby.Audio
         string? GetActiveSid(string walletId);
 
         /// <summary>
-        /// <c>true</c> when <paramref name="sid"/> is the resolver's current pick for <paramref name="walletId"/>.
+        /// <c>true</c> when <paramref name="key"/>.sid is the resolver's current pick for <paramref name="key"/>.identity.
         /// Cleanup uses this in place of "sid disappeared from snapshot" — it also reaps demoted ghost sids that
         /// still exist in the registry but lost to a fresher candidate.
         /// </summary>
-        bool IsActiveSid(string walletId, string sid);
+        bool IsActiveSid(StreamKey key);
 
         /// <summary>
         /// Returns <c>true</c> if <paramref name="walletId"/> was present in the latest

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
@@ -25,9 +25,10 @@ namespace DCL.VoiceChat.Nearby.Audio
         Weak<AudioStream> GetActiveStream(StreamKey key);
 
         /// <summary>
-        /// The single active sid for an identity (the candidate that most recently emitted a media frame across all
-        /// known sids), or <c>null</c> if the identity has no sids OR none of its candidates have ever emitted a frame.
-        /// The latter is a transient "not-yet-decided" window: the bridge will re-poll next tick and self-heal.
+        /// The single active sid for an identity. Returns <c>null</c> if the identity has no sids.
+        /// Single-candidate fast path: returned eagerly without consulting the frame oracle (a lone candidate is active by definition).
+        /// Multi-candidate: picks the sid that most recently emitted a media frame; returns <c>null</c> if none of the candidates has
+        /// ever emitted a frame — a transient "not-yet-decided" window that the bridge re-polls next tick and self-heals.
         /// </summary>
         string? GetActiveSid(string walletId);
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
@@ -35,6 +35,20 @@ namespace DCL.VoiceChat.Nearby.Audio
         bool IsStreamGone(StreamKey key);
 
         /// <summary>
+        /// The single active sid for an identity (the candidate that most recently emitted a media frame across all
+        /// known sids), or <c>null</c> if the identity has no sids OR none of its candidates have ever emitted a frame.
+        /// The latter is a transient "not-yet-decided" window: the bridge will re-poll next tick and self-heal.
+        /// </summary>
+        string? GetActiveSid(string walletId);
+
+        /// <summary>
+        /// <c>true</c> when <paramref name="sid"/> is the resolver's current pick for <paramref name="walletId"/>.
+        /// Cleanup uses this in place of "sid disappeared from snapshot" — it also reaps demoted ghost sids that
+        /// still exist in the registry but lost to a fresher candidate.
+        /// </summary>
+        bool IsActiveSid(string walletId, string sid);
+
+        /// <summary>
         /// Returns <c>true</c> if <paramref name="walletId"/> was present in the latest
         /// <see cref="LiveKit.Rooms.ActiveSpeakers.IActiveSpeakers.Updated"/> snapshot. Pull-based and
         /// allocation-free so per-frame ECS systems can call it without touching <see cref="LiveKit.Rooms.IRoom"/>.

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/INearbyAudioStreamRegistry.cs
@@ -19,20 +19,10 @@ namespace DCL.VoiceChat.Nearby.Audio
         bool HasAudioStream(string walletId);
 
         /// <summary>
-        /// Raw reference to the registry's copy-on-write sid array. <c>null</c> when the wallet is not indexed.
-        /// Used by <see cref="LiveKit.Rooms.IRoom"/>-driven systems that need to compare snapshots via
-        /// <see cref="object.ReferenceEquals(object,object)"/> — a different reference ↔ content changed.
-        /// <b>Never mutate.</b> Treat the returned array as immutable from the caller's perspective.
-        /// </summary>
-        string[]? GetAudioSidsArray(string walletId);
-
-        /// <summary>
         /// Resolves a stream lazily. Must be called from the main thread — <see cref="AudioStream"/>'s constructor
         /// reads Unity audio settings and performs a synchronous FFI request.
         /// </summary>
         Weak<AudioStream> GetActiveStream(StreamKey key);
-
-        bool IsStreamGone(StreamKey key);
 
         /// <summary>
         /// The single active sid for an identity (the candidate that most recently emitted a media frame across all

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
@@ -242,7 +242,7 @@ namespace DCL.VoiceChat.Nearby.Audio
         // Publishes a NEW filtered array on every successful update; never mutates 'prev'.
         // Required by the immutability contract in the class XML: GetActiveSid iterates the
         // array assuming snapshot semantics — in-place edits would race the resolver mid-pick.
-        // Single-writer assumption (serial FFI dispatch) — no CAS retry needed.
+        // Single-writer assumption (serial FFI dispatch).
         private void RemoveAudioSid(string identity, string sid)
         {
             DCLConcurrentDictionary<string, string[]> snap = DCLVolatile.Read(ref streamsByIdentity);

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
@@ -134,6 +134,42 @@ namespace DCL.VoiceChat.Nearby.Audio
             return Array.IndexOf(sids, key.sid) < 0;
         }
 
+        public string? GetActiveSid(string walletId)
+        {
+            if (!DCLVolatile.Read(ref streamsByIdentity).TryGetValue(walletId, out string[]? sids) || sids.Length == 0)
+                return null;
+
+            // Hot path: a single candidate is the active sid by definition; do not consult the frame oracle.
+            if (sids.Length == 1) return sids[0];
+
+            int bestTick = 0;
+            string? bestSid = null;
+
+            foreach (string sid in sids)
+            {
+                int t = room.AudioStreams.GetLastFrameReceivedAt(new StreamKey(walletId, sid));
+
+                // -1 sentinel: AudioStream missing or never decoded a frame. Ghosts and not-yet-live tracks both
+                // land here; we cannot let them win against a candidate that has provably emitted audio.
+                if (t == -1) continue;
+
+                // unchecked(t - bestTick) > 0 is wrap-safe across the ~49-day Environment.TickCount window.
+                if (bestSid is null || unchecked(t - bestTick) > 0)
+                {
+                    bestTick = t;
+                    bestSid = sid;
+                }
+            }
+
+            return bestSid;
+        }
+
+        public bool IsActiveSid(string walletId, string sid)
+        {
+            string? active = GetActiveSid(walletId);
+            return active is not null && string.Equals(active, sid, StringComparison.Ordinal);
+        }
+
         private void OnConnectionUpdated(IRoom _, ConnectionUpdate update, LKDisconnectReason? __)
         {
             switch (update)

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
@@ -42,8 +42,7 @@ namespace DCL.VoiceChat.Nearby.Audio
     {
         private readonly IRoom room;
 
-        // Frame-activity oracle seam: the LiveKit-side helper lives on an extension and AudioStream itself is
-        // FFI-bound + non-virtual, so a delegate is the only injectable shape for tests.
+        // delegate is the only injectable shape for tests.
         private readonly Func<StreamKey, Option<int>> getLastFrameReceivedAt;
 
         // Immutability contract — see class XML. Swappable via Interlocked.Exchange / Volatile.Read. // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
@@ -42,6 +42,10 @@ namespace DCL.VoiceChat.Nearby.Audio
     {
         private readonly IRoom room;
 
+        // Frame-activity oracle seam: the LiveKit-side helper lives on an extension and AudioStream itself is
+        // FFI-bound + non-virtual, so a delegate is the only injectable shape for tests.
+        private readonly Func<StreamKey, Option<int>> getLastFrameReceivedAt;
+
         // Immutability contract — see class XML. Swappable via Interlocked.Exchange / Volatile.Read. // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
         // concurrencyLevel: 1 — FFI dispatch is serial, only one writer ever; saves the per-instance lock array (default = Environment.ProcessorCount).
         private DCLConcurrentDictionary<string, string[]> streamsByIdentity = NewSnapshot();
@@ -53,8 +57,12 @@ namespace DCL.VoiceChat.Nearby.Audio
         public int RebuildEpoch => DCLVolatile.Read(ref rebuildEpoch);
 
         public NearbyAudioStreamsRegistry(IRoom room)
+            : this(room, key => room.AudioStreams.GetLastFrameReceivedAt(key)) { }
+
+        internal NearbyAudioStreamsRegistry(IRoom room, Func<StreamKey, Option<int>> getLastFrameReceivedAt)
         {
             this.room = room;
+            this.getLastFrameReceivedAt = getLastFrameReceivedAt;
 
             room.ConnectionUpdated += OnConnectionUpdated;
 
@@ -135,10 +143,12 @@ namespace DCL.VoiceChat.Nearby.Audio
 
             foreach (string sid in sids)
             {
-                int t = room.AudioStreams.GetLastFrameReceivedAt(new StreamKey(walletId, sid));
+                Option<int> lastFrame = getLastFrameReceivedAt(new StreamKey(walletId, sid));
 
-                // -1 sentinel: AudioStream missing or never decoded a frame.
-                if (t == -1) continue;
+                // Option.None: AudioStream missing or never decoded a frame.
+                if (!lastFrame.Has) continue;
+
+                int t = lastFrame.Value;
 
                 if (bestSid is null || unchecked(t - bestTick) > 0)
                 {

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
@@ -35,7 +35,7 @@ namespace DCL.VoiceChat.Nearby.Audio
     ///         <b>Immutability contract.</b> Per-identity <c>string[]</c> arrays are copy-on-write
     ///         (every mutation publishes a new reference); the dictionary itself is swapped atomically on rehydrate / disconnect.
     ///         Do <b>not</b> reintroduce in-place mutation (array resize, pooled buffers, dict <c>Clear()</c>+rebuild) —
-    ///         the bridge's <c>ReferenceEquals</c> freshness check and the cleanup system's "stream gone" detection both rely on these invariants.
+    ///         <see cref="GetActiveSid"/> iterates the array assuming snapshot semantics; in-place edits would race the resolver.
     ///     </para>
     /// </summary>
     public sealed class NearbyAudioStreamsRegistry : INearbyAudioStreamRegistry
@@ -119,20 +119,8 @@ namespace DCL.VoiceChat.Nearby.Audio
         public bool HasAudioStream(string walletId) =>
             DCLVolatile.Read(ref streamsByIdentity).ContainsKey(walletId);
 
-        // ReSharper disable once CanSimplifyDictionaryTryGetValueWithGetValueOrDefault
-        public string[]? GetAudioSidsArray(string walletId) =>
-            DCLVolatile.Read(ref streamsByIdentity).TryGetValue(walletId, out string[]? arr) ? arr : null;
-
         public Weak<AudioStream> GetActiveStream(StreamKey key) =>
             room.AudioStreams.ActiveStream(key);
-
-        public bool IsStreamGone(StreamKey key)
-        {
-            if (!DCLVolatile.Read(ref streamsByIdentity).TryGetValue(key.identity, out string[]? sids))
-                return true;
-
-            return Array.IndexOf(sids, key.sid) < 0;
-        }
 
         public string? GetActiveSid(string walletId)
         {
@@ -252,9 +240,8 @@ namespace DCL.VoiceChat.Nearby.Audio
         }
 
         // Publishes a NEW filtered array on every successful update; never mutates 'prev'.
-        // Required by the immutability contract in the class XML: NearbyLivekitBridgeSystem
-        // uses ReferenceEquals(observed, current) for its per-frame freshness check, so any
-        // in-place mutation of a published array would silently hide the change from the bridge.
+        // Required by the immutability contract in the class XML: GetActiveSid iterates the
+        // array assuming snapshot semantics — in-place edits would race the resolver mid-pick.
         // Single-writer assumption (serial FFI dispatch) — no CAS retry needed.
         private void RemoveAudioSid(string identity, string sid)
         {

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Core/NearbyAudioStreamsRegistry.cs
@@ -137,11 +137,9 @@ namespace DCL.VoiceChat.Nearby.Audio
             {
                 int t = room.AudioStreams.GetLastFrameReceivedAt(new StreamKey(walletId, sid));
 
-                // -1 sentinel: AudioStream missing or never decoded a frame. Ghosts and not-yet-live tracks both
-                // land here; we cannot let them win against a candidate that has provably emitted audio.
+                // -1 sentinel: AudioStream missing or never decoded a frame.
                 if (t == -1) continue;
 
-                // unchecked(t - bestTick) > 0 is wrap-safe across the ~49-day Environment.TickCount window.
                 if (bestSid is null || unchecked(t - bestTick) > 0)
                 {
                     bestTick = t;
@@ -152,10 +150,10 @@ namespace DCL.VoiceChat.Nearby.Audio
             return bestSid;
         }
 
-        public bool IsActiveSid(string walletId, string sid)
+        public bool IsActiveSid(StreamKey key)
         {
-            string? active = GetActiveSid(walletId);
-            return active is not null && string.Equals(active, sid, StringComparison.Ordinal);
+            string? active = GetActiveSid(key.identity);
+            return active is not null && string.Equals(active, key.sid, StringComparison.Ordinal);
         }
 
         private void OnConnectionUpdated(IRoom _, ConnectionUpdate update, LKDisconnectReason? __)

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioBindingSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioBindingSystem.cs
@@ -11,35 +11,29 @@ using ECS.LifeCycle.Components;
 using LiveKit.Rooms.Streaming;
 using LiveKit.Rooms.Streaming.Audio;
 using RichTypes;
-using System.Collections.Generic;
 
 namespace DCL.VoiceChat.Nearby.Systems
 {
     /// <summary>
     ///     Owns the creation part of the Nearby audio-source lifecycle.
     ///     For every avatar entity (<see cref="Profile"/> + <see cref="AvatarBase"/> + <see cref="NearbyAudioStreamerComponent"/> + <see cref="InAudibleRangeTag"/>)
-    ///     the system materializes a single audio-source entity for the resolver-picked <c>(walletId, CurrentSid)</c> pair when one does not yet exist.
-    ///     Throttled to a fixed budget per frame so a crowd ramp-up does not spike a single tick.
+    ///     the system materializes the audio-source component for the resolver-picked <c>(walletId, CurrentSid)</c> pair when one does not yet exist.
     /// </summary>
     [UpdateInGroup(typeof(NearbyVoiceChatGroup))]
     [UpdateAfter(typeof(NearbyAudibleRangeSystem))]
     [UpdateBefore(typeof(NearbyAudioPositionSystem))]
     public partial class NearbyAudioBindingSystem : BaseUnityLoopSystem
     {
-        internal const int MAX_CREATIONS_PER_FRAME = 10;
-
         private readonly INearbyAudioStreamRegistry registry;
-        private readonly HashSet<StreamKey> bindings;
         private readonly IUserBlockingCache userBlockingCache;
         private readonly NearbyVoiceChatStateModel stateModel;
         private readonly INearbyAudioSourceFactory sourceFactory;
         private readonly RoomMetadataCurrentScene roomMetadataCurrentScene;
 
 
-        internal NearbyAudioBindingSystem(World world, INearbyAudioStreamRegistry registry, HashSet<StreamKey> bindings, IUserBlockingCache userBlockingCache, NearbyVoiceChatStateModel stateModel, INearbyAudioSourceFactory sourceFactory, RoomMetadataCurrentScene roomMetadataCurrentScene) : base(world)
+        internal NearbyAudioBindingSystem(World world, INearbyAudioStreamRegistry registry, IUserBlockingCache userBlockingCache, NearbyVoiceChatStateModel stateModel, INearbyAudioSourceFactory sourceFactory, RoomMetadataCurrentScene roomMetadataCurrentScene) : base(world)
         {
             this.registry = registry;
-            this.bindings = bindings;
             this.userBlockingCache = userBlockingCache;
             this.stateModel = stateModel;
             this.sourceFactory = sourceFactory;
@@ -73,9 +67,10 @@ namespace DCL.VoiceChat.Nearby.Systems
 
             // The resolver dedup contract guarantees one active sid per participant — bridge keeps CurrentSid
             // in sync with the registry's pick. Iterate it directly; no per-avatar registry call on the hot path.
+            // Dedup against duplicate creation lives in the [None<NearbyAudioSourceComponent>] archetype filter — one
+            // source per avatar entity is the invariant, and the one-avatar-per-walletId invariant from the profile
+            // layer guarantees this also dedups by StreamKey.
             var key = new StreamKey(walletId, nearby.CurrentSid);
-
-            if (bindings.Contains(key)) return;
 
             Weak<AudioStream> stream = registry.GetActiveStream(key);
 
@@ -84,8 +79,6 @@ namespace DCL.VoiceChat.Nearby.Systems
 
             LivekitAudioSource source = sourceFactory.Create(key, stream);
             World.Add(avatarEntity, new NearbyAudioSourceComponent(key, source));
-
-            bindings.Add(key);
         }
     }
 }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioBindingSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioBindingSystem.cs
@@ -61,7 +61,7 @@ namespace DCL.VoiceChat.Nearby.Systems
         }
 
         [Query]
-        [None(typeof(DeleteEntityIntention))]
+        [None(typeof(NearbyAudioSourceComponent), typeof(DeleteEntityIntention))]
         [All(typeof(AvatarBase), typeof(NearbyAudioStreamerComponent), typeof(InAudibleRangeTag))]
         private void CreateAndBindAudioSourcesToStreamers(Entity avatarEntity, in Profile profile, in NearbyAudioStreamerComponent nearby)
         {
@@ -83,8 +83,8 @@ namespace DCL.VoiceChat.Nearby.Systems
             if (!stream.Resource.Has) return;
 
             LivekitAudioSource source = sourceFactory.Create(key, stream);
+            World.Add(avatarEntity, new NearbyAudioSourceComponent(key, source));
 
-            World.Create(new NearbyAudioSourceComponent(key, avatarEntity, source));
             bindings.Add(key);
         }
     }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioBindingSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioBindingSystem.cs
@@ -18,7 +18,7 @@ namespace DCL.VoiceChat.Nearby.Systems
     /// <summary>
     ///     Owns the creation part of the Nearby audio-source lifecycle.
     ///     For every avatar entity (<see cref="Profile"/> + <see cref="AvatarBase"/> + <see cref="NearbyAudioStreamerComponent"/> + <see cref="InAudibleRangeTag"/>)
-    ///     the system iterates the snapshotted sids on the entity itself and materializes an audio-source entity per <c>(walletId, sid)</c> pair that does not yet have one.
+    ///     the system materializes a single audio-source entity for the resolver-picked <c>(walletId, CurrentSid)</c> pair when one does not yet exist.
     ///     Throttled to a fixed budget per frame so a crowd ramp-up does not spike a single tick.
     /// </summary>
     [UpdateInGroup(typeof(NearbyVoiceChatGroup))]
@@ -71,25 +71,21 @@ namespace DCL.VoiceChat.Nearby.Systems
             // Skip blocked / scene-banned identities. Cleanup system handles already-bound entities; this filter prevents creation in the first place.
             if (userBlockingCache.UserIsBlocked(walletId) || roomMetadataCurrentScene.IsUserBanned(walletId)) return;
 
-            // Sids ride on the entity itself — no registry call on the per-avatar hot path.
-            // Bridge system guarantees SidsSnapshot is non-null for any entity that has the component.
-            foreach (string sid in nearby.StreamSidsSnapshot)
-            {
-                var key = new StreamKey(walletId, sid);
+            // The resolver dedup contract guarantees one active sid per participant — bridge keeps CurrentSid
+            // in sync with the registry's pick. Iterate it directly; no per-avatar registry call on the hot path.
+            var key = new StreamKey(walletId, nearby.CurrentSid);
 
-                if (!bindings.Contains(key))
-                {
-                    Weak<AudioStream> stream = registry.GetActiveStream(key);
+            if (bindings.Contains(key)) return;
 
-                    // Track was unsubscribed between collection (snapshot read) and resolve (GetActiveStream); skip to avoid a one-frame ghost source.
-                    if (!stream.Resource.Has) continue;
+            Weak<AudioStream> stream = registry.GetActiveStream(key);
 
-                    LivekitAudioSource source = sourceFactory.Create(key, stream);
+            // Track was unsubscribed between bridge tick and resolve (GetActiveStream); skip to avoid a one-frame ghost source.
+            if (!stream.Resource.Has) return;
 
-                    World.Create(new NearbyAudioSourceComponent(key, avatarEntity, source));
-                    bindings.Add(key);
-                }
-            }
+            LivekitAudioSource source = sourceFactory.Create(key, stream);
+
+            World.Create(new NearbyAudioSourceComponent(key, avatarEntity, source));
+            bindings.Add(key);
         }
     }
 }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioBindingSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioBindingSystem.cs
@@ -16,7 +16,7 @@ namespace DCL.VoiceChat.Nearby.Systems
 {
     /// <summary>
     ///     Owns the creation part of the Nearby audio-source lifecycle.
-    ///     For every avatar entity (<see cref="Profile"/> + <see cref="AvatarBase"/> + <see cref="NearbyAudioStreamerComponent"/> + <see cref="InAudibleRangeTag"/>)
+    ///     Creates audio source component for every avatar streamer in audible range
     ///     the system materializes the audio-source component for the resolver-picked <c>(walletId, CurrentSid)</c> pair when one does not yet exist.
     /// </summary>
     [UpdateInGroup(typeof(NearbyVoiceChatGroup))]
@@ -56,7 +56,7 @@ namespace DCL.VoiceChat.Nearby.Systems
 
         [Query]
         [None(typeof(NearbyAudioSourceComponent), typeof(DeleteEntityIntention))]
-        [All(typeof(AvatarBase), typeof(NearbyAudioStreamerComponent), typeof(InAudibleRangeTag))]
+        [All(typeof(AvatarBase), typeof(InAudibleRangeTag))]
         private void CreateAndBindAudioSourcesToStreamers(Entity avatarEntity, in Profile profile, in NearbyAudioStreamerComponent nearby)
         {
             string walletId = profile.UserId;
@@ -65,20 +65,14 @@ namespace DCL.VoiceChat.Nearby.Systems
             // Skip blocked / scene-banned identities. Cleanup system handles already-bound entities; this filter prevents creation in the first place.
             if (userBlockingCache.UserIsBlocked(walletId) || roomMetadataCurrentScene.IsUserBanned(walletId)) return;
 
-            // The resolver dedup contract guarantees one active sid per participant — bridge keeps CurrentSid
-            // in sync with the registry's pick. Iterate it directly; no per-avatar registry call on the hot path.
-            // Dedup against duplicate creation lives in the [None<NearbyAudioSourceComponent>] archetype filter — one
-            // source per avatar entity is the invariant, and the one-avatar-per-walletId invariant from the profile
-            // layer guarantees this also dedups by StreamKey.
             var key = new StreamKey(walletId, nearby.CurrentSid);
-
             Weak<AudioStream> stream = registry.GetActiveStream(key);
 
-            // Track was unsubscribed between bridge tick and resolve (GetActiveStream); skip to avoid a one-frame ghost source.
-            if (!stream.Resource.Has) return;
-
-            LivekitAudioSource source = sourceFactory.Create(key, stream);
-            World.Add(avatarEntity, new NearbyAudioSourceComponent(key, source));
+            if (stream.Resource.Has)
+            {
+                LivekitAudioSource source = sourceFactory.Create(key, stream);
+                World.Add(avatarEntity, new NearbyAudioSourceComponent(key, source));
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
@@ -14,21 +14,18 @@ using System.Collections.Generic;
 namespace DCL.VoiceChat.Nearby.Systems
 {
     /// <summary>
-    ///     Detection + teardown for Nearby audio-source entities.
+    ///     Detection + teardown for Nearby audio-source components (co-located on the avatar entity).
     ///     <para>
-    ///         <b>Detection</b> — per tick tags doomed audio entities with <see cref="DeleteEntityIntention"/> on any of:
+    ///         <b>Triggers:</b>
     ///         <list type="bullet">
-    ///             <item><description><b>Trigger #1 (avatar gone)</b> — linked avatar entity is dead or flagged with  <see cref="DeleteEntityIntention"/>.</description></item>
-    ///             <item><description><b>Trigger #2 (sid not active)</b> — registry's resolver no longer picks the bound <c>(walletId, sid)</c> (either the sid was evicted, or a fresher candidate won).</description></item>
-    ///             <item><description><b>Trigger #3 (blocked)</b> — <see cref="IUserBlockingCache.UserIsBlocked"/> returns  <c>true</c> for the bound <c>walletId</c>.</description></item>
-    ///             <item><description><b>Trigger #4 (scene-banned)</b> — <see cref="RoomMetadataCurrentScene.IsUserBanned"/> returns <c>true</c> for the bound <c>walletId</c>.</description></item>
-    ///             <item><description><b>Trigger #5 (listening gate)</b> — bulk removal when <see cref="NearbyVoiceChatStateModel"/> is in   <see cref="NearbyVoiceChatState.SUPPRESSED"/> or <see cref="NearbyVoiceChatState.DISABLED"/>;</description></item>
+    ///             <item><description><b>#1 streamer marker gone</b> — avatar lost <see cref="NearbyAudioStreamerComponent"/>.</description></item>
+    ///             <item><description><b>#2 out of range</b> — avatar lost <see cref="InAudibleRangeTag"/>.</description></item>
+    ///             <item><description><b>#3 sid not active</b> — registry's resolver no longer picks the bound <c>(walletId, sid)</c>.</description></item>
+    ///             <item><description><b>#4 blocked</b> — <see cref="IUserBlockingCache.UserIsBlocked"/> returns <c>true</c>.</description></item>
+    ///             <item><description><b>#5 scene-banned</b> — <see cref="RoomMetadataCurrentScene.IsUserBanned"/> returns <c>true</c>.</description></item>
+    ///             <item><description><b>#6 listening gate</b> — bulk removal when state is <see cref="NearbyVoiceChatState.SUPPRESSED"/> / <see cref="NearbyVoiceChatState.DISABLED"/>.</description></item>
+    ///             <item><description><b>#7 avatar dying</b> — avatar carries <see cref="DeleteEntityIntention"/>; dispose source, component goes away with the entity.</description></item>
     ///         </list>
-    ///     </para>
-    ///     <para>
-    ///         <b>Teardown</b> — reacts to entities now carrying <see cref="DeleteEntityIntention"/>:
-    ///          - disposes the <see cref="LivekitAudioSource"/> to the pool via <see cref="NearbyAudioSourceFactory"/> (Stop → Free → SafeDestroyGameObject)
-    ///          - removes the <c>(walletId, sid) → entity</c> binding. Physical entity destruction is delegated to <see cref="DestroyEntitiesSystem"/>.
     ///     </para>
     /// </summary>
     [UpdateInGroup(typeof(CleanUpGroup))]
@@ -71,47 +68,62 @@ namespace DCL.VoiceChat.Nearby.Systems
                 sourceFactory.InvalidateForDeviceChange();
             }
 
-            // Listening-gate AND device-change are bulk archetype-moves; per-entity detection is skipped in either case.
+            // Listening-gate AND device-change are bulk component-removes; per-entity detection is skipped in either case.
             if (stateModel.IsListeningDisabled || deviceChanged)
-                World.Add<DeleteEntityIntention>(in LIVE_AUDIO_QUERY);
+            {
+                DisposeAllLiveSourcesQuery(World);
+                World.Remove<NearbyAudioSourceComponent>(in LIVE_AUDIO_QUERY);
+                bindings.Clear();
+            }
             else
-                FlagDoomedAudioEntitiesQuery(World);
+                CleanupDoomedSourceQuery(World);
 
-            TearDownMarkedAudioEntitiesQuery(World);
+            // Trigger #7: avatars marked for deletion still carry the component until the entity is destroyed
+            // elsewhere. Dispose the source; do NOT World.Remove (the avatar takes the component with it).
+            DisposeDyingAvatarSourcesQuery(World);
         }
 
         protected override void OnDispose()
         {
-            DisposeAllAudioSourcesQuery(World);
+            DisposeAllLiveSourcesQuery(World);
+            DisposeDyingAvatarSourcesQuery(World);
             bindings.Clear();
+        }
+
+        // !IsActiveSid covers two cases: (1) sid evicted entirely → resolver returns different sid or null;
+        // (2) sid demoted → resolver picked a fresher candidate. The ghost loser of the pick is reaped here
+        // so binding can spawn the new winner.
+        [Query]
+        [None(typeof(DeleteEntityIntention))]
+        private void CleanupDoomedSource(Entity entity, ref NearbyAudioSourceComponent comp)
+        {
+            bool doomed = !World.Has<NearbyAudioStreamerComponent>(entity)
+                          || !World.Has<InAudibleRangeTag>(entity)
+                          || !registry.IsActiveSid(comp.Key.identity, comp.Key.sid)
+                          || userBlockingCache.UserIsBlocked(comp.Key.identity)
+                          || roomMetadataCurrentScene.IsUserBanned(comp.Key.identity);
+
+            if (!doomed) return;
+
+            sourceFactory.Dispose(comp.LivekitAudioSource);
+            StreamKey key = comp.Key;
+            World.Remove<NearbyAudioSourceComponent>(entity);
+            bindings.Remove(key);
         }
 
         [Query]
         [None(typeof(DeleteEntityIntention))]
-        private void FlagDoomedAudioEntities(Entity audioEntity, ref NearbyAudioSourceComponent comp)
+        private void DisposeAllLiveSources(ref NearbyAudioSourceComponent comp)
         {
-            Entity avatar = comp.AvatarEntity;
-
-            // Component absence ≠ avatar gone. Component absence ≠ specific sid gone either. Both fallbacks must remain.
-            // !IsActiveSid covers two cases: (1) sid evicted entirely → resolver returns different sid or null; (2) sid demoted →
-            // resolver picked a fresher candidate. The ghost loser of the pick is reaped here so binding can spawn the new winner.
-            bool avatarGoneOrOutOfRange = !World.IsAlive(avatar) || World.Has<DeleteEntityIntention>(avatar) || !World.Has<NearbyAudioStreamerComponent>(avatar) || !World.Has<InAudibleRangeTag>(avatar);
-            if (avatarGoneOrOutOfRange || !registry.IsActiveSid(comp.Key.identity, comp.Key.sid) || userBlockingCache.UserIsBlocked(comp.Key.identity) || roomMetadataCurrentScene.IsUserBanned(comp.Key.identity))
-                World.Add<DeleteEntityIntention>(audioEntity);
+            sourceFactory.Dispose(comp.LivekitAudioSource);
         }
 
         [Query]
         [All(typeof(DeleteEntityIntention))]
-        private void TearDownMarkedAudioEntities(ref NearbyAudioSourceComponent comp)
+        private void DisposeDyingAvatarSources(ref NearbyAudioSourceComponent comp)
         {
             sourceFactory.Dispose(comp.LivekitAudioSource);
             bindings.Remove(comp.Key);
-        }
-
-        [Query]
-        private void DisposeAllAudioSources(ref NearbyAudioSourceComponent comp)
-        {
-            sourceFactory.Dispose(comp.LivekitAudioSource);
         }
     }
 }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
@@ -19,7 +19,7 @@ namespace DCL.VoiceChat.Nearby.Systems
     ///         <b>Detection</b> — per tick tags doomed audio entities with <see cref="DeleteEntityIntention"/> on any of:
     ///         <list type="bullet">
     ///             <item><description><b>Trigger #1 (avatar gone)</b> — linked avatar entity is dead or flagged with  <see cref="DeleteEntityIntention"/>.</description></item>
-    ///             <item><description><b>Trigger #2 (stream gone)</b> — registry no longer reports the bound <c>(walletId, sid)</c>.</description></item>
+    ///             <item><description><b>Trigger #2 (sid not active)</b> — registry's resolver no longer picks the bound <c>(walletId, sid)</c> (either the sid was evicted, or a fresher candidate won).</description></item>
     ///             <item><description><b>Trigger #3 (blocked)</b> — <see cref="IUserBlockingCache.UserIsBlocked"/> returns  <c>true</c> for the bound <c>walletId</c>.</description></item>
     ///             <item><description><b>Trigger #4 (scene-banned)</b> — <see cref="RoomMetadataCurrentScene.IsUserBanned"/> returns <c>true</c> for the bound <c>walletId</c>.</description></item>
     ///             <item><description><b>Trigger #5 (listening gate)</b> — bulk removal when <see cref="NearbyVoiceChatStateModel"/> is in   <see cref="NearbyVoiceChatState.SUPPRESSED"/> or <see cref="NearbyVoiceChatState.DISABLED"/>;</description></item>
@@ -93,8 +93,10 @@ namespace DCL.VoiceChat.Nearby.Systems
             Entity avatar = comp.AvatarEntity;
 
             // Component absence ≠ avatar gone. Component absence ≠ specific sid gone either. Both fallbacks must remain.
+            // !IsActiveSid covers two cases: (1) sid evicted entirely → resolver returns different sid or null; (2) sid demoted →
+            // resolver picked a fresher candidate. The ghost loser of the pick is reaped here so binding can spawn the new winner.
             bool avatarGoneOrOutOfRange = !World.IsAlive(avatar) || World.Has<DeleteEntityIntention>(avatar) || !World.Has<NearbyAudioStreamerComponent>(avatar) || !World.Has<InAudibleRangeTag>(avatar);
-            if (avatarGoneOrOutOfRange || registry.IsStreamGone(comp.Key) || userBlockingCache.UserIsBlocked(comp.Key.identity) || roomMetadataCurrentScene.IsUserBanned(comp.Key.identity))
+            if (avatarGoneOrOutOfRange || !registry.IsActiveSid(comp.Key.identity, comp.Key.sid) || userBlockingCache.UserIsBlocked(comp.Key.identity) || roomMetadataCurrentScene.IsUserBanned(comp.Key.identity))
                 World.Add<DeleteEntityIntention>(audioEntity);
         }
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
@@ -30,9 +30,6 @@ namespace DCL.VoiceChat.Nearby.Systems
     [LogCategory(ReportCategory.NEARBY_VOICE_CHAT)]
     public partial class NearbyAudioCleanupSystem : BaseUnityLoopSystem
     {
-        private static readonly QueryDescription LIVE_AUDIO_QUERY =
-            new QueryDescription().WithAll<NearbyAudioSourceComponent>().WithNone<DeleteEntityIntention>();
-
         private readonly INearbyAudioStreamRegistry registry;
         private readonly IUserBlockingCache userBlockingCache;
         private readonly NearbyVoiceChatStateModel stateModel;
@@ -64,22 +61,17 @@ namespace DCL.VoiceChat.Nearby.Systems
                 sourceFactory.InvalidateForDeviceChange();
             }
 
-            // Listening-gate AND device-change are bulk component-removes; per-entity detection is skipped in either case.
+            // Listening-gate AND device-change wipe every live source; per-entity detection is skipped in either case.
             if (stateModel.IsListeningDisabled || deviceChanged)
-            {
                 DisposeAllLiveSourcesQuery(World);
-                World.Remove<NearbyAudioSourceComponent>(in LIVE_AUDIO_QUERY);
-            }
             else
             {
                 ReapOrphanedSourceQuery(World);     // #1: streamer marker gone
                 ReapOutOfRangeSourceQuery(World);   // #2: audible-range tag gone
-                ReapFilteredSourceQuery(World);     // #3 sid demoted / #4 blocked / #5 scene-banned
+                ReapFilteredSourceQuery(World);     // #3-4-5 sid demoted / user blocked or banned by the scene
             }
 
-            // Trigger #7: avatars marked for deletion still carry the component until the entity is destroyed
-            // elsewhere. Dispose the source; do NOT World.Remove (the avatar takes the component with it).
-            DisposeDyingAvatarSourcesQuery(World);
+            DisposeDyingAvatarSourcesQuery(World); // #7: avatars marked for deletion
         }
 
         protected override void OnDispose()
@@ -88,31 +80,32 @@ namespace DCL.VoiceChat.Nearby.Systems
             DisposeDyingAvatarSourcesQuery(World);
         }
 
-        // Trigger #1: avatar lost NearbyAudioStreamerComponent — unconditional reap.
+        // #1: avatar is not a streamer anymore (lost NearbyAudioStreamerComponent).
         [Query]
         [None(typeof(DeleteEntityIntention), typeof(NearbyAudioStreamerComponent))]
         private void ReapOrphanedSource(Entity entity, ref NearbyAudioSourceComponent comp) =>
             DisposeAndRemove(entity, ref comp);
 
-        // Trigger #2: avatar left audible range — unconditional reap.
+        // #2: avatar left audible range.
         [Query]
         [All(typeof(NearbyAudioStreamerComponent))]
         [None(typeof(DeleteEntityIntention), typeof(InAudibleRangeTag))]
         private void ReapOutOfRangeSource(Entity entity, ref NearbyAudioSourceComponent comp) =>
             DisposeAndRemove(entity, ref comp);
 
-        // Triggers #3/#4/#5: !IsActiveSid covers sid evicted entirely (resolver picks different/null sid)
+        // #3/#4/#5:
+        // !IsActiveSid covers sid evicted entirely (resolver picks different/null sid)
         // AND sid demoted (resolver picked a fresher candidate — ghost loser reaped here so binding spawns the winner).
         [Query]
         [All(typeof(NearbyAudioStreamerComponent), typeof(InAudibleRangeTag))]
         [None(typeof(DeleteEntityIntention))]
         private void ReapFilteredSource(Entity entity, ref NearbyAudioSourceComponent comp)
         {
-            bool keep = registry.IsActiveSid(comp.Key.identity, comp.Key.sid)
-                        && !userBlockingCache.UserIsBlocked(comp.Key.identity)
-                        && !roomMetadataCurrentScene.IsUserBanned(comp.Key.identity);
+            bool remove = userBlockingCache.UserIsBlocked(comp.Key.identity)
+                          || roomMetadataCurrentScene.IsUserBanned(comp.Key.identity)
+                          || !registry.IsActiveSid(comp.Key);
 
-            if (!keep)
+            if (remove)
                 DisposeAndRemove(entity, ref comp);
         }
 
@@ -124,10 +117,8 @@ namespace DCL.VoiceChat.Nearby.Systems
 
         [Query]
         [None(typeof(DeleteEntityIntention))]
-        private void DisposeAllLiveSources(ref NearbyAudioSourceComponent comp)
-        {
-            sourceFactory.Dispose(comp.LivekitAudioSource);
-        }
+        private void DisposeAllLiveSources(Entity entity, ref NearbyAudioSourceComponent comp) =>
+            DisposeAndRemove(entity, ref comp);
 
         [Query]
         [All(typeof(DeleteEntityIntention))]

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
@@ -83,15 +83,15 @@ namespace DCL.VoiceChat.Nearby.Systems
         // #1: avatar is not a streamer anymore (lost NearbyAudioStreamerComponent).
         [Query]
         [None(typeof(DeleteEntityIntention), typeof(NearbyAudioStreamerComponent))]
-        private void ReapOrphanedSource(Entity entity, ref NearbyAudioSourceComponent comp) =>
-            DisposeAndRemove(entity, ref comp);
+        private void ReapOrphanedSource(Entity entity, in NearbyAudioSourceComponent comp) =>
+            DisposeAndRemove(entity, in comp);
 
         // #2: avatar left audible range.
         [Query]
         [All(typeof(NearbyAudioStreamerComponent))]
         [None(typeof(DeleteEntityIntention), typeof(InAudibleRangeTag))]
-        private void ReapOutOfRangeSource(Entity entity, ref NearbyAudioSourceComponent comp) =>
-            DisposeAndRemove(entity, ref comp);
+        private void ReapOutOfRangeSource(Entity entity, in NearbyAudioSourceComponent comp) =>
+            DisposeAndRemove(entity, in comp);
 
         // #3/#4/#5:
         // !IsActiveSid covers sid evicted entirely (resolver picks different/null sid)
@@ -99,17 +99,17 @@ namespace DCL.VoiceChat.Nearby.Systems
         [Query]
         [All(typeof(NearbyAudioStreamerComponent), typeof(InAudibleRangeTag))]
         [None(typeof(DeleteEntityIntention))]
-        private void ReapFilteredSource(Entity entity, ref NearbyAudioSourceComponent comp)
+        private void ReapFilteredSource(Entity entity, in NearbyAudioSourceComponent comp)
         {
             bool remove = userBlockingCache.UserIsBlocked(comp.Key.identity)
                           || roomMetadataCurrentScene.IsUserBanned(comp.Key.identity)
                           || !registry.IsActiveSid(comp.Key);
 
             if (remove)
-                DisposeAndRemove(entity, ref comp);
+                DisposeAndRemove(entity, in comp);
         }
 
-        private void DisposeAndRemove(Entity entity, ref NearbyAudioSourceComponent comp)
+        private void DisposeAndRemove(Entity entity, in NearbyAudioSourceComponent comp)
         {
             sourceFactory.Dispose(comp.LivekitAudioSource);
             World.Remove<NearbyAudioSourceComponent>(entity);
@@ -117,12 +117,12 @@ namespace DCL.VoiceChat.Nearby.Systems
 
         [Query]
         [None(typeof(DeleteEntityIntention))]
-        private void DisposeAllLiveSources(Entity entity, ref NearbyAudioSourceComponent comp) =>
-            DisposeAndRemove(entity, ref comp);
+        private void DisposeAllLiveSources(Entity entity, in NearbyAudioSourceComponent comp) =>
+            DisposeAndRemove(entity, in comp);
 
         [Query]
         [All(typeof(DeleteEntityIntention))]
-        private void DisposeDyingAvatarSources(ref NearbyAudioSourceComponent comp)
+        private void DisposeDyingAvatarSources(in NearbyAudioSourceComponent comp)
         {
             sourceFactory.Dispose(comp.LivekitAudioSource);
         }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
@@ -8,8 +8,6 @@ using DCL.VoiceChat.Nearby.Audio;
 using ECS.Abstract;
 using ECS.Groups;
 using ECS.LifeCycle.Components;
-using LiveKit.Rooms.Streaming;
-using System.Collections.Generic;
 
 namespace DCL.VoiceChat.Nearby.Systems
 {
@@ -36,7 +34,6 @@ namespace DCL.VoiceChat.Nearby.Systems
             new QueryDescription().WithAll<NearbyAudioSourceComponent>().WithNone<DeleteEntityIntention>();
 
         private readonly INearbyAudioStreamRegistry registry;
-        private readonly HashSet<StreamKey> bindings;
         private readonly IUserBlockingCache userBlockingCache;
         private readonly NearbyVoiceChatStateModel stateModel;
         private readonly INearbyAudioSourceFactory sourceFactory;
@@ -45,10 +42,9 @@ namespace DCL.VoiceChat.Nearby.Systems
         // Mismatch with registry.RebuildEpoch ⇒ output-device changed since last tick.
         private int lastSeenRebuildEpoch;
 
-        internal NearbyAudioCleanupSystem(World world, INearbyAudioStreamRegistry registry, HashSet<StreamKey> bindings, IUserBlockingCache userBlockingCache, NearbyVoiceChatStateModel stateModel, INearbyAudioSourceFactory sourceFactory, RoomMetadataCurrentScene roomMetadataCurrentScene) : base(world)
+        internal NearbyAudioCleanupSystem(World world, INearbyAudioStreamRegistry registry, IUserBlockingCache userBlockingCache, NearbyVoiceChatStateModel stateModel, INearbyAudioSourceFactory sourceFactory, RoomMetadataCurrentScene roomMetadataCurrentScene) : base(world)
         {
             this.registry = registry;
-            this.bindings = bindings;
             this.userBlockingCache = userBlockingCache;
             this.stateModel = stateModel;
             this.sourceFactory = sourceFactory;
@@ -73,7 +69,6 @@ namespace DCL.VoiceChat.Nearby.Systems
             {
                 DisposeAllLiveSourcesQuery(World);
                 World.Remove<NearbyAudioSourceComponent>(in LIVE_AUDIO_QUERY);
-                bindings.Clear();
             }
             else
             {
@@ -91,7 +86,6 @@ namespace DCL.VoiceChat.Nearby.Systems
         {
             DisposeAllLiveSourcesQuery(World);
             DisposeDyingAvatarSourcesQuery(World);
-            bindings.Clear();
         }
 
         // Trigger #1: avatar lost NearbyAudioStreamerComponent — unconditional reap.
@@ -125,9 +119,7 @@ namespace DCL.VoiceChat.Nearby.Systems
         private void DisposeAndRemove(Entity entity, ref NearbyAudioSourceComponent comp)
         {
             sourceFactory.Dispose(comp.LivekitAudioSource);
-            StreamKey key = comp.Key;
             World.Remove<NearbyAudioSourceComponent>(entity);
-            bindings.Remove(key);
         }
 
         [Query]
@@ -142,7 +134,6 @@ namespace DCL.VoiceChat.Nearby.Systems
         private void DisposeDyingAvatarSources(ref NearbyAudioSourceComponent comp)
         {
             sourceFactory.Dispose(comp.LivekitAudioSource);
-            bindings.Remove(comp.Key);
         }
     }
 }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioCleanupSystem.cs
@@ -76,7 +76,11 @@ namespace DCL.VoiceChat.Nearby.Systems
                 bindings.Clear();
             }
             else
-                CleanupDoomedSourceQuery(World);
+            {
+                ReapOrphanedSourceQuery(World);     // #1: streamer marker gone
+                ReapOutOfRangeSourceQuery(World);   // #2: audible-range tag gone
+                ReapFilteredSourceQuery(World);     // #3 sid demoted / #4 blocked / #5 scene-banned
+            }
 
             // Trigger #7: avatars marked for deletion still carry the component until the entity is destroyed
             // elsewhere. Dispose the source; do NOT World.Remove (the avatar takes the component with it).
@@ -90,21 +94,36 @@ namespace DCL.VoiceChat.Nearby.Systems
             bindings.Clear();
         }
 
-        // !IsActiveSid covers two cases: (1) sid evicted entirely → resolver returns different sid or null;
-        // (2) sid demoted → resolver picked a fresher candidate. The ghost loser of the pick is reaped here
-        // so binding can spawn the new winner.
+        // Trigger #1: avatar lost NearbyAudioStreamerComponent — unconditional reap.
         [Query]
+        [None(typeof(DeleteEntityIntention), typeof(NearbyAudioStreamerComponent))]
+        private void ReapOrphanedSource(Entity entity, ref NearbyAudioSourceComponent comp) =>
+            DisposeAndRemove(entity, ref comp);
+
+        // Trigger #2: avatar left audible range — unconditional reap.
+        [Query]
+        [All(typeof(NearbyAudioStreamerComponent))]
+        [None(typeof(DeleteEntityIntention), typeof(InAudibleRangeTag))]
+        private void ReapOutOfRangeSource(Entity entity, ref NearbyAudioSourceComponent comp) =>
+            DisposeAndRemove(entity, ref comp);
+
+        // Triggers #3/#4/#5: !IsActiveSid covers sid evicted entirely (resolver picks different/null sid)
+        // AND sid demoted (resolver picked a fresher candidate — ghost loser reaped here so binding spawns the winner).
+        [Query]
+        [All(typeof(NearbyAudioStreamerComponent), typeof(InAudibleRangeTag))]
         [None(typeof(DeleteEntityIntention))]
-        private void CleanupDoomedSource(Entity entity, ref NearbyAudioSourceComponent comp)
+        private void ReapFilteredSource(Entity entity, ref NearbyAudioSourceComponent comp)
         {
-            bool doomed = !World.Has<NearbyAudioStreamerComponent>(entity)
-                          || !World.Has<InAudibleRangeTag>(entity)
-                          || !registry.IsActiveSid(comp.Key.identity, comp.Key.sid)
-                          || userBlockingCache.UserIsBlocked(comp.Key.identity)
-                          || roomMetadataCurrentScene.IsUserBanned(comp.Key.identity);
+            bool keep = registry.IsActiveSid(comp.Key.identity, comp.Key.sid)
+                        && !userBlockingCache.UserIsBlocked(comp.Key.identity)
+                        && !roomMetadataCurrentScene.IsUserBanned(comp.Key.identity);
 
-            if (!doomed) return;
+            if (!keep)
+                DisposeAndRemove(entity, ref comp);
+        }
 
+        private void DisposeAndRemove(Entity entity, ref NearbyAudioSourceComponent comp)
+        {
             sourceFactory.Dispose(comp.LivekitAudioSource);
             StreamKey key = comp.Key;
             World.Remove<NearbyAudioSourceComponent>(entity);

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioPositionSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioPositionSystem.cs
@@ -12,8 +12,9 @@ using UnityEngine;
 namespace DCL.VoiceChat.Nearby.Systems
 {
     /// <summary>
-    ///     Reads position from the avatar entity referenced by <see cref="NearbyAudioSourceComponent.AvatarEntity"/>
-    ///     and drives the <see cref="LivekitAudioSource"/> transform + spatial angles each frame.
+    ///     Drives the <see cref="LivekitAudioSource"/> transform + spatial angles each frame.
+    ///     Reads <see cref="AvatarBase"/> from the same entity that carries the audio-source component
+    ///     (co-located after the slice-4 collapse — no cross-entity hop).
     /// </summary>
     [UpdateInGroup(typeof(NearbyVoiceChatGroup))]
     [UpdateAfter(typeof(NearbyAudioBindingSystem))]
@@ -36,16 +37,12 @@ namespace DCL.VoiceChat.Nearby.Systems
         }
 
         [Query]
+        [All(typeof(NearbyAudioStreamerComponent))]
         [None(typeof(DeleteEntityIntention))]
-        private void SyncPositionsAndSpatialAngles([Data] Transform listenerTransform, [Data] Vector3 playerHeadPos, ref NearbyAudioSourceComponent nearbyAudio)
+        private void SyncPositionsAndSpatialAngles([Data] Transform listenerTransform, [Data] Vector3 playerHeadPos, Entity entity, in AvatarBase avatarBase, ref NearbyAudioSourceComponent nearbyAudio)
         {
-            // Stale avatar entity reference — NearbyAudioCleanupSystem will tear this audio entity down in CleanUpGroup.
-            bool hasAvatar = World.TryGet(nearbyAudio.AvatarEntity, out AvatarBase? avatarBase);
-            if (!hasAvatar) return;
-
-            // Per-frame idempotent inactive-state application — self-healing
-            Entity avatar = nearbyAudio.AvatarEntity;
-            bool inactive = !World.TryGet(avatar, out InAudibleRangeTag rangeTag) || rangeTag.IsSuspended;
+            // Per-frame idempotent inactive-state application — self-healing.
+            bool inactive = !World.TryGet(entity, out InAudibleRangeTag rangeTag) || rangeTag.IsSuspended;
 
             LivekitAudioSource src = nearbyAudio.LivekitAudioSource;
 
@@ -61,7 +58,7 @@ namespace DCL.VoiceChat.Nearby.Systems
             if (inactive) return;
 
             // reprojection, so gain is calculated relative to the head and not the camera position (audioListener is on the camera)
-            Vector3 remoteAvatarHeadPos = avatarBase!.HeadAnchorPoint.position;
+            Vector3 remoteAvatarHeadPos = avatarBase.HeadAnchorPoint.position;
             Vector3 sourcePos = listenerTransform.position + (remoteAvatarHeadPos - playerHeadPos);
 
             if ((sourcePos - nearbyAudio.LastWrittenPos).sqrMagnitude > POSITION_EPSILON_SQR)

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioPositionSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioPositionSystem.cs
@@ -6,7 +6,6 @@ using ECS.Abstract;
 using ECS.LifeCycle.Components;
 using LiveKit.Rooms.Streaming.Audio;
 using Unity.Mathematics;
-using Unity.Profiling;
 using UnityEngine;
 
 namespace DCL.VoiceChat.Nearby.Systems
@@ -33,29 +32,32 @@ namespace DCL.VoiceChat.Nearby.Systems
 
         protected override void Update(float t)
         {
-            SyncPositionsAndSpatialAnglesQuery(World, listenerState.ListenerTransform, listenerState.PlayerHeadPosition);
+            SyncActiveAudioQuery(World, listenerState.ListenerTransform, listenerState.PlayerHeadPosition);
+            SyncInactiveOutOfRangeAudioQuery(World);
         }
 
+        // In-range path: archetype filter guarantees InAudibleRangeTag is present — no World.TryGet needed.
+        // Suspended-but-in-range is the only sub-case where we early-out via StopIfPlaying.
         [Query]
         [All(typeof(NearbyAudioStreamerComponent))]
         [None(typeof(DeleteEntityIntention))]
-        private void SyncPositionsAndSpatialAngles([Data] Transform listenerTransform, [Data] Vector3 playerHeadPos, Entity entity, in AvatarBase avatarBase, ref NearbyAudioSourceComponent nearbyAudio)
+        private void SyncActiveAudio([Data] Transform listenerTransform, [Data] Vector3 playerHeadPos, in InAudibleRangeTag rangeTag, in AvatarBase avatarBase, ref NearbyAudioSourceComponent nearbyAudio)
         {
-            // Per-frame idempotent inactive-state application — self-healing.
-            bool inactive = !World.TryGet(entity, out InAudibleRangeTag rangeTag) || rangeTag.IsSuspended;
+            if (rangeTag.IsSuspended)
+            {
+                StopIfPlaying(ref nearbyAudio);
+                return;
+            }
 
             LivekitAudioSource src = nearbyAudio.LivekitAudioSource;
 
-            // Diff-write: Stop/Play is a state change on the AudioSource voice slot, not a topology change to the DSP graph
+            // Diff-write: Stop/Play is a state change on the AudioSource voice slot, not a topology change to the DSP graph.
             // Pessimistic init (LastInactive=false matches factory's enabled=true hand-off) forces the first-tick write when an avatar binds directly into the suspend band.
-            if (inactive != nearbyAudio.LastInactive)
+            if (nearbyAudio.LastInactive)
             {
-                if (inactive) src.AudioSource.Stop();
-                else src.AudioSource.Play();
-                nearbyAudio.LastInactive = inactive;
+                src.AudioSource.Play();
+                nearbyAudio.LastInactive = false;
             }
-
-            if (inactive) return;
 
             // reprojection, so gain is calculated relative to the head and not the camera position (audioListener is on the camera)
             Vector3 remoteAvatarHeadPos = avatarBase.HeadAnchorPoint.position;
@@ -85,6 +87,23 @@ namespace DCL.VoiceChat.Nearby.Systems
                 }
                 nearbyAudio.LastSeenMuteVersion = cacheVersion;
             }
+        }
+
+        // Out-of-range path: between AudibleRangeSystem removing the tag and CleanupSystem reaping the source,
+        [Query]
+        [All(typeof(NearbyAudioStreamerComponent))]
+        [None(typeof(InAudibleRangeTag), typeof(DeleteEntityIntention))]
+        private void SyncInactiveOutOfRangeAudio(ref NearbyAudioSourceComponent nearbyAudio)
+        {
+            StopIfPlaying(ref nearbyAudio);
+        }
+
+        private static void StopIfPlaying(ref NearbyAudioSourceComponent nearbyAudio)
+        {
+            if (nearbyAudio.LastInactive) return;
+
+            nearbyAudio.LivekitAudioSource.AudioSource.Stop();
+            nearbyAudio.LastInactive = true;
         }
 
         private static (float azimuth, float elevation) CalculateSpatialAngles(Transform listenerTransform, Vector3 sourcePosition)

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioPositionSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyAudioPositionSystem.cs
@@ -12,8 +12,6 @@ namespace DCL.VoiceChat.Nearby.Systems
 {
     /// <summary>
     ///     Drives the <see cref="LivekitAudioSource"/> transform + spatial angles each frame.
-    ///     Reads <see cref="AvatarBase"/> from the same entity that carries the audio-source component
-    ///     (co-located after the slice-4 collapse — no cross-entity hop).
     /// </summary>
     [UpdateInGroup(typeof(NearbyVoiceChatGroup))]
     [UpdateAfter(typeof(NearbyAudioBindingSystem))]
@@ -32,16 +30,22 @@ namespace DCL.VoiceChat.Nearby.Systems
 
         protected override void Update(float t)
         {
-            SyncActiveAudioQuery(World, listenerState.ListenerTransform, listenerState.PlayerHeadPosition);
-            SyncInactiveOutOfRangeAudioQuery(World);
+            StopPlayingOutOfRangeSourcesQuery(World);
+            SpatializeActiveSourceQuery(World, listenerState.ListenerTransform, listenerState.PlayerHeadPosition);
         }
 
-        // In-range path: archetype filter guarantees InAudibleRangeTag is present — no World.TryGet needed.
-        // Suspended-but-in-range is the only sub-case where we early-out via StopIfPlaying.
+        [Query]
+        [All(typeof(NearbyAudioStreamerComponent))]
+        [None(typeof(InAudibleRangeTag), typeof(DeleteEntityIntention))]
+        private void StopPlayingOutOfRangeSources(ref NearbyAudioSourceComponent nearbyAudio)
+        {
+            StopIfPlaying(ref nearbyAudio);
+        }
+
         [Query]
         [All(typeof(NearbyAudioStreamerComponent))]
         [None(typeof(DeleteEntityIntention))]
-        private void SyncActiveAudio([Data] Transform listenerTransform, [Data] Vector3 playerHeadPos, in InAudibleRangeTag rangeTag, in AvatarBase avatarBase, ref NearbyAudioSourceComponent nearbyAudio)
+        private void SpatializeActiveSource([Data] Transform listenerTransform, [Data] Vector3 playerHeadPos, in InAudibleRangeTag rangeTag, in AvatarBase avatarBase, ref NearbyAudioSourceComponent nearbyAudio)
         {
             if (rangeTag.IsSuspended)
             {
@@ -76,26 +80,7 @@ namespace DCL.VoiceChat.Nearby.Systems
                 src.SetSpatialAngles(azimuth, elevation);
             }
 
-            uint cacheVersion = muteService.CacheVersion;
-            if (nearbyAudio.LastSeenMuteVersion != cacheVersion)
-            {
-                bool muted = muteService.IsMuted(nearbyAudio.Key.identity);
-                if (muted != nearbyAudio.LastAppliedMute)
-                {
-                    src.AudioSource.mute = muted;
-                    nearbyAudio.LastAppliedMute = muted;
-                }
-                nearbyAudio.LastSeenMuteVersion = cacheVersion;
-            }
-        }
-
-        // Out-of-range path: between AudibleRangeSystem removing the tag and CleanupSystem reaping the source,
-        [Query]
-        [All(typeof(NearbyAudioStreamerComponent))]
-        [None(typeof(InAudibleRangeTag), typeof(DeleteEntityIntention))]
-        private void SyncInactiveOutOfRangeAudio(ref NearbyAudioSourceComponent nearbyAudio)
-        {
-            StopIfPlaying(ref nearbyAudio);
+            UpdateMute(ref nearbyAudio, src);
         }
 
         private static void StopIfPlaying(ref NearbyAudioSourceComponent nearbyAudio)
@@ -116,6 +101,21 @@ namespace DCL.VoiceChat.Nearby.Systems
             float azimuth = math.atan2(local.x, local.z);
 
             return (azimuth, elevation);
+        }
+
+        private void UpdateMute(ref NearbyAudioSourceComponent nearbyAudio, LivekitAudioSource src)
+        {
+            uint cacheVersion = muteService.CacheVersion;
+            if (nearbyAudio.LastSeenMuteVersion != cacheVersion)
+            {
+                bool muted = muteService.IsMuted(nearbyAudio.Key.identity);
+                if (muted != nearbyAudio.LastAppliedMute)
+                {
+                    src.AudioSource.mute = muted;
+                    nearbyAudio.LastAppliedMute = muted;
+                }
+                nearbyAudio.LastSeenMuteVersion = cacheVersion;
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyLivekitBridgeSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyLivekitBridgeSystem.cs
@@ -15,9 +15,9 @@ namespace DCL.VoiceChat.Nearby.Systems
     ///     Runs every tick in <see cref="NearbyVoiceChatGroup"/>, before <see cref="NearbyAudioBindingSystem"/>.
     ///     Stateless — pass-through under the listening gate (markers reflect LiveKit, not nearby-chat policy; consumers gate on policy).
     ///     <para>
-    ///         Maintains the avatar's <see cref="NearbyAudioStreamerComponent.StreamSidsSnapshot"/> as a
-    ///         reference to the registry's copy-on-write sid array — <c>ReferenceEquals</c> is the
-    ///         freshness signal, no version counter is needed.
+    ///         Maintains the avatar's <see cref="NearbyAudioStreamerComponent.CurrentSid"/> as the resolver's pick.
+    ///         A flip from one active sid to another mutates the field in place; the cleanup system reaps the
+    ///         old <c>(walletId, oldSid)</c> audio entity on the next tick and binding creates the new one.
     ///     </para>
     /// </summary>
     [UpdateInGroup(typeof(NearbyVoiceChatGroup))]
@@ -35,8 +35,8 @@ namespace DCL.VoiceChat.Nearby.Systems
         protected override void Update(float t)
         {
             // Order matters:
-            AddStreamingQuery(World); // 1. Attach NearbyAudioStreamerComponent to avatars whose stream just appeared.
-            RefreshStreamingQuery(World); // 2a. Refresh SidsSnapshot reference on avatars that already carry the component (ref-mutation only, no structural changes).
+            AddStreamingQuery(World); // 1. Attach NearbyAudioStreamerComponent to avatars whose resolver just picked an active sid.
+            RefreshStreamingQuery(World); // 2a. Mutate CurrentSid in place when the resolver flipped to a different sid (ref-mutation only, no structural changes).
             RemoveStreamingQuery(World); // 2b. Cascade-remove on avatars whose stream disappeared (structural changes).
             AddSpeakingQuery(World); // 3. Tag avatars whose active-speaker signal just rose (only those still streaming).
             RemoveSpeakingQuery(World); // 4. Untag avatars whose active-speaker signal just dropped.
@@ -50,9 +50,11 @@ namespace DCL.VoiceChat.Nearby.Systems
             string walletId = profile.UserId;
             if (string.IsNullOrEmpty(walletId)) return;
 
-            string[]? arr = registry.GetAudioSidsArray(walletId);
-            if (arr != null)
-                World.Add(entity, new NearbyAudioStreamerComponent(arr));
+            // Resolver null = either no sids (case a → no-op here, RemoveStreaming has no component to drop)
+            // or all-zeros window (case b → wait for next tick). Either way, do nothing on the Add path.
+            string? activeSid = registry.GetActiveSid(walletId);
+            if (activeSid != null)
+                World.Add(entity, new NearbyAudioStreamerComponent(activeSid));
         }
 
         [Query]
@@ -63,12 +65,15 @@ namespace DCL.VoiceChat.Nearby.Systems
             string userId = profile.UserId;
             if (string.IsNullOrEmpty(userId)) return;
 
-            string[]? current = registry.GetAudioSidsArray(userId);
-            if (current == null) return; // cleanup is RemoveStreaming's responsibility
+            // Null means: registry has no sids (RemoveStreaming handles), or all-zeros window (wait).
+            // Either way, do not touch CurrentSid here.
+            string? activeSid = registry.GetActiveSid(userId);
+            if (activeSid == null) return;
 
-            // Refresh path — registry published a new array (content changed) since we last observed.
-            if (!ReferenceEquals(nearby.StreamSidsSnapshot, current))
-                nearby.StreamSidsSnapshot = current;
+            // Flip path — resolver picked a different sid since we last observed (winner was demoted by a fresher candidate,
+            // or the previous sid was unsubscribed and a new one is active). Cleanup reaps the old (walletId, oldSid) entity.
+            if (!string.Equals(nearby.CurrentSid, activeSid, System.StringComparison.Ordinal))
+                nearby.CurrentSid = activeSid;
         }
 
         [Query]
@@ -77,7 +82,14 @@ namespace DCL.VoiceChat.Nearby.Systems
         private void RemoveStreaming(Entity entity, in Profile profile)
         {
             string userId = profile.UserId;
-            if (string.IsNullOrEmpty(userId) || registry.GetAudioSidsArray(userId) != null) return;
+            if (string.IsNullOrEmpty(userId)) return;
+
+            // Critical guard: resolver returning null is ambiguous.
+            //   a) HasAudioStream == false → identity has zero sids → drop.
+            //   b) HasAudioStream == true  → all-zeros window (>=1 sid registered, none have emitted a frame yet) → wait, do not drop.
+            // RefreshStreaming already kept CurrentSid in sync with whichever sid is currently picked,
+            // so the only remaining job of RemoveStreaming is to detect case (a).
+            if (registry.HasAudioStream(userId)) return;
 
             // Drop NearbyAudioStreamerComponent and every dependent marker so invariants (speaking ⊆ streaming, audible ⊆ streaming) hold.
             World.Remove<NearbyAudioStreamerComponent>(entity);

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyLivekitBridgeSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyLivekitBridgeSystem.cs
@@ -50,8 +50,6 @@ namespace DCL.VoiceChat.Nearby.Systems
             string walletId = profile.UserId;
             if (string.IsNullOrEmpty(walletId)) return;
 
-            // Resolver null = either no sids (case a → no-op here, RemoveStreaming has no component to drop)
-            // or all-zeros window (case b → wait for next tick). Either way, do nothing on the Add path.
             string? activeSid = registry.GetActiveSid(walletId);
             if (activeSid != null)
                 World.Add(entity, new NearbyAudioStreamerComponent(activeSid));
@@ -66,12 +64,10 @@ namespace DCL.VoiceChat.Nearby.Systems
             if (string.IsNullOrEmpty(userId)) return;
 
             // Null means: registry has no sids (RemoveStreaming handles), or all-zeros window (wait).
-            // Either way, do not touch CurrentSid here.
             string? activeSid = registry.GetActiveSid(userId);
             if (activeSid == null) return;
 
-            // Flip path — resolver picked a different sid since we last observed (winner was demoted by a fresher candidate,
-            // or the previous sid was unsubscribed and a new one is active). Cleanup reaps the old (walletId, oldSid) entity.
+            // Cleanup reaps the old (walletId, oldSid) entity.
             if (!string.Equals(nearby.CurrentSid, activeSid, System.StringComparison.Ordinal))
                 nearby.CurrentSid = activeSid;
         }
@@ -82,14 +78,7 @@ namespace DCL.VoiceChat.Nearby.Systems
         private void RemoveStreaming(Entity entity, in Profile profile)
         {
             string userId = profile.UserId;
-            if (string.IsNullOrEmpty(userId)) return;
-
-            // Critical guard: resolver returning null is ambiguous.
-            //   a) HasAudioStream == false → identity has zero sids → drop.
-            //   b) HasAudioStream == true  → all-zeros window (>=1 sid registered, none have emitted a frame yet) → wait, do not drop.
-            // RefreshStreaming already kept CurrentSid in sync with whichever sid is currently picked,
-            // so the only remaining job of RemoveStreaming is to detect case (a).
-            if (registry.HasAudioStream(userId)) return;
+            if (string.IsNullOrEmpty(userId) || registry.HasAudioStream(userId)) return;
 
             // Drop NearbyAudioStreamerComponent and every dependent marker so invariants (speaking ⊆ streaming, audible ⊆ streaming) hold.
             World.Remove<NearbyAudioStreamerComponent>(entity);

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyVoiceChatDebugSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyVoiceChatDebugSystem.cs
@@ -197,7 +197,7 @@ namespace DCL.VoiceChat.Nearby.Systems
             ulong audioSourceCount = 0;
             if (isConnected)
                 foreach (KeyValuePair<string, LKParticipant> entry in islandRoom.Participants.RemoteParticipantIdentities())
-                    audioSourceCount += (ulong)(streamRegistry.GetAudioSidsArray(entry.Key)?.Length ?? 0);
+                    audioSourceCount += streamRegistry.HasAudioStream(entry.Key) ? 1ul : 0ul;
             activeAudioSourcesBinding.Value = audioSourceCount;
 
             ulong componentCount = (ulong)World.CountEntities(in COMPONENT_QUERY);

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyVoiceChatDebugSystem.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Systems/NearbyVoiceChatDebugSystem.cs
@@ -237,7 +237,7 @@ namespace DCL.VoiceChat.Nearby.Systems
 
         [Query]
         [None(typeof(DeleteEntityIntention))]
-        private void ApplySettings(ref NearbyAudioSourceComponent nearbyAudio)
+        private void ApplySettings(in NearbyAudioSourceComponent nearbyAudio)
         {
             nearbyAudio.LivekitAudioSource.ApplySpatialSettings(configuration);
         }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudibleRangeMarkerSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudibleRangeMarkerSystemShould.cs
@@ -342,7 +342,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         {
             string wallet = $"wallet-{distance}";
             Entity e = CreateAvatarEntityAtDistance(wallet, distance, initialized);
-            world.Add(e, new NearbyAudioStreamerComponent(new[] { "sid-test" }));
+            world.Add(e, new NearbyAudioStreamerComponent("sid-test"));
             return e;
         }
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
@@ -94,24 +94,11 @@ namespace DCL.VoiceChat.Nearby.Tests
         }
 
         [Test]
-        public void MultiStreamPerAvatarCreatesDistinctEntities()
-        {
-            const string WALLET = "wallet-alice";
-            CreateStreamingAvatar(WALLET, "sid-1", "sid-2");
-            registry.SeedActiveStream(WALLET, "sid-1");
-            registry.SeedActiveStream(WALLET, "sid-2");
-
-            system.Update(0);
-
-            Assert.That(CountAudioEntities(), Is.EqualTo(2));
-        }
-
-        [Test]
         public void AvatarWithoutAvatarBaseIsSkipped()
         {
             const string WALLET = "wallet-alice";
             Entity avatarEntity = world.Create(new Profile(WALLET, WALLET, new Avatar()));
-            world.Add(avatarEntity, new NearbyAudioStreamerComponent(new[] { "sid-1" }));
+            world.Add(avatarEntity, new NearbyAudioStreamerComponent("sid-1"));
             world.Add<InAudibleRangeTag>(avatarEntity);
             registry.SeedActiveStream(WALLET, "sid-1");
 
@@ -288,7 +275,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             const string SID = "sid-1";
 
             Entity avatarEntity = CreateAvatarEntity(WALLET);
-            world.Add(avatarEntity, new NearbyAudioStreamerComponent(new[] { SID }));
+            world.Add(avatarEntity, new NearbyAudioStreamerComponent(SID));
             world.Add<InAudibleRangeTag>(avatarEntity);
             registry.SeedActiveStream(WALLET, SID);
 
@@ -305,7 +292,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             const string SID = "sid-1";
 
             Entity avatarEntity = CreateAvatarEntity(WALLET);
-            world.Add(avatarEntity, new NearbyAudioStreamerComponent(new[] { SID }));
+            world.Add(avatarEntity, new NearbyAudioStreamerComponent(SID));
             world.Add<InAudibleRangeTag>(avatarEntity);
             registry.SeedActiveStream(WALLET, SID);
             userBlockingCache.UserIsBlocked(WALLET).Returns(true);
@@ -323,7 +310,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             const string SID = "sid-1";
 
             Entity avatarEntity = CreateAvatarEntity(WALLET);
-            world.Add(avatarEntity, new NearbyAudioStreamerComponent(new[] { SID }));
+            world.Add(avatarEntity, new NearbyAudioStreamerComponent(SID));
             // intentionally no InAudibleRangeTag — out of range
             registry.SeedActiveStream(WALLET, SID);
 
@@ -356,16 +343,17 @@ namespace DCL.VoiceChat.Nearby.Tests
         // ── B2.1: zero-alloc data path on the per-avatar hot path ───
 
         [Test]
-        public void BindingIteratesSidsFromComponentWithoutCallingRegistryGetAudioSids()
+        public void BindingReadsCurrentSidFromComponentWithoutQueryingRegistryResolver()
         {
-            // Verifies the §1 design goal: CollectPendingCreations reads sids from the entity,
-            // not the registry. A mock registry counts data-path reads — must be zero after Update.
+            // Verifies the dedup design goal: the per-avatar hot path reads CurrentSid from the entity,
+            // never re-asks the registry for the active sid or wallet presence. Only GetActiveStream
+            // (the resolve step) is allowed on the hot path. A mock registry counts data-path reads.
             INearbyAudioStreamRegistry mock = Substitute.For<INearbyAudioStreamRegistry>();
-            mock.GetAudioSidsArray(Arg.Any<string>()).Returns((string[]?)null);
-            mock.HasAudioStream(Arg.Any<string>()).Returns(false);
-            mock.GetActiveStream(Arg.Any<StreamKey>()).Returns(Weak<AudioStream>.Null);
-            mock.IsStreamGone(Arg.Any<StreamKey>()).Returns(false);
-            mock.IsActiveSpeaker(Arg.Any<string>()).Returns(false);
+            mock.HasAudioStream(Arg.Any<string>()).ReturnsForAnyArgs(false);
+            mock.GetActiveStream(Arg.Any<StreamKey>()).ReturnsForAnyArgs(Weak<AudioStream>.Null);
+            mock.GetActiveSid(Arg.Any<string>()).ReturnsForAnyArgs((string?)null);
+            mock.IsActiveSid(Arg.Any<string>(), Arg.Any<string>()).ReturnsForAnyArgs(false);
+            mock.IsActiveSpeaker(Arg.Any<string>()).ReturnsForAnyArgs(false);
 
             // Replace registry with the mock for the lifetime of this test.
             var localBindings = new HashSet<StreamKey>();
@@ -384,11 +372,9 @@ namespace DCL.VoiceChat.Nearby.Tests
 
                 localSystem.Update(0);
 
-                mock.DidNotReceive().GetAudioSidsArray(Arg.Any<string>());
-                // ReadOnlySpan<string>-returning overload — also untouched by the hot path.
-                // Substitute treats it like any other call; verifying the array-returning overload
-                // is sufficient since both feed off the same internal storage.
+                mock.DidNotReceive().GetActiveSid(Arg.Any<string>());
                 mock.DidNotReceive().HasAudioStream(Arg.Any<string>());
+                mock.DidNotReceive().IsActiveSid(Arg.Any<string>(), Arg.Any<string>());
             }
             finally
             {
@@ -422,10 +408,12 @@ namespace DCL.VoiceChat.Nearby.Tests
 
         // After B2.1 the binding query is gated by StreamingAudioComponent + InAudibleRangeTag;
         // the helper seeds both directly so existing trigger tests do not depend on Bridge.
-        private Entity CreateStreamingAvatar(string walletId, params string[] sids)
+        // After the resolver-dedup collapse, the component carries a single CurrentSid; tests calling
+        // this helper with multi-sid signatures are obsolete (the multi-sid case can no longer exist).
+        private Entity CreateStreamingAvatar(string walletId, string sid)
         {
             Entity entity = CreateAvatarEntity(walletId);
-            world.Add(entity, new NearbyAudioStreamerComponent(sids));
+            world.Add(entity, new NearbyAudioStreamerComponent(sid));
             world.Add<InAudibleRangeTag>(entity);
             return entity;
         }
@@ -468,8 +456,6 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             public bool HasAudioStream(string walletId) => false;
 
-            public string[]? GetAudioSidsArray(string walletId) => null;
-
             public Weak<AudioStream> GetActiveStream(StreamKey key)
             {
                 if (unsubscribed.Contains(key)) return Weak<AudioStream>.Null;
@@ -478,8 +464,6 @@ namespace DCL.VoiceChat.Nearby.Tests
                     ? owned.Downgrade()
                     : Weak<AudioStream>.Null;
             }
-
-            public bool IsStreamGone(StreamKey key) => !streamsByKey.ContainsKey(key);
 
             public string? GetActiveSid(string walletId) => null;
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
@@ -24,11 +24,9 @@ namespace DCL.VoiceChat.Nearby.Tests
     /// <summary>
     /// Documents <see cref="NearbyAudioBindingSystem"/> contract:
     ///
-    /// - One audio-source entity per <c>(walletId, sid)</c> pair, created only when the avatar entity is fully ready
-    ///   (Profile + AvatarBase + StreamingAudioComponent + InAudibleRangeTag, no DeleteEntityIntention).
-    /// - Throttled to <see cref="NearbyAudioBindingSystem.MAX_CREATIONS_PER_FRAME"/> per tick — large crowd ramp-ups
-    ///   spread across multiple frames instead of spiking a single one.
-    /// - Idempotent: re-ticking with no registry changes does not duplicate bindings.
+    /// - One audio-source component per avatar entity, created only when the avatar is fully ready
+    ///   (Profile + AvatarBase + NearbyAudioStreamerComponent + InAudibleRangeTag, no DeleteEntityIntention).
+    /// - Idempotent: re-ticking with no registry changes does not duplicate sources.
     /// - Hot path reads sids from the per-entity <see cref="NearbyAudioStreamerComponent"/>, not the registry.
     /// </summary>
     public class NearbyAudioBindingSystemShould : UnitySystemTestBase<NearbyAudioBindingSystem>
@@ -41,7 +39,6 @@ namespace DCL.VoiceChat.Nearby.Tests
             typeof(AvatarBase).GetField("<HeadAnchorPoint>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
         private FakeStreamRegistry registry;
-        private HashSet<StreamKey> bindings;
         private IUserBlockingCache userBlockingCache;
         private NearbyVoiceChatStateModel stateModel;
 
@@ -55,12 +52,11 @@ namespace DCL.VoiceChat.Nearby.Tests
             EcsTestsUtils.SetUpFeaturesRegistry();
 
             registry = new FakeStreamRegistry();
-            bindings = new HashSet<StreamKey>();
             userBlockingCache = Substitute.For<IUserBlockingCache>();
             stateModel = new NearbyVoiceChatStateModel(NearbyVoiceChatState.IDLE);
             sourceFactory = new FakeNearbyAudioSourceFactory();
 
-            system = new NearbyAudioBindingSystem(world, registry, bindings, userBlockingCache, stateModel, sourceFactory, RoomMetadataCurrentScene.CreateForTest());
+            system = new NearbyAudioBindingSystem(world, registry, userBlockingCache, stateModel, sourceFactory, RoomMetadataCurrentScene.CreateForTest());
         }
 
         protected override void OnTearDown()
@@ -72,7 +68,6 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             gameObjects.Clear();
 
-            bindings.Clear();
             stateModel.Dispose();
 
             EcsTestsUtils.TearDownFeaturesRegistry();
@@ -154,8 +149,6 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             Assert.That(CountAudioEntities(), Is.EqualTo(0),
                 "blocked identity must not allocate an audio entity");
-            Assert.That(bindings.Contains(new StreamKey(WALLET, SID)), Is.False,
-                "skipped creation must not poison the bindings index");
         }
 
         [Test]
@@ -248,8 +241,6 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             Assert.That(CountAudioEntities(), Is.EqualTo(0),
                 "Weak<AudioStream>.Null on resolve must not create an audio entity");
-            Assert.That(bindings.Contains(new StreamKey(WALLET, SID)), Is.False,
-                "skipped creation must not poison the bindings index");
         }
 
         // ── Archetype gate via StreamingAudioComponent / InAudibleRangeTag ─
@@ -269,7 +260,6 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             Assert.That(CountAudioEntities(), Is.EqualTo(0),
                 "absent StreamingAudioComponent must skip the avatar at archetype level");
-            Assert.That(bindings.Contains(new StreamKey(WALLET, SID)), Is.False);
         }
 
         [Test]
@@ -287,7 +277,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             system.Update(0);
 
             Assert.That(CountAudioEntities(), Is.EqualTo(1));
-            Assert.That(bindings.Contains(new StreamKey(WALLET, SID)), Is.True);
+            Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.True);
         }
 
         [Test]
@@ -323,7 +313,6 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             Assert.That(CountAudioEntities(), Is.EqualTo(0),
                 "absent InAudibleRangeTag must skip the avatar at archetype level");
-            Assert.That(bindings.Contains(new StreamKey(WALLET, SID)), Is.False);
         }
 
         [Test]
@@ -361,12 +350,11 @@ namespace DCL.VoiceChat.Nearby.Tests
             mock.IsActiveSpeaker(Arg.Any<string>()).ReturnsForAnyArgs(false);
 
             // Replace registry with the mock for the lifetime of this test.
-            var localBindings = new HashSet<StreamKey>();
             using var localStateModel = new NearbyVoiceChatStateModel(NearbyVoiceChatState.IDLE);
             var localFactory = new FakeNearbyAudioSourceFactory();
             try
             {
-                var localSystem = new NearbyAudioBindingSystem(world, mock, localBindings, userBlockingCache, localStateModel, localFactory, RoomMetadataCurrentScene.CreateForTest());
+                var localSystem = new NearbyAudioBindingSystem(world, mock, userBlockingCache, localStateModel, localFactory, RoomMetadataCurrentScene.CreateForTest());
 
                 const string WALLET = "wallet-alice";
                 const string SID = "sid-1";

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
@@ -481,6 +481,10 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             public bool IsStreamGone(StreamKey key) => !streamsByKey.ContainsKey(key);
 
+            public string? GetActiveSid(string walletId) => null;
+
+            public bool IsActiveSid(string walletId, string sid) => false;
+
             public bool IsActiveSpeaker(string walletId) => false;
 
             public int RebuildEpoch => 0;

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
@@ -346,7 +346,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             mock.HasAudioStream(Arg.Any<string>()).ReturnsForAnyArgs(false);
             mock.GetActiveStream(Arg.Any<StreamKey>()).ReturnsForAnyArgs(Weak<AudioStream>.Null);
             mock.GetActiveSid(Arg.Any<string>()).ReturnsForAnyArgs((string?)null);
-            mock.IsActiveSid(Arg.Any<string>(), Arg.Any<string>()).ReturnsForAnyArgs(false);
+            mock.IsActiveSid(Arg.Any<StreamKey>()).ReturnsForAnyArgs(false);
             mock.IsActiveSpeaker(Arg.Any<string>()).ReturnsForAnyArgs(false);
 
             // Replace registry with the mock for the lifetime of this test.
@@ -367,7 +367,7 @@ namespace DCL.VoiceChat.Nearby.Tests
 
                 mock.DidNotReceive().GetActiveSid(Arg.Any<string>());
                 mock.DidNotReceive().HasAudioStream(Arg.Any<string>());
-                mock.DidNotReceive().IsActiveSid(Arg.Any<string>(), Arg.Any<string>());
+                mock.DidNotReceive().IsActiveSid(Arg.Any<StreamKey>());
             }
             finally
             {
@@ -460,7 +460,7 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             public string? GetActiveSid(string walletId) => null;
 
-            public bool IsActiveSid(string walletId, string sid) => false;
+            public bool IsActiveSid(StreamKey key) => false;
 
             public bool IsActiveSpeaker(string walletId) => false;
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioBindingSystemShould.cs
@@ -33,7 +33,9 @@ namespace DCL.VoiceChat.Nearby.Tests
     /// </summary>
     public class NearbyAudioBindingSystemShould : UnitySystemTestBase<NearbyAudioBindingSystem>
     {
-        private static readonly QueryDescription AUDIO_SOURCE_QUERY = new QueryDescription().WithAll<NearbyAudioSourceComponent>();
+        // Co-located after slice 4: NearbyAudioSourceComponent lives on the avatar entity itself, alongside
+        // AvatarBase. The "audio source count" question is therefore "how many avatars carry the component".
+        private static readonly QueryDescription AUDIO_SOURCE_QUERY = new QueryDescription().WithAll<NearbyAudioSourceComponent, AvatarBase>();
 
         private static readonly FieldInfo HEAD_ANCHOR_FIELD =
             typeof(AvatarBase).GetField("<HeadAnchorPoint>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)!;
@@ -77,7 +79,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         }
 
         [Test]
-        public void SingleAvatarSingleStreamCreatesOneEntity()
+        public void SingleAvatarSingleStreamAddsComponentOnAvatar()
         {
             const string WALLET = "wallet-alice";
             Entity avatarEntity = CreateStreamingAvatar(WALLET, "sid-1");
@@ -87,9 +89,12 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             Assert.That(CountAudioEntities(), Is.EqualTo(1));
 
-            NearbyAudioSourceComponent comp = GetSingleAudioComponent();
+            // Co-location: the component must live on the avatar entity itself (no separate audio entity).
+            Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.True,
+                "component must be added directly onto the avatar entity (slice-4 co-location)");
+
+            NearbyAudioSourceComponent comp = world.Get<NearbyAudioSourceComponent>(avatarEntity);
             Assert.That(comp.Key, Is.EqualTo(new StreamKey(WALLET, "sid-1")));
-            Assert.That(comp.AvatarEntity, Is.EqualTo(avatarEntity));
             Assert.That(comp.LivekitAudioSource, Is.Not.Null);
         }
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
@@ -30,9 +30,9 @@ namespace DCL.VoiceChat.Nearby.Tests
     /// - Listening-gate / device-change paths bulk-remove the component from every live entity.
     /// - Avatars carrying <see cref="DeleteEntityIntention"/> get only their source disposed — the
     ///   component goes away with the entity when DestroyEntitiesSystem runs.
-    /// - Tests assert the system's own contribution: component removed (live triggers) / source disposed,
-    ///   bindings index in sync. They do NOT assert avatar-entity destruction (out of scope).
-    /// - <see cref="NearbyAudioCleanupSystem.Dispose"/> disposes any survivors and clears bindings.
+    /// - Tests assert the system's own contribution: component removed (live triggers) / source disposed.
+    ///   They do NOT assert avatar-entity destruction (out of scope).
+    /// - <see cref="NearbyAudioCleanupSystem.Dispose"/> disposes any survivors.
     /// </summary>
     public class NearbyAudioCleanupSystemShould : UnitySystemTestBase<NearbyAudioCleanupSystem>
     {
@@ -46,7 +46,6 @@ namespace DCL.VoiceChat.Nearby.Tests
             typeof(AvatarBase).GetField("<HeadAnchorPoint>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
         private FakeStreamRegistry registry = null!;
-        private HashSet<StreamKey> bindings = null!;
         private IUserBlockingCache userBlockingCache = null!;
         private NearbyVoiceChatStateModel stateModel = null!;
         private VoiceChatConfiguration configuration = null!;
@@ -59,13 +58,12 @@ namespace DCL.VoiceChat.Nearby.Tests
             EcsTestsUtils.SetUpFeaturesRegistry();
 
             registry = new FakeStreamRegistry();
-            bindings = new HashSet<StreamKey>();
             userBlockingCache = Substitute.For<IUserBlockingCache>();
             stateModel = new NearbyVoiceChatStateModel(NearbyVoiceChatState.IDLE);
             configuration = ScriptableObject.CreateInstance<VoiceChatConfiguration>();
             sourceFactory = new NearbyAudioSourceFactory(configuration);
 
-            system = new NearbyAudioCleanupSystem(world, registry, bindings, userBlockingCache, stateModel, sourceFactory, RoomMetadataCurrentScene.CreateForTest());
+            system = new NearbyAudioCleanupSystem(world, registry, userBlockingCache, stateModel, sourceFactory, RoomMetadataCurrentScene.CreateForTest());
         }
 
         protected override void OnTearDown()
@@ -74,7 +72,6 @@ namespace DCL.VoiceChat.Nearby.Tests
                 if (go != null) Object.DestroyImmediate(go);
 
             gameObjects.Clear();
-            bindings.Clear();
             stateModel.Dispose();
 
             if (configuration != null) Object.DestroyImmediate(configuration);
@@ -97,11 +94,9 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             system.Update(0);
 
-            // Trigger #7 disposes the source and drops the bindings entry, but does NOT World.Remove the
-            // component — the dying avatar will take it down on physical destruction.
+            // Trigger #7 disposes the source but does NOT World.Remove the component — the dying avatar
+            // will take it down on physical destruction.
             AssertSourceTornDown(source);
-            Assert.That(bindings.Contains(new StreamKey(PARTICIPANT_A, SID_1)), Is.False,
-                "bindings entry must be dropped when the avatar is on its way out");
         }
 
         // ── Trigger #2: stream gone ─────────────────────────────────
@@ -161,7 +156,6 @@ namespace DCL.VoiceChat.Nearby.Tests
             system.Update(0);
 
             Assert.That(world.CountEntities(in LIVE_AUDIO_QUERY), Is.EqualTo(0), "all audio components must be removed");
-            Assert.That(bindings, Is.Empty);
             foreach ((Entity avatarEntity, LivekitAudioSource source, _) in seeded)
             {
                 Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.False,
@@ -188,7 +182,6 @@ namespace DCL.VoiceChat.Nearby.Tests
             system.Update(0);
 
             Assert.That(world.CountEntities(in LIVE_AUDIO_QUERY), Is.EqualTo(0));
-            Assert.That(bindings, Is.Empty);
             foreach ((Entity avatarEntity, LivekitAudioSource source, _) in seeded)
             {
                 Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.False);
@@ -267,7 +260,6 @@ namespace DCL.VoiceChat.Nearby.Tests
                 "healthy steady-state entity must keep its audio-source component");
             Assert.That(world.IsAlive(avatarEntity), Is.True);
             Assert.That(source == null, Is.False, "LivekitAudioSource must remain alive");
-            Assert.That(bindings.Contains(new StreamKey(PARTICIPANT_A, SID_1)), Is.True);
         }
 
         // FlagsLosingSidAudioEntityWhenResolverPicksSibling — DELETED.
@@ -318,8 +310,6 @@ namespace DCL.VoiceChat.Nearby.Tests
             system.Update(0);
 
             AssertSourceTornDown(source);
-            Assert.That(bindings.Contains(new StreamKey(PARTICIPANT_A, SID_1)), Is.False,
-                "bindings entry must be dropped for a dying avatar");
             Assert.That(world.Has<NearbyAudioStreamerComponent>(avatarEntity), Is.True,
                 "Bridge's [None<DeleteEntityIntention>] filter prevents component removal on a doomed avatar");
         }
@@ -389,7 +379,6 @@ namespace DCL.VoiceChat.Nearby.Tests
             Assert.That(world.IsAlive(avatarEntity), Is.True);
             Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.True);
             Assert.That(source == null, Is.False);
-            Assert.That(bindings.Contains(new StreamKey(PARTICIPANT_A, SID_1)), Is.True);
             Assert.That(world.CountEntities(in LIVE_AUDIO_QUERY), Is.EqualTo(1));
         }
 
@@ -412,22 +401,19 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             foreach (LivekitAudioSource source in sources)
                 AssertSourceTornDown(source);
-
-            Assert.That(bindings, Is.Empty);
         }
 
         // ── Helpers ─────────────────────────────────────────────────
 
         // Slice 4: cleanup contract for the LIVE doom path — component removed from the avatar entity,
-        // source torn down, binding dropped. The avatar entity itself stays alive (it's the avatar; it
-        // just no longer carries an audio-source pair).
+        // source torn down. The avatar entity itself stays alive (it's the avatar; it just no longer
+        // carries an audio-source pair).
         private void AssertCleanedUp(Entity avatarEntity, LivekitAudioSource source, string walletId, string sid)
         {
             Assert.That(world.IsAlive(avatarEntity), Is.True, "avatar entity destruction is out of scope here");
             Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.False,
                 "audio-source component must be removed from the avatar");
             AssertSourceTornDown(source, "LivekitAudioSource must be torn down (destroyed in legacy path, parked inactive in pool path)");
-            Assert.That(bindings.Contains(new StreamKey(walletId, sid)), Is.False, "binding must be removed");
         }
 
         // A2 made source teardown reference-stable: the pool keeps the GO alive after Dispose. Both
@@ -457,7 +443,6 @@ namespace DCL.VoiceChat.Nearby.Tests
             var key = new StreamKey(walletId, sid);
             LivekitAudioSource source = CreateLivekitAudioSource(key);
             world.Add(avatarEntity, new NearbyAudioSourceComponent(key, source));
-            bindings.Add(key);
 
             return (avatarEntity, avatarEntity, source);
         }

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
@@ -89,7 +89,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         [Test]
         public void AvatarWithDeleteEntityIntentionDisposesSource()
         {
-            (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             world.Add<DeleteEntityIntention>(avatarEntity);
 
             system.Update(0);
@@ -104,24 +104,24 @@ namespace DCL.VoiceChat.Nearby.Tests
         [Test]
         public void RegistryMissingWalletCausesCleanup()
         {
-            (Entity audioEntity, _, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             registry.RemoveAll(PARTICIPANT_A);
 
             system.Update(0);
 
-            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
+            AssertCleanedUp(avatarEntity, source, PARTICIPANT_A, SID_1);
         }
 
         [Test]
         public void RegistryMissingSidCausesCleanup()
         {
-            (Entity audioEntity, _, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             registry.Add(PARTICIPANT_A, "sid-other"); // wallet still in registry, but bound sid is gone
             registry.RemoveSid(PARTICIPANT_A, SID_1);
 
             system.Update(0);
 
-            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
+            AssertCleanedUp(avatarEntity, source, PARTICIPANT_A, SID_1);
         }
 
         // ── Trigger #3: blocked identity ────────────────────────────
@@ -129,12 +129,12 @@ namespace DCL.VoiceChat.Nearby.Tests
         [Test]
         public void BlockedIdentityCausesCleanup()
         {
-            (Entity audioEntity, _, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             userBlockingCache.UserIsBlocked(PARTICIPANT_A).Returns(true);
 
             system.Update(0);
 
-            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
+            AssertCleanedUp(avatarEntity, source, PARTICIPANT_A, SID_1);
         }
 
         // ── Trigger #4: listening gate ──────────────────────────────
@@ -147,7 +147,7 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             for (int i = 0; i < COUNT; i++)
             {
-                (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
+                (Entity avatarEntity, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
                 seeded.Add((avatarEntity, source, $"wallet-{i}"));
             }
 
@@ -173,7 +173,7 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             for (int i = 0; i < COUNT; i++)
             {
-                (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
+                (Entity avatarEntity, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
                 seeded.Add((avatarEntity, source, $"wallet-{i}"));
             }
 
@@ -197,7 +197,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         {
             // Compound trigger — registry drops the identity AND user gets blocked in the same frame.
             // Both clauses dock onto the same per-entity collect pass; the result is one teardown, not two.
-            (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             registry.RemoveAll(PARTICIPANT_A);
             userBlockingCache.UserIsBlocked(PARTICIPANT_A).Returns(true);
 
@@ -214,7 +214,7 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             for (int i = 0; i < COUNT; i++)
             {
-                (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
+                (Entity avatarEntity, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
                 seeded.Add((avatarEntity, source));
             }
 
@@ -239,12 +239,12 @@ namespace DCL.VoiceChat.Nearby.Tests
             // its StreamingAudioComponent (Bridge dropped it because the registry no longer reports
             // sids for that walletId), the audio entity must be doomed without consulting the
             // registry or the blocking cache.
-            (Entity audioEntity, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             world.Remove<NearbyAudioStreamerComponent>(avatarEntity);
 
             system.Update(0);
 
-            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
+            AssertCleanedUp(avatarEntity, source, PARTICIPANT_A, SID_1);
         }
 
         [Test]
@@ -252,7 +252,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         {
             // Steady state — marker on, registry has the sid, not blocked, avatar alive.
             // The cleanup query must not touch this entity. This is the dominant per-frame path.
-            (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
 
             system.Update(0);
 
@@ -276,7 +276,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             // Distinct from RegistryMissingSidCausesCleanup: here the sid still EXISTS in the registry
             // (HasAudioStream=true), it just lost the active-pick race. The !IsActiveSid predicate
             // must reap it regardless of whether the registry still indexes the sid.
-            (Entity audioEntity, _, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
 
             // Resolver demotes sid-1 in favour of a fresher candidate; HasAudioStream stays true
             // (registry still holds candidates for the identity).
@@ -293,7 +293,7 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             system.Update(0);
 
-            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
+            AssertCleanedUp(avatarEntity, source, PARTICIPANT_A, SID_1);
         }
 
         [Test]
@@ -303,7 +303,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             // [None<DeleteEntityIntention>], so a doomed avatar keeps its marker until physical
             // destruction. The dying-avatar trigger #7 must dispose the source regardless of marker state;
             // it does NOT World.Remove the audio-source component (the entity itself is on its way out).
-            (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             world.Add<DeleteEntityIntention>(avatarEntity);
             // marker intentionally NOT removed — F1 contract
 
@@ -319,7 +319,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         {
             // Optional sanity — proves the cheap shortcut actually short-circuits the registry call.
             // If the marker-absence clause fires, registry.IsActiveSid must NOT be invoked.
-            (_, Entity avatarEntity, _) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, _) = SeedBinding(PARTICIPANT_A, SID_1);
             world.Remove<NearbyAudioStreamerComponent>(avatarEntity);
 
             registry.ResetCallCounters();
@@ -340,12 +340,12 @@ namespace DCL.VoiceChat.Nearby.Tests
             // A1 adds a fourth clause to the cheap-shortcut chain — when AudibleRangeMarker drops
             // InAudibleRangeTag (avatar crossed 22 m outward) Cleanup must doom the audio entity
             // in the same frame, before the registry / blocking-cache fallbacks fire.
-            (Entity audioEntity, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             world.Remove<InAudibleRangeTag>(avatarEntity);
 
             system.Update(0);
 
-            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
+            AssertCleanedUp(avatarEntity, source, PARTICIPANT_A, SID_1);
         }
 
         [Test]
@@ -353,7 +353,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         {
             // Cost-shortcut semantics — the marker-absence clause must short-circuit before the
             // registry lookup fires. Mirrors the streaming-tag short-circuit guard from A5.2.
-            (_, Entity avatarEntity, _) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, _) = SeedBinding(PARTICIPANT_A, SID_1);
             world.Remove<InAudibleRangeTag>(avatarEntity);
 
             registry.ResetCallCounters();
@@ -371,7 +371,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         [Test]
         public void IdleTickWithNoTriggersDoesNotMutateWorld()
         {
-            (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
 
             system.Update(0);
             system.Update(0);
@@ -392,7 +392,7 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             for (int i = 0; i < COUNT; i++)
             {
-                (_, _, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
+                (_, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
                 sources.Add(source);
             }
 
@@ -428,10 +428,10 @@ namespace DCL.VoiceChat.Nearby.Tests
             Assert.That(source.gameObject.activeSelf, Is.False, message ?? "pooled source must be inactive");
         }
 
-        // Slice 4: audio-source component is co-located on the avatar. There is no separate audio entity —
-        // the seeded "audioEntity" returned here IS the avatar (kept named distinctly to minimise churn in
-        // call sites that bind both locally).
-        private (Entity audioEntity, Entity avatarEntity, LivekitAudioSource source) SeedBinding(string walletId, string sid)
+        // Slice 4: audio-source component is co-located on the avatar — there is no separate audio entity.
+        // Callers that previously needed an "audioEntity" alias should just reuse avatarEntity; AssertCleanedUp
+        // takes the same entity for both the liveness check and the component-removed check.
+        private (Entity avatarEntity, LivekitAudioSource source) SeedBinding(string walletId, string sid)
         {
             Entity avatarEntity = CreateAvatarEntity(walletId);
             // Realistic state for a live audio component: streamer marker + audible range tag both present.
@@ -444,7 +444,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             LivekitAudioSource source = CreateLivekitAudioSource(key);
             world.Add(avatarEntity, new NearbyAudioSourceComponent(key, source));
 
-            return (avatarEntity, avatarEntity, source);
+            return (avatarEntity, source);
         }
 
         private Entity CreateAvatarEntity(string walletId)

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
@@ -532,6 +532,10 @@ namespace DCL.VoiceChat.Nearby.Tests
                 return !sidsByIdentity.TryGetValue(key.identity, out HashSet<string>? sids) || !sids.Contains(key.sid);
             }
 
+            public string? GetActiveSid(string walletId) => null;
+
+            public bool IsActiveSid(string walletId, string sid) => false;
+
             public bool IsActiveSpeaker(string walletId) => false;
 
             public int RebuildEpoch => 0;

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
@@ -22,15 +22,16 @@ using Object = UnityEngine.Object;
 namespace DCL.VoiceChat.Nearby.Tests
 {
     /// <summary>
-    /// Documents <see cref="NearbyAudioCleanupSystem"/> contract:
+    /// Documents <see cref="NearbyAudioCleanupSystem"/> contract (slice 4 — co-located component):
     ///
-    /// - Detection marks doomed audio entities with <see cref="DeleteEntityIntention"/>; physical destruction is delegated to
-    ///   <see cref="ECS.LifeCycle.Systems.DestroyEntitiesSystem"/> (deliberately not in this test rig).
-    /// - Pull-based detection: per tick, four triggers per entity — avatar gone, stream gone, identity blocked, listening gate.
-    /// - Teardown reacts to <see cref="DeleteEntityIntention"/>: disposes the <see cref="LivekitAudioSource"/>
-    ///   (Stop → Free → SafeDestroyGameObject) and removes the <c>(walletId, sid) → entity</c> binding.
-    /// - Tests assert the system's own contribution: the entity is marked + the source is disposed + the binding is removed.
-    ///   They deliberately do NOT assert <see cref="World.IsAlive"/>, since this system no longer owns entity destruction.
+    /// - Detection collects doomed avatars (lost streamer marker / out of range / sid demoted / blocked /
+    ///   scene-banned), disposes their <see cref="LivekitAudioSource"/>, then removes the
+    ///   <see cref="NearbyAudioSourceComponent"/> from the avatar entity (avatar itself stays alive).
+    /// - Listening-gate / device-change paths bulk-remove the component from every live entity.
+    /// - Avatars carrying <see cref="DeleteEntityIntention"/> get only their source disposed — the
+    ///   component goes away with the entity when DestroyEntitiesSystem runs.
+    /// - Tests assert the system's own contribution: component removed (live triggers) / source disposed,
+    ///   bindings index in sync. They do NOT assert avatar-entity destruction (out of scope).
     /// - <see cref="NearbyAudioCleanupSystem.Dispose"/> disposes any survivors and clears bindings.
     /// </summary>
     public class NearbyAudioCleanupSystemShould : UnitySystemTestBase<NearbyAudioCleanupSystem>
@@ -81,28 +82,26 @@ namespace DCL.VoiceChat.Nearby.Tests
             EcsTestsUtils.TearDownFeaturesRegistry();
         }
 
-        // ── Trigger #1: avatar gone ─────────────────────────────────
+        // ── Trigger #7: avatar dying ────────────────────────────────
+        // Slice 4 collapsed the audio entity onto the avatar. The "hard-destroy the avatar"
+        // premise from the old test is no longer reachable in practice (avatar destruction
+        // is gated through DeleteEntityIntention → DestroyEntitiesSystem) — and the legacy
+        // separate-audio-entity test would have nothing to clean up either. The
+        // DeleteEntityIntention path below is the only meaningful "avatar gone" scenario now.
 
         [Test]
-        public void DeadAvatarEntityCausesCleanup()
+        public void AvatarWithDeleteEntityIntentionDisposesSource()
         {
-            (Entity audioEntity, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
-            world.Destroy(avatarEntity);
-
-            system.Update(0);
-
-            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
-        }
-
-        [Test]
-        public void AvatarWithDeleteEntityIntentionCausesCleanup()
-        {
-            (Entity audioEntity, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             world.Add<DeleteEntityIntention>(avatarEntity);
 
             system.Update(0);
 
-            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
+            // Trigger #7 disposes the source and drops the bindings entry, but does NOT World.Remove the
+            // component — the dying avatar will take it down on physical destruction.
+            AssertSourceTornDown(source);
+            Assert.That(bindings.Contains(new StreamKey(PARTICIPANT_A, SID_1)), Is.False,
+                "bindings entry must be dropped when the avatar is on its way out");
         }
 
         // ── Trigger #2: stream gone ─────────────────────────────────
@@ -146,40 +145,42 @@ namespace DCL.VoiceChat.Nearby.Tests
         // ── Trigger #4: listening gate ──────────────────────────────
 
         [Test]
-        public void SuppressedStateTearsDownAllAudioEntities()
+        public void SuppressedStateTearsDownAllAudioSources()
         {
             const int COUNT = 3;
-            var seeded = new List<(Entity audioEntity, LivekitAudioSource source, string wallet)>(COUNT);
+            var seeded = new List<(Entity avatarEntity, LivekitAudioSource source, string wallet)>(COUNT);
 
             for (int i = 0; i < COUNT; i++)
             {
-                (Entity audioEntity, _, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
-                seeded.Add((audioEntity, source, $"wallet-{i}"));
+                (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
+                seeded.Add((avatarEntity, source, $"wallet-{i}"));
             }
 
             stateModel.Suppress(SuppressionReason.CALL);
 
             system.Update(0);
 
-            Assert.That(world.CountEntities(in LIVE_AUDIO_QUERY), Is.EqualTo(0), "all audio entities must be marked");
+            Assert.That(world.CountEntities(in LIVE_AUDIO_QUERY), Is.EqualTo(0), "all audio components must be removed");
             Assert.That(bindings, Is.Empty);
-            foreach ((Entity audioEntity, LivekitAudioSource source, _) in seeded)
+            foreach ((Entity avatarEntity, LivekitAudioSource source, _) in seeded)
             {
-                Assert.That(world.Has<DeleteEntityIntention>(audioEntity), Is.True);
+                Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.False,
+                    "listening-gate bulk path removes the component from every live entity");
+                Assert.That(world.IsAlive(avatarEntity), Is.True, "avatar itself must stay alive");
                 AssertSourceTornDown(source);
             }
         }
 
         [Test]
-        public void DisabledStateTearsDownAllAudioEntities()
+        public void DisabledStateTearsDownAllAudioSources()
         {
             const int COUNT = 3;
-            var seeded = new List<(Entity audioEntity, LivekitAudioSource source, string wallet)>(COUNT);
+            var seeded = new List<(Entity avatarEntity, LivekitAudioSource source, string wallet)>(COUNT);
 
             for (int i = 0; i < COUNT; i++)
             {
-                (Entity audioEntity, _, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
-                seeded.Add((audioEntity, source, $"wallet-{i}"));
+                (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
+                seeded.Add((avatarEntity, source, $"wallet-{i}"));
             }
 
             stateModel.Disable();
@@ -188,9 +189,10 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             Assert.That(world.CountEntities(in LIVE_AUDIO_QUERY), Is.EqualTo(0));
             Assert.That(bindings, Is.Empty);
-            foreach ((Entity audioEntity, LivekitAudioSource source, _) in seeded)
+            foreach ((Entity avatarEntity, LivekitAudioSource source, _) in seeded)
             {
-                Assert.That(world.Has<DeleteEntityIntention>(audioEntity), Is.True);
+                Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.False);
+                Assert.That(world.IsAlive(avatarEntity), Is.True);
                 AssertSourceTornDown(source);
             }
         }
@@ -200,25 +202,27 @@ namespace DCL.VoiceChat.Nearby.Tests
         [Test]
         public void BothTriggersPresentResultInSingleTeardown()
         {
-            (Entity audioEntity, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
-            world.Destroy(avatarEntity);
+            // Compound trigger — registry drops the identity AND user gets blocked in the same frame.
+            // Both clauses dock onto the same per-entity collect pass; the result is one teardown, not two.
+            (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             registry.RemoveAll(PARTICIPANT_A);
+            userBlockingCache.UserIsBlocked(PARTICIPANT_A).Returns(true);
 
             Assert.DoesNotThrow(() => system.Update(0));
 
-            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
+            AssertCleanedUp(avatarEntity, source, PARTICIPANT_A, SID_1);
         }
 
         [Test]
         public void MassCleanupOnDisconnected()
         {
             const int COUNT = 10;
-            var seeded = new List<(Entity audioEntity, LivekitAudioSource source)>(COUNT);
+            var seeded = new List<(Entity avatarEntity, LivekitAudioSource source)>(COUNT);
 
             for (int i = 0; i < COUNT; i++)
             {
-                (Entity audioEntity, _, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
-                seeded.Add((audioEntity, source));
+                (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding($"wallet-{i}", SID_1);
+                seeded.Add((avatarEntity, source));
             }
 
             registry.ClearAll();
@@ -226,9 +230,9 @@ namespace DCL.VoiceChat.Nearby.Tests
             system.Update(0);
 
             Assert.That(world.CountEntities(in LIVE_AUDIO_QUERY), Is.EqualTo(0));
-            foreach ((Entity audioEntity, LivekitAudioSource source) in seeded)
+            foreach ((Entity avatarEntity, LivekitAudioSource source) in seeded)
             {
-                Assert.That(world.Has<DeleteEntityIntention>(audioEntity), Is.True);
+                Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.False);
                 AssertSourceTornDown(source);
             }
         }
@@ -251,49 +255,27 @@ namespace DCL.VoiceChat.Nearby.Tests
         }
 
         [Test]
-        public void KeepsAudioEntityWhenMarkerPresentAndRegistryAlive()
+        public void KeepsAudioComponentWhenMarkerPresentAndRegistryAlive()
         {
             // Steady state — marker on, registry has the sid, not blocked, avatar alive.
-            // The cleanup query must not flag this entity. This is the dominant per-frame path.
-            (Entity audioEntity, _, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            // The cleanup query must not touch this entity. This is the dominant per-frame path.
+            (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
 
             system.Update(0);
 
-            Assert.That(world.Has<DeleteEntityIntention>(audioEntity), Is.False,
-                "healthy steady-state entity must not be flagged");
-            Assert.That(world.IsAlive(audioEntity), Is.True);
+            Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.True,
+                "healthy steady-state entity must keep its audio-source component");
+            Assert.That(world.IsAlive(avatarEntity), Is.True);
             Assert.That(source == null, Is.False, "LivekitAudioSource must remain alive");
             Assert.That(bindings.Contains(new StreamKey(PARTICIPANT_A, SID_1)), Is.True);
         }
 
-        [Test]
-        public void FlagsLosingSidAudioEntityWhenResolverPicksSibling()
-        {
-            // Ghost-vs-winner — the registry still holds two candidate sids for the wallet (LiveKit
-            // dropped an unsubscribe), but the resolver now picks only one. Both audio entities exist
-            // as a hangover from before the flip (sid-1 was the previous pick, sid-2 just won).
-            // Per-sid doom arrives via !registry.IsActiveSid(comp.Key.identity, comp.Key.sid) — the
-            // demoted ghost sid is reaped, the winner survives, the marker stays (it tracks the wallet,
-            // not the sid).
-            const string SID_2 = "sid-2";
-            (Entity audioEntity1, Entity avatarEntity, LivekitAudioSource source1) = SeedBinding(PARTICIPANT_A, SID_1);
-
-            // Sid-2 entity coexists; both audio entities share the same avatar (and its marker).
-            var key2 = new StreamKey(PARTICIPANT_A, SID_2);
-            LivekitAudioSource source2 = CreateLivekitAudioSource(key2);
-            Entity audioEntity2 = world.Create(new NearbyAudioSourceComponent(key2, avatarEntity, source2));
-            bindings.Add(key2);
-
-            // Resolver flips to sid-2; sid-1 stays in the registry as a ghost.
-            registry.SetActiveSid(PARTICIPANT_A, SID_2);
-
-            system.Update(0);
-
-            AssertCleanedUp(audioEntity1, source1, PARTICIPANT_A, SID_1);
-            Assert.That(world.Has<DeleteEntityIntention>(audioEntity2), Is.False,
-                "winning sid must remain alive — only the demoted ghost is reaped");
-            Assert.That(source2 == null, Is.False);
-        }
+        // FlagsLosingSidAudioEntityWhenResolverPicksSibling — DELETED.
+        // Premise required two NearbyAudioSourceComponent instances on the same avatar (one per sid).
+        // After slice-4 co-location, the component lives on the avatar entity and Arch allows at most one
+        // instance of a given component type per entity. The resolver-dedup contract collapsed multi-sid
+        // state into a single CurrentSid, and GhostSidLosingResolverPickCausesCleanup below covers the
+        // single-sid ghost-demotion case.
 
         [Test]
         public void GhostSidLosingResolverPickCausesCleanup()
@@ -323,19 +305,21 @@ namespace DCL.VoiceChat.Nearby.Tests
         }
 
         [Test]
-        public void FlagsAudioEntityWhenAvatarHasDeleteIntentionButMarkerRemains()
+        public void DisposesSourceWhenAvatarHasDeleteIntentionButMarkerRemains()
         {
             // F1-deliberate invariant: NearbyLivekitBridgeSystem.UpdateStreaming filters with
             // [None<DeleteEntityIntention>], so a doomed avatar keeps its marker until physical
-            // destruction. Cleanup must catch this via the World.Has<DeleteEntityIntention>(avatar)
-            // clause, not the marker-absence clause.
-            (Entity audioEntity, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            // destruction. The dying-avatar trigger #7 must dispose the source regardless of marker state;
+            // it does NOT World.Remove the audio-source component (the entity itself is on its way out).
+            (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
             world.Add<DeleteEntityIntention>(avatarEntity);
             // marker intentionally NOT removed — F1 contract
 
             system.Update(0);
 
-            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
+            AssertSourceTornDown(source);
+            Assert.That(bindings.Contains(new StreamKey(PARTICIPANT_A, SID_1)), Is.False,
+                "bindings entry must be dropped for a dying avatar");
             Assert.That(world.Has<NearbyAudioStreamerComponent>(avatarEntity), Is.True,
                 "Bridge's [None<DeleteEntityIntention>] filter prevents component removal on a doomed avatar");
         }
@@ -397,13 +381,13 @@ namespace DCL.VoiceChat.Nearby.Tests
         [Test]
         public void IdleTickWithNoTriggersDoesNotMutateWorld()
         {
-            (Entity audioEntity, _, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+            (_, Entity avatarEntity, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
 
             system.Update(0);
             system.Update(0);
 
-            Assert.That(world.IsAlive(audioEntity), Is.True);
-            Assert.That(world.Has<DeleteEntityIntention>(audioEntity), Is.False);
+            Assert.That(world.IsAlive(avatarEntity), Is.True);
+            Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.True);
             Assert.That(source == null, Is.False);
             Assert.That(bindings.Contains(new StreamKey(PARTICIPANT_A, SID_1)), Is.True);
             Assert.That(world.CountEntities(in LIVE_AUDIO_QUERY), Is.EqualTo(1));
@@ -434,10 +418,14 @@ namespace DCL.VoiceChat.Nearby.Tests
 
         // ── Helpers ─────────────────────────────────────────────────
 
-        private void AssertCleanedUp(Entity audioEntity, LivekitAudioSource source, string walletId, string sid)
+        // Slice 4: cleanup contract for the LIVE doom path — component removed from the avatar entity,
+        // source torn down, binding dropped. The avatar entity itself stays alive (it's the avatar; it
+        // just no longer carries an audio-source pair).
+        private void AssertCleanedUp(Entity avatarEntity, LivekitAudioSource source, string walletId, string sid)
         {
-            Assert.That(world.IsAlive(audioEntity), Is.True, "entity destruction is delegated to DestroyEntitiesSystem and is out of scope here");
-            Assert.That(world.Has<DeleteEntityIntention>(audioEntity), Is.True, "audio entity must be marked for deletion");
+            Assert.That(world.IsAlive(avatarEntity), Is.True, "avatar entity destruction is out of scope here");
+            Assert.That(world.Has<NearbyAudioSourceComponent>(avatarEntity), Is.False,
+                "audio-source component must be removed from the avatar");
             AssertSourceTornDown(source, "LivekitAudioSource must be torn down (destroyed in legacy path, parked inactive in pool path)");
             Assert.That(bindings.Contains(new StreamKey(walletId, sid)), Is.False, "binding must be removed");
         }
@@ -454,25 +442,24 @@ namespace DCL.VoiceChat.Nearby.Tests
             Assert.That(source.gameObject.activeSelf, Is.False, message ?? "pooled source must be inactive");
         }
 
+        // Slice 4: audio-source component is co-located on the avatar. There is no separate audio entity —
+        // the seeded "audioEntity" returned here IS the avatar (kept named distinctly to minimise churn in
+        // call sites that bind both locally).
         private (Entity audioEntity, Entity avatarEntity, LivekitAudioSource source) SeedBinding(string walletId, string sid)
         {
             Entity avatarEntity = CreateAvatarEntity(walletId);
-            // After A5.2 the cleanup shortcut treats streaming-marker absence as a doom signal;
-            // A1 adds InAudibleRangeTag absence as a fourth shortcut clause. Realistic state for
-            // a live audio entity is both markers present — Bridge applied StreamingAudioComponent
-            // and AudibleRangeMarker applied InAudibleRangeTag before Binding spawned the entity.
-            // Pair all three in the seed so existing trigger tests exercise the intended fallbacks
-            // (!IsActiveSid / UserIsBlocked / lifecycle), not the marker-absence shortcuts by accident.
+            // Realistic state for a live audio component: streamer marker + audible range tag both present.
+            // Trigger tests that want the !IsActiveSid / UserIsBlocked / lifecycle fallbacks rely on this baseline.
             world.Add(avatarEntity, new NearbyAudioStreamerComponent(sid));
             world.Add<InAudibleRangeTag>(avatarEntity);
             registry.Add(walletId, sid);
 
             var key = new StreamKey(walletId, sid);
             LivekitAudioSource source = CreateLivekitAudioSource(key);
-            Entity audioEntity = world.Create(new NearbyAudioSourceComponent(key, avatarEntity, source));
+            world.Add(avatarEntity, new NearbyAudioSourceComponent(key, source));
             bindings.Add(key);
 
-            return (audioEntity, avatarEntity, source);
+            return (avatarEntity, avatarEntity, source);
         }
 
         private Entity CreateAvatarEntity(string walletId)

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
@@ -267,14 +267,16 @@ namespace DCL.VoiceChat.Nearby.Tests
         }
 
         [Test]
-        public void FlagsAudioEntityWhenOneOfNSidsGoneButMarkerPresent()
+        public void FlagsLosingSidAudioEntityWhenResolverPicksSibling()
         {
-            // Multi-sid granularity — the marker is per-walletId, so removing one sid leaves
-            // the marker and the other sid's audio entity in place. Per-sid doom must arrive
-            // through the registry.IsStreamGone(comp.Key) fallback, not the marker shortcut.
+            // Ghost-vs-winner — the registry still holds two candidate sids for the wallet (LiveKit
+            // dropped an unsubscribe), but the resolver now picks only one. Both audio entities exist
+            // as a hangover from before the flip (sid-1 was the previous pick, sid-2 just won).
+            // Per-sid doom arrives via !registry.IsActiveSid(comp.Key.identity, comp.Key.sid) — the
+            // demoted ghost sid is reaped, the winner survives, the marker stays (it tracks the wallet,
+            // not the sid).
             const string SID_2 = "sid-2";
             (Entity audioEntity1, Entity avatarEntity, LivekitAudioSource source1) = SeedBinding(PARTICIPANT_A, SID_1);
-            registry.Add(PARTICIPANT_A, SID_2);
 
             // Sid-2 entity coexists; both audio entities share the same avatar (and its marker).
             var key2 = new StreamKey(PARTICIPANT_A, SID_2);
@@ -282,15 +284,42 @@ namespace DCL.VoiceChat.Nearby.Tests
             Entity audioEntity2 = world.Create(new NearbyAudioSourceComponent(key2, avatarEntity, source2));
             bindings.Add(key2);
 
-            // Drop only sid-1 from the registry. Marker stays (sid-2 still present).
-            registry.RemoveSid(PARTICIPANT_A, SID_1);
+            // Resolver flips to sid-2; sid-1 stays in the registry as a ghost.
+            registry.SetActiveSid(PARTICIPANT_A, SID_2);
 
             system.Update(0);
 
             AssertCleanedUp(audioEntity1, source1, PARTICIPANT_A, SID_1);
             Assert.That(world.Has<DeleteEntityIntention>(audioEntity2), Is.False,
-                "sibling sid must remain alive — multi-sid is the case the registry fallback exists for");
+                "winning sid must remain alive — only the demoted ghost is reaped");
             Assert.That(source2 == null, Is.False);
+        }
+
+        [Test]
+        public void GhostSidLosingResolverPickCausesCleanup()
+        {
+            // Test 9 from the spec — the audio entity's sid is no longer the resolver's pick.
+            // Distinct from RegistryMissingSidCausesCleanup: here the sid still EXISTS in the registry
+            // (HasAudioStream=true), it just lost the active-pick race. The !IsActiveSid predicate
+            // must reap it regardless of whether the registry still indexes the sid.
+            (Entity audioEntity, _, LivekitAudioSource source) = SeedBinding(PARTICIPANT_A, SID_1);
+
+            // Resolver demotes sid-1 in favour of a fresher candidate; HasAudioStream stays true
+            // (registry still holds candidates for the identity).
+            const string SID_FRESH = "sid-fresh";
+            registry.SetActiveSid(PARTICIPANT_A, SID_FRESH);
+
+            // Sanity-check the precondition the test depends on.
+            Assert.That(registry.HasAudioStream(PARTICIPANT_A), Is.True,
+                "precondition: identity still indexed (only the active pick changed)");
+            Assert.That(registry.IsActiveSid(PARTICIPANT_A, SID_1), Is.False,
+                "precondition: bound sid is no longer the active one");
+            // The Asserts above bumped IsActiveSidCallCount via the precondition; reset before the system tick.
+            registry.ResetCallCounters();
+
+            system.Update(0);
+
+            AssertCleanedUp(audioEntity, source, PARTICIPANT_A, SID_1);
         }
 
         [Test]
@@ -315,7 +344,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         public void DoesNotQueryRegistryWhenMarkerAbsentPathDoomsEntity()
         {
             // Optional sanity — proves the cheap shortcut actually short-circuits the registry call.
-            // If the marker-absence clause fires, registry.IsStreamGone must NOT be invoked.
+            // If the marker-absence clause fires, registry.IsActiveSid must NOT be invoked.
             (_, Entity avatarEntity, _) = SeedBinding(PARTICIPANT_A, SID_1);
             world.Remove<NearbyAudioStreamerComponent>(avatarEntity);
 
@@ -323,7 +352,7 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             system.Update(0);
 
-            Assert.That(registry.IsStreamGoneCallCount, Is.EqualTo(0),
+            Assert.That(registry.IsActiveSidCallCount, Is.EqualTo(0),
                 "marker-absence must short-circuit before the registry lookup");
             Assert.That(userBlockingCache.ReceivedCalls(), Is.Empty,
                 "marker-absence must short-circuit before the blocking cache lookup");
@@ -357,7 +386,7 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             system.Update(0);
 
-            Assert.That(registry.IsStreamGoneCallCount, Is.EqualTo(0),
+            Assert.That(registry.IsActiveSidCallCount, Is.EqualTo(0),
                 "InAudibleRangeTag absence must short-circuit before the registry lookup");
             Assert.That(userBlockingCache.ReceivedCalls(), Is.Empty,
                 "InAudibleRangeTag absence must short-circuit before the blocking cache lookup");
@@ -433,8 +462,8 @@ namespace DCL.VoiceChat.Nearby.Tests
             // a live audio entity is both markers present — Bridge applied StreamingAudioComponent
             // and AudibleRangeMarker applied InAudibleRangeTag before Binding spawned the entity.
             // Pair all three in the seed so existing trigger tests exercise the intended fallbacks
-            // (IsStreamGone / UserIsBlocked / lifecycle), not the marker-absence shortcuts by accident.
-            world.Add(avatarEntity, new NearbyAudioStreamerComponent(new[] { sid }));
+            // (!IsActiveSid / UserIsBlocked / lifecycle), not the marker-absence shortcuts by accident.
+            world.Add(avatarEntity, new NearbyAudioStreamerComponent(sid));
             world.Add<InAudibleRangeTag>(avatarEntity);
             registry.Add(walletId, sid);
 
@@ -475,66 +504,80 @@ namespace DCL.VoiceChat.Nearby.Tests
 
         private sealed class FakeStreamRegistry : INearbyAudioStreamRegistry
         {
-            // Per-wallet sid set as a HashSet — cleanup tests only need point-lookup semantics
-            // (IsStreamGone), not COW reference identity. Bridge tests are the place that
-            // exercises reference-equality contract.
-            private readonly Dictionary<string, HashSet<string>> sidsByIdentity = new ();
+            // Per-wallet active sid map. Cleanup interrogates the registry via IsActiveSid;
+            // the resolver-dedup contract guarantees at most one active sid per identity, so a
+            // plain wallet → sid map suffices.
+            private readonly Dictionary<string, string> activeSidByIdentity = new ();
+
+            // Per-wallet "registry has at least one sid for this identity" flag, decoupled from
+            // active-pick state so tests can model the all-zeros window (HasAudioStream=true,
+            // GetActiveSid=null) and ghost-demotion (sid exists in the registry but lost the pick).
+            private readonly HashSet<string> hasAudioStreamByIdentity = new ();
 
             // Call counters for asserting short-circuit behaviour. NSubstitute is overkill here —
             // INearbyAudioStreamRegistry has a hand-rolled fake to drive trigger combinations,
             // and a single counter keeps the cleanup-shortcut test honest.
-            public int IsStreamGoneCallCount { get; private set; }
+            public int IsActiveSidCallCount { get; private set; }
 
-            public void ResetCallCounters() => IsStreamGoneCallCount = 0;
+            public void ResetCallCounters() => IsActiveSidCallCount = 0;
 
             public void Add(string walletId, string sid)
             {
-                if (!sidsByIdentity.TryGetValue(walletId, out HashSet<string>? sids))
-                {
-                    sids = new HashSet<string>();
-                    sidsByIdentity[walletId] = sids;
-                }
-
-                sids.Add(sid);
+                // Mirrors production: an Add publishes a new active pick. Tests that need to model
+                // ghost-vs-winner can use SetActiveSid / DemoteToGhost directly.
+                hasAudioStreamByIdentity.Add(walletId);
+                activeSidByIdentity[walletId] = sid;
             }
 
-            public void RemoveAll(string walletId) =>
-                sidsByIdentity.Remove(walletId);
+            public void RemoveAll(string walletId)
+            {
+                hasAudioStreamByIdentity.Remove(walletId);
+                activeSidByIdentity.Remove(walletId);
+            }
 
             public void RemoveSid(string walletId, string sid)
             {
-                if (sidsByIdentity.TryGetValue(walletId, out HashSet<string>? sids))
-                    sids.Remove(sid);
+                // Mirrors production semantics — when the registry drops the sid that was the active
+                // pick, the identity has no winner anymore. If it was not the active pick (i.e. a
+                // ghost), HasAudioStream stays unchanged.
+                if (activeSidByIdentity.TryGetValue(walletId, out string? active) && active == sid)
+                {
+                    activeSidByIdentity.Remove(walletId);
+                    hasAudioStreamByIdentity.Remove(walletId);
+                }
             }
 
-            public void ClearAll() =>
-                sidsByIdentity.Clear();
+            /// <summary>
+            /// Promotes a different sid to the active pick for <paramref name="walletId"/>, leaving the
+            /// previous one as a "ghost" — it still exists in the registry (HasAudioStream=true) but
+            /// <see cref="IsActiveSid"/> returns false for it. Models the resolver flipping winners.
+            /// </summary>
+            public void SetActiveSid(string walletId, string sid)
+            {
+                hasAudioStreamByIdentity.Add(walletId);
+                activeSidByIdentity[walletId] = sid;
+            }
+
+            public void ClearAll()
+            {
+                hasAudioStreamByIdentity.Clear();
+                activeSidByIdentity.Clear();
+            }
 
             public bool HasAudioStream(string walletId) =>
-                sidsByIdentity.TryGetValue(walletId, out HashSet<string>? sids) && sids.Count > 0;
-
-            public string[]? GetAudioSidsArray(string walletId)
-            {
-                if (!sidsByIdentity.TryGetValue(walletId, out HashSet<string>? sids) || sids.Count == 0)
-                    return null;
-
-                var arr = new string[sids.Count];
-                sids.CopyTo(arr);
-                return arr;
-            }
+                hasAudioStreamByIdentity.Contains(walletId);
 
             public Weak<AudioStream> GetActiveStream(StreamKey key) =>
                 Weak<AudioStream>.Null;
 
-            public bool IsStreamGone(StreamKey key)
+            public string? GetActiveSid(string walletId) =>
+                activeSidByIdentity.TryGetValue(walletId, out string? sid) ? sid : null;
+
+            public bool IsActiveSid(string walletId, string sid)
             {
-                IsStreamGoneCallCount++;
-                return !sidsByIdentity.TryGetValue(key.identity, out HashSet<string>? sids) || !sids.Contains(key.sid);
+                IsActiveSidCallCount++;
+                return activeSidByIdentity.TryGetValue(walletId, out string? active) && active == sid;
             }
-
-            public string? GetActiveSid(string walletId) => null;
-
-            public bool IsActiveSid(string walletId, string sid) => false;
 
             public bool IsActiveSpeaker(string walletId) => false;
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioCleanupSystemShould.cs
@@ -286,7 +286,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             // Sanity-check the precondition the test depends on.
             Assert.That(registry.HasAudioStream(PARTICIPANT_A), Is.True,
                 "precondition: identity still indexed (only the active pick changed)");
-            Assert.That(registry.IsActiveSid(PARTICIPANT_A, SID_1), Is.False,
+            Assert.That(registry.IsActiveSid(new StreamKey(PARTICIPANT_A, SID_1)), Is.False,
                 "precondition: bound sid is no longer the active one");
             // The Asserts above bumped IsActiveSidCallCount via the precondition; reset before the system tick.
             registry.ResetCallCounters();
@@ -545,10 +545,10 @@ namespace DCL.VoiceChat.Nearby.Tests
             public string? GetActiveSid(string walletId) =>
                 activeSidByIdentity.TryGetValue(walletId, out string? sid) ? sid : null;
 
-            public bool IsActiveSid(string walletId, string sid)
+            public bool IsActiveSid(StreamKey key)
             {
                 IsActiveSidCallCount++;
-                return activeSidByIdentity.TryGetValue(walletId, out string? active) && active == sid;
+                return activeSidByIdentity.TryGetValue(key.identity, out string? active) && active == key.sid;
             }
 
             public bool IsActiveSpeaker(string walletId) => false;

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioPositionSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioPositionSystemShould.cs
@@ -20,11 +20,12 @@ namespace DCL.VoiceChat.Nearby.Tests
     /// <summary>
     /// Documents the Nearby Audio Position System behavior — strict read+drive, no lifecycle responsibility:
     ///
-    /// - Reads avatar position via <see cref="NearbyAudioSourceComponent.AvatarEntity"/>.
+    /// - Reads avatar position from the SAME entity that carries <see cref="NearbyAudioSourceComponent"/>
+    ///   (co-located after slice 4 — no cross-entity hop).
     /// - Drives <see cref="LivekitAudioSource"/> transform + spatial angles each frame.
     /// - Reprojects source position relative to the player head.
     ///
-    /// Structural changes for audio entities are owned exclusively by <see cref="NearbyAudioCleanupSystem"/>.
+    /// Structural changes for audio components are owned exclusively by <see cref="NearbyAudioCleanupSystem"/>.
     /// </summary>
     public class NearbyAudioPositionSystemShould : UnitySystemTestBase<NearbyAudioPositionSystem>
     {
@@ -429,14 +430,21 @@ namespace DCL.VoiceChat.Nearby.Tests
                 avatarBase,
                 new CharacterTransform(avatarGo.transform));
 
+            // Slice 4: PositionSystem's query is gated on NearbyAudioStreamerComponent (co-located on the
+            // avatar entity). Seed it so the per-frame contract tests below all hit the spatial pipeline.
+            world.Add(entity, new NearbyAudioStreamerComponent("sid-1"));
             world.Add<InAudibleRangeTag>(entity);
             return entity;
         }
 
+        // Slice 4: the audio-source component is co-located on the avatar entity. There is no separate
+        // audio entity anymore — this helper now just attaches the component to the existing avatar and
+        // returns the same Entity for tests that still bind a local to "audio entity".
         private Entity CreateAudioEntity(string identity, string sid, Entity avatarEntity, LivekitAudioSource source)
         {
             var key = new StreamKey(identity, sid);
-            return world.Create(new NearbyAudioSourceComponent(key, avatarEntity, source));
+            world.Add(avatarEntity, new NearbyAudioSourceComponent(key, source));
+            return avatarEntity;
         }
 
         private LivekitAudioSource CreateLivekitAudioSource()

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioStreamRegistryShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioStreamRegistryShould.cs
@@ -160,14 +160,14 @@ namespace DCL.VoiceChat.Nearby.Tests
             RaiseTrackUnsubscribed(WALLET_A, SID_1);
 
             Assert.That(registry.HasAudioStream(WALLET_A), Is.False);
-            Assert.That(registry.GetAudioSidsArray(WALLET_A), Is.Null);
+            Assert.That(registry.GetActiveSid(WALLET_A), Is.Null);
         }
 
         [Test]
         public void ReturnNullForUnknownWallet()
         {
             Assert.That(registry.HasAudioStream("0xUNKNOWN"), Is.False);
-            Assert.That(registry.GetAudioSidsArray("0xUNKNOWN"), Is.Null);
+            Assert.That(registry.GetActiveSid("0xUNKNOWN"), Is.Null);
         }
 
         [Test]
@@ -344,26 +344,25 @@ namespace DCL.VoiceChat.Nearby.Tests
         [Test]
         public void ReaderNeverObservesPartialSnapshotDuringConcurrentReconnect()
         {
-            // Atomic-publish invariant: a main-thread reader polling GetAudioSidsArray for an identity
-            // that is present both before and after rehydrate must never observe null mid-rehydrate.
-            // With in-place Clear()+rebuild the reader would see a transient null window; with
-            // Interlocked.Exchange-based snapshot swap it sees only pre-state or post-state references.
+            // Atomic-publish invariant: a main-thread reader polling HasAudioStream for an identity
+            // that is present both before and after rehydrate must never observe a transient false
+            // mid-rehydrate. With in-place Clear()+rebuild the reader would see a "wallet missing"
+            // window; with Interlocked.Exchange-based snapshot swap it only sees pre- or post-state.
             SetupRemoteParticipants((WALLET_A, new[] { (SID_1, TrackKind.KindAudio) }));
             RaiseConnectionUpdated(ConnectionUpdate.Connected);
 
             const int RECONNECT_ITERATIONS = 500;
             using var cts = new CancellationTokenSource();
-            string? observedNullAt = null;
+            string? observedMissingAt = null;
 
             Task reader = Task.Run(() =>
             {
                 int loops = 0;
                 while (!cts.IsCancellationRequested)
                 {
-                    string[]? arr = registry.GetAudioSidsArray(WALLET_A);
-                    if (arr == null)
+                    if (!registry.HasAudioStream(WALLET_A))
                     {
-                        observedNullAt = "loop " + loops;
+                        observedMissingAt = "loop " + loops;
                         return;
                     }
                     loops++;
@@ -380,8 +379,8 @@ namespace DCL.VoiceChat.Nearby.Tests
             cts.Cancel();
             Assert.That(reader.Wait(millisecondsTimeout: 5000), Is.True, "reader must terminate within timeout");
 
-            Assert.That(observedNullAt, Is.Null,
-                $"WALLET_A is present pre- and post-rehydrate; reader observed transient null at {observedNullAt}");
+            Assert.That(observedMissingAt, Is.Null,
+                $"WALLET_A is present pre- and post-rehydrate; reader observed transient absence at {observedMissingAt}");
         }
 
         [Test]
@@ -404,57 +403,25 @@ namespace DCL.VoiceChat.Nearby.Tests
             {
                 for (int i = 0; i < ITERATIONS && !cts.IsCancellationRequested; i++)
                 {
-                    string[]? snapshot = registry.GetAudioSidsArray(WALLET_A);
-                    if (snapshot == null) continue;
-                    // Iterate the snapshot — the reference is immutable by COW contract,
-                    // so no torn state is observable even while writer is pushing new versions.
-                    for (int j = 0; j < snapshot.Length; j++) { _ = snapshot[j]; }
+                    // Pull-based reader: the resolver iterates a COW array internally; any snapshot
+                    // it touches is immutable post-publication, so no torn state is observable even
+                    // while writer is pushing new versions. Discard the result — we only care that
+                    // the call returns cleanly under contention.
+                    _ = registry.GetActiveSid(WALLET_A);
                 }
             });
 
             Assert.DoesNotThrow(() => Task.WaitAll(new[] { writer, reader }, millisecondsTimeout: 5000));
         }
 
-        // ── B2.1: COW reference-equality contract ───────────────────
-
         [Test]
-        public void SubscribingThenUnsubscribingSameSidProducesDistinctArrayReferences()
-        {
-            RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
-            string[] ref1 = registry.GetAudioSidsArray(WALLET_A)!;
-
-            RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
-            string[] ref2 = registry.GetAudioSidsArray(WALLET_A)!;
-
-            RaiseTrackUnsubscribed(WALLET_A, SID_1);
-            string[] ref3 = registry.GetAudioSidsArray(WALLET_A)!;
-
-            Assert.That(ReferenceEquals(ref1, ref2), Is.False, "subscribe must publish a NEW array reference");
-            Assert.That(ReferenceEquals(ref2, ref3), Is.False, "unsubscribe must publish a NEW array reference");
-            Assert.That(ReferenceEquals(ref1, ref3), Is.False, "no path may reuse a prior reference");
-        }
-
-        [Test]
-        public void SameSidSetObservedTwiceReturnsSameReference()
-        {
-            RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
-
-            string[]? a = registry.GetAudioSidsArray(WALLET_A);
-            string[]? b = registry.GetAudioSidsArray(WALLET_A);
-
-            Assert.That(a, Is.Not.Null);
-            Assert.That(ReferenceEquals(a, b), Is.True,
-                "two reads with no intervening event must return the same reference — Bridge's no-op invariant");
-        }
-
-        [Test]
-        public void IsStreamGoneReturnsTrueAfterLastSidUnsubscribed()
+        public void HasAudioStreamReturnsFalseAfterLastSidUnsubscribed()
         {
             RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
             RaiseTrackUnsubscribed(WALLET_A, SID_1);
 
-            Assert.That(registry.IsStreamGone(new StreamKey(WALLET_A, SID_1)), Is.True);
             Assert.That(registry.HasAudioStream(WALLET_A), Is.False);
+            Assert.That(registry.GetActiveSid(WALLET_A), Is.Null);
         }
 
         // ── Active-sid resolver (frame-activity oracle) ──────────────
@@ -566,11 +533,13 @@ namespace DCL.VoiceChat.Nearby.Tests
             }
         }
 
-        private bool ContainsSid(string walletId, string sid)
-        {
-            string[]? arr = registry.GetAudioSidsArray(walletId);
-            return arr != null && Array.IndexOf(arr, sid) >= 0;
-        }
+        // Post-dedup the registry no longer exposes the underlying sid array. For tests that
+        // subscribe a single sid, IsActiveSid is an equivalent presence probe (single candidate
+        // is automatically the active pick by hot-path contract). Multi-sid tests that depended
+        // on per-sid index probing were either deleted (reference-equality on the array) or were
+        // already updated to use the resolver semantics directly.
+        private bool ContainsSid(string walletId, string sid) =>
+            registry.IsActiveSid(walletId, sid);
 
         private void RaiseTrackSubscribed(string identity, string sid, TrackKind kind, TrackSource source = TrackSource.SourceMicrophone)
         {

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioStreamRegistryShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioStreamRegistryShould.cs
@@ -5,6 +5,7 @@ using LiveKit.Rooms;
 using LiveKit.Rooms.ActiveSpeakers;
 using LiveKit.Rooms.Participants;
 using LiveKit.Rooms.Streaming;
+using LiveKit.Rooms.Streaming.Audio;
 using LiveKit.Rooms.TrackPublications;
 using LiveKit.Rooms.Tracks.Hub;
 using NSubstitute;
@@ -29,6 +30,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         private IRoom room = null!;
         private IParticipantsHub participantsHub = null!;
         private FakeActiveSpeakers activeSpeakers = null!;
+        private IAudioStreams audioStreams = null!;
         private NearbyAudioStreamsRegistry registry = null!;
 
         [SetUp]
@@ -39,6 +41,11 @@ namespace DCL.VoiceChat.Nearby.Tests
             room.Participants.Returns(participantsHub);
             activeSpeakers = new FakeActiveSpeakers();
             room.ActiveSpeakers.Returns(activeSpeakers);
+            audioStreams = Substitute.For<IAudioStreams>();
+            // -1 sentinel matches production: missing stream / never decoded a frame.
+            audioStreams.GetLastFrameReceivedAt(default).ReturnsForAnyArgs(-1);
+            audioStreams.ClearReceivedCalls(); // stub-setup call counts as received; clear so DidNotReceive assertions are clean.
+            room.AudioStreams.Returns(audioStreams);
             registry = new NearbyAudioStreamsRegistry(room);
         }
 
@@ -448,6 +455,91 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             Assert.That(registry.IsStreamGone(new StreamKey(WALLET_A, SID_1)), Is.True);
             Assert.That(registry.HasAudioStream(WALLET_A), Is.False);
+        }
+
+        // ── Active-sid resolver (frame-activity oracle) ──────────────
+
+        [Test]
+        public void ReturnNullActiveSidForUnknownWallet()
+        {
+            Assert.That(registry.GetActiveSid("0xUNKNOWN"), Is.Null);
+        }
+
+        [Test]
+        public void ReturnSingleSidAsActiveWithoutConsultingFrameOracle()
+        {
+            RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
+
+            Assert.That(registry.GetActiveSid(WALLET_A), Is.EqualTo(SID_1));
+            audioStreams.DidNotReceiveWithAnyArgs().GetLastFrameReceivedAt(default);
+        }
+
+        [Test]
+        public void ReturnNullActiveSidWhenAllCandidatesAreGhosts()
+        {
+            RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
+            RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
+            // Both stay at the default -1 sentinel — none have ever decoded a frame.
+
+            Assert.That(registry.GetActiveSid(WALLET_A), Is.Null);
+        }
+
+        [Test]
+        public void PickTheOnlyCandidateWithFrameActivity()
+        {
+            RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
+            RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
+
+            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_2)).Returns(100);
+            // SID_1 keeps the default -1 sentinel (ghost).
+
+            Assert.That(registry.GetActiveSid(WALLET_A), Is.EqualTo(SID_2));
+        }
+
+        [Test]
+        public void PickTheNewestCandidateWhenSeveralAreLive()
+        {
+            RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
+            RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
+
+            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_1)).Returns(100);
+            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_2)).Returns(200);
+
+            Assert.That(registry.GetActiveSid(WALLET_A), Is.EqualTo(SID_2));
+        }
+
+        [Test]
+        public void TreatTickCounterWrapAroundAsNewerNotOlder()
+        {
+            RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
+            RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
+
+            // Pre-wrap (older), positive end of the range.
+            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_1)).Returns(int.MaxValue - 50);
+            // Post-wrap (newer in unchecked arithmetic), negative end of the range.
+            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_2)).Returns(int.MinValue + 50);
+
+            Assert.That(registry.GetActiveSid(WALLET_A), Is.EqualTo(SID_2),
+                "unchecked(SID_2_tick - SID_1_tick) == 101 > 0 — resolver must prefer the post-wrap candidate");
+        }
+
+        [Test]
+        public void IsActiveSidTrueForWinnerFalseForGhostLoser()
+        {
+            RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
+            RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
+
+            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_2)).Returns(500);
+            // SID_1 keeps -1 (ghost).
+
+            Assert.That(registry.IsActiveSid(WALLET_A, SID_2), Is.True);
+            Assert.That(registry.IsActiveSid(WALLET_A, SID_1), Is.False);
+        }
+
+        [Test]
+        public void IsActiveSidFalseWhenWalletHasNoSids()
+        {
+            Assert.That(registry.IsActiveSid("0xUNKNOWN", SID_1), Is.False);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioStreamRegistryShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioStreamRegistryShould.cs
@@ -10,6 +10,7 @@ using LiveKit.Rooms.TrackPublications;
 using LiveKit.Rooms.Tracks.Hub;
 using NSubstitute;
 using NUnit.Framework;
+using RichTypes;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -31,6 +32,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         private IParticipantsHub participantsHub = null!;
         private FakeActiveSpeakers activeSpeakers = null!;
         private IAudioStreams audioStreams = null!;
+        private FrameOracleStub frameOracle = null!;
         private NearbyAudioStreamsRegistry registry = null!;
 
         [SetUp]
@@ -42,11 +44,9 @@ namespace DCL.VoiceChat.Nearby.Tests
             activeSpeakers = new FakeActiveSpeakers();
             room.ActiveSpeakers.Returns(activeSpeakers);
             audioStreams = Substitute.For<IAudioStreams>();
-            // -1 sentinel matches production: missing stream / never decoded a frame.
-            audioStreams.GetLastFrameReceivedAt(default).ReturnsForAnyArgs(-1);
-            audioStreams.ClearReceivedCalls(); // stub-setup call counts as received; clear so DidNotReceive assertions are clean.
             room.AudioStreams.Returns(audioStreams);
-            registry = new NearbyAudioStreamsRegistry(room);
+            frameOracle = new FrameOracleStub();
+            registry = new NearbyAudioStreamsRegistry(room, frameOracle.Get);
         }
 
         [TearDown]
@@ -438,7 +438,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
 
             Assert.That(registry.GetActiveSid(WALLET_A), Is.EqualTo(SID_1));
-            audioStreams.DidNotReceiveWithAnyArgs().GetLastFrameReceivedAt(default);
+            Assert.That(frameOracle.Calls, Is.Zero, "single-sid hot path must not consult the frame oracle");
         }
 
         [Test]
@@ -446,7 +446,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         {
             RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
             RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
-            // Both stay at the default -1 sentinel — none have ever decoded a frame.
+            // Both stay at the default Option.None — none have ever decoded a frame.
 
             Assert.That(registry.GetActiveSid(WALLET_A), Is.Null);
         }
@@ -457,8 +457,8 @@ namespace DCL.VoiceChat.Nearby.Tests
             RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
             RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
 
-            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_2)).Returns(100);
-            // SID_1 keeps the default -1 sentinel (ghost).
+            frameOracle.Set(new StreamKey(WALLET_A, SID_2), 100);
+            // SID_1 keeps the default Option.None (ghost).
 
             Assert.That(registry.GetActiveSid(WALLET_A), Is.EqualTo(SID_2));
         }
@@ -469,8 +469,8 @@ namespace DCL.VoiceChat.Nearby.Tests
             RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
             RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
 
-            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_1)).Returns(100);
-            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_2)).Returns(200);
+            frameOracle.Set(new StreamKey(WALLET_A, SID_1), 100);
+            frameOracle.Set(new StreamKey(WALLET_A, SID_2), 200);
 
             Assert.That(registry.GetActiveSid(WALLET_A), Is.EqualTo(SID_2));
         }
@@ -482,9 +482,9 @@ namespace DCL.VoiceChat.Nearby.Tests
             RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
 
             // Pre-wrap (older), positive end of the range.
-            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_1)).Returns(int.MaxValue - 50);
+            frameOracle.Set(new StreamKey(WALLET_A, SID_1), int.MaxValue - 50);
             // Post-wrap (newer in unchecked arithmetic), negative end of the range.
-            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_2)).Returns(int.MinValue + 50);
+            frameOracle.Set(new StreamKey(WALLET_A, SID_2), int.MinValue + 50);
 
             Assert.That(registry.GetActiveSid(WALLET_A), Is.EqualTo(SID_2),
                 "unchecked(SID_2_tick - SID_1_tick) == 101 > 0 — resolver must prefer the post-wrap candidate");
@@ -496,8 +496,8 @@ namespace DCL.VoiceChat.Nearby.Tests
             RaiseTrackSubscribed(WALLET_A, SID_1, TrackKind.KindAudio);
             RaiseTrackSubscribed(WALLET_A, SID_2, TrackKind.KindAudio);
 
-            audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_2)).Returns(500);
-            // SID_1 keeps -1 (ghost).
+            frameOracle.Set(new StreamKey(WALLET_A, SID_2), 500);
+            // SID_1 keeps Option.None (ghost).
 
             Assert.That(registry.IsActiveSid(new StreamKey(WALLET_A, SID_2)), Is.True);
             Assert.That(registry.IsActiveSid(new StreamKey(WALLET_A, SID_1)), Is.False);
@@ -624,6 +624,24 @@ namespace DCL.VoiceChat.Nearby.Tests
             typeof(TrackPublication).GetField("info", BindingFlags.Instance | BindingFlags.NonPublic)!
                                     .SetValue(publication, info);
             return publication;
+        }
+
+        // Replaces NSubstitute stubs for the frame-activity oracle: the production seam is a
+        // Func<StreamKey, Option<int>> because the LiveKit helper is an extension method (not on the
+        // interface) and AudioStream itself is FFI-bound and non-virtual.
+        private sealed class FrameOracleStub
+        {
+            private readonly Dictionary<StreamKey, int> values = new ();
+            public int Calls { get; private set; }
+
+            public void Set(StreamKey key, int tick) =>
+                values[key] = tick;
+
+            public Option<int> Get(StreamKey key)
+            {
+                Calls++;
+                return values.TryGetValue(key, out int v) ? Option<int>.Some(v) : Option<int>.None;
+            }
         }
 
         private sealed class FakeActiveSpeakers : IActiveSpeakers

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioStreamRegistryShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyAudioStreamRegistryShould.cs
@@ -499,14 +499,14 @@ namespace DCL.VoiceChat.Nearby.Tests
             audioStreams.GetLastFrameReceivedAt(new StreamKey(WALLET_A, SID_2)).Returns(500);
             // SID_1 keeps -1 (ghost).
 
-            Assert.That(registry.IsActiveSid(WALLET_A, SID_2), Is.True);
-            Assert.That(registry.IsActiveSid(WALLET_A, SID_1), Is.False);
+            Assert.That(registry.IsActiveSid(new StreamKey(WALLET_A, SID_2)), Is.True);
+            Assert.That(registry.IsActiveSid(new StreamKey(WALLET_A, SID_1)), Is.False);
         }
 
         [Test]
         public void IsActiveSidFalseWhenWalletHasNoSids()
         {
-            Assert.That(registry.IsActiveSid("0xUNKNOWN", SID_1), Is.False);
+            Assert.That(registry.IsActiveSid(new StreamKey("0xUNKNOWN", SID_1)), Is.False);
         }
 
         [Test]
@@ -539,7 +539,7 @@ namespace DCL.VoiceChat.Nearby.Tests
         // on per-sid index probing were either deleted (reference-equality on the array) or were
         // already updated to use the resolver semantics directly.
         private bool ContainsSid(string walletId, string sid) =>
-            registry.IsActiveSid(walletId, sid);
+            registry.IsActiveSid(new StreamKey(walletId, sid));
 
         private void RaiseTrackSubscribed(string identity, string sid, TrackKind kind, TrackSource source = TrackSource.SourceMicrophone)
         {

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyLivekitBridgeSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyLivekitBridgeSystemShould.cs
@@ -215,11 +215,10 @@ namespace DCL.VoiceChat.Nearby.Tests
         }
 
         [Test]
-        public void T8_AvatarLosesComponentWhenHasAudioStreamGoesFalseButNotDuringAllZerosWindow()
+        public void T8a_PreservesComponentDuringAllZerosWindow()
         {
-            // Test 8 from the spec — combined two-step assertion.
-            //   Step A — all-zeros window: HasAudioStream=true, GetActiveSid=null → wait, do NOT drop.
-            //   Step B — identity gone: HasAudioStream=false, GetActiveSid=null → drop with cascade.
+            // Test 8 (Step A) from the spec — all-zeros window: HasAudioStream=true, GetActiveSid=null.
+            // The bridge must wait it out; dropping here would thrash the component until the resolver self-heals.
             const string WALLET = "wallet-a";
             Entity e = CreateAvatarEntity(WALLET);
 
@@ -231,7 +230,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             Assert.That(world.Has<IsActivelySpeakingTag>(e), Is.True, "precondition: speaking tag set");
             world.Add(e, new InAudibleRangeTag { IsSuspended = false });
 
-            // Step A — resolver enters all-zeros window (identity still indexed, no candidate emitting).
+            // Resolver enters the all-zeros window: identity still indexed, no candidate emitting.
             registry.GetActiveSid(WALLET).Returns((string?)null);
             registry.HasAudioStream(WALLET).Returns(true);
 
@@ -241,8 +240,25 @@ namespace DCL.VoiceChat.Nearby.Tests
                 "all-zeros window (HasAudioStream && active=null) must NOT drop the component");
             Assert.That(world.Has<IsActivelySpeakingTag>(e), Is.True, "speaking tag must persist through the all-zeros window");
             Assert.That(world.Has<InAudibleRangeTag>(e), Is.True, "audible-range tag must persist through the all-zeros window");
+        }
 
-            // Step B — identity disappears entirely.
+        [Test]
+        public void T8b_DropsComponentWhenIdentityFullyGone()
+        {
+            // Test 8 (Step B) from the spec — identity disappears entirely: HasAudioStream=false → drop with cascade.
+            const string WALLET = "wallet-a";
+            Entity e = CreateAvatarEntity(WALLET);
+
+            StubStreaming(WALLET, "sid-1");
+            registry.IsActiveSpeaker(WALLET).Returns(true);
+
+            system.Update(0);
+            Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.True, "precondition: component attached");
+            Assert.That(world.Has<IsActivelySpeakingTag>(e), Is.True, "precondition: speaking tag set");
+            world.Add(e, new InAudibleRangeTag { IsSuspended = false });
+
+            // Identity disappears entirely.
+            registry.GetActiveSid(WALLET).Returns((string?)null);
             registry.HasAudioStream(WALLET).Returns(false);
 
             system.Update(0);

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyLivekitBridgeSystemShould.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/EditMode/NearbyLivekitBridgeSystemShould.cs
@@ -16,11 +16,12 @@ using Object = UnityEngine.Object;
 namespace DCL.VoiceChat.Nearby.Tests
 {
     /// <summary>
-    /// Documents the contract of <see cref="NearbyLivekitBridgeSystem"/>: every avatar's
-    /// <see cref="NearbyAudioStreamerComponent.StreamSidsSnapshot"/> reflects the registry's COW sid array
-    /// (reference-equal); <see cref="IsActivelySpeakingTag"/> reflects the registry's active-speaker
-    /// snapshot. Pure pull-mirror; pass-through under listening gate.
-    /// Invariant I1: <c>IsActivelySpeakingTag ⊆ StreamingAudioComponent</c>.
+    /// Documents the contract of <see cref="NearbyLivekitBridgeSystem"/> after the resolver-dedup collapse:
+    /// every avatar's <see cref="NearbyAudioStreamerComponent.CurrentSid"/> reflects the registry's single
+    /// active pick via <see cref="INearbyAudioStreamRegistry.GetActiveSid"/>;
+    /// <see cref="IsActivelySpeakingTag"/> reflects the registry's active-speaker snapshot. Pure pull-mirror;
+    /// pass-through under listening gate.
+    /// Invariant I1: <c>IsActivelySpeakingTag ⊆ NearbyAudioStreamerComponent</c>.
     /// </summary>
     public class NearbyLivekitBridgeSystemShould : UnitySystemTestBase<NearbyLivekitBridgeSystem>
     {
@@ -37,11 +38,11 @@ namespace DCL.VoiceChat.Nearby.Tests
             EcsTestsUtils.SetUpFeaturesRegistry();
 
             registry = Substitute.For<INearbyAudioStreamRegistry>();
-            // Default: no streams, no active speakers — explicit so individual tests only override
-            // the slot they care about. NSubstitute returns null/false for unstubbed reference/bool
-            // returns, but stating the contract makes intent legible.
-            registry.GetAudioSidsArray(Arg.Any<string>()).Returns((string[]?)null);
-            registry.IsActiveSpeaker(Arg.Any<string>()).Returns(false);
+            // Default: no active sid, no participants indexed, no active speakers. ReturnsForAnyArgs so the
+            // default stub does not count as a received call for short-circuit assertions in DoesNotRevisit...
+            registry.GetActiveSid(Arg.Any<string>()).ReturnsForAnyArgs((string?)null);
+            registry.HasAudioStream(Arg.Any<string>()).ReturnsForAnyArgs(false);
+            registry.IsActiveSpeaker(Arg.Any<string>()).ReturnsForAnyArgs(false);
 
             system = new NearbyLivekitBridgeSystem(world, registry);
         }
@@ -58,17 +59,17 @@ namespace DCL.VoiceChat.Nearby.Tests
         // ── AddStreaming query ──────────────────────────────────────
 
         [Test]
-        public void AddStreamingAttachesComponentWhenRegistryHasSids()
+        public void AddStreamingAttachesComponentWhenResolverReturnsActiveSid()
         {
             const string WALLET = "wallet-a";
+            const string SID = "sid-1";
             Entity e = CreateAvatarEntity(WALLET);
-            string[] sids = StubStreaming(WALLET, "sid-1");
+            StubStreaming(WALLET, SID);
 
             system.Update(0);
 
             Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.True);
-            Assert.That(ReferenceEquals(world.Get<NearbyAudioStreamerComponent>(e).StreamSidsSnapshot, sids), Is.True,
-                "SidsSnapshot must be reference-equal to the registry's COW array");
+            Assert.That(world.Get<NearbyAudioStreamerComponent>(e).CurrentSid, Is.EqualTo(SID));
         }
 
         [Test]
@@ -87,35 +88,34 @@ namespace DCL.VoiceChat.Nearby.Tests
         [Test]
         public void AddStreamingSkipsAvatarAlreadyHavingComponent()
         {
-            // Filter [None<StreamingAudioComponent>] must prevent the AddStreaming query from
-            // re-attaching a fresh component on an avatar that already carries one. UpdateStreaming
+            // Filter [None<NearbyAudioStreamerComponent>] must prevent the AddStreaming query from
+            // re-attaching a fresh component on an avatar that already carries one. RefreshStreaming
             // is the single place that mutates an existing component.
             const string WALLET = "wallet-a";
             Entity e = CreateAvatarEntity(WALLET);
-            string[] preexisting = { "sid-pre" };
-            world.Add(e, new NearbyAudioStreamerComponent(preexisting));
+            world.Add(e, new NearbyAudioStreamerComponent("sid-pre"));
             StubStreaming(WALLET, "sid-other");
 
             system.Update(0);
 
-            // Either Update kept it (preexisting reference) or refreshed it to the registry's array;
-            // either way, AddStreaming must NOT have piled on a second component.
+            // Either Update kept it or refreshed CurrentSid in place; either way, AddStreaming must NOT
+            // have piled on a second component (would throw on Arch).
             Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.True);
         }
 
         [Test]
         public void AddStreamingSkipsAvatarWithEmptyWalletId()
         {
-            // Avatar with empty UserId. Poison the empty-string slot with a non-null sids array
-            // so an impl which fails to short-circuit on empty walletId would mistakenly attach
-            // the component. The empty-walletId guard is the observable behavior.
+            // Avatar with empty UserId. Poison the empty-string slot with a non-null active sid so an
+            // impl which fails to short-circuit on empty walletId would mistakenly attach the component.
             var avatarGo = CreateTrackedGameObject("Avatar_empty");
             AvatarBase avatarBase = avatarGo.AddComponent<AvatarBase>();
             var anchorGo = CreateTrackedGameObject("HeadAnchor_empty");
             anchorGo.transform.SetParent(avatarGo.transform);
             HEAD_ANCHOR_FIELD.SetValue(avatarBase, anchorGo.transform);
 
-            registry.GetAudioSidsArray("").Returns(new[] { "sid-poison" });
+            registry.GetActiveSid("").Returns("sid-poison");
+            registry.HasAudioStream("").Returns(true);
 
             Entity e = world.Create(new Profile("", "", new Avatar()), avatarBase);
 
@@ -124,46 +124,132 @@ namespace DCL.VoiceChat.Nearby.Tests
             Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.False);
         }
 
-        // ── UpdateStreaming query ───────────────────────────────────
+        [Test]
+        public void AddStreamingWaitsDuringAllZerosWindow()
+        {
+            // All-zeros window: registry has the identity but the resolver has not picked a sid yet
+            // (no candidate has emitted a frame). The bridge must not attach a component — wait for
+            // the next tick, the resolver self-heals on the first frame.
+            const string WALLET = "wallet-a";
+            Entity e = CreateAvatarEntity(WALLET);
+            registry.GetActiveSid(WALLET).Returns((string?)null);
+            registry.HasAudioStream(WALLET).Returns(true);
+
+            system.Update(0);
+
+            Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.False,
+                "all-zeros window must defer attachment until the resolver picks a sid");
+        }
+
+        // ── RefreshStreaming query ───────────────────────────────────
 
         [Test]
-        public void UpdateStreamingNoOpWhenReferenceUnchanged()
+        public void RefreshStreamingNoOpWhenResolverStable()
         {
             const string WALLET = "wallet-a";
             Entity e = CreateAvatarEntity(WALLET);
-            string[] sids = StubStreaming(WALLET, "sid-1");
+            StubStreaming(WALLET, "sid-1");
 
             system.Update(0);
             Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.True);
 
-            // Two more ticks; registry returns the same array reference each time.
+            // Two more ticks; resolver picks the same sid each time.
             system.Update(0);
             system.Update(0);
 
-            Assert.That(ReferenceEquals(world.Get<NearbyAudioStreamerComponent>(e).StreamSidsSnapshot, sids), Is.True,
-                "stable registry → SidsSnapshot reference must remain unchanged across ticks");
+            Assert.That(world.Get<NearbyAudioStreamerComponent>(e).CurrentSid, Is.EqualTo("sid-1"),
+                "stable resolver → CurrentSid must remain unchanged across ticks");
         }
 
         [Test]
-        public void UpdateStreamingRefreshesReferenceWhenRegistryArrayChanged()
+        public void T6_AvatarGetsComponentWhenResolverFlipsFromNullToSid()
         {
+            // Test 6 from the spec: avatar starts with no component (resolver returns null — either
+            // unknown identity or all-zeros window). On the next tick the resolver picks sid-42; the
+            // bridge must attach NearbyAudioStreamerComponent(CurrentSid = "sid-42").
+            const string WALLET = "wallet-a";
+            const string SID_42 = "sid-42";
+            Entity e = CreateAvatarEntity(WALLET);
+
+            // Resolver: null on tick 1 (no pick yet), wallet not indexed.
+            registry.GetActiveSid(WALLET).Returns((string?)null);
+            registry.HasAudioStream(WALLET).Returns(false);
+
+            system.Update(0);
+            Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.False, "precondition: no component while resolver returns null");
+
+            // Resolver: sid-42 on tick 2.
+            registry.GetActiveSid(WALLET).Returns(SID_42);
+            registry.HasAudioStream(WALLET).Returns(true);
+
+            system.Update(0);
+
+            Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.True, "resolver flip null → sid-42 must attach the component");
+            Assert.That(world.Get<NearbyAudioStreamerComponent>(e).CurrentSid, Is.EqualTo(SID_42));
+        }
+
+        [Test]
+        public void T7_AvatarCurrentSidMutatesInPlaceWhenResolverFlipsSids()
+        {
+            // Test 7 from the spec: avatar already carries the component with CurrentSid = sid-42; on a
+            // later tick the resolver picks sid-7 instead (the previous winner was demoted by a fresher
+            // candidate). Bridge must ref-mutate CurrentSid without dropping/re-adding the component —
+            // structural change here would invalidate the speaking/audible cascade invariants.
+            const string WALLET = "wallet-a";
+            const string SID_42 = "sid-42";
+            const string SID_7 = "sid-7";
+            Entity e = CreateAvatarEntity(WALLET);
+
+            StubStreaming(WALLET, SID_42);
+            system.Update(0);
+            Assert.That(world.Get<NearbyAudioStreamerComponent>(e).CurrentSid, Is.EqualTo(SID_42), "precondition: CurrentSid = sid-42");
+
+            // Resolver flips winner.
+            registry.GetActiveSid(WALLET).Returns(SID_7);
+            // HasAudioStream stays true — only the active pick changed.
+
+            system.Update(0);
+
+            Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.True, "component must persist across the flip (structural stability)");
+            Assert.That(world.Get<NearbyAudioStreamerComponent>(e).CurrentSid, Is.EqualTo(SID_7), "resolver flip sid-42 → sid-7 must ref-mutate CurrentSid");
+        }
+
+        [Test]
+        public void T8_AvatarLosesComponentWhenHasAudioStreamGoesFalseButNotDuringAllZerosWindow()
+        {
+            // Test 8 from the spec — combined two-step assertion.
+            //   Step A — all-zeros window: HasAudioStream=true, GetActiveSid=null → wait, do NOT drop.
+            //   Step B — identity gone: HasAudioStream=false, GetActiveSid=null → drop with cascade.
             const string WALLET = "wallet-a";
             Entity e = CreateAvatarEntity(WALLET);
-            string[] firstRef = StubStreaming(WALLET, "sid-1");
+
+            StubStreaming(WALLET, "sid-1");
+            registry.IsActiveSpeaker(WALLET).Returns(true);
 
             system.Update(0);
-            Assert.That(ReferenceEquals(world.Get<NearbyAudioStreamerComponent>(e).StreamSidsSnapshot, firstRef), Is.True);
+            Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.True, "precondition: component attached");
+            Assert.That(world.Has<IsActivelySpeakingTag>(e), Is.True, "precondition: speaking tag set");
+            world.Add(e, new InAudibleRangeTag { IsSuspended = false });
 
-            // Registry publishes a NEW array (content changed, reference changed) — simulate the
-            // post-OnTrackSubscribed COW snapshot. Bridge must observe the new reference and refresh
-            // the entity's snapshot.
-            string[] secondRef = { "sid-1", "sid-2" };
-            registry.GetAudioSidsArray(WALLET).Returns(secondRef);
+            // Step A — resolver enters all-zeros window (identity still indexed, no candidate emitting).
+            registry.GetActiveSid(WALLET).Returns((string?)null);
+            registry.HasAudioStream(WALLET).Returns(true);
 
             system.Update(0);
 
-            Assert.That(ReferenceEquals(world.Get<NearbyAudioStreamerComponent>(e).StreamSidsSnapshot, secondRef), Is.True,
-                "new registry reference → SidsSnapshot must adopt the new reference");
+            Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.True,
+                "all-zeros window (HasAudioStream && active=null) must NOT drop the component");
+            Assert.That(world.Has<IsActivelySpeakingTag>(e), Is.True, "speaking tag must persist through the all-zeros window");
+            Assert.That(world.Has<InAudibleRangeTag>(e), Is.True, "audible-range tag must persist through the all-zeros window");
+
+            // Step B — identity disappears entirely.
+            registry.HasAudioStream(WALLET).Returns(false);
+
+            system.Update(0);
+
+            Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.False, "HasAudioStream=false must drop the component");
+            Assert.That(world.Has<IsActivelySpeakingTag>(e), Is.False, "cascade must drop speaking tag (invariant I1)");
+            Assert.That(world.Has<InAudibleRangeTag>(e), Is.False, "cascade must drop audible-range tag");
         }
 
         [Test]
@@ -197,9 +283,12 @@ namespace DCL.VoiceChat.Nearby.Tests
                 world.Add(entities[i], new InAudibleRangeTag { IsSuspended = false });
             }
 
-            // Streams disappear for every wallet on the same tick.
+            // Streams disappear for every wallet on the same tick — identity fully gone (not the all-zeros window).
             for (int i = 0; i < COUNT; i++)
-                registry.GetAudioSidsArray(wallets[i]).Returns((string[]?)null);
+            {
+                registry.GetActiveSid(wallets[i]).Returns((string?)null);
+                registry.HasAudioStream(wallets[i]).Returns(false);
+            }
 
             system.Update(0);
 
@@ -212,38 +301,13 @@ namespace DCL.VoiceChat.Nearby.Tests
         }
 
         [Test]
-        public void UpdateStreamingCascadesFullRemovalWhenRegistryReturnsNull()
-        {
-            const string WALLET = "wallet-a";
-            Entity e = CreateAvatarEntity(WALLET);
-            StubStreaming(WALLET, "sid-1");
-            registry.IsActiveSpeaker(WALLET).Returns(true);
-
-            system.Update(0);
-            Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.True, "precondition: component attached");
-            Assert.That(world.Has<IsActivelySpeakingTag>(e), Is.True, "precondition: speaking tag set");
-
-            // Seed the dependent marker AudibleRangeSystem would have placed (suspended-flag rides inside it).
-            world.Add(e, new InAudibleRangeTag { IsSuspended = true });
-
-            // Stream disappears.
-            registry.GetAudioSidsArray(WALLET).Returns((string[]?)null);
-
-            system.Update(0);
-
-            Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.False);
-            Assert.That(world.Has<IsActivelySpeakingTag>(e), Is.False, "cascade must drop speaking (invariant I1)");
-            Assert.That(world.Has<InAudibleRangeTag>(e), Is.False, "cascade must drop audible-range (suspended flag is enforced as subset by type)");
-        }
-
-        [Test]
         public void DoesNotRevisitEntityAfterStructuralChangeInSameQuery()
         {
-            // The filter-trick: AddStreaming's [None<StreamingAudioComponent>] excludes the entity
-            // from its own iterator after `World.Add` migrates it; RefreshStreaming and
-            // RemoveStreaming's [All<StreamingAudioComponent>] symmetrically catch it. Verified by
-            // call count — AddStreaming reads the registry once, RefreshStreaming once,
-            // RemoveStreaming once (the steady-state non-null path returns early).
+            // The filter-trick: AddStreaming's [None<NearbyAudioStreamerComponent>] excludes the entity
+            // from its own iterator after `World.Add` migrates it; RefreshStreaming and RemoveStreaming's
+            // [All<NearbyAudioStreamerComponent>] symmetrically catch it. Verified by call count —
+            // AddStreaming reads the resolver once, RefreshStreaming once (refresh path), RemoveStreaming
+            // reads HasAudioStream once (the steady-state guard, returns early since identity is indexed).
             const string WALLET = "wallet-a";
             CreateAvatarEntity(WALLET);
             StubStreaming(WALLET, "sid-1");
@@ -251,7 +315,10 @@ namespace DCL.VoiceChat.Nearby.Tests
 
             system.Update(0);
 
-            registry.Received(3).GetAudioSidsArray(WALLET);
+            // AddStreaming + RefreshStreaming each call GetActiveSid once.
+            registry.Received(2).GetActiveSid(WALLET);
+            // RemoveStreaming guards via HasAudioStream — exactly one call (identity is indexed → early-return).
+            registry.Received(1).HasAudioStream(WALLET);
         }
 
         // ── Speaking / cascade ──────────────────────────────────────
@@ -273,24 +340,24 @@ namespace DCL.VoiceChat.Nearby.Tests
         [Test]
         public void DoesNotApplySpeakingTagToAvatarWithoutStreamingComponent()
         {
-            // Pins invariant I1: AddSpeaking's [All<StreamingAudioComponent>] filter must prevent
+            // Pins invariant I1: AddSpeaking's [All<NearbyAudioStreamerComponent>] filter must prevent
             // the speaking tag from ever materializing on a non-streaming avatar.
             const string WALLET = "wallet-a";
             Entity e = CreateAvatarEntity(WALLET);
             registry.IsActiveSpeaker(WALLET).Returns(true);
-            // No StubStreaming — registry reports no audio for this walletId.
+            // No StubStreaming — resolver reports no audio for this walletId.
 
             system.Update(0);
 
             Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.False);
             Assert.That(world.Has<IsActivelySpeakingTag>(e), Is.False,
-                "speaking tag must require StreamingAudioComponent (invariant I1)");
+                "speaking tag must require NearbyAudioStreamerComponent (invariant I1)");
         }
 
         [Test]
         public void DoesNotChurnSpeakingTagWhenStreamingPersists()
         {
-            // Regression guard: an unconditional speaking-cascade in UpdateStreaming would drop
+            // Regression guard: an unconditional speaking-cascade in Refresh/Remove would drop
             // IsActivelySpeakingTag every tick, then AddSpeaking would re-add it on the same tick —
             // costing a structural-change pair per active speaker per tick. Steady-state contract:
             // both tags settled, only RemoveSpeaking re-checks IsActiveSpeaker. Measure call count.
@@ -323,7 +390,7 @@ namespace DCL.VoiceChat.Nearby.Tests
             system.Update(0);
 
             Assert.That(world.Has<NearbyAudioStreamerComponent>(e), Is.True,
-                "stream is unchanged — StreamingAudioComponent must persist");
+                "stream is unchanged — NearbyAudioStreamerComponent must persist");
             Assert.That(world.Has<IsActivelySpeakingTag>(e), Is.False);
         }
 
@@ -360,10 +427,16 @@ namespace DCL.VoiceChat.Nearby.Tests
 
         // ── Helpers ─────────────────────────────────────────────────
 
-        private string[] StubStreaming(string walletId, params string[] sids)
+        /// <summary>
+        /// Pins both halves of the resolver contract: GetActiveSid returns the given sid AND
+        /// HasAudioStream is true. Mirrors a steady-state participant — Bridge's RemoveStreaming
+        /// guard ([HasAudioStream==false] is the drop trigger) treats this identity as live.
+        /// </summary>
+        private string StubStreaming(string walletId, string sid)
         {
-            registry.GetAudioSidsArray(walletId).Returns(sids);
-            return sids;
+            registry.GetActiveSid(walletId).Returns(sid);
+            registry.HasAudioStream(walletId).Returns(true);
+            return sid;
         }
 
         private Entity CreateAvatarEntity(string walletId)

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCycleManualTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCycleManualTest.cs
@@ -75,7 +75,6 @@ namespace DCL.VoiceChat.Nearby
         // ── World/system state ──────────────────────────────────────
         private World world;
         private FakeStreamRegistry registry;
-        private HashSet<StreamKey> bindings;
         private NearbyVoiceChatStateModel stateModel;
         private VoiceChatConfiguration configuration;
         private NearbyAudioSourceFactory sourceFactory;
@@ -123,7 +122,6 @@ namespace DCL.VoiceChat.Nearby
             listenerState.BindListener(camera.transform, playerGo.transform);
 
             registry = new FakeStreamRegistry();
-            bindings = new HashSet<StreamKey>();
             stateModel = new NearbyVoiceChatStateModel(NearbyVoiceChatState.IDLE);
             configuration = ScriptableObject.CreateInstance<VoiceChatConfiguration>();
             sourceFactory = new NearbyAudioSourceFactory(configuration);
@@ -133,10 +131,10 @@ namespace DCL.VoiceChat.Nearby
 
             RoomMetadataCurrentScene roomMetadataCurrentScene = RoomMetadataCurrentScene.CreateForTest();
 
-            bindingSystem = new NearbyAudioBindingSystem(world, registry, bindings, userBlockingCache, stateModel, sourceFactory, roomMetadataCurrentScene);
+            bindingSystem = new NearbyAudioBindingSystem(world, registry, userBlockingCache, stateModel, sourceFactory, roomMetadataCurrentScene);
             positionSystem = new NearbyAudioPositionSystem(world, muteService, listenerState);
             positionSystem.Initialize();
-            cleanupSystem = new NearbyAudioCleanupSystem(world, registry, bindings, userBlockingCache, stateModel, sourceFactory, roomMetadataCurrentScene);
+            cleanupSystem = new NearbyAudioCleanupSystem(world, registry, userBlockingCache, stateModel, sourceFactory, roomMetadataCurrentScene);
         }
 
         private void Update()
@@ -290,9 +288,8 @@ namespace DCL.VoiceChat.Nearby
             int markedCount = world.CountEntities(in DELETE_INTENTION_QUERY);
 
             GUI.Label(new Rect(10, 10, 480, 20), $"Avatars: {avatars.Count}/{targetAvatarCount}");
-            GUI.Label(new Rect(10, 30, 480, 20), $"Bindings: {bindings.Count}");
-            GUI.Label(new Rect(10, 50, 480, 20), $"Audio entities: {audioCount} (marked for delete: {markedCount})");
-            GUI.Label(new Rect(10, 70, 480, 20), $"State: {stateModel.State.Value} (Inspector target: {forceState})");
+            GUI.Label(new Rect(10, 30, 480, 20), $"Audio entities: {audioCount} (marked for delete: {markedCount})");
+            GUI.Label(new Rect(10, 50, 480, 20), $"State: {stateModel.State.Value} (Inspector target: {forceState})");
         }
 
         // ── Inspector context-menu actions ──────────────────────────

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCycleManualTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCycleManualTest.cs
@@ -343,8 +343,8 @@ namespace DCL.VoiceChat.Nearby
             public string? GetActiveSid(string walletId) =>
                 activeSidByIdentity.TryGetValue(walletId, out string? sid) ? sid : null;
 
-            public bool IsActiveSid(string walletId, string sid) =>
-                activeSidByIdentity.TryGetValue(walletId, out string? active) && active == sid;
+            public bool IsActiveSid(StreamKey key) =>
+                activeSidByIdentity.TryGetValue(key.identity, out string? active) && active == key.sid;
 
             public bool IsActiveSpeaker(string walletId) =>
                 throw new NotImplementedException();

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCycleManualTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCycleManualTest.cs
@@ -313,32 +313,17 @@ namespace DCL.VoiceChat.Nearby
         private void ForceMassCleanup() => registry?.ClearAll();
 
         // ── Fake stream registry ────────────────────────────────────
-        // Mirrors the binding test fake: Owned<AudioStream>(null) yields a Weak whose Resource.Has
-        // is true, so the binding system actually instantiates LivekitAudioSource through the real
-        // factory — we want the integration cost, not a stubbed-out short-circuit.
+        // Post-dedup: one active sid per wallet. Owned<AudioStream>(null) yields a Weak whose
+        // Resource.Has is true, so the binding system actually instantiates LivekitAudioSource through
+        // the real factory — we want the integration cost, not a stubbed-out short-circuit.
         private sealed class FakeStreamRegistry : INearbyAudioStreamRegistry
         {
-            // COW-style storage to mirror production semantics: every Add publishes a NEW
-            // string[] reference, matching the registry's reference-equality contract.
-            private readonly Dictionary<string, string[]> sidsByIdentity = new ();
+            private readonly Dictionary<string, string> activeSidByIdentity = new ();
             private readonly Dictionary<StreamKey, Owned<AudioStream>> streamsByKey = new ();
 
             public void Add(string walletId, string sid)
             {
-                if (sidsByIdentity.TryGetValue(walletId, out string[]? prev))
-                {
-                    if (Array.IndexOf(prev, sid) < 0)
-                    {
-                        var next = new string[prev.Length + 1];
-                        Array.Copy(prev, next, prev.Length);
-                        next[prev.Length] = sid;
-                        sidsByIdentity[walletId] = next;
-                    }
-                }
-                else
-                {
-                    sidsByIdentity[walletId] = new[] { sid };
-                }
+                activeSidByIdentity[walletId] = sid;
 
                 var key = new StreamKey(walletId, sid);
                 if (!streamsByKey.ContainsKey(key))
@@ -346,30 +331,23 @@ namespace DCL.VoiceChat.Nearby
             }
 
             public void RemoveAll(string walletId) =>
-                sidsByIdentity.Remove(walletId);
+                activeSidByIdentity.Remove(walletId);
 
             public void ClearAll() =>
-                sidsByIdentity.Clear();
+                activeSidByIdentity.Clear();
 
-            public bool HasAudioStream(string walletId) => sidsByIdentity.ContainsKey(walletId);
-
-            public string[]? GetAudioSidsArray(string walletId) =>
-                sidsByIdentity.TryGetValue(walletId, out string[]? arr) ? arr : null;
+            public bool HasAudioStream(string walletId) => activeSidByIdentity.ContainsKey(walletId);
 
             public Weak<AudioStream> GetActiveStream(StreamKey key) =>
                 streamsByKey.TryGetValue(key, out Owned<AudioStream>? owned)
                     ? owned.Downgrade()
                     : Weak<AudioStream>.Null;
 
-            public bool IsStreamGone(StreamKey key)
-            {
-                if (!sidsByIdentity.TryGetValue(key.identity, out string[]? arr)) return true;
-                return Array.IndexOf(arr, key.sid) < 0;
-            }
+            public string? GetActiveSid(string walletId) =>
+                activeSidByIdentity.TryGetValue(walletId, out string? sid) ? sid : null;
 
-            public string? GetActiveSid(string walletId) => null;
-
-            public bool IsActiveSid(string walletId, string sid) => false;
+            public bool IsActiveSid(string walletId, string sid) =>
+                activeSidByIdentity.TryGetValue(walletId, out string? active) && active == sid;
 
             public bool IsActiveSpeaker(string walletId) =>
                 throw new NotImplementedException();

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCycleManualTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCycleManualTest.cs
@@ -367,6 +367,10 @@ namespace DCL.VoiceChat.Nearby
                 return Array.IndexOf(arr, key.sid) < 0;
             }
 
+            public string? GetActiveSid(string walletId) => null;
+
+            public bool IsActiveSid(string walletId, string sid) => false;
+
             public bool IsActiveSpeaker(string walletId) =>
                 throw new NotImplementedException();
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCyclePerformanceTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCyclePerformanceTest.cs
@@ -46,7 +46,6 @@ namespace DCL.VoiceChat.Nearby
         private readonly List<GameObject> gameObjects = new (256);
 
         private FakeStreamRegistry registry;
-        private HashSet<StreamKey> bindings;
         private NearbyVoiceChatStateModel stateModel;
         private VoiceChatConfiguration configuration;
         private NearbyAudioSourceFactory sourceFactory;
@@ -69,7 +68,6 @@ namespace DCL.VoiceChat.Nearby
             world.Create(new PlayerComponent(playerGo.transform));
 
             registry = new FakeStreamRegistry();
-            bindings = new HashSet<StreamKey>();
             IUserBlockingCache userBlockingCache = Substitute.For<IUserBlockingCache>();
             stateModel = new NearbyVoiceChatStateModel(NearbyVoiceChatState.IDLE);
             configuration = ScriptableObject.CreateInstance<VoiceChatConfiguration>();
@@ -86,9 +84,9 @@ namespace DCL.VoiceChat.Nearby
 
             RoomMetadataCurrentScene roomMetadataCurrentScene = RoomMetadataCurrentScene.CreateForTest();
 
-            system = new NearbyAudioBindingSystem(world, registry, bindings, userBlockingCache, stateModel, sourceFactory, roomMetadataCurrentScene);
+            system = new NearbyAudioBindingSystem(world, registry, userBlockingCache, stateModel, sourceFactory, roomMetadataCurrentScene);
             positionSystem = new NearbyAudioPositionSystem(world, muteService, listenerState);
-            cleanupSystem = new NearbyAudioCleanupSystem(world, registry, bindings, userBlockingCache, stateModel, sourceFactory, roomMetadataCurrentScene);
+            cleanupSystem = new NearbyAudioCleanupSystem(world, registry, userBlockingCache, stateModel, sourceFactory, roomMetadataCurrentScene);
             markerSystem = new NearbyLivekitBridgeSystem(world, registry);
             audibleRangeSystem = new NearbyAudibleRangeSystem(world, configuration, listenerState);
             audibleRangeSystem.Initialize();
@@ -124,7 +122,6 @@ namespace DCL.VoiceChat.Nearby
                 if (go != null) Object.DestroyImmediate(go);
             gameObjects.Clear();
 
-            bindings.Clear();
             stateModel.Dispose();
 
             if (configuration != null) Object.DestroyImmediate(configuration);
@@ -496,9 +493,9 @@ namespace DCL.VoiceChat.Nearby
             }
         }
 
-        private static int ComputeRampUpTicks(int participantCount) =>
-            ((participantCount + NearbyAudioBindingSystem.MAX_CREATIONS_PER_FRAME - 1)
-             / NearbyAudioBindingSystem.MAX_CREATIONS_PER_FRAME) + 1;
+        // Binding now materializes every ready avatar in a single tick (no per-tick budget); two ticks are
+        // enough for the marker + binding + position chain to reach steady state regardless of participant count.
+        private static int ComputeRampUpTicks(int participantCount) => 2;
 
         private Entity CreateAvatarEntity(string walletId)
         {

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCyclePerformanceTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCyclePerformanceTest.cs
@@ -353,7 +353,7 @@ namespace DCL.VoiceChat.Nearby
         /// B2-1 — Binding hot-path allocation profile at 100 avatars in steady state. Isolates
         /// <see cref="NearbyAudioBindingSystem.Update"/> from the rest of the chain so Unity's
         /// Performance Testing reporter attributes GC bytes/frame and ms/tick directly to the
-        /// per-avatar sid iteration over <see cref="NearbyAudioStreamerComponent.StreamSidsSnapshot"/>.
+        /// per-avatar read of <see cref="NearbyAudioStreamerComponent.CurrentSid"/>.
         /// <para>
         /// Pre-B2 baseline: ~128 B / frame per matching avatar from
         /// <c>ConcurrentDictionary&lt;string,byte&gt;.GetEnumerator</c> (≈ 2 KB / frame at this
@@ -522,34 +522,20 @@ namespace DCL.VoiceChat.Nearby
         }
 
         // ── Fake stream registry ────────────────────────────────────
-        // Mirrors NearbyAudioBindingSystemShould's fake: Owned<AudioStream>(null) yields a Weak
-        // whose Resource.Has is true, so binding actually creates LivekitAudioSource instances
-        // through the real factory — we want the integration cost, not a stubbed-out short-circuit.
+        // After the resolver-dedup collapse, the registry exposes GetActiveSid (single winner per
+        // identity) and IsActiveSid (was-it-this-sid predicate). One sid per wallet — multi-sid
+        // tests are out of scope post-dedup. Owned<AudioStream>(null) yields a Weak whose
+        // Resource.Has is true, so binding actually creates LivekitAudioSource through the real
+        // factory — we want the integration cost, not a stubbed-out short-circuit.
         private sealed class FakeStreamRegistry : INearbyAudioStreamRegistry
         {
-            // COW-style storage to mirror production semantics — every Add publishes a NEW
-            // string[] reference, so Bridge's UpdateStreaming ReferenceEquals check behaves
-            // identically against this fake.
-            private readonly Dictionary<string, string[]> sidsByIdentity = new ();
+            private readonly Dictionary<string, string> activeSidByIdentity = new ();
             private readonly Dictionary<StreamKey, Owned<AudioStream>> streamsByKey = new ();
             private readonly HashSet<string> activeSpeakers = new ();
 
             public void Add(string walletId, string sid)
             {
-                if (sidsByIdentity.TryGetValue(walletId, out string[]? prev))
-                {
-                    if (Array.IndexOf(prev, sid) < 0)
-                    {
-                        var next = new string[prev.Length + 1];
-                        Array.Copy(prev, next, prev.Length);
-                        next[prev.Length] = sid;
-                        sidsByIdentity[walletId] = next;
-                    }
-                }
-                else
-                {
-                    sidsByIdentity[walletId] = new[] { sid };
-                }
+                activeSidByIdentity[walletId] = sid;
 
                 var key = new StreamKey(walletId, sid);
                 if (!streamsByKey.ContainsKey(key))
@@ -558,25 +544,18 @@ namespace DCL.VoiceChat.Nearby
 
             public void MarkAsActiveSpeaker(string walletId) => activeSpeakers.Add(walletId);
 
-            public bool HasAudioStream(string walletId) => sidsByIdentity.ContainsKey(walletId);
-
-            public string[]? GetAudioSidsArray(string walletId) =>
-                sidsByIdentity.TryGetValue(walletId, out string[]? arr) ? arr : null;
+            public bool HasAudioStream(string walletId) => activeSidByIdentity.ContainsKey(walletId);
 
             public Weak<AudioStream> GetActiveStream(StreamKey key) =>
                 streamsByKey.TryGetValue(key, out Owned<AudioStream>? owned)
                     ? owned.Downgrade()
                     : Weak<AudioStream>.Null;
 
-            public bool IsStreamGone(StreamKey key)
-            {
-                if (!sidsByIdentity.TryGetValue(key.identity, out string[]? arr)) return true;
-                return Array.IndexOf(arr, key.sid) < 0;
-            }
+            public string? GetActiveSid(string walletId) =>
+                activeSidByIdentity.TryGetValue(walletId, out string? sid) ? sid : null;
 
-            public string? GetActiveSid(string walletId) => null;
-
-            public bool IsActiveSid(string walletId, string sid) => false;
+            public bool IsActiveSid(string walletId, string sid) =>
+                activeSidByIdentity.TryGetValue(walletId, out string? active) && active == sid;
 
             public bool IsActiveSpeaker(string walletId) => activeSpeakers.Contains(walletId);
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCyclePerformanceTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCyclePerformanceTest.cs
@@ -551,8 +551,8 @@ namespace DCL.VoiceChat.Nearby
             public string? GetActiveSid(string walletId) =>
                 activeSidByIdentity.TryGetValue(walletId, out string? sid) ? sid : null;
 
-            public bool IsActiveSid(string walletId, string sid) =>
-                activeSidByIdentity.TryGetValue(walletId, out string? active) && active == sid;
+            public bool IsActiveSid(StreamKey key) =>
+                activeSidByIdentity.TryGetValue(key.identity, out string? active) && active == key.sid;
 
             public bool IsActiveSpeaker(string walletId) => activeSpeakers.Contains(walletId);
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCyclePerformanceTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioFullCyclePerformanceTest.cs
@@ -574,6 +574,10 @@ namespace DCL.VoiceChat.Nearby
                 return Array.IndexOf(arr, key.sid) < 0;
             }
 
+            public string? GetActiveSid(string walletId) => null;
+
+            public bool IsActiveSid(string walletId, string sid) => false;
+
             public bool IsActiveSpeaker(string walletId) => activeSpeakers.Contains(walletId);
 
             public int RebuildEpoch => 0;

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioPositionHotPathPerformanceTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioPositionHotPathPerformanceTest.cs
@@ -114,7 +114,11 @@ namespace DCL.VoiceChat.Nearby
                 gameObjects.Add(source.gameObject);
                 audioSources[i] = source;
 
-                world.Create(new NearbyAudioSourceComponent(new StreamKey(id, "sid"), avatarEntity, source));
+                // Slice 4: NearbyAudioSourceComponent is co-located on the avatar entity. PositionSystem's
+                // query is now [All(AvatarBase, NearbyAudioStreamerComponent)] [None(DeleteEntityIntention)],
+                // so add NearbyAudioStreamerComponent here too so the benchmark exercises the hot path.
+                world.Add(avatarEntity, new NearbyAudioStreamerComponent("sid"));
+                world.Add(avatarEntity, new NearbyAudioSourceComponent(new StreamKey(id, "sid"), source));
             }
         }
 

--- a/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioPositionSystemPerformanceTest.cs
+++ b/Explorer/Assets/DCL/VoiceChat/NearbyVoiceChat/Tests/PerformanceTests/NearbyAudioPositionSystemPerformanceTest.cs
@@ -116,7 +116,10 @@ namespace DCL.VoiceChat.Nearby
             LivekitAudioSource source = LivekitAudioSource.New();
             gameObjects.Add(source.gameObject);
 
-            world.Create(new NearbyAudioSourceComponent(new StreamKey(id, "sid"), avatarEntity, source));
+            // Slice 4: NearbyAudioSourceComponent is co-located on the avatar; position query is now
+            // gated by NearbyAudioStreamerComponent. Both must be added so the benchmark hits the hot path.
+            world.Add(avatarEntity, new NearbyAudioStreamerComponent("sid"));
+            world.Add(avatarEntity, new NearbyAudioSourceComponent(new StreamKey(id, "sid"), source));
         }
 
         private GameObject CreateTrackedGameObject(string name)

--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.dcl.gpui-assets": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.dcl.gpui-assets",
     "com.decentraland.filebrowserpro": "git@github.com:decentraland/unity-explorer-packages.git?path=/FileBrowserPro",
-    "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git",
+    "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git#chore/frame-activity-oracle-on-AudioStream",
     "com.decentraland.renum": "https://github.com/NickKhalow/REnum.git?path=REnum",
     "com.decentraland.renum.sourcegen": "https://github.com/NickKhalow/REnum.git#sourcegen/1.1.4",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src#f3dd251c7837cc2d844e1c07e741177a53676064",

--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -10,7 +10,7 @@
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.dcl.gpui-assets": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.dcl.gpui-assets",
     "com.decentraland.filebrowserpro": "git@github.com:decentraland/unity-explorer-packages.git?path=/FileBrowserPro",
-    "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git#chore/frame-activity-oracle-on-AudioStream",
+    "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git",
     "com.decentraland.renum": "https://github.com/NickKhalow/REnum.git?path=REnum",
     "com.decentraland.renum.sourcegen": "https://github.com/NickKhalow/REnum.git#sourcegen/1.1.4",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src#f3dd251c7837cc2d844e1c07e741177a53676064",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -90,7 +90,7 @@
       "hash": "f57b137a6bd76527ea144b7e03cd7743f1b39599"
     },
     "com.decentraland.livekit-sdk": {
-      "version": "https://github.com/decentraland/client-sdk-unity.git#chore/frame-activity-oracle-on-AudioStream",
+      "version": "https://github.com/decentraland/client-sdk-unity.git",
       "depth": 0,
       "source": "git",
       "dependencies": {
@@ -98,7 +98,7 @@
         "com.nickkhalow.richtypes": "https://github.com/NickKhalow/RichTypesUnity.git?path=/Packages/RichTypes",
         "io.livekit.unity": "https://github.com/livekit/client-sdk-unity-web.git"
       },
-      "hash": "9c06f180d260fa0905d1dcb7587e6675e674fee9"
+      "hash": "9caeba7fb88547062f227b2e246b18b6927e4435"
     },
     "com.decentraland.renum": {
       "version": "https://github.com/NickKhalow/REnum.git?path=REnum",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -90,7 +90,7 @@
       "hash": "f57b137a6bd76527ea144b7e03cd7743f1b39599"
     },
     "com.decentraland.livekit-sdk": {
-      "version": "https://github.com/decentraland/client-sdk-unity.git",
+      "version": "https://github.com/decentraland/client-sdk-unity.git#chore/frame-activity-oracle-on-AudioStream",
       "depth": 0,
       "source": "git",
       "dependencies": {
@@ -98,7 +98,7 @@
         "com.nickkhalow.richtypes": "https://github.com/NickKhalow/RichTypesUnity.git?path=/Packages/RichTypes",
         "io.livekit.unity": "https://github.com/livekit/client-sdk-unity-web.git"
       },
-      "hash": "dc6e479148106b1f8a68f0fbdba475bf7b96693e"
+      "hash": "9c06f180d260fa0905d1dcb7587e6675e674fee9"
     },
     "com.decentraland.renum": {
       "version": "https://github.com/NickKhalow/REnum.git?path=REnum",


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes the long-standing "ghost stream" pathology in Nearby Voice Chat — the case where LiveKit silently fails to deliver a track-unsubscribe event and the Explorer keeps stale audio sources around for the same participant. Until now multiple `LivekitAudioSource` instances could exist for one speaker, of which at most one carried real audio; the rest played silence but still consumed Unity audio voices, position-system updates, and spatialisation budget. Visible symptoms: another player sounds choppy, silent, or "missing" even though they are clearly speaking.

The fix turns the registry into the authoritative oracle for **which sid is alive right now**:

1. **LiveKit fork** — each `AudioStream` exposes `LastFrameReceivedAt` (a monotonic tick written from inside the FFI frame callback). Ghosts never decode a frame, so their tick stays at the sentinel value.
2. **`INearbyAudioStreamRegistry`** — new resolver: `GetActiveSid(walletId)` returns the sid with the freshest frame tick (single active candidate per participant); `IsActiveSid(StreamKey)` is the cleanup predicate. Wrap-safe arithmetic, allocation-free, no memoisation across ticks.
3. **ECS collapse** — `NearbyAudioStreamerComponent` drops the `string[]` snapshot in favour of a single `string CurrentSid`. `NearbyAudioSourceComponent` loses its `AvatarEntity` back-reference and now lives **directly on the avatar entity** (no separate audio entity, no cross-entity transform lookup, no second `World.Create`).
4. **Systems** — `NearbyLivekitBridgeSystem` polls the resolver each tick (add / refresh / remove branches with an "all-zeros" guard so a freshly-reconnected speaker isn't dropped before the first frame). `NearbyAudioBindingSystem` reads `CurrentSid` only — no foreach over a sids array. `NearbyAudioPositionSystem` becomes a single same-entity query. `NearbyAudioCleanupSystem` ditches the "sid disappeared from snapshot" predicate, reaps demoted ghost sids via `!IsActiveSid`, and inlines the bulk-remove path into the per-entity query.
5. **Tests** — full coverage rewrite for `NearbyAudioStreamRegistryShould`, `NearbyAudioBindingSystemShould`, `NearbyAudioCleanupSystemShould`, `NearbyLivekitBridgeSystemShould` against the new contract; performance harness updated for the 1:1 layout.

## Test Instructions

```bash
metaforge explorer run 8817
```

### Prerequisites
- [ ] Two test accounts (use a second device, an alt browser profile, or `metaforge account create --clear` on a second machine).
- [ ] Working microphone on the speaker account; headphones recommended on the listener side to catch overlap / phantom playback.
- [ ] In-world voice chat enabled in settings on both sides (no scene-level NearbyVoiceChat restriction).

### Test Steps

**1. Baseline — two avatars speaking, no overlap**
1. Account A and account B teleport to the same parcel and stand within ~5 m of each other.
2. A speaks for ~10 s, then B speaks for ~10 s, alternating.
3. **Expected:** each voice is heard clearly with no echo, no phantom second-source overlap, and no choppy drop-outs. Spatial direction matches the speaker's position when you rotate the camera.

**2. Reconnect — ghost-sid eradication (primary fix scenario)**
1. A and B stand within 5 m. A speaks — verify B hears A normally.
2. Force-disconnect A from the room: kill the network on A's machine (toggle Wi-Fi, or use OS-level offline mode) for ~10 s, then bring it back. A's client will reconnect automatically.
3. Within 2–3 s after reconnect, A starts speaking again.
4. **Expected:** B hears A's voice on the **new** stream only — no overlapping playback of the pre-reconnect track, no doubled / robot-like timbre, no silent dead-air window longer than ~1 frame. (Repeat 3× — this race is non-deterministic.)

**3. Range — audible region join / leave**
1. A stands still and speaks continuously (use a looped voice clip if available, or just talk).
2. B walks slowly away from A past ~22 m, then back inside the range.
3. **Expected:** voice silences smoothly when B crosses the outer threshold and resumes when B re-enters. No residual playback of the previous source after stepping out; no ghost source remains audible.

**4. Block — mid-conversation user block**
1. A is speaking, B can hear them.
2. B opens A's user profile from the passport / friends panel and blocks A.
3. **Expected:** A's voice silences for B within ~1 frame. Unblock → voice resumes the next time A speaks.

**5. Mute toggle per participant**
1. A is speaking, B can hear them.
2. B opens the voice-chat side panel and toggles "mute" for A.
3. **Expected:** A's voice silences for B immediately while A remains visible as a speaker. Toggle back — voice resumes.

**6. Output device change**
1. A is speaking, B can hear them through Device 1 (e.g. speakers).
2. B unplugs Device 1 and switches to Device 2 (e.g. headphones) via Windows / macOS sound settings.
3. **Expected:** within ~1 s A's voice resumes through Device 2, no artifacts, no double-audio.

**7. Suppression gates — call / loading / scene gate**
1. A is speaking, B can hear them.
2. Trigger one of the suppression sources in turn:
   - B initiates a private call (call status active).
   - B teleports to a new scene (loading screen visible).
   - B enters a scene whose `NearbyVoiceChatEnabled` flag is `false` (use any test scene that disables it).
3. **Expected:** A's voice silences for B while the gate is active and resumes immediately once the gate releases. No bleed-through during the suppressed window.

**8. Crowd — many speakers nearby**
1. Use the multi-bot harness (`metaforge`) or coordinate 4+ accounts at the same parcel.
2. Have at least 3 of them speak simultaneously for ~30 s.
3. **Expected:** every speaker is heard, each spatialised to their world position; no participant becomes silent or "ghosted out"; no audio-source slot leak (frame-rate should be stable across the window).

**9. Avatar leaves / reappears**
1. A is speaking near B.
2. A teleports far away (out of B's parcel range), then teleports back close to B and speaks again.
3. **Expected:** voice cleanly stops when A leaves, cleanly resumes when A returns. No phantom audio playing from A's previous location.

**10. Self-suppression sanity**
1. A is in a room alone, speaks into the microphone.
2. **Expected:** A does **not** hear their own voice echoed back (Explorer-side filter on local participant must keep working — this PR does not change that path, but verify it didn't regress).

### Additional Testing Notes
- The ghost-sid case (Test 2) is the headline fix — please run it multiple times under different network conditions (clean disconnect, flaky Wi-Fi, VPN drop).
- If you observe a 1–2 frame silence on a freshly-reconnected speaker before their voice resumes, that is **expected** — the resolver waits for the first decoded frame on a new candidate before promoting it.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (N/A — internal refactor; spec lives in `docs/superpowers/specs/`)
- [x] Performance impact has been considered (1:1 mapping reduces per-tick entity count for crowded scenes; allocation-free hot paths preserved)
- [ ] For SDK features: Test scene is included (N/A — not an SDK feature)

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting.
