### PR TITLE
fix: avoid usage of .mesh which instantiates a copy.

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
@@ -220,7 +220,7 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
             for (int i = 0; i < meshes.Count; ++i)
             {
-                Bounds meshBounds = meshes[i].Mesh.mesh.bounds;
+                 Bounds meshBounds = meshes[i].Mesh.sharedMesh.bounds;
 
                 if (maxCorner.x < meshBounds.max.x)
                     maxCorner.x = meshBounds.max.x;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
@@ -220,7 +220,7 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
             for (int i = 0; i < meshes.Count; ++i)
             {
-                 Bounds meshBounds = meshes[i].Mesh.sharedMesh.bounds;
+                Bounds meshBounds = meshes[i].Mesh.sharedMesh.bounds;
 
                 if (maxCorner.x < meshBounds.max.x)
                     maxCorner.x = meshBounds.max.x;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes duplicated avatar mesh data in memory caused by an accidental `MeshFilter.mesh` access in the GPU-skinning pipeline. Makes progress on [this issue](https://github.com/decentraland/unity-explorer/issues/8055).

**The problem:** In `ComputeShaderSkinning.CalculateLocalBoundsFromMeshes`, the per-avatar local bounds were read via:

```csharp
Bounds meshBounds = meshes[i].Mesh.mesh.bounds;
```

`meshes[i].Mesh` is a `MeshFilter`. Reading the **`.mesh` (instance) getter** has a well-known Unity side effect: on first access it **deep-copies the shared mesh into a unique per-instance `Mesh`** and reassigns the filter to point at that copy — severing the reference to the original asset-bundle mesh.

Because wearable GameObjects are **pooled** (`AttachmentsAssetsCache`) rather than destroyed, each pooled instance ended up carrying its own duplicate mesh, which stayed resident for the lifetime of the pool entry. With many avatars sharing the same wearable, this multiplied mesh memory by the number of pooled instances and completely defeated the shared-mesh design the rest of the pipeline maintains (every other read uses `.sharedMesh`). The duplication showed up clearly in memory dumps as repeated identical mesh data despite all avatars referencing the same asset bundle.

**The fix:** Read bounds from the shared mesh instead, which never instantiates a copy:

```csharp
Bounds meshBounds = meshes[i].Mesh.sharedMesh.bounds;
```

`.bounds` is a read-only query, so `.sharedMesh` is both correct and copy-free. Pooled wearable instances now genuinely share a single mesh again.

**Scope:** one-line change in `ComputeShaderSkinning.cs`. No behavioural change to skinning, bounds, or nametag positioning — bounds values are identical; only the redundant mesh duplication is removed.

## Results

<img width="554" height="939" alt="image" src="https://github.com/user-attachments/assets/b8495f1e-ec38-4dd8-bcca-a8460458eba3" />

<img width="1287" height="613" alt="image" src="https://github.com/user-attachments/assets/901b509a-1402-4c32-b54a-ff2626cfe5e1" />


## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 8948 # ← replace with this PR number
```

### Test Steps
1. Run the PR build and enter a populated area (or instantiate many random avatars via the Avatar Debug widget).
2. Visually verify avatars, wearables, and facial features render correctly and nametags sit at the right height.

### Additional Testing Notes
- Verify avatars whose wearables change at runtime (re-instantiation via `InstantiateExistingAvatar`) still render correctly and don't reintroduce per-instance meshes.
- Verify pooled wearable reuse after destroying and re-spawning avatars.
- No expected impact on local bounds values — nametag offset uses the same bounds.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
