### PR TITLE
chore: add snapshot parsing skill

### DIFF
--- a/.claude/skills/unity-memory-snapshot/SKILL.md
+++ b/.claude/skills/unity-memory-snapshot/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: unity-memory-snapshot
+description: "Parse Unity Memory Profiler `.snap` capture files headlessly to extract native-object memory grouped by type, and diff/scale memory across captures. Use whenever you need to read a Unity memory dump/snapshot without the Editor, answer 'what's using memory' from a .snap, document a memory baseline, compare two captures, find per-instance (e.g. per-avatar) memory costs, or investigate textures/meshes/materials/animators/render-textures growth. The .snap format is proprietary and was reverse-engineered once — always use the bundled parser instead of re-deriving it."
+user-invocable: true
+---
+
+# Unity Memory Snapshot Parser
+
+Reads Unity Memory Profiler `.snap` files (the `QueriedSnapshot` binary format) directly, so
+you can extract and compare memory without opening the Editor. The format is undocumented and
+chunked; the bundled `scripts/parse_snapshot.py` encodes it (reverse-engineered from the
+`com.unity.memoryprofiler` package source and validated against real captures). **Never
+re-reverse-engineer the format — call the script.**
+
+`.snap` files normally live in `<project>/MemoryCaptures/`.
+
+## What it reports
+
+`NativeObjects_Size` grouped by `NativeTypes_Name` — i.e. the same per-type "allocated size" the
+Memory Profiler's *Unity Objects* table shows (Texture2D, Texture2DArray, RenderTexture, Mesh,
+Material, Animator, Transform, etc.), plus object counts and totals.
+
+Important scope limits (state these when reporting, so numbers aren't over-claimed):
+- These are **native object own-sizes**. They exclude exclusively-owned child allocations (e.g. an
+  Animator's PlayableGraph), the managed/GC heap, and graphics-resource accounting
+  (`NativeGfxResourceReferences`) — so `ComputeBuffer`/`GraphicsBuffer` (skinning buffers, the GVB)
+  and some texture GPU memory are **not** in this view.
+- The Memory Profiler's grand total (which includes managed + graphics) will be larger than the
+  "total native object size" reported here.
+
+## Usage
+
+Run with the project's Python (3.x). Quote paths containing `#` or spaces.
+
+```bash
+# Per-type breakdown of one capture (top 30 by size)
+python .claude/skills/unity-memory-snapshot/scripts/parse_snapshot.py summary "Explorer/MemoryCaptures/100_Avatars.snap"
+
+# JSON output (for further processing / documenting baselines)
+python .../parse_snapshot.py summary path/to.snap --json --top 50
+
+# Delta between two captures (A - B), optionally per-N (e.g. per avatar)
+python .../parse_snapshot.py diff "100_Avatars.snap" "No_Avatars.snap" --per 100
+
+# Category x capture matrix across many files (linear-per-instance vs shared/flat)
+python .../parse_snapshot.py scale No=No_Avatars.snap 100=100_Avatars.snap 500=500_Avatars.snap \
+    --categories Texture2DArray,Animator,Mesh,Material,Transform
+```
+
+## How to use the results
+
+- **Baseline / "what's using memory":** run `summary`. The top types are your memory budget.
+- **Find per-instance cost (per avatar, per NPC, per scene object):** capture with N and with 0 of
+  the thing, then `diff A B --per N`. A clean diff shows *exactly* N of each per-instance object
+  (e.g. +N Animators) — that self-validates the comparison; call it out.
+- **Distinguish a real per-instance cost from a shared/slab cost:** run `scale` across several
+  counts. Linear growth = per-instance (optimization target); flat = shared (leave it).
+- **Caveat to watch:** two captures from different sessions can have different base scenes loaded.
+  Trust categories whose delta scales cleanly with the instance count; be skeptical of one-off jumps
+  in otherwise-flat categories (often capture artifacts like profiler RenderTextures).
+
+## Extending
+
+The parser exposes a `Snapshot` class. `native_objects_by_type()` is the main entry point;
+`type_names()`, `const_array_ints(entry_type)`, and `dynamic_array_bytes(entry_type)` give raw
+access to any `EntryType` (ordinals listed at the top of the script; full enum in the package's
+`EntryType.cs`). To pull object names, instance IDs, connections, or graphics-resource sizes, read
+the corresponding entries via those primitives rather than rewriting the file reader.

--- a/.claude/skills/unity-memory-snapshot/scripts/parse_snapshot.py
+++ b/.claude/skills/unity-memory-snapshot/scripts/parse_snapshot.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+Parser for Unity Memory Profiler `.snap` files (QueriedSnapshot binary format).
+
+Provenance / attribution:
+    The `.snap` file layout implemented here was derived by reading the source of the
+    `com.unity.memoryprofiler` package (v1.1.11), which Unity ships to the project in
+    source form under the Unity Companion License
+    (https://unity3d.com/legal/licenses/unity_companion_license).
+    This is an INDEPENDENT, clean-room re-implementation of the file *format* (a
+    functional interface) written for use with this Unity-dependent project. No Unity
+    source code, comments, or assets are reproduced here. Provided "AS IS" with no
+    warranty, consistent with the UCL.
+
+Why this exists: the `.snap` format is a proprietary chunked binary with no public
+spec. This parser encodes that format (see the layout notes below) and was VALIDATED
+against known captures (per-object size arrays match block totals; the No->N avatar
+diff adds exactly +1 of each per-instance object per avatar). Use this instead of
+opening snapshots in the Editor when you need scriptable, diff-able, headless
+extraction of native-object memory by type.
+
+=========================== FORMAT (from package source) ===========================
+Header:  uint32 magic 0xAEABCDCD @ 0
+Footer:  uint32 magic 0xABCDCDAE @ filelen-4 ; uint64 directoryOffset @ filelen-12
+Directory @ dirOff:
+    uint32 0xCDCDAEAB ; uint32 chapterVer 0x20170724 ; uint64 blockSectionOff @ dirOff+8
+    int32  entryCount @ dirOff+16 ; entryCount x uint64 chapterOffsets @ dirOff+20
+        (indexed by EntryType ordinal; 0 == entry absent)
+Block section @ blockSectionOff:
+    uint32 blockVer 0x20170724 ; int32 blockCount @ +4 ; blockCount x uint64 blockOffsets @ +8
+Block @ blockOff:
+    uint64 ChunkSize ; uint64 TotalBytes ; then OffsetCount x int64 chunk file-offsets @ +16
+    OffsetCount = ceil(TotalBytes / ChunkSize). Block data is split into ChunkSize chunks
+    scattered through the file; logical offset L -> chunk[L//ChunkSize] + (L % ChunkSize).
+EntryHeader (18 bytes, pack=2) @ chapterOffset:
+    uint16 Format @0 ; uint32 BlockIndex @2 ; uint32 EntriesMeta @6 ; uint64 HeaderMeta @10
+    Format: 1=SingleElement, 2=ConstantSizeElementArray, 3=DynamicSizeElementArray
+    ConstantSizeElementArray: count = (uint32)HeaderMeta  (LOW 32 BITS); element size = EntriesMeta
+    DynamicSizeElementArray:  count = EntriesMeta; per-element start offsets read as
+        EntriesMeta x int64 @ chapterOffset+18. After the package's fixup:
+        offsets[0]=HeaderMeta, offsets[i]=disk[i-1] (i>=1), total=disk[count-1].
+EntryType ordinals used here: NativeTypes_Name=5, NativeObjects_NativeTypeArrayIndex=7,
+    NativeObjects_Name=11, NativeObjects_Size=13. (Full enum in EntryType.cs.)
+====================================================================================
+"""
+import struct, sys, collections, argparse, json
+
+# --- EntryType ordinals (subset; see EntryType.cs for the full list) ---
+ET_NativeTypes_Name = 5
+ET_NativeObjects_NativeTypeArrayIndex = 7
+ET_NativeObjects_Name = 11
+ET_NativeObjects_Size = 13
+
+HEADER_MAGIC = 0xAEABCDCD
+FOOTER_MAGIC = 0xABCDCDAE
+DIR_MAGIC = 0xCDCDAEAB
+SECTION_VER = 0x20170724
+
+
+class Snapshot:
+    def __init__(self, path):
+        self.path = path
+        with open(path, "rb") as f:
+            self.data = f.read()
+        self._open()
+
+    # primitive readers
+    def _u32(self, o): return struct.unpack_from("<I", self.data, o)[0]
+    def _i32(self, o): return struct.unpack_from("<i", self.data, o)[0]
+    def _u64(self, o): return struct.unpack_from("<Q", self.data, o)[0]
+    def _i64(self, o): return struct.unpack_from("<q", self.data, o)[0]
+
+    def _open(self):
+        d = self.data
+        flen = len(d)
+        if self._u32(0) != HEADER_MAGIC:
+            raise ValueError(f"{self.path}: not a Unity snapshot (bad header magic)")
+        if self._u32(flen - 4) != FOOTER_MAGIC:
+            raise ValueError(f"{self.path}: bad footer magic")
+        dir_off = self._u64(flen - 12)
+        if self._u32(dir_off) != DIR_MAGIC:
+            raise ValueError(f"{self.path}: bad directory signature")
+        if self._u32(dir_off + 4) != SECTION_VER:
+            raise ValueError(f"{self.path}: unexpected chapter section version")
+        block_section_off = self._u64(dir_off + 8)
+        entry_count = self._i32(dir_off + 16)
+        self.chapter_offsets = [self._u64(dir_off + 20 + 8 * i) for i in range(entry_count)]
+        if self._u32(block_section_off) != SECTION_VER:
+            raise ValueError(f"{self.path}: unexpected block section version")
+        block_count = self._i32(block_section_off + 4)
+        block_offsets = [self._u64(block_section_off + 8 + 8 * i) for i in range(block_count)]
+        self.blocks = []
+        for bo in block_offsets:
+            chunk = self._u64(bo)
+            total = self._u64(bo + 8)
+            oc = total // chunk + (1 if total % chunk else 0)
+            coffs = [self._u64(bo + 16 + 8 * i) for i in range(oc)]
+            self.blocks.append((chunk, coffs))
+
+    def _block_read(self, bi, start, length):
+        chunk, coffs = self.blocks[bi]
+        out = bytearray()
+        L, rem = start, length
+        while rem > 0:
+            ci, within = divmod(L, chunk)
+            n = min(rem, chunk - within)
+            fp = coffs[ci] + within
+            out += self.data[fp:fp + n]
+            L += n
+            rem -= n
+        return bytes(out)
+
+    def _header(self, et):
+        off = self.chapter_offsets[et] if et < len(self.chapter_offsets) else 0
+        if off == 0:
+            return None
+        return dict(
+            off=off,
+            fmt=struct.unpack_from("<H", self.data, off)[0],
+            blk=struct.unpack_from("<I", self.data, off + 2)[0],
+            em=struct.unpack_from("<I", self.data, off + 6)[0],
+            hm=struct.unpack_from("<Q", self.data, off + 10)[0],
+        )
+
+    def const_array_ints(self, et):
+        """ConstantSizeElementArray of little-endian unsigned ints -> list[int]."""
+        h = self._header(et)
+        if not h or h["fmt"] != 2:
+            return None
+        count = h["hm"] & 0xFFFFFFFF
+        esize = h["em"]
+        raw = self._block_read(h["blk"], 0, count * esize)
+        return [int.from_bytes(raw[i * esize:(i + 1) * esize], "little") for i in range(count)]
+
+    def dynamic_array_bytes(self, et):
+        """DynamicSizeElementArray -> list[bytes] (e.g. name strings)."""
+        h = self._header(et)
+        if not h or h["fmt"] != 3:
+            return None
+        count = h["em"]
+        disk = [self._i64(h["off"] + 18 + 8 * i) for i in range(count)]
+        offs = [0] * (count + 1)
+        offs[0] = h["hm"]
+        for i in range(1, count):
+            offs[i] = disk[i - 1]
+        offs[count] = disk[count - 1] if count > 0 else h["hm"]
+        return [self._block_read(h["blk"], offs[i], offs[i + 1] - offs[i]) for i in range(count)]
+
+    def type_names(self):
+        return [b.decode("utf-8", "replace") for b in (self.dynamic_array_bytes(ET_NativeTypes_Name) or [])]
+
+    def native_objects_by_type(self):
+        """Returns {type_name: [count, total_bytes]}, plus (num_objects, total_bytes)."""
+        names = self.type_names()
+        tidx = self.const_array_ints(ET_NativeObjects_NativeTypeArrayIndex) or []
+        sizes = self.const_array_ints(ET_NativeObjects_Size) or []
+        agg = collections.defaultdict(lambda: [0, 0])
+        for t, s in zip(tidx, sizes):
+            n = names[t] if 0 <= t < len(names) else f"<type {t}>"
+            agg[n][0] += 1
+            agg[n][1] += s
+        return dict(agg), len(sizes), sum(sizes)
+
+
+MB = 1024 * 1024
+
+
+def cmd_summary(args):
+    snap = Snapshot(args.file)
+    agg, nobj, total = snap.native_objects_by_type()
+    rows = sorted(agg.items(), key=lambda kv: -kv[1][1])
+    if args.top:
+        rows = rows[:args.top]
+    if args.json:
+        print(json.dumps({"file": args.file, "num_objects": nobj, "total_bytes": total,
+                          "types": {k: {"count": c, "bytes": b} for k, (c, b) in rows}}, indent=2))
+        return
+    print(f"{args.file}: {nobj:,} native objects, {total/MB:,.1f} MB total native object size\n")
+    print(f"{'Type':36}{'Count':>10}{'Total MB':>12}")
+    for name, (c, b) in rows:
+        print(f"{name[:36]:36}{c:>10,}{b/MB:>12.2f}")
+
+
+def cmd_diff(args):
+    a = Snapshot(args.file_a); b = Snapshot(args.file_b)
+    aa, na, ta = a.native_objects_by_type()
+    bb, nb, tb = b.native_objects_by_type()
+    print(f"A {args.file_a}: {na:,} objs, {ta/MB:,.1f} MB")
+    print(f"B {args.file_b}: {nb:,} objs, {tb/MB:,.1f} MB")
+    print(f"delta: {na-nb:+,} objs, {(ta-tb)/MB:+,.1f} MB native\n")
+    keys = set(aa) | set(bb)
+    rows = [(k, aa.get(k, [0, 0])[0] - bb.get(k, [0, 0])[0],
+             aa.get(k, [0, 0])[1] - bb.get(k, [0, 0])[1]) for k in keys]
+    rows.sort(key=lambda r: -r[2])
+    if args.top:
+        rows = rows[:args.top]
+    per = f" / {args.per}" if args.per else ""
+    hdr = f"{'Type':30}{'dCount':>10}{'dMB':>10}"
+    if args.per:
+        hdr += f"{'MB' + per:>12}"
+    print(hdr)
+    for k, dc, ds in rows:
+        line = f"{k[:30]:30}{dc:>10,}{ds/MB:>10.2f}"
+        if args.per:
+            line += f"{ds/MB/args.per:>12.4f}"
+        print(line)
+
+
+def cmd_scale(args):
+    """Category x snapshot matrix. Pass label=path pairs."""
+    pairs = []
+    for spec in args.specs:
+        label, _, path = spec.partition("=")
+        pairs.append((label, path if path else label))
+    data = {}
+    for label, path in pairs:
+        agg, n, t = Snapshot(path).native_objects_by_type()
+        data[label] = (agg, n, t)
+    cats = args.categories.split(",") if args.categories else None
+    if not cats:
+        # union of top types across all
+        allt = collections.defaultdict(float)
+        for agg, _, _ in data.values():
+            for k, (c, b) in agg.items():
+                allt[k] += b
+        cats = [k for k, _ in sorted(allt.items(), key=lambda kv: -kv[1])[:args.top]]
+    labels = [l for l, _ in pairs]
+    print(f"{'Category (MB)':28}" + "".join(f"{l:>10}" for l in labels))
+    for c in cats:
+        print(f"{c[:28]:28}" + "".join(f"{data[l][0].get(c, [0,0])[1]/MB:>10.1f}" for l in labels))
+    print(f"{'TOTAL native MB':28}" + "".join(f"{data[l][2]/MB:>10.0f}" for l in labels))
+    print(f"{'object count':28}" + "".join(f"{data[l][1]:>10,}" for l in labels))
+
+
+def main():
+    p = argparse.ArgumentParser(description="Parse Unity Memory Profiler .snap files.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("summary", help="per-type native memory for one snapshot")
+    s.add_argument("file")
+    s.add_argument("--top", type=int, default=30)
+    s.add_argument("--json", action="store_true")
+    s.set_defaults(func=cmd_summary)
+
+    d = sub.add_parser("diff", help="per-type delta between two snapshots (A - B)")
+    d.add_argument("file_a"); d.add_argument("file_b")
+    d.add_argument("--top", type=int, default=25)
+    d.add_argument("--per", type=int, default=0, help="divide deltas by N (e.g. avatar count)")
+    d.set_defaults(func=cmd_diff)
+
+    sc = sub.add_parser("scale", help="category x snapshot matrix across many files")
+    sc.add_argument("specs", nargs="+", help="label=path (or just path)")
+    sc.add_argument("--categories", help="comma-separated type names; default = top by size")
+    sc.add_argument("--top", type=int, default=15)
+    sc.set_defaults(func=cmd_scale)
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Adds a Claude Code skill, **`unity-memory-snapshot`**, that parses Unity Memory Profiler `.snap` capture files **headlessly** (without opening the Editor) to extract native-object memory grouped by type, and to **diff** and **scale** memory across multiple captures.

**Why:** While working the avatar memory health-check (#8055), we needed to read `.snap` captures programmatically — to document baselines, compute per-instance (per-avatar) costs, and compare captures. The `.snap` `QueriedSnapshot` format is proprietary and undocumented, so this had to be reverse-engineered once. This skill **captures that work so the format never has to be re-derived**, and gives anyone a scriptable, diff-able way to answer "what's using memory" from a dump.

**What's included:**
- `.claude/skills/unity-memory-snapshot/SKILL.md` — when/how to use it, with scope caveats.
- `.claude/skills/unity-memory-snapshot/scripts/parse_snapshot.py` — pure-stdlib (Python 3) parser with three subcommands:
  - `summary <snap>` — per-type native memory table (+ `--json`, `--top`)
  - `diff <A> <B> --per N` — per-type delta, optionally divided per instance
  - `scale label=path … --categories …` — category × capture matrix (linear-per-instance vs shared)

**Scope / non-goals:**
- **No Explorer runtime/gameplay code changes.** This is developer tooling only.
- Reports native-object *own-size* (matches the Profiler's *Unity Objects* table). It does **not** include the managed/GC heap, exclusively-owned child allocations (e.g. an Animator's PlayableGraph), or graphics buffers (`ComputeBuffer`/GVB) — documented in `SKILL.md` so results aren't over-claimed.

**Provenance / licensing:** The format was derived by reading the `com.unity.memoryprofiler` package source (v1.1.11), which Unity ships in source form under the **Unity Companion License**. The parser is an independent re-implementation of the file *format* for use with this Unity-dependent project — **no Unity source, comments, or assets are reproduced.** A provenance note is included at the top of the script.

**Related:** Produced the baseline for #8055 (Avatar memory health check with 100 avatars).

## Test Instructions

> ⚠️ This PR adds developer tooling with **no Explorer runtime changes**, so the standard `metaforge explorer run` / `metaforge explorer test` steps are **N/A** — there is nothing to observe in the app. Verify by running the parser against a local `.snap` capture.

## Quality Checklist
- [x] Changes have been tested locally (parser validated against multiple captures)
- [x] Documentation has been updated (SKILL.md documents usage + scope caveats; provenance note in script)
- [x] Performance impact has been considered (tooling-only; no runtime impact)

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
