### PR TITLE
fix: comment build links on release PRs by reusing the existing dev build

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -62,8 +62,11 @@ jobs:
           SHORT_SHA="${HEAD_SHA:0:7}"
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
 
-          RUN_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&status=success&per_page=20" \
-            --jq '[.workflow_runs[] | select(.name == "Unity Cloud Build") | select(.event == "pull_request" or .event == "push")] | .[0]')
+          # Scoped to the build workflow file — a repo-wide head_sha listing
+          # gets crowded out by bot runs sharing the SHA and the build falls
+          # past the first page.
+          RUN_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&status=success&per_page=20" \
+            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")] | .[0]')
 
           if [ -z "$RUN_JSON" ] || [ "$RUN_JSON" = "null" ]; then
             {

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -63,7 +63,7 @@ jobs:
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
 
           RUN_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&status=success&per_page=20" \
-            --jq '[.workflow_runs[] | select(.name == "Unity Cloud Build")] | .[0]')
+            --jq '[.workflow_runs[] | select(.name == "Unity Cloud Build") | select(.event == "pull_request" or .event == "push")] | .[0]')
 
           if [ -z "$RUN_JSON" ] || [ "$RUN_JSON" = "null" ]; then
             {

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -51,12 +51,25 @@ jobs:
           # comment gets posted. The release branch is cut from dev tip, whose
           # SHA was already built by the push to dev — reuse that run's
           # artifacts instead of rebuilding.
-          EXISTING=$(gh pr view "$BRANCH_NAME" --json comments \
-            --jq '[.comments[] | select(.author.login == "github-actions") | select(.body | contains("img.shields.io/badge/Build"))] | length')
-          if [ "$EXISTING" -gt 0 ]; then
-            echo "Build comment already present, skipping."
+          PR_NUMBER=$(gh pr view "$BRANCH_NAME" --json number --jq '.number')
+          EXISTING=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("img.shields.io/badge/Build"))] | .[0] // empty')
+
+          # A "Build Not Found" comment is upgraded in place on re-run once the
+          # build exists; only a success comment short-circuits.
+          if [ -n "$EXISTING" ] && jq -e '.body | contains("Build-Success")' <<< "$EXISTING" > /dev/null; then
+            echo "Build links comment already present, skipping."
             exit 0
           fi
+          COMMENT_ID=$([ -n "$EXISTING" ] && jq -r '.id' <<< "$EXISTING" || echo "")
+
+          post_comment() {
+            if [ -n "$COMMENT_ID" ]; then
+              gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" -F body=@comment.md > /dev/null
+            else
+              gh pr comment "$BRANCH_NAME" --body-file comment.md
+            fi
+          }
 
           HEAD_SHA=$(git rev-parse HEAD)
           SHORT_SHA="${HEAD_SHA:0:7}"
@@ -76,7 +89,7 @@ jobs:
               echo ""
               echo "[badge]: https://img.shields.io/badge/Build-Not%20Found-yellow?logo=github&style=for-the-badge"
             } > comment.md
-            gh pr comment "$BRANCH_NAME" --body-file comment.md
+            post_comment
             exit 0
           fi
 
@@ -122,4 +135,4 @@ jobs:
             echo ""
             echo "[badge]: https://img.shields.io/badge/Build-Success!-3fb950?logo=github&style=for-the-badge"
           } > comment.md
-          gh pr comment "$BRANCH_NAME" --body-file comment.md
+          post_comment

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -39,3 +39,84 @@ jobs:
 
           # Always ensure labels are applied (handles 502 / retry scenarios)
           gh pr edit "$BRANCH_NAME" --add-label "release,auto-pr"
