### PR TITLE
fix: freeze player works in preview not prod

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/InputModifier/Systems/InputModifierHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/InputModifier/Systems/InputModifierHandlerSystem.cs
@@ -107,13 +107,17 @@ namespace DCL.SDKComponents.PlayerInputMovement.Systems
         {
             if (value)
                 ApplyModifiersQuery(World, true);
-            else
+
+            // Only reset the shared global modifier if this scene was the one actively asserting it.
+            else if (lastBusMessageAction == SceneRestrictionsAction.APPLIED)
                 ResetModifiers();
         }
 
         public void FinalizeComponents(in Query query)
         {
-            ResetModifiers();
+            // Only reset the shared global modifier if this scene was the one actively asserting it.
+            if (lastBusMessageAction == SceneRestrictionsAction.APPLIED)
+                ResetModifiers();
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/InputModifier/Tests/InputModifierHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/InputModifier/Tests/InputModifierHandlerSystemShould.cs
@@ -428,6 +428,7 @@ namespace DCL.SDKComponents.InputModifier.Tests
         public void OnSceneIsCurrentChanged_False_NoOp_WhenSceneNeverApplied()
         {
             // Issue #8807: a scene that never applied a modifier must not reset the
+            // A scene that never applied a modifier must not reset the
             // shared global when it simply transitions to non-current.
             ref InputModifierComponent inputModifier = ref globalWorld.Get<InputModifierComponent>(playerEntity);
             inputModifier.DisableAll = true;

--- a/Explorer/Assets/DCL/SDKComponents/InputModifier/Tests/InputModifierHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/InputModifier/Tests/InputModifierHandlerSystemShould.cs
@@ -405,6 +405,37 @@ namespace DCL.SDKComponents.InputModifier.Tests
             // Assert - Should not remove the component since it's not a player entity
             Assert.IsTrue(world.Has<InputModifierComponent>(entity));
         }
+
+        [Test]
+        public void FinalizeComponents_NoOp_WhenSceneNeverApplied()
+        {
+            // Issue #8807: in multi-scene worlds, a scene that never applied a modifier
+            // must not reset the shared global on its own teardown, or it would clobber
+            // a modifier set by a different (still-running) scene.
+            ref InputModifierComponent inputModifier = ref globalWorld.Get<InputModifierComponent>(playerEntity);
+            inputModifier.DisableAll = true;
+            sceneRestrictionBusController.ClearReceivedCalls();
+
+            system.FinalizeComponents(default);
+
+            Assert.IsTrue(globalWorld.Get<InputModifierComponent>(playerEntity).DisableAll);
+            sceneRestrictionBusController.DidNotReceiveWithAnyArgs().PushSceneRestriction(default);
+        }
+
+        [Test]
+        public void OnSceneIsCurrentChanged_False_NoOp_WhenSceneNeverApplied()
+        {
+            // Issue #8807: a scene that never applied a modifier must not reset the
+            // shared global when it simply transitions to non-current.
+            ref InputModifierComponent inputModifier = ref globalWorld.Get<InputModifierComponent>(playerEntity);
+            inputModifier.DisableAll = true;
+            sceneRestrictionBusController.ClearReceivedCalls();
+
+            system.OnSceneIsCurrentChanged(false);
+
+            Assert.IsTrue(globalWorld.Get<InputModifierComponent>(playerEntity).DisableAll);
+            sceneRestrictionBusController.DidNotReceiveWithAnyArgs().PushSceneRestriction(default);
+        }
     }
 }
 

--- a/Explorer/Assets/DCL/SDKComponents/InputModifier/Tests/InputModifierHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/InputModifier/Tests/InputModifierHandlerSystemShould.cs
@@ -411,6 +411,8 @@ namespace DCL.SDKComponents.InputModifier.Tests
         {
             // Issue #8807: in multi-scene worlds, a scene that never applied a modifier
             // must not reset the shared global on its own teardown, or it would clobber
+            // In multi-scene worlds, a scene that never applied a modifier
+            // must not reset the shared global on its own teardown, or it would clobber
             // a modifier set by a different (still-running) scene.
             ref InputModifierComponent inputModifier = ref globalWorld.Get<InputModifierComponent>(playerEntity);
             inputModifier.DisableAll = true;

--- a/Explorer/Assets/DCL/SDKComponents/InputModifier/Tests/InputModifierHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/InputModifier/Tests/InputModifierHandlerSystemShould.cs
@@ -409,8 +409,6 @@ namespace DCL.SDKComponents.InputModifier.Tests
         [Test]
         public void FinalizeComponents_NoOp_WhenSceneNeverApplied()
         {
-            // Issue #8807: in multi-scene worlds, a scene that never applied a modifier
-            // must not reset the shared global on its own teardown, or it would clobber
             // In multi-scene worlds, a scene that never applied a modifier
             // must not reset the shared global on its own teardown, or it would clobber
             // a modifier set by a different (still-running) scene.
@@ -427,7 +425,6 @@ namespace DCL.SDKComponents.InputModifier.Tests
         [Test]
         public void OnSceneIsCurrentChanged_False_NoOp_WhenSceneNeverApplied()
         {
-            // Issue #8807: a scene that never applied a modifier must not reset the
             // A scene that never applied a modifier must not reset the
             // shared global when it simply transitions to non-current.
             ref InputModifierComponent inputModifier = ref globalWorld.Get<InputModifierComponent>(playerEntity);


### PR DESCRIPTION
# Pull Request Description
Fix #8807

## What does this PR change?
The player-input modifier is a **shared global** state, but every scene's `InputModifierHandlerSystem` resets it unconditionally on teardown / when becoming non-current.

In multi-scene worlds this caused the bug: 
1. scene A applies the modifier
2. neighboring scene B that never applied anything tears down or goes non-current and **resets the global**, clobbering scene A's still-active modifier.

Fix: only reset the shared global modifier when *this* scene was the one that actually applied it

## Test Instructions

### Test Steps
1. Run the PR build and go to `italy2026.dcl.eth` world.
2. Move to Pravus' arcade game at `27,18`.
3. Click on an arcade console to play the game.
4. Verify that when moving with `WASD` keys the avatar does not move.
5. Exit the arcade game with the dedicated button.
6. Verify that the avatar can actually move.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included
