### PR TITLE
fix: disable jump / double jump / glide don't work as expected

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/UpdateInputJumpSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/UpdateInputJumpSystem.cs
@@ -43,8 +43,9 @@ namespace DCL.CharacterMotion.Systems
                 // The input action itself is disabled, no jumping or gliding are allowed
                 return;
 
-            // Jump and double jump only prevent input if gliding is also disabled
-            // That way it's still possible to glide when falling down, even if jumping is not possible
+            // Each flag gates only its own action so they can be disabled independently.
+            // The jump button is shared between normal jump, air/double jump and gliding; which action a
+            // press maps to is decided downstream from JumpCount vs MaxAirJumpCount in ApplyJump/ApplyGliding.
 
             bool isNormalJump = jumpState.JumpCount == 0;
 
@@ -52,16 +53,19 @@ namespace DCL.CharacterMotion.Systems
             bool disableDoubleJump = inputModifierComponent.DisableDoubleJump || !FeaturesRegistry.Instance.IsEnabled(FeatureId.DOUBLE_JUMP);
             bool disableGliding = inputModifierComponent.DisableGliding || !FeaturesRegistry.Instance.IsEnabled(FeatureId.GLIDING);
 
-            if (disableJump && disableGliding && isNormalJump)
-                // Trying to jump but BOTH normal jump and gliding are disabled
+            if (disableJump && isNormalJump)
+                // Trying to do a normal (ground) jump but jumping is disabled.
+                // Gliding is impossible from a normal jump state (JumpCount == 0), so this never blocks a glide.
                 return;
 
             if (disableDoubleJump && disableGliding && !isNormalJump)
-                // Trying to double jump but BOTH double jump and gliding are disabled
+                // Trying to air jump but BOTH double jump and gliding are disabled.
+                // If gliding is still enabled we let the press through so the player can glide while falling.
                 return;
 
-            // If jumping is disabled set 0 max air jumps regardless of settings, that way we go directly to gliding
-            jumpState.MaxAirJumpCount = disableJump || disableDoubleJump ? 0 : settings.AirJumpCount;
+            // Double jump availability depends solely on disableDoubleJump.
+            // Setting 0 max air jumps routes the input straight to gliding.
+            jumpState.MaxAirJumpCount = disableDoubleJump ? 0 : settings.AirJumpCount;
 
             if (disableGliding && jumpState.JumpCount > jumpState.MaxAirJumpCount)
                 // Trying to glide but gliding is disabled

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Tests/JumpButtonShould.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Tests/JumpButtonShould.cs
@@ -86,5 +86,108 @@ namespace DCL.CharacterMotion.Tests
             //This simulated another fixed update. On this call, the jump should occur
             Assert.IsTrue(world.Get<JumpInputComponent>(playerEntity).Trigger.IsAvailable(fixedTick.GetPhysicsTickComponent(world).Tick, 0));
         }
