### PR TITLE
fix: null pointers and a multi threading contention

### DIFF
--- a/Explorer/Assets/DCL/ApplicationsGuards/ApplicationLivekitGuard/LivekitHealtGuardController.cs
+++ b/Explorer/Assets/DCL/ApplicationsGuards/ApplicationLivekitGuard/LivekitHealtGuardController.cs
@@ -11,7 +11,7 @@ public class LivekitHealtGuardController : ControllerBase<LivekitHealthGuardView
 
     protected override void OnViewInstantiated()
     {
-        viewInstance.ExitButton.onClick.AddListener(ExitUtils.Exit);
+        viewInstance!.ExitButton.onClick.AddListener(ExitUtils.Exit);
     }
 
     protected override UniTask WaitForCloseIntentAsync(CancellationToken ct) =>

--- a/Explorer/Assets/DCL/ApplicationsGuards/ApplicationVersionGuard/LauncherRedirectionScreenController.cs
+++ b/Explorer/Assets/DCL/ApplicationsGuards/ApplicationVersionGuard/LauncherRedirectionScreenController.cs
@@ -26,7 +26,7 @@ namespace DCL.AuthenticationScreenFlow
 
         protected override void OnViewInstantiated()
         {
-            viewInstance.SetVersions(current, latest);
+            viewInstance!.SetVersions(current, latest);
             viewInstance.CloseButton.onClick.AddListener(ExitUtils.Exit);
             viewInstance.CloseWithLauncherButton.onClick.AddListener(HandleVersionUpdate);
         }

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -92,8 +92,8 @@ namespace DCL.AuthenticationScreenFlow
         internal void RaiseProfileFinalized() =>
             ProfileFinalized?.Invoke();
 
-        private MVCStateMachine<AuthStateBase> fsm;
-        private AuthenticationScreenAudio audio;
+        private MVCStateMachine<AuthStateBase>? fsm;
+        private AuthenticationScreenAudio? audio;
 
         public AuthenticationScreenController(
             ViewFactoryMethod viewFactory,
@@ -141,8 +141,11 @@ namespace DCL.AuthenticationScreenFlow
             characterPreviewController?.Dispose();
 
             CancelLoginProcess();
-            audio.Dispose();
-            fsm.Dispose();
+
+            // audio (and the fsm state it drives) is created in OnViewInstantiated; when the view was
+            // never shown (e.g. --skip-auth-screen) disposing the controller must not throw
+            audio?.Dispose();
+            fsm?.Dispose();
         }
 
         protected override void OnViewInstantiated()
@@ -203,7 +206,7 @@ namespace DCL.AuthenticationScreenFlow
             }
             else
             {
-                fsm.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
+                fsm!.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
             }
         }
 
@@ -214,10 +217,10 @@ namespace DCL.AuthenticationScreenFlow
                 bool autoLoginSuccess = await web3Authenticator.TryAutoLoginAsync(ct);
 
                 if (autoLoginSuccess)
-                    fsm.Enter<ProfileFetchingAuthState, ProfileFetchingPayload>(new (storedIdentity, storedIdentity.Source != IWeb3Identity.Web3IdentitySource.TokenFile, ct));
+                    fsm!.Enter<ProfileFetchingAuthState, ProfileFetchingPayload>(new (storedIdentity, storedIdentity.Source != IWeb3Identity.Web3IdentitySource.TokenFile, ct));
                 else
                 {
-                    fsm.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
+                    fsm!.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
                 }
             }
             catch (OperationCanceledException)
@@ -226,7 +229,7 @@ namespace DCL.AuthenticationScreenFlow
             catch (Exception e)
             {
                 ReportHub.LogException(e, new ReportData(ReportCategory.AUTHENTICATION));
-                fsm.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
+                fsm!.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
             }
         }
 
@@ -235,18 +238,18 @@ namespace DCL.AuthenticationScreenFlow
             base.OnViewShow();
 
             BlockUnwantedInputs();
-            audio.OnShow();
+            audio!.OnShow();
         }
 
         protected override void OnViewClose()
         {
             base.OnViewClose();
 
-            fsm.CurrentState?.Exit();
+            fsm!.CurrentState?.Exit();
             CancelLoginProcess();
 
             UnblockUnwantedInputs();
-            audio.OnHide();
+            audio!.OnHide();
         }
 
         protected override async UniTask WaitForCloseIntentAsync(CancellationToken ct)
@@ -285,7 +288,7 @@ namespace DCL.AuthenticationScreenFlow
 
                 await web3Authenticator.LogoutAsync(ct);
 
-                fsm.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.SLIDE, true);
+                fsm!.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.SLIDE, true);
             }
         }
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarShapeVisibilitySystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarShapeVisibilitySystemShould.cs
@@ -423,7 +423,6 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
 
             // Add skinning component for dither test
             var skinningMaterials = new List<AvatarCustomSkinningComponent.MaterialSetup>();
-            var skinningComponent = new AvatarCustomSkinningComponent();
 
             // Act - This update should trigger ResetDitherState due to IsDirty
             system.Update(0);

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/FinalizeEmoteLoadingSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/FinalizeEmoteLoadingSystem.cs
@@ -83,7 +83,7 @@ namespace DCL.AvatarRendering.Emotes
                     AssignEmoteResult(emote, bodyShape, regularAssetResult);
                 else
                 {
-                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO.id} failed to load from the AB");
+                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO?.id} failed to load from the AB");
                     AssignFailedEmoteResult(emote, bodyShape);
                 }
 
@@ -108,7 +108,7 @@ namespace DCL.AvatarRendering.Emotes
                     AssignEmoteResult(emote, bodyShape, regularAssetResult);
                 else
                 {
-                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO.id} failed to load from the GLTF");
+                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO?.id} failed to load from the GLTF");
                     AssignFailedEmoteResult(emote, bodyShape);
                 }
 
