### PR TITLE
fix: duplicate preloaded gltf assets on request

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
@@ -1,6 +1,7 @@
 using DCL.SDKComponents.MediaStream;
 using ECS.StreamableLoading.AudioClips;
 using ECS.StreamableLoading.Textures;
+using ECS.Unity.GLTFContainer;
 using ECS.Unity.GLTFContainer.Asset.Cache;
 using ECS.Unity.GLTFContainer.Asset.Components;
 using System;
@@ -10,12 +11,56 @@ namespace ECS.Unity.AssetLoad.Cache
 {
     public class AssetPreLoadCache : IDisposable
     {
+        /// <summary>
+        ///     The never-handed-out template plus its live clones, so every copy can be released on teardown.
+        /// </summary>
+        private sealed class GltfTemplate
+        {
+            public readonly GltfContainerAsset Template;
+            public readonly string Hash;
+            public readonly List<GltfContainerAsset> Copies = new ();
+
+            public GltfTemplate(GltfContainerAsset template, string hash)
+            {
+                Template = template;
+                Hash = hash;
+            }
+        }
+
         private readonly IGltfContainerAssetsCache gltfCache;
         private readonly Dictionary<string, object> cache = new ();
 
         public AssetPreLoadCache(IGltfContainerAssetsCache gltfCache)
         {
             this.gltfCache = gltfCache;
+        }
+
+        public bool TryAddGltf(string key, string hash, GltfContainerAsset template) =>
+            cache.TryAdd(key, new GltfTemplate (template, hash));
+
+        public bool ContainsGltf(string key) =>
+            cache.TryGetValue(key, out object? value) && value is GltfTemplate;
+
+        public bool TryGetGltfInstance(string key, out GltfContainerAsset? instance)
+        {
+            if (cache.TryGetValue(key, out object? value) && value is GltfTemplate gltfTemplate
+                && Utils.TryDuplicateGltfAssetFromTemplate(gltfTemplate.Template, gltfTemplate.Hash, out GltfContainerAsset duplicate))
+            {
+                gltfTemplate.Copies.Add(duplicate);
+                instance = duplicate;
+                return true;
+            }
+
+            instance = null;
+            return false;
+        }
+
+        public void ReleaseGltfInstance(string key, GltfContainerAsset instance)
+        {
+            if (cache.TryGetValue(key, out object? value) && value is GltfTemplate gltfTemplate)
+                gltfTemplate.Copies.Remove(instance);
+
+            instance.Dispose();
         }
 
         public bool TryAdd<T>(string key, T asset)
@@ -62,8 +107,11 @@ namespace ECS.Unity.AssetLoad.Cache
             foreach(var kvp in cache)
                 switch (kvp.Value)
                 {
-                    case GltfContainerAsset gltfAsset:
-                        gltfCache.Dereference(kvp.Key, gltfAsset, handleAssetLoad: false);
+                    case GltfTemplate gltfTemplate:
+                        foreach (GltfContainerAsset copy in gltfTemplate.Copies)
+                            copy.Dispose();
+
+                        gltfCache.Dereference(kvp.Key, gltfTemplate.Template, handleAssetLoad: false);
                         break;
                     case AudioClipData audioClipData:
                         audioClipData.Dereference();

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
@@ -44,9 +44,9 @@ namespace ECS.Unity.AssetLoad.Cache
         public bool TryGetGltfInstance(string key, out GltfContainerAsset? instance)
         {
             if (cache.TryGetValue(key, out object? value) && value is GltfTemplate gltfTemplate
-                && Utils.TryDuplicateGltfAssetFromTemplate(gltfTemplate.Template, gltfTemplate.Hash, out GltfContainerAsset duplicate))
+                && Utils.TryDuplicateGltfAssetFromTemplate(gltfTemplate.Template, gltfTemplate.Hash, out GltfContainerAsset? duplicate))
             {
-                gltfTemplate.Copies.Add(duplicate);
+                gltfTemplate.Copies.Add(duplicate!);
                 instance = duplicate;
                 return true;
             }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
@@ -97,10 +97,8 @@ namespace ECS.Unity.AssetLoad.Cache
             return false;
         }
 
-        public void Dispose()
-        {
-            cache.Clear();
-        }
+        public void Dispose() =>
+            Clear();
 
         public void Clear()
         {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Systems/FinalizeAssetPreLoadSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Systems/FinalizeAssetPreLoadSystem.cs
@@ -57,8 +57,8 @@ namespace ECS.Unity.AssetLoad.Systems
                 && component.Promise.TryConsume(World!, out StreamableLoadingResult<GltfContainerAsset> result))
             {
                 if (result.Succeeded)
-                    // Must match the key used by GltfContainerAssetsCache.TryGet (and looked up via assetLoadCache.TryGet there)
-                    assetPreLoadCache.TryAdd(component.CacheKey, result.Asset);
+                    // Hash is stored alongside the key because the AB clone needs the bare hash, not the composed CacheKey.
+                    assetPreLoadCache.TryAddGltf(component.CacheKey, component.Hash, result.Asset);
 
                 MarkForUpdate(result.Succeeded ? LoadingState.Finished : LoadingState.FinishedWithError, ref assetPreLoadLoadingStateComponent);
             }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
@@ -90,14 +90,9 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
         /// </summary>
         public void Dereference(in string key, GltfContainerAsset asset, bool putInBridge = false, bool handleAssetLoad = true)
         {
-            // A preloaded copy is unique to its consumer, so it can't return to the shared pool (the bridge still needs it for LOD visuals).
             if (handleAssetLoad && assetLoadCache != null && assetLoadCache.ContainsGltf(key))
             {
-                if (putInBridge)
-                    DereferenceFinalOperation(asset, true);
-                else
-                    assetLoadCache.ReleaseGltfInstance(key, asset);
-
+                assetLoadCache.ReleaseGltfInstance(key, asset);
                 return;
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
@@ -63,10 +63,10 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
 
         public bool TryGet(in string key, out GltfContainerAsset? asset)
         {
-            // First check if the asset is being handled by the AssetLoadCache
-            if (assetLoadCache != null && assetLoadCache.TryGet(key, out GltfContainerAsset cachedAsset))
+            // Serve a clone so two live GltfContainers don't fight over one shared preloaded Root.
+            if (assetLoadCache != null && assetLoadCache.TryGetGltfInstance(key, out GltfContainerAsset? instance))
             {
-                asset = cachedAsset;
+                asset = instance;
                 return true;
             }
 
@@ -90,10 +90,14 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
         /// </summary>
         public void Dereference(in string key, GltfContainerAsset asset, bool putInBridge = false, bool handleAssetLoad = true)
         {
-            // If the asset is being handled by the AssetLoadCache, we don't need to add it to this cache
-            if (handleAssetLoad && assetLoadCache != null && assetLoadCache.TryGet(key, out GltfContainerAsset _))
+            // A preloaded copy is unique to its consumer, so it can't return to the shared pool (the bridge still needs it for LOD visuals).
+            if (handleAssetLoad && assetLoadCache != null && assetLoadCache.ContainsGltf(key))
             {
-                DereferenceFinalOperation(asset, putInBridge);
+                if (putInBridge)
+                    DereferenceFinalOperation(asset, true);
+                else
+                    assetLoadCache.ReleaseGltfInstance(key, asset);
+
                 return;
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromRawGltfSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromRawGltfSystem.cs
@@ -72,7 +72,7 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
 
         }
 
-        private static GltfContainerAsset CreateGltfObject(GLTFData gltfData)
+        public static GltfContainerAsset CreateGltfObject(GLTFData gltfData)
         {
             // Instantiate a per-consumer copy of the template hierarchy. Mesh, Material, Texture and AnimationClip
             // references are shared with gltfData.Root — Object.Instantiate only clones GameObjects and Component

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromRawGltfSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromRawGltfSystem.cs
@@ -3,19 +3,13 @@ using Arch.System;
 using Arch.SystemGroups;
 using DCL.Diagnostics;
 using DCL.Optimization.PerformanceBudgeting;
-using DCL.Optimization.Pools;
 using ECS.Abstract;
 using ECS.StreamableLoading;
 using ECS.StreamableLoading.Common;
 using ECS.StreamableLoading.Common.Components;
 using ECS.StreamableLoading.GLTF;
 using ECS.Unity.GLTFContainer.Asset.Components;
-using ECS.Unity.SceneBoundsChecker;
-using System;
-using System.Collections.Generic;
 using UnityEngine;
-using Utility;
-using Object = UnityEngine.Object;
 
 namespace ECS.Unity.GLTFContainer.Asset.Systems
 {
@@ -23,8 +17,6 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
     [LogCategory(ReportCategory.GLTF_CONTAINER)]
     public partial class CreateGltfAssetFromRawGltfSystem : BaseUnityLoopSystem
     {
-        private const string COLLIDER_SUFFIX = "_collider";
-        private const StringComparison IGNORE_CASE = StringComparison.CurrentCultureIgnoreCase;
         private readonly IPerformanceBudget instantiationFrameTimeBudget;
         private readonly IPerformanceBudget memoryBudget;
 
@@ -65,132 +57,10 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
                 return;
 
             if (gltfDataResult.Succeeded)
-                World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(CreateGltfObject(gltfDataResult.Asset)));
+                World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(Utils.CreateGltfObject(gltfDataResult.Asset)));
             else
                 World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(GetReportData(),
                     new StreamableLoadingException(LogType.Exception, gltfDataResult.Exception.Message, gltfDataResult.Exception)));
-
         }
-
-        public static GltfContainerAsset CreateGltfObject(GLTFData gltfData)
-        {
-            // Instantiate a per-consumer copy of the template hierarchy. Mesh, Material, Texture and AnimationClip
-            // references are shared with gltfData.Root — Object.Instantiate only clones GameObjects and Component
-            // metadata, not the underlying asset data. This mirrors Utils.TryCreateGltfObject for the AB path and
-            // is what lets 50 entities share one GltfImport's mesh/texture memory instead of loading 50 copies.
-            GameObject cloneRoot = Object.Instantiate(gltfData.Root);
-            cloneRoot.SetActive(false);
-
-            var result = GltfContainerAsset.Create(cloneRoot, gltfData, hierarchyPaths: gltfData.HierarchyPaths);
-
-            // Collect all renderers, they are needed for Visibility system
-            using (PoolExtensions.Scope<List<Renderer>> instanceRenderers = GltfContainerAsset.RENDERERS_POOL.AutoScope())
-            {
-                cloneRoot.GetComponentsInChildren(true, instanceRenderers.Value);
-                result.Renderers.AddRange(instanceRenderers.Value);
-            }
-
-            // Collect all Animations as they are used in Animation System (only for legacy support, as all of them will eventually be converted to Animators)
-            using (PoolExtensions.Scope<List<Animation>> animationScope = GltfContainerAsset.ANIMATIONS_POOL.AutoScope())
-            {
-                cloneRoot.GetComponentsInChildren(true, animationScope.Value);
-                result.Animations.AddRange(animationScope.Value);
-            }
-
-            // Collect all Animators as they are used in Animation System
-            using (PoolExtensions.Scope<List<Animator>> animatorScope = GltfContainerAsset.ANIMATORS_POOL.AutoScope())
-            {
-                cloneRoot.GetComponentsInChildren(true, animatorScope.Value);
-                result.Animators.AddRange(animatorScope.Value);
-            }
-
-            // Collect colliders from mesh filters
-            // Colliders are created/fetched disabled as its layer is controlled by another system
-            using (PoolExtensions.Scope<List<MeshFilter>> meshFilterScope = GltfContainerAsset.MESH_FILTERS_POOL.AutoScope())
-            {
-                List<MeshFilter> list = meshFilterScope.Value;
-                cloneRoot.GetComponentsInChildren(true, list);
-
-                foreach (MeshFilter meshFilter in list)
-                {
-                    GameObject go = meshFilter.gameObject;
-
-                    // This treatment mimics what's being done in the AB converter
-                    if (meshFilter.name.Contains(COLLIDER_SUFFIX, IGNORE_CASE))
-                    {
-                        MeshCollider newCollider = AddMeshCollider(meshFilter, go);
-                        result.InvisibleColliders.Add(new SDKCollider(newCollider));
-                    }
-                    else
-                    {
-                        // Consider it a visible collider when it has a renderer on it
-                        if (go.GetComponent<Renderer>())
-                            AddVisibleMeshCollider(result.VisibleColliderMeshes, go, meshFilter.sharedMesh);
-                        else
-
-                            // Gather invisible colliders
-                            CreateAndAddMeshCollider(result.InvisibleColliders, go);
-                    }
-                }
-            }
-
-            // Collect colliders from skinned mesh renderers
-            using (PoolExtensions.Scope<List<SkinnedMeshRenderer>> instanceRenderers = GltfContainerAsset.SKINNED_RENDERERS_POOL.AutoScope())
-            {
-                cloneRoot.GetComponentsInChildren(true, instanceRenderers.Value);
-
-                foreach (SkinnedMeshRenderer skinnedMeshRenderer in instanceRenderers.Value)
-                {
-                    GameObject go = skinnedMeshRenderer.gameObject;
-
-                    // Always considered as visible collider
-                    AddVisibleMeshCollider(result.VisibleColliderMeshes, go, skinnedMeshRenderer.sharedMesh);
-                }
-            }
-
-            return result;
-        }
-
-
-        // If we update AddVisibleMeshCollider and/or CreateAndAddMeshCollider please check and update them in CreateGltfAssetFromAssetBundleSystem.cs
-        // As a tech-debt we might want to move these functions elsewhere to avoid repetition, but for now it's acceptable since this is only for local development
-
-#region Helper Collider Methods
-        private static void AddVisibleMeshCollider(List<GltfContainerAsset.VisibleMeshCollider> result, GameObject go, Mesh mesh)
-        {
-            result.Add(new GltfContainerAsset.VisibleMeshCollider
-            {
-                GameObject = go,
-                Mesh = mesh,
-            });
-        }
-
-        private static void CreateAndAddMeshCollider(List<SDKCollider> result, GameObject go)
-        {
-            // Asset Bundle converter creates Colliders during the processing in some cases
-            Collider collider = go.GetComponent<Collider>();
-
-            if (collider)
-            {
-                // Disable it as its activity controlled by another system based on PBGltfContainer component
-                collider.enabled = false;
-
-                result.Add(new SDKCollider(collider));
-            }
-        }
-
-        private static MeshCollider AddMeshCollider(MeshFilter meshFilter, GameObject go)
-        {
-            Physics.BakeMesh(meshFilter.sharedMesh.GetInstanceID(), false);
-            MeshCollider newCollider = go.AddComponent<MeshCollider>();
-            var renderer = go.GetComponent<MeshRenderer>();
-
-            if (renderer)
-                renderer.enabled = false;
-
-            UnityObjectUtils.SafeDestroy(meshFilter);
-            return newCollider;
-        }
-#endregion
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Utils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Utils.cs
@@ -7,12 +7,131 @@ using ECS.Unity.SceneBoundsChecker;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Utility;
 using Object = UnityEngine.Object;
 
 namespace ECS.Unity.GLTFContainer
 {
     public class Utils
     {
+        private const string COLLIDER_SUFFIX = "_collider";
+        private const StringComparison IGNORE_CASE = StringComparison.CurrentCultureIgnoreCase;
+
+        private static void AddVisibleMeshCollider(List<GltfContainerAsset.VisibleMeshCollider> result, GameObject go, Mesh mesh)
+        {
+            result.Add(new GltfContainerAsset.VisibleMeshCollider
+            {
+                GameObject = go,
+                Mesh = mesh,
+            });
+        }
+
+        private static void CreateAndAddMeshCollider(List<SDKCollider> result, GameObject go)
+        {
+            // Asset Bundle converter creates Colliders during the processing in some cases
+            Collider collider = go.GetComponent<Collider>();
+
+            if (collider)
+            {
+                // Disable it as its activity controlled by another system based on PBGltfContainer component
+                collider.enabled = false;
+
+                result.Add(new SDKCollider(collider));
+            }
+        }
+
+        private static MeshCollider AddMeshCollider(MeshFilter meshFilter, GameObject go)
+        {
+            Physics.BakeMesh(meshFilter.sharedMesh.GetInstanceID(), false);
+            MeshCollider newCollider = go.AddComponent<MeshCollider>();
+            var renderer = go.GetComponent<MeshRenderer>();
+
+            if (renderer)
+                renderer.enabled = false;
+
+            UnityObjectUtils.SafeDestroy(meshFilter);
+            return newCollider;
+        }
+
+        public static GltfContainerAsset CreateGltfObject(GLTFData gltfData)
+        {
+            // Instantiate a per-consumer copy of the template hierarchy. Mesh, Material, Texture and AnimationClip
+            // references are shared with gltfData.Root — Object.Instantiate only clones GameObjects and Component
+            // metadata, not the underlying asset data. This mirrors Utils.TryCreateGltfObject for the AB path and
+            // is what lets 50 entities share one GltfImport's mesh/texture memory instead of loading 50 copies.
+            GameObject cloneRoot = Object.Instantiate(gltfData.Root);
+            cloneRoot.SetActive(false);
+
+            var result = GltfContainerAsset.Create(cloneRoot, gltfData, hierarchyPaths: gltfData.HierarchyPaths);
+
+            // Collect all renderers, they are needed for Visibility system
+            using (PoolExtensions.Scope<List<Renderer>> instanceRenderers = GltfContainerAsset.RENDERERS_POOL.AutoScope())
+            {
+                cloneRoot.GetComponentsInChildren(true, instanceRenderers.Value);
+                result.Renderers.AddRange(instanceRenderers.Value);
+            }
+
+            // Collect all Animations as they are used in Animation System (only for legacy support, as all of them will eventually be converted to Animators)
+            using (PoolExtensions.Scope<List<Animation>> animationScope = GltfContainerAsset.ANIMATIONS_POOL.AutoScope())
+            {
+                cloneRoot.GetComponentsInChildren(true, animationScope.Value);
+                result.Animations.AddRange(animationScope.Value);
+            }
+
+            // Collect all Animators as they are used in Animation System
+            using (PoolExtensions.Scope<List<Animator>> animatorScope = GltfContainerAsset.ANIMATORS_POOL.AutoScope())
+            {
+                cloneRoot.GetComponentsInChildren(true, animatorScope.Value);
+                result.Animators.AddRange(animatorScope.Value);
+            }
+
+            // Collect colliders from mesh filters
+            // Colliders are created/fetched disabled as its layer is controlled by another system
+            using (PoolExtensions.Scope<List<MeshFilter>> meshFilterScope = GltfContainerAsset.MESH_FILTERS_POOL.AutoScope())
+            {
+                List<MeshFilter> list = meshFilterScope.Value;
+                cloneRoot.GetComponentsInChildren(true, list);
+
+                foreach (MeshFilter meshFilter in list)
+                {
+                    GameObject go = meshFilter.gameObject;
+
+                    // This treatment mimics what's being done in the AB converter
+                    if (meshFilter.name.Contains(COLLIDER_SUFFIX, IGNORE_CASE))
+                    {
+                        MeshCollider newCollider = AddMeshCollider(meshFilter, go);
+                        result.InvisibleColliders.Add(new SDKCollider(newCollider));
+                    }
+                    else
+                    {
+                        // Consider it a visible collider when it has a renderer on it
+                        if (go.GetComponent<Renderer>())
+                            AddVisibleMeshCollider(result.VisibleColliderMeshes, go, meshFilter.sharedMesh);
+                        else
+
+                            // Gather invisible colliders
+                            CreateAndAddMeshCollider(result.InvisibleColliders, go);
+                    }
+                }
+            }
+
+            // Collect colliders from skinned mesh renderers
+            using (PoolExtensions.Scope<List<SkinnedMeshRenderer>> instanceRenderers = GltfContainerAsset.SKINNED_RENDERERS_POOL.AutoScope())
+            {
+                cloneRoot.GetComponentsInChildren(true, instanceRenderers.Value);
+
+                foreach (SkinnedMeshRenderer skinnedMeshRenderer in instanceRenderers.Value)
+                {
+                    GameObject go = skinnedMeshRenderer.gameObject;
+
+                    // Always considered as visible collider
+                    AddVisibleMeshCollider(result.VisibleColliderMeshes, go, skinnedMeshRenderer.sharedMesh);
+                }
+            }
+
+            return result;
+        }
+
         public static bool TryDuplicateGltfAssetFromTemplate(GltfContainerAsset template, string hash, out GltfContainerAsset? duplicate)
         {
             switch (template.AssetData)
@@ -22,7 +141,7 @@ namespace ECS.Unity.GLTFContainer
                     assetBundleData.AcquireRef();
                     return true;
                 case GLTFData gltfData:
-                    duplicate = CreateGltfAssetFromRawGltfSystem.CreateGltfObject(gltfData);
+                    duplicate = CreateGltfObject(gltfData);
                     gltfData.AcquireRef();
                     return true;
                 default:

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Utils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Utils.cs
@@ -2,7 +2,6 @@ using DCL.Optimization.Pools;
 using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.GLTF;
 using ECS.Unity.GLTFContainer.Asset.Components;
-using ECS.Unity.GLTFContainer.Asset.Systems;
 using ECS.Unity.SceneBoundsChecker;
 using System;
 using System.Collections.Generic;
@@ -228,9 +227,6 @@ namespace ECS.Unity.GLTFContainer
             gltfContainerAsset = result;
             return true;
         }
-
-        // If we update AddVisibleMeshCollider and/or CreateAndAddMeshCollider please check and update them in CreateGltfAssetFromRawGltfSystem.cs
-        // As a tech-debt we might want to move these functions elsewhere to avoid repetition, but for now it's acceptable since the other one is only for local scene development
 
 #region Helper Collider Methods
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Utils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Utils.cs
@@ -13,7 +13,7 @@ namespace ECS.Unity.GLTFContainer
 {
     public class Utils
     {
-        public static bool TryDuplicateGltfAssetFromTemplate(GltfContainerAsset template, string hash, out GltfContainerAsset duplicate)
+        public static bool TryDuplicateGltfAssetFromTemplate(GltfContainerAsset template, string hash, out GltfContainerAsset? duplicate)
         {
             switch (template.AssetData)
             {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Utils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Utils.cs
@@ -1,6 +1,8 @@
 using DCL.Optimization.Pools;
 using ECS.StreamableLoading.AssetBundles;
+using ECS.StreamableLoading.GLTF;
 using ECS.Unity.GLTFContainer.Asset.Components;
+using ECS.Unity.GLTFContainer.Asset.Systems;
 using ECS.Unity.SceneBoundsChecker;
 using System;
 using System.Collections.Generic;
@@ -11,6 +13,24 @@ namespace ECS.Unity.GLTFContainer
 {
     public class Utils
     {
+        public static bool TryDuplicateGltfAssetFromTemplate(GltfContainerAsset template, string hash, out GltfContainerAsset duplicate)
+        {
+            switch (template.AssetData)
+            {
+                case AssetBundleData assetBundleData when TryCreateGltfObject(assetBundleData, hash, out duplicate):
+                    // Factories leave ref-counting to the cache layer, so the clone must take its own reference to balance Dispose().
+                    assetBundleData.AcquireRef();
+                    return true;
+                case GLTFData gltfData:
+                    duplicate = CreateGltfAssetFromRawGltfSystem.CreateGltfObject(gltfData);
+                    gltfData.AcquireRef();
+                    return true;
+                default:
+                    duplicate = null;
+                    return false;
+            }
+        }
+
         public static bool TryCreateGltfObject(AssetBundleData assetBundleData, string assetHash, out GltfContainerAsset gltfContainerAsset)
         {
             if (!assetBundleData.TryGetAsset(out GameObject asset, assetHash))


### PR DESCRIPTION
# Pull Request Description

If a gltf asset was pre-loaded with the dedicated SDK component, every container created at the sdk level was handed by the client with the very same instance. This meant that one couldn't instantiate more than 1 preloaded asset in the scene.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR treats the pre-loaded gltf asset as a template so that every future container requested by the SDK will receive a clone of that instance -> multiple can coexist and will get the pre-load benefit.


### Test Steps
1. Go to `eax.dcl.eth` with multiple users and verify that each one of them will have a wooden rod in their hand
2. Reload the scene and verify everything works as expected
3. Using prod will cause the very latest joiner to be the only one with the rod

If you leave the scene, you will see floating rods inside it: that's to be expected.


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
