### PR TITLE
fix: log on startup list of enabled feature flags

### DIFF
--- a/Explorer/Assets/DCL/FeatureFlags/HttpFeatureFlagsProvider.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/HttpFeatureFlagsProvider.cs
@@ -4,7 +4,6 @@ using DCL.Diagnostics;
 using DCL.WebRequests;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 
 namespace DCL.FeatureFlags
@@ -47,24 +46,7 @@ namespace DCL.FeatureFlags
             FeatureFlagsConfiguration.Reset();
             FeatureFlagsConfiguration.Initialize(config);
 
-            LogEnabledFlags(config);
-
             return config;
-        }
-
-        private static void LogEnabledFlags(FeatureFlagsConfiguration config)
-        {
-            var sb = new StringBuilder();
-            int count = 0;
-
-            foreach (string flag in config.AllEnabledFlags)
-            {
-                if (count > 0) sb.Append(", ");
-                sb.Append(flag);
-                count++;
-            }
-
-            ReportHub.LogProductionInfo($"[FEATURE FLAGS] {count} enabled: {sb}");
         }
 
         private static FeatureFlagsResultDto StripAppNameFromKeys(string name, FeatureFlagsResultDto response)

--- a/Explorer/Assets/DCL/FeatureFlags/HttpFeatureFlagsProvider.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/HttpFeatureFlagsProvider.cs
@@ -4,6 +4,7 @@ using DCL.Diagnostics;
 using DCL.WebRequests;
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 
 namespace DCL.FeatureFlags
@@ -46,7 +47,24 @@ namespace DCL.FeatureFlags
             FeatureFlagsConfiguration.Reset();
             FeatureFlagsConfiguration.Initialize(config);
 
+            LogEnabledFlags(config);
+
             return config;
+        }
+
+        private static void LogEnabledFlags(FeatureFlagsConfiguration config)
+        {
+            var sb = new StringBuilder();
+            int count = 0;
+
+            foreach (string flag in config.AllEnabledFlags)
+            {
+                if (count > 0) sb.Append(", ");
+                sb.Append(flag);
+                count++;
+            }
+
+            ReportHub.LogProductionInfo($"[FEATURE FLAGS] {count} enabled: {sb}");
         }
 
         private static FeatureFlagsResultDto StripAppNameFromKeys(string name, FeatureFlagsResultDto response)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -293,6 +293,8 @@ namespace Global.Dynamic
                 bootstrap.InitializeFeaturesRegistry();
                 bootstrap.ApplyFeatureFlagConfigs(FeatureFlagsConfiguration.Instance);
 
+                DiagnosticInfoUtils.LogFeatureFlags(FeatureFlagsConfiguration.Instance.AllEnabledFlags);
+
                 // Need to ensure clock sync ASAP due to some requests may fail due this problem.
                 // Checking for clock desync after feature flags (or any other process that performs an http request)
                 // potentially saves one extra HEAD request

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/DiagnosticInfoUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/DiagnosticInfoUtils.cs
@@ -2,6 +2,7 @@
 using Sentry;
 using Sentry.Unity;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine.Device;
@@ -83,6 +84,26 @@ namespace DCL.Diagnostics
             {
                 stringBuilder.AppendFormat("{0}: {1}\n", decentralandUrl.ToString(), decentralandUrlsSource.Probe(decentralandUrl));
             }
+            AppendFooter(stringBuilder);
+
+            ReportHub.LogProductionInfo(stringBuilder.ToString());
+        }
+
+        public static void LogFeatureFlags(IEnumerable<string> enabledFlags)
+        {
+            var stringBuilder = new StringBuilder();
+            AppendHeader(stringBuilder, "ENABLED FEATURE FLAGS");
+
+            var count = 0;
+            foreach (string flag in enabledFlags)
+            {
+                stringBuilder.AppendFormat("{0} ", flag);
+                count++;
+            }
+
+            if (count == 0)
+                stringBuilder.AppendLine("<none>");
+
             AppendFooter(stringBuilder);
 
             ReportHub.LogProductionInfo(stringBuilder.ToString());


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #8995
Add a log stating which feature flags are enabled

## Test Instructions

### Test Steps
1. Launch the client
2. Check in the logs that a list of enabled feature flags appears, a message similar to `==================
ENABLED FEATURE FLAGS`

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
