### PR TITLE
fix: stop Build Gate from passing when no build actually ran

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -159,14 +159,33 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.install_source }}
+  # Only cancel an in-flight build when the new event will actually produce a new useful build.
+  # Otherwise an incidental pull_request event (e.g. converted_to_draft race, non-override label change)
+  # would cancel a real in-progress build and let the new run skip prebuild/build, leaving the
+  # Build Gate falsely green.
   cancel-in-progress: >-
     ${{
-      github.event_name != 'pull_request' ||
-      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-      github.event.label.name == 'force-build' ||
-      github.event.label.name == 'clean-build' ||
-      github.event.label.name == 'windows-only' ||
-      github.event.label.name == 'macos-only'
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'merge_group' ||
+      (
+        github.event_name == 'pull_request' &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'synchronize' ||
+          github.event.action == 'ready_for_review' ||
+          (
+            (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+            (
+              github.event.label.name == 'force-build' ||
+              github.event.label.name == 'clean-build' ||
+              github.event.label.name == 'windows-only' ||
+              github.event.label.name == 'macos-only'
+            )
+          )
+        )
+      )
     }}
 
 jobs:
@@ -888,10 +907,19 @@ jobs:
           should_build='${{ needs.prebuild.outputs.should_build }}'
           prebuild_result='${{ needs.prebuild.result }}'
 
-          # No Explorer/ changes, draft without override, or perf_test path — gate is not applicable.
-          if [ "$prebuild_result" != "success" ] || [ "$should_build" != "true" ]; then
-            echo "Gate not applicable (prebuild=$prebuild_result, should_build='$should_build'). Passing."
+          # Legit no-op: prebuild ran and decided no build is needed (no Explorer/ changes).
+          # The Prebuild job's "Skip build and test checks" step already posts per-target success
+          # statuses for this case, so the gate can safely pass.
+          if [ "$prebuild_result" = "success" ] && [ "$should_build" != "true" ]; then
+            echo "Gate not applicable (prebuild ran, no Explorer/ changes). Passing."
             exit 0
+          fi
+
+          # Any other prebuild outcome (skipped/cancelled/failure) means no real build happened.
+          # Fail closed so an incidental PR event can't silently produce a green Build Gate.
+          if [ "$prebuild_result" != "success" ]; then
+            echo "::error::Prebuild did not succeed (result: $prebuild_result). No build produced for this commit; re-trigger the workflow (e.g. push a new commit or add the 'force-build' label)."
+            exit 1
           fi
 
           targets='${{ needs.prebuild.outputs.targets }}'


### PR DESCRIPTION
## Summary

PRs have been showing a green `Build Gate (Windows + macOS)` check without any build artifact being produced — most recently visible on #8858. Two bugs introduced in #8822 combine to cause this:

1. **`concurrency.cancel-in-progress`** evaluated `true` for almost every `pull_request` event (the expression was "cancel unless it's a non-override label change"). An incidental PR event — e.g. a transient draft toggle, an auto-labeler firing — would cancel the real in-flight Windows/macOS builds.
2. **The Build Gate auto-passed** whenever `prebuild.result != 'success'`, which is exactly what happens after the cancellation above. The skipped/cancelled prebuild produced "Gate not applicable → exit 0", and the PR went green on a commit nothing was ever built for.

### Repro on #8858

- 11:30:05Z — PR marked ready_for_review → workflow run `26285219799` fires, Prebuild succeeds, Build matrix starts.
- ~11:31:27Z — second `pull_request` event lands on the same SHA (the second Auto-Assign-Reviewers log on that run says *"Skips ... since PR type is draft"*, so the PR briefly went back to draft).
- Old `cancel-in-progress` evaluates `true` → cancels the in-flight `Build (windows64)` and `Build (macos)` of run 1.
- The new run skips Prebuild (the prebuild `if:` rejects the action), skips Build, and the gate posts ✅ via the "Gate not applicable" branch.

## Changes

- Invert `concurrency.cancel-in-progress` to only cancel for events that will actually produce a new build (push, workflow_dispatch, merge_group, or PR actions `opened`/`reopened`/`synchronize`/`ready_for_review`, or `labeled`/`unlabeled` for `force-build`/`clean-build`/`windows-only`/`macos-only`).
- Make `build-gate` fail closed. Only the legitimate skip path (`prebuild.result == 'success' && should_build != 'true'`, i.e. no `Explorer/` changes — already covered by Prebuild's per-target commit-status step) auto-passes. Any other prebuild outcome now fails with an actionable error pointing at re-trigger paths.

## Behavior change to flag

Draft PRs without a `force-build`/`clean-build` override will now show a red Build Gate instead of a green one. That's arguably more correct (drafts aren't built), but it's user-visible. If we'd rather hide the gate on those, we can gate it behind a job-level `if:` mirroring `prebuild`'s whitelist — happy to follow up.

## Test plan

- [ ] After merge, mark a fresh PR ready_for_review and confirm one Unity Cloud Build run executes end-to-end on the head SHA (no spurious second run).
- [ ] Toggle a PR draft → ready_for_review → draft → ready_for_review quickly and confirm the in-flight build is not cancelled by a non-build-producing event, and the gate reflects the actual build outcome.
- [ ] Add and remove a non-override label on an open PR and confirm the in-flight build is not cancelled.
- [ ] PR with no \`Explorer/\` changes: gate still passes green via the "Gate not applicable" branch.
- [ ] Apply `windows-only` / `macos-only` labels and confirm the gate correctly fails (only one target built) — unchanged behavior from #8822.

Closes the regression introduced in #8822. cc @NickKhalow