### PR TITLE
fix: show real offline users count in friends panel

### DIFF
--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/FriendPanelDoubleCollectionRequestManager.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/FriendPanelDoubleCollectionRequestManager.cs
@@ -55,6 +55,10 @@ namespace DCL.Friends.UI.FriendPanel.Sections
         protected abstract int GetFirstCollectionCount();
         protected abstract int GetSecondCollectionCount();
 
+        protected virtual int GetFirstCollectionDisplayCount() => GetFirstCollectionCount();
+
+        protected virtual int GetSecondCollectionDisplayCount() => GetSecondCollectionCount();
+
         protected abstract Profile.CompactInfo GetFirstCollectionElement(int index);
 
         protected abstract Profile.CompactInfo GetSecondCollectionElement(int index);
@@ -93,7 +97,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections
             {
                 listItem = loopListView.NewListViewItem(loopListView.ItemPrefabDataList[statusElementIndex].mItemPrefab.name);
                 StatusWrapperView statusWrapperView = listItem.GetComponent<StatusWrapperView>();
-                statusWrapperView.SetStatusText(firstCollectionStatus, GetFirstCollectionCount());
+                statusWrapperView.SetStatusText(firstCollectionStatus, GetFirstCollectionDisplayCount());
                 statusWrapperView.FolderButtonClicked = FolderClick;
             }
             else if (index > 0 && index <= onlineFriendMarker)
@@ -117,7 +121,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections
             {
                 listItem = loopListView.NewListViewItem(loopListView.ItemPrefabDataList[statusElementIndex].mItemPrefab.name);
                 StatusWrapperView statusWrapperView = listItem.GetComponent<StatusWrapperView>();
-                statusWrapperView.SetStatusText(secondCollectionStatus, GetSecondCollectionCount());
+                statusWrapperView.SetStatusText(secondCollectionStatus, GetSecondCollectionDisplayCount());
                 statusWrapperView.FolderButtonClicked = FolderClick;
             }
             else if (index > onlineFriendMarker + 1 && index <= onlineFriendMarker + 1 + offlineFriendMarker + 1)

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListPagedDoubleCollectionRequestManager.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/Friends/FriendListPagedDoubleCollectionRequestManager.cs
@@ -172,6 +172,12 @@ namespace DCL.Friends.UI.FriendPanel.Sections.Friends
         protected override int GetSecondCollectionCount() =>
             offlineFriends.Count;
 
+        protected override int GetSecondCollectionDisplayCount()
+        {
+            int trueOffline = totalToFetch - onlineFriends.Count;
+            return Mathf.Max(trueOffline, offlineFriends.Count);
+        }
+
         protected override void CustomiseElement(FriendListUserView elementView, int collectionIndex, FriendPanelStatus section)
         {
             elementView.ContextMenuButton.onClick.RemoveAllListeners();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #8774
Fixes the offline friends count in the friends panel to include all count

## Test Instructions

### Prerequisites
- [ ] Have more than 50 friends

### Test Steps
1. Open the friend list
2. Verify that the offline count is not counting only 50 but all the offline count of users

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
