### PR TITLE
fix: non claimed name input preserve previous name

### DIFF
--- a/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
@@ -173,7 +173,7 @@ namespace DCL.UI.ProfileNames
             {
                 config.userHashLabel.text = $"#{profile.UserId[^4..]}";
                 config.saveButtonInteractable = false;
-                config.nameInputField.SetValue(profile.Name);
+                config.nameInputField.SetValue(profile.HasClaimedName ? string.Empty : profile.Name);
                 config.saveLoading.SetActive(false);
             }
         }

--- a/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
@@ -173,6 +173,7 @@ namespace DCL.UI.ProfileNames
             {
                 config.userHashLabel.text = $"#{profile.UserId[^4..]}";
                 config.saveButtonInteractable = false;
+                config.nameInputField.SetValue(profile.Name);
                 config.saveLoading.SetActive(false);
             }
         }

--- a/Explorer/Assets/DCL/UI/TextInputFields/NameInputFieldView.cs
+++ b/Explorer/Assets/DCL/UI/TextInputFields/NameInputFieldView.cs
@@ -38,6 +38,11 @@ namespace DCL.UI
         public string Text => inputField.text;
         public bool IsValidName => inputField.text.Length > 0 && inputField.text.Length <= maxNameLength;
 
+        public void SetValue(string inputNameValue)
+        {
+            inputField.text = inputNameValue;
+        }
+
         private void Awake()
         {
             inputErrorMessage.text = characterLimitReachedMessage;

--- a/Explorer/Assets/DCL/UI/TextInputFields/NameInputFieldView.cs
+++ b/Explorer/Assets/DCL/UI/TextInputFields/NameInputFieldView.cs
@@ -41,6 +41,7 @@ namespace DCL.UI
         public void SetValue(string inputNameValue)
         {
             inputField.text = inputNameValue;
+            characterCountLabel.text = $"{inputNameValue.Length}/{maxNameLength}";
         }
 
         private void Awake()
@@ -57,7 +58,6 @@ namespace DCL.UI
 
         private void OnEnable()
         {
-            inputField.text = string.Empty;
             characterCountLabel.text = $"{0}/{maxNameLength}";
 
             outline.enabled = false;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #8816
Preserve previous name in non claimed name input box

## Test Instructions

### Test Steps
1. Open the change name popup
2. Write a non claimed name and save it
3. Open again the name popup
4. Verify that the input box contains the previous name

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
