### PR TITLE
fix: purge Burst cache after unclean Cloud Build + CI actions node24/SHA pinning

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -25,13 +25,13 @@ jobs:
     if: needs.detect-pr-type.outputs.is-feature == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.0
+      - uses: kentaro-m/auto-assign-action@v2.0.2
         with:
           configuration-path: '.github/auto_assign_config_dev.yml'
 
   assign-qa:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.0
+      - uses: kentaro-m/auto-assign-action@v2.0.2
         with:
           configuration-path: '.github/auto_assign_config_qa.yml'

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Check PR type
         id: check
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const title = context.payload.pull_request.title || '';
@@ -25,13 +25,13 @@ jobs:
     if: needs.detect-pr-type.outputs.is-feature == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.2
+      - uses: kentaro-m/auto-assign-action@0a2c53d3721e4c5cfcce6afd4014aecc337979f6 # v2.0.2
         with:
           configuration-path: '.github/auto_assign_config_dev.yml'
 
   assign-qa:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.2
+      - uses: kentaro-m/auto-assign-action@0a2c53d3721e4c5cfcce6afd4014aecc337979f6 # v2.0.2
         with:
           configuration-path: '.github/auto_assign_config_qa.yml'

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -17,12 +17,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
       - name: AI label analysis
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           allowed_bots: "sentry"
           prompt: |

--- a/.github/workflows/auto-sync-main-to-dev.yml
+++ b/.github/workflows/auto-sync-main-to-dev.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Create or update branch
         run: |