+
+      - name: Comment build links on the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLIC_URL_PREFIX: ${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}
+        run: |
+          set -euo pipefail
+
+          # Bot-created PRs trigger no workflows, so no build runs and no badge
+          # comment gets posted. The release branch is cut from dev tip, whose
+          # SHA was already built by the push to dev — reuse that run's
+          # artifacts instead of rebuilding.
+          EXISTING=$(gh pr view "$BRANCH_NAME" --json comments \
+            --jq '[.comments[] | select(.author.login == "github-actions") | select(.body | contains("img.shields.io/badge/Build"))] | length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Build comment already present, skipping."
+            exit 0
+          fi
+
+          HEAD_SHA=$(git rev-parse HEAD)
+          SHORT_SHA="${HEAD_SHA:0:7}"
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+
+          RUN_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&status=success&per_page=20" \
+            --jq '[.workflow_runs[] | select(.name == "Unity Cloud Build")] | .[0]')
+
+          if [ -z "$RUN_JSON" ] || [ "$RUN_JSON" = "null" ]; then
+            {
+              echo '![badge]  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">'
+              echo ""
+              echo "No completed Unity Cloud Build found for \`${SHORT_SHA}\` — check the [build runs](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml) and re-run this workflow once one finishes."
+              echo ""
+              echo "[badge]: https://img.shields.io/badge/Build-Not%20Found-yellow?logo=github&style=for-the-badge"
+            } > comment.md
+            gh pr comment "$BRANCH_NAME" --body-file comment.md
+            exit 0
+          fi
+
+          RUN_ID=$(jq -r '.id' <<< "$RUN_JSON")
+          RUN_NUMBER=$(jq -r '.run_number' <<< "$RUN_JSON")
+          SUITE_ID=$(jq -r '.check_suite_id' <<< "$RUN_JSON")
+          RUN_EVENT=$(jq -r '.event' <<< "$RUN_JSON")
+          RUN_BRANCH=$(jq -r '.head_branch' <<< "$RUN_JSON")
+          BUILD_DATE=$(jq -r '.updated_at' <<< "$RUN_JSON")
+
+          # Same event -> S3 prefix mapping as build-unitycloud.yml
+          case "$RUN_EVENT" in
+            pull_request) BUILD_PREFIX="pr" ;;
+            push) BUILD_PREFIX="pu" ;;
+            merge_group) BUILD_PREFIX="mg" ;;
+            workflow_dispatch) BUILD_PREFIX="wd" ;;
+            workflow_call) BUILD_PREFIX="wc" ;;
+            schedule) BUILD_PREFIX="sc" ;;
+            *) BUILD_PREFIX="gn" ;;
+          esac
+
+          S3_PATH="@dcl/${REPO_NAME}/branch/${RUN_BRANCH}/${BUILD_PREFIX}-${RUN_NUMBER}-${SHORT_SHA}"
+
+          WINDOWS_ARTIFACT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '.artifacts[] | select(.name == "Decentraland_windows64") | .id' || true)
+          MAC_ARTIFACT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '.artifacts[] | select(.name == "Decentraland_macos") | .id' || true)
+
+          {
+            echo '![badge]  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">'
+            echo ""
+            echo "Windows and Mac build successful in Unity Cloud! Links reused from the existing \`${RUN_BRANCH}\` build of this commit."
+            echo ""
+            echo "| Name                | Link                    |"
+            echo "| --------            | ----------------------- |"
+            echo "| Commit              | ${HEAD_SHA} |"
+            echo "| Logs                | ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID} |"
+            echo "| Download Windows    | ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/suites/${SUITE_ID}/artifacts/${WINDOWS_ARTIFACT_ID} |"
+            echo "| Download Windows S3 | ${PUBLIC_URL_PREFIX}/${S3_PATH}/Decentraland_windows64.zip |"
+            echo "| Download Mac        | ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/suites/${SUITE_ID}/artifacts/${MAC_ARTIFACT_ID} |"
+            echo "| Download Mac S3     | ${PUBLIC_URL_PREFIX}/${S3_PATH}/Decentraland_macos.zip |"
+            echo "| Built on            | ${BUILD_DATE} |"
+            echo ""
+            echo "[badge]: https://img.shields.io/badge/Build-Success!-3fb950?logo=github&style=for-the-badge"
+          } > comment.md
+          gh pr comment "$BRANCH_NAME" --body-file comment.md

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -102,11 +102,14 @@ jobs:
           SHORT_SHA="${HEAD_SHA:0:7}"
 
           # 2. Find the most recent successful Unity Cloud Build run for this
-          #    SHA. Only pull_request/push builds qualify — dispatch builds can
+          #    SHA, scoped to the build workflow file — a repo-wide head_sha
+          #    listing gets crowded out by bot runs sharing the SHA (90+ on a
+          #    typical release commit) and the build falls past the first page.
+          #    Only pull_request/push builds qualify — dispatch builds can
           #    carry non-default options (e.g. profiling) that break the
           #    determinism visual tests rely on.
