### PR TITLE
fix: backpack thumbnails exception handling & improvement on cancelled operations

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IThumbnailAttachment.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IThumbnailAttachment.cs
@@ -1,5 +1,6 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
+using DCL.AvatarRendering.Loading.Exceptions;
 using DCL.Ipfs;
 using ECS.StreamableLoading.Common.Components;
 using ECS.StreamableLoading.Textures;
@@ -55,7 +56,12 @@ namespace DCL.AvatarRendering.Loading.Components
             do await UniTask.Delay(checkInterval, cancellationToken: ct);
             while (ThumbnailAssetResult is not { IsInitialized: true });
 
-            return ThumbnailAssetResult!.Value.Asset;
+            StreamableLoadingResult<SpriteData>.WithFallback result = ThumbnailAssetResult!.Value;
+
+            if (!result.Succeeded)
+                throw new ThumbnailLoadFailedException();
+
+            return result.Asset;
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Exceptions.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Exceptions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b85bda799aff4c5cb8d1ad7e9a3a372
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Exceptions/ThumbnailLoadFailedException.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Exceptions/ThumbnailLoadFailedException.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace DCL.AvatarRendering.Loading.Exceptions
+{
+    /// <summary>
+    ///     Thrown when a thumbnail request reaches a terminal failure state (e.g. the underlying
+    ///     promise was cancelled mid-flight). Distinct from <see cref="OperationCanceledException"/>,
+    ///     which is reserved for caller-initiated cancellation.
+    /// </summary>
+    public class ThumbnailLoadFailedException : Exception
+    {
+        public ThumbnailLoadFailedException() : base("Thumbnail load failed or was cancelled before completion") { }
+
+        public ThumbnailLoadFailedException(string message) : base(message) { }
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Exceptions/ThumbnailLoadFailedException.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Exceptions/ThumbnailLoadFailedException.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a8a91fa98b31847e9af2dd20b0b65c21

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/ECSThumbnailProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/ECSThumbnailProvider.cs
@@ -1,11 +1,14 @@
 using Arch.Core;
 using Cysharp.Threading.Tasks;
 using DCL.AvatarRendering.Loading.Components;
-using ECS;
-using ECS.Prioritization.Components;
-using System.Threading;
+using DCL.AvatarRendering.Loading.Exceptions;
 using DCL.AvatarRendering.Thumbnails.Utils;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using ECS.Prioritization.Components;
+using ECS.StreamableLoading.Common.Components;
+using ECS.StreamableLoading.Textures;
+using System;
+using System.Threading;
 using UnityEngine;
 
 namespace DCL.AvatarRendering.Wearables
@@ -21,21 +24,50 @@ namespace DCL.AvatarRendering.Wearables
             this.world = world;
         }
 
-        public async UniTask<Sprite> GetAsync(IThumbnailAttachment avatarAttachment, CancellationToken ct)
+        public async UniTask<Sprite> GetAsync(IThumbnailAttachment avatarAttachment, CancellationToken ct, int timeoutMs = IThumbnailProvider.DEFAULT_TIMEOUT_MS)
         {
-            if (avatarAttachment.ThumbnailAssetResult is { IsInitialized: true })
-                return avatarAttachment.ThumbnailAssetResult.Value.Asset;
+            if (avatarAttachment.ThumbnailAssetResult is { IsInitialized: true } existing)
+            {
+                if (existing.Succeeded)
+                    return existing.Asset;
+
+                // A previous attempt was cancelled (e.g. page change). Clear so a fresh promise
+                // can spawn below. Sticky failures keep the slot and fall through to throw.
+                if (existing.Cancelled)
+                    avatarAttachment.ThumbnailAssetResult = null;
+                else
+                    throw new ThumbnailLoadFailedException();
+            }
+
+            CancellationTokenSource promiseCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
             LoadThumbnailsUtils.CreateThumbnailABPromise(
                 urlsSource,
                 avatarAttachment,
                 world,
                 PartitionComponent.TOP_PRIORITY,
-                CancellationTokenSource.CreateLinkedTokenSource(ct));
+                promiseCts);
 
-            // We dont create an async task from the promise since it needs to be consumed at the proper system, not here
-            // The promise's result will eventually get replicated into the avatar attachment
-            return await avatarAttachment.WaitForThumbnailAsync(0, ct);
+            using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(timeoutMs);
+
+            try
+            {
+                // We dont create an async task from the promise since it needs to be consumed at the proper system, not here
+                // The promise's result will eventually get replicated into the avatar attachment
+                return await avatarAttachment.WaitForThumbnailAsync(0, timeoutCts.Token);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                // Timed out: cancel the underlying promise so the resolver cleans it up, and record
+                // a sticky Failed on the attachment so subsequent calls don't immediately re-attempt
+                // a load that we already gave up on. (The resolver will see IsCancellationRequested
+                // but skip overwriting because the slot is now Failed, not Cancelled.)
+                promiseCts.Cancel();
+                avatarAttachment.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.Failed();
+
+                throw new ThumbnailLoadFailedException($"Thumbnail load timed out after {timeoutMs}ms");
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/IThumbnailProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/IThumbnailProvider.cs
@@ -7,6 +7,13 @@ namespace DCL.AvatarRendering.Wearables
 {
     public interface IThumbnailProvider
     {
-        UniTask<Sprite> GetAsync(IThumbnailAttachment avatarAttachment, CancellationToken ct);
+        /// <summary>
+        ///     Bounds the wait on a thumbnail load to a sensible UX budget, so requests that stall
+        ///     in the streaming pipeline (e.g. budget starvation, lost promises, curl aborts)
+        ///     do not leave callers spinning indefinitely.
+        /// </summary>
+        public const int DEFAULT_TIMEOUT_MS = 30_000;
+
+        UniTask<Sprite> GetAsync(IThumbnailAttachment avatarAttachment, CancellationToken ct, int timeoutMs = DEFAULT_TIMEOUT_MS);
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
@@ -58,6 +58,10 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
             if (promise.IsCancellationRequested(World))
             {
                 // Mark as Cancelled so the next GetAsync call clears the slot and retries.
+                // Don't overwrite a sticky Failed (e.g. from a consumer timeout).
+                if (wearable.ThumbnailAssetResult is not { IsInitialized: true } existing
+                    || existing.Succeeded || existing.Cancelled)
+                    wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);
                 return;

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
@@ -35,11 +35,9 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
             if (promise.IsCancellationRequested(World))
             {
                 // Mark as Cancelled so the next GetAsync call clears the slot and retries.
-                // Mark as Cancelled so the next GetAsync call clears the slot and retries.
                 // Don't overwrite a sticky Failed (e.g. from a consumer timeout); only reset to
-                // Cancelled when the slot is clear, successful, or already Cancelled.
-                if (wearable.ThumbnailAssetResult is not { IsInitialized: true } existing
-                    || existing.Succeeded || existing.Cancelled)
+                // Cancelled when the slot is clear.
+                if (wearable.ThumbnailAssetResult is not { IsInitialized: true })
                     wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);
                 return;
@@ -59,10 +57,8 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
             {
                 // Mark as Cancelled so the next GetAsync call clears the slot and retries.
                 // Don't overwrite a sticky Failed (e.g. from a consumer timeout).
-                if (wearable.ThumbnailAssetResult is not { IsInitialized: true } existing
-                    || existing.Succeeded || existing.Cancelled)
+                if (wearable.ThumbnailAssetResult is not { IsInitialized: true })
                     wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
-                wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);
                 return;
             }

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
@@ -34,7 +34,8 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
         {
             if (promise.IsCancellationRequested(World))
             {
-                wearable.ThumbnailAssetResult = null;
+                // Mark as Cancelled so the next GetAsync call clears the slot and retries.
+                wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);
                 return;
             }
@@ -51,7 +52,8 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
         {
             if (promise.IsCancellationRequested(World))
             {
-                wearable.ThumbnailAssetResult = null;
+                // Mark as Cancelled so the next GetAsync call clears the slot and retries.
+                wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);
                 return;
             }

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
@@ -35,7 +35,12 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
             if (promise.IsCancellationRequested(World))
             {
                 // Mark as Cancelled so the next GetAsync call clears the slot and retries.
-                wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
+                // Mark as Cancelled so the next GetAsync call clears the slot and retries.
+                // Don't overwrite a sticky Failed (e.g. from a consumer timeout); only reset to
+                // Cancelled when the slot is clear, successful, or already Cancelled.
+                if (wearable.ThumbnailAssetResult is not { IsInitialized: true } existing
+                    || existing.Succeeded || existing.Cancelled)
+                    wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);
                 return;
             }

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -1,6 +1,7 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
+using DCL.AvatarRendering.Thumbnails.Utils;
 using DCL.AvatarRendering.Wearables;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.AvatarRendering.Wearables.Equipped;
@@ -409,13 +410,29 @@ namespace DCL.Backpack
 
         private async UniTaskVoid InitializeItemViewAsync(ITrimmedWearable itemWearable, BackpackItemView itemView, CancellationToken ct)
         {
-            Sprite sprite = await thumbnailProvider.GetAsync(itemWearable, ct);
-            if (ct.IsCancellationRequested) return;
+            try
+            {
+                Sprite sprite = await thumbnailProvider.GetAsync(itemWearable, ct);
+                if (ct.IsCancellationRequested) return;
 
-            itemView.WearableThumbnail.sprite = sprite;
-            itemView.LoadingView.FinishLoadingAnimation(itemView.FullBackpackItem);
+                itemView.WearableThumbnail.sprite = sprite;
+                itemView.LoadingView.FinishLoadingAnimation(itemView.FullBackpackItem);
 
-            itemView.SmartWearableBadgeContainer.SetActive(itemWearable.IsSmart());
+                itemView.SmartWearableBadgeContainer.SetActive(itemWearable.IsSmart());
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception e)
+            {
+                ReportHub.LogException(e, new ReportData(ReportCategory.THUMBNAILS));
+
+                // Failure path must still unblock the cell, otherwise it sits in the "loading"
+                // state forever and the surrounding grid input stays gated.
+                if (ct.IsCancellationRequested) return;
+
+                itemView.WearableThumbnail.sprite = LoadThumbnailsUtils.DEFAULT_THUMBNAIL.Sprite;
+                itemView.LoadingView.FinishLoadingAnimation(itemView.FullBackpackItem);
+                itemView.SmartWearableBadgeContainer.SetActive(itemWearable.IsSmart());
+            }
         }
 
         private void ClearPoolElements()

--- a/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/EmotesSection/BackpackEmoteGridController.cs
@@ -4,6 +4,7 @@ using DCL.AssetsProvision;
 using DCL.AvatarRendering.Emotes;
 using DCL.AvatarRendering.Emotes.Equipped;
 using DCL.AvatarRendering.Loading.Components;
+using DCL.AvatarRendering.Thumbnails.Utils;
 using DCL.AvatarRendering.Wearables;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.Backpack.BackpackBus;
@@ -360,12 +361,27 @@ namespace DCL.Backpack.EmotesSection
 
         private async UniTaskVoid WaitForThumbnailAsync(IThumbnailAttachment emote, BackpackItemView itemView, CancellationToken ct)
         {
-            ct.ThrowIfCancellationRequested();
+            try
+            {
+                Sprite sprite = await thumbnailProvider.GetAsync(emote, ct);
 
-            Sprite sprite = await thumbnailProvider.GetAsync(emote, ct);
+                if (ct.IsCancellationRequested) return;
 
-            itemView.WearableThumbnail.sprite = sprite;
-            itemView.LoadingView.FinishLoadingAnimation(itemView.FullBackpackItem);
+                itemView.WearableThumbnail.sprite = sprite;
+                itemView.LoadingView.FinishLoadingAnimation(itemView.FullBackpackItem);
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception e)
+            {
+                ReportHub.LogException(e, new ReportData(ReportCategory.THUMBNAILS));
+
+                // Failure path must still unblock the cell, otherwise it sits in the "loading"
+                // state forever and the surrounding grid input stays gated.
+                if (ct.IsCancellationRequested) return;
+
+                itemView.WearableThumbnail.sprite = LoadThumbnailsUtils.DEFAULT_THUMBNAIL.Sprite;
+                itemView.LoadingView.FinishLoadingAnimation(itemView.FullBackpackItem);
+            }
         }
 
         private void ClearPoolElements()

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Common/Components/StreamableLoadingResult.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/Common/Components/StreamableLoadingResult.cs
@@ -23,11 +23,40 @@ namespace ECS.StreamableLoading.Common.Components
             /// </summary>
             private readonly bool initialized;
 
+            /// <summary>
+            ///     True when the request reached a terminal successful (or fallback-acceptable) state.
+            ///     False when the request failed or was cancelled; check <see cref="Cancelled"/>
+            ///     to distinguish a transient cancellation from a sticky failure.
+            /// </summary>
+            public readonly bool Succeeded;
+
+            /// <summary>
+            ///     True when the request was cancelled mid-flight (transient state — consumers can
+            ///     clear the slot and retry). False for both genuine successes and sticky failures.
+            /// </summary>
+            public readonly bool Cancelled;
+
             public WithFallback(T asset)
             {
                 Asset = asset;
                 initialized = true;
+                Succeeded = true;
+                Cancelled = false;
             }
+
+            private WithFallback(T asset, bool initialized, bool succeeded, bool cancelled)
+            {
+                Asset = asset;
+                this.initialized = initialized;
+                Succeeded = succeeded;
+                Cancelled = cancelled;
+            }
+
+            public static WithFallback Failed() =>
+                new (default!, initialized: true, succeeded: false, cancelled: false);
+
+            public static WithFallback CancelledResult() =>
+                new (default!, initialized: true, succeeded: false, cancelled: true);
 
             /// <summary>
             ///     Can be uninitialized if structure was created with default constructor
@@ -35,7 +64,7 @@ namespace ECS.StreamableLoading.Common.Components
             public bool IsInitialized => initialized;
 
             public static implicit operator StreamableLoadingResult<T>(WithFallback withFallback) =>
-                withFallback.IsInitialized ? new StreamableLoadingResult<T>(withFallback.Asset) : new StreamableLoadingResult<T>();
+                withFallback.IsInitialized && withFallback.Succeeded ? new StreamableLoadingResult<T>(withFallback.Asset) : new StreamableLoadingResult<T>();
         }
 
         private readonly (ReportData reportData, Exception exception)? exceptionData;


### PR DESCRIPTION
Fixes https://github.com/decentraland/unity-explorer/issues/8241

## Problem

The grid's cell-input layer is gated behind thumbnail load completion. The path from "cell unblocked" back to "thumbnail ready" had several failure points:

1. The process for resolving the thumbnail could spin forever when the thumbnail intention gets cancelled.
2. No consumer-side timeout. Even when the underlying streaming pipeline stalls for non-cancellation reasons, nothing bounded the consumer's wait.
3. The thumbnail was not retried when it was cancelled due to page switching.

Combined, a stalled or cancelled thumbnail load could leave the grid cell input gated forever, hence the symptoms.

## Solution

1. When the thumbnail is cancelled (due to page switching), its resolved with cancelled result, instead of null. 
2. Added a timeout (set by the consumer) that cancels the pending intention.
3. When the thumbnail is marked as cancelled, it allows the next load try to be performed instead of keeping it failed forever.
4. Backpack controller has better exception handling and properly sets a default thumbnail when the operation fails.

## Test plan

Open the backpack either wearables or emotes. Switch fast through pages. Check that thumbnails load as expected and you can interact with the items.