### PR TITLE
feat(cloudbuild): allow CI to compile with NO_LIVEKIT_MODE

### DIFF
--- a/Explorer/Assets/Editor/CloudBuild.cs
+++ b/Explorer/Assets/Editor/CloudBuild.cs
@@ -70,7 +70,50 @@ namespace Editor
                 AltBuilder.RemoveAltTesterFromScriptingDefineSymbols(BuildTargetGroup.Standalone);
             }
 
+            // CI-only escape hatch for hosts with a broken audio HAL.
+            //
+            // On GH-hosted macos-14 paravirt VMs (Apple Virtualization Framework
+            // nested under their cloud hypervisor) the AppleVirtualSoundDevice
+            // never replies in AudioDeviceCreateIOProcID / AudioObjectHasProperty
+            // mach_msg calls. rust_audio_input_device_names → cpal::supports_input
+            // iterates every HAL device and wedges on the very first one, blocking
+            // the Unity main thread for the entire bootstrap (we observed the
+            // freeze in three back-to-back sample(1) thread dumps on the
+            // explorer-automation runner-validation workflow, all parked in
+            // semaphore_wait_trap under HALC_ProxyIOContext::TellServerAboutStreamUsage).
+            //
+            // NO_LIVEKIT_MODE short-circuits both RustAudioClient.Init() and the
+            // LiveKit branches of MultiplayerPlugin. We therefore enable it ONLY
+            // for CI smoke builds via DCL_CI_NO_LIVEKIT=1 — production builds
+            // (where this env var is unset) keep multiplayer comms / scene chat /
+            // presence fully functional. CI smoke runs solo (no other players,
+            // alfa-voice-chat feature flag off) so losing the LiveKit transport
+            // there has no observable test impact.
+            //
+            // Remove this block once a runtime gate lands upstream in
+            // decentraland/client-sdk-unity RustAudioClient.Init that can disable
+            // only the rust_audio bring-up without touching LiveKit transport.
+            if (Parameters.TryGetValue("DCL_CI_NO_LIVEKIT", out object noLivekit)
+                && (noLivekit as string) == "1")
+            {
+                Debug.Log("[CI]: DCL_CI_NO_LIVEKIT=1 — adding NO_LIVEKIT_MODE to Standalone scripting defines");
+                AddScriptingDefine(BuildTargetGroup.Standalone, "NO_LIVEKIT_MODE");
+            }
+
             DesktopStandaloneSettings.CopyPDBFiles = true;
+        }
+
+        private static void AddScriptingDefine(BuildTargetGroup group, string define)
+        {
+            PlayerSettings.GetScriptingDefineSymbolsForGroup(group, out string[] defines);
+            if (defines.Contains(define))
+            {
+                Debug.Log($"[CI]: {define} already present in {group} defines — no-op");
+                return;
+            }
+            var newDefines = string.Join(";", defines.Append(define));
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(group, newDefines);
+            Debug.Log($"[CI]: {group} scripting defines now: {newDefines}");
         }
 
         // Defined in the @T_MacOS/@T_Windows64 configurations in Unity Cloud


### PR DESCRIPTION
  GH-hosted macos-14 paravirt VMs ship a broken AppleVirtualSoundDevice
  that never returns in CoreAudio AudioDeviceCreateIOProcID /
  AudioObjectHasProperty mach_msg calls. rust_audio_input_device_names
  (via cpal::supports_input) iterates every HAL device and wedges on
  the first one, blocking the Unity main thread for the entire
  bootstrap. Observed across three back-to-back runs in the
  explorer-automation runner-validation workflow via sample(1) thread
  dumps, all parked in semaphore_wait_trap under
  HALC_ProxyIOContext::TellServerAboutStreamUsage.

  NO_LIVEKIT_MODE already exists as a compile-time short-circuit in
  RustAudioClient.Init and MultiplayerPlugin. Wire it through the
  existing CloudBuild PreExport hook (already mutates scripting defines
  for the AltTester-on-release-build case) so CI smoke builds can opt
  in via DCL_CI_NO_LIVEKIT=1 without touching production builds.

  Trade-off: CI builds lose LiveKit transport, which means no
  multiplayer comms / scene chat / presence in those builds. Acceptable
  for solo smoke runs (alfa-voice-chat is off by default; the InWorld
  suite tests load → HUD → sidebar interactions, none of which depend
  on LiveKit). Production builds — where DCL_CI_NO_LIVEKIT is unset —
  behave identically to today.

  Drop this block once a runtime gate lands upstream in
  decentraland/client-sdk-unity that disables only the rust_audio
  bring-up without touching the LiveKit transport.

# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, copy-pasteable steps for testing these changes.

### Quick reference

# Run this PR (with cache)
metaforge explorer run <this-PR-number>

# Run this PR (without cache — clears Explorer data)
metaforge explorer run <this-PR-number> --clear

# Run this PR (fresh account — clears everything and creates a new account)
metaforge account create --clear
metaforge explorer run <this-PR-number>

# Tail logs while testing
metaforge explorer logs tail --filter "<relevant text>"

# Run automation tests against this PR
metaforge explorer test <this-PR-number>
-->

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
