### PR TITLE
fix: keep jiggle bones glued to avatar when simulation is stopped

### DIFF
--- a/Explorer/Assets/DCL/SpringBones/Systems/SpringBonesSimulationSystem.cs
+++ b/Explorer/Assets/DCL/SpringBones/Systems/SpringBonesSimulationSystem.cs
@@ -121,9 +121,14 @@ namespace DCL.SpringBones
                     continue;
                 }
 
+                // Always glue the cloned wearable pivot to its avatar bone, even for slots that
+                // aren't being simulated (simulation disabled, or avatar beyond MaxSimulatedAvatars).
+                // The pivot isn't parented under the animated skeleton, so without this re-sync the
+                // hair freezes in world space and trails the avatar as it moves.
+                Vector3 avatarLossy = SpringBoneTransformSync.SyncWearableParentToAvatar(slot.WearableParent, slot.AvatarParent);
+
                 if (springBoneService.IsSlotActive(slot.SlotIndex))
                 {
-                    Vector3 avatarLossy = SpringBoneTransformSync.SyncWearableParentToAvatar(slot.WearableParent, slot.AvatarParent);
                     Vector3 restScale = slot.RestAvatarScale;
                     float scaleFactor = (
                         SafeRatio(avatarLossy.x, restScale.x) +


### PR DESCRIPTION
Pull Request Description

What does this PR change?

SyncParentBones only re-synced the cloned wearable pivot to its avatar bone for active slots. When simulation is disabled all slots are deactivated, so the pivot stopped tracking the skeleton and the hair trailed the moving avatar. Always sync the pivot for valid slots; keep the sim parent-data push gated behind IsSlotActive.

Test Instructions

Test Steps
  1. Equip an avatar with spring-bone hair (or any wearable with jiggle bones).
  2. Turn jiggle bones off, both via the Settings toggle (Graphics → Physics → Jiggle Bones) and via the Low quality preset.
  3. Walk, run, and rotate the avatar around.
  4. Expected: hair stays glued to the head with no trailing/lag in both cases.
  5. Re-enable jiggle bones and confirm spring simulation resumes.

Quality Checklist
  - [x] Changes have been tested locally
  - [ ] Documentation has been updated (if required)
  - [x] Performance impact has been considered
  - [ ] For SDK features: Test scene is included
