### PR TITLE
chore: report exception of command on failure

### DIFF
--- a/Explorer/Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/CommandsHandleChatMessageBus.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Utility;
+using DCL.Diagnostics;
 
 namespace DCL.Chat.MessageBus
 {
@@ -69,7 +70,11 @@ namespace DCL.Chat.MessageBus
                         string response = await command.ExecuteCommandAsync(parameters, commandCts.Token);
                         SendFromSystem(channelId, channelType, response);
                     }
-                    catch (Exception) { SendFromSystem(channelId, channelType, "🔴 Error running command."); }
+                    catch (Exception e) 
+                    { 
+                        SendFromSystem(channelId, channelType, "🔴 Error running command."); 
+                        ReportHub.LogError(ReportCategory.UNSPECIFIED, $"Error running command: {e}");
+                    }
 
                     return;
                 }


### PR DESCRIPTION
## What does this PR change?

When a chat command throws an exception, the error was caught and a generic "🔴 Error running command." message was shown to the user — but the exception itself was silently swallowed, making it impossible to diagnose failures from logs.

This PR adds a `ReportHub.LogError` call inside the `catch` block in `CommandsHandleChatMessageBus.HandleChatCommandAsync`, so the full exception (message + stack trace) is now reported to the diagnostics system alongside the user-facing error message.

### Changes
- `CommandsHandleChatMessageBus.cs`: Capture the exception variable in the `catch` block and log it via `ReportHub.LogError(ReportCategory.UNSPECIFIED, ...)`.
- Added `using DCL.Diagnostics` import.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 8852
```

**Expected result**:
1. Open the chat and trigger a command that is expected to fail (e.g., malformed input).
2. Confirm the user still sees the "🔴 Error running command." message in chat.
3. Check the logs — the full exception details should now appear via `ReportHub`.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included