### PR TITLE
fix: input field argument out of range with emojis

### DIFF
--- a/Explorer/Assets/DCL/UI/CustomInputField/CustomInputField.cs
+++ b/Explorer/Assets/DCL/UI/CustomInputField/CustomInputField.cs
@@ -69,7 +69,7 @@ namespace DCL.UI.CustomInputField
             TMP_TextInfo textInfo = textComponent.textInfo;
             bool coloredAny = false;
 
-            // Match indices are raw-string offsets; emojis make them diverge from glyph indices (UNITY-EXPLORER-PAH).
+            // Match indices are raw-string offsets; emojis are surrogate pairs so they diverge from glyph indices.
             for (int i = 0; i < textInfo.characterCount; i++)
             {
                 TMP_CharacterInfo characterInfo = textInfo.characterInfo[i];
@@ -154,7 +154,7 @@ namespace DCL.UI.CustomInputField
 
         public void InsertTextAtCaretPosition(string newText)
         {
-            // A stale Select-All left TMP's caret indices out of sync with the text, crashing Delete (UNITY-EXPLORER-PAH).
+            // TMP caret indices go out of sync when a selection is active; collapse it before inserting.
             ReplaceActiveSelection();
             InsertTextAtPosition(newText, stringPosition);
             OnSelect(null);

--- a/Explorer/Assets/DCL/UI/CustomInputField/CustomInputField.cs
+++ b/Explorer/Assets/DCL/UI/CustomInputField/CustomInputField.cs
@@ -64,24 +64,39 @@ namespace DCL.UI.CustomInputField
 
         private void ApplyVertexColors()
         {
-            if (string.IsNullOrEmpty(text)) return;
+            if (string.IsNullOrEmpty(text) || inputMatchesInfo.Count == 0) return;
 
-            var textInfo = textComponent.textInfo;
-            foreach (var matchInfo in inputMatchesInfo)
-                for (int i = matchInfo.match.Index; i < matchInfo.match.Index + matchInfo.match.Length; i++)
-                {
-                    int meshIndex = textInfo.characterInfo[i].materialReferenceIndex;
-                    int vertexIndex = textInfo.characterInfo[i].vertexIndex;
+            TMP_TextInfo textInfo = textComponent.textInfo;
+            bool coloredAny = false;
 
-                    Color32[] vertexColors = textInfo.meshInfo[meshIndex].colors32;
-                    vertexColors[vertexIndex + 0] = keywordColor;
-                    vertexColors[vertexIndex + 1] = keywordColor;
-                    vertexColors[vertexIndex + 2] = keywordColor;
-                    vertexColors[vertexIndex + 3] = keywordColor;
-                }
+            // Match indices are raw-string offsets; emojis make them diverge from glyph indices (UNITY-EXPLORER-PAH).
+            for (int i = 0; i < textInfo.characterCount; i++)
+            {
+                TMP_CharacterInfo characterInfo = textInfo.characterInfo[i];
 
-            if (inputMatchesInfo.Count > 0)
+                if (!characterInfo.isVisible || !IsWithinAnyMatch(characterInfo.index))
+                    continue;
+
+                Color32[] vertexColors = textInfo.meshInfo[characterInfo.materialReferenceIndex].colors32;
+                int vertexIndex = characterInfo.vertexIndex;
+                vertexColors[vertexIndex + 0] = keywordColor;
+                vertexColors[vertexIndex + 1] = keywordColor;
+                vertexColors[vertexIndex + 2] = keywordColor;
+                vertexColors[vertexIndex + 3] = keywordColor;
+                coloredAny = true;
+            }
+
+            if (coloredAny)
                 textComponent.UpdateVertexData(TMP_VertexDataUpdateFlags.Colors32);
+        }
+
+        private bool IsWithinAnyMatch(int stringIndex)
+        {
+            foreach ((TextFormatMatchType _, Match match) in inputMatchesInfo)
+                if (stringIndex >= match.Index && stringIndex < match.Index + match.Length)
+                    return true;
+
+            return false;
         }
 
         public override void OnDeselect(BaseEventData eventData)
@@ -139,8 +154,27 @@ namespace DCL.UI.CustomInputField
 
         public void InsertTextAtCaretPosition(string newText)
         {
+            // A stale Select-All left TMP's caret indices out of sync with the text, crashing Delete (UNITY-EXPLORER-PAH).
+            ReplaceActiveSelection();
             InsertTextAtPosition(newText, stringPosition);
             OnSelect(null);
+        }
+
+        private void ReplaceActiveSelection()
+        {
+            if (m_StringPosition == m_StringSelectPosition && !m_isSelectAll)
+                return;
+
+            int length = text.Length;
+            int start = Mathf.Clamp(Mathf.Min(m_StringPosition, m_StringSelectPosition), 0, length);
+            int end = Mathf.Clamp(Mathf.Max(m_StringPosition, m_StringSelectPosition), 0, length);
+
+            m_isSelectAll = false;
+
+            if (end > start)
+                text = text.Remove(start, end - start);
+
+            stringPosition = start;
         }
 
         /// <summary>


### PR DESCRIPTION
# Pull Request Description
Fixes #8913

Inserting an emoji into the chat input while a Select-All selection was active threw `ArgumentOutOfRangeException`.
Our `CustomInputField` inserted text without replacing the active selection or clearing `m_isSelectAll`, leaving TMP's caret/string indices out of sync with the text.
Because an emoji is a surrogate pair (2 raw chars, 1 glyph), the stale indices then ran past the string/characterInfo bounds. The vertex-colored coordinate compounded it: ApplyVertexColors indexed characterInfo by raw-string match offsets, which overrun the glyph array once emojis shifted the indices.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

- InsertTextAtCaretPosition now collapses/replaces any live selection and clears `m_isSelectAll` before inserting (mirrors TMP's own typing path); endpoints are clamped so it's safe even if positions were already corrupted. Select-all + emoji now correctly replaces the text.
- ApplyVertexColors walks rendered glyphs and maps each glyph's raw characterInfo[i].index against match ranges, instead of indexing characterInfo by raw-string offsets fixing the latent IndexOutOfRangeException on the same path.

### Test Steps
1. Smoke test on the chat input field: tags, coordinates, emojis. All should operate as normal without logging `ArgumentOutOfRangeException` exceptions

The exact repro step of the linked issue are:
1. type a message with a coordinate
2. open emoji panel
3. select all (cmd/ctrl + a)
4. click an emoji once or twice
5. the mentioned error would spam


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
