### PR TITLE
fix: scene message handler duplicate key

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
@@ -88,7 +88,9 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
             SubscriberKey key = new (sceneId, msgType);
 
             lock (sceneMessageHandlers)
-                sceneMessageHandlers.Add(key, onSceneMessage);
+            {
+                sceneMessageHandlers[key] = onSceneMessage;
+            }
         }
 
         public void RemoveSceneMessageHandler(string sceneId, ISceneCommunicationPipe.MsgType msgType, ISceneCommunicationPipe.SceneMessageHandler onSceneMessage)

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
@@ -89,7 +89,6 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
 
             lock (sceneMessageHandlers)
             {
-                // Dont add but replace
                 // See: https://github.com/decentraland/unity-explorer/issues/8183
                 sceneMessageHandlers[key] = onSceneMessage;
             }

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
@@ -99,7 +99,11 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
             SubscriberKey key = new (sceneId, msgType);
 
             lock (sceneMessageHandlers)
-                sceneMessageHandlers.Remove(key);
+            {
+                // Since message handlers might be replaced, we need to check that the removal of the key belongs to the handler
+                if (sceneMessageHandlers.TryGetValue(key, out var current) && current == onSceneMessage)
+                    sceneMessageHandlers.Remove(key);
+            }
         }
 
         public void SendMessage(ReadOnlySpan<byte> message, string sceneId, ISceneCommunicationPipe.ConnectivityAssertiveness assertiveness, CancellationToken ct, string? specialRecipient = null)

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
@@ -89,6 +89,8 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
 
             lock (sceneMessageHandlers)
             {
+                // Dont add but replace
+                // See: https://github.com/decentraland/unity-explorer/issues/8183
                 sceneMessageHandlers[key] = onSceneMessage;
             }
         }


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/8183

Fixes any possible key duplication when registering the scene message handler.
The root of the issue might be caused due disposal issues, but it should have been fixed here: https://github.com/decentraland/unity-explorer/pull/8702

## Test Instructions

Go through different scenes. Check that they work normally.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
