### PR TITLE
fix: gpui occlusion nre

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/LandscapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/LandscapePlugin.cs
@@ -87,8 +87,9 @@ namespace DCL.PluginSystem.Global
             {
                 await UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate, ct);
 
-                GPUICoreAPI.RegisterRenderer(landscape.Root, treePrototypes[prototypeIndex].asset,
-                    treesProfile, out treeRendererKeys[prototypeIndex]);
+                var result = await GPUICoreAPI.RegisterRenderer(landscape.Root,
+                    treePrototypes[prototypeIndex].asset, treesProfile);
+                treeRendererKeys[prototypeIndex] = result.rendererKey;
 
                 ReportHub.Log(ReportCategory.LANDSCAPE, $"LandscapePlugin: Registered Renderer Key {treeRendererKeys[prototypeIndex]} for prototype {prototypeIndex} ({treePrototypes[prototypeIndex].asset.name})");
             }

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -80,7 +80,7 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "2488227ce1013f3bf65408447d0fbc6531e54ed5"
+      "hash": "e68a493d0dfd76232103b71c9af6233131048950"
     },
     "com.decentraland.filebrowserpro": {
       "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/FileBrowserPro",
@@ -137,7 +137,7 @@
         "com.unity.collections": "1.2.0",
         "com.unity.mathematics": "1.2.0"
       },
-      "hash": "d8112ca7ebc0c660d7850d72850d46a3e376dc08"
+      "hash": "e68a493d0dfd76232103b71c9af6233131048950"
     },
     "com.gurbu.gpui-pro.terrain": {
       "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.gurbu.gpui-pro.terrain",
@@ -146,7 +146,7 @@
       "dependencies": {
         "com.gurbu.gpui-pro": "0.9.19"
       },
-      "hash": "a9457c91aba8e0783db4928e54d6ae9bf9b7abef"
+      "hash": "e68a493d0dfd76232103b71c9af6233131048950"
     },
     "com.mackysoft.serializereference-extensions": {
       "version": "1.3.1",


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/8680
Fixes https://github.com/decentraland/unity-explorer/issues/8215

Fixes a NullReferenceException happening on the GPUI-PRO package: https://github.com/decentraland/unity-explorer-packages/pull/58

It can happen from unity 6. Seems to be race condition. The camera might trigger the rendering before the urp has finished registering the asset.

## Test Instructions

Go through different scenes & worlds. . Check everything renders normally. 

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
