### PR TITLE
docs: add asmdef conflict-resolution skill ahead of #8961

### DIFF
--- a/.claude/skills/consolidate-assembly-definitions/SKILL.md
+++ b/.claude/skills/consolidate-assembly-definitions/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: consolidate-assembly-definitions
+description: Use when merging, folding, renaming, or removing asmdef/asmref assemblies in this project — reducing assembly count, converting an .asmdef to an .asmref, moving code between assemblies, or reviewing assembly structure for redundant references and cycles.
+---
+
+# Consolidate Assembly Definitions
+
+## Overview
+
+Folding an assembly X into an anchor Y = delete `X.asmdef`, point an `.asmref` at Y (or nothing, if X's folder is inside Y's tree), retarget every reference. **Every merge must be cycle-simulated BEFORE touching files** — Unity forbids reference cycles and the transitive graph hides them. Verification gate = clean batch compile (never the full test suite).
+
+Scripts live in `scripts/` next to this skill. Run `regen-graph.ps1` first — never trust stale assumptions about current references.
+
+## Workflow
+
+1. **Regen graph**: `scripts/regen-graph.ps1` → `graph.json` (refs resolved to names), `asmrefs.json`, `guidmap.txt`. Record the UNRESOLVED count (external packages — acceptance is "no NEW unresolved", not zero).
+2. **Simulate**: `scripts/simulate-merge.ps1 -Anchor Y -Members X1,X2`. CYCLE → don't fold; check if folding the cycle-edge member *simultaneously* dissolves it (e.g. Backpack alone cycled via `RewardPanel → Backpack`; Backpack+RewardPanel together was clean).
+3. **Fold**: `scripts/fold.py <plan.json>` (declarative `{folds:[{member,anchor}], renames:[{asmdef,newName}]}`). It deletes asmdef+meta, writes asmref+fresh-guid meta, retargets all referencing asmdefs/asmrefs, unions refs/unsafe/precompiled into the anchor.
+4. **Reconcile by hand** (fold.py doesn't do these):
+   - `csc.rsp`: delete member copies identical to the anchor's; if the anchor lacks one and a member had `-nullable:enable`, move it to the anchor folder. csc.rsp next to an `.asmref` is dead — Unity ignores it.
+   - `InternalsVisibleTo`: grep for grants TO folded/renamed names → retarget. Grants inside folded folders move with the code (duplicates are legal).
+   - Renames only: grep `link.xml` fullname entries, asmdef name-form refs, and serialized assets for `Type, OldAssemblyName` strings.
+5. **Hygiene scan**: `scripts/scan-hygiene.py` — must report zero redundant asmrefs (ancestor already provides the same assembly) and zero code-less assembly folders. Delete empty folders entirely (+ folder .meta).
+6. **Verify**: regen graph (expected count, no new unresolved, DFS cycle-free) + **batch compile only**: `Unity.exe -batchmode -quit -projectPath Explorer -logFile <log>`; zero `error CS` + "Exiting batchmode successfully". Editor must be closed. Do NOT run the EditMode suite.
+7. One commit per fold group, concise bullets, skips documented with the blocking chain.
+8. **Docs once at plan end** (not per iteration): refresh the layout tables + counts in `docs/directories-and-assemblies-structure.md`.
+
+## Quick reference
+
+| Situation | Action |
+|---|---|
+| Member folder's nearest ancestor assembly == the anchor | Delete member asmdef, **no asmref at all** |
+| Nearest ancestor is a DIFFERENT assembly (or none) | asmref `{"reference": "GUID:<anchor-guid>"}` (GUID form = repo convention) — required even when physically nested under another assembly's tree |
+| `Tests/`, `Systems/`, bus subfolders with own asmref | Excluded subtrees — keep them |
+| Member has `defineConstraints` anchor lacks | `#if`-guard the sources first, or don't fold |
+| Member unsafe, anchor not | Set anchor `allowUnsafeCode: true` |
+| Renaming an anchor | Edit `name` field + `git mv` the file; GUID (meta) must not change |
+| Reference "looks dead" by grep | Re-verify: namespaces span assemblies (`DCL.Ipfs` lives in DCL.Network) — compile is the proof |
+
+## Hard rules (each cost a broken build or review round when violated)
+
+- **Pick anchors by domain, not just by graph**: a clean cycle simulation is necessary, not sufficient. Read the member's source first — what is this code FOR? — then choose the anchor whose purpose matches (e.g. bootstrap/debug configuration belongs with `DCL.Platform`/app config, not with whatever assembly happens to share its references).
+- **UPM package references are never a fold blocker**: packages (LiveKit, UniTask, …) are always leaves — they cannot reference project assemblies, so they cannot cycle and carrying one into an anchor is fine. Do not mirror package types or decouple package refs to "protect" an anchor; only PROJECT-assembly direction matters.
+- **Preserve reusable leaves**: a natural leaf assembly (small, self-contained, several current or plausible future consumers across features) stays a leaf even when a fold simulates clean. Folding it into a fat anchor forces future consumers to take the anchor's whole tail, and splitting back out later is far costlier than keeping it now. Fold only terminal members — code consumed solely by the composition-root tier (DCL.Plugins/tests) or by exactly the anchor's own domain.
+- **Lean leaves never merge upward**: Utility, DCL.Network, Web3, ECS, SceneRunner.Scene (incl. Realm), CRDT, Character, DCL.CharacterMotion.Components, DCL.Input, AssetsProvision (no domain-true anchor exists: Utility cycles via DCL.Network, Network/ECS.Unity are domain-distant - team-confirmed keep).
+- **Production code must never reference DCL.Plugins** — only Playgrounds and tests may. If a fold target is DCL.Plugins and a production assembly consumes the member, pick another anchor.
+- **Namespace shadowing**: after folds, namespaces like `DCL.Time`/`DCL.Chat` become visible to more code and shadow `UnityEngine.Time`/protobuf `Chat` inside `namespace DCL.*` blocks (CS0234/CS0118). Fix with full qualification (`UnityEngine.Time.` — repo idiom) or a using-alias **inside the namespace block** (file-level aliases lose to enclosing-namespace lookup).
+- Known cycle-locked merges — do not re-attempt without decoupling first: Analytics+Implementation (`Flows → Profiles → Analytics`), Chat.History→Social (`RealmNavigation`), SceneLoadingScreens→Flows, SmartWearables→anything (`UI → SmartWearables`), Settings/MapRenderer→Social (`Backpack → Settings → Landscape`), Prefs→Platform, Hud↔Social one-way only.
+
+## Red flags
+
+- Creating an asmref without checking the nearest ancestor assembly first
+- Folding before simulating ("the graph looked fine")
+- Removing an asmdef reference because grep found no `using` (qualified usage, asmref-folded folders, namespace≠assembly)
+- Running the 23k-test EditMode suite as a gate (compile is the gate; suite crashes batch mode)
+- Leaving a folder whose only content is an asmref/asmdef

--- a/.claude/skills/consolidate-assembly-definitions/scripts/fold.py
+++ b/.claude/skills/consolidate-assembly-definitions/scripts/fold.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Executes asmdef folds (member -> anchor) per the consolidation recipe.
+
+Usage: python3 fold.py <plan-file.json> [--assets <path-to-Explorer/Assets>]
+
+Plan file:
+  {"renames": [{"asmdef": "<rel path>", "newName": "..."}],
+   "folds":   [{"member": "<rel path to member .asmdef>", "anchor": "<rel path to anchor .asmdef>"}]}
+Paths relative to Explorer/Assets. Renames run BEFORE folds.
+
+Per fold: deletes member asmdef+meta, writes an asmref (GUID form) + fresh-guid meta,
+retargets every asmdef/asmref referencing the member, unions the member's references,
+allowUnsafeCode, and precompiledReferences into the anchor.
+
+Does NOT handle (do by hand, see SKILL.md): csc.rsp reconciliation, InternalsVisibleTo
+retargets, link.xml / serialized "Type, Assembly" strings, descendant-of-anchor
+detection (it always writes an asmref; delete it afterwards if scan-hygiene flags it).
+Aborts a fold if the member has defineConstraints or platform mismatch vs the anchor.
+"""
+import json, os, sys, uuid, io
+
+def find_assets():
+    if "--assets" in sys.argv:
+        return sys.argv[sys.argv.index("--assets") + 1]
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.normpath(os.path.join(here, "..", "..", "..", "..", "Explorer", "Assets"))
+
+ASSETS = find_assets()
+
+def read_json(p):
+    with io.open(p, "r", encoding="utf-8-sig") as f:
+        return json.load(f)
+
+def write_json(p, data):
+    with io.open(p, "w", encoding="utf-8", newline="\n") as f:
+        json.dump(data, f, indent=4, ensure_ascii=False)
+        f.write("\n")
+
+def meta_guid(asset_path):
+    with io.open(asset_path + ".meta", "r", encoding="utf-8-sig") as f:
+        for line in f:
+            if line.startswith("guid:"):
+                return line.split(":", 1)[1].strip()
+    raise RuntimeError("no guid in " + asset_path + ".meta")
+
+def all_files(ext):
+    for root, _dirs, files in os.walk(ASSETS):
+        for fn in files:
+            if fn.endswith(ext):
+                yield os.path.join(root, fn)
+
+META_TEMPLATE = """fileFormatVersion: 2
+guid: {guid}
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {{}}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+"""
+
+def do_rename(asmdef_rel, new_name):
+    path = os.path.join(ASSETS, asmdef_rel)
+    data = read_json(path)
+    old_name = data["name"]
+    data["name"] = new_name
+    write_json(path, data)
+    new_path = os.path.join(os.path.dirname(path), new_name + ".asmdef")
+    if new_path != path:
+        os.rename(path, new_path)
+        os.rename(path + ".meta", new_path + ".meta")
+    print(f"RENAMED: {old_name} -> {new_name} ({new_path})")
+    return new_path
+
+def do_fold(member_rel, anchor_path_abs):
+    member_path = os.path.join(ASSETS, member_rel)
+    xguid = meta_guid(member_path)
+    yguid = meta_guid(anchor_path_abs)
+    xdata = read_json(member_path)
+    ydata = read_json(anchor_path_abs)
+    xname = xdata["name"]
+
+    if xdata.get("defineConstraints"):
+        raise RuntimeError(f"ABORT {xname}: has defineConstraints {xdata['defineConstraints']}")
+    if (xdata.get("includePlatforms") or []) != (ydata.get("includePlatforms") or []):
+        raise RuntimeError(f"ABORT {xname}: platform mismatch vs anchor")
+
+    os.remove(member_path)
+    os.remove(member_path + ".meta")
+
+    ref_path = os.path.splitext(member_path)[0] + ".asmref"
+    with io.open(ref_path, "w", encoding="utf-8", newline="\n") as f:
+        f.write('{\n    "reference": "GUID:%s"\n}\n' % yguid)
+    with io.open(ref_path + ".meta", "w", encoding="utf-8", newline="\n") as f:
+        f.write(META_TEMPLATE.format(guid=uuid.uuid4().hex))
+
+    xref = "GUID:" + xguid
+    yref = "GUID:" + yguid
+    for p in all_files(".asmdef"):
+        d = read_json(p)
+        refs = d.get("references") or []
+        if xref in refs:
+            refs = [r for r in refs if r != xref]
+            is_anchor = os.path.normcase(p) == os.path.normcase(anchor_path_abs)
+            if (not is_anchor) and (yref not in refs):
+                refs.append(yref)
+            d["references"] = refs
+            write_json(p, d)
+            print(f"RETARGET asmdef: {p}")
+
+    for p in all_files(".asmref"):
+        d = read_json(p)
+        if d.get("reference") in (xref, xname):
+            d["reference"] = yref
+            write_json(p, d)
+            print(f"RETARGET asmref: {p}")
+
+    ydata = read_json(anchor_path_abs)
+    yrefs = ydata.get("references") or []
+    added = []
+    for r in xdata.get("references") or []:
+        if r == yref or r in yrefs:
+            continue
+        yrefs.append(r)
+        added.append(r)
+    changed = bool(added)
+    if xdata.get("allowUnsafeCode") and not ydata.get("allowUnsafeCode"):
+        ydata["allowUnsafeCode"] = True
+        changed = True
+        print(f"UNSAFE: anchor {ydata['name']} set allowUnsafeCode=true (from {xname})")
+    xpre = xdata.get("precompiledReferences") or []
+    if xpre:
+        ypre = ydata.get("precompiledReferences") or []
+        for pr in xpre:
+            if pr not in ypre:
+                ypre.append(pr)
+        ydata["precompiledReferences"] = ypre
+        ydata["overrideReferences"] = True
+        changed = True
+        print(f"PRECOMPILED union from {xname}: {xpre}")
+    if changed:
+        ydata["references"] = yrefs
+        write_json(anchor_path_abs, ydata)
+    print(f"FOLDED: {xname} -> {ydata['name']} (union added {len(added)} refs)")
+
+def main():
+    plan = read_json(sys.argv[1])
+    renamed = {}
+    for r in plan.get("renames", []):
+        renamed[r["asmdef"]] = do_rename(r["asmdef"], r["newName"])
+    for f in plan.get("folds", []):
+        anchor_abs = renamed.get(f["anchor"]) or os.path.join(ASSETS, f["anchor"])
+        do_fold(f["member"], anchor_abs)
+    print("ALL DONE")
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/consolidate-assembly-definitions/scripts/regen-graph.ps1
+++ b/.claude/skills/consolidate-assembly-definitions/scripts/regen-graph.ps1
@@ -1,0 +1,56 @@
+param(
+    [string]$Suffix = "",
+    [string]$ProjectRoot = (Resolve-Path "$PSScriptRoot\..\..\..\..").Path,
+    [string]$OutDir = "$env:TEMP\asm-analysis"
+)
+$root = Join-Path $ProjectRoot "Explorer"
+New-Item -ItemType Directory -Force $OutDir | Out-Null
+$all = Get-ChildItem -Recurse -Filter *.asmdef -Path $root -ErrorAction SilentlyContinue
+$guidMap = @{}
+foreach ($f in $all) {
+    $meta = "$($f.FullName).meta"
+    if (Test-Path $meta) {
+        $guidLine = (Select-String -Path $meta -Pattern '^guid:\s*(\w+)' | Select-Object -First 1)
+        if ($guidLine) {
+            $guid = $guidLine.Matches[0].Groups[1].Value
+            try { $name = (Get-Content $f.FullName -Raw | ConvertFrom-Json).name } catch { $name = $f.BaseName }
+            $guidMap[$guid] = $name
+        }
+    }
+}
+$guidMap.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" } | Set-Content "$OutDir\guidmap$Suffix.txt" -Encoding utf8
+$assets = $all | Where-Object { $_.FullName -like "$root\Assets\*" }
+$graph = foreach ($f in $assets) {
+    $j = Get-Content $f.FullName -Raw | ConvertFrom-Json
+    $refs = @()
+    if ($j.references) {
+        foreach ($r in $j.references) {
+            if ($r -like "GUID:*") {
+                $g = $r.Substring(5)
+                if ($guidMap.ContainsKey($g)) { $refs += $guidMap[$g] } else { $refs += "UNRESOLVED:$g" }
+            } else { $refs += $r }
+        }
+    }
+    [PSCustomObject]@{
+        name = $j.name
+        path = $f.FullName.Replace("$root\Assets\","")
+        references = $refs
+        editorOnly = ($j.includePlatforms -and $j.includePlatforms.Count -eq 1 -and $j.includePlatforms[0] -eq "Editor")
+        defineConstraints = $j.defineConstraints
+        autoReferenced = $j.autoReferenced
+    }
+}
+$graph | ConvertTo-Json -Depth 5 | Set-Content "$OutDir\graph$Suffix.json" -Encoding utf8
+"asmdefs: $($graph.Count)"
+$asmrefs = Get-ChildItem -Recurse -Filter *.asmref -Path "$root\Assets" -ErrorAction SilentlyContinue
+$refList = foreach ($f in $asmrefs) {
+    $j = Get-Content $f.FullName -Raw | ConvertFrom-Json
+    $target = $j.reference
+    if ($target -like "GUID:*") { $g = $target.Substring(5); if ($guidMap.ContainsKey($g)) { $target = $guidMap[$g] } }
+    [PSCustomObject]@{ path = $f.FullName.Replace("$root\Assets\",""); target = $target }
+}
+$refList | ConvertTo-Json | Set-Content "$OutDir\asmrefs$Suffix.json" -Encoding utf8
+"asmrefs: $($asmrefs.Count)"
+$unresolvedEdges = ($graph | ForEach-Object { $_.references } | Where-Object { $_ -like "UNRESOLVED:*" })
+"unresolved edges: $(($unresolvedEdges | Measure-Object).Count); distinct: $(($unresolvedEdges | Sort-Object -Unique | Measure-Object).Count)"
+"output: $OutDir"

--- a/.claude/skills/consolidate-assembly-definitions/scripts/scan-hygiene.py
+++ b/.claude/skills/consolidate-assembly-definitions/scripts/scan-hygiene.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Assembly folder hygiene scan. Reports:
+1. REDUNDANT asmrefs — the nearest ancestor asmdef/asmref already provides the same
+   assembly (delete the asmref; the folder is covered anyway).
+2. Assembly folders with NO source below (excluding nested assemblies) — delete the
+   folder entirely (asmref-only folders are pointless; a code-less asmdef anchor
+   should be relocated into one of its member folders).
+
+Usage: python3 scan-hygiene.py [--assets <path-to-Explorer/Assets>]
+Exits 1 if anything is found (CI-friendly).
+"""
+import os, json, io, sys
+
+def find_assets():
+    if "--assets" in sys.argv:
+        return sys.argv[sys.argv.index("--assets") + 1]
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.normpath(os.path.join(here, "..", "..", "..", "..", "Explorer", "Assets"))
+
+ASSETS = find_assets()
+
+def read_json(p):
+    with io.open(p, "r", encoding="utf-8-sig") as f:
+        return json.load(f)
+
+# guid -> assembly name, from asmdef metas
+guidmap = {}
+for root, _d, files in os.walk(os.path.join(ASSETS, "..")):
+    for fn in files:
+        if fn.endswith(".asmdef"):
+            p = os.path.join(root, fn)
+            try:
+                name = read_json(p)["name"]
+                with io.open(p + ".meta", encoding="utf-8-sig") as f:
+                    for line in f:
+                        if line.startswith("guid:"):
+                            guidmap[line.split(":", 1)[1].strip()] = name
+                            break
+            except (OSError, ValueError, KeyError):
+                pass
+
+defs = {}
+for root, _d, files in os.walk(ASSETS):
+    for fn in files:
+        if fn.endswith(".asmdef"):
+            defs[root] = ("asmdef", read_json(os.path.join(root, fn))["name"], fn)
+        elif fn.endswith(".asmref"):
+            ref = read_json(os.path.join(root, fn))["reference"]
+            name = guidmap.get(ref[5:], ref) if ref.startswith("GUID:") else ref
+            defs[root] = ("asmref", name, fn)
+
+def governing(d):
+    p = os.path.dirname(d)
+    while len(p) >= len(ASSETS):
+        if p in defs:
+            return defs[p]
+        p = os.path.dirname(p)
+    return None
+
+found = 0
+print("--- REDUNDANT asmrefs (ancestor already provides same assembly):")
+for d in sorted(defs):
+    kind, name, fn = defs[d]
+    if kind != "asmref":
+        continue
+    g = governing(d)
+    if g and g[1] == name:
+        print(f"  {os.path.relpath(d, ASSETS)}\\{fn}  -> {name} (ancestor {g[0]} -> {g[1]})")
+        found += 1
+
+print("--- assembly folders with NO source below (excluding nested assemblies):")
+CODE_EXT = (".cs", ".jslib", ".dll", ".uxml", ".uss", ".shader", ".asset", ".prefab",
+            ".cginc", ".hlsl", ".compute", ".json", ".txt", ".png", ".mat", ".anim")
+for d in sorted(defs):
+    kind, name, fn = defs[d]
+    has_code = False
+    for root, dirs, files in os.walk(d):
+        if root != d and root in defs:
+            dirs[:] = []
+            continue
+        if any(f.endswith(CODE_EXT) and not f.endswith(".meta") for f in files):
+            has_code = True
+            break
+    if not has_code:
+        print(f"  {os.path.relpath(d, ASSETS)}  ({kind} -> {name})")
+        found += 1
+
+sys.exit(1 if found else 0)

--- a/.claude/skills/consolidate-assembly-definitions/scripts/simulate-merge.ps1
+++ b/.claude/skills/consolidate-assembly-definitions/scripts/simulate-merge.ps1
@@ -1,0 +1,51 @@
+param(
+    [Parameter(Mandatory)][string]$Anchor,
+    [Parameter(Mandatory)][string[]]$Members,
+    [string]$GraphPath = "$env:TEMP\asm-analysis\graph.json"
+)
+# Simulates folding $Members into $Anchor: the merged node's union of outward
+# references must not transitively reach any group member. Prints OK or the cycle chain.
+# Also runs a full-graph DFS afterwards to confirm the current graph itself is cycle-free.
+$g = Get-Content $GraphPath -Raw | ConvertFrom-Json
+$names = @{}; foreach ($a in $g) { $names[$a.name] = $a }
+$adj = @{}; foreach ($a in $g) { $adj[$a.name] = @($a.references | Where-Object { $names.ContainsKey($_) }) }
+
+$group = @($Anchor) + $Members
+foreach ($x in $group) { if (-not $adj.ContainsKey($x)) { Write-Output "MISSING assembly: $x"; exit 1 } }
+$union = @(); foreach ($x in $group) { $union += $adj[$x] }
+$union = $union | Sort-Object -Unique | Where-Object { $group -notcontains $_ }
+$result = "OK"
+foreach ($start in $union) {
+    $visited = New-Object System.Collections.Generic.HashSet[string]
+    $queue = New-Object System.Collections.Generic.Queue[string]
+    $parent = @{}
+    $queue.Enqueue($start); $null = $visited.Add($start)
+    while ($queue.Count -gt 0) {
+        $cur = $queue.Dequeue()
+        foreach ($n in $adj[$cur]) {
+            if ($group -contains $n) {
+                $chain = @($n, $cur); $p = $cur
+                while ($parent.ContainsKey($p)) { $p = $parent[$p]; $chain += $p }
+                $result = "CYCLE: " + (($chain[($chain.Count-1)..0]) -join " -> ")
+                break
+            }
+            if (-not $visited.Contains($n)) { $null = $visited.Add($n); $parent[$n] = $cur; $queue.Enqueue($n) }
+        }
+        if ($result -ne "OK") { break }
+    }
+    if ($result -ne "OK") { break }
+}
+"merge [$($Members -join ', ')] -> ${Anchor}: $result"
+
+# full-graph cycle check (sanity on current state)
+$color = @{}; foreach ($k in $adj.Keys) { $color[$k] = 0 }; $cycle = $null
+function Visit($n) {
+    $script:color[$n] = 1
+    foreach ($m in $adj[$n]) {
+        if ($script:color[$m] -eq 1) { $script:cycle = "$n -> $m"; return $true }
+        if ($script:color[$m] -eq 0) { if (Visit $m) { return $true } }
+    }
+    $script:color[$n] = 2; $false
+}
+foreach ($k in @($adj.Keys)) { if ($color[$k] -eq 0) { if (Visit $k) { break } } }
+if ($cycle) { "current graph CYCLE: $cycle" } else { "current graph: cycle-free" }

--- a/.claude/skills/resolve-asmdef-merge-conflicts/SKILL.md
+++ b/.claude/skills/resolve-asmdef-merge-conflicts/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: resolve-asmdef-merge-conflicts
+description: Use when merging/rebasing a branch that consolidated or renamed asmdef assemblies and the base branch changed assemblies in parallel — modify/delete conflicts on .asmdef files, dangling GUID references, new asmdefs/asmrefs added in base, code added into folded folders, or InternalsVisibleTo/link.xml entries naming old assemblies.
+---
+
+# Resolve Asmdef Merge Conflicts
+
+## Overview
+
+When the base branch evolves while a consolidation PR is open, conflicts are rarely just textual — the base may reference assemblies that no longer exist on the branch. **The resolution is always: keep the consolidation, port the base's *intent* onto the new structure**, then re-verify with the tooling from `consolidate-assembly-definitions` (its `scripts/` are the source of truth: `regen-graph.ps1`, `simulate-merge.ps1`, `scan-hygiene.py`).
+
+**Both merge directions are covered.** On the consolidation branch merging dev, the base "did" the things below. On a feature branch merging a dev that already contains the consolidation, the situation mirrors: *dev* deleted/renamed the assembly *you* modified — the resolutions are identical (keep the consolidation, port YOUR delta to the anchor using the mapping appendix below).
+
+## Procedure
+
+1. `git merge origin/dev` (or rebase). Inventory conflicts: `git status --short | grep -E "asmdef|asmref|AssemblyInfo|link.xml|csc.rsp"`.
+2. Resolve per the table below — never restore a folded asmdef to silence a conflict.
+3. After ALL resolutions: `regen-graph.ps1` (count as expected, **0 unresolved** — every dangling GUID is a base-branch edit you haven't ported yet), `scan-hygiene.py` (0 redundant asmrefs / empty folders), full-graph cycle check, then the batch compile gate (`Unity.exe -batchmode -quit`, zero `error CS`; never the test suite).
+
+## Conflict classes
+
+| Base branch did | Resolution |
+|---|---|
+| Modified an `.asmdef` the branch DELETED (modify/delete conflict) | Keep the deletion (`git rm`). Diff the base's version vs the pre-fold one (`git diff <merge-base> MERGE_HEAD -- <file>`) and port the delta into the ANCHOR's asmdef: new references → union (skip now-intra/already-present); `allowUnsafeCode: true` → set on anchor; new `defineConstraints` → `#if`-guard the folded sources instead; new precompiled refs → union. |
+| Added a reference to a folded/renamed assembly's GUID in some consumer | No textual conflict — caught by regen-graph as `UNRESOLVED`. Replace with the anchor's GUID (dedupe if already present). |
+| Added a NEW `.asmdef` or `.asmref` | Check the nearest-ancestor rule: if the folder's governing assembly already equals the target, the new asmref is redundant — delete it. New test asmdefs → fold into `DCL.EditMode.Tests`/`DCL.PlayMode.Tests` per project rules. New feature asmdef: **fold-first** - per consolidate-assembly-definitions find the best domain anchor (read its source for purpose, cycle-sim, check consumers); keep it standalone only as a LAST RESORT (heavily-referenced new leaf or no domain-true anchor). A package (UPM) assembly reference is never an issue - packages are leaves. |
+| Added source files INTO a folder that now folds into an anchor | Files compile into the anchor automatically. Risks: (a) the file `using`s an assembly the anchor doesn't reference → add the ref (cycle-sim first); (b) namespace shadowing — bare `Time.`, `Chat`, etc. now resolve to `DCL.*` namespaces (CS0234/CS0118) → qualify (`UnityEngine.Time.`) or use a using-alias INSIDE the namespace block. The compile gate surfaces both. |
+| Added `InternalsVisibleTo("<old name>")` or `link.xml`/serialized `Type, OldAssembly` entries | Retarget to the new assembly name (renames in this PR: ECS→ECS.Core, AvatarShape→DCL.AvatarRendering, CharacterMotion→DCL.Character, ScreencaptureCamera→DCL.InWorldCamera, MainUi→DCL.UI.Hud, NftPrompt→DCL.UI.Prompts, AuthenticationScreenFlow→DCL.UI.Flows, LambdasService→DCL.ApiServices, NativeWindowManager→DCL.Native; folded assemblies → their anchor per `docs/directories-and-assemblies-structure.md`). |
+| Edited a `csc.rsp` in a folded folder | csc.rsp next to an `.asmref` is dead. Port new flags to the anchor's csc.rsp; delete the member copy. |
+| Moved/added files under old paths (`Infrastructure/ECS/SceneLifeCycle`, `ECS/StreamableLoading`, …) | Apply the base's change at the NEW path (directories moved during consolidation); `git status` shows these as add+delete pairs, not conflicts. |
+
+## Red flags
+
+- Restoring a deleted `.asmdef` "to make the merge compile" — port to the anchor instead
+- Accepting "theirs" on an anchor asmdef wholesale — you'll silently drop the unioned refs/flags the folds added
+- Declaring the merge done without a fresh `regen-graph.ps1` showing 0 unresolved — textual resolution does not catch dangling GUIDs
+- Skipping the compile gate because "only JSON changed" — base-added source in folded folders can shadow-break (`DCL.Time` vs `UnityEngine.Time`)
+## Appendix: old assembly -> new home (PR #8961)
+
+Renames (same code, new name): ECS -> ECS.Core; AvatarShape -> DCL.AvatarRendering; CharacterMotion -> DCL.Character; ScreencaptureCamera -> DCL.InWorldCamera; MainUi -> DCL.UI.Hud; NftPrompt -> DCL.UI.Prompts; AuthenticationScreenFlow -> DCL.UI.Flows; LambdasService -> DCL.ApiServices; DCL.NativeWindowManager -> DCL.Native.
+
+Folded (old assembly -> anchor it compiles into):
+- -> **Utility**: ScenePermissions, DCL.Prefs, DebugUtilities, DCLWebSocket.Abstract, DCL.Platform (AppArgs, Global.Versioning, Clipboard, DCL.Time, SOConfigurations, Global.Dynamic.DebugSettings)
+- -> **CRDT**: CRDT.ECS.Bridge, WorldSynchronizer, SDKComponentCommandBufferSyncronizer, SDKObservableEvents
+- -> **SceneRuntime**: JsModulesImplementation, SceneRunner.Mapping, SceneRunner.Debugging.WorldInfo, CurrentSceneRoomMetadata, SceneBannedUsers
+- -> **SceneRunner.Scene**: Realm
+- -> **SceneLifeCycle**: DCL.GlobalWorld, PortableExperiencesController, DCL.LOD, DCL.Roads, DCL.CacheCleaner
+- -> **ECS.Unity**: SceneUI, NFTShape, DCL.Gizmos, AudioAnalysis(-> DCL.Native), StreamableLoading/Prioritization (now plain subfolders)
+- -> **DCL.AvatarRendering**: Wearables, AvatarRendering.Loading, DCL.SpringBones, DCL.Nametags, DCL.SmartWearables
+- -> **DCL.Character**: DCL.CharacterPreview
+- -> **DCL.Social**: DCL.Translation, Backpack, RewardPanel, DCL.InWorldCamera members (ReelActions, DCL.CameraReelStorageService)
+- -> **DCL.Multiplayer**: DCL.Multiplayer.Connections; -> **DCL.Network**: DCL.Multiplayer.Connectivity
+- -> **DCL.SharedAPI**: DCL.SharedAPI.Events, SceneRestrictionsBus
+- -> **DCL.ApiServices**: PlacesAPIService, DCL.EventsApi, BadgesAPIService, NftInfoAPIService
+- -> **UI**: UI.LayoutGroups, GenericContextMenu, DCL.UI.InputSuggestions, UI.ErrorPopup, DCL.UIToolkit, ChangeRealmPrompt, TeleportPrompt, ExternalUrlPrompt
+- -> **DCL.UI.Hud**: Minimap, UI.Sidebar, Notifications, MarketplaceCredits, DCL.UI.DebugMenu, UI.ConnectionStatusPanel
+- -> **DCL.UI.Flows**: DCL.UserInAppInitializationFlow, ApplicationGuards; -> **DCL.RealmNavigation**: DCL.SceneLoadingScreens
+- -> **DCL.Plugins**: DCL.Analytics.Implementation, DCL.Diagnostics.AutoPilot, RuntimeDeepLink, DCL.Interaction; -> **DCL.Analytics**: RustSegment.Server
+- -> **DCL.EditMode.Tests**: all standalone EditMode test asmdefs; -> **DCL.Editor**: DCL.Landscape.Editor, ReportsHanding.Settings.Editor, AssetBundles.Editor, DCL.AvatarAnimation.Editor
+- -> **MapRenderer**: MapPins; -> **DCL.Landscape**: DCL.Rendering.GPUInstancing; -> **DCL.Playgrounds**: ScenesDebug; -> **SocketIOClient**: SocketIOClient.Newtonsoft.Json
+- Directory moves only (assembly unchanged): Infrastructure/ECS/SceneLifeCycle -> Infrastructure/SceneLifeCycle; ECS/StreamableLoading + ECS/Prioritization -> under ECS/Unity.


### PR DESCRIPTION
Lands the conflict-resolution playbook in `dev` **before** the assembly consolidation (#8961) merges, so every open branch that syncs `dev` knows how to resolve the incoming conflicts.

- `.claude/skills/resolve-asmdef-merge-conflicts/` — conflict classes table (modify/delete porting, dangling GUID refs, new asmdefs fold-first, code added into folded folders, InternalsVisibleTo/link.xml retargets, moved paths), covering both merge directions, with an old-assembly → new-home mapping appendix.
- `.claude/skills/consolidate-assembly-definitions/` — the workflow + verification scripts the conflict skill uses (graph regen, cycle simulation, hygiene scan).

Files are **byte-identical** to the same paths in #8961, so the later merge auto-resolves with zero conflicts. Validated on a synthetic 6-trap merge scenario and the real `dev` merge into #8961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)