### PR TITLE
fix: notifications panel empty state

### DIFF
--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -80,6 +80,7 @@ namespace DCL.FeatureFlags
         public const string AB_DEPS_DIGEST_CACHE_KEY = "alfa-ab-deps-digest-cache-key";
         public const string BYTE_WEIGHTED_LOADING_PROGRESS = "alfa-byte-weighted-loading-progress";
         public const string NEW_LODS = "new-lods";
+        public const string FOUNDATION_COMMUNITY_ID = "alfa-foundation-community-id";
 
         public static class Endpoints
         {

--- a/Explorer/Assets/DCL/Notifications/Assets/NotificationsMenu.prefab
+++ b/Explorer/Assets/DCL/Notifications/Assets/NotificationsMenu.prefab
@@ -198,6 +198,102 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &963210969267826171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3494296864734750825}
+  - component: {fileID: 6917462299186460030}
+  - component: {fileID: 6050065599883958636}
+  - component: {fileID: 7262387888469332374}
+  m_Layer: 5
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3494296864734750825
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963210969267826171}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7626756492888028338}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 190, y: -224.77664}
+  m_SizeDelta: {x: 101, y: 110}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6917462299186460030
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963210969267826171}
+  m_CullTransparentMesh: 1
+--- !u!114 &6050065599883958636
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963210969267826171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 92b594b367c834b8c8729a74f2c5f448, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7262387888469332374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963210969267826171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.LayoutElement
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: 101
+  m_PreferredHeight: 110
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &1404027126306597108
 GameObject:
   m_ObjectHideFlags: 0
@@ -393,10 +489,330 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 8531737267419439595}
   m_HandleRect: {fileID: 7422092395756913748}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &4179714084473202792
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8481520286894367343}
+  - component: {fileID: 4554546185496148921}
+  - component: {fileID: 4411044357477329003}
+  m_Layer: 5
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8481520286894367343
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4179714084473202792}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7626756492888028338}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 190, y: -311.74164}
+  m_SizeDelta: {x: 194.5, y: 23.93}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4554546185496148921
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4179714084473202792}
+  m_CullTransparentMesh: 1
+--- !u!114 &4411044357477329003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4179714084473202792}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: No Notifications Yet
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5200063625699031905
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5703060791393500075}
+  - component: {fileID: 4752958187292225126}
+  - component: {fileID: 7253662967234192852}
+  - component: {fileID: 1656864585580355527}
+  m_Layer: 5
+  m_Name: Description
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5703060791393500075
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5200063625699031905}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7626756492888028338}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 190, y: -375.39163}
+  m_SizeDelta: {x: 340, y: 63.37}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4752958187292225126
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5200063625699031905}
+  m_CullTransparentMesh: 1
+--- !u!114 &7253662967234192852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5200063625699031905}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "Say hi \U0001F44B, join the <color=#FF2D55>Decentraland Foundation Community</color>,
+    or drop into an event\u2014this space will come to life."
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16
+  m_fontSizeBase: 16
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &1656864585580355527
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5200063625699031905}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7253662967234192852}
+  m_OnClick:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &6789636141309246352
@@ -437,6 +853,7 @@ RectTransform:
   m_Children:
   - {fileID: 3442319900602386561}
   - {fileID: 883202052376073070}
+  - {fileID: 7626756492888028338}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -575,6 +992,8 @@ MonoBehaviour:
   <notificationIndicator>k__BackingField: {fileID: 0}
   <LoadingSpinner>k__BackingField: {fileID: 1236069814820928485}
   <ContentContainer>k__BackingField: {fileID: 7452264080537212193}
+  <EmptyState>k__BackingField: {fileID: 7232095729196490626}
+  <FoundationCommunityButton>k__BackingField: {fileID: 1656864585580355527}
 --- !u!114 &243641309283680884
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -625,6 +1044,71 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7232095729196490626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7626756492888028338}
+  - component: {fileID: 3465980505259273146}
+  m_Layer: 5
+  m_Name: EmptyState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &7626756492888028338
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7232095729196490626}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3494296864734750825}
+  - {fileID: 8481520286894367343}
+  - {fileID: 5703060791393500075}
+  m_Father: {fileID: 5519781503074448261}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3465980505259273146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7232095729196490626}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.VerticalLayoutGroup
+  m_Padding:
+    m_Left: 20
+    m_Right: 20
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 20
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &7277020438940685974
 GameObject:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Notifications/Assets/NotificationsMenu.prefab
