### PR TITLE
chore: regenerate protocol with the Node protoc-gen-bitwise plugin

### DIFF
--- a/.claude/agents/dcl-sdk-feature-implementation/dcl-explorer-specialist.md
+++ b/.claude/agents/dcl-sdk-feature-implementation/dcl-explorer-specialist.md
@@ -46,7 +46,7 @@ After installing a new protocol package, always re-run `npm run build-protocol` 
 
 ## Protocol Generation
 
-> **Prerequisite:** `build-protocol` runs a Python `protoc` plugin (`protoc-gen-bitwise`, for the quantized/bit-packed Pulse network state) in addition to the Node toolchain. **Python 3** must be on `PATH` with the **`protobuf`** package installed (`python3 -m pip install protobuf`), otherwise generation fails with `ModuleNotFoundError: No module named 'google'`.
+> **Prerequisite:** Node toolchain only. `build-protocol` runs the `protoc-gen-bitwise` plugin (for the quantized/bit-packed Pulse network state), a dependency-free Node script bundled in `@dcl/protocol` — no Python or extra packages required.
 
 To generate C# code from protocol definitions:
 ```bash

--- a/.claude/skills/sdk-component-implementation/SKILL.md
+++ b/.claude/skills/sdk-component-implementation/SKILL.md
@@ -30,7 +30,7 @@ In `js-sdk-toolchain`, generate serialization code and optional helper functions
 
 In `unity-explorer`:
 1. Run protocol update: `npm install @dcl/protocol@experimental && npm run build-protocol`
-   - Requires **Python 3** on `PATH` with the **`protobuf`** package (`python3 -m pip install protobuf`) — `build-protocol` runs a Python `protoc` plugin (`protoc-gen-bitwise`); without it the build fails with `ModuleNotFoundError: No module named 'google'`.
+   - Node/npm only — `build-protocol` runs the `protoc-gen-bitwise` plugin, a dependency-free Node script bundled in `@dcl/protocol` (no Python or extra packages required).
 2. Add partial class to `IDirtyMarker.cs`
 3. Register in `ComponentsContainer.cs` using `SDKComponentBuilder<T>`
 4. Create feature folder under `Explorer/Assets/DCL/SDKComponents/<Feature>/`

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -533,10 +533,7 @@ For guidance on detached flows, cancellation, `SuppressToResultAsync`, and the e
 
 ## How to update protocol
 
-> **Prerequisites:** Besides Node/npm, the protocol build runs a Python `protoc` plugin (`protoc-gen-bitwise`, used for the quantized/bit-packed Pulse network state). You need **Python 3** on your `PATH` with the **`protobuf`** package installed, otherwise `build-protocol` fails with `ModuleNotFoundError: No module named 'google'`:
-> ```bash
-> python3 -m pip install protobuf
-> ```
+> **Prerequisites:** Node/npm only. The protocol build runs the `protoc-gen-bitwise` plugin (for the quantized/bit-packed Pulse network state), which ships inside the `@dcl/protocol` package as a dependency-free Node script — no Python or extra packages required.
 
 To update the protocol to the last version of the protocol, open a terminal like CMD and navigate to your working copy of the repository, there you will see a folder named 'scripts'; execute the following commands:
 

--- a/docs/how-to-implement-new-sdk-components.md
+++ b/docs/how-to-implement-new-sdk-components.md
@@ -114,7 +114,7 @@ npm install
 npm run build-protocol
 ```
 
