### PR TITLE
chore: segment error filtering

### DIFF
--- a/Explorer/Assets/Plugins/RustSegment/.native/.cargo/config.toml
+++ b/Explorer/Assets/Plugins/RustSegment/.native/.cargo/config.toml
@@ -1,0 +1,4 @@
+[build]
+rustflags = [
+  "-Dwarnings",         # treat all warnings as errors
+]

--- a/Explorer/Assets/Plugins/RustSegment/.native/Cargo.toml
+++ b/Explorer/Assets/Plugins/RustSegment/.native/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 lazy_static = "1.5.0"
-segment = { git = "https://github.com/decentraland/segment", rev = "6c97226b10d70f2d1576b529af432209c45415f0", default-features = false, features = ["rustls-tls"] }
+segment = { git = "https://github.com/decentraland/segment", rev = "2d46f10f9a5da2feac6554daedfc17d1ba49952e", default-features = false, features = ["rustls-tls"] }
 serde = "1.0.210"
 serde_json = "1.0.128"
 tokio = { version = "1.40.0", features = ["full", "parking_lot"] }

--- a/Explorer/Assets/Plugins/RustSegment/.native/compile_mac.sh
+++ b/Explorer/Assets/Plugins/RustSegment/.native/compile_mac.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # This script is used to compile the Rust code on macOS for both x86_64 and aarch64
 export RUST_BACKTRACE=full
 cargo build --release --target x86_64-apple-darwin

--- a/Explorer/Assets/Plugins/RustSegment/.native/src/server.rs
+++ b/Explorer/Assets/Plugins/RustSegment/.native/src/server.rs
@@ -84,7 +84,8 @@ impl Server {
                     queue_file_path,
                     queue_count_limit,
                     writer_key,
-                    event_bridge.input()
+                    event_bridge.input(),
+                    &new_runtime,
                 );
 
                 *state = ServerState::Ready(Arc::new(server), new_runtime, event_bridge);
@@ -235,6 +236,7 @@ impl SegmentServer {
         queue_count_limit: u32,
         writer_key: String,
         event_input: EventInput,
+        async_runtime: &tokio::runtime::Runtime,
     ) -> Self {
         let error_event_input = event_input.clone();
         let error_fn = Box::new(move |message: &str| {
@@ -262,12 +264,19 @@ impl SegmentServer {
             AnalyticsEventSendDaemon::new(event_queue.clone(), None, writer_key.clone(), client);
         let send_daemon = Arc::new(parking_lot::Mutex::new(send_daemon));
 
-        let daemon_event_input = event_input.clone();
+        let moved_send_daemon = send_daemon.clone();
 
-        send_daemon.lock().start(move |message: &str| {
-            let message = String::from(message);
-            daemon_event_input.try_enqueue_error(message);
-        });
+        let daemon_event_input = event_input.clone();
+        async_runtime.spawn(
+            AssertUnwindSafe(async move {
+                let mut guard = moved_send_daemon.lock();
+                guard.start(move |message: &str| {
+                    let message = String::from(message);
+                    daemon_event_input.try_enqueue_error(message);
+                });
+            })
+            .catch_unwind(),
+        );
 
         let direct_client = HttpClient::default();
 

--- a/Explorer/Assets/Plugins/RustSegment/.native/src/server.rs
+++ b/Explorer/Assets/Plugins/RustSegment/.native/src/server.rs
@@ -84,8 +84,7 @@ impl Server {
                     queue_file_path,
                     queue_count_limit,
                     writer_key,
-                    event_bridge.input(),
-                    &new_runtime,
+                    event_bridge.input()
                 );
 
                 *state = ServerState::Ready(Arc::new(server), new_runtime, event_bridge);
@@ -236,7 +235,6 @@ impl SegmentServer {
         queue_count_limit: u32,
         writer_key: String,
         event_input: EventInput,
-        async_runtime: &tokio::runtime::Runtime,
     ) -> Self {
         let error_event_input = event_input.clone();
         let error_fn = Box::new(move |message: &str| {
@@ -264,19 +262,12 @@ impl SegmentServer {
             AnalyticsEventSendDaemon::new(event_queue.clone(), None, writer_key.clone(), client);
         let send_daemon = Arc::new(parking_lot::Mutex::new(send_daemon));
 
-        let moved_send_daemon = send_daemon.clone();
-
         let daemon_event_input = event_input.clone();
-        async_runtime.spawn(
-            AssertUnwindSafe(async move {
-                let mut guard = moved_send_daemon.lock();
-                guard.start(move |message: &str| {
-                    let message = String::from(message);
-                    daemon_event_input.try_enqueue_error(message);
-                });
-            })
-            .catch_unwind(),
-        );
+
+        send_daemon.lock().start(move |message: &str| {
+            let message = String::from(message);
+            daemon_event_input.try_enqueue_error(message);
+        });
 
         let direct_client = HttpClient::default();
 

--- a/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/Libraries/Windows/segment-server.dll
+++ b/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/Libraries/Windows/segment-server.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9829f071c4aebeb2c9a788763361c613f8cd1b1a3ea81e8c755c8f827e91039f
-size 4553216
+oid sha256:dd98676dd01f93691a8f1fa115b999898dc47e0de1e711eb5166092c5af1460c
+size 4560896

--- a/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/Libraries/Windows/segment-server.dll
+++ b/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/Libraries/Windows/segment-server.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d12143afcdb37fc669012d6688d6e0ef419d6fed813c0596af317db715d210e0
-size 4560384
+oid sha256:9829f071c4aebeb2c9a788763361c613f8cd1b1a3ea81e8c755c8f827e91039f
+size 4553216


### PR DESCRIPTION
## What does this PR change?

Fixes the recurring Sentry issue [`UNITY-EXPLORER-P13`](https://decentraland.sentry.io/issues/?query=UNITY-EXPLORER-P13) — a `NetworkError(IncompleteMessage)` caused by ungraceful HTTP connection closures when sending analytics batches to the Segment API.

**Root cause:** The Segment send daemon was spawned inside an async runtime with `AssertUnwindSafe` + `catch_unwind`, which could swallow network failures without proper retry handling. The underlying `segment` library lacked retry logic for transient network errors (e.g. connection reset, incomplete TLS handshake).

**Changes:**

- *Updated `segment` dependency* — bumped to `2d46f10` which adds retry logic for transient network errors (incomplete messages, connection resets)
- *Simplified send daemon startup* — removed the unnecessary async runtime spawn + `AssertUnwindSafe`/`catch_unwind` wrapper; the daemon now starts synchronously via `send_daemon.lock().start(...)`, making error propagation straightforward
- *Removed unused `async_runtime` parameter* from `SegmentServer::new()`
- *Added `.cargo/config.toml`* — treats all Rust warnings as errors (`-Dwarnings`) to enforce code quality
- *Added `set -e` to `compile_mac.sh`* — ensures the build script fails fast on any error

## Test Instructions

1. Happy path
2. Verify analytics report works as expected
3. No segment errors should occur

Requested by Nikita Khalov via Slack