### PR TITLE
fix: deep link to world redirects to Genesis after account change

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Realm/IRealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Realm/IRealmController.cs
@@ -1,6 +1,5 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
-using System;
 using System.Threading;
 
 namespace ECS.SceneLifeCycle.Realm
@@ -32,9 +31,6 @@ namespace ECS.SceneLifeCycle.Realm
                 UniTask.CompletedTask;
 
             public async UniTask<bool> IsReachableAsync(URLDomain realm, CancellationToken ct) =>
-                false;
-
-            public async UniTask<bool> IsUserAuthorisedToAccessWorldAsync(URLDomain realm, CancellationToken ct) =>
                 false;
 
             public void DisposeGlobalWorld()

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Realm/IRealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/Realm/IRealmController.cs
@@ -15,8 +15,6 @@ namespace ECS.SceneLifeCycle.Realm
 
         UniTask<bool> IsReachableAsync(URLDomain realm, CancellationToken ct);
 
-        UniTask<bool> IsUserAuthorisedToAccessWorldAsync(URLDomain realm, CancellationToken ct);
-
         /// <summary>
         ///     Dispose everything on application quit
         /// </summary>

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/Bootstraper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/Bootstraper.cs
@@ -2,7 +2,6 @@ using Arch.Core;
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Audio;
-using DCL.Chat.History;
 using DCL.DebugUtilities;
 using DCL.Diagnostics;
 using DCL.FeatureFlags;
@@ -286,27 +285,6 @@ namespace Global.Dynamic
 
             if (startingRealm.HasValue == false)
                 throw new InvalidOperationException("Starting realm is not set");
-
-            if (realmLaunchSettings.initialRealm is InitialRealm.World)
-            {
-                bool isAuthorized = await dynamicWorldContainer.RealmController
-                    .IsUserAuthorisedToAccessWorldAsync(startingRealm.Value, ct);
-
-                if (!isAuthorized)
-                {
-                    ReportHub.LogWarning(ReportCategory.REALM,
-                        $"[Bootstrap] Startup world '{realmLaunchSettings.TargetWorld}' is not authorized for auto-entry, falling back to Genesis.");
-
-                    dynamicWorldContainer.ChatHistory.AddMessage(
-                        ChatChannel.NEARBY_CHANNEL_ID,
-                        ChatChannel.ChatChannelType.NEARBY,
-                        ChatMessage.NewFromSystem($"Could not auto-enter '{realmLaunchSettings.TargetWorld}' due to world permissions. You were sent to Genesis Plaza."));
-
-                    await dynamicWorldContainer.RealmController
-                        .SetRealmAsync(URLDomain.FromString(realmUrls.GenesisRealm()), ct);
-                    return;
-                }
-            }
 
             await dynamicWorldContainer.RealmController.SetRealmAsync(startingRealm.Value, ct);
         }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -381,7 +381,6 @@ namespace Global.Dynamic
 
             var realmContainer = RealmContainer.Create(
                 staticContainer,
-                identityCache,
                 dynamicWorldParams.StaticLoadPositions,
                 debugBuilder,
                 loadingScreenTimeout,
@@ -390,8 +389,7 @@ namespace Global.Dynamic
                 bootstrapContainer.DecentralandUrlsSource,
                 appArgs,
                 teleportController,
-                bootstrapContainer.Environment,
-                worldPermissionsService);
+                bootstrapContainer.Environment);
 
             var terrainContainer = TerrainContainer.Create(staticContainer, realmContainer, dynamicWorldParams.EnableLandscape, localSceneDevelopment);
 
@@ -514,7 +512,9 @@ namespace Global.Dynamic
                 roomHub,
                 localSceneDevelopment,
                 staticContainer.CharacterContainer,
