### PR TITLE
fix: persist windowed resolution

### DIFF
--- a/Explorer/Assets/DCL/Prefs/DCLPrefKeys.cs
+++ b/Explorer/Assets/DCL/Prefs/DCLPrefKeys.cs
@@ -57,6 +57,7 @@ namespace DCL.Prefs
         public const string PS_PLAY_CURRENT_SCENE_STREAMS_ONLY = "QS_PlayCurrentSceneStreamsOnly";
         public const string PS_SPRING_BONE_SIMULATION = "QS_SpringBoneSimulation";
         public const string PS_RESOLUTION = "QS_Resolution";
+        public const string PS_WINDOWED_RESOLUTION = "QS_WindowedResolution";
 
         public const string SETTINGS_HIDE_BLOCKED_USERS_MESSAGES = "Settings_HideBlockedUsersChatMessages";
         public const string SETTINGS_AVATAR_VOLUME = "Settings_AvatarVolume";

--- a/Explorer/Assets/Plugins/NativeWindowManager/NativeWindowManager.cs
+++ b/Explorer/Assets/Plugins/NativeWindowManager/NativeWindowManager.cs
@@ -104,9 +104,13 @@ namespace Plugins.NativeWindowManager
             else
                 fullscreen = Screen.fullScreenMode != FullScreenMode.Windowed;
 
-            // --resolution takes priority over the saved pref.
-            Vector2Int targetResolution = resolutionOverride
-                                          ?? DCLPlayerPrefs.GetVector2Int(DCLPrefKeys.PS_RESOLUTION, ResolutionUtils.GetDefaultResolution());
+            Vector2Int targetResolution;
+            if (resolutionOverride.HasValue)
+                targetResolution = resolutionOverride.Value;
+            else if (fullscreen)
+                targetResolution = DCLPlayerPrefs.GetVector2Int(DCLPrefKeys.PS_RESOLUTION, ResolutionUtils.GetDefaultResolution());
+            else
+                targetResolution = DCLPlayerPrefs.GetVector2Int(DCLPrefKeys.PS_WINDOWED_RESOLUTION, ResolutionUtils.GetDefaultResolution());
 
             FullScreenMode targetMode = ResolveFullScreenMode(fullscreen, resolutionOverride.HasValue);
 
@@ -120,6 +124,7 @@ namespace Plugins.NativeWindowManager
 
             var resolutionListenerGO = new GameObject("ResolutionListener");
             resolutionListener = resolutionListenerGO.AddComponent<ResolutionListener>();
+            resolutionListener.ResolutionChanged += OnResolutionChanged;
         }
 
         private static FullScreenMode ResolveFullScreenMode(bool fullscreen, bool hasResolutionOverride)
@@ -192,7 +197,8 @@ namespace Plugins.NativeWindowManager
             }
             else
             {
-                Screen.fullScreenMode = FullScreenMode.Windowed;
+                Vector2Int windowed = DCLPlayerPrefs.GetVector2Int(DCLPrefKeys.PS_WINDOWED_RESOLUTION, ResolutionUtils.GetDefaultResolution());
+                Screen.SetResolution(windowed.x, windowed.y, FullScreenMode.Windowed);
                 ApplyConstraints(true);
             }
 
@@ -200,6 +206,13 @@ namespace Plugins.NativeWindowManager
 
             if (store)
                 DCLPlayerPrefs.SetBool(DCLPrefKeys.SETTINGS_FULLSCREEN, enabled);
+        }
+
+        private static void OnResolutionChanged(Vector2Int resolution)
+        {
+            // Skip temporary-window requests so their transient size doesn't overwrite the user's real windowed pref.
+            if (requestCounter == 0 && Screen.fullScreenMode == FullScreenMode.Windowed)
+                DCLPlayerPrefs.SetVector2Int(DCLPrefKeys.PS_WINDOWED_RESOLUTION, resolution);
         }
 
         private static void ApplyConstraints(bool enabled)


### PR DESCRIPTION
# Pull Request Description
Fixes #8796

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR persists the configured windowed resolution in its own pref so that it can be restored across sessions.


### Test Steps
1. Follow repro steps of the linked issue
2. Notice the resolution is also restored within the same session by just switching between windowed/fullscreen


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
