### PR TITLE
chore: bump GitHub-maintained actions to node24 runtime

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Check PR type
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = context.payload.pull_request.title || '';

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/auto-sync-main-to-dev.yml
+++ b/.github/workflows/auto-sync-main-to-dev.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create or update branch
         run: |

--- a/.github/workflows/build-game-ci-image.yml
+++ b/.github/workflows/build-game-ci-image.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: Ubuntu-Big
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Clone game-ci/docker
         run: git clone https://github.com/game-ci/docker.git

--- a/.github/workflows/build-profile-nightly.yml
+++ b/.github/workflows/build-profile-nightly.yml
@@ -12,7 +12,7 @@ jobs:
       should_build: ${{ steps.check.outputs.should_build }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: dev
@@ -59,7 +59,7 @@ jobs:
       tag_version: ${{ steps.get_version.outputs.tag_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: dev

--- a/.github/workflows/build-release-main-page.yml
+++ b/.github/workflows/build-release-main-page.yml
@@ -20,7 +20,7 @@ jobs:
       tag_version: ${{ steps.get_version.outputs.next_tag_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: 'main'
@@ -37,7 +37,7 @@ jobs:
     needs: get-info
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: 'main'

--- a/.github/workflows/build-release-main.yml
+++ b/.github/workflows/build-release-main.yml
@@ -16,7 +16,7 @@ jobs:
       tag_version: ${{ steps.get_version.outputs.next_tag_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -248,7 +248,7 @@ jobs:
       targets: ${{ steps.get_targets.outputs.targets }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -312,7 +312,7 @@ jobs:
 
       - name: Skip build and test checks
         if: steps.decide.outputs.should_build == 'false' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const sha = context.payload.pull_request.head.sha;
@@ -538,13 +538,13 @@ jobs:
         target: ${{ fromJSON(needs.prebuild.outputs.targets) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12.3
 
@@ -654,7 +654,7 @@ jobs:
       - name: Upload artifact for macOS
         id: upload-macos-artifact
         if: matrix.target == 'macos'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.artifact_name }}
           path: build.tar
@@ -663,7 +663,7 @@ jobs:
       - name: Upload artifact for Windows
         id: upload-windows-artifact
         if: matrix.target == 'windows64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.artifact_name }}
           path: |
@@ -824,7 +824,7 @@ jobs:
 
       - name: Upload size report
         if: always() && steps.size_check.outputs.result != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: size_report_${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}
           path: size_report/
@@ -878,7 +878,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload debug symbols
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.artifact_name }}_debug_symbols
           path: |
@@ -902,7 +902,7 @@ jobs:
       # Will run always (even if failing)
       - name: Upload cloud logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}_unity_log
           path: unity_cloud_log.log
@@ -925,7 +925,7 @@ jobs:
           ./scripts/Generate-ShaderReport.ps1 -InputLog "unity_cloud_log.log" -OutputReport "shader_compilation_report.log"
 
       - name: Upload Shader Compilation Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}_shader_compilation_report
           path: shader_compilation_report.log

--- a/.github/workflows/claude-pr-review-require.yml
+++ b/.github/workflows/claude-pr-review-require.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check PR type
         id: check-type
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = context.payload.pull_request.title || '';
@@ -21,7 +21,7 @@ jobs:
 
       - name: Set pending status for feature PRs
         if: steps.check-type.outputs.is-auto-review == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.repos.createCommitStatus({

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Check PR type
         id: check-type
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = context.payload.pull_request.title || '';
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set status to pending
         if: steps.check-type.outputs.is-auto-review == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -70,7 +70,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-type.outputs.is-auto-review == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
@@ -112,7 +112,7 @@ jobs:
             
       - name: Upload Claude execution output
         if: steps.check-type.outputs.is-auto-review == 'true' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: claude-execution-output-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
           path: /home/runner/work/_temp/claude-execution-output.json
@@ -121,7 +121,7 @@ jobs:
 
       - name: Set status and approve if eligible
         if: steps.check-type.outputs.is-auto-review == 'true' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = ${{ github.event.pull_request.number }};
@@ -328,7 +328,7 @@ jobs:
     steps:
       - name: Resolve PR head (rejects post-comment pushes)
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -357,7 +357,7 @@ jobs:
             core.setOutput('is_draft', pr.data.draft);
 
       - name: Set status to pending
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -370,7 +370,7 @@ jobs:
             });
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.sha }}
           fetch-depth: 1
@@ -412,7 +412,7 @@ jobs:
 
       - name: Upload Claude execution output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: claude-execution-output-${{ github.event.issue.number }}-${{ github.run_attempt }}
           path: /home/runner/work/_temp/claude-execution-output.json
@@ -421,7 +421,7 @@ jobs:
 
       - name: Set final commit status
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 30

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -9,7 +9,7 @@ jobs:
     
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: dev
           

--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -32,7 +32,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -99,7 +99,7 @@ jobs:
 
       - name: Add label
         if: steps.detect.outputs.has-changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.addLabels({
@@ -111,7 +111,7 @@ jobs:
 
       - name: Set status to pending
         if: steps.detect.outputs.has-changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -165,7 +165,7 @@ jobs:
 
       - name: Set final status
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const hasChanges = '${{ steps.detect.outputs.has-changes }}' === 'true';

--- a/.github/workflows/issue-deduplication.yml
+++ b/.github/workflows/issue-deduplication.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Check for duplicate issues

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12.3
 

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -46,7 +46,7 @@ jobs:
           df -h /mnt /mnt/docker
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
@@ -56,7 +56,7 @@ jobs:
         run: git lfs ls-files -l | awk '{print $1}' | sort > .lfs-assets-id
 
       - name: Restore LFS cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: lfs-cache
         with:
           path: .git/lfs
@@ -79,7 +79,7 @@ jobs:
           chmod 600 /home/runner/.ssh/known_hosts
 
       - name: Restore Library cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Explorer/Library
           key: Library-Explorer-Ubuntu
@@ -165,7 +165,7 @@ jobs:
       # Generate PDF report
       - name: Set up Python
         if: always()
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -181,7 +181,7 @@ jobs:
 
       # Upload performance test results JSON
       - name: Upload performance test results (JSON)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: Performance test results (JSON)
@@ -190,7 +190,7 @@ jobs:
 
       # Upload performance report PDF
       - name: Upload performance report (PDF)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: Performance benchmark report (PDF)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           df -h
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
@@ -81,7 +81,7 @@ jobs:
         run: git lfs ls-files -l | awk '{print $1}' | sort > .lfs-assets-id
 
       - name: Restore LFS cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: lfs-cache
         with:
           path: .git/lfs
@@ -106,7 +106,7 @@ jobs:
           chmod 600 ~/.ssh/known_hosts
 
       - name: Restore Library cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Explorer/Library
           key: Library-Explorer-Ubuntu-${{ hashFiles('Explorer/Packages/packages-lock.json', 'Explorer/ProjectSettings/ProjectVersion.txt') }}
@@ -218,7 +218,7 @@ jobs:
           use-actions-summary: true
 
       # Upload artifact
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: Test results (${{ matrix.testMode }})


### PR DESCRIPTION
Node 20 is EOL. Bumps first-party actions to a major running on node24:

- `actions/checkout` v4 → v6
- `actions/github-script` v7 → v8
- `actions/upload-artifact` v4 → v6
- `actions/cache` v4 → v5
- `actions/setup-python` v5 → v6
- `actions/stale` v9 → v10

Version-only changes; no removed inputs in use. Third-party actions left for a separate pass.