### PR TITLE
fix: hide situational reactions button when we are in the nearby peop…

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Presenters/ChatReactionsPresenter.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Presenters/ChatReactionsPresenter.cs
@@ -275,6 +275,7 @@ namespace DCL.Chat.ChatReactions.Presenters
         public void Hide()
         {
             HideBar();
+            buttonPresenter.Hide();
         }
 
         private void SyncShowOthersToggle()


### PR DESCRIPTION
# Pull Request Description
Solves #8820

## What does this PR change?
When in nearby chat connected user list hide situational reactions button, no need to be there (it was overlapping with the menus)

### Test Steps
1. Go to nearby connected users in the chat
2. Observe that situational button is hidden and it can't overlap with users items in the list

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
