### PR TITLE
fix: inner level fallback when gltfnodemodifier doesnt find a path

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GltfNodeModifiers/Systems/GltfNodeModifierSystemBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GltfNodeModifiers/Systems/GltfNodeModifierSystemBase.cs
@@ -46,7 +46,10 @@ namespace ECS.Unity.GltfNodeModifiers.Systems
         }
 
         /// <summary>
-        ///     Finds a renderer by path, returning null if not found
+        ///     Finds a renderer by path, returning null if not found.
+        ///     Tolerant of glTFast's optional scene-wrapper GameObject: it is created only when the model has
+        ///     more than one root node (SceneObjectCreation.WhenMultipleRootNodes), which otherwise shifts every
+        ///     path by one segment depending on the root-node count and breaks paths across model variants (#8895).
         /// </summary>
         protected static Renderer? FindRendererByPath(Transform gltfRootTransform, string path, IReadOnlyList<string>? availablePaths = null)
         {
@@ -56,10 +59,43 @@ namespace ECS.Unity.GltfNodeModifiers.Systems
             // There's always 1 child GameObject in both AB or Raw GLTF instantiated GltfContainer...
             // AB: The GO name is "AB:hash"
             // Raw GLTF: the GO name is "Scene"
-            Transform? rendererTransform = gltfRootTransform.GetChild(0).Find(path);
+            Transform anchor = gltfRootTransform.GetChild(0);
 
-            if (rendererTransform != null && rendererTransform.TryGetComponent(out Renderer renderer))
+            // 1. Exact match relative to the anchor. Preserves every path that resolves today.
+            if (TryGetRendererAt(anchor, path, out Renderer? renderer))
                 return renderer;
+
+            // 2. Wrapper present, short path authored against the un-wrapped variant: descend one level and
+            //    retry the path under each root node. Pick the first hit in sibling order, which resolves to
+            //    the same node on AB and raw builds (see #8895). One level only, to bound ambiguity.
+            Renderer? firstMatch = null;
+            var matchCount = 0;
+
+            for (var i = 0; i < anchor.childCount; i++)
+            {
+                if (TryGetRendererAt(anchor.GetChild(i), path, out Renderer? childMatch))
+                {
+                    matchCount++;
+                    firstMatch ??= childMatch;
+                }
+            }
+
+            if (firstMatch != null)
+            {
+                if (matchCount > 1)
+                    ReportHub.LogWarning(ReportCategory.GLTF_CONTAINER,
+                        $"GLTF Node path '{path}' is ambiguous: {matchCount} renderers matched it under different root nodes. Using the first one in hierarchy order.");
+
+                return firstMatch;
+            }
+
+            // 3. Wrapper absent, wrapper-prefixed path authored against the wrapped variant: drop the leading
+            //    root-node segment and retry against the anchor.
+            var separatorIndex = path.IndexOf('/');
+
+            if (separatorIndex >= 0 && separatorIndex < path.Length - 1
+                && TryGetRendererAt(anchor, path.Substring(separatorIndex + 1), out Renderer? strippedMatch))
+                return strippedMatch;
 
             ReportHub.LogError(ReportCategory.GLTF_CONTAINER,
                 $"GLTF Node path '{path}' not found.");
@@ -73,6 +109,23 @@ namespace ECS.Unity.GltfNodeModifiers.Systems
             }
 
             return null;
+        }
+
+        /// <summary>
+        ///     Resolves <paramref name="path" /> relative to <paramref name="root" /> and returns its renderer, if any.
+        /// </summary>
+        private static bool TryGetRendererAt(Transform root, string path, out Renderer? renderer)
+        {
+            Transform? found = root.Find(path);
+
+            if (found != null && found.TryGetComponent(out Renderer foundRenderer))
+            {
+                renderer = foundRenderer;
+                return true;
+            }
+
+            renderer = null;
+            return false;
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GltfNodeModifiers/Tests/SetupGltfNodeModifierSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GltfNodeModifiers/Tests/SetupGltfNodeModifierSystemShould.cs
@@ -9,6 +9,7 @@ using ECS.Unity.GLTFContainer.Components;
 using ECS.Unity.GltfNodeModifiers.Components;
 using ECS.Unity.GltfNodeModifiers.Systems;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using UnityEngine;
@@ -29,6 +30,7 @@ namespace ECS.Unity.GltfNodeModifiers.Tests
         private Material originalRootMaterial;
         private Material originalChildMaterial;
         private Material testMaterial;
+        private readonly List<GameObject> extraRoots = new ();
 
         [SetUp]
         public void SetUp()
@@ -67,6 +69,12 @@ namespace ECS.Unity.GltfNodeModifiers.Tests
 
             if (testMaterial != null)
                 Object.DestroyImmediate(testMaterial);
+
+            foreach (GameObject extraRoot in extraRoots)
+                if (extraRoot != null)
+                    Object.DestroyImmediate(extraRoot);
+
+            extraRoots.Clear();
         }
 
         private GltfContainerComponent CreateGltfContainer()
