### PR TITLE
chore: bump third-party actions to node24 runtime

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -25,13 +25,13 @@ jobs:
     if: needs.detect-pr-type.outputs.is-feature == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.0
+      - uses: kentaro-m/auto-assign-action@v2.0.2
         with:
           configuration-path: '.github/auto_assign_config_dev.yml'
 
   assign-qa:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.0
+      - uses: kentaro-m/auto-assign-action@v2.0.2
         with:
           configuration-path: '.github/auto_assign_config_qa.yml'

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Check PR type
         id: check
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const title = context.payload.pull_request.title || '';
@@ -25,13 +25,13 @@ jobs:
     if: needs.detect-pr-type.outputs.is-feature == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.2
+      - uses: kentaro-m/auto-assign-action@0a2c53d3721e4c5cfcce6afd4014aecc337979f6 # v2.0.2
         with:
           configuration-path: '.github/auto_assign_config_dev.yml'
 
   assign-qa:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.2
+      - uses: kentaro-m/auto-assign-action@0a2c53d3721e4c5cfcce6afd4014aecc337979f6 # v2.0.2
         with:
           configuration-path: '.github/auto_assign_config_qa.yml'

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -17,12 +17,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
       - name: AI label analysis
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           allowed_bots: "sentry"
           prompt: |

--- a/.github/workflows/auto-sync-main-to-dev.yml
+++ b/.github/workflows/auto-sync-main-to-dev.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Create or update branch
         run: |

