### PR TITLE
fix: safer avatar cleanup

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarGhostCleanupSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarGhostCleanupSystem.cs
@@ -3,12 +3,10 @@ using Arch.System;
 using Arch.SystemGroups;
 using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.AvatarRendering.AvatarShape.UnityInterface;
-using DCL.AvatarRendering.Loading.Assets;
 using DCL.Diagnostics;
 using ECS.Abstract;
 using ECS.Groups;
 using ECS.LifeCycle.Components;
-using UnityEngine;
 using Utility;
 
 namespace DCL.AvatarRendering.AvatarShape
@@ -47,7 +45,10 @@ namespace DCL.AvatarRendering.AvatarShape
             if (UnityObjectUtils.IsQuitting)
                 return;
 
-            avatarBase.GhostGameObject.SetActive(false);
+            // The avatar hierarchy can be destroyed out-of-band before this delete-pending cleanup runs
+            if (avatarBase != null && avatarBase.GhostGameObject != null)
+                avatarBase.GhostGameObject.SetActive(false);
+
             UnityObjectUtils.SafeDestroy(ghost.GhostMaterial);
         }
     }


### PR DESCRIPTION
# Pull Request Description
Fixes #8910

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR adds a guard so that out-of-band-destroyed avatars can no longer throw NREs because their ghost object was already destroyed.


### Test Steps
1. Smoke test: focus on teleporting back and to crowded zone
2. Verify you don't get the exception mentioned in the linked issue

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
