### PR TITLE
fix: stuck sidebar modals

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
@@ -1,5 +1,6 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
+using DCL.Utilities.Extensions;
 using MVC.PopupsController.PopupCloser;
 using System;
 using System.Collections.Generic;
@@ -151,9 +152,9 @@ namespace MVC
             }
             finally
             {
-                // Hide with None, never ct: a cancelled hide leaves the view stuck at ViewFocused and unreachable on reopen.
+                // Teardown must always finish: None (not ct) so a cancel can't wedge the view, suppressed so it can't throw out of finally before cleanup.
                 if (controller.State != ControllerState.ViewHidden)
-                    await controller.HideViewAsync(CancellationToken.None);
+                    await controller.HideViewAsync(CancellationToken.None).SuppressToResultAsync(ReportCategory.MVC);
             }
         }
 
@@ -210,9 +211,9 @@ namespace MVC
             }
             finally
             {
-                // Hide with None, never ct: a cancelled hide leaves the view stuck at ViewFocused and unreachable on reopen.
+                // Teardown must always finish: None (not ct) so a cancel can't wedge the view, suppressed so it can't throw out of finally before cleanup.
                 if (controller.State != ControllerState.ViewHidden)
-                    await controller.HideViewAsync(CancellationToken.None);
+                    await controller.HideViewAsync(CancellationToken.None).SuppressToResultAsync(ReportCategory.MVC);
 
                 windowsStackManager.PopFullscreen(controller);
             }
@@ -237,9 +238,9 @@ namespace MVC
             }
             finally
             {
-                // Hide with None, never ct: a cancelled hide leaves the view stuck at ViewFocused and unreachable on reopen.
+                // Teardown must always finish: None (not ct) so a cancel can't wedge the view, suppressed so it can't throw out of finally before cleanup.
                 if (controller.State != ControllerState.ViewHidden)
-                    await controller.HideViewAsync(CancellationToken.None);
+                    await controller.HideViewAsync(CancellationToken.None).SuppressToResultAsync(ReportCategory.MVC);
 
                 // Pop the stack
                 PopupPopInfo popupPopInfo = windowsStackManager.PopPopup(controller, windowsStackManager.GetControllerClosure(controller)?.Task.Status != UniTaskStatus.Succeeded);

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
@@ -144,9 +144,17 @@ namespace MVC
             // Hide the popup closer
             await popupCloser.HideAsync(ct);
 
-            await UniTask.WhenAny(command.Execute(controller, overlayPushInfo.ControllerOrdering, ct), windowsStackManager.GetControllerClosure(controller)?.Task ?? UniTask.Never(ct));
-
-            await controller.HideViewAsync(ct);
+            try
+            {
+                await UniTask.WhenAny(command.Execute(controller, overlayPushInfo.ControllerOrdering, ct),
+                    windowsStackManager.GetControllerClosure(controller)?.Task ?? UniTask.Never(ct));
+            }
+            finally
+            {
+                // Hide with None, never ct: a cancelled hide leaves the view stuck at ViewFocused and unreachable on reopen.
+                if (controller.State != ControllerState.ViewHidden)
+                    await controller.HideViewAsync(CancellationToken.None);
+            }
         }
 
         private async UniTask ShowPersistentAsync<TView, TInputData>(ShowCommand<TView, TInputData> command, IController controller, CancellationToken ct)
@@ -199,17 +207,12 @@ namespace MVC
                 await UniTask.WhenAny(command.Execute(controller, fullscreenPushInfo.ControllerOrdering, ct),
                     fullscreenPushInfo.OnClose?.Task ?? UniTask.Never(ct),
                     windowsStackManager.GetControllerClosure(controller)?.Task ?? UniTask.Never(ct));
-
-                await controller.HideViewAsync(ct);
             }
             finally
             {
-                // If the lifecycle was aborted by cancellation before HideViewAsync completed,
-                // force a clean tear-down so State returns to ViewHidden. Otherwise, the view
-                // stays active and interactive while the controller is stuck at ViewFocused,
-                // making it unreachable on subsequent opens and breaking its close intents.
+                // Hide with None, never ct: a cancelled hide leaves the view stuck at ViewFocused and unreachable on reopen.
                 if (controller.State != ControllerState.ViewHidden)
-                    await controller.HideViewAsync(CancellationToken.None).SuppressCancellationThrow();
+                    await controller.HideViewAsync(CancellationToken.None);
 
                 windowsStackManager.PopFullscreen(controller);
             }
@@ -231,12 +234,13 @@ namespace MVC
                     WaitForPopupCloserClickAsync(controller, ct),
                     pushPopupPush.OnClose?.Task ?? UniTask.Never(ct),
                     windowsStackManager.GetControllerClosure(controller)?.Task ?? UniTask.Never(ct));
-
-                // "Close" command has been received
-                await controller.HideViewAsync(ct);
             }
             finally
             {
+                // Hide with None, never ct: a cancelled hide leaves the view stuck at ViewFocused and unreachable on reopen.
+                if (controller.State != ControllerState.ViewHidden)
+                    await controller.HideViewAsync(CancellationToken.None);
+
                 // Pop the stack
                 PopupPopInfo popupPopInfo = windowsStackManager.PopPopup(controller, windowsStackManager.GetControllerClosure(controller)?.Task.Status != UniTaskStatus.Succeeded);
 
@@ -245,7 +249,8 @@ namespace MVC
                     popupCloser.SetDrawOrder(popupPopInfo.PopupCloserOrdering);
                     popupPopInfo.NewTopMostController.Focus();
                 }