@@ -121,7 +121,7 @@ namespace DCL.AvatarRendering.Emotes
         {
             var asset = new StreamableLoadingResult<AttachmentRegularAsset>(regularAssetResult);
 
-            if (emote.IsUnisex() && emote.HasSameClipForAllGenders())
+            if (emote.DTO != null && emote.IsUnisex() && emote.HasSameClipForAllGenders())
             {
                 emote.AssetResults[BodyShape.MALE] = asset;
                 emote.AssetResults[BodyShape.FEMALE] = asset;
@@ -134,9 +134,9 @@ namespace DCL.AvatarRendering.Emotes
         {
             var failedResult = new StreamableLoadingResult<AttachmentRegularAsset>(
                 GetReportData(),
-                new Exception($"Emote {emote.DTO.id} failed to load"));
+                new Exception($"Emote {emote.DTO?.id} failed to load"));
 
-            if (emote.IsUnisex() && emote.HasSameClipForAllGenders())
+            if (emote.DTO != null && emote.IsUnisex() && emote.HasSameClipForAllGenders())
             {
                 emote.AssetResults[BodyShape.MALE] = failedResult;
                 emote.AssetResults[BodyShape.FEMALE] = failedResult;

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
@@ -1,4 +1,5 @@
 using CommunicationData.URLHelpers;
+using DCL.AvatarRendering.Emotes;
 using DCL.AvatarRendering.Loading.DTO;
 using DCL.Diagnostics;
 using DCL.Ipfs;
@@ -157,7 +158,16 @@ namespace DCL.AvatarRendering.Loading.Components
                     }
             }
             else
-                ReportHub.LogError(ReportCategory.WEARABLE, $"No content found in DTO for wearable with ID: {DTO.Metadata.id}");
+            {
+                // Scene emotes are built in-client with no content array at all (see
+                // LoadSceneEmotesSystem): their asset is loaded directly by the hash embedded in
+                // the URN, so a missing content map is their designed state, not an error. For
+                // catalog wearables a null content array IS a real data problem - keep reporting it.
+                string id = DTO.Metadata?.id ?? string.Empty;
+
+                if (!id.StartsWith(GetSceneEmoteFromRealmIntention.SCENE_EMOTE_PREFIX, StringComparison.Ordinal))
+                    ReportHub.LogError(ReportCategory.WEARABLE, $"No content found in DTO for wearable with ID: {id}");
+            }
 
             hash = null;
             return false;

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
@@ -13,6 +13,13 @@ namespace DCL.AvatarRendering.Loading.Components
 
         public void UpdateLoadingStatus(bool isLoading);
 
+        /// <summary>
+        ///     Null until the attachment's model resolves (and on a failed load - concrete getters back this
+        ///     with <c>Model.Asset!</c>, which FinalizeEmoteLoadingSystem guards on). The metadata accessors
+        ///     below that return a nullable type (manifest version, download url, entity id) propagate that
+        ///     null with <c>?.</c>; the value-returning helpers (hash, urn, category, thumbnail, ...) have a
+        ///     loaded precondition and dereference it directly.
+        /// </summary>
         AvatarAttachmentDTO? DTO { get; }
 
         int Amount { get; }
@@ -24,13 +31,13 @@ namespace DCL.AvatarRendering.Loading.Components
             DTO.GetHash();
 
         public new AssetBundleManifestVersion? GetAssetBundleManifestVersion() =>
-            DTO.assetBundleManifestVersion;
+            DTO?.assetBundleManifestVersion;
 
         public new string? GetContentDownloadUrl() =>
-            DTO.ContentDownloadUrl;
+            DTO?.ContentDownloadUrl;
 
         public new string? GetEntityId() =>
-            DTO.id;
+            DTO?.id;
 
         public bool IsUnisex()
         {

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Equipped/EquippedWearables.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Equipped/EquippedWearables.cs
@@ -31,7 +31,7 @@ namespace DCL.AvatarRendering.Wearables.Equipped
 
         public bool IsEquipped(ITrimmedWearable wearable)
         {
-            return wearables[wearable.GetCategory()]?.DTO.id == wearable.TrimmedDTO.id;
+            return wearables[wearable.GetCategory()]?.DTO?.id == wearable.TrimmedDTO.id;
         }
 
         public void Equip(IWearable wearable) =>

--- a/Explorer/Assets/DCL/Backpack/BackpackController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackController.cs
@@ -322,6 +322,12 @@ namespace DCL.Backpack
 
         public void ResetAnimator()
         {
+            // Sections are reset in bulk by SectionSelectorController.ResetAnimators while at most
+            // one is active; an inactive panel discards its animator state on disable anyway, so
+            // the reset is a no-op that would only log the Update-on-inactive-object warning.
+            if (!view.PanelAnimator.gameObject.activeInHierarchy)
+                return;
+
             view.PanelAnimator.Rebind();
             view.HeaderAnimator.Rebind();
             view.PanelAnimator.Update(0);

--- a/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftSelection/GiftSelectionController.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftSelection/GiftSelectionController.cs
@@ -119,8 +119,10 @@ namespace DCL.Backpack.Gifting.Presenters
                 wearablesGridPresenter?.SetSearchText(string.Empty);
                 emotesGridPresenter?.SetSearchText(string.Empty);
             }
-            catch (Exception)
+            catch (OperationCanceledException) { }
+            catch (Exception e)
             {
+                ReportHub.LogException(e, ReportCategory.GIFTING);
             }
         }
 

--- a/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftSelection/GiftSelectionController.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftSelection/GiftSelectionController.cs
@@ -119,7 +119,7 @@ namespace DCL.Backpack.Gifting.Presenters
                 wearablesGridPresenter?.SetSearchText(string.Empty);
                 emotesGridPresenter?.SetSearchText(string.Empty);
             }
-            catch (Exception e)
+            catch (Exception)
             {
             }
         }

