### PR TITLE
fix: prevent loading stale profiles on realm change

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -58,6 +58,8 @@ using DCL.Multiplayer.Movement.Systems;
 using DCL.Multiplayer.Profiles.BroadcastProfiles;
 using DCL.Multiplayer.Profiles.Entities;
 using DCL.Multiplayer.Profiles.Poses;
+using DCL.Multiplayer.Profiles.RemoteAnnouncements;
+using DCL.Multiplayer.Profiles.RemoteProfiles;
 using DCL.Multiplayer.Profiles.Tables;
 using DCL.Multiplayer.SDK.Systems.GlobalWorld;
 using DCL.Navmap;
@@ -443,6 +445,11 @@ namespace Global.Dynamic
 
             var messagePipesHub = new MessagePipesHub(roomHub, MultiPoolFactory(), memoryPool, islandThroughputBunch, sceneThroughputBunch, chatThroughputBunch);
 
+            var remoteMetadata = new DebounceRemoteMetadata(new RemoteMetadata(roomHub, staticContainer.RealmData, bootstrapContainer.DecentralandUrlsSource));
+
+            var remoteAnnouncements = new RemoteAnnouncements(messagePipesHub);
+            var remoteProfiles = new RemoteProfiles(profilesRepository, remoteMetadata);
+
             var roomsStatus = new RoomsStatus(
                 roomHub,
 
@@ -471,7 +478,7 @@ namespace Global.Dynamic
 
             var worldAccessGate = new PrivateWorldAccessHandler(worldPermissionsService, mvcManager, staticContainer.RealmData);
             var realmNavigatorContainer = RealmNavigationContainer.Create
-                (staticContainer, bootstrapContainer, lodContainer, realmContainer, remoteEntities, globalWorld, roomHub, terrainContainer.Landscape, exposedGlobalDataContainer, loadingScreen, placesAPIService, worldAccessGate);
+                (staticContainer, bootstrapContainer, lodContainer, realmContainer, remoteEntities, remoteAnnouncements, remoteProfiles, globalWorld, roomHub, terrainContainer.Landscape, exposedGlobalDataContainer, loadingScreen, placesAPIService, worldAccessGate);
 
             IHealthCheck livekitHealthCheck = bootstrapContainer.DebugSettings.EnableEmulateNoLivekitConnection
                 ? new IHealthCheck.AlwaysFails()
@@ -649,8 +656,6 @@ namespace Global.Dynamic
             // Configure proxies for scene-side masked emote system
             staticContainer.EmotesMessageBusProxy.SetObject(multiplayerEmotesMessageBus);
 
-            var remoteMetadata = new DebounceRemoteMetadata(new RemoteMetadata(roomHub, staticContainer.RealmData, bootstrapContainer.DecentralandUrlsSource));
-
             var characterPreviewEventBus = new CharacterPreviewEventBus();
             var upscaleController = new UpscalingController(mvcManager);
 
@@ -780,6 +785,8 @@ namespace Global.Dynamic
                     entityParticipantTable,
                     messagePipesHub,
                     remoteMetadata,
+                    remoteAnnouncements,
+                    remoteProfiles,
                     staticContainer.CharacterContainer.CharacterObject,
                     staticContainer.RealmData,
                     remoteEntities,

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/Announcements/RemoteAnnouncements.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/Announcements/RemoteAnnouncements.cs
@@ -25,5 +25,10 @@ namespace DCL.Multiplayer.Profiles.RemoteAnnouncements
 
         public Bunch<RemoteAnnouncement> Bunch() =>
             new (list);
+
+        public void Reset()
+        {
+            list.Clear();
+        }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/RemoteProfiles/RemoteProfiles.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/RemoteProfiles/RemoteProfiles.cs
@@ -67,6 +67,15 @@ namespace DCL.Multiplayer.Profiles.RemoteProfiles
         public Bunch<RemoteProfile> Bunch() =>
             new (remoteProfiles);
 
+        public void Reset()
+        {
+            foreach (var kv in pendingProfiles)
+                kv.Value.Cts.SafeCancelAndDispose();
+
+            pendingProfiles.Clear();
+            remoteProfiles.Clear();
+        }
+
         private async UniTaskVoid TryDownloadAsync(RemoteAnnouncement remoteAnnouncement)
         {
             URLDomain? lambdasEndpoint = remoteMetadata.GetLambdaDomainOrNull(remoteAnnouncement.WalletId);
@@ -107,8 +116,12 @@ namespace DCL.Multiplayer.Profiles.RemoteProfiles
                 if (profile is null)
                     return;
 
-                // Take the room source from the dictionary as the value could be updated
-                remoteProfiles.Add(new RemoteProfile(profile, remoteAnnouncement.WalletId, pendingProfiles[remoteAnnouncement.WalletId].FromRoom));
+                // Reset() may have cancelled and cleared pendingProfiles while we were awaiting.
+                // Without this guard a stale profile from a previous realm would slip into the next consumer pass and create a ghost avatar.
+                if (cts.IsCancellationRequested || !pendingProfiles.TryGetValue(remoteAnnouncement.WalletId, out PendingRequest currentRequest))
+                    return;
+
+                remoteProfiles.Add(new RemoteProfile(profile, remoteAnnouncement.WalletId, currentRequest.FromRoom));
 
                 ReportHub.Log(ReportCategory.PROFILE,
                     $"{remoteAnnouncement} was downloaded for {(DateTime.Now - startedAt).TotalSeconds} s.");

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/RemoteProfiles/RemoteProfiles.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/RemoteProfiles/RemoteProfiles.cs
@@ -117,7 +117,6 @@ namespace DCL.Multiplayer.Profiles.RemoteProfiles
                     return;
 
                 // Reset() may have cancelled and cleared pendingProfiles while we were awaiting.
-                // Without this guard a stale profile from a previous realm would slip into the next consumer pass and create a ghost avatar.
                 if (cts.IsCancellationRequested || !pendingProfiles.TryGetValue(remoteAnnouncement.WalletId, out PendingRequest currentRequest))
                     return;
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/MultiplayerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/MultiplayerPlugin.cs
@@ -57,6 +57,8 @@ namespace DCL.PluginSystem.Global
         private readonly IRealmData realmData;
         private readonly IRemoteEntities remoteEntities;
         private readonly IRemoteMetadata remoteMetadata;
+        private readonly RemoteAnnouncements remoteAnnouncements;
+        private readonly RemoteProfiles remoteProfiles;
         private readonly IRoomHub roomHub;
         private readonly RoomsStatus roomsStatus;
         private readonly IScenesCache scenesCache;
@@ -81,6 +83,8 @@ namespace DCL.PluginSystem.Global
             IEntityParticipantTable entityParticipantTable,
             IMessagePipesHub messagePipesHub,
             IRemoteMetadata remoteMetadata,
+            RemoteAnnouncements remoteAnnouncements,
+            RemoteProfiles remoteProfiles,
             ICharacterObject characterObject,
             IRealmData realmData,
             IRemoteEntities remoteEntities,
@@ -104,6 +108,8 @@ namespace DCL.PluginSystem.Global
             this.entityParticipantTable = entityParticipantTable;
             this.messagePipesHub = messagePipesHub;
             this.remoteMetadata = remoteMetadata;
+            this.remoteAnnouncements = remoteAnnouncements;
+            this.remoteProfiles = remoteProfiles;
             this.characterObject = characterObject;
             this.remoteEntities = remoteEntities;
             this.realmData = realmData;
@@ -141,11 +147,11 @@ namespace DCL.PluginSystem.Global
             DebugThroughputRoomsSystem.InjectToWorld(ref builder, roomHub, debugContainerBuilder, islandThroughputBufferBunch, sceneThroughputBufferBunch);
 
             MultiplayerProfilesSystem.InjectToWorld(ref builder,
-                new RemoteAnnouncements(messagePipesHub),
+                remoteAnnouncements,
                 new LogRemoveIntentions(
                     new ThreadSafeRemoveIntentions(roomHub)
                 ),
-                new RemoteProfiles(profileRepository, remoteMetadata),
+                remoteProfiles,
                 profileBroadcast,
                 remoteEntities,
                 remoteMetadata,

--- a/Explorer/Assets/DCL/RealmNavigation/Container/RealmNavigationContainer.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/Container/RealmNavigationContainer.cs
@@ -4,6 +4,8 @@ using DCL.Diagnostics;
 using DCL.LOD.Systems;
 using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Multiplayer.Profiles.Entities;
+using DCL.Multiplayer.Profiles.RemoteAnnouncements;
+using DCL.Multiplayer.Profiles.RemoteProfiles;
 using DCL.PerformanceAndDiagnostics.Analytics;
 using DCL.PlacesAPIService;
 using DCL.PrivateWorlds;
@@ -38,6 +40,8 @@ namespace DCL.RealmNavigation
             LODContainer lodContainer,
             RealmContainer realmContainer,
             RemoteEntities remoteEntities,
+            RemoteAnnouncements remoteAnnouncements,
+            RemoteProfiles remoteProfiles,
             World globalWorld,
             IRoomHub roomHub,
             ILandscape landscape,
@@ -53,7 +57,7 @@ namespace DCL.RealmNavigation
             var realmChangeOperations = new AnalyticsSequentialLoadingOperation<TeleportParams>(staticContainer.LoadingStatus, new ITeleportOperation[]
                 {
                     new RestartLoadingStatus(),
-                    new RemoveRemoteEntitiesTeleportOperation(remoteEntities, globalWorld),
+                    new RemoveRemoteEntitiesTeleportOperation(remoteEntities, remoteAnnouncements, remoteProfiles, globalWorld),
                     new StopRoomAsyncTeleportOperation(roomHub, LIVEKIT_TIMEOUT),
                     new RemoveCameraSamplingDataTeleportOperation(globalWorld, exposedGlobalDataContainer.ExposedCameraData.CameraEntityProxy),
                     new ClearWorldsCacheTeleportOperation(placesAPIService),

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/RemoveRemoteEntitiesTeleportOperation.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/RemoveRemoteEntitiesTeleportOperation.cs
@@ -1,6 +1,8 @@
 using Arch.Core;
 using Cysharp.Threading.Tasks;
 using DCL.Multiplayer.Profiles.Entities;
+using DCL.Multiplayer.Profiles.RemoteAnnouncements;
+using DCL.Multiplayer.Profiles.RemoteProfiles;
 using System.Threading;
 
 namespace DCL.RealmNavigation.TeleportOperations
@@ -8,16 +10,24 @@ namespace DCL.RealmNavigation.TeleportOperations
     public class RemoveRemoteEntitiesTeleportOperation : TeleportOperationBase
     {
         private readonly IRemoteEntities remoteEntities;
+        private readonly RemoteAnnouncements remoteAnnouncements;
+        private readonly RemoteProfiles remoteProfiles;
         private readonly World globalWorld;
 
-        public RemoveRemoteEntitiesTeleportOperation(IRemoteEntities remoteEntities, World globalWorld)
+        public RemoveRemoteEntitiesTeleportOperation(IRemoteEntities remoteEntities, RemoteAnnouncements remoteAnnouncements, RemoteProfiles remoteProfiles, World globalWorld)
         {
             this.remoteEntities = remoteEntities;
+            this.remoteAnnouncements = remoteAnnouncements;
+            this.remoteProfiles = remoteProfiles;
             this.globalWorld = globalWorld;
         }
 
         protected override UniTask InternalExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
         {
+            // In-flight profile downloads and queued announcements from the previous realm must be dropped here:
+            // otherwise they resolve after the teleport and TryCreateOrUpdateRemoteEntity rebuilds them as ghost avatars in the new realm.
+            remoteAnnouncements.Reset();
+            remoteProfiles.Reset();
             remoteEntities.ForceRemoveAll(globalWorld);
             return UniTask.CompletedTask;
         }

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/RemoveRemoteEntitiesTeleportOperation.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/RemoveRemoteEntitiesTeleportOperation.cs
@@ -24,7 +24,7 @@ namespace DCL.RealmNavigation.TeleportOperations
 
         protected override UniTask InternalExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
         {
-            // Drop in-flight profile downloads and queued announcements from the previous realm must so they don't appear as ghosts
+            // Drop in-flight profile downloads and queued announcements from the previous realm so they don't appear as ghosts
             remoteAnnouncements.Reset();
             remoteProfiles.Reset();
             remoteEntities.ForceRemoveAll(globalWorld);

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/RemoveRemoteEntitiesTeleportOperation.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/RemoveRemoteEntitiesTeleportOperation.cs
@@ -24,8 +24,7 @@ namespace DCL.RealmNavigation.TeleportOperations
 
         protected override UniTask InternalExecuteAsync(TeleportParams teleportParams, CancellationToken ct)
         {
-            // In-flight profile downloads and queued announcements from the previous realm must be dropped here:
-            // otherwise they resolve after the teleport and TryCreateOrUpdateRemoteEntity rebuilds them as ghost avatars in the new realm.
+            // Drop in-flight profile downloads and queued announcements from the previous realm must so they don't appear as ghosts
             remoteAnnouncements.Reset();
             remoteProfiles.Reset();
             remoteEntities.ForceRemoveAll(globalWorld);


### PR DESCRIPTION
# Pull Request Description
Fixes #8827

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes sure that on realm change, profiles that are being downloaded for the previous realm, are cancelled (`RemoteProfiles.TryDownloadAsync` is a fire & forget) so that when they are completed, they don't get included into `remoteProfiles` leading to "ghost avatars".


### Test Steps
1. Follow repro steps of the linked issue
2. Smoke test, everything should operate as normal (especially in terms of remote avatars across teleports between worlds and Genesis City)


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