--- a/.github/workflows/build-game-ci-image.yml
+++ b/.github/workflows/build-game-ci-image.yml
@@ -51,7 +51,7 @@ jobs:
         run: git clone https://github.com/game-ci/docker.git
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-game-ci-image.yml
+++ b/.github/workflows/build-game-ci-image.yml
@@ -45,13 +45,13 @@ jobs:
     runs-on: Ubuntu-Big
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Clone game-ci/docker
         run: git clone https://github.com/game-ci/docker.git
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-profile-nightly.yml
+++ b/.github/workflows/build-profile-nightly.yml
@@ -12,7 +12,7 @@ jobs:
       should_build: ${{ steps.check.outputs.should_build }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: dev
@@ -59,7 +59,7 @@ jobs:
       tag_version: ${{ steps.get_version.outputs.tag_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: dev

--- a/.github/workflows/build-release-main-page.yml
+++ b/.github/workflows/build-release-main-page.yml
@@ -20,7 +20,7 @@ jobs:
       tag_version: ${{ steps.get_version.outputs.next_tag_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: 'main'
@@ -37,7 +37,7 @@ jobs:
     needs: get-info
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: 'main'
@@ -53,7 +53,7 @@ jobs:
           fi
 
       - name: Download artifacts
-        uses: dawidd6/action-download-artifact@v21
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: Decentraland_.*
@@ -61,7 +61,7 @@ jobs:
           skip_unpack: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
           draft: true # Swap to auto-release!

--- a/.github/workflows/build-release-main-page.yml
+++ b/.github/workflows/build-release-main-page.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
       - name: Download artifacts
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v21
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: Decentraland_.*
@@ -61,7 +61,7 @@ jobs:
           skip_unpack: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           draft: true # Swap to auto-release!

--- a/.github/workflows/build-release-main.yml
+++ b/.github/workflows/build-release-main.yml
@@ -16,7 +16,7 @@ jobs:
       tag_version: ${{ steps.get_version.outputs.next_tag_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -987,4 +987,3 @@ jobs:
           fi
 
           echo "Both Windows and macOS builds passed."
-# Test change

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -254,7 +254,7 @@ jobs:
 
       - name: Detect changes under Explorer/**
         id: changed_explorer
-        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
+        uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad # v47.0.5
         with:
           files: |
             Explorer/**
@@ -554,7 +554,7 @@ jobs:
           pip install -r scripts/cloudbuild/requirements.txt
 
       - name: Execute Unity Cloud build
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           # Wraps QUEUE_TIMEOUT (240m) + BUILD_TIMEOUT (180m) + buffer.
           timeout_minutes: 450

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -248,7 +248,7 @@ jobs:
       targets: ${{ steps.get_targets.outputs.targets }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -312,7 +312,7 @@ jobs:
 
       - name: Skip build and test checks
         if: steps.decide.outputs.should_build == 'false' && github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const sha = context.payload.pull_request.head.sha;
@@ -538,13 +538,13 @@ jobs:
         target: ${{ fromJSON(needs.prebuild.outputs.targets) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12.3
 
@@ -554,7 +554,7 @@ jobs:
           pip install -r scripts/cloudbuild/requirements.txt
 
       - name: Execute Unity Cloud build
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           # Wraps QUEUE_TIMEOUT (240m) + BUILD_TIMEOUT (180m) + buffer.
           timeout_minutes: 450
@@ -654,7 +654,7 @@ jobs:
       - name: Upload artifact for macOS
         id: upload-macos-artifact
         if: matrix.target == 'macos'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ env.artifact_name }}
           path: build.tar
@@ -663,7 +663,7 @@ jobs:
       - name: Upload artifact for Windows
         id: upload-windows-artifact
         if: matrix.target == 'windows64'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ env.artifact_name }}
           path: |
@@ -824,7 +824,7 @@ jobs:
 
       - name: Upload size report
         if: always() && steps.size_check.outputs.result != ''
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: size_report_${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}
           path: size_report/
@@ -878,7 +878,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload debug symbols
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ env.artifact_name }}_debug_symbols
           path: |
@@ -902,7 +902,7 @@ jobs:
       # Will run always (even if failing)
       - name: Upload cloud logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}_unity_log
           path: unity_cloud_log.log
@@ -925,7 +925,7 @@ jobs:
           ./scripts/Generate-ShaderReport.ps1 -InputLog "unity_cloud_log.log" -OutputReport "shader_compilation_report.log"
 
       - name: Upload Shader Compilation Report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}_shader_compilation_report
           path: shader_compilation_report.log

--- a/.github/workflows/claude-pr-review-require.yml
+++ b/.github/workflows/claude-pr-review-require.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check PR type
         id: check-type
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const title = context.payload.pull_request.title || '';
@@ -21,7 +21,7 @@ jobs:
 
       - name: Set pending status for feature PRs
         if: steps.check-type.outputs.is-auto-review == 'false'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.repos.createCommitStatus({

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Check PR type
         id: check-type
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const title = context.payload.pull_request.title || '';
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set status to pending
         if: steps.check-type.outputs.is-auto-review == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -70,7 +70,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-type.outputs.is-auto-review == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
@@ -94,7 +94,7 @@ jobs:
       - name: Claude Review
         if: steps.check-type.outputs.is-auto-review == 'true'
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -112,7 +112,7 @@ jobs:
             
       - name: Upload Claude execution output
         if: steps.check-type.outputs.is-auto-review == 'true' && always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: claude-execution-output-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
           path: /home/runner/work/_temp/claude-execution-output.json
@@ -121,7 +121,7 @@ jobs:
 
       - name: Set status and approve if eligible
         if: steps.check-type.outputs.is-auto-review == 'true' && always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const prNumber = ${{ github.event.pull_request.number }};
@@ -328,7 +328,7 @@ jobs:
     steps:
       - name: Resolve PR head (rejects post-comment pushes)
         id: pr
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -357,7 +357,7 @@ jobs:
             core.setOutput('is_draft', pr.data.draft);
 
       - name: Set status to pending
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -370,7 +370,7 @@ jobs:
             });
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ steps.pr.outputs.sha }}
           fetch-depth: 1
@@ -392,7 +392,7 @@ jobs:
 
       - name: Claude Review
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -412,7 +412,7 @@ jobs:
 
       - name: Upload Claude execution output
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: claude-execution-output-${{ github.event.issue.number }}-${{ github.run_attempt }}
           path: /home/runner/work/_temp/claude-execution-output.json
@@ -421,7 +421,7 @@ jobs:
 
       - name: Set final commit status
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 30

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -9,7 +9,7 @@ jobs:
     
     steps:
       - name: Check out the code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: dev
           

--- a/.github/workflows/dependency-security-review.yml
+++ b/.github/workflows/dependency-security-review.yml
@@ -32,7 +32,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -99,7 +99,7 @@ jobs:
 
       - name: Add label
         if: steps.detect.outputs.has-changes == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.issues.addLabels({
@@ -111,7 +111,7 @@ jobs:
 
       - name: Set status to pending
         if: steps.detect.outputs.has-changes == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -142,7 +142,7 @@ jobs:
       - name: Claude Dependency Review
         if: steps.detect.outputs.has-changes == 'true'
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -165,7 +165,7 @@ jobs:
 
       - name: Set final status
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const hasChanges = '${{ steps.detect.outputs.has-changes }}' === 'true';

--- a/.github/workflows/issue-deduplication.yml
+++ b/.github/workflows/issue-deduplication.yml
@@ -17,11 +17,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
       - name: Check for duplicate issues
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0cb4f3e5e764d2e00407d29b6bf0aa9df0976d88 # v1.0.146
         with:
           allowed_bots: "sentry"
           prompt: |

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12.3
 

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -65,14 +65,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
 
       - name: Post skipped comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -195,7 +195,7 @@ jobs:
           fi
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
@@ -209,7 +209,7 @@ jobs:
           MAC_ARTIFACT_URL: "${{ github.server_url }}/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.MAC_ARTIFACT_ID }}"
           MAC_ARTIFACT_S3_URL: "${{ format('{0}/{1}/Decentraland_macos.zip', vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL, env.ARTIFACT_S3_DESTINATION_PATH) }}"
           HEAD_SHA: "${{ env.HEAD_SHA }}"
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -260,14 +260,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -65,14 +65,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
 
       - name: Post skipped comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -195,7 +195,7 @@ jobs:
           fi
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
@@ -209,7 +209,7 @@ jobs:
           MAC_ARTIFACT_URL: "${{ github.server_url }}/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.MAC_ARTIFACT_ID }}"
           MAC_ARTIFACT_S3_URL: "${{ format('{0}/{1}/Decentraland_macos.zip', vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL, env.ARTIFACT_S3_DESTINATION_PATH) }}"
           HEAD_SHA: "${{ env.HEAD_SHA }}"
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -239,7 +239,7 @@ jobs:
         run: gh release view -R $GITHUB_REPOSITORY --json tagName --template "RELEASE_TAG={{.tagName}}" >> $GITHUB_ENV
 
       - name: Trigger performance test
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           repository: decentraland/performance-testing
           event-type: unity-explorer
@@ -260,14 +260,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/pr-comment-delete-artifact-url.yml
+++ b/.github/workflows/pr-comment-delete-artifact-url.yml
@@ -31,13 +31,13 @@ jobs:
           echo "Pull request Number: $PR_NUMBER"
           echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         id: find-comment
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-author: 'github-actions[bot]'
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/pr-comment-delete-artifact-url.yml
+++ b/.github/workflows/pr-comment-delete-artifact-url.yml
@@ -31,13 +31,13 @@ jobs:
           echo "Pull request Number: $PR_NUMBER"
           echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-author: 'github-actions[bot]'
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -46,7 +46,7 @@ jobs:
           df -h /mnt /mnt/docker
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           lfs: true
@@ -56,7 +56,7 @@ jobs:
         run: git lfs ls-files -l | awk '{print $1}' | sort > .lfs-assets-id
 
       - name: Restore LFS cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: lfs-cache
         with:
           path: .git/lfs
@@ -68,7 +68,7 @@ jobs:
           git add .
           git reset --hard
 
-      - uses: webfactory/ssh-agent@v0.10.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -79,7 +79,7 @@ jobs:
           chmod 600 /home/runner/.ssh/known_hosts
 
       - name: Restore Library cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: Explorer/Library
           key: Library-Explorer-Ubuntu
@@ -122,7 +122,7 @@ jobs:
 
       # --- Log into GHCR ---
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -148,7 +148,7 @@ jobs:
           echo "Seeded GHCR: $ghcr"
 
       # Configure test runner for Performance tests only
-      - uses: game-ci/unity-test-runner@v4.3.1
+      - uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4.3.1
         id: testRunner
         timeout-minutes: 180
         continue-on-error: true
@@ -165,7 +165,7 @@ jobs:
       # Generate PDF report
       - name: Set up Python
         if: always()
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
@@ -181,7 +181,7 @@ jobs:
 
       # Upload performance test results JSON
       - name: Upload performance test results (JSON)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: Performance test results (JSON)
@@ -190,7 +190,7 @@ jobs:
 
       # Upload performance report PDF
       - name: Upload performance report (PDF)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: Performance benchmark report (PDF)

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -68,7 +68,7 @@ jobs:
           git add .
           git reset --hard
 
-      - uses: webfactory/ssh-agent@v0.8.0
+      - uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -122,7 +122,7 @@ jobs:
 
       # --- Log into GHCR ---
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
           git add .
           git reset --hard
           
-      - uses: webfactory/ssh-agent@v0.8.0
+      - uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           
@@ -150,7 +150,7 @@ jobs:
 
       # --- Log into GHCR ---
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -208,7 +208,7 @@ jobs:
 
       - name: Report test results
         if: always()
-        uses: dorny/test-reporter@v2.1.1
+        uses: dorny/test-reporter@v3.0.0
         with:
           name: Unity Tests (${{ matrix.testMode }})
           path: ${{ steps.testRunner.outputs.artifactsPath }}/*.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           df -h
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           lfs: true
@@ -81,7 +81,7 @@ jobs:
         run: git lfs ls-files -l | awk '{print $1}' | sort > .lfs-assets-id
 
       - name: Restore LFS cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: lfs-cache
         with:
           path: .git/lfs
@@ -93,7 +93,7 @@ jobs:
           git add .
           git reset --hard
           
-      - uses: webfactory/ssh-agent@v0.10.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           
@@ -106,7 +106,7 @@ jobs:
           chmod 600 ~/.ssh/known_hosts
 
       - name: Restore Library cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: Explorer/Library
           key: Library-Explorer-Ubuntu-${{ hashFiles('Explorer/Packages/packages-lock.json', 'Explorer/ProjectSettings/ProjectVersion.txt') }}
@@ -150,7 +150,7 @@ jobs:
 
       # --- Log into GHCR ---
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -192,7 +192,7 @@ jobs:
           echo "Built derived image with ripgrep: $derived"
 
       # Configure test runner
-      - uses: game-ci/unity-test-runner@v4.3.1
+      - uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4.3.1
         id: testRunner
         timeout-minutes: 80
         continue-on-error: true
@@ -208,7 +208,7 @@ jobs:
 
       - name: Report test results
         if: always()
-        uses: dorny/test-reporter@v3.0.0
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: Unity Tests (${{ matrix.testMode }})
           path: ${{ steps.testRunner.outputs.artifactsPath }}/*.xml
@@ -218,7 +218,7 @@ jobs:
           use-actions-summary: true
 
       # Upload artifact
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: Test results (${{ matrix.testMode }})

--- a/.github/workflows/upload-build-epic-store.yml
+++ b/.github/workflows/upload-build-epic-store.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set platform flags
       id: platforms
@@ -112,7 +112,7 @@ jobs:
 
     - name: Cache BuildPatchTool
       id: bpt_cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ runner.temp }}\BuildPatchTool\Engine
         key: ${{ steps.bpt_version.outputs.cache_key }}


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Follow-up to #8877 (which covered GitHub-maintained actions). Two commits:

**1. Bump third-party actions to node24** — CI runs still emit "Node.js 20 actions are deprecated" warnings from third-party actions. Verified by reading `runs.using` from each pinned tag's `action.yml`; release notes checked for breaking changes (none; all majors are pure runtime/dependency bumps):

| Action | From | To |
|---|---|---|
| nick-fields/retry | v3 (node20) | v4 |
| peter-evans/find-comment | v2 (node16) | v4 |
| peter-evans/create-or-update-comment | v3 (node16) | v5 |
| docker/login-action | v3 (node20) | v4 |
| webfactory/ssh-agent | v0.8.0 (node16) | v0.10.0 |
| kentaro-m/auto-assign-action | v2.0.0 (node20) | v2.0.2 |
| softprops/action-gh-release | v2 (node20) | v3 |
| dorny/test-reporter | v2.1.1 (node20) | v3.0.0 |
| dawidd6/action-download-artifact | v6 (node20) | v21 |
| step-security/changed-files | sha-pinned v45.0.1 (node20) | sha-pinned v47.0.5 |

Not bumped (no node24 release upstream yet): `game-ci/unity-test-runner@v4.3.1`, `sslcom/esigner-codesign` (sha-pinned v1.3.1).

**2. Pin all external actions to commit SHAs** — mutable version tags are a supply-chain risk (see the March 2025 tj-actions/changed-files tag-rewrite attack, which is why this repo already uses the sha-pinned step-security fork). Every external action — GitHub-maintained and third-party — is now pinned to the commit SHA of its release, with a `# vX.Y.Z` comment for readability. Internal `decentraland/*` reusable workflows keep ref pins (same trust domain). Each SHA was resolved from the release tag via the GitHub API (annotated tags dereferenced to commits).

## Test Instructions

**Steps (standard run)**: N/A — CI configuration only.

**Expected result**: N/A

**Steps (fresh account)**: N/A

**Expected result**: N/A

**Automation** (if applicable): N/A

### Prerequisites
- [ ] None

### Test Steps
1. Let this PR's CI run (tests, build, auto-assign).
2. Check run annotations — no "Node.js 20 actions are deprecated" warnings should remain except the two listed upstream stragglers.
3. Verify the badge comment posts and tests report correctly (find-comment / create-or-update-comment / test-reporter majors in action).

### Additional Testing Notes
- Without a Dependabot config for the `github-actions` ecosystem, SHA pins won't get automated updates — deliberately left out of this PR.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included