### PR TITLE
fix: open community card on invite notification

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
@@ -174,6 +174,7 @@ namespace DCL.Communities.CommunitiesCard
             NotificationsBusController.Instance.SubscribeToNotificationTypeClick(NotificationType.COMMUNITY_POST_ADDED, OnOpenCommunityCardFromNotification);
             NotificationsBusController.Instance.SubscribeToNotificationTypeClick(NotificationType.COMMUNITY_OWNERSHIP_TRANSFERRED, OnOpenCommunityCardFromNotification);
             NotificationsBusController.Instance.SubscribeToNotificationTypeClick(NotificationType.COMMUNITY_DEEP_LINK, OnOpenCommunityCardFromNotification);
+            NotificationsBusController.Instance.SubscribeToNotificationTypeClick(NotificationType.COMMUNITY_INVITE_RECEIVED, OnOpenCommunityCardFromNotification);
             NotificationsBusController.Instance.SubscribeToNotificationTypeReceived(NotificationType.COMMUNITY_REQUEST_TO_JOIN_ACCEPTED, OnJoinRequestAccepted);
             NotificationsBusController.Instance.SubscribeToNotificationTypeReceived(NotificationType.COMMUNITY_DELETED_CONTENT_VIOLATION, OnCommunityDeleted);
             NotificationsBusController.Instance.SubscribeToNotificationTypeReceived(NotificationType.COMMUNITY_DELETED, OnCommunityDeleted);
@@ -235,6 +236,7 @@ namespace DCL.Communities.CommunitiesCard
                                      CommunityPostAddedNotification postAddedNotification => postAddedNotification.Metadata.CommunityId,
                                      CommunityOwnershipTransferredNotification ownershipTransferredNotification => ownershipTransferredNotification.Metadata.CommunityId,
                                      CommunityDeepLinkNotification deepLinkNotification => deepLinkNotification.CommunityId,
+                                     CommunityUserInvitedNotification inviteReceivedNotification => inviteReceivedNotification.Metadata.CommunityId,
                                      _ => string.Empty,
                                  };
 

--- a/Explorer/Assets/DCL/ExplorePanel/ExplorePanelController.cs
+++ b/Explorer/Assets/DCL/ExplorePanel/ExplorePanelController.cs
@@ -108,7 +108,6 @@ namespace DCL.ExplorePanel
             PlacesController = placesController;
 
             NotificationsBusController.Instance.SubscribeToNotificationTypeClick(NotificationType.REWARD_ASSIGNMENT, p => OnShowSectionFromNotificationAsync(p, ExploreSections.Backpack).Forget());
-            NotificationsBusController.Instance.SubscribeToNotificationTypeClick(NotificationType.COMMUNITY_INVITE_RECEIVED, p => OnShowSectionFromNotificationAsync(p, ExploreSections.Communities).Forget());
 
             EventsController = eventsController;
         }


### PR DESCRIPTION
# Pull Request Description
Fixes #8436

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR removes the wrong bus subscription and replaces it with the correct one in order to open the community card instead of the explore panel's community tab.

### Test Steps
1. Follow repro steps in the linked issue


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
