### PR TITLE
fix: increase height of nametag when gliding

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/AvatarBase.prefab
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Assets/AvatarBase.prefab
@@ -3993,6 +3993,7 @@ MonoBehaviour:
   nametagMaxOffset: 2
   nametagBoundedOffset: 1
   nametagBuffer: 0.025
+  nametagGlideOffset: 0.8
   headAramatureBone: {fileID: 4808891874506309325}
   potentialHighestBones:
   - {fileID: 4332106098282305372}

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/DCL.AvatarRendering.asmdef
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/DCL.AvatarRendering.asmdef
@@ -26,7 +26,8 @@
         "GUID:75469ad4d38634e559750d17036d5f7c",
         "GUID:a42927d1d4a3b4cda9b076a7adecb9cc",
         "GUID:2f30d6e5229a74284acedda491abcc6e",
-        "GUID:029c1c1b674aaae47a6841a0b89ad80e"
+        "GUID:029c1c1b674aaae47a6841a0b89ad80e",
+        "GUID:d832748739a186646b8656bdbd447ad0"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
@@ -130,7 +130,7 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         [SerializeField] [Tooltip("Small buffer to have some air/space between nametag and head, [m]")]
         private float nametagBuffer = 0.025f;
         [SerializeField] [Tooltip("Extra height added to the nametag while the glider is deployed, to avoid clipping the glider model, [m]")]
-        private float nametagGlideOffset = 0.4f;
+        private float nametagGlideOffset = 0.8f;
 
         [SerializeField] private Transform headAramatureBone;
         [SerializeField] private Transform[] potentialHighestBones;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
@@ -129,11 +129,15 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         private float nametagBoundedOffset = 1f;
         [SerializeField] [Tooltip("Small buffer to have some air/space between nametag and head, [m]")]
         private float nametagBuffer = 0.025f;
+        [SerializeField] [Tooltip("Extra height added to the nametag while the glider is deployed, to avoid clipping the glider model, [m]")]
+        private float nametagGlideOffset = 0.4f;
 
         [SerializeField] private Transform headAramatureBone;
         [SerializeField] private Transform[] potentialHighestBones;
         private float cachedHeadWearableOffset; // Cached offset from head bone to the highest point of head wearables (like tall hats). Updated when wearables change.
         private Vector3 headArmatureBoneStartPosition;
+
+        public float NametagGlideOffset => nametagGlideOffset;
 
         public bool IsLegacyAnimationPlaying => LegacyAnimation != null && LegacyAnimation.isPlaying;
         public bool IsMaskedLegacyEmotePlaying => maskedLegacyBlender != null && maskedLegacyBlender.IsPlaying;

--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -5,6 +5,7 @@ using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.Character.Components;
 using DCL.CharacterCamera;
+using DCL.CharacterMotion.Components;
 using DCL.Chat;
 using DCL.Diagnostics;
 using DCL.Profiles;
@@ -185,7 +186,12 @@ namespace DCL.Nametags
                 return;
             }
 
-            UpdateTagPositionAndRotation(nametagHolder.transform, avatarBase.GetAdaptiveNametagPosition(), cameraForward, cameraUp);
+            Vector3 nametagPosition = avatarBase.GetAdaptiveNametagPosition();
+
+            if (World.Has<GliderPropEnabled>(e))
+                nametagPosition.y += avatarBase.NametagGlideOffset;
+
+            UpdateTagPositionAndRotation(nametagHolder.transform, nametagPosition, cameraForward, cameraUp);
             UpdateTagTransparencyAndScale(nametagHolder, camera.Camera.transform.position, characterTransform.Position, fovScaleFactor);
         }
 

--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -39,6 +39,7 @@ namespace DCL.Nametags
 
         private readonly IObjectPool<NametagHolder> nametagHolderPool;
         private readonly NametagsData nametagsData;
+        private Vector3 nametagPosition;
 
         // When ghosts are enabled, nametags should appear immediately (alongside the ghost placeholder).
         // Otherwise, wait until the avatar has been fully instantiated before showing the nametag.
@@ -186,7 +187,7 @@ namespace DCL.Nametags
                 return;
             }
 
-            Vector3 nametagPosition = avatarBase.GetAdaptiveNametagPosition();
+            nametagPosition = avatarBase.GetAdaptiveNametagPosition();
 
             if (World.Has<GliderPropEnabled>(e))
                 nametagPosition.y += avatarBase.NametagGlideOffset;

--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -187,7 +187,7 @@ namespace DCL.Nametags
                 return;
             }
 
-            nametagPosition = avatarBase.GetAdaptiveNametagPosition();
+            Vector3 nametagPosition = avatarBase.GetAdaptiveNametagPosition();
 
             if (World.Has<GliderPropEnabled>(e))
                 nametagPosition.y += avatarBase.NametagGlideOffset;

--- a/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
+++ b/Explorer/Assets/DCL/NameTags/Systems/NametagPlacementSystem.cs
@@ -39,7 +39,6 @@ namespace DCL.Nametags
 
         private readonly IObjectPool<NametagHolder> nametagHolderPool;
         private readonly NametagsData nametagsData;
-        private Vector3 nametagPosition;
 
         // When ghosts are enabled, nametags should appear immediately (alongside the ghost placeholder).
         // Otherwise, wait until the avatar has been fully instantiated before showing the nametag.


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7274 
Fix #7273 
This Pr increases the height of the nametag when gliding to avoid compenetrations with the glider

## Test Instructions

### Test Steps
1. Launch the client
2. Double jump and glide
3. Verify that the nametag appears higher than the glider so that it's not clipping with the 3d model of it

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
