### PR TITLE
chore: hide stale Claude review comments instead of deleting

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,10 +8,6 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
-concurrency:
-  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   auto-review:
     if: |
@@ -20,6 +16,9 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'no review') &&
       !contains(github.event.pull_request.labels.*.name, 'auto-pr')
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-auto-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       id-token: write
       contents: read
@@ -317,6 +316,9 @@ jobs:
     needs: check-member
     if: needs.check-member.outputs.is-member == 'true'
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-on-demand-review-${{ github.event.issue.number }}
+      cancel-in-progress: true
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -134,7 +134,9 @@ jobs:
               owner, repo, issue_number: prNumber, per_page: 100
             });
 
-            const claudeComments = comments.data.filter(c => c.user?.login === 'claude[bot]');
+            const claudeComments = comments.data.filter(c =>
+              c.user?.login === 'claude[bot]' && c.body?.includes('REVIEW_RESULT:')
+            );
             const claudeComment = claudeComments[claudeComments.length - 1];
 
             const output = claudeComment?.body ?? '';
@@ -215,9 +217,14 @@ jobs:
             }
 
             for (const c of claudeComments.slice(0, -1)) {
-              await github.rest.issues.deleteComment({
-                owner, repo, comment_id: c.id
-              }).catch(e => console.log(`deleteComment ${c.id}: ${e.message}`));
+              await github.graphql(
+                `mutation($id: ID!) {
+                  minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                    minimizedComment { isMinimized }
+                  }
+                }`,
+                { id: c.node_id }
+              ).catch(e => console.log(`minimizeComment ${c.id}: ${e.message}`));
             }
 
             let description;
@@ -422,7 +429,9 @@ jobs:
               per_page: 100
             });
 
-            const claudeComments = comments.data.filter(c => c.user?.login === 'claude[bot]');
+            const claudeComments = comments.data.filter(c =>
+              c.user?.login === 'claude[bot]' && c.body?.includes('REVIEW_RESULT:')
+            );
             const claudeComment = claudeComments[claudeComments.length - 1];
 
             const output = claudeComment?.body ?? '';
@@ -433,11 +442,14 @@ jobs:
             const hasReviewResult = output.includes('REVIEW_RESULT:');
 
             for (const c of claudeComments.slice(0, -1)) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: c.id
-              }).catch(e => console.log(`deleteComment ${c.id}: ${e.message}`));
+              await github.graphql(
+                `mutation($id: ID!) {
+                  minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                    minimizedComment { isMinimized }
+                  }
+                }`,
+                { id: c.node_id }
+              ).catch(e => console.log(`minimizeComment ${c.id}: ${e.message}`));
             }
 
             let description;

--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -16,6 +16,10 @@ on:
       - '.github/workflows/**'
       - '.github/prompts/**'
 
+concurrency:
+  group: dependency-security-review-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   detect-and-review:
     if: github.event.pull_request.draft == false
@@ -182,9 +186,21 @@ jobs:
                 issue_number: ${{ github.event.pull_request.number }},
               });
 
-              const claudeComment = comments
-                .reverse()
-                .find(c => c.user?.login === 'claude[bot]');
+              const claudeComments = comments.filter(c =>
+                c.user?.login === 'claude[bot]' && c.body?.includes('DEPENDENCY_REVIEW:')
+              );
+              const claudeComment = claudeComments[claudeComments.length - 1];
+
+              for (const c of claudeComments.slice(0, -1)) {
+                await github.graphql(
+                  `mutation($id: ID!) {
+                    minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                      minimizedComment { isMinimized }
+                    }
+                  }`,
+                  { id: c.node_id }
+                ).catch(e => console.log(`minimizeComment ${c.id}: ${e.message}`));
+              }
 
               const output = claudeComment?.body ?? '';
               const errored = '${{ steps.claude.outcome }}' === 'failure';


### PR DESCRIPTION
## Summary
- Scope code-review dedupe to comments containing `REVIEW_RESULT:` and security-review dedupe to `DEPENDENCY_REVIEW:` so the two reviews don't clobber each other.
- Replace `deleteComment` with GraphQL `minimizeComment(classifier: OUTDATED)` in both workflows — older verdicts collapse as "outdated" instead of disappearing.
- Add `concurrency: cancel-in-progress` to the dependency security review so rapid pushes only finalize the latest run.