### PR TITLE
fix: wait for just teleported to consume emote

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -265,7 +265,7 @@ namespace DCL.AvatarRendering.Emotes.Play
 
         // This query takes care of consuming the CharacterEmoteIntent to trigger an emote
         [Query]
-        [None(typeof(DeleteEntityIntention))]
+        [None(typeof(DeleteEntityIntention), typeof(PlayerTeleportIntent.JustTeleported))]
         private void ConsumeEmoteIntent([Data] float dt, Entity entity,
             ref CharacterEmoteComponent emoteComponent,
             ref CharacterEmoteIntent emoteIntent,


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR waits the teleport "cooldown" in order to consume an emote intent.
By doing this, we can safely rotate the player using the teleport intent (`movePlayerTo`) without having the emote being blocked by this very action downstream.

### Test Steps
1. Go to `dclexperience2.dcl.eth`
2. play a couple of rounds in the fishing pond (don't try to win, make it faster by losing)
3. verify that when you hit a fish, there's a fighting against the fish animation playing
4. Smoke test the emotes: all should operate as normal


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
