### PR TITLE
fix: reconciliation of global entities position after the scene has concluded

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/GatherGltfAssetsSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Systems/GatherGltfAssetsSystem.cs
@@ -9,6 +9,7 @@ using ECS.Groups;
 using ECS.SceneLifeCycle.Reporting;
 using ECS.Unity.GLTFContainer.Components;
 using ECS.Unity.Transforms.Components;
+using ECS.Unity.Transforms.Systems;
 using SceneRunner.Scene;
 using System;
 using System.Collections.Generic;
@@ -18,6 +19,9 @@ using UnityEngine.Pool;
 namespace ECS.SceneLifeCycle.Systems
 {
     [UpdateInGroup(typeof(SyncedPreRenderingSystemGroup))]
+
+    // SyncGlobalTransformSystem must run after to reconcile the player entity position after Conclude() was called
+    [UpdateBefore(typeof(SyncGlobalTransformSystem))]
     public partial class GatherGltfAssetsSystem : BaseUnityLoopSystem
     {
         private static readonly TimeSpan TIMEOUT = TimeSpan.FromSeconds(60);


### PR DESCRIPTION
Fixes #7315

With the wrong order there was one-frame gap that affected `AvatarShapeHandlerSystem.LoadAvatarShape`:
```
new CharacterInterpolationMovementComponent(
                    transformComponent.Transform.position,
                    transformComponent.Transform.position,
                    transformComponent.Transform.rotation),
```
