### PR TITLE
fix: evaluate home position at ctx-menu open + SDK6 teleport fix

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/IScenesCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/IScenesCache.cs
@@ -27,6 +27,8 @@ namespace ECS.SceneLifeCycle
 
         bool Contains(Vector2Int parcel);
 
+        bool ContainsNonRealScene(Vector2Int parcel);
+
         bool TryGetByParcel(Vector2Int parcel, out ISceneFacade sceneFacade);
 
         bool TryGetBySceneId(string sceneId, out ISceneFacade? sceneFacade);
@@ -100,6 +102,9 @@ namespace ECS.SceneLifeCycle
 
         public bool Contains(Vector2Int parcel) =>
             scenesByParcels.ContainsKey(parcel) || nonRealSceneByParcel.Contains(parcel);
+
+        public bool ContainsNonRealScene(Vector2Int parcel) =>
+            nonRealSceneByParcel.Contains(parcel);
 
         public bool TryGetByParcel(Vector2Int parcel, out ISceneFacade sceneFacade) =>
             scenesByParcels.TryGetValue(parcel, out sceneFacade);

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Reporting/SceneReadinessReportQueue.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Reporting/SceneReadinessReportQueue.cs
@@ -21,10 +21,13 @@ namespace ECS.SceneLifeCycle.Reporting
 
         public void Enqueue(Vector2Int parcel, AsyncLoadProcessReport report)
         {
-            // Shortcut
-            if (scenesCache.TryGetByParcel(parcel, out ISceneFacade scene)
-                && scene.SceneStateProvider.State == SceneState.Running)
-                // conclude immediately
+            // Shortcut: conclude immediately if the destination is already loaded. Non-real scenes
+            // (SDK6 LODs, roads) resolve reports only once, when they finish instantiating, so a report
+            // enqueued while they are already shown would never be dequeued and the loading screen
+            // would hang at 20%.
+            if ((scenesCache.TryGetByParcel(parcel, out ISceneFacade scene)
+                 && scene.SceneStateProvider.State == SceneState.Running)
+                || scenesCache.ContainsNonRealScene(parcel))
                 report.SetProgress(1f);
 
             if (!queue.TryGetValue(parcel, out PooledLoadReportList queuedReport))

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/SceneReadinessReportQueueShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/SceneReadinessReportQueueShould.cs
@@ -1,0 +1,75 @@
+using Cysharp.Threading.Tasks;
+using DCL.Utilities;
+using ECS.SceneLifeCycle.Reporting;
+using NSubstitute;
+using NUnit.Framework;
+using SceneRunner.Scene;
+using System.Threading;
+using UnityEngine;
+using Utility.Multithreading;
+
+namespace ECS.SceneLifeCycle.Tests
+{
+    [TestFixture]
+    public class SceneReadinessReportQueueShould
+    {
+        private static readonly Vector2Int PARCEL = new (100, 100);
+
+        private IScenesCache scenesCache;
+        private SceneReadinessReportQueue queue;
+
+        [SetUp]
+        public void SetUp()
+        {
+            scenesCache = Substitute.For<IScenesCache>();
+            queue = new SceneReadinessReportQueue(scenesCache);
+        }
+
+        [Test]
+        public void KeepReportPendingWhenSceneIsNotLoaded()
+        {
+            var report = AsyncLoadProcessReport.Create(CancellationToken.None);
+
+            queue.Enqueue(PARCEL, report);
+
+            Assert.That(report.GetStatus().TaskStatus, Is.EqualTo(UniTaskStatus.Pending));
+            Assert.That(queue.TryDequeue(PARCEL, out _), Is.True);
+        }
+
+        [Test]
+        public void ConcludeReportImmediatelyWhenSceneIsRunning()
+        {
+            var scene = Substitute.For<ISceneFacade>();
+            var stateProvider = Substitute.For<ISceneStateProvider>();
+            stateProvider.State = new Atomic<SceneState>(SceneState.Running);
+            scene.SceneStateProvider.Returns(stateProvider);
+
+            scenesCache.TryGetByParcel(PARCEL, out Arg.Any<ISceneFacade>())
+                       .Returns(x =>
+                        {
+                            x[1] = scene;
+                            return true;
+                        });
+
+            var report = AsyncLoadProcessReport.Create(CancellationToken.None);
+
+            queue.Enqueue(PARCEL, report);
+
+            Assert.That(report.GetStatus().TaskStatus, Is.EqualTo(UniTaskStatus.Succeeded));
+        }
+
+        [Test]
+        public void ConcludeReportImmediatelyWhenNonRealSceneIsAlreadyLoaded()
+        {
+            // Re-teleporting to an SDK6 (LOD-only) or road scene that is still instantiated:
+            // no system would dequeue the report, so it must conclude at enqueue time.
+            scenesCache.ContainsNonRealScene(PARCEL).Returns(true);
+
+            var report = AsyncLoadProcessReport.Create(CancellationToken.None);
+
+            queue.Enqueue(PARCEL, report);
+
+            Assert.That(report.GetStatus().TaskStatus, Is.EqualTo(UniTaskStatus.Succeeded));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/SceneReadinessReportQueueShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/SceneReadinessReportQueueShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6cfd1198db3864ece8e0d5e1b3a68958

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -230,7 +230,6 @@ namespace DCL.Minimap
                          .AddControl(new ButtonContextMenuControlSettings(minimapContextMenuSettings.ReloadSceneText, minimapContextMenuSettings.ReloadSceneSprite, ReloadScene));
 
             EvaluateDonateToCreatorButton(donationsService.DonationsEnabledCurrentScene.Value);
-            SetInitialHomeToggleValue();
             viewInstance.contextMenuButton.onClick.AddListener(ShowContextMenu);
 
             if (includeBannedUsersFromScene)
@@ -265,6 +264,7 @@ namespace DCL.Minimap
 
         private void ShowContextMenu()
         {
+            SetInitialHomeToggleValue();
             mvcManager.ShowAsync(GenericContextMenuController.IssueCommand(
                            new GenericContextMenuParameter(contextMenu!, viewInstance!.contextMenuButton.transform.position)))
                       .Forget();


### PR DESCRIPTION
# Pull Request Description
Fixes #8618

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes sure the toggle initial state is evaluated right before the context menu opened in order to reflect the actual current state.

Before it was set only `OnViewInstantiated` so it reflected the very initial state only.

In this PR it is also addressed a problem with teleporting to SDK6 scenes multiple times: scene-readiness report for SDK6 destinations is only resolved once (at the moment its LOD/mock representation finishes instantiating). On a second visit nothing ever dequeues the report, so the loading screen waits forever.
The fix is achieved by extending the existing "already loaded" shortcut in `SceneReadinessReportQueue.Enqueue` (it already did this for running real scenes) to also conclude immediately when the parcel is covered by an already-loaded non-real scene.

### Test Steps
1. Use repro steps in the linked issue

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
