### PR TITLE
feat: script debugging from ci + sentry QoL

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -53,6 +53,11 @@ on:
         required: false
         type: boolean
         default: false
+      script_debugging:
+        description: 'Enable Script Debugging (forces Development build)'
+        required: false
+        type: boolean
+        default: false
       delta_threshold_macos_mb:
         description: 'Warn if macOS growth > this MB (0 = off)'
         required: false
@@ -109,6 +114,10 @@ on:
         required: true
         type: string
       sentry_enabled:
+        required: false
+        type: boolean
+        default: false
+      script_debugging:
         required: false
         type: boolean
         default: false
@@ -336,13 +345,20 @@ jobs:
         run: |
           #!/bin/bash
 
-          if [[ "${{ github.event.inputs.sentry_enabled || inputs.sentry_enabled }}" == "true" ]]; then
+          sentry_enabled="${{ github.event.inputs.sentry_enabled || inputs.sentry_enabled }}"
+
+          if [[ "$sentry_enabled" != "true" && "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Checking PR labels: ${{ join(github.event.pull_request.labels.*.name, ', ') }}"
+            sentry_enabled=$(echo "${{ join(github.event.pull_request.labels.*.name, ' ') }}" | grep -qw 'enable-sentry' && echo true || echo false)
+          fi
+
+          if [[ "$sentry_enabled" == "true" ]]; then
             if [[ "${{ inputs.is_release_build }}" == "true" ]]; then
               echo "environment=production" >> "$GITHUB_OUTPUT"
             else
               echo "environment=development" >> "$GITHUB_OUTPUT"
             fi
-          
+
             echo "upload_symbols=true" >> "$GITHUB_OUTPUT"
             echo "sentry_enabled=true" >> "$GITHUB_OUTPUT"
           else
@@ -418,6 +434,22 @@ jobs:
 
           if [[ "$profile" == "deep" ]]; then
             options+=("EnableDeepProfilingSupport")
+          fi
+
+          # Script Debugging: input toggle (workflow_dispatch / workflow_call) or 'script-debugging' PR label.
+          # AllowDebugging requires a Development build to be honored by Unity.
+          script_debugging="${{ github.event.inputs.script_debugging || inputs.script_debugging }}"
+
+          if [[ "$script_debugging" != "true" && "${{ github.event_name }}" == "pull_request" ]]; then
+            script_debugging=$(echo "${{ join(github.event.pull_request.labels.*.name, ' ') }}" | grep -qw 'script-debugging' && echo true || echo false)
+          fi
+
+          if [[ "$script_debugging" == "true" ]]; then
+            # Add Development only if not already added by profile mode
+            if [[ ! " ${options[*]} " =~ " Development " ]]; then
+              options+=("Development")
+            fi
+            options+=("AllowDebugging")
           fi
 
           # Write the array as a comma-separated string
@@ -796,20 +828,35 @@ jobs:
             *) echo "BUILD_PREFIX=gn" >> $GITHUB_ENV ;;
           esac
 
+      - name: Compute S3 destination path
+        env:
+          RESOLVED_DESTINATION_PATH: "${{
+            inputs.is_release_build && format('@dcl/{0}/releases/{1}', github.event.repository.name, inputs.tag_version)
+            || format('@dcl/{0}/branch/{1}/{2}-{3}-{4}', github.event.repository.name, env.SAFE_BRANCH_NAME, env.BUILD_PREFIX, github.run_number, env.SHA_SHORT)
+          }}"
+        run: |
+          echo "DESTINATION_PATH=${RESOLVED_DESTINATION_PATH}" >> $GITHUB_ENV
+
       - name: Upload artifact to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
           EXPLORER_TEAM_S3_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
-          DESTINATION_PATH: "${{
-            inputs.is_release_build && format('@dcl/{0}/releases/{1}', github.event.repository.name, inputs.tag_version)
-            || format('@dcl/{0}/branch/{1}/{2}-{3}-{4}', github.event.repository.name, env.SAFE_BRANCH_NAME, env.BUILD_PREFIX, github.run_number, env.SHA_SHORT)
-          }}"
         run: |
           npx @dcl/cdn-uploader@next \
             --bucket $EXPLORER_TEAM_S3_BUCKET \
             --local-folder upload_to_s3 \
             --bucket-folder $DESTINATION_PATH
+
+      - name: Print S3 upload URL
+        run: |
+          ARTIFACT_URL="https://explorer-artifacts.decentraland.org/${DESTINATION_PATH}/${{ env.artifact_name }}.zip"
+          echo "::notice::Artifact uploaded to: ${ARTIFACT_URL}"
+          {
+            echo "### Artifact upload URL (${{ matrix.target }})"
+            echo
+            echo "[${ARTIFACT_URL}](${ARTIFACT_URL})"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What does this PR change?

Adds *Script Debugging* support to the Unity Cloud CI build workflow, along with several quality-of-life improvements for CI artifact handling and Sentry configuration.

### Script Debugging from CI
- Adds a new `script_debugging` boolean input to both `workflow_dispatch` and `workflow_call` triggers.
- When enabled (via input toggle or the `script-debugging` PR label), the build includes `AllowDebugging` in Unity build options and forces a `Development` build — required by Unity for `AllowDebugging` to take effect.
- Label-based activation allows developers to simply tag a PR instead of manually triggering a workflow.

### Sentry label-based activation for PRs
- Refactors the Sentry-enable logic so that PR builds can also activate Sentry via the `enable-sentry` PR label, not just via workflow inputs.

### S3 upload path & URL visibility
- Extracts the `DESTINATION_PATH` computation into its own step ("Compute S3 destination path"), making the env var available to subsequent steps.
- Adds a "Print S3 upload URL" step that outputs the artifact URL as a `::notice::` annotation and writes it to the GitHub Step Summary for easy discovery.

## Test Instructions

*Steps (workflow_dispatch)*:
1. Trigger `build-unitycloud` manually with `script_debugging: true`.
2. Verify the build options logged include `AllowDebugging` and `Development`.
3. Verify the Step Summary shows the S3 artifact URL.

*Steps (PR label)*:
1. Add the `script-debugging` label to a test PR.
2. Verify the PR build picks up the label and includes `AllowDebugging` + `Development`.
3. Add the `enable-sentry` label and verify Sentry is activated with `environment=development`.

*Expected result*:
- Builds with script debugging produce a Development build with `AllowDebugging`.
- S3 artifact URL is visible in the Step Summary and as a workflow annotation.
- Sentry activation works via both input and PR label.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered