### PR TITLE
fix: an item with the same key has already been added

### DIFF
--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -80,7 +80,7 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "e68a493d0dfd76232103b71c9af6233131048950"
+      "hash": "53f8551acaf204b3319d3f9999c12e688a19ff13"
     },
     "com.decentraland.filebrowserpro": {
       "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/FileBrowserPro",
@@ -137,7 +137,7 @@
         "com.unity.collections": "1.2.0",
         "com.unity.mathematics": "1.2.0"
       },
-      "hash": "e68a493d0dfd76232103b71c9af6233131048950"
+      "hash": "53f8551acaf204b3319d3f9999c12e688a19ff13"
     },
     "com.gurbu.gpui-pro.terrain": {
       "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.gurbu.gpui-pro.terrain",
@@ -146,7 +146,7 @@
       "dependencies": {
         "com.gurbu.gpui-pro": "0.9.19"
       },
-      "hash": "e68a493d0dfd76232103b71c9af6233131048950"
+      "hash": "53f8551acaf204b3319d3f9999c12e688a19ff13"
     },
     "com.mackysoft.serializereference-extensions": {
       "version": "1.3.1",


### PR DESCRIPTION
# Pull Request Description
Fix #8883 

## What does this PR change?
Bumps `com.dcl.gpui-assets`, `com.gurbu.gpui-pro` and `com.gurbu.gpui-pro.terrain` to the latest `unity-explorer-packages` main, which carries the fix for an async check-then-act race in `GPUIMaterialProvider.TryGetReplacementMaterial`: two concurrent calls for the same material could both miss the cache across the `await` and both `_dataDict.Add(key, ...)`. The cache is now re-checked after the await; the duplicate copy is discarded and the cached material reused.

The race became reachable in 0.150.0 when the GPUI pin was bumped from a July-2025 (synchronous) build to a build where shader/material resolution is `async`.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 8919
```
### Test Steps
1. Load into Genesis Plaza
3. When the plaza is loaded check the `player.log` file
4. Verify that this exception is not found there:
`System.ArgumentException: An item with the same key has already been added` from `GPUIMaterialProvider`
5. Teleport to a place where trees, grass, etc. (landscape) is present
6. Verify that trees, grass, rocks, bushes are displayed correctly

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included