-          RUN_JSON=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${HEAD_SHA}&status=success&per_page=20" \
-            --jq '[.workflow_runs[] | select(.name == "Unity Cloud Build") | select(.event == "pull_request" or .event == "push")] | .[0]')
+          RUN_JSON=$(gh api "repos/${{ github.repository }}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&status=success&per_page=20" \
+            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")] | .[0]')
           if [ -z "$RUN_JSON" ] || [ "$RUN_JSON" = "null" ]; then
             echo "::error::No successful Unity Cloud Build run found for SHA ${SHORT_SHA}. Is the build still in progress, or did it fail?"
             exit 1

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -110,19 +110,24 @@ jobs:
           fi
           RUN_NUMBER=$(echo "$RUN_JSON" | jq -r '.run_number')
           ORIGINAL_EVENT=$(echo "$RUN_JSON" | jq -r '.event')
+          RUN_BRANCH=$(echo "$RUN_JSON" | jq -r '.head_branch')
 
-          # /visual-tests is only meaningful against a PR build. If the
-          # latest successful Unity Cloud Build for this SHA was triggered
-          # by something else (push to dev, scheduled run, manual dispatch),
-          # the artifact path uses a different prefix and our URL would
-          # 404. Fail loudly so the user knows to wait for a PR build
-          # rather than chasing a phantom 404 inside metaforge.
-          if [ "$ORIGINAL_EVENT" != "pull_request" ]; then
-            echo "::error::Latest successful Unity Cloud Build for ${SHORT_SHA} was triggered by '${ORIGINAL_EVENT}', not 'pull_request'. Visual tests can only run against PR builds."
-            exit 1
-          fi
+          # The S3 prefix and branch segment depend on the event and branch of
+          # the run that produced the build (see build-unitycloud.yml), not on
+          # this PR. Derive both from the run so /visual-tests also works on
+          # PRs whose only build for the SHA ran on another trigger — e.g.
+          # bot-created release PRs, whose tip is built by the push to dev.
+          case "$ORIGINAL_EVENT" in
+            pull_request) BUILD_PREFIX="pr" ;;
+            push) BUILD_PREFIX="pu" ;;
+            merge_group) BUILD_PREFIX="mg" ;;
+            workflow_dispatch) BUILD_PREFIX="wd" ;;
+            workflow_call) BUILD_PREFIX="wc" ;;
+            schedule) BUILD_PREFIX="sc" ;;
+            *) BUILD_PREFIX="gn" ;;
+          esac
 
-          ARTIFACT_PATH="@dcl/${{ github.event.repository.name }}/branch/${HEAD_REF}/pr-${RUN_NUMBER}-${SHORT_SHA}"
+          ARTIFACT_PATH="@dcl/${{ github.event.repository.name }}/branch/${RUN_BRANCH}/${BUILD_PREFIX}-${RUN_NUMBER}-${SHORT_SHA}"
           BUILD_URL="${PUBLIC_URL_PREFIX}/${ARTIFACT_PATH}/Decentraland_macos.zip"
 
           {

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -101,9 +101,12 @@ jobs:
           HEAD_REF=$(echo "$PR_JSON" | jq -r '.head.ref')
           SHORT_SHA="${HEAD_SHA:0:7}"
 
-          # 2. Find the most recent successful Unity Cloud Build run for this SHA.
+          # 2. Find the most recent successful Unity Cloud Build run for this
+          #    SHA. Only pull_request/push builds qualify — dispatch builds can
+          #    carry non-default options (e.g. profiling) that break the
+          #    determinism visual tests rely on.
           RUN_JSON=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${HEAD_SHA}&status=success&per_page=20" \
-            --jq '[.workflow_runs[] | select(.name == "Unity Cloud Build")] | .[0]')
+            --jq '[.workflow_runs[] | select(.name == "Unity Cloud Build") | select(.event == "pull_request" or .event == "push")] | .[0]')
           if [ -z "$RUN_JSON" ] || [ "$RUN_JSON" = "null" ]; then
             echo "::error::No successful Unity Cloud Build run found for SHA ${SHORT_SHA}. Is the build still in progress, or did it fail?"
             exit 1


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Release PRs are opened by the `github-actions` bot, and bot-created PRs never trigger workflows. So a clean release cut gets no build links comment, and `/visual-tests` refuses to run on it — even though the branch tip is the dev tip, which was already built on push to dev. (Compare #8926 — clean cut, no comment — with #8878, which only got one because a fix was pushed after creation.)

Fix — surface the existing dev build instead of triggering a new one:

1. `create-release-branch.yml` posts the usual badge comment on the release PR, reusing the dev build's artifact links. If the build hasn't finished yet, it posts a yellow "Build Not Found" badge; re-running the workflow later upgrades it in place to the green links comment.
2. `visual-regression.yml` no longer hard-fails on non-PR builds — it derives the S3 path from the build run's trigger and branch, so release PRs resolve the dev build URL (verified: HTTP 200 for the last release SHA).
3. Build lookup is now scoped to the `build-unitycloud.yml` workflow — the old repo-wide listing got crowded out by 90+ bot runs sharing the SHA and falsely reported "no build found".
4. Only `pull_request`/`push` builds qualify, keeping dispatched profiling builds away from visual tests.

No extra Unity Cloud builds, no PAT, no new secrets.

## Test Instructions

**Steps (standard run)**: N/A — CI workflow change only.

**Expected result**: N/A

**Steps (fresh account)**: N/A

**Expected result**: N/A

**Automation** (if applicable): N/A

### Prerequisites
- [ ] Merge to dev (the release workflow runs from the default branch)

### Test Steps
1. Run the "Create Release Branch and PR" workflow.
2. The new release PR should have the green badge comment with working Windows/Mac links pointing at the dev build of the same commit.
3. Comment `/visual-tests` on it — the suite should dispatch instead of erroring.

### Additional Testing Notes
- Normal PRs are unaffected: same `pr-...` URLs as before, `/visual-tests` gating unchanged.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included