@@ -633,6 +641,166 @@ namespace ECS.Unity.GltfNodeModifiers.Tests
             // Assert
             Components.GltfNodeModifiers nodeModifiers = world.Get<Components.GltfNodeModifiers>(entity);
             Assert.That(nodeModifiers.GltfNodeEntities.Count, Is.EqualTo(0)); // No entities should be created for invalid path
+        }
+
+        [Test]
+        public void ResolveShortPath_WhenSceneWrapperPresent()
+        {
+            // Mirrors Pride_LampostBig.glb: multiple root nodes force glTFast to insert a "Scene" wrapper,
+            // so GetChild(0) is the wrapper and the lamp sits one level deeper than in the single-root variant.
+            (GameObject container, MeshRenderer lamp) = BuildLamppostWithWrapper();
+            GltfContainerComponent gltfContainer = CreateContainerComponent(container, lamp);
+
+            // The path authored for the un-wrapped model must keep working.
+            Entity entity = SetupWithPath(gltfContainer, "LampostBig_Lamp");
+
+            AssertResolvedTo(entity, lamp, "LampostBig_Lamp");
+        }
+
+        [Test]
+        public void ResolveExactLongPath_WhenSceneWrapperPresent()
+        {
+            (GameObject container, MeshRenderer lamp) = BuildLamppostWithWrapper();
+            GltfContainerComponent gltfContainer = CreateContainerComponent(container, lamp);
+
+            // The full path (as Explorer reports it for the wrapped model) resolves via the exact match.
+            Entity entity = SetupWithPath(gltfContainer, "LampostBig/LampostBig_Lamp");
+
+            AssertResolvedTo(entity, lamp, "LampostBig/LampostBig_Lamp");
+        }
+
+        [Test]
+        public void ResolveWrapperPrefixedPath_WhenNoSceneWrapper()
+        {
+            // Mirrors LampostBig.glb: single root node, no wrapper, GetChild(0) is "LampostBig" itself.
+            (GameObject container, MeshRenderer lamp) = BuildLamppostWithoutWrapper();
+            GltfContainerComponent gltfContainer = CreateContainerComponent(container, lamp);
+
+            // A path copied from the wrapped variant must still resolve by dropping the leading root segment.
+            Entity entity = SetupWithPath(gltfContainer, "LampostBig/LampostBig_Lamp");
+
+            AssertResolvedTo(entity, lamp, "LampostBig/LampostBig_Lamp");
+        }
+
+        [Test]
+        public void ResolveAmbiguousShortPath_PicksFirstInHierarchyOrderAndWarns()
+        {
+            // Two root nodes each contain a "Lamp" child (legal in glTF: names are unique only among siblings).
+            var container = new GameObject("container");
+            extraRoots.Add(container);
+
+            var wrapper = new GameObject("Scene");
+            wrapper.transform.SetParent(container.transform);
+
+            MeshRenderer first = AddNode(wrapper.transform, "LampostBig", "Lamp");
+            MeshRenderer second = AddNode(wrapper.transform, "LampostSmall", "Lamp");
+
+            GltfContainerComponent gltfContainer = CreateContainerComponent(container, first, second);
+
+            LogAssert.Expect(LogType.Warning,
+                "GLTF Node path 'Lamp' is ambiguous: 2 renderers matched it under different root nodes. Using the first one in hierarchy order.");
+
+            Entity entity = SetupWithPath(gltfContainer, "Lamp");
+
+            // First in sibling order wins, deterministically.
+            AssertResolvedTo(entity, first, "Lamp");
+        }
+
+        /// <summary>
+        ///     container → "Scene" (wrapper) → "LampostBig" → "LampostBig_Lamp" (+ a sibling root node).
+        /// </summary>
+        private (GameObject container, MeshRenderer lamp) BuildLamppostWithWrapper()
+        {
+            var container = new GameObject("container");
+            extraRoots.Add(container);
+
+            var wrapper = new GameObject("Scene");
+            wrapper.transform.SetParent(container.transform);
+
+            MeshRenderer lamp = AddNode(wrapper.transform, "LampostBig", "LampostBig_Lamp");
+
+            // Extra root-level node: this is what tips glTFast into creating the wrapper.
+            var prop = new GameObject("Plane.016");
+            prop.transform.SetParent(wrapper.transform);
+
+            return (container, lamp);
+        }
+
+        /// <summary>
+        ///     container → "LampostBig" → "LampostBig_Lamp".
+        /// </summary>
+        private (GameObject container, MeshRenderer lamp) BuildLamppostWithoutWrapper()
+        {
+            var container = new GameObject("container");
+            extraRoots.Add(container);
+
+            MeshRenderer lamp = AddNode(container.transform, "LampostBig", "LampostBig_Lamp");
+            return (container, lamp);
+        }
+
+        private static MeshRenderer AddNode(Transform parent, string rootNodeName, string leafName)
+        {
+            var rootNode = new GameObject(rootNodeName);
+            rootNode.transform.SetParent(parent);
+
+            var leaf = new GameObject(leafName);
+            leaf.transform.SetParent(rootNode.transform);
+
+            return leaf.AddComponent<MeshRenderer>();
+        }
+
+        private GltfContainerComponent CreateContainerComponent(GameObject container, params Renderer[] renderers)
+        {
+            var promise = AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(
+                world,
+                new GetGltfContainerAssetIntention("test", "test_hash", new CancellationTokenSource()),
+                PartitionComponent.TOP_PRIORITY);
+
+            var asset = GltfContainerAsset.Create(container, null);
+
+            foreach (Renderer renderer in renderers)
+                asset.Renderers.Add(renderer);
+
+            world.Add(promise.Entity, new StreamableLoadingResult<GltfContainerAsset>(asset));
+            promise.TryConsume(world, out _);
+
+            return new GltfContainerComponent
+            {
+                Promise = promise,
+                State = LoadingState.Finished,
+                RootGameObject = container,
+            };
+        }
+
+        private Entity SetupWithPath(GltfContainerComponent gltfContainer, string path)
+        {
+            var gltfNodeModifiers = new PBGltfNodeModifiers
+            {
+                Modifiers =
+                {
+                    new PBGltfNodeModifiers.Types.GltfNodeModifier
+                    {
+                        Path = path,
+                        Material = CreatePbrMaterial(Color.red),
+                    },
+                },
+            };
+
+            Entity entity = world.Create(gltfNodeModifiers, gltfContainer, PartitionComponent.TOP_PRIORITY);
+            system.Update(0);
+            return entity;
+        }
+
+        private void AssertResolvedTo(Entity entity, Renderer expectedRenderer, string expectedPath)
+        {
+            Components.GltfNodeModifiers nodeModifiers = world.Get<Components.GltfNodeModifiers>(entity);
+            Assert.That(nodeModifiers.GltfNodeEntities.Count, Is.EqualTo(1));
+
+            Entity nodeEntity = nodeModifiers.GltfNodeEntities.Keys.First();
+            GltfNode gltfNode = world.Get<GltfNode>(nodeEntity);
+            Assert.That(gltfNode.Renderers.Count, Is.EqualTo(1));
+            Assert.That(gltfNode.Renderers[0], Is.EqualTo(expectedRenderer));
+            Assert.That(gltfNode.Path, Is.EqualTo(expectedPath));
         }
 
         private static PBMaterial CreatePbrMaterial(Color color) =>


