### PR TITLE
chore: update badge message

### DIFF
--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -275,6 +275,7 @@ jobs:
           body: |-
             ![badge]  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30"> 
             
-            Build failed! Check the logs to see what went wrong
+            Build failed! Check the logs to see what went wrong.
+            If the error repeats please consider the `clean-build` tag.
 
             [badge]: https://img.shields.io/badge/Build-Failed!-ff0000?logo=github&style=for-the-badge


### PR DESCRIPTION
Update the build failed message to highlight the clean-build option.