--- a/.github/workflows/build-game-ci-image.yml
+++ b/.github/workflows/build-game-ci-image.yml
@@ -51,7 +51,7 @@ jobs:
         run: git clone https://github.com/game-ci/docker.git
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-game-ci-image.yml
+++ b/.github/workflows/build-game-ci-image.yml
@@ -45,13 +45,13 @@ jobs:
     runs-on: Ubuntu-Big
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Clone game-ci/docker
         run: git clone https://github.com/game-ci/docker.git
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-profile-nightly.yml
+++ b/.github/workflows/build-profile-nightly.yml
@@ -12,7 +12,7 @@ jobs:
       should_build: ${{ steps.check.outputs.should_build }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: dev
@@ -59,7 +59,7 @@ jobs:
       tag_version: ${{ steps.get_version.outputs.tag_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: dev

--- a/.github/workflows/build-release-main-page.yml
+++ b/.github/workflows/build-release-main-page.yml
@@ -20,7 +20,7 @@ jobs:
       tag_version: ${{ steps.get_version.outputs.next_tag_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: 'main'
@@ -37,7 +37,7 @@ jobs:
     needs: get-info
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: 'main'
@@ -53,7 +53,7 @@ jobs:
           fi
 
       - name: Download artifacts
-        uses: dawidd6/action-download-artifact@v21
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: Decentraland_.*
@@ -61,7 +61,7 @@ jobs:
           skip_unpack: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
           draft: true # Swap to auto-release!

--- a/.github/workflows/build-release-main-page.yml
+++ b/.github/workflows/build-release-main-page.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
       - name: Download artifacts
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v21
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: Decentraland_.*
@@ -61,7 +61,7 @@ jobs:
           skip_unpack: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           draft: true # Swap to auto-release!

--- a/.github/workflows/build-release-main.yml
+++ b/.github/workflows/build-release-main.yml
@@ -16,7 +16,7 @@ jobs:
       tag_version: ${{ steps.get_version.outputs.next_tag_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -987,4 +987,3 @@ jobs:
           fi
 
           echo "Both Windows and macOS builds passed."
-# Test change

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -899,6 +899,16 @@ jobs:
             --project "$SENTRY_PROJECT" \
             "build"
 
+      # The poll loop only downloads the log on completion; when the runner is
+      # cancelled mid-build, fetch the partial log so the artifact still exists.
+      - name: Fetch cloud log after cancellation
+        if: cancelled()
+        env:
+          API_KEY: ${{ secrets.UNITY_CLOUD_API_KEY }}
+          ORG_ID: ${{ secrets.UNITY_CLOUD_ORG_ID }}
+          PROJECT_ID: ${{ secrets.UNITY_CLOUD_PROJECT_ID }}
+        run: python -u scripts/cloudbuild/build.py --fetch-log || true
+
       # Will run always (even if failing)
       - name: Upload cloud logs
         if: always()
@@ -906,18 +916,47 @@ jobs:
         with:
           name: ${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}_unity_log
           path: unity_cloud_log.log
-          if-no-files-found: error
+          # Absence is expected when the run is cancelled before the build starts.
+          if-no-files-found: warn
 
-      # Will run always (even if failing)
+      # The full log is huge (20k+ lines) and always available as an artifact,
+      # so only dump it inline when something went wrong.
       - name: Print cloud logs
-        if: always()
+        if: failure()
         run: cat unity_cloud_log.log
 
       - name: Extract and display errors
         if: always()
         run: |
           echo "=== Extracted Errors for ${{ matrix.target }} ${{ needs.prebuild.outputs.install_source }} ==="
-          grep -iE "error c|fatal" unity_cloud_log.log | sed 's/^/\x1b[31m/' | sed 's/$/\x1b[0m/' || echo "No 'error c' or 'fatal' errors found in ${{ matrix.target }} log."
+
+          if [ ! -f unity_cloud_log.log ]; then
+            echo "No unity_cloud_log.log present (run cancelled before the build started?)."
+            exit 0
+          fi
+
+          PATTERN="error CS[0-9]|FATAL|fatal|Player export failed|Failed to find entry-points|BuildFailedException"
+          ERRORS=$(grep -B2 -A15 -E "$PATTERN" unity_cloud_log.log || true)
+
+          if [ -z "$ERRORS" ]; then
+            echo "No errors matched in ${{ matrix.target }} log."
+            exit 0
+          fi
+
+          echo "$ERRORS" | sed 's/^/\x1b[31m/' | sed 's/$/\x1b[0m/'
+
+          # Surface the root cause on the run page, but only when the job is
+          # actually failing - successful Unity builds still log benign matches.
+          if [ "${{ job.status }}" != "success" ]; then
+            REASON=$(grep -m1 -E "Player export failed\. Reason: .*|error CS[0-9].*" unity_cloud_log.log || true)
+            [ -n "$REASON" ] && echo "::error::${REASON:0:400}"
+            {
+              echo "### Unity errors (${{ matrix.target }})"
+              echo '```'
+              echo "$ERRORS" | head -200
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Generate Shader Compilation Report
         shell: pwsh
@@ -938,7 +977,7 @@ jobs:
           API_KEY: ${{ secrets.UNITY_CLOUD_API_KEY }}
           ORG_ID: ${{ secrets.UNITY_CLOUD_ORG_ID }}
           PROJECT_ID: ${{ secrets.UNITY_CLOUD_PROJECT_ID }}
-        run: python -u scripts/cloudbuild/build.py --cancel || true
+        run: python -u scripts/cloudbuild/build.py --cancel || echo "::warning::Failed to cancel the Unity Cloud build - it may still be holding a build slot. Check cloud.unity.com -> Build Automation."
 
   build-gate:
     name: Build Gate (Windows + macOS)
@@ -981,8 +1020,12 @@ jobs:
           fi
 
           build_result='${{ needs.build.result }}'
+          if [ "$build_result" = "cancelled" ]; then
+            echo "::error::Build was cancelled - usually superseded by a newer run for this PR (cancel-in-progress). This red gate is expected; the replacing run's gate is the one that counts."
+            exit 1
+          fi
           if [ "$build_result" != "success" ]; then
-            echo "::error::Build matrix did not succeed (result: $build_result)"
+            echo "::error::Build matrix did not succeed (result: $build_result). Check the Build job's 'Extract and display errors' step for the root cause."
             exit 1
           fi
 

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -172,6 +172,10 @@ concurrency:
   # Otherwise an incidental pull_request event (e.g. converted_to_draft race, non-override label change)
   # would cancel a real in-progress build and let the new run skip prebuild/build, leaving the
   # Build Gate falsely green.
+  # Removing 'force-build'/'clean-build' is in that incidental category: on a draft PR the new
+  # run skips prebuild entirely, so cancelling would kill a legitimate in-flight build and
+  # replace it with nothing. Removing a platform filter still cancels - the replacing run
+  # builds both targets.
   cancel-in-progress: >-
     ${{
       github.event_name == 'push' ||
@@ -185,10 +189,17 @@ concurrency:
           github.event.action == 'synchronize' ||
           github.event.action == 'ready_for_review' ||
           (
-            (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+            github.event.action == 'labeled' &&
             (
               github.event.label.name == 'force-build' ||
               github.event.label.name == 'clean-build' ||
+              github.event.label.name == 'windows-only' ||
+              github.event.label.name == 'macos-only'
+            )
+          ) ||
+          (
+            github.event.action == 'unlabeled' &&
+            (
               github.event.label.name == 'windows-only' ||
               github.event.label.name == 'macos-only'
             )
@@ -289,12 +300,14 @@ jobs:
             fi
           fi
 
+          skip_reason=""
           if [ "$should_build" = "false" ]; then
             # If still draft and no override => do not build
             is_draft="${{ github.event.pull_request.draft }}"
             echo "[check draft] is_draft='$is_draft'"
             if [ "$is_draft" = "true" ]; then
               echo "[draft] TRUE -> should_build=false"
+              skip_reason="draft PR (add the force-build label to build)"
             else
               explorer_changed="${{ steps.changed_explorer.outputs.any_changed }}"
               echo "[check explorer_changed] explorer_changed='$explorer_changed'"
@@ -303,12 +316,14 @@ jobs:
                 should_build=true
               else
                 echo "[explorer_changed] FALSE -> should_build=false"
+                skip_reason="no Explorer/ changes detected"
               fi
             fi
           fi
 
           echo "should_build=$should_build" >> "$GITHUB_OUTPUT"
-          echo "Final decision: should_build=$should_build"
+          echo "skip_reason=$skip_reason" >> "$GITHUB_OUTPUT"
+          echo "Final decision: should_build=$should_build${skip_reason:+ ($skip_reason)}"
 
       - name: Skip build and test checks
         if: steps.decide.outputs.should_build == 'false' && github.event_name == 'pull_request'
@@ -316,6 +331,7 @@ jobs:
         with:
           script: |
             const sha = context.payload.pull_request.head.sha;
+            const reason = ${{ toJSON(steps.decide.outputs.skip_reason) }} || 'no build required';
             const checks = [
               'Build (macos)',
               'Build (windows64)',
@@ -329,10 +345,10 @@ jobs:
                 sha,
                 state: 'success',
                 context: check,
-                description: 'Skipped — no Explorer/ changes detected'
+                description: `Skipped — ${reason}`
               });
             }
-            console.log(`Posted success statuses for: ${checks.join(', ')}`);
+            console.log(`Posted success statuses for: ${checks.join(', ')} (${reason})`);
 
       - name: Get commit SHA
         if: steps.decide.outputs.should_build == 'true'
@@ -993,9 +1009,10 @@ jobs:
           should_build='${{ needs.prebuild.outputs.should_build }}'
           prebuild_result='${{ needs.prebuild.result }}'
 
-          # Legit no-op: prebuild ran and decided no build is needed (no Explorer/ changes).
-          # The Prebuild job's "Skip build and test checks" step already posts per-target success
-          # statuses for this case, so the gate can safely pass.
+          # Legit no-op: prebuild ran and decided no build is needed (no Explorer/ changes,
+          # or a draft PR without an override label). The Prebuild job's "Skip build and test
+          # checks" step already posts per-target statuses stating the reason, so the gate can
+          # safely pass; drafts get a real build on ready_for_review.
           if [ "$prebuild_result" = "success" ] && [ "$should_build" != "true" ]; then
             echo "Gate not applicable (prebuild ran, no Explorer/ changes). Passing."
             exit 0

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -254,7 +254,7 @@ jobs:
 
       - name: Detect changes under Explorer/**
         id: changed_explorer
-        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
+        uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad # v47.0.5
         with:
           files: |
             Explorer/**
@@ -554,7 +554,7 @@ jobs:
           pip install -r scripts/cloudbuild/requirements.txt
 
       - name: Execute Unity Cloud build
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           # Wraps QUEUE_TIMEOUT (240m) + BUILD_TIMEOUT (180m) + buffer.
           timeout_minutes: 450

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -248,7 +248,7 @@ jobs:
       targets: ${{ steps.get_targets.outputs.targets }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -312,7 +312,7 @@ jobs:
 
       - name: Skip build and test checks
         if: steps.decide.outputs.should_build == 'false' && github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const sha = context.payload.pull_request.head.sha;
@@ -538,13 +538,13 @@ jobs:
         target: ${{ fromJSON(needs.prebuild.outputs.targets) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12.3
 
@@ -554,7 +554,7 @@ jobs:
           pip install -r scripts/cloudbuild/requirements.txt
 
       - name: Execute Unity Cloud build
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           # Wraps QUEUE_TIMEOUT (240m) + BUILD_TIMEOUT (180m) + buffer.
           timeout_minutes: 450
@@ -654,7 +654,7 @@ jobs:
       - name: Upload artifact for macOS
         id: upload-macos-artifact
         if: matrix.target == 'macos'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ env.artifact_name }}
           path: build.tar
@@ -663,7 +663,7 @@ jobs:
       - name: Upload artifact for Windows
         id: upload-windows-artifact
         if: matrix.target == 'windows64'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ env.artifact_name }}
           path: |
@@ -824,7 +824,7 @@ jobs:
 
       - name: Upload size report
         if: always() && steps.size_check.outputs.result != ''
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: size_report_${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}
           path: size_report/
@@ -878,7 +878,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload debug symbols
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ env.artifact_name }}_debug_symbols
           path: |
@@ -902,7 +902,7 @@ jobs:
       # Will run always (even if failing)
       - name: Upload cloud logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}_unity_log
           path: unity_cloud_log.log
@@ -925,7 +925,7 @@ jobs:
           ./scripts/Generate-ShaderReport.ps1 -InputLog "unity_cloud_log.log" -OutputReport "shader_compilation_report.log"
 
       - name: Upload Shader Compilation Report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}_shader_compilation_report
           path: shader_compilation_report.log

--- a/.github/workflows/claude-pr-review-require.yml
+++ b/.github/workflows/claude-pr-review-require.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check PR type
         id: check-type
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const title = context.payload.pull_request.title || '';
@@ -21,7 +21,7 @@ jobs:
 
       - name: Set pending status for feature PRs
         if: steps.check-type.outputs.is-auto-review == 'false'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.repos.createCommitStatus({

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Check PR type
         id: check-type
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const title = context.payload.pull_request.title || '';
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set status to pending
         if: steps.check-type.outputs.is-auto-review == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -70,7 +70,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-type.outputs.is-auto-review == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
@@ -94,7 +94,7 @@ jobs:
       - name: Claude Review
         if: steps.check-type.outputs.is-auto-review == 'true'
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -112,7 +112,7 @@ jobs:
             
       - name: Upload Claude execution output
         if: steps.check-type.outputs.is-auto-review == 'true' && always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: claude-execution-output-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
           path: /home/runner/work/_temp/claude-execution-output.json
@@ -121,7 +121,7 @@ jobs:
 
       - name: Set status and approve if eligible
         if: steps.check-type.outputs.is-auto-review == 'true' && always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const prNumber = ${{ github.event.pull_request.number }};
@@ -328,7 +328,7 @@ jobs:
     steps:
       - name: Resolve PR head (rejects post-comment pushes)
         id: pr
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -357,7 +357,7 @@ jobs:
             core.setOutput('is_draft', pr.data.draft);
 
       - name: Set status to pending
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -370,7 +370,7 @@ jobs:
             });
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ steps.pr.outputs.sha }}
           fetch-depth: 1
@@ -392,7 +392,7 @@ jobs:
 
       - name: Claude Review
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -412,7 +412,7 @@ jobs:
 
       - name: Upload Claude execution output
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: claude-execution-output-${{ github.event.issue.number }}-${{ github.run_attempt }}
           path: /home/runner/work/_temp/claude-execution-output.json
@@ -421,7 +421,7 @@ jobs:
 
       - name: Set final commit status
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 30

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -9,7 +9,7 @@ jobs:
     
     steps:
       - name: Check out the code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: dev
           

--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -32,7 +32,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -99,7 +99,7 @@ jobs:
 
       - name: Add label
         if: steps.detect.outputs.has-changes == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.issues.addLabels({
@@ -111,7 +111,7 @@ jobs:
 
       - name: Set status to pending
         if: steps.detect.outputs.has-changes == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -142,7 +142,7 @@ jobs:
       - name: Claude Dependency Review
         if: steps.detect.outputs.has-changes == 'true'
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -165,7 +165,7 @@ jobs:
 
       - name: Set final status
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const hasChanges = '${{ steps.detect.outputs.has-changes }}' === 'true';

--- a/.github/workflows/issue-deduplication.yml
+++ b/.github/workflows/issue-deduplication.yml
@@ -17,11 +17,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: Check for duplicate issues
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           allowed_bots: "sentry"
           prompt: |

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12.3
 

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -65,14 +65,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
 
       - name: Post skipped comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -195,7 +195,7 @@ jobs:
           fi
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
@@ -209,7 +209,7 @@ jobs:
           MAC_ARTIFACT_URL: "${{ github.server_url }}/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.MAC_ARTIFACT_ID }}"
           MAC_ARTIFACT_S3_URL: "${{ format('{0}/{1}/Decentraland_macos.zip', vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL, env.ARTIFACT_S3_DESTINATION_PATH) }}"
           HEAD_SHA: "${{ env.HEAD_SHA }}"
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -260,14 +260,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -65,14 +65,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
 
       - name: Post skipped comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -195,7 +195,7 @@ jobs:
           fi
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
@@ -209,7 +209,7 @@ jobs:
           MAC_ARTIFACT_URL: "${{ github.server_url }}/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.MAC_ARTIFACT_ID }}"
           MAC_ARTIFACT_S3_URL: "${{ format('{0}/{1}/Decentraland_macos.zip', vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL, env.ARTIFACT_S3_DESTINATION_PATH) }}"
           HEAD_SHA: "${{ env.HEAD_SHA }}"
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -239,7 +239,7 @@ jobs:
         run: gh release view -R $GITHUB_REPOSITORY --json tagName --template "RELEASE_TAG={{.tagName}}" >> $GITHUB_ENV
 
       - name: Trigger performance test
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           repository: decentraland/performance-testing
           event-type: unity-explorer
@@ -260,14 +260,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/pr-comment-delete-artifact-url.yml
+++ b/.github/workflows/pr-comment-delete-artifact-url.yml
@@ -31,13 +31,13 @@ jobs:
           echo "Pull request Number: $PR_NUMBER"
           echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         id: find-comment
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-author: 'github-actions[bot]'
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/pr-comment-delete-artifact-url.yml
+++ b/.github/workflows/pr-comment-delete-artifact-url.yml
@@ -31,13 +31,13 @@ jobs:
           echo "Pull request Number: $PR_NUMBER"
           echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-author: 'github-actions[bot]'
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -46,7 +46,7 @@ jobs:
           df -h /mnt /mnt/docker
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           lfs: true
@@ -56,7 +56,7 @@ jobs:
         run: git lfs ls-files -l | awk '{print $1}' | sort > .lfs-assets-id
 
       - name: Restore LFS cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: lfs-cache
         with:
           path: .git/lfs
@@ -68,7 +68,7 @@ jobs:
           git add .
           git reset --hard
 
-      - uses: webfactory/ssh-agent@v0.10.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -79,7 +79,7 @@ jobs:
           chmod 600 /home/runner/.ssh/known_hosts
 
       - name: Restore Library cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: Explorer/Library
           key: Library-Explorer-Ubuntu
@@ -122,7 +122,7 @@ jobs:
 
       # --- Log into GHCR ---
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -148,7 +148,7 @@ jobs:
           echo "Seeded GHCR: $ghcr"
 
       # Configure test runner for Performance tests only
-      - uses: game-ci/unity-test-runner@v4.3.1
+      - uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4.3.1
         id: testRunner
         timeout-minutes: 180
         continue-on-error: true
@@ -165,7 +165,7 @@ jobs:
       # Generate PDF report
       - name: Set up Python
         if: always()
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
@@ -181,7 +181,7 @@ jobs:
 
       # Upload performance test results JSON
       - name: Upload performance test results (JSON)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: Performance test results (JSON)
@@ -190,7 +190,7 @@ jobs:
 
       # Upload performance report PDF
       - name: Upload performance report (PDF)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: Performance benchmark report (PDF)

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -68,7 +68,7 @@ jobs:
           git add .
           git reset --hard
 
-      - uses: webfactory/ssh-agent@v0.8.0
+      - uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -122,7 +122,7 @@ jobs:
 
       # --- Log into GHCR ---
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
           git add .
           git reset --hard
           
-      - uses: webfactory/ssh-agent@v0.8.0
+      - uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           
@@ -150,7 +150,7 @@ jobs:
 
       # --- Log into GHCR ---
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -208,7 +208,7 @@ jobs:
 
       - name: Report test results
         if: always()
-        uses: dorny/test-reporter@v2.1.1
+        uses: dorny/test-reporter@v3.0.0
         with:
           name: Unity Tests (${{ matrix.testMode }})
           path: ${{ steps.testRunner.outputs.artifactsPath }}/*.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           df -h
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           lfs: true
@@ -81,7 +81,7 @@ jobs:
         run: git lfs ls-files -l | awk '{print $1}' | sort > .lfs-assets-id
 
       - name: Restore LFS cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: lfs-cache
         with:
           path: .git/lfs
@@ -93,7 +93,7 @@ jobs:
           git add .
           git reset --hard
           
-      - uses: webfactory/ssh-agent@v0.10.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           
@@ -106,7 +106,7 @@ jobs:
           chmod 600 ~/.ssh/known_hosts
 
       - name: Restore Library cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: Explorer/Library
           key: Library-Explorer-Ubuntu-${{ hashFiles('Explorer/Packages/packages-lock.json', 'Explorer/ProjectSettings/ProjectVersion.txt') }}
@@ -150,7 +150,7 @@ jobs:
 
       # --- Log into GHCR ---
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -192,7 +192,7 @@ jobs:
           echo "Built derived image with ripgrep: $derived"
 
       # Configure test runner
-      - uses: game-ci/unity-test-runner@v4.3.1
+      - uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4.3.1
         id: testRunner
         timeout-minutes: 80
         continue-on-error: true
@@ -208,7 +208,7 @@ jobs:
 
       - name: Report test results
         if: always()
-        uses: dorny/test-reporter@v3.0.0
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: Unity Tests (${{ matrix.testMode }})
           path: ${{ steps.testRunner.outputs.artifactsPath }}/*.xml
@@ -218,7 +218,7 @@ jobs:
           use-actions-summary: true
 
       # Upload artifact
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: Test results (${{ matrix.testMode }})

--- a/.github/workflows/upload-build-epic-store.yml
+++ b/.github/workflows/upload-build-epic-store.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set platform flags
       id: platforms
@@ -112,7 +112,7 @@ jobs:
 
     - name: Cache BuildPatchTool
       id: bpt_cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ runner.temp }}\BuildPatchTool\Engine
         key: ${{ steps.bpt_version.outputs.cache_key }}

--- a/Explorer/Assets/Editor/CloudBuild.cs
+++ b/Explorer/Assets/Editor/CloudBuild.cs
@@ -25,11 +25,11 @@ namespace Editor
         {
             Debug.Log($"~~ {nameof(CloudBuild)} PreExport ~~");
 
-            PurgeBurstCache();
-
             // Get all environment variables
             var environmentVariables = Environment.GetEnvironmentVariables();
             Parameters = environmentVariables.Cast<DictionaryEntry>().ToDictionary(x => x.Key.ToString(), x => x.Value);
+
+            PurgeBurstCacheIfRequested();
 
             // E.g. access like:
             // Debug.Log(Parameters["TEST_VALUE"] as string);
@@ -82,11 +82,18 @@ namespace Editor
             Debug.Log($"~~ {nameof(CloudBuild)} PostExport ~~");
         }
 
-        // The Library cache restored by Unity Cloud Build can contain truncated Burst
-        // hash-cache files (e.g. from builds cancelled mid-cache-write), which crash the
-        // Burst AOT step with EndOfStreamException instead of being treated as a cache miss.
-        private static void PurgeBurstCache()
+        // A build cancelled mid-cache-write can leave truncated Burst hash-cache files in
+        // the restored Library cache, which crash the Burst AOT step with EndOfStreamException
+        // instead of being treated as a cache miss. build.py sets PURGE_BURST_CACHE when the
+        // previous build on the target did not complete cleanly.
+        private static void PurgeBurstCacheIfRequested()
         {
+            if (!Parameters.TryGetValue("PURGE_BURST_CACHE", out object purge) || (purge as string) != "true")
+            {
+                Debug.Log("[BURST]: purge not requested, keeping BurstCache");
+                return;
+            }
+
             string path = Path.Combine(Directory.GetCurrentDirectory(), "Library", "BurstCache");
 
             if (!Directory.Exists(path))

--- a/Explorer/Assets/Editor/CloudBuild.cs
+++ b/Explorer/Assets/Editor/CloudBuild.cs
@@ -25,6 +25,8 @@ namespace Editor
         {
             Debug.Log($"~~ {nameof(CloudBuild)} PreExport ~~");
 
+            PurgeBurstCache();
+
             // Get all environment variables
             var environmentVariables = Environment.GetEnvironmentVariables();
             Parameters = environmentVariables.Cast<DictionaryEntry>().ToDictionary(x => x.Key.ToString(), x => x.Value);
@@ -78,6 +80,30 @@ namespace Editor
         public static void PostExport()
         {
             Debug.Log($"~~ {nameof(CloudBuild)} PostExport ~~");
+        }
+
+        // The Library cache restored by Unity Cloud Build can contain truncated Burst
+        // hash-cache files (e.g. from builds cancelled mid-cache-write), which crash the
+        // Burst AOT step with EndOfStreamException instead of being treated as a cache miss.
+        private static void PurgeBurstCache()
+        {
+            string path = Path.Combine(Directory.GetCurrentDirectory(), "Library", "BurstCache");
+
+            if (!Directory.Exists(path))
+            {
+                Debug.Log("[BURST]: no BurstCache directory found, nothing to purge");
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(path, true);
+                Debug.Log("[BURST]: purged restored Library/BurstCache");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[BURST]: failed to purge BurstCache: {e.Message}");
+            }
         }
 
         private static void WriteReleaseStoreToBuildData(string installSource)

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -245,7 +245,7 @@ def run_build(branch, clean):
                 print(f'Build response (attempt {attempt + 1}):', response_json)
                 
                 if 'error' in response_json[0] and 'already a build pending' in response_json[0]['error']:
-                    print('A build is already pending. Attempting to cancel it...')
+                    print(f'A build is already pending on target "{os.getenv('TARGET')}" - cancelling it so this build can start. The run polling that build will report status "canceled".')
                     latest_build = get_latest_build(os.getenv('TARGET'))
                     if latest_build:
                         cancel_build(latest_build['build'])
@@ -782,8 +782,10 @@ download_artifact(id)
 download_log(id)
 
 if not build_healthy:
-    print(f'::error::Unity Cloud build did not succeed: target "{os.getenv('TARGET')}", build {id}. See the "Extract and display errors" step below, the unity_log artifact, or cloud.unity.com -> Build Automation.')
-    print(f'Build unhealthy - check the downloaded logs or go to https://cloud.unity.com/ and search for target "{os.getenv('TARGET')}" and build ID "{id}"')
+    if final_outcome == 'canceled':
+        print(f'::error::Unity Cloud build was cancelled: target "{os.getenv('TARGET')}", build {id}. See the warning above for the likely cause.')
+    else:
+        print(f'::error::Unity Cloud build failed: target "{os.getenv('TARGET')}", build {id}. See the "Extract and display errors" step, the unity_log artifact, or search the target at https://cloud.unity.com/')
     sys.exit(1)
 
 # Cleanup (only if build is healthy and not release)

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -57,6 +57,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--resume', help='Resume tracking a running build stored in build_info.json', action='store_true')
 parser.add_argument('--cancel', help='Cancel a running build stored in build_info.json', action='store_true')
 parser.add_argument('--delete', help='Delete build target after PR is closed or merged', action='store_true')
+parser.add_argument('--fetch-log', help='Download the Unity log of the build stored in build_info.json (e.g. after the runner was cancelled)', action='store_true')
 
 def validate_branch_name(branch_name):
     #Validates the branch name to ensure it does not contain special characters like +, ., or @."""
@@ -340,6 +341,8 @@ def poll_build(id):
             return False, status, response_json
         case 'failure' | 'canceled' | 'unknown':
             print(f'Build error! Last known status: "{status}"')
+            if status == 'canceled':
+                print('::warning::The Unity Cloud build was cancelled outside this runner - typically a newer build for the same branch evicted it from the shared target (run_build cancels pending builds), or it was cancelled manually in the dashboard.')
             build_healthy = False
             return False, status, response_json
         case _:
@@ -607,6 +610,7 @@ def run_poll_loop(id, build_already_active=False, resumed_build_elapsed=0):
     """
     phase_durations = collections.defaultdict(float)
     queue_reasons = set()
+    queue_warned = False
 
     now = time.time()
     queue_start = now
@@ -624,6 +628,10 @@ def run_poll_loop(id, build_already_active=False, resumed_build_elapsed=0):
 
         if build_start is None:
             queue_elapsed = now - queue_start
+            if not queue_warned and queue_elapsed > 1800:
+                reasons = ', '.join(sorted(queue_reasons)) or 'unknown'
+                print(f'::warning::Unity Cloud build queued for over 30 minutes (reasons seen: {reasons}). Build concurrency is likely saturated.')
+                queue_warned = True
             if queue_elapsed > QUEUE_TIMEOUT:
                 print(
                     f'Queue timeout exceeded ({datetime.timedelta(seconds=int(queue_elapsed))} '
@@ -647,7 +655,7 @@ def run_poll_loop(id, build_already_active=False, resumed_build_elapsed=0):
 
         if build_start is None and status in ACTIVE_STATUSES:
             build_start = now
-            print(f'Build picked up by builder after {datetime.timedelta(seconds=int(now - queue_start))} in queue.')
+            print(f'::notice::Build picked up by builder after {datetime.timedelta(seconds=int(now - queue_start))} in queue.')
 
         if status != last_status:
             queue_elapsed = (build_start or now) - queue_start
@@ -682,13 +690,21 @@ resumed_build_elapsed = 0
 
 if args.delete:
     delete_current_target()
-elif args.resume or args.cancel:
+elif args.resume or args.cancel or args.fetch_log:
     build_info = utils.read_build_info()
     if build_info is None:
+        if args.cancel or args.fetch_log:
+            # Runner was cancelled before a build was triggered - nothing to act on.
+            print('No persisted build info - nothing to do.')
+            sys.exit(0)
         sys.exit(1)
 
     os.environ['TARGET'] = build_info["target"]
     id = build_info["id"]
+
+    if args.fetch_log:
+        download_log(id)
+        sys.exit(0)
 
     if args.cancel:
         cancel_build(id)
@@ -766,6 +782,7 @@ download_artifact(id)
 download_log(id)
 
 if not build_healthy:
+    print(f'::error::Unity Cloud build did not succeed: target "{os.getenv('TARGET')}", build {id}. See the "Extract and display errors" step below, the unity_log artifact, or cloud.unity.com -> Build Automation.')
     print(f'Build unhealthy - check the downloaded logs or go to https://cloud.unity.com/ and search for target "{os.getenv('TARGET')}" and build ID "{id}"')
     sys.exit(1)
 

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -712,6 +712,18 @@ else:
         except Exception as e:
             print(f"Operation failed: {e}")
 
+        # A build cancelled mid-cache-write leaves truncated Burst hash-cache files in
+        # the target's Library cache, which crash the Burst AOT step on the next build.
+        # Ask PreExport to purge the Burst cache when the previous build on this target
+        # did not complete cleanly (or there is none - the cache was inherited from the
+        # template target unverified). Always set the param so a stale 'true' from an
+        # earlier run cannot stick on the target's env vars.
+        last_build = get_latest_build(os.getenv('TARGET'))
+        last_status = last_build.get('buildStatus') if last_build else None
+        purge_burst_cache = last_status is None or last_status in ('canceled', 'unknown')
+        print(f'Previous build status on target: {last_status} -> purge_burst_cache={purge_burst_cache}')
+        os.environ['PARAM_PURGE_BURST_CACHE'] = 'true' if purge_burst_cache else 'false'
+
         # Set parameters immediately before run_build to avoid races with concurrent
         # builds on shared targets.
         set_parameters(get_param_env_variables())


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Windows builds have been failing on and off (half of the runs on Jun 10) with a Burst error:

```
Error: Failed to find entry-points:
System.IO.EndOfStreamException: Unable to read beyond the end of the stream.
```

Root cause: when a build gets cancelled while it's uploading its Library cache, the Burst hash-cache files end up truncated, and every following build on that target trips over them. New PR targets can inherit the broken cache too, since it's cloned from the template target. A clean build fixes it, but only for that one target, and it gets poisoned again on the next cancellation. It's not a code issue — the same commit built fine and failed 24s apart on two runs.

The fix: before triggering a build, `build.py` checks the previous build's status on the target. If it was `canceled`/`unknown` (or the target is brand new), it tells `PreExport` to delete `Library/BurstCache` so Burst regenerates it. Healthy targets keep their warm cache (Burst AOT is ~4.5 min warm).

While I was in here I also cleaned up around the workflow:

- moved the remaining third-party actions to node24 and pinned all external actions to commit SHAs (replaces #8982)
- build failures are readable now: the actual Unity error shows up as an annotation and in the step summary instead of being buried in a 20k-line log, which is only dumped on failure
- cancelled runners still fetch and upload the partial Unity log
- queue visibility: a notice when the build gets picked up, a warning if it sits queued for >30 min, and Unity-side cancellations now say that another build probably evicted them
- Build Gate says when a red is just "superseded by a newer run" vs a real failure
- skip statuses state the real reason (draft PR vs no Explorer/ changes)
- removing the force-build/clean-build label no longer cancels a build that's already running
- removed a leftover `# Test change` comment

## Test Instructions

**Steps (standard run)**: N/A — CI/build infrastructure only.

**Expected result**: N/A

**Steps (fresh account)**: N/A

**Expected result**: N/A

**Automation** (if applicable): N/A

### Prerequisites
- [ ] `force-build` label on this PR (it's a draft)

### Test Steps
1. Cancel a build on this PR mid-flight, then re-trigger.
2. The next build's logs should show `purge_burst_cache=True` (Prebuild) and `[BURST]: purged restored Library/BurstCache` (Unity log).
3. A build after a green one should show `purge_burst_cache=False` and keep the cache, with bcl.exe time around the usual ~274s.
4. No more node20 deprecation warnings in run annotations (except game-ci/unity-test-runner and sslcom/esigner-codesign — no node24 release upstream yet).

### Additional Testing Notes
- Comparing `bcl.exe exited after N ms` between purged and non-purged builds tells us the real cost of a cold Burst cache.
- Corruption that happens without a cancellation (e.g. infra crash during cache upload) won't trigger the purge — the clean-build label is still the escape hatch for that.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included