--- a/Explorer/Assets/DCL/Chat/ChatEntryMessageBubbleElement.cs
+++ b/Explorer/Assets/DCL/Chat/ChatEntryMessageBubbleElement.cs
@@ -142,12 +142,12 @@ namespace DCL.Chat
         private float CalculatePreferredWidth(string displayText, ChatMessage originalMessage, string usernameOverride = null, string walletIdOverride = null)
         {
             string username = string.IsNullOrEmpty(usernameOverride) ? originalMessage.SenderValidatedName : usernameOverride;
-            int nameLength = 0;
 
-            if (string.IsNullOrEmpty(username))
-                ReportHub.LogError(ReportCategory.CHAT_MESSAGES, $"SenderValidatedName is null or empty for message: {originalMessage.MessageId} sent by wallet: {originalMessage.SenderWalletAddress}");
-            else
-                nameLength = username.Length;
+            // An empty name is an expected state, not an error: ChatMessageFactory fills
+            // SenderValidatedName with string.Empty whenever the sender's profile isn't available yet,
+            // and UpdateName re-runs this layout once the profile resolves. Until then the width
+            // calculation simply proceeds with the wallet id alone.
+            int nameLength = string.IsNullOrEmpty(username) ? 0 : username.Length;
 
             string walletId = string.IsNullOrEmpty(walletIdOverride) ? originalMessage.SenderWalletId : walletIdOverride;
             int walletIdLength = string.IsNullOrEmpty(walletId) ? 0 : walletId.Length;

--- a/Explorer/Assets/DCL/Chat/Commands/AnrDumpChatCommand.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/AnrDumpChatCommand.cs
@@ -3,7 +3,6 @@ using Cysharp.Threading.Tasks;
 using DCL.Diagnostics.Sentry;
 using RichTypes;
 using System.Threading;
-using Cysharp.Threading.Tasks;
 
 namespace DCL.Chat.Commands
 {

--- a/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesBrowser/CommunitiesBrowserView.cs
@@ -122,6 +122,12 @@ namespace DCL.Communities.CommunitiesBrowser
 
         public void ResetAnimator()
         {
+            // Sections are reset in bulk by SectionSelectorController.ResetAnimators while at most
+            // one is active; an inactive panel discards its animator state on disable anyway, so
+            // the reset is a no-op that would only log the Update-on-inactive-object warning.
+            if (!panelAnimator.gameObject.activeInHierarchy)
+                return;
+
             panelAnimator.Rebind();
             headerAnimator.Rebind();
             panelAnimator.Update(0);

--- a/Explorer/Assets/DCL/Events/EventsView.cs
+++ b/Explorer/Assets/DCL/Events/EventsView.cs
@@ -49,6 +49,12 @@ namespace DCL.Events
 
         public void ResetAnimator()
         {
+            // Sections are reset in bulk by SectionSelectorController.ResetAnimators while at most
+            // one is active; an inactive panel discards its animator state on disable anyway, so
+            // the reset is a no-op that would only log the Update-on-inactive-object warning.
+            if (!panelAnimator.gameObject.activeInHierarchy)
+                return;
+
             panelAnimator.Rebind();
             headerAnimator.Rebind();
             panelAnimator.Update(0);

--- a/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/CameraReelGallery/CameraReelController.cs
@@ -121,6 +121,12 @@ namespace DCL.InWorldCamera.CameraReelGallery
 
         public void ResetAnimator()
         {
+            // Sections are reset in bulk by SectionSelectorController.ResetAnimators while at most
+            // one is active; an inactive panel discards its animator state on disable anyway, so
+            // the reset is a no-op that would only log the Update-on-inactive-object warning.
+            if (!view.panelAnimator.gameObject.activeInHierarchy)
+                return;
+
             view.panelAnimator.Rebind();
             view.headerAnimator.Rebind();
             view.panelAnimator.Update(0);

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
@@ -69,7 +69,7 @@ namespace ECS.Unity.GLTFContainer.Tests
 
                 usedResources = false;
             }
-            catch (Exception e)
+            catch (Exception)
             {
             }
         }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/LoadGltfContainerSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/LoadGltfContainerSystemShould.cs
@@ -72,7 +72,7 @@ namespace ECS.Unity.GLTFContainer.Tests
 
                 usedResources = false;
             }
-            catch (Exception e)
+            catch (Exception)
             {
             }
         }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -167,7 +167,7 @@ namespace Global.Dynamic
         {
             // Dispose just in case, but if the process ends normally or by a crash, the lock should also be released due to how native OS works
             try { singleInstanceLock?.Dispose(); }
-            catch { }
+            catch (Exception e) { ReportHub.LogWarning(ReportCategory.ENGINE, $"Failed to release the single-instance lock on quit: {e}"); }
 
             DisableAllSelectableTransitions();
         }

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ResolveSceneStateByIncreasingRadiusSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ResolveSceneStateByIncreasingRadiusSystemShould.cs
@@ -39,9 +39,6 @@ namespace ECS.SceneLifeCycle.Tests
 
         private SceneLoadingLimit sceneLoadingLimit;
         private ISystemMemoryCap systemMemoryCap;
-        private int maximumAmountOfScenesThatCanLoad;
-        private int maximumAmountOfLODThatCanLoad;
-        private int maximumAmountOfLODReductedThatCanLoad;
 
         private int SDK7LODThreshold;
         private Entity playerEntity;
@@ -62,9 +59,6 @@ namespace ECS.SceneLifeCycle.Tests
 
             RealmData realmData = new RealmData(new TestIpfsRealm());
 
-            maximumAmountOfScenesThatCanLoad = 6;
-            maximumAmountOfLODThatCanLoad = 5;
-            maximumAmountOfLODReductedThatCanLoad = 8;
 
             systemMemoryCap = Substitute.For<ISystemMemoryCap>();
             systemMemoryCap.MemoryCapInMB.Returns(long.MaxValue);

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/IGetHash.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/IGetHash.cs
@@ -36,7 +36,7 @@ namespace SceneRunner.Scene
                 }
             }
             catch (OperationCanceledException) { throw; }
-            catch (Exception) { }
+            catch (Exception e) { ReportHub.LogException(e, reportCategory); }
 
             ReportHub.LogError(reportCategory, $"Trying to load hybrid scene with coordinates {coordinate} failed. You wont get the asset bundles");
             return (false, "");
@@ -77,7 +77,7 @@ namespace SceneRunner.Scene
                 }
             }
             catch (OperationCanceledException) { throw; }
-            catch (Exception) { }
+            catch (Exception e) { ReportHub.LogException(e, reportCategory); }
 
             ReportHub.LogError(reportCategory, $"Trying to load hybrid scene with coordinates {coordinate} failed. You wont get the asset bundles");
             return (false, "");
@@ -97,7 +97,7 @@ namespace SceneRunner.Scene
                 return (true, getSceneDefinition[0].id!);
             }
             catch (OperationCanceledException) { throw; }
-            catch (Exception) { }
+            catch (Exception e) { ReportHub.LogException(e, reportCategory); }
 
             ReportHub.LogError(reportCategory, $"Trying to load hybrid scene with coordinates {coordinate} failed. You wont get the asset bundles");
             return (false, "");

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Tests/SceneFacadeShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Tests/SceneFacadeShould.cs
@@ -138,7 +138,6 @@ namespace SceneRunner.Tests
         private SceneRuntimeFactory sceneRuntimeFactory = null!;
         private IECSWorldFactory ecsWorldFactory = null!;
         private ISharedPoolsProvider sharedPoolsProvider = null!;
-        private ICRDTDeserializer crdtDeserializer = null!;
         private ICRDTSerializer crdtSerializer = null!;
         private ISDKComponentsRegistry componentsRegistry = null!;
         private SceneFactory sceneFactory = null!;

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Extensions/NullExtensions.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Extensions/NullExtensions.cs
@@ -16,6 +16,6 @@ namespace DCL.Utilities.Extensions
         public static T EnsureGetComponent<T>(this GameObject? value) =>
             value.EnsureNotNull("GameObject is null")
                  .GetComponent<T>()
-                 .EnsureNotNull($"{typeof(T).Name} component not found on the gameobject {value.name}");
+                 .EnsureNotNull($"{typeof(T).Name} component not found on the gameobject {value!.name}");
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/PlatformUtils.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/PlatformUtils.cs
@@ -60,7 +60,7 @@ namespace DCL.Utility
                     TotalSize = (ulong)drive.TotalSize
                 };
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 return null;
             }
@@ -83,7 +83,7 @@ namespace DCL.Utility
                 return new List<DriveData>();
 #endif
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return new List<DriveData>();
             }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/ReactiveProperties/IReactiveProperty.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/ReactiveProperties/IReactiveProperty.cs
@@ -79,7 +79,9 @@ namespace DCL.Utilities
 
             public void Dispose()
             {
-                reactiveProperty.Unsubscribe(observer);
+                // a default(DisposableSubscription<T>) - e.g. a controller torn down before it ever
+                // subscribed - carries a null reactiveProperty; the ?. keeps that default safe to dispose
+                reactiveProperty?.Unsubscribe(observer);
             }
         }
     }

