### PR TITLE
fix: banned users cannot teleport after second attempt

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/IncreasingRadius/ResolveSceneStateByIncreasingRadiusSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/IncreasingRadius/ResolveSceneStateByIncreasingRadiusSystem.cs
@@ -281,6 +281,10 @@ namespace ECS.SceneLifeCycle.IncreasingRadius
         private void UpdateLoadingState(IIpfsRealm ipfsRealm, in Entity entity, in SceneDefinitionComponent sceneDefinitionComponent, in PartitionComponent partitionComponent,
             SceneLoadingState sceneState)
         {
+            // HandleNotCreatedScenes filters banned scenes, so a promise issued here would never be consumed and leak its SceneFacade.
+            if (World.Has<BannedSceneComponent>(entity))
+                return;
+
             VisualSceneState candidateBy
                 = visualSceneStateResolver.ResolveVisualSceneState(partitionComponent, sceneDefinitionComponent, sceneState.VisualSceneState, ipfsRealm.SceneUrns.Count > 0);
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/IncreasingRadius/ResolveSceneStateByIncreasingRadiusSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/SceneLifeCycle/IncreasingRadius/ResolveSceneStateByIncreasingRadiusSystem.cs
@@ -281,7 +281,7 @@ namespace ECS.SceneLifeCycle.IncreasingRadius
         private void UpdateLoadingState(IIpfsRealm ipfsRealm, in Entity entity, in SceneDefinitionComponent sceneDefinitionComponent, in PartitionComponent partitionComponent,
             SceneLoadingState sceneState)
         {
-            // HandleNotCreatedScenes filters banned scenes, so a promise issued here would never be consumed and leak its SceneFacade.
+            // Promises for banned-scene entities are not consumed downstream; issuing one here would leak its SceneFacade.
             if (World.Has<BannedSceneComponent>(entity))
                 return;
 

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportController.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportController.cs
@@ -5,8 +5,11 @@ using DCL.CharacterMotion.Components;
 using DCL.Ipfs;
 using DCL.Utilities;
 using ECS.SceneLifeCycle;
+using ECS.SceneLifeCycle.Components;
 using ECS.SceneLifeCycle.Reporting;
+using ECS.SceneLifeCycle.SceneDefinition;
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using UnityEngine;
 
@@ -14,6 +17,9 @@ namespace DCL.RealmNavigation
 {
     public class TeleportController : ITeleportController
     {
+        private static readonly QueryDescription BANNED_SCENES_QUERY =
+            new QueryDescription().WithAll<SceneDefinitionComponent, BannedSceneComponent>();
+
         private readonly ISceneReadinessReportQueue sceneReadinessReportQueue;
 
         private IRetrieveScene? retrieveScene;
@@ -88,7 +94,37 @@ namespace DCL.RealmNavigation
                 return null;
             }
 
+            // Banned destination: the scene has been disposed and won't be reloaded, so no system will ever
+            // dequeue the readiness report. Complete it now so the loading screen closes and the avatar lands
+            // at the requested position with the scene unloaded (same UX as cross-realm entry into a banned world).
+            if (IsSceneBanned(sceneDef.id))
+            {
+                loadReport.SetProgress(1f);
+                return null;
+            }
+
             return new WaitForSceneReadiness(parcel, loadReport, sceneReadinessReportQueue);
+        }
+
+        private bool IsSceneBanned(string? sceneId)
+        {
+            if (world == null || string.IsNullOrEmpty(sceneId)) return false;
+
+            // Chunk iteration to avoid the delegate/closure allocation of World.Query(ForEach).
+            // The matched archetype is empty in the common case (no current bans), so iteration is effectively free.
+            foreach (ref Chunk chunk in world.Query(in BANNED_SCENES_QUERY).GetChunkIterator())
+            {
+                ref SceneDefinitionComponent first = ref chunk.GetFirst<SceneDefinitionComponent>();
+
+                foreach (int i in chunk)
+                {
+                    ref SceneDefinitionComponent definition = ref Unsafe.Add(ref first, i);
+                    if (definition.Definition.id == sceneId)
+                        return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description
Fix #7505 

## What does this PR change?
- Banned users could not teleport after the second attempt to the banned scene; the chat showed `An item with the same key has already been added. Key: SceneCommunicationPipe+SubscriberKey` in builds, or `Cannot add the same SystemGroupWorld twice` in editor, and all further teleports stopped working.
- Root cause: after `ECSBannedScene.TrySetCurrentSceneAsBannedAsync` disposed the banned scene it reset `SceneLoadingState` to `UNINITIALIZED/PromiseCreated=false` so the scene could load again once the ban was lifted, but left `BannedSceneComponent` on the entity. On the next frame `ResolveSceneStateByIncreasingRadiusSystem.UpdateLoadingState` did not filter by `BannedSceneComponent` and issued a fresh `AssetPromise<ISceneFacade>`. `LoadSceneSystem` resolved it into a new `SceneFacade` (registering it in `SystemGroupSnapshot`), but `ControlSceneUpdateLoopSystem.HandleNotCreatedScenes` does filter by `BannedSceneComponent` so the promise was never consumed and the `SceneFacade` leaked along with its `SystemGroupWorld` registration. Re-entering the scene later created a second `SceneFacade` with the same registration key and collided with the orphan.
- Fix: short-circuit `UpdateLoadingState` for entities that carry `BannedSceneComponent`, matching the semantics already used by `HandleNotCreatedScenes`. The orphan promise (and therefore the orphan `SceneFacade`) is never created, and the unban path is unaffected — once `BannedSceneComponent` is removed the entity flows through `UpdateLoadingState` as before.

### Test Steps
- [ ] As an admin, ban a user from a scene (e.g. Genesis Plaza).
- [ ] As the banned user, enter the banned scene → scene unloads and ban notification shows (unchanged behavior).
- [ ] Teleport to a non-banned parcel.
- [ ] Teleport back to the banned scene → no chat error, no `SystemGroupWorld twice` exception in editor.
- [ ] Continue teleporting freely between scenes; behavior matches a non-banned user.
- [ ] Unban the user, return to the previously banned scene → scene loads normally.

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.