+++ b/Explorer/Assets/DCL/Notifications/Assets/NotificationsMenu.prefab
@@ -233,8 +233,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 190, y: -224.77664}
-  m_SizeDelta: {x: 101, y: 110}
+  m_AnchoredPosition: {x: 210, y: -0}
+  m_SizeDelta: {x: 101, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6917462299186460030
 CanvasRenderer:
@@ -529,8 +529,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 190, y: -311.74164}
-  m_SizeDelta: {x: 194.5, y: 23.93}
+  m_AnchoredPosition: {x: 210, y: -20}
+  m_SizeDelta: {x: 194.5, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4554546185496148921
 CanvasRenderer:
@@ -667,8 +667,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 190, y: -375.39163}
-  m_SizeDelta: {x: 340, y: 63.37}
+  m_AnchoredPosition: {x: 210, y: -40}
+  m_SizeDelta: {x: 380, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4752958187292225126
 CanvasRenderer:
@@ -698,18 +698,18 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "Say hi \U0001F44B, join the <color=#FF2D55>Decentraland Foundation Community</color>,
-    or drop into an event\u2014this space will come to life."
+  m_text: "Say hi \U0001F44B, join the <color=#FF2D55><b>Decentraland Foundation
+    Community</b></color>, or drop into an event\u2014this space will come to life."
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
-  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+    rgba: 4290688697
+  m_fontColor: {r: 0.7258126, g: 0.7136436, b: 0.745283, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -736,7 +736,7 @@ MonoBehaviour:
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
-  m_characterSpacing: 0
+  m_characterSpacing: -2
   m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0

--- a/Explorer/Assets/DCL/Notifications/Assets/NotificationsMenu.prefab
+++ b/Explorer/Assets/DCL/Notifications/Assets/NotificationsMenu.prefab
@@ -993,7 +993,7 @@ MonoBehaviour:
   <LoadingSpinner>k__BackingField: {fileID: 1236069814820928485}
   <ContentContainer>k__BackingField: {fileID: 7452264080537212193}
   <EmptyState>k__BackingField: {fileID: 7232095729196490626}
-  <FoundationCommunityButton>k__BackingField: {fileID: 1656864585580355527}
+  <foundationCommunityButton>k__BackingField: {fileID: 1656864585580355527}
 --- !u!114 &243641309283680884
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuView.cs
@@ -1,6 +1,7 @@
 using DCL.Diagnostics;
 using MVC;
 using SuperScrollView;
+using System;
 using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -29,7 +30,21 @@ namespace DCL.Notifications.NotificationsMenu
         public GameObject EmptyState { get; private set; } = null!;
 
         [field: SerializeField]
-        public Button FoundationCommunityButton { get; private set; } = null!;
+        private Button foundationCommunityButton { get; set; } = null!;
+
+        public event Action? FoundationCommunityButtonClicked;
+
+        private void Awake()
+        {
+            foundationCommunityButton.onClick.AddListener(OnFoundationCommunityButtonClick);
+        }
+
+        private void OnDestroy()
+        {
+            foundationCommunityButton.onClick.RemoveListener(OnFoundationCommunityButtonClick);
+        }
+
+        private void OnFoundationCommunityButtonClick() => FoundationCommunityButtonClicked?.Invoke();
 
         public void SetLoading(bool isLoading)
         {

--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsMenuView.cs
@@ -4,6 +4,7 @@ using SuperScrollView;
 using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
 namespace DCL.Notifications.NotificationsMenu
 {
@@ -24,11 +25,19 @@ namespace DCL.Notifications.NotificationsMenu
         [field: SerializeField]
         public GameObject ContentContainer { get; private set; } = null!;
 
+        [field: SerializeField]
+        public GameObject EmptyState { get; private set; } = null!;
+
+        [field: SerializeField]
+        public Button FoundationCommunityButton { get; private set; } = null!;
+
         public void SetLoading(bool isLoading)
         {
             LoadingSpinner.SetActive(isLoading);
             ContentContainer.SetActive(!isLoading);
         }
+
+        public void ShowEmptyState(bool show) => EmptyState.SetActive(show);
 
         // Swallow the click event so it's not processed by the main sidebar button: retriggers -> cancel previous token -> panel stuck
         public void OnPointerClick(PointerEventData eventData)

--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsPanelController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsPanelController.cs
@@ -91,7 +91,7 @@ namespace DCL.Notifications.NotificationsMenu
             web3IdentityCache.OnIdentityChanged += OnIdentityChanged;
             NotificationsBusController.Instance.SubscribeToAllNotificationTypesReceived(OnNotificationReceived);
             viewInstance.LoopList.gameObject.GetComponent<ScrollRect>()?.SetScrollSensitivityBasedOnPlatform();
-            viewInstance.FoundationCommunityButton.onClick.AddListener(OnFoundationCommunityButtonClicked);
+            viewInstance.FoundationCommunityButtonClicked += OnFoundationCommunityButtonClicked;
         }
 
         private void OnFoundationCommunityButtonClicked() =>
@@ -119,7 +119,8 @@ namespace DCL.Notifications.NotificationsMenu
             lifeCycleCts.SafeCancelAndDispose();
             web3IdentityCache.OnIdentityChanged -= OnIdentityChanged;
 
-            viewInstance?.FoundationCommunityButton.onClick.RemoveListener(OnFoundationCommunityButtonClicked);
+            if (viewInstance != null)
+                viewInstance.FoundationCommunityButtonClicked -= OnFoundationCommunityButtonClicked;
         }
 
         protected override void OnViewShow()
@@ -169,6 +170,7 @@ namespace DCL.Notifications.NotificationsMenu
 
                 UpdateUnreadNotificationRender();
                 viewInstance.SetLoading(false);
+                viewInstance!.ShowEmptyState(notifications.Count == 0);
             }
             catch (OperationCanceledException) { }
             catch (Exception e)
@@ -177,8 +179,6 @@ namespace DCL.Notifications.NotificationsMenu
                 ReportHub.LogException(e, ReportCategory.UI);
                 NotificationsBusController.Instance.AddNotification(new ServerErrorNotification(GET_NOTIFICATIONS_ERROR_MESSAGE));
             }
