### PR TITLE
fix: community's chat thumbnail size

### DIFF
--- a/Explorer/Assets/DCL/Chat/Assets/ConversationToolbar/ChatConversationsToolbarViewItem_Community.prefab
+++ b/Explorer/Assets/DCL/Chat/Assets/ConversationToolbar/ChatConversationsToolbarViewItem_Community.prefab
@@ -489,6 +489,22 @@ PrefabInstance:
       propertyPath: m_PixelsPerUnitMultiplier
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 5714849469400794328, guid: 9c539eb546569c843a1d69f353b89bee, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5714849469400794328, guid: 9c539eb546569c843a1d69f353b89bee, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5714849469400794328, guid: 9c539eb546569c843a1d69f353b89bee, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5714849469400794328, guid: 9c539eb546569c843a1d69f353b89bee, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5752101683759274867, guid: 9c539eb546569c843a1d69f353b89bee, type: 3}
       propertyPath: aspectRatioFitter
       value: 
@@ -503,6 +519,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7352371846437751057, guid: 9c539eb546569c843a1d69f353b89bee, type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7352371846437751057, guid: 9c539eb546569c843a1d69f353b89bee, type: 3}
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7465909787489353167, guid: 9c539eb546569c843a1d69f353b89bee, type: 3}


### PR DESCRIPTION
## What does this PR change?
Fixes the size of the community chat thumbnail size, in the chat toolbar, which in dev looks massive.

### Test Steps
1. Launch the client.
2. Open the chat and visualise that, in the conversation tool bar, communities thumbnail look harmonic compared to users snapshot thumbnails. Validate it with the example shared bellow under the title `after`.
<img width="979" height="858" alt="Screenshot 2026-06-12 at 15 01 06" src="https://github.com/user-attachments/assets/e80c9528-db07-4ecd-afca-5154d0c5a07b" />