### PR TITLE
fix: updated share to x copy for camera reels

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryMessagesSettings.asset
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelGalleryMessagesSettings.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: da7a65211f804d0090f8b5e4c353ed31, type: 3}
   m_Name: CameraReelGalleryMessagesSettings
   m_EditorClassIdentifier: 
-  <ShareToXMessage>k__BackingField: Check out what I'm doing in @decentraland right
-    now and join me!
+  <ShareToXMessage>k__BackingField: "Happening right now in @decentraland. \\n\\nCome
+    hang out \U0001F44B\\n\\n"
   <PhotoSuccessfullyDeletedMessage>k__BackingField: Photo successfully deleted
   <PhotoSuccessfullyUpdatedMessage>k__BackingField: Photo successfully updated
   <PhotoSuccessfullyDownloadedMessage>k__BackingField: Photo successfully downloaded

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Components/CameraReelGalleryMessagesConfiguration.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Components/CameraReelGalleryMessagesConfiguration.cs
@@ -5,7 +5,7 @@ namespace DCL.InWorldCamera.CameraReelGallery.Components
     [CreateAssetMenu(fileName = "CameraReelGalleryMessagesSettings", menuName = "DCL/CameraReelGallery/ActionMessages")]
     public class CameraReelGalleryMessagesConfiguration : ScriptableObject
     {
-        [field: SerializeField] public string ShareToXMessage { get; private set; } = "Check out what I'm doing in @decentraland right now and join me!";
+        [field: SerializeField] public string ShareToXMessage { get; private set; } = "Happening right now in @decentraland.\n\nCome hang out \ud83d\udc4b \n\n";
         [field: SerializeField] public string PhotoSuccessfullyDeletedMessage { get; private set; } = "Photo successfully deleted";
         [field: SerializeField] public string PhotoSuccessfullyUpdatedMessage { get; private set; } = "Photo successfully updated";
         [field: SerializeField] public string PhotoSuccessfullyDownloadedMessage { get; private set; } = "Photo successfully downloaded";

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Components/CameraReelGalleryMessagesConfiguration.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/Components/CameraReelGalleryMessagesConfiguration.cs
@@ -5,7 +5,7 @@ namespace DCL.InWorldCamera.CameraReelGallery.Components
     [CreateAssetMenu(fileName = "CameraReelGalleryMessagesSettings", menuName = "DCL/CameraReelGallery/ActionMessages")]
     public class CameraReelGalleryMessagesConfiguration : ScriptableObject
     {
-        [field: SerializeField] public string ShareToXMessage { get; private set; } = "Happening right now in @decentraland.\n\nCome hang out \ud83d\udc4b \n\n";
+        [field: SerializeField] public string ShareToXMessage { get; private set; } = "Happening right now in @decentraland.\n\nCome hang out \ud83d\udc4b\n\n";
         [field: SerializeField] public string PhotoSuccessfullyDeletedMessage { get; private set; } = "Photo successfully deleted";
         [field: SerializeField] public string PhotoSuccessfullyUpdatedMessage { get; private set; } = "Photo successfully updated";
         [field: SerializeField] public string PhotoSuccessfullyDownloadedMessage { get; private set; } = "Photo successfully downloaded";

--- a/Explorer/Assets/DCL/InWorldCamera/ReelActions/ReelCommonActions.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/ReelActions/ReelCommonActions.cs
@@ -22,6 +22,7 @@ namespace DCL.InWorldCamera.ReelActions
         {
             string description = shareToXMessage;
             string url = $"{decentralandUrlsSource.Url(DecentralandUrl.CameraReelLink)}/{reelId}";
+            description = description.Replace("\\n", "\n");
             string xUrl = $"https://x.com/intent/post?text={description}&hashtags=DCLCamera&url={url}";
 
             systemClipboard.Set(xUrl);

--- a/Explorer/Assets/DCL/InWorldCamera/ReelActions/ReelCommonActions.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/ReelActions/ReelCommonActions.cs
@@ -23,7 +23,7 @@ namespace DCL.InWorldCamera.ReelActions
             string description = shareToXMessage;
             string url = $"{decentralandUrlsSource.Url(DecentralandUrl.CameraReelLink)}/{reelId}";
             description = description.Replace("\\n", "\n");
-            string xUrl = $"https://x.com/intent/post?text={description}&hashtags=DCLCamera&url={url}";
+            string xUrl = $"https://x.com/intent/post?text={description}&url={url}";
 
             systemClipboard.Set(xUrl);
             webBrowser.OpenUrl(xUrl);

--- a/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
@@ -1141,8 +1141,8 @@ MonoBehaviour:
           m_SubObjectType: 
           m_SubObjectGUID: 
           m_EditorAssetChanged: 0
-        <ShareToXMessage>k__BackingField: Check out what I'm doing in @decentraland
-          right now and join me!
+        <ShareToXMessage>k__BackingField: "Happening right now in @decentraland.
+          \\n\\nCome hang out \U0001F44B \\n\\n"
         <PhotoSuccessfullyDownloadedMessage>k__BackingField: Photo successfully downloaded
         <PhotoSuccessfullySetAsPublicMessage>k__BackingField: Photo successfully
           updated

--- a/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Global Plugins Settings.asset
@@ -1142,7 +1142,7 @@ MonoBehaviour:
           m_SubObjectGUID: 
           m_EditorAssetChanged: 0
         <ShareToXMessage>k__BackingField: "Happening right now in @decentraland.
-          \\n\\nCome hang out \U0001F44B \\n\\n"
+          \\n\\nCome hang out \U0001F44B\\n\\n"
         <PhotoSuccessfullyDownloadedMessage>k__BackingField: Photo successfully downloaded
         <PhotoSuccessfullySetAsPublicMessage>k__BackingField: Photo successfully
           updated


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
This PR updated the copy of the post generated when pressing share to x button for camera reels

## Test Instructions

### Test Steps
1. Open the camera reel
2. Open a reel
3. Click the share to x button
4. Verify that it follows the new copy as below

<img width="605" height="486" alt="Screenshot 2026-06-10 at 10 22 12" src="https://github.com/user-attachments/assets/56fd57ad-fb7e-41ef-8973-8f6c4a84c1f6" />


### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