-
-            viewInstance!.ShowEmptyState(notifications.Count == 0);
         }
 
         private void UpdateUnreadNotificationRender()
@@ -416,7 +416,7 @@ namespace DCL.Notifications.NotificationsMenu
             if (NOTIFICATION_TYPES_TO_IGNORE.Contains(notification.Type))
                 return;
 
-            viewInstance!.ShowEmptyState(false);
+            viewInstance?.ShowEmptyState(false);
 
             notifications.Insert(0, notification);
             viewInstance?.LoopList.SetListItemCount(notifications.Count, false);

--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsPanelController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsPanelController.cs
@@ -1,7 +1,9 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Backpack;
+using DCL.Communities.CommunitiesCard;
 using DCL.Diagnostics;
+using DCL.FeatureFlags;
 using DCL.Notifications.NotificationEntry;
 using DCL.NotificationsBus;
 using DCL.NotificationsBus.NotificationTypes;
@@ -30,6 +32,7 @@ namespace DCL.Notifications.NotificationsMenu
         private const int FRIENDS_NOTIFICATION_INDEX = 1;
         private const int GIFT_NOTIFICATION_INDEX = 2;
         private const string GET_NOTIFICATIONS_ERROR_MESSAGE = "There was an error loading notifications. Please try again.";
+        private const string FOUNDATION_COMMUNITY_ID_FALLBACK = "e99471aa-31c4-4952-abf6-99905445f43b";
 
         private static readonly List<NotificationType> NOTIFICATION_TYPES_TO_IGNORE = new ()
         {
@@ -46,11 +49,13 @@ namespace DCL.Notifications.NotificationsMenu
         private readonly IWebRequestController webRequestController;
         private readonly NftTypeIconSO rarityBackgroundMapping;
         private readonly IWeb3IdentityCache web3IdentityCache;
+        private readonly IMVCManager mvcManager;
         private readonly Dictionary<string, Sprite> notificationThumbnailCache = new ();
         private readonly List<INotification> notifications = new ();
         private readonly CancellationTokenSource lifeCycleCts = new ();
         private readonly ProfileRepositoryWrapper profileRepository;
         private readonly CancellationTokenSource notificationThumbnailCts = new ();
+        private readonly string foundationCommunityId;
 
         private UniTaskCompletionSource? closeViewTask;
         private int unreadNotifications;
@@ -64,7 +69,8 @@ namespace DCL.Notifications.NotificationsMenu
             IWebRequestController webRequestController,
             NftTypeIconSO rarityBackgroundMapping,
             IWeb3IdentityCache web3IdentityCache,
-            ProfileRepositoryWrapper profileRepository) : base(viewFactory)
+            ProfileRepositoryWrapper profileRepository,
+            IMVCManager mvcManager) : base(viewFactory)
         {
             this.notificationsRequestController = notificationsRequestController;
             this.notificationIconTypes = notificationIconTypes;
@@ -73,6 +79,10 @@ namespace DCL.Notifications.NotificationsMenu
             this.rarityBackgroundMapping = rarityBackgroundMapping;
             this.web3IdentityCache = web3IdentityCache;
             this.profileRepository = profileRepository;
+            this.mvcManager = mvcManager;
+
+            FeatureFlagsConfiguration.Instance.TryGetTextPayload(FeatureFlagsStrings.FOUNDATION_COMMUNITY_ID, "main", out string? communityId);
+            foundationCommunityId = communityId ?? FOUNDATION_COMMUNITY_ID_FALLBACK;
         }
 
         protected override void OnViewInstantiated()
@@ -81,7 +91,11 @@ namespace DCL.Notifications.NotificationsMenu
             web3IdentityCache.OnIdentityChanged += OnIdentityChanged;
             NotificationsBusController.Instance.SubscribeToAllNotificationTypesReceived(OnNotificationReceived);
             viewInstance.LoopList.gameObject.GetComponent<ScrollRect>()?.SetScrollSensitivityBasedOnPlatform();
