### PR TITLE
chore: gate ISS descriptor behind new-lods feature flag

### DIFF
--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -78,6 +78,7 @@ namespace DCL.FeatureFlags
         public const string DOUBLE_CLICK_WALK = "alfa-double-click-walk";
         public const string AB_DEPS_DIGEST_CACHE_KEY = "alfa-ab-deps-digest-cache-key";
         public const string BYTE_WEIGHTED_LOADING_PROGRESS = "alfa-byte-weighted-loading-progress";
+        public const string NEW_LODS = "new-lods";
 
         public static class Endpoints
         {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/ECS.asmdef
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/ECS.asmdef
@@ -8,7 +8,8 @@
         "GUID:101b8b6ebaf64668909b49c4b7a1420d",
         "GUID:286980af24684da6acc1caa413039811",
         "GUID:275e22790c04e9b47a5085d7b0c4432a",
-        "GUID:3640f3c0b42946b0b8794a1ed8e06ca5"
+        "GUID:3640f3c0b42946b0b8794a1ed8e06ca5",
+        "GUID:e25ef972de004615a22937e739de2def"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/InitialSceneState/LoadISSDescriptorSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/StreamableLoading/AssetBundles/InitialSceneState/LoadISSDescriptorSystem.cs
@@ -3,6 +3,7 @@ using Arch.SystemGroups;
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
+using DCL.FeatureFlags;
 using DCL.Ipfs;
 using DCL.Utility;
 using DCL.WebRequests;
@@ -50,6 +51,13 @@ namespace ECS.StreamableLoading.AssetBundles.InitialSceneState
 
         protected override async UniTask<StreamableLoadingResult<ISSDescriptorMetadata>> FlowInternalAsync(GetISSDescriptorIntention intention, StreamableLoadingState state, IPartitionComponent partition, CancellationToken ct)
         {
+            // Feature-flag gate: when disabled, short-circuit with a failed result so the consumer
+            // in ResolveISSDescriptorSystem treats every scene as "no ISS" and falls back to the
+            // pre-ISS code path. Same shape as the SupportsISS check below — failed result is not
+            // persisted to disk by LoadSystemBase.
+            if (!FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.NEW_LODS))
+                return new StreamableLoadingResult<ISSDescriptorMetadata>(GetReportData(), new Exception("new-lods feature flag disabled"));
+
             // Skip network roundtrips entirely for AB versions that pre-date ISS support. Returning a
             // failed result (plain Exception, not StreamableLoadingException) keeps the disk cache clean
             // — LoadSystemBase only persists on success — and doesn't spam logs from the result ctor.


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Adds a kill-switch feature flag (`new-lods`) for the Initial Scene State (ISS) flow, gated at the **descriptor fetch level** in `LoadISSDescriptorSystem`.

When the flag is **disabled**, the system short-circuits with a failed `StreamableLoadingResult` before any network roundtrip — same shape as the existing `SupportsISS()` check. The consumer in `ResolveISSDescriptorSystem` already treats failed results as "no ISS for this scene" and falls back to the pre-ISS code path, so no other call site needs to change.

When the flag is **enabled**, behavior is identical to today.

### Changes
- `FeatureFlagsStrings.cs` — adds `NEW_LODS = "new-lods"` constant.
- `LoadISSDescriptorSystem.cs` — adds the FF check as the first guard in `FlowInternalAsync`. Failed result is not persisted to disk by `LoadSystemBase` (PutAsync is gated on success), so no stale cache entries get written when the flag is off.
- `ECS.asmdef` — adds a reference to `DCL.Network` (where `FeatureFlagsConfiguration` lives) so the FF API is reachable from this assembly. No new circular dependency introduced.

### Notes for reviewers
- Naming: the flag is `new-lods` (no `alfa-` prefix) per request — happy to rename if convention demands `alfa-new-lods`.
- Gating point chosen on purpose: at the descriptor fetch entry the rest of the ISS pipeline is naturally inert because every scene resolves to `ISSDescriptor.MarkAsNone`. No further gates are needed in `ResolveISSDescriptorSystem`, `ResolveISSLODSystem`, etc.
- The flag is read on every descriptor fetch (one async call per scene load), so live-toggling is supported without restart — useful for incident response.

## Test Instructions

1. Ensure that Genesis Plaza loads just fine in `org`.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered (kill-switch is a single static `IsEnabled` call per descriptor fetch — negligible)
- [ ] For SDK features: Test scene is included (N/A)

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting.