### PR TITLE
fix: avoid generating terrain on 0 parcels, to avoid sentry error

### DIFF
--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -144,6 +144,12 @@ namespace DCL.Landscape
         {
             if (!isInitialized) return;
 
+            if (worldManifest.GetOccupiedParcels().Count == 0)
+            {
+                ReportHub.LogWarning(reportData, "Skipping genesis terrain generation: occupied parcels set is empty.");
+                return;
+            }
+
             TerrainModel = new TerrainModel(ParcelSize, worldManifest.GetOccupiedParcels(), terrainGenData.borderPadding);
 
             float startMemory = profilingProvider.SystemUsedMemoryInBytes / (1024 * 1024);

--- a/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/Worlds/WorldTerrainGenerator.cs
@@ -73,6 +73,12 @@ namespace DCL.Landscape
         {
             if (!IsInitialized) return;
 
+            if (ownedParcels.Count == 0)
+            {
+                ReportHub.LogWarning(ReportCategory.LANDSCAPE, "Skipping world terrain generation: occupied parcels set is empty.");
+                return;
+            }
+
             TerrainModel = new TerrainModel(ParcelSize, ownedParcels, terrainGenData.borderPadding, true);
 
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #7723
Avoids terrain generation when parcels are 0, this already resulted in an empty terrain and was throwing issues to sentry

## Test Instructions

### Test Steps
1. Launch the client
2. Verify that terrain works in genesis city and in worlds

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