+            viewInstance.FoundationCommunityButton.onClick.AddListener(OnFoundationCommunityButtonClicked);
         }
+
+        private void OnFoundationCommunityButtonClicked() =>
+            mvcManager.ShowAndForget(CommunityCardController.IssueCommand(new CommunityCardParameter(foundationCommunityId)));
 
         protected override void OnBeforeViewShow()
         {
@@ -104,6 +118,8 @@ namespace DCL.Notifications.NotificationsMenu
             notificationThumbnailCts.SafeCancelAndDispose();
             lifeCycleCts.SafeCancelAndDispose();
             web3IdentityCache.OnIdentityChanged -= OnIdentityChanged;
+
+            viewInstance?.FoundationCommunityButton.onClick.RemoveListener(OnFoundationCommunityButtonClicked);
         }
 
         protected override void OnViewShow()
@@ -161,6 +177,8 @@ namespace DCL.Notifications.NotificationsMenu
                 ReportHub.LogException(e, ReportCategory.UI);
                 NotificationsBusController.Instance.AddNotification(new ServerErrorNotification(GET_NOTIFICATIONS_ERROR_MESSAGE));
             }
+
+            viewInstance!.ShowEmptyState(notifications.Count == 0);
         }
 
         private void UpdateUnreadNotificationRender()
@@ -397,6 +415,8 @@ namespace DCL.Notifications.NotificationsMenu
         {
             if (NOTIFICATION_TYPES_TO_IGNORE.Contains(notification.Type))
                 return;
+
+            viewInstance!.ShowEmptyState(false);
 
             notifications.Insert(0, notification);
             viewInstance?.LoopList.SetListItemCount(notifications.Count, false);

--- a/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SidebarPlugin.cs
@@ -170,7 +170,7 @@ namespace DCL.PluginSystem.Global
             ControlsPanelController.Preallocate(panelViewAsset, null!, out ControlsPanelView controlsPanelView);
 
             controlsPanelController = new ControlsPanelController(() => controlsPanelView);
-            notificationsPanelController = new NotificationsPanelController(() => mainUIView.SidebarView.NotificationsMenuView, notificationsRequestController, notificationIconTypes, notificationDefaultThumbnails, webRequestController, rarityBackgroundMapping, web3IdentityCache, profileRepositoryWrapper);
+            notificationsPanelController = new NotificationsPanelController(() => mainUIView.SidebarView.NotificationsMenuView, notificationsRequestController, notificationIconTypes, notificationDefaultThumbnails, webRequestController, rarityBackgroundMapping, web3IdentityCache, profileRepositoryWrapper, mvcManager);
             profileButtonPresenter = new SidebarProfileButtonPresenter( mainUIView.SidebarView.ProfileWidget, web3IdentityCache, profileRepository, profileChangesBus);
             profileMenuController = new ProfileMenuController(() => mainUIView.SidebarView.ProfileMenuView, web3IdentityCache, globalWorld, playerEntity, webBrowser, web3Authenticator, userInAppInitializationFlow, profileCache, passportBridge, profileRepositoryWrapper);
             skyboxMenuController = new SkyboxMenuController(() => mainUIView.SidebarView.SkyboxMenuView, settings.SettingsAsset, sceneRestrictionBusController);

--- a/Explorer/Assets/Textures/Notifications/NotificationsImg.png
+++ b/Explorer/Assets/Textures/Notifications/NotificationsImg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4435a4bd82db924b79746dcf8ce87d0fafa2f6c37dcffd85ac96aaeae9577d7b
+size 1580

--- a/Explorer/Assets/Textures/Notifications/NotificationsImg.png.meta
+++ b/Explorer/Assets/Textures/Notifications/NotificationsImg.png.meta
@@ -1,0 +1,117 @@
+fileFormatVersion: 2
+guid: 92b594b367c834b8c8729a74f2c5f448
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 0
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 0
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Pull Request Description
Fixes #8292

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR introduces an empty state for the notifications panel. It has a clickable text that opens the Foundation Community.
The community id comes from the `alfa-foundation-community-id` feature flag (text type) and falls back to the current logged id (shouldn't change at all, but if it does, we can remotely fix it).

The state is shown after the notifications fetch if there's none and is hidden upon receiving a notification.


### Test Steps
1. With a brand new account, enter the world and verify you have no notifications -> empty state as in the Figma (linked inside the linked issue)
2. Verify that clicking on the empty state's description opens the foundation community card
3. Receive a notification -> verify the empty state is gone 
4. Cross verify the behaviour by loggin out/in to another account: use both another new one and an old one: the state should always represent the current state accordingly


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