+
+        // Double jump availability is driven solely by MaxAirJumpCount, which must depend only on DisableDoubleJump.
+
+        [Test]
+        public void DisableJumpDoesNotDisableDoubleJump()
+        {
+            // Regression for #8622: DisableJump used to zero MaxAirJumpCount, wrongly killing the double jump.
+            SetAirJumpCount(1);
+            SetModifier(disableJump: true);
+            SetJumpCount(1); // airborne, so the normal-jump gate does not apply
+
+            updatePhysicsTickSystem.Update(0);
+            updateInputJumpSystem.Update(0);
+
+            Assert.AreEqual(1, world.Get<JumpState>(playerEntity).MaxAirJumpCount);
+        }
+
+        [Test]
+        public void DisableDoubleJumpZeroesMaxAirJumpCount()
+        {
+            SetAirJumpCount(1);
+            SetModifier(disableDoubleJump: true);
+
+            updatePhysicsTickSystem.Update(0);
+            updateInputJumpSystem.Update(0);
+
+            Assert.AreEqual(0, world.Get<JumpState>(playerEntity).MaxAirJumpCount);
+        }
+
+        [Test]
+        public void NoModifiersKeepConfiguredMaxAirJumpCount()
+        {
+            SetAirJumpCount(1);
+
+            updatePhysicsTickSystem.Update(0);
+            updateInputJumpSystem.Update(0);
+
+            Assert.AreEqual(1, world.Get<JumpState>(playerEntity).MaxAirJumpCount);
+        }
+
+        // The normal (ground) jump is blocked by withholding the input passthrough when DisableJump is set,
+        // independently of DisableDoubleJump / DisableGliding.
+
+        [Test]
+        public async Task NormalJumpBlockedWhenJumpIsDisabled()
+        {
+            SetAirJumpCount(1);
+            SetModifier(disableJump: true); // JumpCount stays 0 -> normal jump
+
+            Assert.IsFalse(await JumpInputPassesThroughAsync());
+        }
+
+        [Test]
+        public async Task NormalJumpBlockedWhenJumpAndDoubleJumpAreDisabled()
+        {
+            // Regression for #8622: with both flags set the player could still perform the normal jump.
+            SetAirJumpCount(1);
+            SetModifier(disableJump: true, disableDoubleJump: true);
+
+            Assert.IsFalse(await JumpInputPassesThroughAsync());
+        }
+
+        private void SetAirJumpCount(int count) =>
+            world.Get<ICharacterControllerSettings>(playerEntity).AirJumpCount.Returns(count);
+
+        private void SetModifier(bool disableJump = false, bool disableDoubleJump = false, bool disableGliding = false)
+        {
+            var modifier = new InputModifierComponent
+            {
+                DisableJump = disableJump,
+                DisableDoubleJump = disableDoubleJump,
+                DisableGliding = disableGliding,
+            };
+
+            world.Set(playerEntity, modifier);
+        }
+
+        private void SetJumpCount(int count)
+        {
+            ref JumpState jumpState = ref world.Get<JumpState>(playerEntity);
+            jumpState.JumpCount = count;
+        }
+
+        // Presses and releases the jump button following the proven timing of JumpOccursOnCorrectPhysicalFrame,
+        // and returns whether the press reached the JumpInputComponent (i.e. the input was not gated out).
+        private async Task<bool> JumpInputPassesThroughAsync()
+        {
+            updatePhysicsTickSystem.Update(0);
+
+            Press(inputDevice.spaceKey);
+            updateInputJumpSystem.Update(0);
+
+            await UniTask.Yield();
+
+            Release(inputDevice.spaceKey);
+            updateInputJumpSystem.Update(1);
+
+            updatePhysicsTickSystem.Update(1);
+
+            await UniTask.Yield();
+
+            return world.Get<JumpInputComponent>(playerEntity).Trigger.IsAvailable(fixedTick.GetPhysicsTickComponent(world).Tick, 0);
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Description
Fix #8622

## What does this PR change?
Makes the `InputModifier` flags `disableJump`, `disableDoubleJump` and `disableGliding` disable **only** their own action, independently of each other.

Before, in `UpdateInputJumpSystem`:
- The normal jump was only blocked when gliding was *also* disabled.
- `disableJump` also zeroed `MaxAirJumpCount`, so it wrongly disabled the double jump too.

Now the normal-jump gate depends only on `disableJump`, and `MaxAirJumpCount` depends only on `disableDoubleJump`. 
Falling (e.g. dropping off a ledge) counts as having jumped once, so the jump button while airborne maps to double jump → glide, gated by their own flags. 

Added unit tests in `JumpButtonShould`.

### Truth table
Disabled flags (input) vs. allowed actions (output).

| Disabled: Jump | Disabled: DoubleJump | Disabled: Glide | | Can Jump | Can DoubleJump | Can Glide |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| ❌ | ❌ | ❌ | ➜ | ✅ | ✅ | ✅ |
| ✅ | ❌ | ❌ | ➜ | ❌ | ✅ | ✅ |
| ❌ | ✅ | ❌ | ➜ | ✅ | ❌ | ✅ |
| ❌ | ❌ | ✅ | ➜ | ✅ | ✅ | ❌ |
| ✅ | ✅ | ❌ | ➜ | ❌ | ❌ | ✅ |
| ✅ | ❌ | ✅ | ➜ | ❌ | ✅ | ❌ |
| ❌ | ✅ | ✅ | ➜ | ✅ | ❌ | ❌ |
| ✅ | ✅ | ✅ | ➜ | ❌ | ❌ | ❌ |

> **Falling:** when Jump is disabled you can't leave the ground, so reach the air by **dropping off the stairs**. Falling counts as one jump, so the first button press becomes a DoubleJump (if enabled) or a Glide (if enabled) — verify the DoubleJump/Glide columns this way for the rows where Jump is disabled.

## Test Instructions
```bash
metaforge explorer run 8946
```
1. Go to world `nebi.dcl.eth` (has stairs to drop from).
2. Toggle Jump / DoubleJump / Glide with keys `1` / `2` / `3`.
3. For each truth-table row, verify Jump (from ground), DoubleJump and Glide.
4. For rows where Jump is disabled, walk off the stairs and press jump to verify DoubleJump / Glide from falling.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [x] For SDK features: Test scene is included