### PR DESCRIPTION
##  What does this PR change?

Fixes GltfNodeModifier paths that fail to resolve when a model's root structure differs from the structure the path was authored against. Closes #8895.

  The root cause is glTFast's optional scene-wrapper GameObject. glTFast only inserts a wrapper node (SceneObjectCreation.WhenMultipleRootNodes) when a model has more than one root node. That means the same logical node lives at a different hierarchy depth depending on the model variant:

  - Single root node (e.g. LampostBig.glb) → no wrapper → GetChild(0) is the root node itself.
  - Multiple root nodes (e.g. Pride_LampostBig.glb) → glTFast inserts a Scene wrapper → GetChild(0) is the wrapper, and every node sits one segment deeper.

  Because FindRendererByPath only tried an exact match relative to GetChild(0), a path authored for one variant broke on the other (and across AB vs raw GLTF builds).

  FindRendererByPath now resolves a path in three ordered steps, preserving every path that resolves today:

  1. Exact match relative to the anchor (GetChild(0)). Unchanged behavior, tried first.
  2. Short path, wrapper present (path authored against the un-wrapped variant): descend one level and retry under each root node, picking the first hit in sibling order. This is deterministic and resolves to the same node on AB and raw builds. Bounded to one level to limit ambiguity. If more than one root node matches, it
  logs a warning and uses the first in hierarchy order.
  3. Wrapper-prefixed path, wrapper absent (path copied from the wrapped variant): drop the leading root-node segment and retry against the anchor.

  If all three fail, it logs the existing "path not found" error.

  Path resolution was extracted into a small TryGetRendererAt helper to keep the three branches readable.
  
##  Test Steps

  1. Create a new scene in the Creator Hub.
  2. Download the zip from the ticket  #8895 and unzip it into the scene's assets folder.
  3. Add an entity with a GLTF component.
  4. Add a Swap Materials (GltfNodeModifier) component to the same entity:
    - Path: LampostBig_Lamp
    - Material: PBR
    - Emissive: 1, color blue
  5. Preview the scene and confirm the lamp bulb renders blue-ish.
  6. Back in the Creator Hub, change the GLTF component's model to Pride_LampostBig.glb.
  7. Leave the Swap Materials path as LampostBig_Lamp (do not prefix or change it).
  8. Preview again and confirm the lamp bulb is still blue-ish.