-                moderationDataProvider);
+                moderationDataProvider,
+                worldPermissionsService,
+                chatHistory);
 
             IRealmNavigator realmNavigator = realmNavigatorContainer.RealmNavigator;
             HomePlaceEventBus homePlaceEventBus = new HomePlaceEventBus();

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
@@ -1,9 +1,11 @@
 ﻿using DCL.ApplicationBlocklistGuard;
 using DCL.Audio;
 using DCL.Character.Plugin;
+using DCL.Chat.History;
 using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Multiplayer.HealthChecks;
+using DCL.PrivateWorlds;
 using DCL.Profiles.Self;
 using DCL.RealmNavigation;
 using DCL.RealmNavigation.LoadingOperation;
@@ -37,7 +39,9 @@ namespace DCL.UserInAppInitializationFlow
             IRoomHub roomHub,
             bool localSceneDevelopment,
             CharacterContainer characterContainer,
-            ModerationDataProvider moderationDataProvider)
+            ModerationDataProvider moderationDataProvider,
+            IWorldPermissionsService worldPermissionsService,
+            IChatHistory chatHistory)
         {
             ILoadingStatus? loadingStatus = staticContainer.LoadingStatus;
 
@@ -100,7 +104,9 @@ namespace DCL.UserInAppInitializationFlow
                     characterContainer.CharacterObject,
                     characterContainer.Transform,
                     dynamicWorldParams.StartParcel,
-                    localSceneDevelopment),
+                    localSceneDevelopment,
+                    worldPermissionsService,
+                    chatHistory),
             };
         }
     }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -10,7 +10,6 @@ using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Optimization.Pools;
 using DCL.Utilities;
 using DCL.Utilities.Extensions;
-using DCL.Web3.Identities;
 using DCL.WebRequests;
 using ECS;
 using ECS.Prioritization.Components;
@@ -30,7 +29,6 @@ using ECS.SceneLifeCycle.Systems;
 using Global.AppArgs;
 using Unity.Mathematics;
 using UnityEngine;
-using DCL.PrivateWorlds;
 using DCL.UserInAppInitializationFlow.StartupOperations;
 using Utility;
 
@@ -195,25 +193,6 @@ namespace Global.Dynamic
 
         public async UniTask<bool> IsReachableAsync(URLDomain realm, CancellationToken ct) =>
             await webRequestController.IsHeadReachableAsync(ReportCategory.REALM, realm.Append(new URLPath("/about")), ct);
