### PR TITLE
fix: handle destroyed gameobjects in pool get

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Pools/GameObjectPool.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Pools/GameObjectPool.cs
@@ -1,7 +1,6 @@
 using DCL.Diagnostics;
 using System;
 using UnityEngine;
-using UnityEngine.Assertions;
 using UnityEngine.Pool;
 using Utility;
 
@@ -31,14 +30,21 @@ namespace DCL.Optimization.Pools
 
             if (onRelease != null) this.onRelease += onRelease;
             if (onGet != null) this.onGet += onGet;
-            gameObjectPool = new ExtendedObjectPool<T>(creationHandler ?? HandleCreation, actionOnGet: HandleGet, actionOnRelease: HandleRelease, actionOnDestroy: UnityObjectUtils.SafeDestroyGameObject, defaultCapacity: maxSize / 4, maxSize: maxSize);
+
+            gameObjectPool = new ExtendedObjectPool<T>(
+                creationHandler ?? HandleCreation,
+                actionOnGet: HandleGet,
+                actionOnRelease: HandleRelease,
+                actionOnDestroy: UnityObjectUtils.SafeDestroyGameObject,
+                defaultCapacity: maxSize / 4,
+                maxSize: maxSize);
         }
 
         public void Dispose() =>
             Clear();
 
         public PooledObject<T> Get(out T v) =>
-            gameObjectPool.Get(out v);
+            new (v = Get(), this);
 
         public void Release(T element)
         {
@@ -54,8 +60,19 @@ namespace DCL.Optimization.Pools
             gameObjectPool.Release(element);
         }
 
-        public T Get() =>
-            gameObjectPool.Get();
+        public T Get()
+        {
+            T component = gameObjectPool.Get();
+
+            while (component == null && !UnityObjectUtils.IsQuitting)
+            {
+                ReportHub.LogError(ReportCategory.ENGINE,
+                    $"{typeof(T).Name} has been destroyed while in the pool.");
+                component = gameObjectPool.Get();
+            }
+
+            return component!;
+        }
 
         public void Clear() =>
             gameObjectPool.Clear();
@@ -77,6 +94,9 @@ namespace DCL.Optimization.Pools
                 ReportHub.LogError(ReportCategory.ENGINE, $"Trying to get a component {typeof(T).Name} from a pool while quitting!");
                 return;
             }
+
+            if (component == null)
+                return;
 
             component.gameObject.SetActive(true);
             onGet?.Invoke(component);

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Pools/Tests/UnityComponentPoolShould.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/Pools/Tests/UnityComponentPoolShould.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace DCL.Optimization.Pools.Tests
 {
@@ -9,7 +10,8 @@ namespace DCL.Optimization.Pools.Tests
         [SetUp]
         public void SetUp()
         {
-            gameObjectPool = new GameObjectPool<Transform>(null, null, null, 1000);
+            onGetCallCount = 0;
+            gameObjectPool = new GameObjectPool<Transform>(null, null, null, 1000, _ => onGetCallCount++);
         }
 
         [TearDown]
@@ -19,6 +21,7 @@ namespace DCL.Optimization.Pools.Tests
         }
 
         private GameObjectPool<Transform> gameObjectPool;
+        private int onGetCallCount;
 
         [Test]
         public void GetGameObject()
@@ -55,6 +58,30 @@ namespace DCL.Optimization.Pools.Tests
             //Assert
             Assert.IsTrue(component == null);
             Assert.AreEqual(0, gameObjectPool.CountInactive);
+        }
+
+        [Test]
+        public void SkipDestroyedObjectAndReturnValidComponent()
+        {
+            // Arrange: place a component in the pool, then destroy its GameObject while it sits inactive
+            Transform pooled = gameObjectPool.Get();
+            gameObjectPool.Release(pooled);
+            Assert.AreEqual(1, gameObjectPool.CountInactive);
+
+            Object.DestroyImmediate(pooled.gameObject);
+
+            // Act: Get() must skip the destroyed entry (logging the error is expected) and return a live component
+            LogAssert.Expect(LogType.Error, "Transform has been destroyed while in the pool.");
+            Transform result = gameObjectPool.Get();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.IsTrue(result.gameObject.activeSelf);
+
+            // onGet callback must have fired for the valid component (twice total: first Get + this Get)
+            Assert.AreEqual(2, onGetCallCount);
+
+            gameObjectPool.Release(result);
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description
Fixes #7701 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Given that a pooled transform's gameobject could be destroyed, the item was then sent back to the pool. When this particular object was drafted again from the pool to be used, the exception was thrown as the underlying gameobject is null.

The fix makes sure that every item got from the pool cannot be null (same logic applied from #7783)


### Test Steps
1. Generic smoke test: scenes/avatars and everything in world must load as expected


## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
