### PR TITLE
feat: report sentry status and enable-sentry flag in CI

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -318,13 +318,20 @@ jobs:
         run: |
           #!/bin/bash
 
-          if [[ "${{ github.event.inputs.sentry_enabled || inputs.sentry_enabled }}" == "true" ]]; then
+          sentry_enabled="${{ github.event.inputs.sentry_enabled || inputs.sentry_enabled }}"
+
+          if [[ "$sentry_enabled" != "true" && "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Checking PR labels: ${{ join(github.event.pull_request.labels.*.name, ', ') }}"
+            sentry_enabled=$(echo "${{ join(github.event.pull_request.labels.*.name, ' ') }}" | grep -qw 'enable-sentry' && echo true || echo false)
+          fi
+
+          if [[ "$sentry_enabled" == "true" ]]; then
             if [[ "${{ inputs.is_release_build }}" == "true" ]]; then
               echo "environment=production" >> "$GITHUB_OUTPUT"
             else
               echo "environment=development" >> "$GITHUB_OUTPUT"
             fi
-          
+
             echo "upload_symbols=true" >> "$GITHUB_OUTPUT"
             echo "sentry_enabled=true" >> "$GITHUB_OUTPUT"
           else

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/DiagnosticInfoUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/DiagnosticInfoUtils.cs
@@ -60,6 +60,16 @@ namespace DCL.Diagnostics
             stringBuilder.AppendFormat("Window Mode: {0}\n", Screen.fullScreenMode.ToString());
             AppendFooter(stringBuilder);
 
+            AppendHeader(stringBuilder, "SENTRY");
+            stringBuilder.AppendFormat("Enabled: {0}\n", SentrySdk.IsEnabled);
+            SentryUnityOptions? sentryOptions = ScriptableSentryUnityOptions.LoadSentryUnityOptions();
+            if (sentryOptions != null)
+            {
+                stringBuilder.AppendFormat("Environment: {0}\n", sentryOptions.Environment ?? "<unset>");
+                stringBuilder.AppendFormat("Release: {0}\n", sentryOptions.Release ?? "<unset>");
+                stringBuilder.AppendFormat("DSN: {0}\n", string.IsNullOrEmpty(sentryOptions.Dsn) ? "<unset>" : "<set>");
+            }
+            AppendFooter(stringBuilder);
 
             ReportHub.LogProductionInfo(stringBuilder.ToString());
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Adds visibility into Sentry status for debugging and diagnostics:

1. **CI: `enable-sentry` label support** — The `build-unitycloud.yml` workflow now checks for an `enable-sentry` label on pull requests. If the label is present and `sentry_enabled` was not already set via workflow input, Sentry is automatically enabled for the build. This makes it easy to opt-in to Sentry for specific PRs without manually triggering the workflow with a custom input.

2. **Runtime: Sentry diagnostics logging** — `DiagnosticInfoUtils.LogSystem()` now includes a `SENTRY` section in the system diagnostics log output. It reports:
   - Whether the Sentry SDK is currently enabled
   - The configured environment (e.g. `production`, `development`)
   - The configured release version
   - Whether a DSN is set (without exposing the actual value)

This helps developers quickly verify Sentry configuration when investigating crash reporting issues or confirming that Sentry is active in a given build.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 8825
```

**Expected result**:
- In the Player.log / diagnostics output, a new `SENTRY` section should appear with `Enabled`, `Environment`, `Release`, and `DSN` fields.

**CI label test**:
1. Add the `enable-sentry` label to a PR
2. Trigger a build via the `build-unitycloud` workflow
3. Verify Sentry is enabled in the build output logs (look for `sentry_enabled=true`)

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included