-
-        private static bool TryExtractWorldName(URLDomain realm, out string worldName)
-        {
-            worldName = string.Empty;
-
-            if (!Uri.TryCreate(realm.Value, UriKind.Absolute, out Uri? uri))
-                return false;
-
-            string path = uri.AbsolutePath.Trim('/');
-            if (string.IsNullOrEmpty(path))
-                return false;
-
-            string[] segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
-            if (segments.Length == 0)
-                return false;
-
-            worldName = segments[^1];
-            return !string.IsNullOrEmpty(worldName);
-        }
 
         public async UniTask<List<SceneEntityDefinition>> WaitForFixedScenePromisesAsync(CancellationToken ct)
         {

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -8,7 +8,6 @@ using DCL.Global.Dynamic;
 using DCL.Ipfs;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Optimization.Pools;
-using DCL.PluginSystem.Global;
 using DCL.Utilities;
 using DCL.Utilities.Extensions;
 using DCL.Web3.Identities;
@@ -54,11 +53,9 @@ namespace Global.Dynamic
 
         private readonly List<ISceneFacade> allScenes = new (PoolConstants.SCENES_COUNT);
         private readonly ServerAbout serverAbout = new ();
-        private readonly IWeb3IdentityCache web3IdentityCache;
         private readonly IWebRequestController webRequestController;
         private readonly IReadOnlyList<int2> staticLoadPositions;
         private readonly RealmData realmData;
-        private readonly IWorldPermissionsService worldPermissionsService;
         private readonly RetrieveSceneFromFixedRealm retrieveSceneFromFixedRealm;
         private readonly RetrieveSceneFromVolatileWorld retrieveSceneFromVolatileWorld;
         private readonly TeleportController teleportController;
@@ -92,7 +89,6 @@ namespace Global.Dynamic
         }
 
         public RealmController(
-            IWeb3IdentityCache web3IdentityCache,
             IWebRequestController webRequestController,
             TeleportController teleportController,
             RetrieveSceneFromFixedRealm retrieveSceneFromFixedRealm,
@@ -107,14 +103,11 @@ namespace Global.Dynamic
             IAppArgs appArgs,
             IDecentralandUrlsSource decentralandUrlsSource,
             DecentralandEnvironment environment,
-            WorldManifestProvider worldManifestProvider,
-            IWorldPermissionsService worldPermissionsService)
+            WorldManifestProvider worldManifestProvider)
         {
-            this.web3IdentityCache = web3IdentityCache;
             this.webRequestController = webRequestController;
             this.staticLoadPositions = staticLoadPositions;
             this.realmData = realmData;
-            this.worldPermissionsService = worldPermissionsService;
             this.teleportController = teleportController;
             this.retrieveSceneFromFixedRealm = retrieveSceneFromFixedRealm;
             this.retrieveSceneFromVolatileWorld = retrieveSceneFromVolatileWorld;
@@ -202,31 +195,6 @@ namespace Global.Dynamic
 
         public async UniTask<bool> IsReachableAsync(URLDomain realm, CancellationToken ct) =>
             await webRequestController.IsHeadReachableAsync(ReportCategory.REALM, realm.Append(new URLPath("/about")), ct);
-
-        public async UniTask<bool> IsUserAuthorisedToAccessWorldAsync(URLDomain realm, CancellationToken ct)
-        {
-            if (!TryExtractWorldName(realm, out string worldName))
-            {
-                ReportHub.LogWarning(ReportCategory.REALM,
-                    $"[RealmController] Failed to extract world name from realm '{realm}'.");
-                return false;
-            }
-
-            WorldAccessCheckContext context;
-            try
-            {
-                context = await worldPermissionsService.CheckWorldAccessAsync(worldName, ct);
-            }
-            catch (OperationCanceledException) { throw; }
-            catch (Exception e)
-            {
-                ReportHub.LogWarning(ReportCategory.REALM,
-                    $"[RealmController] Failed to verify world access for '{worldName}' via world permissions: {e.Message}");
-                return false;
-            }
-
-            return context.Result == WorldAccessCheckResult.Allowed;
-        }
 
         private static bool TryExtractWorldName(URLDomain realm, out string worldName)
         {

--- a/Explorer/Assets/DCL/RealmNavigation/Container/RealmContainer.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/Container/RealmContainer.cs
@@ -32,7 +32,6 @@ namespace DCL.RealmNavigation
 
         public static RealmContainer Create(
             StaticContainer staticContainer,
-            IWeb3IdentityCache identityCache,
             IReadOnlyList<int2> staticLoadPositions,
             IDebugContainerBuilder debugContainerBuilder,
             LoadingScreenTimeout loadingScreenTimeout,
@@ -41,8 +40,7 @@ namespace DCL.RealmNavigation
             IDecentralandUrlsSource urlsSource,
             IAppArgs appArgs,
             TeleportController teleportController,
-            DecentralandEnvironment dclEnvironment,
-            IWorldPermissionsService worldPermissionsService)
+            DecentralandEnvironment dclEnvironment)
         {
             var retrieveSceneFromFixedRealm = new RetrieveSceneFromFixedRealm();
             var retrieveSceneFromVolatileWorld = new RetrieveSceneFromVolatileWorld(staticContainer.RealmData, urlsSource);
@@ -50,7 +48,6 @@ namespace DCL.RealmNavigation
             var realmNavigatorDebugView = new RealmNavigatorDebugView(debugContainerBuilder);
 
             var realmController = new RealmController(
-                identityCache,
                 staticContainer.WebRequestsContainer.WebRequestController,
                 teleportController,
                 retrieveSceneFromFixedRealm,
@@ -66,8 +63,7 @@ namespace DCL.RealmNavigation
                 appArgs,
                 urlsSource,
                 dclEnvironment,
-                staticContainer.WorldManifestProvider,
-                worldPermissionsService
+                staticContainer.WorldManifestProvider
             );
 
             BuildDebugWidget(teleportController, debugContainerBuilder, loadingScreen, loadingScreenTimeout);

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/DCL.UserInAppInitializationFlow.asmdef
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/DCL.UserInAppInitializationFlow.asmdef
@@ -32,7 +32,8 @@
         "GUID:c80c82a8f4e04453b85fbab973d6774a",
         "GUID:54d33bbd50a28174e8ba0110106203c2",
         "GUID:875a5d5129614170bd769ed012c2eb3d",
-        "GUID:8614faad1014549c88b57654b0fb41bd"
+        "GUID:8614faad1014549c88b57654b0fb41bd",
+        "GUID:f8127c6ac263abf468221dcbccbde182"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -24,7 +24,6 @@ using ECS.SceneLifeCycle.Realm;
 using Global.AppArgs;
 using MVC;
 using PortableExperiences.Controller;
-using System.Threading.Tasks;
 using UnityEngine;
 using Utility;
 using ChatMessage = DCL.Chat.History.ChatMessage;
@@ -247,7 +246,7 @@ namespace DCL.UserInAppInitializationFlow
             {
                 ReportHub.LogWarning(ReportCategory.REALM,
                     $"[RealmController] Failed to extract world name from realm '{realmController.CurrentDomain.Value.ToString()}'.");
-                await GenesisFallback();
+                await GenesisFallbackAsync();
                 return;
             }
 
@@ -262,7 +261,7 @@ namespace DCL.UserInAppInitializationFlow
             {
                 ReportHub.LogWarning(ReportCategory.REALM,
                     $"[StartUp] Failed to verify world access for '{worldName}' via world permissions: {e.Message}");
-                await GenesisFallback();
+                await GenesisFallbackAsync();
                 return;
             }
 
@@ -275,12 +274,12 @@ namespace DCL.UserInAppInitializationFlow
                 case WorldAccessCheckResult.PasswordRequired:
                     ReportHub.LogWarning(ReportCategory.REALM,
                         $"[StartUp] World '{worldName}' is not authorized for auto-entry, falling back to Genesis.");
-                    await GenesisFallback();
+                    await GenesisFallbackAsync();
                     return;
                 default: throw new ArgumentOutOfRangeException();
             }
 
-            async UniTask GenesisFallback()
+            async UniTask GenesisFallbackAsync()
             {
                 chatHistory.AddMessage(
                     ChatChannel.NEARBY_CHANNEL_ID,

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -256,8 +256,7 @@ namespace DCL.UserInAppInitializationFlow
             {
                 context = await worldPermissionsService.CheckWorldAccessAsync(worldName, ct);
             }
-            catch (OperationCanceledException) { throw; }
-            catch (Exception e)
+            catch (Exception e) when (e is not OperationCanceledException)
             {
                 ReportHub.LogWarning(ReportCategory.REALM,
                     $"[StartUp] Failed to verify world access for '{worldName}' via world permissions: {e.Message}");

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -256,7 +256,8 @@ namespace DCL.UserInAppInitializationFlow
             {
                 context = await worldPermissionsService.CheckWorldAccessAsync(worldName, ct);
             }
-            catch (Exception e) when (e is not OperationCanceledException)
+            catch (OperationCanceledException) { return; }
+            catch (Exception e)
             {
                 ReportHub.LogWarning(ReportCategory.REALM,
                     $"[StartUp] Failed to verify world access for '{worldName}' via world permissions: {e.Message}");

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -6,10 +6,12 @@ using DCL.ApplicationBlocklistGuard;
 using DCL.Audio;
 using DCL.AuthenticationScreenFlow;
 using DCL.Character;
+using DCL.Chat.History;
 using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Prefs;
+using DCL.PrivateWorlds;
 using DCL.RealmNavigation;
 using DCL.RealmNavigation.LoadingOperation;
 using DCL.SceneLoadingScreens.LoadingScreen;
@@ -17,12 +19,15 @@ using DCL.UI.ErrorPopup;
 using DCL.Utilities;
 using DCL.Utility.Types;
 using DCL.Web3.Identities;
+using ECS;
 using ECS.SceneLifeCycle.Realm;
 using Global.AppArgs;
 using MVC;
 using PortableExperiences.Controller;
+using System.Threading.Tasks;
 using UnityEngine;
 using Utility;
+using ChatMessage = DCL.Chat.History.ChatMessage;
 
 namespace DCL.UserInAppInitializationFlow
 {
@@ -50,6 +55,8 @@ namespace DCL.UserInAppInitializationFlow
         private readonly ExposedTransform characterExposedTransform;
         private readonly StartParcel startParcel;
         private readonly bool isLocalSceneDevelopment;
+        private readonly IWorldPermissionsService worldPermissionsService;
+        private readonly IChatHistory chatHistory;
 
         public RealUserInAppInitializationFlow(
             ILoadingStatus loadingStatus,
@@ -69,7 +76,9 @@ namespace DCL.UserInAppInitializationFlow
             ICharacterObject characterObject,
             ExposedTransform characterExposedTransform,
             StartParcel startParcel,
-            bool isLocalSceneDevelopment)
+            bool isLocalSceneDevelopment,
+            IWorldPermissionsService worldPermissionsService,
+            IChatHistory chatHistory)
         {
             this.initOps = initOps;
             this.reloginOps = reloginOps;
@@ -80,6 +89,8 @@ namespace DCL.UserInAppInitializationFlow
             this.startParcel = startParcel;
             this.isLocalSceneDevelopment = isLocalSceneDevelopment;
             this.characterExposedTransform = characterExposedTransform;
+            this.worldPermissionsService = worldPermissionsService;
+            this.chatHistory = chatHistory;
 
             this.loadingStatus = loadingStatus;
             this.decentralandUrlsSource = decentralandUrlsSource;
@@ -161,6 +172,11 @@ namespace DCL.UserInAppInitializationFlow
                     .ShowWhileExecuteTaskAsync(
                         async (parentLoadReport, ct) =>
                         {
+                            // After authentication completes, verify the user can actually access the current realm if it's a world.
+                            // The realm was set during bootstrap before the user had a chance to switch accounts, so the identity
+                            // that's now authenticated may differ from the one assumed at startup.
+                            await VerifyWorldAccessAndFallbackIfNeededAsync(ct);
+
                             //Set initial position and start async livekit connection
                             characterExposedTransform.Position.Value
                                 = characterObject.Controller.transform.position
@@ -219,6 +235,82 @@ namespace DCL.UserInAppInitializationFlow
                 }
             }
             while (result.Success == false && parameters.ShowAuthentication);
+        }
+
+        private async UniTask VerifyWorldAccessAndFallbackIfNeededAsync(CancellationToken ct)
+        {
+            if (isLocalSceneDevelopment) return;
+            if (!realmController.RealmData.IsWorld()) return;
+            if (realmController.CurrentDomain == null) return;
+
+            if (!TryExtractWorldName(realmController.CurrentDomain.Value, out string worldName))
+            {
+                ReportHub.LogWarning(ReportCategory.REALM,
+                    $"[RealmController] Failed to extract world name from realm '{realmController.CurrentDomain.Value.ToString()}'.");
+                await GenesisFallback();
+                return;
+            }
+
+            WorldAccessCheckContext context;
+
+            try
+            {
+                context = await worldPermissionsService.CheckWorldAccessAsync(worldName, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception e)
+            {
+                ReportHub.LogWarning(ReportCategory.REALM,
+                    $"[StartUp] Failed to verify world access for '{worldName}' via world permissions: {e.Message}");
+                await GenesisFallback();
+                return;
+            }
+
+            switch (context.Result)
+            {
+                case WorldAccessCheckResult.Allowed:
+                    return;
+                case WorldAccessCheckResult.CheckFailed:
+                case WorldAccessCheckResult.AccessDenied:
+                case WorldAccessCheckResult.PasswordRequired:
+                    ReportHub.LogWarning(ReportCategory.REALM,
+                        $"[StartUp] World '{worldName}' is not authorized for auto-entry, falling back to Genesis.");
+                    await GenesisFallback();
+                    return;
+                default: throw new ArgumentOutOfRangeException();
+            }
+
+            async UniTask GenesisFallback()
+            {
+                chatHistory.AddMessage(
+                    ChatChannel.NEARBY_CHANNEL_ID,
+                    ChatChannel.ChatChannelType.NEARBY,
+                    ChatMessage.NewFromSystem($"Could not enter '{worldName}' due to world permissions. You were sent to Genesis Plaza."));
+
+                await realmController.SetRealmAsync(
+                    URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.Genesis)), ct);
+            }
+        }
+
+        private static bool TryExtractWorldName(URLDomain realm, out string worldName)
+        {
+            worldName = string.Empty;
+
+            if (!Uri.TryCreate(realm.Value, UriKind.Absolute, out Uri? uri))
+                return false;
+
+            string path = uri.AbsolutePath.Trim('/');
+
+            if (string.IsNullOrEmpty(path))
+                return false;
+
+            string[] segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            if (segments.Length == 0)
+                return false;
+
+            worldName = segments[^1];
+            return !string.IsNullOrEmpty(worldName);
         }
 
         // TODO should be an operation


### PR DESCRIPTION
# Pull Request Description
Fix #8802 

## What does this PR change?
This PR moves the world access check from bootstrap to post-auth in the loading flow, this fixes a bug where changing accounts would lead to an inconsistent state regarding world permission since they were checked only against the initial identity.

Moved world access check from bootstrap to post-auth in the loading flow, so it runs against the identity the user actually picked (rather than the cached one). 
Removed the now-dead IsUserAuthorisedToAccessWorldAsync from IRealmController.

## Test Instructions

### Prerequisites
- [ ] Launch this PR's build with `--realm italy2026.dcl.eth --position 20,20 --debug` args.
- [ ] Two accounts available: one with access to `italy2026.dcl.eth`, one without (can be tested with any world to which at least one of your accounts have access).

### Test Steps
1. **Primary repro (cached account has NO access, switch to one that does):**
   - Make sure the cached account does NOT have access to the target restricted world
   - Open the client via deep link to the restricted world
   - On the auth screen, click "Change Account" and log in with the account that DOES have access
   - Click "Enter Decentraland"
   - **Expected:** lands in the world (no Genesis fallback)

2. **Reverse case (cached account HAS access, switch to one that doesn't):**
   - Cached account has access to the restricted world
   - Open the client via deep link to that world
   - On the auth screen, change to an account without access
   - Click "Enter Decentraland"
   - **Expected:** loading screen shows, then the user is sent to Genesis with a chat message "Could not enter '<world>' due to world permissions. You were sent to Genesis Plaza."

3. **Direct entry regression:**
   - Cached account has access → deep link to that world → enter without switching accounts
   - **Expected:** lands in the world at the deep-linked coordinates

4. **Public world:**
   - Deep link to a public/unrestricted world → enter with any account
   - **Expected:** lands in the world

5. **Normal launch (no deep link):**
   - **Expected:** goes to home/Genesis as usual

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included