### PR TITLE
fix: chat reaction last used live update

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Presenters/ChatReactionsSelectorPresenter.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Presenters/ChatReactionsSelectorPresenter.cs
@@ -69,15 +69,17 @@ namespace DCL.Chat.ChatReactions.Presenters
             view.Show();
         }
 
-        public void Hide() => 
+        public void Hide() =>
             view.Hide();
 
-        /// <summary>
-        /// Records that the user sent this emoji without refreshing the bar.
-        /// The bar updates next time <see cref="Show"/> is called.
-        /// </summary>
-        public void RecordUsage(int atlasIndex) => 
+        public void RecordUsage(int atlasIndex)
+        {
             recentsService.RecordUsage(atlasIndex);
+
+            // Re-render live so the bar reflects the new usage without a close/reopen; Skip if hidden as will be ran in Show()
+            if (IsVisible)
+                RefreshRecents();
+        }
 
         public void Dispose()
         {

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Presenters/ChatReactionsSelectorPresenter.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Presenters/ChatReactionsSelectorPresenter.cs
@@ -76,7 +76,7 @@ namespace DCL.Chat.ChatReactions.Presenters
         {
             recentsService.RecordUsage(atlasIndex);
 
-            // Re-render live so the bar reflects the new usage without a close/reopen; Skip if hidden as will be ran in Show()
+            // Skip the refresh if hidden as it will run in Show()
             if (IsVisible)
                 RefreshRecents();
         }


### PR DESCRIPTION
# Pull Request Description
Fixes #8432

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes the recently used chat reaction update live when the selector is opened so the user is not required to close/open the panel to see the "recently used" update.

### Test Steps
1. Follow the repro steps of the linked issue

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