--- a/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
+++ b/Explorer/Assets/DCL/Interaction/Raycast/Systems/ExecuteRaycastSystem.cs
@@ -100,7 +100,7 @@ namespace DCL.Interaction.Raycast.Systems
         private void BudgetAndExecute(Vector3 scenePosition)
         {
             // Process only not executed raycasts which bucket is not farther than the max allowed distance
-            orderedRaycastData.Clear();
+            orderedRaycastData!.Clear();
 
             GatherSpecialEntitiesRaycastIntentsQuery(World);
             GatherRaycastIntentsQuery(World);
@@ -155,7 +155,7 @@ namespace DCL.Interaction.Raycast.Systems
             // Filter out invalid type
             if (raycast.QueryType == RaycastQueryType.RqtNone) return;
 
-            orderedRaycastData.Add(new RaycastData
+            orderedRaycastData!.Add(new RaycastData
             {
                 Partition = partitionComponent,
                 Component = new ManagedTypePointer<RaycastComponent>(ref raycastComponent),

--- a/Explorer/Assets/DCL/LOD/Systems/InstantiateSceneLODInfoSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/InstantiateSceneLODInfoSystem.cs
@@ -91,7 +91,7 @@ namespace DCL.LOD.Systems
         {
             if (sceneLODInfo.CurrentLODPromise.TryConsume(World, out StreamableLoadingResult<AssetBundleData> result))
             {
-                if (result.Succeeded && result.Asset.TryGetAsset(out GameObject go))
+                if (result.Succeeded && result.Asset?.TryGetAsset(out GameObject go) == true)
                 {
                     GameObject? instantiatedLOD = Object.Instantiate(go,
                         sceneDefinitionComponent.SceneGeometry.BaseParcelPosition,

--- a/Explorer/Assets/DCL/LOD/Systems/ResolveISSLODSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/ResolveISSLODSystem.cs
@@ -133,7 +133,7 @@ namespace DCL.LOD.Systems
                     if (Utils.TryCreateGltfObject(Result.Asset, creationHelper.AssetNameInBundle, out GltfContainerAsset asset))
                     {
                         PositionAsset(creationHelper.InitialSceneStateLOD, creationHelper.Entry, creationHelper.CacheKey, asset,
-                            creationHelper.InitialSceneStateLOD.ParentContainer.transform);
+                            creationHelper.InitialSceneStateLOD.ParentContainer!.transform);
                     }
                     else
                     {

--- a/Explorer/Assets/DCL/LOD/Systems/UpdateSceneLODInfoSystem.cs
+++ b/Explorer/Assets/DCL/LOD/Systems/UpdateSceneLODInfoSystem.cs
@@ -86,7 +86,7 @@ namespace DCL.LOD.Systems
                 // descriptor in None state — no ISS for this scene; fall through to legacy LOD.
             }
 
-            string platformLODKey = $"{sceneDefinitionComponent.Definition.id.ToLower()}_{level.ToString()}{PlatformUtils.GetCurrentPlatform()}";
+            string platformLODKey = $"{sceneDefinitionComponent.Definition.id?.ToLower()}_{level.ToString()}{PlatformUtils.GetCurrentPlatform()}";
 
             var assetBundleIntention = GetAssetBundleIntention.FromHash(
                 platformLODKey,

--- a/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererChunkComponentsFactory.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/MapRendererChunkComponentsFactory.cs
@@ -2,7 +2,6 @@
 using DCL.AssetsProvision;
 using DCL.MapPins.Bus;
 using DCL.EventsApi;
-using DCL.MapPins.Bus;
 using DCL.MapRenderer.CoordsUtils;
 using DCL.MapRenderer.Culling;
 using DCL.MapRenderer.MapCameraController;

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/HomeMarker/HomeMarkerController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/HomeMarker/HomeMarkerController.cs
@@ -227,7 +227,7 @@ namespace DCL.MapRenderer.MapLayers.HomeMarker
 					return;
 				navmapBus.SelectPlaceAsync(placeInfo, placesCts.Token, true, coords.Value).Forget();
 			}
-			catch (OperationCanceledException _) { }
+			catch (OperationCanceledException) { }
 			catch (Exception e)
 			{
 				ReportHub.LogError(ReportCategory.UNSPECIFIED, "HomeMarkerController: Error while fetching place info" + e);

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -524,7 +524,7 @@ namespace DCL.Minimap
             {
                 return await placesAPIService.GetWorldAsync(parcelPosition, worldName, ct);
             }
-            catch (OperationCanceledException _) { }
+            catch (OperationCanceledException) { }
             catch (NotAPlaceException notAPlaceException)
             {
                 ReportHub.LogWarning(ReportCategory.UNSPECIFIED, $"Not a world requested: {notAPlaceException.Message}");

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/IGateKeeperSceneRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/IGateKeeperSceneRoom.cs
@@ -34,9 +34,11 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
 
         class Fake : Null, IGateKeeperSceneRoom
         {
+            #pragma warning disable CS0067 // no-op Fake null object; interface events intentionally never raised
             public event Action? CurrentSceneRoomConnected;
             public event Action? CurrentSceneRoomDisconnected;
             public event Action? CurrentSceneRoomForbiddenAccess;
+            #pragma warning restore CS0067
             public MetaData? ConnectedScene { get; } = new MetaData("Fake", Vector2Int.zero, new MetaData.Input());
 
             public bool Activated => true;

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/NullRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/NullRoom.cs
@@ -21,6 +21,7 @@ namespace DCL.Multiplayer.Connections.Rooms
 {
     public class NullRoom : IRoom
     {
+#pragma warning disable CS0067 // NullRoom is a no-op IRoom implementation; these interface events are intentionally never raised
         public static readonly NullRoom INSTANCE = new ();
         public static readonly WeakReference<IRoom> WEAK_INSTANCE = new (INSTANCE);
 
@@ -62,5 +63,6 @@ namespace DCL.Multiplayer.Connections.Rooms
 
         public UniTask DisconnectAsync(CancellationToken cancellationToken) =>
             UniTask.CompletedTask;
+#pragma warning restore CS0067
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullActiveSpeakers.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullActiveSpeakers.cs
@@ -7,6 +7,7 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
 {
     public class NullActiveSpeakers : IActiveSpeakers
     {
+#pragma warning disable CS0067 // NullActiveSpeakers is a no-op IActiveSpeakers null object; this interface event is intentionally never raised
         public static readonly NullActiveSpeakers INSTANCE = new ();
 
         public int Count => 0;
@@ -20,5 +21,6 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
 
         IEnumerator IEnumerable.GetEnumerator() =>
             GetEnumerator();
+#pragma warning restore CS0067
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullDataPipe.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullDataPipe.cs
@@ -8,6 +8,7 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
 {
     public class NullDataPipe : IDataPipe
     {
+#pragma warning disable CS0067 // NullDataPipe is a no-op IDataPipe null object; this interface event is intentionally never raised
         public static readonly NullDataPipe INSTANCE = new ();
 
         public event ReceivedDataDelegate? DataReceived;
@@ -16,5 +17,6 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
         {
             //ignore
         }
+#pragma warning restore CS0067
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullParticipantsHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullParticipantsHub.cs
@@ -6,6 +6,7 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
 {
     public class NullParticipantsHub : IParticipantsHub
     {
+#pragma warning disable CS0067 // NullParticipantsHub is a no-op IParticipantsHub null object; this interface event is intentionally never raised
         private static readonly IReadOnlyDictionary<string, LKParticipant> EMPTY_DICTIONARY = new Dictionary<string, LKParticipant>();
 
         public static readonly NullParticipantsHub INSTANCE = new ();
@@ -22,5 +23,6 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
 
         public IReadOnlyDictionary<string, LKParticipant> RemoteParticipantIdentities() =>
             EMPTY_DICTIONARY;
+#pragma warning restore CS0067
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/AvatarEmoteCommandPropagationSystem.cs
+++ b/Explorer/Assets/DCL/Multiplayer/SDK/Systems/GlobalWorld/AvatarEmoteCommandPropagationSystem.cs
@@ -37,7 +37,8 @@ namespace DCL.Multiplayer.SDK.Systems.GlobalWorld
 
             if (!emoteStorage.TryGetElement(emoteIntent.EmoteId.Shorten(), out IEmote emote)) return;
 
-            SceneEcsExecutor sceneEcsExecutor = playerCRDTEntity.SceneFacade.EcsExecutor;
+            // AssignedToScene guarantees SceneFacade is non-null; null-forgive for the compiler.
+            SceneEcsExecutor sceneEcsExecutor = playerCRDTEntity.SceneFacade!.EcsExecutor;
             World sceneWorld = sceneEcsExecutor.World;
 
             bool componentFound = sceneWorld.TryGet(playerCRDTEntity.SceneWorldEntity, out AvatarEmoteCommandComponent emoteCommandComponent);

--- a/Explorer/Assets/DCL/Navmap/NavmapController.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapController.cs
@@ -233,6 +233,12 @@ namespace DCL.Navmap
 
         public void ResetAnimator()
         {
+            // Sections are reset in bulk by SectionSelectorController.ResetAnimators while at most
+            // one is active; an inactive panel discards its animator state on disable anyway, so
+            // the reset is a no-op that would only log the Update-on-inactive-object warning.
+            if (!navmapView.PanelAnimator.gameObject.activeInHierarchy)
+                return;
+
             navmapView.PanelAnimator.Rebind();
             navmapView.PanelAnimator.Update(0);
         }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Multithreading/MultiThreadSync.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Multithreading/MultiThreadSync.cs
@@ -110,15 +110,40 @@ namespace Utility.Multithreading
                 {
                     lock (monitor)
                     {
-                        DateTime time = DateTime.Now;
-                        AcquisitionInfo current = currentAcquisitionInfo!.Value;
-                        TimeSpan difference = time - current.AcquiredAt;
+                        // Remove the abandoned waiter before throwing: leaving it enqueued makes the
+                        // holder's next Release signal an owner that is no longer waiting, which stalls
+                        // every waiter queued behind it (cascading timeouts) and trips
+                        // OwnerMismatchException on later releases.
+                        bool ownerWasSignaled = owner.IsSignaled;
+                        RemoveFromQueue(owner);
+
+                        // If the release signal landed right as the wait timed out, the turn was ours -
+                        // forfeit it by passing the signal to the next waiter in line.
+                        if (ownerWasSignaled)
+                        {
+                            owner.Reset();
+
+                            if (queue.TryPeek(out Owner? next))
+                                next.Set();
+                        }
+
+                        // The holder may have released between the timeout and taking this lock -
+                        // the diagnostic must not crash on the empty nullable (was an
+                        // InvalidOperationException masking the timeout).
+                        var currentDescription = "unknown (already released)";
+
+                        if (currentAcquisitionInfo.HasValue)
+                        {
+                            AcquisitionInfo current = currentAcquisitionInfo.Value;
+                            TimeSpan difference = DateTime.Now - current.AcquiredAt;
+                            currentDescription = $"\"{current.Owner?.Name}\" takes too long: {difference.TotalSeconds}";
+                        }
 
                         int requestingThreadId = NativeThread.CurrentId;
                         int owningThreadId = SYNC_OWNERSHIP.TryGetValue(syncId, out int ownerThread) ? ownerThread : -1;
 
                         syncLogsBuffer.Print();
-                        throw new TimeoutException($"{nameof(MultiThreadSync)} timeout, cannot acquire for: {owner.Name}, current owner: \"{current.Owner!.Name}\" takes too long: {difference.TotalSeconds}. Owning thread: {owningThreadId}, requesting thread: {requestingThreadId}");
+                        throw new TimeoutException($"{nameof(MultiThreadSync)} timeout, cannot acquire for: {owner.Name}, current owner: {currentDescription}. Owning thread: {owningThreadId}, requesting thread: {requestingThreadId}");
                     }
                 }
             }
@@ -176,6 +201,20 @@ namespace Utility.Multithreading
             }
         }
 
+        // Queue<T> has no arbitrary remove; rebuild without the abandoned entry. Called only
+        // under monitor on the exceptional timeout path; the queue holds a handful of owners.
+        private void RemoveFromQueue(Owner owner)
+        {
+            var remaining = new List<Owner>(queue.Count);
+
+            while (queue.TryDequeue(out Owner? o))
+                if (!ReferenceEquals(o, owner))
+                    remaining.Add(o);
+
+            foreach (Owner o in remaining)
+                queue.Enqueue(o);
+        }
+
         public Scope GetScope(Owner source)
         {
             COMMON_SAMPLER.Begin(source.Name);
@@ -227,6 +266,8 @@ namespace Utility.Multithreading
         {
             private readonly ManualResetEventSlim eventSlim = new (false);
             public readonly string Name;
+
+            internal bool IsSignaled => eventSlim.IsSet;
 
             public Owner(string name)
             {

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/UnityObjectUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/UnityObjectUtils.cs
@@ -56,9 +56,9 @@ namespace Utility
                 return;
 
             if (!Application.isPlaying)
-                Object.DestroyImmediate(component.gameObject);
+                Object.DestroyImmediate(component?.gameObject);
             else
-                Object.Destroy(component.gameObject);
+                Object.Destroy(component?.gameObject);
         }
 
         public static void SafeDestroy(Object? @object)

--- a/Explorer/Assets/DCL/Places/PlacesView.cs
+++ b/Explorer/Assets/DCL/Places/PlacesView.cs
@@ -117,6 +117,12 @@ namespace DCL.Places
 
         public void ResetAnimator()
         {
+            // Sections are reset in bulk by SectionSelectorController.ResetAnimators while at most
+            // one is active; an inactive panel discards its animator state on disable anyway, so
+            // the reset is a no-op that would only log the Update-on-inactive-object warning.
+            if (!panelAnimator.gameObject.activeInHierarchy)
+                return;
+
             panelAnimator.Rebind();
             headerAnimator.Rebind();
             panelAnimator.Update(0);

--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
@@ -263,7 +263,7 @@ namespace DCL.PlacesAPIService
             {
                 await client.SetPlaceFavoriteAsync(placeId, isFavorite, ct);
             }
-            catch (Exception _)
+            catch (Exception)
             {
                 // Returning original value in case of exception.
                 TryUpdateCachedPlaceFavorite(placeId, cachedIsFavorite);

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -418,7 +418,7 @@ namespace DCL.SDKComponents.MediaStream
 
         private static bool ConsumePromise(ref MediaPlayerComponent component, bool autoPlay)
         {
-            if (!component.OpenMediaPromise.IsResolved) return false;
+            if (component.OpenMediaPromise is not { IsResolved: true }) return false;
             if (component.OpenMediaPromise.IsConsumed) return false;
 
             // On macOS, enforce minimum gap between HLS stream opens to prevent

--- a/Explorer/Assets/DCL/SDKComponents/ParticleSystem/Systems/ParticleSystemApplyPropertiesSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/ParticleSystem/Systems/ParticleSystemApplyPropertiesSystem.cs
@@ -121,7 +121,7 @@ namespace DCL.SDKComponents.ParticleSystem.Systems
 
             for (int i = 0; i < burstCount; i++)
             {
-                var protoBurst = bursts.Values[i];
+                var protoBurst = bursts!.Values[i];
                 short count = (short)protoBurst.Count;
                 component.CachedBursts[i] = new UnityEngine.ParticleSystem.Burst(
                     protoBurst.Time,

--- a/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
@@ -92,7 +92,16 @@ namespace DCL.SceneLoadingScreens.LoadingScreen
                                                 .SuppressToResultAsync(ReportCategory.SCENE_LOADING);
 
                 if (loadReport.GetStatus().TaskStatus == UniTaskStatus.Pending)
-                    ReportHub.LogError(ReportCategory.SCENE_LOADING, "Loading screen finished unexpectedly, but the loading process continues");
+                {
+                    // The screen's close and the operation's result-setting are continuations of the
+                    // same completion and can land in either order within a frame. Give the racing
+                    // continuation one frame before concluding the loading flow is genuinely still
+                    // running - only then is this worth reporting.
+                    await UniTask.Yield();
+
+                    if (!finalResult.HasValue && loadReport.GetStatus().TaskStatus == UniTaskStatus.Pending)
+                        ReportHub.LogError(ReportCategory.SCENE_LOADING, "Loading screen finished unexpectedly, but the loading process continues");
+                }
 
                 if (finalResult.HasValue && !result.Success)
                     ReportHub.LogError(ReportCategory.SCENE_LOADING, $"Loading screen finished with an error after the flow has finished: {result.Error.AsMessage()}");

--- a/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
@@ -97,7 +97,9 @@ namespace DCL.SceneLoadingScreens.LoadingScreen
                     // same completion and can land in either order within a frame. Give the racing
                     // continuation one frame before concluding the loading flow is genuinely still
                     // running - only then is this worth reporting.
-                    await UniTask.Yield();
+                    await UniTask.Yield(ct);
+
+                    if (ct.IsCancellationRequested) return result;
 
                     if (!finalResult.HasValue && loadReport.GetStatus().TaskStatus == UniTaskStatus.Pending)
                         ReportHub.LogError(ReportCategory.SCENE_LOADING, "Loading screen finished unexpectedly, but the loading process continues");

--- a/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenController.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenController.cs
@@ -269,6 +269,11 @@ namespace DCL.SceneLoadingScreens
                 currentTip.Value = index;
 
                 await FadeOthers(ct);
+
+                // OnViewClose cancels this token and then clears the carousel; bail before driving the
+                // (possibly disposed/cleared) view so we don't race ClearTips into a dangling tip view.
+                if (ct.IsCancellationRequested) return;
+
                 await viewInstance!.ShowTipWithFadeAsync(index, DURATION, ct);
             }
 

--- a/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenController.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenController.cs
@@ -63,21 +63,21 @@ namespace DCL.SceneLoadingScreens
         {
             base.OnViewInstantiated();
 
-            viewInstance.ShowNextButton.onClick.AddListener(() =>
+            viewInstance!.ShowNextButton.onClick.AddListener(() =>
             {
                 ShowTipWithFade(currentTip.Value + 1);
                 tipsRotationCancellationToken = tipsRotationCancellationToken.SafeRestart();
                 RotateTipsOverTimeAsync(tips.Duration, tipsRotationCancellationToken.Token).Forget();
             });
 
-            viewInstance.ShowPreviousButton.onClick.AddListener(() =>
+            viewInstance!.ShowPreviousButton.onClick.AddListener(() =>
             {
                 ShowTipWithFade(currentTip.Value - 1);
                 tipsRotationCancellationToken = tipsRotationCancellationToken.SafeRestart();
                 RotateTipsOverTimeAsync(tips.Duration, tipsRotationCancellationToken.Token).Forget();
             });
 
-            viewInstance.OnBreadcrumbClicked += ShowTipWithFade;
+            viewInstance!.OnBreadcrumbClicked += ShowTipWithFade;
 
             UpdateLocalizedTextAsync().Forget();
         }
@@ -85,7 +85,7 @@ namespace DCL.SceneLoadingScreens
         private async UniTaskVoid UpdateLocalizedTextAsync()
         {
             AsyncOperationHandle<string> handle =
-                viewInstance.ProgressLabel.StringReference!.GetLocalizedStringAsync();
+                viewInstance!.ProgressLabel.StringReference!.GetLocalizedStringAsync();
 
             await handle;
 
@@ -106,14 +106,14 @@ namespace DCL.SceneLoadingScreens
             tipsFadeCancellationToken = tipsFadeCancellationToken.SafeRestart();
             BlockUnwantedInputs();
             SetLoadProgress(0);
-            viewInstance.ClearTips();
+            viewInstance!.ClearTips();
         }
 
         protected override void OnViewShow()
         {
             base.OnViewShow();
-            viewInstance.RootCanvasGroup.alpha = 1f;
-            viewInstance.ContentCanvasGroup.alpha = 1f;
+            viewInstance!.RootCanvasGroup.alpha = 1f;
+            viewInstance!.ContentCanvasGroup.alpha = 1f;
 
             audioMixerVolumesController.MuteGroup(AudioMixerExposedParam.World_Volume);
             audioMixerVolumesController.MuteGroup(AudioMixerExposedParam.Avatar_Volume);
@@ -133,7 +133,7 @@ namespace DCL.SceneLoadingScreens
             audioMixerVolumesController.UnmuteGroup(AudioMixerExposedParam.Avatar_Volume);
             audioMixerVolumesController.UnmuteGroup(AudioMixerExposedParam.Chat_Volume);
 
-            viewInstance.ClearTips();
+            viewInstance!.ClearTips();
             tips.Release();
         }
 
@@ -163,8 +163,8 @@ namespace DCL.SceneLoadingScreens
 
         private async UniTask FadeOutAsync(CancellationToken ct)
         {
-            var contentTask = viewInstance.ContentCanvasGroup.DOFade(0f, 0.5f).ToUniTask(cancellationToken: ct);
-            var rootTask = viewInstance.RootCanvasGroup.DOFade(0f, 0.7f).ToUniTask(cancellationToken: ct);
+            var contentTask = viewInstance!.ContentCanvasGroup.DOFade(0f, 0.5f).ToUniTask(cancellationToken: ct);
+            var rootTask = viewInstance!.RootCanvasGroup.DOFade(0f, 0.7f).ToUniTask(cancellationToken: ct);
             await UniTask.WhenAll(contentTask, rootTask);
             UnblockUnwantedInputs();
         }
@@ -194,7 +194,7 @@ namespace DCL.SceneLoadingScreens
             foreach (SceneTips.Tip tip in tips.Tips) tasks.Add(tip.LoadAsync());
             var loaded = await UniTask.WhenAll(tasks!);
 
-            foreach (SceneTips.LoadedTip tip in loaded) viewInstance.AddTip(tip);
+            foreach (SceneTips.LoadedTip tip in loaded) viewInstance!.AddTip(tip);
         }
 
         private async UniTask WaitUntilWorldIsLoadedAsync(float progressProportion, CancellationToken ct)
@@ -218,15 +218,15 @@ namespace DCL.SceneLoadingScreens
         private void SetLoadProgress(float progress)
         {
             progress = Mathf.Clamp01(progress);
-            viewInstance.ProgressBar.normalizedValue = progress;
+            viewInstance!.ProgressBar.normalizedValue = progress;
 
             var value = (int)(progress * 100);
             string formatted = progressLocalizationString.Replace("0", value.ToString());
-            viewInstance.LoadingPercentageText.SetText(formatted);
+            viewInstance!.LoadingPercentageText.SetText(formatted);
         }
 
         private void AddLoadProgress(float progress) =>
-            SetLoadProgress(viewInstance.ProgressBar.normalizedValue + progress);
+            SetLoadProgress(viewInstance!.ProgressBar.normalizedValue + progress);
 
         private void ShowTip(int index)
         {
@@ -237,8 +237,8 @@ namespace DCL.SceneLoadingScreens
 
             index %= tips.Tips.Count;
 
-            viewInstance.HideAllTips();
-            viewInstance.ShowTip(index);
+            viewInstance!.HideAllTips();
+            viewInstance!.ShowTip(index);
 
             currentTip.Value = index;
         }
@@ -252,7 +252,7 @@ namespace DCL.SceneLoadingScreens
                 fadingTasks.Clear();
 
                 for (var i = 0; i < tips.Tips.Count; i++)
-                    fadingTasks.Add(viewInstance.HideTipWithFadeAsync(i, DURATION, ct));
+                    fadingTasks.Add(viewInstance!.HideTipWithFadeAsync(i, DURATION, ct));
 
                 return UniTask.WhenAll(fadingTasks);
             }
@@ -269,7 +269,7 @@ namespace DCL.SceneLoadingScreens
                 currentTip.Value = index;
 
                 await FadeOthers(ct);
-                await viewInstance.ShowTipWithFadeAsync(index, DURATION, ct);
+                await viewInstance!.ShowTipWithFadeAsync(index, DURATION, ct);
             }
 
             ShowTipWithFadeAsync(tipsFadeCancellationToken!.Token).Forget();

--- a/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenView.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenView.cs
@@ -130,7 +130,7 @@ namespace DCL.SceneLoadingScreens
 
             if (tipView.Has == false)
             {
-                ReportHub.LogError(ReportCategory.UI, $"View does not exist: {index}");
+                ReportHub.LogError(ReportCategory.UI, $"{nameof(SceneLoadingScreenView)}: tip view does not exist at index {index}");
                 return;
             }
 
@@ -147,7 +147,7 @@ namespace DCL.SceneLoadingScreens
 
             if (tipView.Has == false)
             {
-                ReportHub.LogError(ReportCategory.UI, $"View does not exist: {index}");
+                ReportHub.LogError(ReportCategory.UI, $"{nameof(SceneLoadingScreenView)}: tip view does not exist at index {index}");
                 return;
             }
 

--- a/Explorer/Assets/DCL/Settings/SettingsController.cs
+++ b/Explorer/Assets/DCL/Settings/SettingsController.cs
@@ -148,6 +148,12 @@ namespace DCL.Settings
 
         public void ResetAnimator()
         {
+            // Sections are reset in bulk by SectionSelectorController.ResetAnimators while at most
+            // one is active; an inactive panel discards its animator state on disable anyway, so
+            // the reset is a no-op that would only log the Update-on-inactive-object warning.
+            if (!view.PanelAnimator.gameObject.activeInHierarchy)
+                return;
+
             view.PanelAnimator.Rebind();
             view.HeaderAnimator.Rebind();
             view.PanelAnimator.Update(0);

--- a/Explorer/Assets/DCL/TeleportPrompt/TeleportPromptController.cs
+++ b/Explorer/Assets/DCL/TeleportPrompt/TeleportPromptController.cs
@@ -40,9 +40,9 @@ namespace DCL.TeleportPrompt
 
         protected override void OnViewInstantiated()
         {
-            placeImageController = imageControllerProvider.Create(viewInstance.placeImage);
-            viewInstance.cancelButton.onClick.AddListener(Dismiss);
-            viewInstance.continueButton.onClick.AddListener(Approve);
+            placeImageController = imageControllerProvider.Create(viewInstance!.placeImage);
+            viewInstance!.cancelButton.onClick.AddListener(Dismiss);
+            viewInstance!.continueButton.onClick.AddListener(Approve);
         }
 
         protected override void OnViewShow()
@@ -69,8 +69,8 @@ namespace DCL.TeleportPrompt
 
         protected override UniTask WaitForCloseIntentAsync(CancellationToken ct) =>
             UniTask.WhenAny(
-                viewInstance.cancelButton.OnClickAsync(ct),
-                viewInstance.continueButton.OnClickAsync(ct));
+                viewInstance!.cancelButton.OnClickAsync(ct),
+                viewInstance!.continueButton.OnClickAsync(ct));
 
         private void RequestTeleport(Vector2Int coords, Action<TeleportPromptResultType> result)
         {
@@ -90,7 +90,7 @@ namespace DCL.TeleportPrompt
         {
             try
             {
-                placeImageController.SetImage(viewInstance.defaultImage);
+                placeImageController!.SetImage(viewInstance!.defaultImage);
                 SetPopupAsLoading(true);
                 await UniTask.Delay(300, cancellationToken: ct);
                 PlacesData.PlaceInfo? placeInfo = await placesAPIService.GetPlaceAsync(parcel, ct);
@@ -112,27 +112,27 @@ namespace DCL.TeleportPrompt
         private void SetPlaceInfo(PlacesData.PlaceInfo placeInfo)
         {
             SetPopupAsLoading(false);
-            placeImageController.RequestImage(placeInfo.image);
-            viewInstance.placeName.text = placeInfo.title;
-            viewInstance.placeCreator.text = $"created by <b>{placeInfo.contact_name}</b>";
-            viewInstance.location.text = placeInfo.base_position;
+            placeImageController!.RequestImage(placeInfo.image);
+            viewInstance!.placeName.text = placeInfo.title;
+            viewInstance!.placeCreator.text = $"created by <b>{placeInfo.contact_name}</b>";
+            viewInstance!.location.text = placeInfo.base_position;
         }
 
         private void SetEmptyPlaceInfo(Vector2Int parcel)
         {
             SetPopupAsLoading(false);
-            viewInstance.placeName.text = "Empty parcel";
-            viewInstance.placeCreator.text = "created by <b>Unknown</b>";
-            viewInstance.location.text = parcel.ToString();
+            viewInstance!.placeName.text = "Empty parcel";
+            viewInstance!.placeCreator.text = "created by <b>Unknown</b>";
+            viewInstance!.location.text = parcel.ToString();
         }
 
         private void SetPopupAsLoading(bool isLoading)
         {
-            viewInstance.loadingSpinner.SetActive(isLoading);
-            viewInstance.loadingPlaceContainer.SetActive(isLoading);
-            viewInstance.placeInfoContainer.SetActive(!isLoading);
-            viewInstance.cancelButton.interactable = !isLoading;
-            viewInstance.continueButton.interactable = !isLoading;
+            viewInstance!.loadingSpinner.SetActive(isLoading);
+            viewInstance!.loadingPlaceContainer.SetActive(isLoading);
+            viewInstance!.placeInfoContainer.SetActive(!isLoading);
+            viewInstance!.cancelButton.interactable = !isLoading;
+            viewInstance!.continueButton.interactable = !isLoading;
         }
     }
 }

--- a/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
@@ -10,7 +10,6 @@ using System.Diagnostics;
 using UnityEditor;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Linq;
 using UnityEngine;
 using static Utility.Tests.TestsCategories;
 

--- a/Explorer/Assets/DCL/UI/Controls/ControlsPanel.prefab
+++ b/Explorer/Assets/DCL/UI/Controls/ControlsPanel.prefab
@@ -671,7 +671,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 4974685691c134a35bcea75af1936381, type: 3}
+  m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/ChatOptionsContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controllers/ChatOptionsContextMenuController.cs
@@ -13,8 +13,6 @@ namespace DCL.UI
         private const int CONTEXT_MENU_WIDTH = 210;
         private const int CONTEXT_MENU_ELEMENTS_SPACING = 8;
         private static readonly RectOffset CONTEXT_MENU_VERTICAL_LAYOUT_PADDING = new (15, 15, 14, 14);
-        private static readonly RectOffset HORIZONTAL_LAYOUT_PADDING = new (0, 0, 0, 0);
-        private static readonly int HORIZONTAL_LAYOUT_SPACING = 8;
         private static readonly Vector2 CONTEXT_MENU_OFFSET = new (0, 80);
 
         private readonly IMVCManager mvcManager;
@@ -31,9 +29,7 @@ namespace DCL.UI
             contextMenu = new GenericContextMenu(CONTEXT_MENU_WIDTH, CONTEXT_MENU_OFFSET, CONTEXT_MENU_VERTICAL_LAYOUT_PADDING, CONTEXT_MENU_ELEMENTS_SPACING, anchorPoint: ContextMenuOpenDirection.TOP_LEFT)
                 .AddControl(deleteChatHistoryButton);
 
-            //Disabled until we got multiple channels working
-            //.AddControl(new SeparatorContextMenuControlSettings())
-            //.AddControl(new ToggleWithIconContextMenuControlSettings(pinChatToggleTextIcon, pinChatToggleText, OnPinChatToggle, HORIZONTAL_LAYOUT_PADDING, HORIZONTAL_LAYOUT_SPACING));
+            // A separator and a pin-chat toggle control belong here too, but stay out until multiple channels are supported.
         }
 
         public async UniTask ShowContextMenuAsync(Vector2 position, UniTask closeMenuTask, Action onContextMenuHide = null)

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controls/GenericContextMenuSubMenuButtonView.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controls/GenericContextMenuSubMenuButtonView.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.UI.Controls.Configs;
 using System;
 using System.Threading;
@@ -148,7 +149,8 @@ namespace DCL.UI.Controls
                 if (!isHovering)
                     ShowSubmenu(false);
             }
-            catch (Exception) { }
+            catch (OperationCanceledException) { }
+            catch (Exception e) { ReportHub.LogException(e, ReportCategory.UI); }
         }
     }
 }

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
@@ -410,7 +410,6 @@ namespace DCL.UI
 
             float bestOutOfBoundsPercent = adjustedOutOfBoundsPercent;
             float3 bestPosition = adjustedPosition;
-            var foundPerfectPosition = false;
 
             for (var i = 0; i < fallbackDirectionsCount; i++)
             {

--- a/Explorer/Assets/DCL/VoiceChat/Core/VoiceChatParticipantsStateService.cs
+++ b/Explorer/Assets/DCL/VoiceChat/Core/VoiceChatParticipantsStateService.cs
@@ -12,7 +12,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 using UnityEngine.Pool;
-using DCL.LiveKit.Public;
 using Utility.Multithreading;
 
 namespace DCL.VoiceChat

--- a/Explorer/Assets/DCL/VoiceChat/PrivateVoiceChat/PrivateVoiceChatCallStatusServiceNull.cs
+++ b/Explorer/Assets/DCL/VoiceChat/PrivateVoiceChat/PrivateVoiceChatCallStatusServiceNull.cs
@@ -6,6 +6,7 @@ namespace DCL.VoiceChat
 {
     public class PrivateVoiceChatCallStatusServiceNull : IPrivateVoiceChatCallStatusService
     {
+#pragma warning disable CS0067 // PrivateVoiceChatCallStatusServiceNull is a no-op null object; this interface event is intentionally never raised
         public string CurrentTargetWallet { get; }
         public event Action<PrivateVoiceChatUpdate>? PrivateVoiceChatUpdateReceived;
         public IReadonlyReactiveProperty<VoiceChatStatus> Status { get; } = new ReactiveProperty<VoiceChatStatus>(VoiceChatStatus.DISCONNECTED);
@@ -34,5 +35,6 @@ namespace DCL.VoiceChat
         public void RejectCall() { }
 
         public void OnPrivateVoiceChatUpdateReceived(PrivateVoiceChatUpdate update) { }
+#pragma warning restore CS0067
     }
 }

--- a/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
@@ -18,8 +18,10 @@ namespace DCL.Web3.Identities
         {
             private readonly IWeb3Identity? identity;
 
+            #pragma warning disable CS0067 // no-op Fake null object; interface events intentionally never raised
             public event Action? OnIdentityCleared;
             public event Action? OnIdentityChanged;
+            #pragma warning restore CS0067
 
             public Fake() : this(new IWeb3Identity.Random()) { }
 


### PR DESCRIPTION
## Summary

A batch of small, low-risk robustness fixes: defensive null handling, quieter logging for states that are actually expected, a concurrency-lock fix on its timeout path, and surfacing exceptions that were previously swallowed. No feature or success-path behavior changes.

**Null-safety hardening (the bulk of the change)**
- Adds null guards / nullable annotations across paths that could dereference null and throw `NullReferenceException`, including: authentication screen teardown when its view was never shown, emote and wearable loading when an attachment's model hasn't resolved, scene-LOD asset resolution, raycast data, particle-system bursts, media-player promise consumption, several view controllers' view access, and reactive-property subscription disposal (a default/never-subscribed subscription is now safe to dispose).
- These make the affected code tolerate the "not-loaded / already-disposed / never-shown" states it can legitimately encounter, instead of throwing.

**Quieter, more correct logging**
- Stops logging errors for states that are expected rather than faulty: an empty sender display name while a profile is still resolving, and the intentionally-empty content map of in-client scene emotes. Genuinely faulty cases (e.g. a real catalog item with missing content) are still reported.
- Reworks a loading-screen completion check so a benign ordering race between "screen closed" and "operation finished" within the same frame is no longer reported as an error.
- Guards an animator reset so it's skipped on already-inactive panels (where it's a no-op anyway), removing a spurious warning.

**Concurrency lock: timeout path**
- On an acquire timeout, the abandoned waiter is now removed from the wait queue, the turn is forfeited to the next waiter if the lock was just handed over, and the timeout diagnostic no longer risks throwing a secondary exception that masks the original timeout. The normal acquire/release path is unchanged.
- The concurrency change touches only the exceptional timeout path; it cleans up state the previous code left dangling (which could stall other waiters) and makes the diagnostic robust. I validated it with a multithreaded stress test exercising the timeout path heavily: the updated lock keeps making progress and stays consistent under contention, where the previous version could wedge — and it shows no regression in the normal case.

**Surface previously-swallowed exceptions**
- Several empty `catch` blocks now log the exception (while still separating expected cancellations), so failures that were silently dropped become visible.

**Compile-warning hygiene**
- Suppresses "event never used" warnings on intentional no-op / null-object implementations whose interface events are never raised, plus minor cleanup of unused usings/fields/locals and a couple of log-message wordings.