### PR TITLE
chore: anchor Claude verdict marker filter to line-start

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -133,8 +133,9 @@ jobs:
               owner, repo, issue_number: prNumber, per_page: 100
             });
 
+            const VERDICT_RE = /(?:^|\n)REVIEW_RESULT: (PASS|FAIL)\b/;
             const claudeComments = comments.data.filter(c =>
-              c.user?.login === 'claude[bot]' && c.body?.includes('REVIEW_RESULT:')
+              c.user?.login === 'claude[bot]' && VERDICT_RE.test(c.body || '')
             );
             const claudeComment = claudeComments[claudeComments.length - 1];
 
@@ -431,8 +432,9 @@ jobs:
               per_page: 100
             });
 
+            const VERDICT_RE = /(?:^|\n)REVIEW_RESULT: (PASS|FAIL)\b/;
             const claudeComments = comments.data.filter(c =>
-              c.user?.login === 'claude[bot]' && c.body?.includes('REVIEW_RESULT:')
+              c.user?.login === 'claude[bot]' && VERDICT_RE.test(c.body || '')
             );
             const claudeComment = claudeComments[claudeComments.length - 1];
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,10 +8,6 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
-concurrency:
-  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   auto-review:
     if: |
@@ -20,6 +16,9 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'no review') &&
       !contains(github.event.pull_request.labels.*.name, 'auto-pr')
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-auto-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       id-token: write
       contents: read
@@ -317,6 +316,9 @@ jobs:
     needs: check-member
     if: needs.check-member.outputs.is-member == 'true'
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-on-demand-review-${{ github.event.issue.number }}
+      cancel-in-progress: true
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -134,7 +134,9 @@ jobs:
               owner, repo, issue_number: prNumber, per_page: 100
             });
 
-            const claudeComments = comments.data.filter(c => c.user?.login === 'claude[bot]');
+            const claudeComments = comments.data.filter(c =>
+              c.user?.login === 'claude[bot]' && c.body?.includes('REVIEW_RESULT:')
+            );
             const claudeComment = claudeComments[claudeComments.length - 1];
 
             const output = claudeComment?.body ?? '';
@@ -215,9 +217,14 @@ jobs:
             }
 
             for (const c of claudeComments.slice(0, -1)) {
-              await github.rest.issues.deleteComment({
-                owner, repo, comment_id: c.id
-              }).catch(e => console.log(`deleteComment ${c.id}: ${e.message}`));
+              await github.graphql(
+                `mutation($id: ID!) {
+                  minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                    minimizedComment { isMinimized }
+                  }
+                }`,
+                { id: c.node_id }
+              ).catch(e => console.log(`minimizeComment ${c.id}: ${e.message}`));
             }
 
             let description;
@@ -422,7 +429,9 @@ jobs:
               per_page: 100
             });
 
-            const claudeComments = comments.data.filter(c => c.user?.login === 'claude[bot]');
+            const claudeComments = comments.data.filter(c =>
+              c.user?.login === 'claude[bot]' && c.body?.includes('REVIEW_RESULT:')
+            );
             const claudeComment = claudeComments[claudeComments.length - 1];
 
             const output = claudeComment?.body ?? '';
@@ -433,11 +442,14 @@ jobs:
             const hasReviewResult = output.includes('REVIEW_RESULT:');
 
             for (const c of claudeComments.slice(0, -1)) {
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: c.id
-              }).catch(e => console.log(`deleteComment ${c.id}: ${e.message}`));
+              await github.graphql(
+                `mutation($id: ID!) {
+                  minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                    minimizedComment { isMinimized }
+                  }
+                }`,
+                { id: c.node_id }
+              ).catch(e => console.log(`minimizeComment ${c.id}: ${e.message}`));
             }
 
             let description;

--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -16,6 +16,10 @@ on:
       - '.github/workflows/**'
       - '.github/prompts/**'
 
+concurrency:
+  group: dependency-security-review-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   detect-and-review:
     if: github.event.pull_request.draft == false
@@ -182,9 +186,21 @@ jobs:
                 issue_number: ${{ github.event.pull_request.number }},
               });
 
-              const claudeComment = comments
-                .reverse()
-                .find(c => c.user?.login === 'claude[bot]');
+              const claudeComments = comments.filter(c =>
+                c.user?.login === 'claude[bot]' && c.body?.includes('DEPENDENCY_REVIEW:')
+              );
+              const claudeComment = claudeComments[claudeComments.length - 1];
+
+              for (const c of claudeComments.slice(0, -1)) {
+                await github.graphql(
+                  `mutation($id: ID!) {
+                    minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                      minimizedComment { isMinimized }
+                    }
+                  }`,
+                  { id: c.node_id }
+                ).catch(e => console.log(`minimizeComment ${c.id}: ${e.message}`));
+              }
 
               const output = claudeComment?.body ?? '';
               const errored = '${{ steps.claude.outcome }}' === 'failure';

--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -186,8 +186,9 @@ jobs:
                 issue_number: ${{ github.event.pull_request.number }},
               });
 
+              const VERDICT_RE = /(?:^|\n)DEPENDENCY_REVIEW: (PASS|BLOCK|NEEDS_ATTENTION)\b/;
               const claudeComments = comments.filter(c =>
-                c.user?.login === 'claude[bot]' && c.body?.includes('DEPENDENCY_REVIEW:')
+                c.user?.login === 'claude[bot]' && VERDICT_RE.test(c.body || '')
               );
               const claudeComment = claudeComments[claudeComments.length - 1];
 

--- a/docs/master-of-bots.md
+++ b/docs/master-of-bots.md
@@ -1,5 +1,5 @@
 # Master of Bots
 
-Master Of Bots allows you to simulate big amounts (tested with up to 100 bots from a single machine) of users with real wallets for debug purposes.
+Master Of Bots allows you to simulate large numbers (tested with up to 100 bots from a single machine) of users with real wallets for debug purposes.
 
 Proceed to https://github.com/decentraland/livekit-bots/tree/explorer-alpha and follow the instructions.


### PR DESCRIPTION
## Summary
Follow-up to #8833. The dedupe filter matched `REVIEW_RESULT:` / `DEPENDENCY_REVIEW:` anywhere in the body, so when one Claude review's verdict text discusses the other's marker (e.g. on workflow-meta PRs) the wrong comment got minimized.

Tighten the filter to require an actual verdict value (`PASS` / `FAIL` for code review; `PASS` / `BLOCK` / `NEEDS_ATTENTION` for dependency security) at the start of a line. Mentions inside prose or inline code no longer match.

Also includes a tiny doc wording tweak in `docs/master-of-bots.md` from the earlier smoke test that surfaced this bug.

## Test plan
- [ ] Auto-review verdict on this PR stays visible; security review verdict (if it fires) stays visible too
- [ ] On a follow-up push, older verdicts collapse as "outdated" — but only their own kind