### PR TITLE
fix: community announcement emoji panel behaviour

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementEmojiController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementEmojiController.cs
@@ -77,7 +77,7 @@ namespace DCL.Communities.CommunitiesCard.Announcements
 
             announcementInput.onValueChanged.AddListener(OnAnnouncementInputValueChanged);
             announcementInput.onValidateInput += OnAnnouncementInputValidateInput;
-            emojiButton.Button.onClick.AddListener(OnOpenEmojisPanel);
+            emojiButton.Button.onClick.AddListener(OnToggleEmojisPanel);
             emojiPanelPresenter.EmojiSelected += OnEmojiSelected;
             DCLInput.Instance.UI.Click.performed += OnUIClicked;
         }
@@ -86,7 +86,7 @@ namespace DCL.Communities.CommunitiesCard.Announcements
         {
             announcementInput.onValueChanged.RemoveListener(OnAnnouncementInputValueChanged);
             announcementInput.onValidateInput -= OnAnnouncementInputValidateInput;
-            emojiButton.Button.onClick.RemoveListener(OnOpenEmojisPanel);
+            emojiButton.Button.onClick.RemoveListener(OnToggleEmojisPanel);
             emojiPanelPresenter.EmojiSelected -= OnEmojiSelected;
             DCLInput.Instance.UI.Click.performed -= OnUIClicked;
 
@@ -137,13 +137,8 @@ namespace DCL.Communities.CommunitiesCard.Announcements
             return addedChar;
         }
 
-        private void OnOpenEmojisPanel()
-        {
-            if (emojiPanel.IsVisible)
-                return;
-
-            SetEmojiPanelVisibility(true);
-        }
+        private void OnToggleEmojisPanel() =>
+            SetEmojiPanelVisibility(!emojiPanel.IsVisible);
 
         private void OnEmojiSelected(string emoji)
         {
@@ -163,7 +158,10 @@ namespace DCL.Communities.CommunitiesCard.Announcements
             var clickPosition = DCLInputUtilities.GetPointerPosition(context);
             bool isClickedInsideEmojiPanel = RectTransformUtility.RectangleContainsScreenPoint((RectTransform)emojiPanel.transform, clickPosition, null);
 
-            if (!isClickedInsideEmojiPanel)
+            // Excluded so its own toggle handler isn't undone by closing here on the same click.
+            bool isClickedOnEmojiButton = RectTransformUtility.RectangleContainsScreenPoint((RectTransform)emojiButton.transform, clickPosition, null);
+
+            if (!isClickedInsideEmojiPanel && !isClickedOnEmojiButton)
                 SetEmojiPanelVisibility(false);
         }
 


### PR DESCRIPTION
# Pull Request Description
Fixes #8624

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR excludes the emoji button itself from being detected as the emoji panel + changes the button behaviour into a toggle to mirror the chat emoji panel behaviour.

### Test Steps
1. Use the repro steps in the linked issue

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
