### PR TITLE
fix: correct visual tests workflow

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -36,7 +36,7 @@ on:
     types: [created]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 concurrency:


### PR DESCRIPTION
Visual test workflow runs fail due to a wrong configuration: https://github.com/decentraland/unity-explorer/actions/runs/26288958503

This PR corrects that, without this change, the explorer-autmation workflow can't post the github PR comments in this repo, **due to Github rules this change cannot work in a PR unless it's already been merged**.