### PR TITLE
fix: catch canceled exceptions when Teleporting

### DIFF
--- a/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
@@ -46,7 +46,12 @@ namespace DCL.SceneLoadingScreens.LoadingScreen
             async UniTask<EnumResult<TaskError>> ExecuteOperationAsync()
             {
                 EnumResult<TaskError> result = await operation(loadReport, timeOut.Token);
-                loadReport.SetResult(result.AsResult());
+
+                if (result.Error?.State is TaskError.Cancelled)
+                    loadReport.SetCancelled();
+                else
+                    loadReport.SetResult(result.AsResult());
+
                 return result;
             }
 

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Tests/LoadingScreenShould.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Tests/LoadingScreenShould.cs
@@ -62,7 +62,12 @@ namespace DCL.SceneLoadingScreens.Tests
             Assert.AreEqual(result, finalRes);
 
             // Report must be modified by the loading screen
-            Assert.That(outerReport!.GetStatus().TaskStatus, result.Success ? Is.EqualTo(UniTaskStatus.Succeeded) : Is.EqualTo(UniTaskStatus.Faulted));
+            UniTaskStatus expectedStatus =
+                result.Success ? UniTaskStatus.Succeeded
+                : result.Error?.State == TaskError.Cancelled ? UniTaskStatus.Canceled
+                : UniTaskStatus.Faulted;
+
+            Assert.That(outerReport!.GetStatus().TaskStatus, Is.EqualTo(expectedStatus));
         }
 
         [Test]
@@ -129,7 +134,7 @@ namespace DCL.SceneLoadingScreens.Tests
             Assert.IsTrue(opCancellation.IsCancellationRequested);
 
             Assert.That(result.Error!.Value.State, Is.EqualTo(TaskError.Timeout));
-            Assert.That(outerReport!.GetStatus().TaskStatus, Is.EqualTo(UniTaskStatus.Faulted));
+            Assert.That(outerReport!.GetStatus().TaskStatus, Is.EqualTo(UniTaskStatus.Canceled));
         }
 
         [Test]


### PR DESCRIPTION
# Pull Request Description

  ## What does this PR change?

  Fixes Sentry issue [UNITY-EXPLORER-NHG](https://decentraland.sentry.io/issues/7317719121/): `System.Exception: Cancelled: OperationCanceledException` reported from `AsyncLoadProcessReport.WaitUntilFinishedAsync` (70 events / 47 users since 2026-03-07).

  **Root cause:** when a scene load operation returned `EnumResult.CancelledResult(TaskError.Cancelled)`, `LoadingScreen.ExecuteOperationAsync` called `loadReport.SetResult(result.AsResult())`. `SetResult` wraps any failure into `new Exception(errorMessage)`, converting the cancellation into a plain `Exception` whose message
  is `"Cancelled: OperationCanceledException"`. `WaitUntilFinishedAsync`'s generic `catch (Exception)` branch then reported it to Sentry via `ReportHub.LogException`.

  **Fix:** in `LoadingScreen.cs:46-56`, route the `Cancelled` state directly to `loadReport.SetCancelled()`, which propagates `OperationCanceledException` through the completion source. `WaitUntilFinishedAsync` catches OCE separately and does not report it to Sentry. All other paths still go through `SetResult`.

  ### Test Steps
  Check that teleporting work as expected. 

  ### Reproduction (optional, dev-only)
  Enable the `Abort Scene Loading` debug widget (DEBUG panel), set Type to `CANCEL` and coords to a scene currently loading. Before the fix: Sentry exception fires. After the fix: silent cancellation, no exception.

  ## Quality Checklist
  - [x] Changes have been tested locally
  - [ ] Documentation has been updated (if required)
  - [x] Performance impact has been considered (none, single conditional branch)
  - [ ] For SDK features: Test scene is included (n/a)