### PR TITLE
feat: windows-only and macos-only ci flags

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -8,6 +8,7 @@ on:
       - synchronize
       - ready_for_review
       - labeled
+      - unlabeled
   merge_group: {}
   push:
     branches:
@@ -152,9 +153,11 @@ concurrency:
   cancel-in-progress: >-
     ${{
       github.event_name != 'pull_request' ||
-      github.event.action != 'labeled' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
       github.event.label.name == 'force-build' ||
-      github.event.label.name == 'clean-build'
+      github.event.label.name == 'clean-build' ||
+      github.event.label.name == 'windows-only' ||
+      github.event.label.name == 'macos-only'
     }}
 
 jobs:
@@ -183,8 +186,13 @@ jobs:
             ) ||
             github.event.action == 'ready_for_review' ||
             (
-              github.event.action == 'labeled' &&
-              (github.event.label.name == 'force-build' || github.event.label.name == 'clean-build')
+              (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+              (
+                github.event.label.name == 'force-build' ||
+                github.event.label.name == 'clean-build' ||
+                github.event.label.name == 'windows-only' ||
+                github.event.label.name == 'macos-only'
+              )
             )
           )
         )
@@ -200,6 +208,7 @@ jobs:
       clean_build: ${{ steps.set_defaults.outputs.clean_build }}
       cache_strategy: ${{ steps.set_defaults.outputs.cache_strategy }}
       install_source: ${{ steps.set_defaults.outputs.install_source }}
