### PR TITLE
fix: proper cleanup of outfit state on panel close

### DIFF
--- a/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/OutfitsPresenter.cs
+++ b/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/OutfitsPresenter.cs
@@ -119,6 +119,9 @@ namespace DCL.Backpack
 
         public void Deactivate()
         {
+            foreach (var presenter in slotPresenters)
+                presenter.ResetHoverState();
+
             EndSlotBusy();
             characterPreviewController.StopEmotes();
             previewOutfitCommand.Restore();

--- a/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/Slots/OutfitSlotPresenter.cs
+++ b/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/Slots/OutfitSlotPresenter.cs
@@ -37,18 +37,13 @@ namespace DCL.Backpack.Slots
         public event Action<OutfitItem>? OnEquipRequested;
         public event Action<OutfitItem>? OnPreviewRequested;
 
-        public bool HasThumbnail()
-        {
-            return currentThumbnail != null;
-        }
-
         public readonly int slotIndex;
 
         private readonly OutfitSlotView view;
         private readonly HoverHandler hoverHandler;
         private readonly IAvatarScreenshotService screenshotService;
         private CancellationTokenSource cts = new ();
-        
+
         private bool isHovered;
         private bool isForcedHover;
         private OutfitSlotState currentState;
@@ -67,16 +62,17 @@ namespace DCL.Backpack.Slots
             view.OnDeleteClicked += HandleDeleteClicked;
             view.OnEquipClicked += HandleEquipClicked;
             view.OnPreviewClicked += HandlePreviewClicked;
-            
+
             hoverHandler = view.hoverHandler;
             hoverHandler.OnHoverEntered += OnHoverEntered;
             hoverHandler.OnHoverExited += OnHoverExited;
         }
 
-        public OutfitItem? GetOutfitData()
-        {
-            return currentOutfitData;
-        }
+        public bool HasThumbnail() =>
+            currentThumbnail != null;
+
+        public OutfitItem? GetOutfitData() =>
+            currentOutfitData;
 
         private void HandleSaveClicked()
         {
@@ -176,6 +172,13 @@ namespace DCL.Backpack.Slots
         public void SetHoverEnabled(bool isEnabled) =>
             view.SetHoverEnabled(isEnabled);
 
+        public void ResetHoverState()
+        {
+            isHovered = false;
+            view.ResetHoverState();
+            UpdateView();
+        }
+
         private void SetState(OutfitSlotState newState, OutfitItem? item = null)
         {
             currentState = newState;
@@ -185,8 +188,8 @@ namespace DCL.Backpack.Slots
 
         private void UpdateView()
         {
-            bool effectiveHover = isHovered || isForcedHover; 
-            
+            bool effectiveHover = isHovered || isForcedHover;
+
             switch (currentState)
             {
                 case OutfitSlotState.Empty: view.ShowEmptyState(isHovered); break;

--- a/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/Slots/OutfitSlotView.cs
+++ b/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/Slots/OutfitSlotView.cs
@@ -226,6 +226,20 @@ namespace DCL.Backpack.AvatarSection.Outfits.Slots
             hoverHandler.enabled = isEnabled;
         }
 
+        public void ResetHoverState()
+        {
+            cts?.SafeCancelAndDispose();
+            cts = null;
+
+            transform.localScale = Vector3.one;
+
+            if (outfitHoverOutline != null)
+            {
+                outfitHoverOutline.transform.localScale = Vector3.zero;
+                outfitHoverOutline.gameObject.SetActive(false);
+            }
+        }
+
         private void ResetEquipButtonContent()
         {
             isEquipLoading = false;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #8611 
Resets outfit slot hover state when closing the backpack

## Test Instructions


### Test Steps
1. Go to the outfits section.
2. Hover any card and close the menu pressing [Esc] (or any of the other keys mentioned above) while still hovering the card.
3. Reopen the outfits menu.
4. Note that the outfits slots appear as they did the first time and no slot is in hover state unless actually hovered with the cursor

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
