### PR TITLE
fix: fixed jiggle bone setting when off

### DIFF
--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsMenuConfiguration.asset
@@ -617,13 +617,13 @@ MonoBehaviour:
         <FeatureId>k__BackingField: 1
         <View>k__BackingField:
           m_AssetGUID: 27c8bedb89b5739458399a3bd3d255ac
-          m_SubObjectName:
-          m_SubObjectType:
-          m_SubObjectGUID:
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_SubObjectGUID: 
           m_EditorAssetChanged: 1
         <Config>k__BackingField:
           <ModuleName>k__BackingField: Voice Chat & Streams
-          <Description>k__BackingField:
+          <Description>k__BackingField: 
           <IsEnabled>k__BackingField: 1
           sliderType: 1
           minValue: 0
@@ -637,13 +637,13 @@ MonoBehaviour:
         <FeatureId>k__BackingField: 1
         <View>k__BackingField:
           m_AssetGUID: 39458b71e0ed84549b1b280c4fb1f105
-          m_SubObjectName:
-          m_SubObjectType:
-          m_SubObjectGUID:
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_SubObjectGUID: 
           m_EditorAssetChanged: 0
         <Config>k__BackingField:
           <ModuleName>k__BackingField: Mute Mic in Background
-          <Description>k__BackingField:
+          <Description>k__BackingField: 
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
         <Feature>k__BackingField: 15
@@ -815,15 +815,32 @@ MonoBehaviour:
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
         <Feature>k__BackingField: 11
+    - rid: 7000000000000000001
+      type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
+      data:
+        <FeatureId>k__BackingField: 0
+        <View>k__BackingField:
+          m_AssetGUID: 39458b71e0ed84549b1b280c4fb1f105
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_SubObjectGUID: 
+          m_EditorAssetChanged: 0
+        <Config>k__BackingField:
+          <ModuleName>k__BackingField: Jiggle Bones
+          <Description>k__BackingField: Enables physics-based secondary motion on
+            avatar accessories (hair, cloth).
+          <IsEnabled>k__BackingField: 1
+          defaultIsOn: 1
+        <Feature>k__BackingField: 16
     - rid: 7533463652475600993
       type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
       data:
         <FeatureId>k__BackingField: 0
         <View>k__BackingField:
           m_AssetGUID: 39458b71e0ed84549b1b280c4fb1f105
-          m_SubObjectName:
-          m_SubObjectType:
-          m_SubObjectGUID:
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_SubObjectGUID: 
           m_EditorAssetChanged: 0
         <Config>k__BackingField:
           <ModuleName>k__BackingField: Play current scene streams only
@@ -832,20 +849,3 @@ MonoBehaviour:
           <IsEnabled>k__BackingField: 1
           defaultIsOn: 0
         <Feature>k__BackingField: 12
-    - rid: 7000000000000000001
-      type: {class: ToggleModuleBinding, ns: DCL.Settings.Configuration, asm: Settings}
-      data:
-        <FeatureId>k__BackingField: 0
-        <View>k__BackingField:
-          m_AssetGUID: 39458b71e0ed84549b1b280c4fb1f105
-          m_SubObjectName:
-          m_SubObjectType:
-          m_SubObjectGUID:
-          m_EditorAssetChanged: 0
-        <Config>k__BackingField:
-          <ModuleName>k__BackingField: Jiggle Bones
-          <Description>k__BackingField: Enables physics-based secondary motion on
-            avatar accessories (hair, cloth).
-          <IsEnabled>k__BackingField: 1
-          defaultIsOn: 1
-        <Feature>k__BackingField: 15


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #8897
Allow the toggle for jiggle bones to properly disable jiggle bones

## Test Instructions

### Test Steps
1. Launch the client
2. Equip a hair model with jiggle bones
3. Disable jiggle bones in the settings
4. Verify that they are disabled
NOTE: when disabled they will look a bit glitched as it happens in this issue: https://github.com/decentraland/unity-explorer/issues/8896 it's a separate issue unrelated to this one!

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
