### PR TITLE
chore: missing preflight check on build-protocol command + docs update

### DIFF
--- a/.claude/agents/dcl-sdk-feature-implementation/dcl-explorer-specialist.md
+++ b/.claude/agents/dcl-sdk-feature-implementation/dcl-explorer-specialist.md
@@ -46,6 +46,8 @@ After installing a new protocol package, always re-run `npm run build-protocol` 
 
 ## Protocol Generation
 
+> **Prerequisite:** `build-protocol` runs a Python `protoc` plugin (`protoc-gen-bitwise`, for the quantized/bit-packed Pulse network state) in addition to the Node toolchain. **Python 3** must be on `PATH` with the **`protobuf`** package installed (`python3 -m pip install protobuf`), otherwise generation fails with `ModuleNotFoundError: No module named 'google'`.
+
 To generate C# code from protocol definitions:
 ```bash
 cd scripts

--- a/.claude/skills/sdk-component-implementation/SKILL.md
+++ b/.claude/skills/sdk-component-implementation/SKILL.md
@@ -30,6 +30,7 @@ In `js-sdk-toolchain`, generate serialization code and optional helper functions
 
 In `unity-explorer`:
 1. Run protocol update: `npm install @dcl/protocol@experimental && npm run build-protocol`
+   - Requires **Python 3** on `PATH` with the **`protobuf`** package (`python3 -m pip install protobuf`) — `build-protocol` runs a Python `protoc` plugin (`protoc-gen-bitwise`); without it the build fails with `ModuleNotFoundError: No module named 'google'`.
 2. Add partial class to `IDirtyMarker.cs`
 3. Register in `ComponentsContainer.cs` using `SDKComponentBuilder<T>`
 4. Create feature folder under `Explorer/Assets/DCL/SDKComponents/<Feature>/`

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -533,6 +533,11 @@ For guidance on detached flows, cancellation, `SuppressToResultAsync`, and the e
 
 ## How to update protocol
 
+> **Prerequisites:** Besides Node/npm, the protocol build runs a Python `protoc` plugin (`protoc-gen-bitwise`, used for the quantized/bit-packed Pulse network state). You need **Python 3** on your `PATH` with the **`protobuf`** package installed, otherwise `build-protocol` fails with `ModuleNotFoundError: No module named 'google'`:
+> ```bash
+> python3 -m pip install protobuf
+> ```
+
 To update the protocol to the last version of the protocol, open a terminal like CMD and navigate to your working copy of the repository, there you will see a folder named 'scripts'; execute the following commands:
 
 **[RECOMMENDED]** For using the protocol [experimental branch](https://github.com/decentraland/protocol/tree/experimental) package (the experimental features depend on this otherwise Unity project won't compile due to missing protobuf message for the experimental components):

--- a/docs/how-to-implement-new-sdk-components.md
+++ b/docs/how-to-implement-new-sdk-components.md
@@ -114,6 +114,8 @@ npm install
 npm run build-protocol
 ```
 
+> **Prerequisite:** Besides Node/npm, `build-protocol` runs a Python `protoc` plugin (`protoc-gen-bitwise`, for the quantized/bit-packed Pulse network state). You need **Python 3** on your `PATH` with the **`protobuf`** package installed, otherwise the build fails with `ModuleNotFoundError: No module named 'google'`. Install it once with `python3 -m pip install protobuf`.
+
 To upgrade to the latest version of the `@dcl/protocol`, we should update using:
 
 ```bash

--- a/scripts/src/build-protocol.ts
+++ b/scripts/src/build-protocol.ts
@@ -34,6 +34,28 @@ const quantizeRuntimeSrc = normalizePath(
   path.resolve(bitwisePluginDir, 'runtime', 'cs', 'Quantize.cs'),
 )
 
+// Python interpreter the bitwise wrapper delegates to (must match createPluginWrapper).
+const pythonCommand = isWin ? 'py' : 'python3'
+
+/**
+ * Verifies the Python interpreter used by the protoc-gen-bitwise plugin is present
+ * and has the `protobuf` package, so the build fails here with an actionable message
+ * instead of an opaque protoc plugin stack trace mid-generation.
+ */
+async function checkPythonProtobuf() {
+  try {
+    await execAsync(
+      `${pythonCommand} -c "import google.protobuf.compiler.plugin_pb2"`,
+      { cwd: workingDirectory },
+    )
+  } catch {
+    throw new Error(
+      `The protoc-gen-bitwise plugin requires Python 3 with the 'protobuf' package, but '${pythonCommand}' could not import it.\n` +
+        `Install it with: ${pythonCommand} -m pip install protobuf`,
+    )
+  }
+}
+
 /**
  * Creates a platform-specific wrapper script that protoc can invoke as
  * --plugin=protoc-gen-bitwise=<path>.  The wrapper delegates to the Python
@@ -82,6 +104,8 @@ async function main() {
   })
 
   await execute(`${protocPath} --version`, workingDirectory)
+
+  await checkPythonProtobuf()
 
   await buildProtocol()
 


### PR DESCRIPTION
### WHY

Pulse implementation [commit](https://github.com/decentraland/unity-explorer/commit/68eb470ba9fe3eeed00060b02fd6f32e1efcbe2a) adds a python script that depends on an external installation that wasn't needed before.

Now anyone running `npm run build-protocol` inside `/scripts` will face the `ModuleNotFoundError:` error.

### WHAT

* Added preflight check with descriptive error in console when the problem happens
* Updated documentation in several places mentioning that the new dependency is needed