-                else { await popupCloser.HideAsync(ct); }
+                else
+                    await popupCloser.HideAsync(CancellationToken.None);
             }
         }
 

--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuView.cs
@@ -33,7 +33,9 @@ namespace DCL.Notifications.NotificationsMenu
         // Swallow the click event so it's not processed by the main sidebar button: retriggers -> cancel previous token -> panel stuck
         public void OnPointerClick(PointerEventData eventData)
         {
+#if UNITY_EDITOR
             ReportHub.Log(ReportCategory.UI, "Swallowed click on view level");
+#endif
         }
     }
 }

--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuView.cs
@@ -1,3 +1,4 @@
+using DCL.Diagnostics;
 using MVC;
 using SuperScrollView;
 using TMPro;
@@ -30,6 +31,9 @@ namespace DCL.Notifications.NotificationsMenu
         }
 
         // Swallow the click event so it's not processed by the main sidebar button: retriggers -> cancel previous token -> panel stuck
-        public void OnPointerClick(PointerEventData eventData) { }
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            ReportHub.Log(ReportCategory.UI, "Swallowed click on view level");
+        }
     }
 }

--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuView.cs
@@ -2,10 +2,11 @@ using MVC;
 using SuperScrollView;
 using TMPro;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 namespace DCL.Notifications.NotificationsMenu
 {
-    public class NotificationsMenuView : ViewBaseWithAnimationElement, IView
+    public class NotificationsMenuView : ViewBaseWithAnimationElement, IView, IPointerClickHandler
     {
         [field: SerializeField]
         public LoopListView2 LoopList { get; private set; }
@@ -27,5 +28,8 @@ namespace DCL.Notifications.NotificationsMenu
             LoadingSpinner.SetActive(isLoading);
             ContentContainer.SetActive(!isLoading);
         }
+
+        // Swallow the click event so it's not processed by the main sidebar button: retriggers -> cancel previous token -> panel stuck
+        public void OnPointerClick(PointerEventData eventData) { }
     }
 }

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarConfigPanelView.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarConfigPanelView.cs
@@ -9,7 +9,9 @@ namespace DCL.UI.Sidebar
         // Swallow the click event so it's not processed by the main sidebar button: retriggers -> cancel previous token -> panel stuck
         public void OnPointerClick(PointerEventData eventData)
         {
+#if UNITY_EDITOR
             ReportHub.Log(ReportCategory.UI, "Swallowed click on view level");
+#endif
         }
     }
 }

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarConfigPanelView.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarConfigPanelView.cs
@@ -1,8 +1,12 @@
 using MVC;
+using UnityEngine.EventSystems;
 
 namespace DCL.UI.Sidebar
 {
-    public class SidebarConfigPanelView : ViewBaseWithAnimationElement, IView
-    { }
+    public class SidebarConfigPanelView : ViewBaseWithAnimationElement, IView, IPointerClickHandler
+    {
+        // Swallow the click event so it's not processed by the main sidebar button: retriggers -> cancel previous token -> panel stuck
+        public void OnPointerClick(PointerEventData eventData) { }
+    }
 }
 

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarConfigPanelView.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarConfigPanelView.cs
@@ -1,3 +1,4 @@
+using DCL.Diagnostics;
 using MVC;
 using UnityEngine.EventSystems;
 
@@ -6,7 +7,10 @@ namespace DCL.UI.Sidebar
     public class SidebarConfigPanelView : ViewBaseWithAnimationElement, IView, IPointerClickHandler
     {
         // Swallow the click event so it's not processed by the main sidebar button: retriggers -> cancel previous token -> panel stuck
-        public void OnPointerClick(PointerEventData eventData) { }
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            ReportHub.Log(ReportCategory.UI, "Swallowed click on view level");
+        }
     }
 }
 

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarController.cs
@@ -419,7 +419,7 @@ namespace DCL.UI.Sidebar
             OpenPanelAsync(viewInstance!.friendsButton, FriendsPanelController.IssueCommand(new FriendsPanelParameter(FriendsPanelController.FriendsPanelTab.FRIENDS))).Forget();
 
         private void OnMarketplaceCreditsButtonClicked() =>
-            OpenPanelAsync(viewInstance!.sidebarConfigButton,
+            OpenPanelAsync(viewInstance!.marketplaceCreditsButton,
                 MarketplaceCreditsMenuController.IssueCommand(new MarketplaceCreditsMenuController.Params(isOpenedFromNotification: false))).Forget();
 
         private void OnHelpButtonClicked() => OpenPanelAsync(viewInstance!.helpButton, HelpMenuController.IssueCommand()).Forget();


### PR DESCRIPTION
# Pull Request Description
Fixes #8881

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Since a couple of sidebar modals don't have any sibling component that can swallow the click event done in none of their components (e.g. the background), the event bubbled up to the main button which re-triggered the opening, cancelling the closure -> modals stuck.

This PR makes sure that such views are able to swallow the event (no-op) so that nothing really happens and the normal (and expected) flow is preserved.

On top of that, the `MVCManager` view types lifecycle has been strengthened by calling `HideViewAsync` in an uncancellable fashion , meaning it will always safely run (guarding the cases of cancelling a token while hiding -> stuck) and complete.

This PR contains another small fix on `OnMarketplaceCreditsButtonClicked` event that was highlighting the wrong button.

### Test Steps
1. Verify the repro steps of the linked issue
2. Smoke test on UIs in general -> all should operate as normal


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