-> **Prerequisite:** Besides Node/npm, `build-protocol` runs a Python `protoc` plugin (`protoc-gen-bitwise`, for the quantized/bit-packed Pulse network state). You need **Python 3** on your `PATH` with the **`protobuf`** package installed, otherwise the build fails with `ModuleNotFoundError: No module named 'google'`. Install it once with `python3 -m pip install protobuf`.
+> **Prerequisite:** Node/npm only. `build-protocol` runs the `protoc-gen-bitwise` plugin (for the quantized/bit-packed Pulse network state), a dependency-free Node script bundled in `@dcl/protocol` — no Python or extra packages required.
 
 To upgrade to the latest version of the `@dcl/protocol`, we should update using:
 

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-27540835405.commit-d1e540d.tgz",
+        "@dcl/protocol": "^1.0.0-27574288540.commit-f0df3e0",
         "@protobuf-ts/protoc": "^2.11.0",
         "@types/fs-extra": "^11.0.1",
         "@types/glob": "^8.0.1",
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-27540835405.commit-d1e540d",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-27540835405.commit-d1e540d.tgz",
-      "integrity": "sha512-KSKBqBlXlHlA4T2fyew+a5RUK7wuRZImHXotXthyVEfy/6lRgUPLFUV9WSne1p4hDFePlaaiX/gs1awbHxO2nQ==",
+      "version": "1.0.0-27574288540.commit-f0df3e0",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-27574288540.commit-f0df3e0.tgz",
+      "integrity": "sha512-AY7xfVOTB3o3FUeK5DjHjabqd9tr0usKmV/+jcEb7CKchNOuosYV1++7aecxOqOyng+zRsRdIlJObr/w/OQZQA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
@@ -608,8 +608,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-27540835405.commit-d1e540d.tgz",
-      "integrity": "sha512-KSKBqBlXlHlA4T2fyew+a5RUK7wuRZImHXotXthyVEfy/6lRgUPLFUV9WSne1p4hDFePlaaiX/gs1awbHxO2nQ==",
+      "version": "1.0.0-27574288540.commit-f0df3e0",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-27574288540.commit-f0df3e0.tgz",
+      "integrity": "sha512-AY7xfVOTB3o3FUeK5DjHjabqd9tr0usKmV/+jcEb7CKchNOuosYV1++7aecxOqOyng+zRsRdIlJObr/w/OQZQA==",
       "requires": {
         "@dcl/ts-proto": "1.154.0",
         "protobufjs": "7.2.4"

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/protocol": "^1.0.0-27358757907.commit-3c70e8a",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-27540835405.commit-d1e540d.tgz",
         "@protobuf-ts/protoc": "^2.11.0",
         "@types/fs-extra": "^11.0.1",
         "@types/glob": "^8.0.1",
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-27358757907.commit-3c70e8a",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-27358757907.commit-3c70e8a.tgz",
-      "integrity": "sha512-DeO6tRAgUUS8uxRQ3nG0Ijwqo24ni+GzHlxlles3pddpmBVVPJIPPmXxQbzXovsk9zYofrlEbunOLYtYNDFy8g==",
+      "version": "1.0.0-27540835405.commit-d1e540d",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-27540835405.commit-d1e540d.tgz",
+      "integrity": "sha512-KSKBqBlXlHlA4T2fyew+a5RUK7wuRZImHXotXthyVEfy/6lRgUPLFUV9WSne1p4hDFePlaaiX/gs1awbHxO2nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
@@ -608,9 +608,8 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-27358757907.commit-3c70e8a",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-27358757907.commit-3c70e8a.tgz",
-      "integrity": "sha512-DeO6tRAgUUS8uxRQ3nG0Ijwqo24ni+GzHlxlles3pddpmBVVPJIPPmXxQbzXovsk9zYofrlEbunOLYtYNDFy8g==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-27540835405.commit-d1e540d.tgz",
+      "integrity": "sha512-KSKBqBlXlHlA4T2fyew+a5RUK7wuRZImHXotXthyVEfy/6lRgUPLFUV9WSne1p4hDFePlaaiX/gs1awbHxO2nQ==",
       "requires": {
         "@dcl/ts-proto": "1.154.0",
         "protobufjs": "7.2.4"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-27540835405.commit-d1e540d.tgz",
+    "@dcl/protocol": "^1.0.0-27574288540.commit-f0df3e0",
     "@protobuf-ts/protoc": "^2.11.0",
     "@types/fs-extra": "^11.0.1",
     "@types/glob": "^8.0.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@dcl/protocol": "^1.0.0-27358757907.commit-3c70e8a",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-27540835405.commit-d1e540d.tgz",
     "@protobuf-ts/protoc": "^2.11.0",
     "@types/fs-extra": "^11.0.1",
     "@types/glob": "^8.0.1",

--- a/scripts/src/build-protocol.ts
+++ b/scripts/src/build-protocol.ts
@@ -203,7 +203,7 @@ async function buildProtocol() {
       .filter((value) => !value.endsWith('v2/comms.proto'))
       .filter((value) => !value.endsWith('v3/comms.proto'))
 
-  // Create a platform-specific wrapper so protoc can invoke the Python plugin
+  // Create a platform-specific wrapper so protoc can invoke the Node plugin
   const pluginWrapper = createPluginWrapper(protocolInputPath)
 
   // Uncomment this line to use the protoc-gen-dclunity plugin and generate the services (rpc dependency)

--- a/scripts/src/build-protocol.ts
+++ b/scripts/src/build-protocol.ts
@@ -28,52 +28,45 @@ const bitwisePluginDir = normalizePath(
   path.resolve(nodeModulesPath, '@dcl/protocol', 'protoc-gen-bitwise'),
 )
 const bitwisePluginScript = normalizePath(
-  path.resolve(bitwisePluginDir, 'plugin.py'),
+  path.resolve(bitwisePluginDir, 'plugin.js'),
 )
 const quantizeRuntimeSrc = normalizePath(
   path.resolve(bitwisePluginDir, 'runtime', 'cs', 'Quantize.cs'),
 )
 
-// Python interpreter the bitwise wrapper delegates to (must match createPluginWrapper).
-const pythonCommand = isWin ? 'py' : 'python3'
-
 /**
- * Verifies the Python interpreter used by the protoc-gen-bitwise plugin is present
- * and has the `protobuf` package, so the build fails here with an actionable message
- * instead of an opaque protoc plugin stack trace mid-generation.
+ * Verifies the installed @dcl/protocol ships the Node protoc-gen-bitwise plugin,
+ * so the build fails here with an actionable message instead of an opaque protoc
+ * plugin error mid-generation. (Node itself is always present — this script runs
+ * under it.)
  */
-async function checkPythonProtobuf() {
-  try {
-    await execAsync(
-      `${pythonCommand} -c "import google.protobuf.compiler.plugin_pb2"`,
-      { cwd: workingDirectory },
-    )
-  } catch {
+function checkBitwisePlugin() {
+  if (!fs.existsSync(bitwisePluginScript)) {
     throw new Error(
-      `The protoc-gen-bitwise plugin requires Python 3 with the 'protobuf' package, but '${pythonCommand}' could not import it.\n` +
-        `Install it with: ${pythonCommand} -m pip install protobuf`,
+      `protoc-gen-bitwise plugin not found at ${bitwisePluginScript}.\n` +
+        `Update the @dcl/protocol dependency to a version that ships the Node plugin (protoc-gen-bitwise/plugin.js).`,
     )
   }
 }
 
 /**
  * Creates a platform-specific wrapper script that protoc can invoke as
- * --plugin=protoc-gen-bitwise=<path>.  The wrapper delegates to the Python
- * plugin.py shipped inside @dcl/protocol.
+ * --plugin=protoc-gen-bitwise=<path>.  The wrapper delegates to the Node
+ * plugin.js shipped inside @dcl/protocol.
  */
 function createPluginWrapper(dir: string): string {
   if (isWin) {
     const wrapper = path.resolve(dir, 'protoc-gen-bitwise.cmd')
     fs.writeFileSync(
       wrapper,
-      `@echo off\r\npy "${bitwisePluginScript}" %*\r\n`,
+      `@echo off\r\nnode "${bitwisePluginScript}" %*\r\n`,
     )
     return normalizePath(wrapper)
   } else {
     const wrapper = path.resolve(dir, 'protoc-gen-bitwise')
     fs.writeFileSync(
       wrapper,
-      `#!/usr/bin/env bash\nexec python3 "${bitwisePluginScript}" "$@"\n`,
+      `#!/usr/bin/env bash\nexec node "${bitwisePluginScript}" "$@"\n`,
     )
     fs.chmodSync(wrapper, 0o755)
     return normalizePath(wrapper)
@@ -105,7 +98,7 @@ async function main() {
 
   await execute(`${protocPath} --version`, workingDirectory)
 
-  await checkPythonProtobuf()
+  checkBitwisePlugin()
 
   await buildProtocol()
 


### PR DESCRIPTION
## What

Updates `@dcl/protocol` to the released **experimental** build (the Node `protoc-gen-bitwise` plugin from decentraland/protocol#423) and adapts `build-protocol` to drive it. `npm run build-protocol` now needs only **Node** — no Python 3 + `protobuf` pip package.

## Changes

- **`scripts/package.json` / `package-lock.json`** — `@dcl/protocol` → `^1.0.0-27574288540.commit-f0df3e0` (the `experimental` dist-tag, i.e. the merge of protocol#423)
- **`scripts/src/build-protocol.ts`** — `createPluginWrapper` writes a `node` wrapper (was `py`/`python3` + `plugin.py`); `checkPythonProtobuf` → `checkBitwisePlugin` (verifies the package ships `plugin.js`)
- **Docs** — `development-guide.md`, `how-to-implement-new-sdk-components.md`, the explorer-specialist agent, and the `sdk-component-implementation` skill: Python prerequisite removed

## Generated code is unchanged

Ran `npm run build-protocol` against the released experimental package: all generated files (~115 `.gen.cs` + both `*.Bitwise.cs` + `Quantize.cs`) are **content byte-identical** to what's committed, so no generated files change here. Only the plugin's implementation language changed; the proto schema is the same.

## Dependency

- decentraland/protocol#423 — ✅ **merged to `experimental`** (`f0df3e0`). The dependency now pins the released experimental build `1.0.0-27574288540.commit-f0df3e0` (no longer a branch-build tarball). Ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