+      targets: ${{ steps.get_targets.outputs.targets }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -407,6 +416,37 @@ jobs:
           IFS=,
           echo "options=${options[*]}" | tee -a "$GITHUB_OUTPUT"
 
+      - name: Determine build targets
+        if: steps.decide.outputs.should_build == 'true'
+        id: get_targets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
+          echo "Labels: '$labels'"
+
+          has_windows_only=false
+          has_macos_only=false
+          if echo "$labels" | grep -qw 'windows-only'; then has_windows_only=true; fi
+          if echo "$labels" | grep -qw 'macos-only'; then has_macos_only=true; fi
+
+          if [ "$has_windows_only" = "true" ] && [ "$has_macos_only" = "true" ]; then
+            echo "::error::Both 'windows-only' and 'macos-only' labels are applied. Remove one — they are mutually exclusive."
+            exit 1
+          fi
+
+          if [ "$has_windows_only" = "true" ]; then
+            targets='["windows64"]'
+          elif [ "$has_macos_only" = "true" ]; then
+            targets='["macos"]'
+          else
+            targets='["windows64","macos"]'
+          fi
+
+          echo "Targets: $targets"
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -416,7 +456,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ['windows64', 'macos']
+        target: ${{ fromJSON(needs.prebuild.outputs.targets) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -801,4 +841,43 @@ jobs:
           ORG_ID: ${{ secrets.UNITY_CLOUD_ORG_ID }}
           PROJECT_ID: ${{ secrets.UNITY_CLOUD_PROJECT_ID }}
         run: python -u scripts/cloudbuild/build.py --cancel
+
+  build-gate:
+    name: Build Gate (Windows + macOS)
+    runs-on: ubuntu-latest
+    needs: [prebuild, build]
+    if: always() && github.event_name == 'pull_request'
+    steps:
+      - name: Verify both targets built and passed
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          should_build='${{ needs.prebuild.outputs.should_build }}'
+          prebuild_result='${{ needs.prebuild.result }}'
+
+          # No Explorer/ changes, draft without override, or perf_test path — gate is not applicable.
+          if [ "$prebuild_result" != "success" ] || [ "$should_build" != "true" ]; then
+            echo "Gate not applicable (prebuild=$prebuild_result, should_build='$should_build'). Passing."
+            exit 0
+          fi
+
+          targets='${{ needs.prebuild.outputs.targets }}'
+          echo "Targets that ran: $targets"
+
+          has_windows=$(echo "$targets" | jq 'any(. == "windows64")')
+          has_macos=$(echo "$targets" | jq 'any(. == "macos")')
+          if [ "$has_windows" != "true" ] || [ "$has_macos" != "true" ]; then
+            echo "::error::Build Gate requires both Windows and macOS builds. This run was filtered to: $targets"
+            echo "::error::Remove the 'windows-only' or 'macos-only' label so both targets build, then push or re-trigger."
+            exit 1
+          fi
+
+          build_result='${{ needs.build.result }}'
+          if [ "$build_result" != "success" ]; then
+            echo "::error::Build matrix did not succeed (result: $build_result)"
+            exit 1
+          fi
+
+          echo "Both Windows and macOS builds passed."
 # Test change

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -78,6 +78,15 @@ on:
         required: false
         default: false
         type: boolean
+      platforms:
+        description: 'Which platforms to build'
+        required: true
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - windows-only
+          - macos-only
   workflow_call:
     inputs:
       profile:
@@ -423,26 +432,44 @@ jobs:
         run: |
           set -euo pipefail
 
-          labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
-          echo "Labels: '$labels'"
+          # platform_build_mode: windows | macos | both
+          platform_build_mode=both
 
-          has_windows_only=false
-          has_macos_only=false
-          if echo "$labels" | grep -qw 'windows-only'; then has_windows_only=true; fi
-          if echo "$labels" | grep -qw 'macos-only'; then has_macos_only=true; fi
+          dispatch_platforms="${{ github.event.inputs.platforms }}"
+          echo "Dispatch platforms: '$dispatch_platforms'"
 
-          if [ "$has_windows_only" = "true" ] && [ "$has_macos_only" = "true" ]; then
-            echo "::error::Both 'windows-only' and 'macos-only' labels are applied. Remove one — they are mutually exclusive."
-            exit 1
-          fi
-
-          if [ "$has_windows_only" = "true" ]; then
-            targets='["windows64"]'
-          elif [ "$has_macos_only" = "true" ]; then
-            targets='["macos"]'
+          if [ "$dispatch_platforms" = "windows-only" ]; then
+            platform_build_mode=windows
+          elif [ "$dispatch_platforms" = "macos-only" ]; then
+            platform_build_mode=macos
           else
-            targets='["windows64","macos"]'
+            labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
+            echo "Labels: '$labels'"
+
+            label_match_count=0
+            if echo "$labels" | grep -qw 'windows-only'; then
+              platform_build_mode=windows
+              label_match_count=$((label_match_count + 1))
+            fi
+            if echo "$labels" | grep -qw 'macos-only'; then
+              platform_build_mode=macos
+              label_match_count=$((label_match_count + 1))
+            fi
+
+            if [ "$label_match_count" -gt 1 ]; then
+              echo "::error::Both 'windows-only' and 'macos-only' labels are applied. Remove one — they are mutually exclusive."
+              exit 1
+            fi
           fi
+
+          echo "Platform build mode: $platform_build_mode"
+
+          case "$platform_build_mode" in
+            windows) targets='["windows64"]' ;;
+            macos)   targets='["macos"]' ;;
+            both)    targets='["windows64","macos"]' ;;
+            *) echo "::error::Unknown platform_build_mode '$platform_build_mode'"; exit 1 ;;
+          esac
 
           echo "Targets: $targets"
           echo "targets=$targets" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

- Adds 2 CI flags: `windows-only` and `macos-only`
- Helps save CI runner time by avoiding compilation of unrequired builds for certain PRs
- Full compilation for both platforms is still required to merge into the `dev` branch

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 8822
```

**Expected result**:
- Apply the `windows-only` label to a PR → only Windows build should run
- Apply the `macos-only` label to a PR → only macOS build should run
- Without either label → both platforms build as usual
- Merging into `dev` still requires both platform builds to pass

### Test Steps
1. Open a test PR and apply the `windows-only` label
2. Verify that only the Windows CI build triggers
3. Remove the label and apply `macos-only`
4. Verify that only the macOS CI build triggers
5. Remove the label and confirm both builds run

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting.