### PR TITLE
feat: fall back from Pulse to LiveKit when unreachable at start-up

### DIFF
--- a/Explorer/Assets/DCL/FeatureFlags/FeaturesRegistry.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeaturesRegistry.cs
@@ -65,7 +65,7 @@ namespace DCL.FeatureFlags
                 [FeatureId.POINT_AT] = appArgs.ResolveFeatureFlagArg(AppArgsFlags.POINT_AT, featureFlags.IsEnabled(FeatureFlagsStrings.POINT_AT) || Application.isEditor),
                 [FeatureId.AVATAR_CONTEXT_MENU] = appArgs.ResolveFeatureFlagArg(AppArgsFlags.AVATAR_CONTEXT_MENU, featureFlags.IsEnabled(FeatureFlagsStrings.AVATAR_CONTEXT_MENU) || Application.isEditor),
                 [FeatureId.DOUBLE_CLICK_WALK] = appArgs.ResolveFeatureFlagArg(AppArgsFlags.DOUBLE_CLICK_WALK, featureFlags.IsEnabled(FeatureFlagsStrings.DOUBLE_CLICK_WALK)),
-                [FeatureId.PULSE] = (appArgs.HasFlag(AppArgsFlags.PULSE_MULTIPLAYER) || featureFlags.IsEnabled(FeatureFlagsStrings.PULSE)) && !localSceneDevelopment,
+                [FeatureId.PULSE] = appArgs.ResolveFeatureFlagArg(AppArgsFlags.PULSE_MULTIPLAYER, featureFlags.IsEnabled(FeatureFlagsStrings.PULSE), requireDebug: false) && !localSceneDevelopment,
                 [FeatureId.AB_DEPS_DIGEST_CACHE_KEY] = featureFlags.IsEnabled(FeatureFlagsStrings.AB_DEPS_DIGEST_CACHE_KEY),
                 [FeatureId.BYTE_WEIGHTED_LOADING_PROGRESS] = appArgs.ResolveFeatureFlagArg(AppArgsFlags.BYTE_WEIGHTED_LOADING_PROGRESS, featureFlags.IsEnabled(FeatureFlagsStrings.BYTE_WEIGHTED_LOADING_PROGRESS) || isEditor),
                 // Note: COMMUNITIES feature is not cached here because it depends on user identity

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -378,6 +378,7 @@ namespace Global.Dynamic
                 moderationDataProvider,
                 multiplayerContainer.PulseMultiplayerService,
                 multiplayerContainer.ProfilePropagation,
+                multiplayerContainer.PulseActivation,
                 realmNavigatorContainer.WorldPermissionsService,
                 chatContainer.ChatHistory);
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
@@ -44,6 +44,7 @@ namespace DCL.UserInAppInitializationFlow
             ModerationDataProvider moderationDataProvider,
             IPulseMultiplayerService pulseMultiplayerService,
             IProfilePropagation profilePropagation,
+            PulseActivation pulseActivation,
             IWorldPermissionsService worldPermissionsService,
             IChatHistory chatHistory)
         {
@@ -52,7 +53,7 @@ namespace DCL.UserInAppInitializationFlow
             var ensureLivekitConnectionStartupOperation = new EnsureLivekitConnectionStartupOperation(liveKitHealthCheck, roomHub);
             var blocklistCheckStartupOperation = new BlocklistCheckStartupOperation(staticContainer.WebRequestsContainer.WebRequestController, bootstrapContainer.IdentityCache!, bootstrapContainer.DecentralandUrlsSource, moderationDataProvider);
             var loadPlayerAvatarStartupOperation = new LoadPlayerAvatarStartupOperation(loadingStatus, selfProfile, staticContainer.MainPlayerAvatarBaseProxy);
-            var startPulseMultiplayerStartupOperation = new StartPulseMultiplayerStartupOperation(pulseMultiplayerService, profilePropagation, selfProfile);
+            var startPulseMultiplayerStartupOperation = new StartPulseMultiplayerStartupOperation(pulseMultiplayerService, profilePropagation, selfProfile, pulseActivation);
             var loadLandscapeStartupOperation = new LoadLandscapeStartupOperation(loadingStatus, terrainContainer.Landscape);
             var teleportStartupOperation = new TeleportStartupOperation(loadingStatus, realmContainer.RealmController, staticContainer.ExposedGlobalDataContainer.ExposedCameraData.CameraEntityProxy, realmContainer.TeleportController, staticContainer.ExposedGlobalDataContainer.CameraSamplingData, dynamicWorldParams.StartParcel, appArgs, dynamicWorldParams.EditorPositionOverrideActive);
 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/IPulseMultiplayerService.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/IPulseMultiplayerService.cs
@@ -25,7 +25,19 @@ namespace DCL.Multiplayer.Connections.Pulse
 
         public void UnregisterAllHandlers();
 
-        public UniTask ConnectAsync(CancellationToken ct);
+        /// <summary>
+        ///     Connects and authenticates against the Pulse server.
+        /// </summary>
+        /// <param name="maxAttempts">
+        ///     Upper bound on connection attempts before giving up on an unreachable server. The start-up
+        ///     operation passes a small bound so it can fall back to LiveKit; runtime reconnection uses the
+        ///     default to keep retrying.
+        /// </param>
+        /// <returns>
+        ///     <c>true</c> once connected and authenticated; <c>false</c> when the server stays unreachable
+        ///     after <paramref name="maxAttempts" /> attempts. Handshake/authentication failures throw instead.
+        /// </returns>
+        public UniTask<bool> ConnectAsync(CancellationToken ct, int maxAttempts = int.MaxValue);
 
         public UniTask DisconnectAsync();
 
@@ -45,8 +57,8 @@ namespace DCL.Multiplayer.Connections.Pulse
 
             public void UnregisterAllHandlers() { }
 
-            public UniTask ConnectAsync(CancellationToken ct) =>
-                UniTask.CompletedTask;
+            public UniTask<bool> ConnectAsync(CancellationToken ct, int maxAttempts = int.MaxValue) =>
+                UniTask.FromResult(true);
 
             public UniTask DisconnectAsync() =>
                 UniTask.CompletedTask;

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseActivation.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseActivation.cs
@@ -1,0 +1,24 @@
+namespace DCL.Multiplayer.Connections.Pulse
+{
+    /// <summary>
+    ///     Session-wide source of truth for whether Pulse is the active multiplayer transport.
+    ///     Seeded from the PULSE feature flag at construction. Set to inactive (one-way) only when
+    ///     the start-up connection is unreachable — a full fallback to LiveKit, after which the client
+    ///     behaves as if Pulse were never present. Never flipped at runtime: runtime reconnection
+    ///     failures keep retrying without changing this value.
+    /// </summary>
+    public sealed class PulseActivation
+    {
+        private volatile bool isActive;
+
+        public bool IsActive => isActive;
+
+        public PulseActivation(bool initiallyActive)
+        {
+            isActive = initiallyActive;
+        }
+
+        public void Deactivate() =>
+            isActive = false;
+    }
+}

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseActivation.cs.meta
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseActivation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 129ad056177242efbd32725a3a1df7bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseMultiplayerService.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseMultiplayerService.cs
@@ -70,12 +70,12 @@ namespace DCL.Multiplayer.Connections.Pulse
             handshakeHandler = null;
         }
 
-        public async UniTask ConnectAsync(CancellationToken ct)
+        public async UniTask<bool> ConnectAsync(CancellationToken ct, int maxAttempts = int.MaxValue)
         {
             if (transport.State is ITransport.TransportState.CONNECTED or ITransport.TransportState.CONNECTING)
-                return;
+                return true;
 
-            await ConnectWithRetriesAsync(ct);
+            return await ConnectWithRetriesAsync(ct, maxAttempts);
         }
 
         public UniTask DisconnectAsync()
@@ -106,7 +106,7 @@ namespace DCL.Multiplayer.Connections.Pulse
             pipe.Send(outgoingMessage);
         }
 
-        private async UniTask ConnectWithRetriesAsync(CancellationToken ct)
+        private async UniTask<bool> ConnectWithRetriesAsync(CancellationToken ct, int maxAttempts)
         {
             var attempt = 1;
 
@@ -115,10 +115,16 @@ namespace DCL.Multiplayer.Connections.Pulse
                 try
                 {
                     await ConnectInternalAsync(ct);
-                    return;
+                    return true;
                 }
                 catch (TimeoutException)
                 {
+                    if (attempt >= maxAttempts)
+                    {
+                        ReportHub.LogWarning(ReportCategory.MULTIPLAYER, $"Pulse connection won't be restored after attempt {attempt}");
+                        return false;
+                    }
+
                     (bool canBeRepeated, TimeSpan retryDelay) = WebRequestUtils.CanBeRepeated(attempt, CONNECTION_RETRY_POLICY, true, null);
 
                     if (canBeRepeated)
@@ -132,7 +138,7 @@ namespace DCL.Multiplayer.Connections.Pulse
                     else
                     {
                         ReportHub.LogWarning(ReportCategory.MULTIPLAYER, $"Pulse connection won't be restored after attempt {attempt}");
-                        return;
+                        return false;
                     }
                 }
 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests.meta
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88afecd8abaaccd42a457b60dacded00
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/DCL.Multiplayer.Pulse.Tests.asmref
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/DCL.Multiplayer.Pulse.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/DCL.Multiplayer.Pulse.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/DCL.Multiplayer.Pulse.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4d375b30c07b49fa976d158658fd31cf
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/PulseActivationShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/PulseActivationShould.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+
+namespace DCL.Multiplayer.Connections.Pulse.Tests
+{
+    [TestFixture]
+    public class PulseActivationShould
+    {
+        [Test]
+        public void StartActiveWhenSeededActive()
+        {
+            // Arrange
+            var activation = new PulseActivation(true);
+
+            // Assert
+            Assert.IsTrue(activation.IsActive);
+        }
+
+        [Test]
+        public void StartInactiveWhenSeededInactive()
+        {
+            // Arrange
+            var activation = new PulseActivation(false);
+
+            // Assert
+            Assert.IsFalse(activation.IsActive);
+        }
+
+        [Test]
+        public void BecomeInactiveAfterDeactivate()
+        {
+            // Arrange
+            var activation = new PulseActivation(true);
+
+            // Act
+            activation.Deactivate();
+
+            // Assert
+            Assert.IsFalse(activation.IsActive);
+        }
+
+        [Test]
+        public void StayInactiveWhenDeactivatedRepeatedly()
+        {
+            // Arrange
+            var activation = new PulseActivation(true);
+
+            // Act
+            activation.Deactivate();
+            activation.Deactivate();
+
+            // Assert
+            Assert.IsFalse(activation.IsActive);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/PulseActivationShould.cs.meta
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/PulseActivationShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a0b456c15bab31744bc27ffbb3ddd0d1

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/PulseMultiplayerServiceShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/PulseMultiplayerServiceShould.cs
@@ -1,0 +1,68 @@
+using Cysharp.Threading.Tasks;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Threading;
+
+namespace DCL.Multiplayer.Connections.Pulse.Tests
+{
+    [TestFixture]
+    public class PulseMultiplayerServiceShould
+    {
+        private ITransport transport;
+        private IDecentralandUrlsSource urlsSource;
+        private PulseMultiplayerService service;
+        private CancellationTokenSource cts;
+
+        [SetUp]
+        public void SetUp()
+        {
+            transport = Substitute.For<ITransport>();
+            transport.State.Returns(ITransport.TransportState.NONE);
+
+            urlsSource = Substitute.For<IDecentralandUrlsSource>();
+
+            service = new PulseMultiplayerService(transport, new MessagePipe(), urlsSource);
+            cts = new CancellationTokenSource();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            service.Dispose();
+            cts.Dispose();
+        }
+
+        [Test]
+        public void ReturnFalseWhenUnreachableWithinMaxAttempts()
+        {
+            // Arrange
+            transport
+               .ConnectAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+               .Returns(_ => throw new TimeoutException());
+
+            // Act
+            bool connected = service.ConnectAsync(cts.Token, maxAttempts: 1).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.IsFalse(connected);
+            Assert.IsFalse(service.IsAuthenticated);
+            transport.Received(1).ConnectAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        }
+
+        [Test]
+        public void NotAttemptConnectionWhenAlreadyConnected()
+        {
+            // Arrange
+            transport.State.Returns(ITransport.TransportState.CONNECTED);
+
+            // Act
+            bool connected = service.ConnectAsync(cts.Token, maxAttempts: 1).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.IsTrue(connected);
+            transport.DidNotReceive().ConnectAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/PulseMultiplayerServiceShould.cs.meta
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/Tests/PulseMultiplayerServiceShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 36ea6f570a4903d4db6bd263e17af092

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Systems/LiveKitMultiplayerContainer.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Systems/LiveKitMultiplayerContainer.cs
@@ -1,6 +1,6 @@
-﻿using DCL.FeatureFlags;
-using DCL.Friends.UserBlocking;
+﻿using DCL.Friends.UserBlocking;
 using DCL.Multiplayer.Connections.Messaging.Hubs;
+using DCL.Multiplayer.Connections.Pulse;
 using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Multiplayer.Emotes;
 using DCL.Multiplayer.Movement.Settings;
@@ -27,10 +27,10 @@ namespace DCL.Multiplayer.Movement
             MovementInbox movementInbox,
             ISelfProfile selfProfile,
             IUserBlockingCache userBlockingCache,
-            MultiplayerDebugSettings multiplayerDebugSettings)
+            MultiplayerDebugSettings multiplayerDebugSettings,
+            PulseActivation pulseActivation)
         {
-            bool backwardCompatibilityMode = FeaturesRegistry.Instance.IsEnabled(FeatureId.PULSE);
-            var broadcaster = new LiveKitMessagesBroadcaster(messagePipesHub, backwardCompatibilityMode);
+            var broadcaster = new LiveKitMessagesBroadcaster(messagePipesHub, pulseActivation);
 
             RemoteAnnouncements = new LiveKitRemoteAnnouncements(messagePipesHub, broadcaster);
             ProfileBroadcast = new DebounceLiveKitProfileBroadcast(new LiveKitProfileBroadcast(selfProfile, broadcaster));

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Systems/MultiplayerContainer.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Systems/MultiplayerContainer.cs
@@ -3,6 +3,7 @@ using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
 using DCL.DebugUtilities;
 using DCL.ECSComponents;
+using DCL.FeatureFlags;
 using DCL.Friends.UserBlocking;
 using DCL.Landscape.Settings;
 using DCL.Multiplayer.Connections.DecentralandUrls;
@@ -188,6 +189,7 @@ namespace DCL.Multiplayer.Movement
         public readonly IRemoteAnnouncements RemoteAnnouncements;
         public readonly IEmotesMessageBus EmotesMessageBus;
         public readonly IRemoveIntentions RemoveIntentions;
+        public readonly PulseActivation PulseActivation;
 
         public IProfileBroadcast ProfileBroadcast => liveKitContainer.ProfileBroadcast;
         public IProfilePropagation ProfilePropagation => pulseContainer.pulseProfilePropagationBus!;
@@ -197,11 +199,12 @@ namespace DCL.Multiplayer.Movement
         public PulseMultiplayerBus PulseMultiplayerBus => pulseContainer.pulseMultiplayerBus!;
         public ITransport PulseTransport => pulseContainer.transport!;
 
-        private MultiplayerContainer(PulseContainer pulseContainer, LiveKitMultiplayerContainer liveKitContainer, ISelfProfile selfProfile)
+        private MultiplayerContainer(PulseContainer pulseContainer, LiveKitMultiplayerContainer liveKitContainer, ISelfProfile selfProfile, PulseActivation pulseActivation)
         {
             this.pulseContainer = pulseContainer;
             this.liveKitContainer = liveKitContainer;
             this.selfProfile = selfProfile;
+            PulseActivation = pulseActivation;
 
             // Create Proxies to expose them to consumers
             MovementMessageBus = new MovementMessageBusProxy(pulseContainer.pulseMultiplayerBus!, liveKitContainer.MovementMessageBus);
@@ -224,12 +227,17 @@ namespace DCL.Multiplayer.Movement
             MultiplayerDebugSettings multiplayerDebugSettings,
             IUserBlockingCache userBlockingCache,
             ISelfProfile selfProfile,
-            CancellationToken ct) =>
-            new (
-                await PulseContainer.CreateAsync(pluginSettingsContainer, identityCache, movementInbox, landscapeData, urlsSource, selfProfile, realmData, ct),
-                new LiveKitMultiplayerContainer(roomHub, messagePipesHub, movementInbox, selfProfile, userBlockingCache, multiplayerDebugSettings),
-                selfProfile
-            );
+            CancellationToken ct)
+        {
+            // Single session-wide source of truth for whether Pulse is the active transport.
+            // Shared with the Pulse container, the LiveKit broadcaster, and the start-up operation that may deactivate it on fallback.
+            var pulseActivation = new PulseActivation(FeaturesRegistry.Instance.IsEnabled(FeatureId.PULSE));
+
+            PulseContainer pulseContainer = await PulseContainer.CreateAsync(pluginSettingsContainer, identityCache, movementInbox, landscapeData, urlsSource, selfProfile, realmData, pulseActivation, ct);
+            var liveKitContainer = new LiveKitMultiplayerContainer(roomHub, messagePipesHub, movementInbox, selfProfile, userBlockingCache, multiplayerDebugSettings, pulseActivation);
+
+            return new MultiplayerContainer(pulseContainer, liveKitContainer, selfProfile, pulseActivation);
+        }
 
         public MultiplayerMovementPlugin CreatePlugin(
             StaticContainer staticContainer,
@@ -255,8 +263,11 @@ namespace DCL.Multiplayer.Movement
                 commsContainer.RemoteMetadata,
                 ParcelEncoder);
 
-        private void OnSelfProfilePropagated(Profile profile) =>
-            ProfilePropagation.Propagate(profile);
+        private void OnSelfProfilePropagated(Profile profile)
+        {
+            if (PulseActivation.IsActive)
+                ProfilePropagation.Propagate(profile);
+        }
 
         public void Dispose()
         {

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Systems/PulseContainer.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Systems/PulseContainer.cs
@@ -1,5 +1,4 @@
 ﻿using Cysharp.Threading.Tasks;
-using DCL.FeatureFlags;
 using DCL.Landscape.Settings;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Multiplayer.Connections.Pulse;
@@ -35,14 +34,15 @@ namespace DCL.Multiplayer.Movement
         public readonly PulseIncomingProfileAnnouncements IncomingProfiles;
         public readonly PulseRemoveIntentions RemoveIntentions;
 
-        public readonly bool FeatureEnabled;
+        private readonly PulseActivation pulseActivation;
 
         internal PulseMultiplayerBus? pulseMultiplayerBus { get; private set; }
         internal IPulseMultiplayerService? pulseMultiplayerService { get; private set; }
         internal IProfilePropagation? pulseProfilePropagationBus { get; private set; }
 
         private PulseContainer(IWeb3IdentityCache identityCache, MovementInbox movementInbox,
-            ParcelEncoder parcelEncoder, IDecentralandUrlsSource urlsSource, ISelfProfile selfProfile, IRealmData realmData)
+            ParcelEncoder parcelEncoder, IDecentralandUrlsSource urlsSource, ISelfProfile selfProfile, IRealmData realmData,
+            PulseActivation pulseActivation)
         {
             this.identityCache = identityCache;
             this.movementInbox = movementInbox;
@@ -50,10 +50,9 @@ namespace DCL.Multiplayer.Movement
             this.urlsSource = urlsSource;
             this.selfProfile = selfProfile;
             this.realmData = realmData;
+            this.pulseActivation = pulseActivation;
             IncomingProfiles = new PulseIncomingProfileAnnouncements();
             RemoveIntentions = new PulseRemoveIntentions();
-
-            FeatureEnabled = FeaturesRegistry.Instance.IsEnabled(FeatureId.PULSE);
         }
 
         public static async UniTask<PulseContainer> CreateAsync(
@@ -64,9 +63,10 @@ namespace DCL.Multiplayer.Movement
             IDecentralandUrlsSource urlsSource,
             ISelfProfile selfProfile,
             IRealmData realmData,
+            PulseActivation pulseActivation,
             CancellationToken ct)
         {
-            var container = new PulseContainer(web3IdentityCache, movementInbox, new ParcelEncoder(landscapeData.terrainData), urlsSource, selfProfile, realmData);
+            var container = new PulseContainer(web3IdentityCache, movementInbox, new ParcelEncoder(landscapeData.terrainData), urlsSource, selfProfile, realmData, pulseActivation);
             await container.InitializeContainerAsync<PulseContainer, Settings>(pluginSettingsContainer, ct);
             return container;
         }
@@ -76,13 +76,13 @@ namespace DCL.Multiplayer.Movement
             lifeCycleCts = lifeCycleCts.SafeRestart();
 
             transport = new ENetTransport(settings.ENetTransportOptions, messagePipe);
-            pulseMultiplayerService = FeatureEnabled ? new PulseMultiplayerService(transport, messagePipe, urlsSource) : new IPulseMultiplayerService.Dummy();
+            pulseMultiplayerService = pulseActivation.IsActive ? new PulseMultiplayerService(transport, messagePipe, urlsSource) : new IPulseMultiplayerService.Dummy();
 
             pulseMultiplayerBus = new PulseMultiplayerBus(pulseMultiplayerService, peerIdCache, movementInbox,
                 parcelEncoder, IncomingProfiles, RemoveIntentions, identityCache, settings.ReconnectionSettings, selfProfile, realmData);
             pulseMultiplayerBus.SubscribeToIncomingMessages();
 
-            pulseProfilePropagationBus = FeatureEnabled ? new PulseProfilePropagationBus(pulseMultiplayerService) : new IProfilePropagation.Dummy();
+            pulseProfilePropagationBus = pulseActivation.IsActive ? new PulseProfilePropagationBus(pulseMultiplayerService) : new IProfilePropagation.Dummy();
 
             return UniTask.CompletedTask;
         }

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/BroadcastProfiles/LiveKitMessagesBroadcaster.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/BroadcastProfiles/LiveKitMessagesBroadcaster.cs
@@ -2,6 +2,7 @@
 using DCL.Multiplayer.Connections.Messaging;
 using DCL.Multiplayer.Connections.Messaging.Hubs;
 using DCL.Multiplayer.Connections.Messaging.Pipe;
+using DCL.Multiplayer.Connections.Pulse;
 using DCL.Multiplayer.Connections.Rooms;
 using Google.Protobuf;
 using System;
@@ -20,22 +21,24 @@ namespace DCL.Multiplayer.Profiles.BroadcastProfiles
         private readonly IMessagePipesHub messagePipesHub;
 
         /// <summary>
-        ///     In the backward compatibility mode Profiles are only broadcasted to the peers that announced their profiles
+        ///     While Pulse is active, messages are sent only to the peers that announced their profiles over
+        ///     LiveKit (the rest receive them over Pulse). When Pulse is absent — disabled or fallen back —
+        ///     messages are broadcast to every peer in the rooms.
         /// </summary>
-        private readonly bool backwardCompatibilityMode;
+        private readonly PulseActivation pulseActivation;
 
         private readonly Dictionary<string, RoomSource> announcedWallets = new ();
 
-        public LiveKitMessagesBroadcaster(IMessagePipesHub messagePipesHub, bool backwardCompatibilityMode)
+        public LiveKitMessagesBroadcaster(IMessagePipesHub messagePipesHub, PulseActivation pulseActivation)
         {
             this.messagePipesHub = messagePipesHub;
-            this.backwardCompatibilityMode = backwardCompatibilityMode;
+            this.pulseActivation = pulseActivation;
         }
 
         public void Send<TInput, TMessage>(Action<TInput, TMessage> buildMessage, TInput args,
             LKDataPacketKind packetKind, CancellationToken ct) where TMessage: class, IMessage, new()
         {
-            if (backwardCompatibilityMode)
+            if (pulseActivation.IsActive)
             {
                 // Build up recipients lists for every room
 

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/StartPulseMultiplayerStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/StartPulseMultiplayerStartupOperation.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.Pulse;
 using DCL.Profiles;
 using DCL.Profiles.Self;
@@ -8,22 +9,39 @@ namespace DCL.UserInAppInitializationFlow
 {
     public class StartPulseMultiplayerStartupOperation : StartUpOperationBase
     {
+        private const int CONNECTION_ATTEMPTS = 5;
+
         private readonly IPulseMultiplayerService service;
         private readonly IProfilePropagation profilePropagation;
         private readonly ISelfProfile selfProfile;
+        private readonly PulseActivation pulseActivation;
 
         public StartPulseMultiplayerStartupOperation(IPulseMultiplayerService service,
             IProfilePropagation profilePropagation,
-            ISelfProfile selfProfile)
+            ISelfProfile selfProfile,
+            PulseActivation pulseActivation)
         {
             this.service = service;
             this.profilePropagation = profilePropagation;
             this.selfProfile = selfProfile;
+            this.pulseActivation = pulseActivation;
         }
 
         protected override async UniTask InternalExecuteAsync(IStartupOperation.Params args, CancellationToken ct)
         {
-            await service.ConnectAsync(ct);
+            // Pulse disabled (feature off / --pulse false) or already fell back in a previous flow — nothing to start.
+            if (!pulseActivation.IsActive)
+                return;
+
+            if (!await service.ConnectAsync(ct, CONNECTION_ATTEMPTS))
+            {
+                // Server is unreachable: fall back fully to LiveKit so the client behaves as if Pulse were absent.
+                pulseActivation.Deactivate();
+                ReportHub.LogWarning(ReportCategory.MULTIPLAYER, "Pulse unreachable at start-up; falling back to LiveKit-only.");
+                await UniTask.SwitchToMainThread();
+                return;
+            }
+
             Profile? profile = await selfProfile.ProfileAsync(ct);
             profilePropagation.Propagate(profile!);
             await UniTask.SwitchToMainThread();

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/StartPulseMultiplayerStartupOperationShould.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/StartPulseMultiplayerStartupOperationShould.cs
@@ -1,0 +1,83 @@
+using Arch.Core;
+using Cysharp.Threading.Tasks;
+using DCL.Multiplayer.Connections.Pulse;
+using DCL.Profiles;
+using DCL.Profiles.Self;
+using DCL.RealmNavigation;
+using DCL.Utilities;
+using NSubstitute;
+using NUnit.Framework;
+using System.Threading;
+
+namespace DCL.UserInAppInitializationFlow.Tests
+{
+    [TestFixture]
+    public class StartPulseMultiplayerStartupOperationShould
+    {
+        private World world;
+        private IPulseMultiplayerService service;
+        private IProfilePropagation profilePropagation;
+        private ISelfProfile selfProfile;
+        private CancellationTokenSource cts;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = World.Create();
+            service = Substitute.For<IPulseMultiplayerService>();
+            profilePropagation = Substitute.For<IProfilePropagation>();
+            selfProfile = Substitute.For<ISelfProfile>();
+            cts = new CancellationTokenSource();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            world.Dispose();
+            cts.Dispose();
+        }
+
+        [Test]
+        public void SkipConnectionWhenPulseInactive()
+        {
+            // Arrange
+            var activation = new PulseActivation(false);
+            var operation = new StartPulseMultiplayerStartupOperation(service, profilePropagation, selfProfile, activation);
+
+            // Act
+            operation.ExecuteAsync(MakeParams(), cts.Token).GetAwaiter().GetResult();
+
+            // Assert
+            service.DidNotReceive().ConnectAsync(Arg.Any<CancellationToken>(), Arg.Any<int>());
+            Assert.IsFalse(activation.IsActive);
+        }
+
+        [Test]
+        public void FallBackToLiveKitWhenUnreachable()
+        {
+            // Arrange
+            var activation = new PulseActivation(true);
+            service.ConnectAsync(Arg.Any<CancellationToken>(), Arg.Any<int>()).Returns(UniTask.FromResult(false));
+            var operation = new StartPulseMultiplayerStartupOperation(service, profilePropagation, selfProfile, activation);
+
+            // Act
+            operation.ExecuteAsync(MakeParams(), cts.Token).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.IsFalse(activation.IsActive);
+            profilePropagation.DidNotReceive().Propagate(Arg.Any<Profile>());
+        }
+
+        private IStartupOperation.Params MakeParams()
+        {
+            var flowParams = new UserInAppInitializationFlowParameters(
+                showAuthentication: false,
+                showLoading: false,
+                loadSource: IUserInAppInitializationFlow.LoadSource.StartUp,
+                world: world,
+                playerEntity: default);
+
+            return new IStartupOperation.Params(AsyncLoadProcessReport.Create(cts.Token), flowParams);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/StartPulseMultiplayerStartupOperationShould.cs.meta
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/StartPulseMultiplayerStartupOperationShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 38eb7c831906b59459a163a415327391

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -369,6 +369,20 @@ More detailed instructions on how to test can be found in the description of rel
 
 ---
 
+## Multiplayer Flags
+
+### `pulse`
+**Type:** Bool (`true` / `false`)
+**Description:** Toggles the Pulse transport (an ENet-based UDP channel that runs alongside LiveKit), overriding the `pulse` remote feature flag. When **specified**, the value wins over the remote flag: `--pulse true` force-enables Pulse, `--pulse false` force-disables it (LiveKit-only, as if Pulse were never present). When **not specified**, Pulse is driven by the remote feature flag. Always ignored during local scene development.
+
+**Usage:**
+```bash
+--pulse true
+--pulse false
+```
+
+---
+
 ## Feature Flags Configuration
 
 ### `feature-flags-url`

--- a/docs/livekit-networking.md
+++ b/docs/livekit-networking.md
@@ -171,7 +171,7 @@ public void Send(NetworkMovementMessage message)
 
 Both compressed (`MovementCompressed` via `NetworkMessageEncoder`) and uncompressed (`Decentraland.Kernel.Comms.Rfc4.Movement`) schemas are supported. The `UseCompression` setting on `MultiplayerMovementSettings` controls which schema is used for outgoing messages; incoming messages of either type are accepted.
 
-> **Note:** When `FeatureId.PULSE` is enabled, `LiveKitMessagesBroadcaster` runs in `backwardCompatibilityMode` — this affects how profile announcements and other control messages are serialized to stay interoperable with Pulse-enabled peers.
+> **Note:** `LiveKitMessagesBroadcaster` reads the shared `PulseActivation` live on every send. When Pulse is active it sends movement / emotes / profile announcements only to the peers that announced over LiveKit (the rest receive them over Pulse, avoiding double-delivery); when Pulse is absent (disabled or fallen back) it broadcasts to every peer in the rooms.
 
 ---
 

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -27,7 +27,7 @@ Two transports are active at the same time: **LiveKit** (Archipelago Island room
 
 Both transports send the same `NetworkMovementMessage` / emote / profile-announcement payloads. On the receive side, incoming items from both transports are de-duplicated by wallet ID so the rest of the ECS pipeline is transport-oblivious.
 
-Pulse is gated by the `FeatureId.PULSE` feature flag. When it is off, Pulse is replaced with no-op dummies and only LiveKit carries traffic. LiveKit also reads the same flag and switches its broadcaster into a `backwardCompatibilityMode` when Pulse is live. See [Transport Selection & Wiring](#transport-selection--wiring) below.
+Pulse is gated by the `FeatureId.PULSE` feature flag, resolved once into a shared `PulseActivation`. When inactive, Pulse is replaced with no-op dummies and only LiveKit carries traffic, with `LiveKitMessagesBroadcaster` broadcasting to all peers. When active, the broadcaster sends only to peers that announced over LiveKit (the rest receive over Pulse). If the Pulse server is unreachable at start-up, the client falls back fully to LiveKit. See [Transport Selection & Wiring](#transport-selection--wiring) below.
 
 ---
 
@@ -67,11 +67,12 @@ All transport-neutral interfaces live under `Explorer/Assets/DCL/Multiplayer/`. 
 
 ### Feature flag decision points
 
-Pulse is gated by `FeatureId.PULSE`:
+Pulse is gated by `FeatureId.PULSE`, read once in `MultiplayerContainer.CreateAsync` into a shared `PulseActivation` (the session-wide "is Pulse the active transport" flag):
 
-- `Movement/Systems/PulseContainer.cs` reads the flag in its constructor and, during init, chooses between the real `PulseMultiplayerService` / `PulseProfilePropagationBus` and their `Dummy` counterparts.
-- `Movement/Systems/LiveKitMultiplayerContainer.cs` also reads the flag and passes `backwardCompatibilityMode` to `LiveKitMessagesBroadcaster`. When Pulse is live, the LiveKit broadcaster adjusts its behavior to avoid redundancy.
-- The `--pulse` program argument flips the flag at launch.
+- `Movement/Systems/PulseContainer.cs` receives the `PulseActivation` and, during init, chooses between the real `PulseMultiplayerService` / `PulseProfilePropagationBus` and their `Dummy` counterparts based on `IsActive`.
+- `Movement/Systems/LiveKitMultiplayerContainer.cs` passes the same `PulseActivation` to `LiveKitMessagesBroadcaster`, which reads `IsActive` live: when active it targets only LiveKit-announced peers, when inactive it broadcasts to all.
+- `StartPulseMultiplayerStartupOperation` calls `PulseActivation.Deactivate()` if Pulse is unreachable at start-up (full fallback to LiveKit). Runtime reconnection failures never deactivate.
+- The `--pulse true` / `--pulse false` program argument overrides the remote flag at launch; when absent, the remote flag drives it.
 
 ### Construction order
 

--- a/docs/pulse.md
+++ b/docs/pulse.md
@@ -27,41 +27,55 @@ See [multiplayer.md → Transport Selection & Wiring](multiplayer.md#transport-s
 
 ## Feature flag and program arg
 
-Pulse is toggled by a single logical flag, evaluated by `FeaturesRegistry` as either a launch arg **or** a remote feature flag:
+Pulse is toggled by a single logical flag, evaluated by `FeaturesRegistry` as a remote feature flag with an optional launch-arg override:
 
 | Source | Symbol | Where |
 |---|---|---|
-| Program arg | `--pulse` | `AppArgsFlags.PULSE_MULTIPLAYER = "pulse"` |
+| Program arg (override) | `--pulse true` / `--pulse false` | `AppArgsFlags.PULSE_MULTIPLAYER = "pulse"` |
 | Remote flag | `"pulse"` | `FeatureFlagsStrings.PULSE = "pulse"` |
 | Registry key | `FeatureId.PULSE` | Final boolean exposed to code |
 
 From `DCL/FeatureFlags/FeaturesRegistry.cs`:
 
 ```csharp
-[FeatureId.PULSE] = appArgs.HasFlag(AppArgsFlags.PULSE_MULTIPLAYER)
-                 || featureFlags.IsEnabled(FeatureFlagsStrings.PULSE),
+[FeatureId.PULSE] = appArgs.ResolveFeatureFlagArg(AppArgsFlags.PULSE_MULTIPLAYER, featureFlags.IsEnabled(FeatureFlagsStrings.PULSE), requireDebug: false)
+                    && !localSceneDevelopment,
 ```
 
-`OR` semantics: passing `--pulse` at launch enables it regardless of the remote flag, useful for local development and integration testing.
+Override semantics: when `--pulse` is **specified** its value wins over the remote flag (`--pulse true` force-enables, `--pulse false` force-disables — useful for local development, integration testing, and ops kill-switching); when it is **not specified**, Pulse is driven by the remote feature flag. Local scene development always forces Pulse off.
 
 ### Where the flag is consumed
 
-- **`PulseContainer`** — reads `FeaturesRegistry.Instance.IsEnabled(FeatureId.PULSE)` in its constructor and stores it as `FeatureEnabled`. During `InitializeInternalAsync`:
-  - `pulseMultiplayerService` is either a real `PulseMultiplayerService(transport, messagePipe, identityCache, urlsSource)` or `new IPulseMultiplayerService.Dummy()`.
+The flag is read **once** in `MultiplayerContainer.CreateAsync`, which seeds a single shared `PulseActivation` (`Connections/Pulse/PulseActivation.cs`) — the session-wide source of truth for "is Pulse the active transport". Consumers read `PulseActivation.IsActive` rather than the flag:
+
+- **`PulseContainer`** — receives the `PulseActivation`. During `InitializeInternalAsync`, from `pulseActivation.IsActive`:
+  - `pulseMultiplayerService` is either a real `PulseMultiplayerService(transport, messagePipe, urlsSource)` or `new IPulseMultiplayerService.Dummy()`.
   - `pulseProfilePropagationBus` is either a real `PulseProfilePropagationBus(...)` or `new IProfilePropagation.Dummy()`.
-  - The `PulseMultiplayerBus`, `PulseIncomingProfileAnnouncements`, `PulseRemoveIntentions`, and `ENetTransport` are **always** constructed; the flag only swaps the Service and ProfilePropagation paths. The bus and incoming collectors simply never receive traffic when the service is a dummy.
-- **`LiveKitMultiplayerContainer`** — reads the same flag and passes `backwardCompatibilityMode = true` to `LiveKitMessagesBroadcaster`. This adjusts how LiveKit serializes certain control messages so Pulse-enabled peers interoperate with LiveKit-only peers without double-delivery or format drift.
+  - The `PulseMultiplayerBus`, `PulseIncomingProfileAnnouncements`, `PulseRemoveIntentions`, and `ENetTransport` are **always** constructed; activation only swaps the Service and ProfilePropagation paths. The bus and incoming collectors simply never receive traffic when the service is a dummy (or the real service is disconnected).
+- **`LiveKitMessagesBroadcaster`** — holds the `PulseActivation` and reads `IsActive` **live** on every send (movement, emotes, and profiles all route through it). When Pulse is active it sends only to the peers that announced over LiveKit (the rest receive over Pulse); when Pulse is absent it broadcasts to every peer in the rooms.
+
+> `PulseActivation.IsActive` starts equal to `FeatureId.PULSE`. It flips to `false` exactly once — when the start-up connection is unreachable (see [Start-up fallback](#start-up-fallback)). It never flips at runtime.
 
 ### Disabling behavior
 
-When the flag is off:
+When Pulse is inactive (`FeatureId.PULSE` off, `--pulse false`, local scene development, or after a start-up fallback):
 
-- All four proxies in `MultiplayerContainer` still fan out to Pulse, but the Pulse side is a no-op — `PulseMultiplayerBus` methods early-return against `pulseMultiplayerService.Dummy`.
+- All four proxies in `MultiplayerContainer` still fan out to Pulse, but the Pulse side is a no-op — `PulseMultiplayerBus` methods early-return against a `Dummy` (or disconnected) service.
 - Incoming proxies' `Fill(...)` / `Bunch()` calls include empty Pulse lists.
-- `IProfilePropagation.Dummy` makes the main self-profile-propagation call a no-op (the profile still propagates over LiveKit via `IProfileBroadcast`).
-- `LiveKitMessagesBroadcaster.backwardCompatibilityMode = false` — LiveKit runs in its original serialization mode.
+- `IProfilePropagation` is a no-op (the profile still propagates over LiveKit via `IProfileBroadcast`); `MultiplayerContainer.OnSelfProfilePropagated` also gates on `IsActive`.
+- `LiveKitMessagesBroadcaster` broadcasts to all peers (its original serialization mode).
 
 The effective runtime cost of Pulse when disabled is a few dummy virtual calls per frame.
+
+### Start-up fallback
+
+`StartPulseMultiplayerStartupOperation` connects to Pulse during login, passing a bounded attempt count (`5`) to `IPulseMultiplayerService.ConnectAsync(ct, maxAttempts)`:
+
+- If Pulse is **unreachable** (the connection keeps timing out across all 5 attempts), the operation calls `PulseActivation.Deactivate()` and returns success — login continues and the client behaves as if Pulse were absent.
+- Handshake/authentication failures are **not** treated as unreachable; they propagate as a normal start-up error.
+- If Pulse is already inactive (disabled / `--pulse false`), the operation is a no-op.
+
+Runtime reconnection failures (after a successful initial connect) do **not** fall back — the `StartRouting` / `HandleDisconnect` reconnection loop keeps retrying without flipping `PulseActivation`.
 
 ---
 
@@ -783,13 +797,21 @@ Key facts:
 ```csharp
 protected override async UniTask InternalExecuteAsync(IStartupOperation.Params args, CancellationToken ct)
 {
-    await service.ConnectAsync(ct);
+    if (!pulseActivation.IsActive) return;                        // disabled / --pulse false
+
+    if (!await service.ConnectAsync(ct, maxAttempts: 5))          // unreachable after 5 attempts
+    {
+        pulseActivation.Deactivate();                            // full fallback to LiveKit-only
+        return;
+    }
+
     Profile? profile = await selfProfile.ProfileAsync(ct);
     profilePropagation.Propagate(profile!);
+    await UniTask.SwitchToMainThread();
 }
 ```
 
-On startup, connect to Pulse, fetch the host's profile, and announce its version. This is a **one-shot** at connect — there's no debounce mechanism like `DebounceLiveKitProfileBroadcast` watching `ISelfProfile.ProfilePropagated` continuously. (LiveKit's broadcast runs on every profile change; Pulse only fires at connect time today.)
+On startup, connect to Pulse, fetch the host's profile, and announce its version. The connect is bounded to 5 attempts; if the server is unreachable the operation deactivates Pulse (full fallback to LiveKit) and lets login continue — see [Start-up fallback](#start-up-fallback). The propagate is a **one-shot** at connect — there's no debounce mechanism like `DebounceLiveKitProfileBroadcast` watching `ISelfProfile.ProfilePropagated` continuously. (LiveKit's broadcast runs on every profile change; Pulse only fires at connect time today.)
 
 `MultiplayerContainer` does also subscribe to `ISelfProfile.ProfilePropagated` and invoke `ProfilePropagation.Propagate(profile)` for later updates — so subsequent profile changes do reach Pulse. But there's no timer-based throttle wrapping that call, so the cadence is whatever `ISelfProfile` chooses to fire at.
 
@@ -885,15 +907,15 @@ Ordered construction of the internal stack:
 
 ```csharp
 transport = new ENetTransport(settings.ENetTransportOptions, messagePipe);
-pulseMultiplayerService = FeatureEnabled
-    ? new PulseMultiplayerService(transport, messagePipe, identityCache, urlsSource)
+pulseMultiplayerService = pulseActivation.IsActive
+    ? new PulseMultiplayerService(transport, messagePipe, urlsSource)
     : new IPulseMultiplayerService.Dummy();
 
-pulseMultiplayerBus = new PulseMultiplayerBus(pulseMultiplayerService, peerIdCache,
-    movementInbox, parcelEncoder, IncomingProfiles, RemoveIntentions, identityCache);
+pulseMultiplayerBus = new PulseMultiplayerBus(pulseMultiplayerService, peerIdCache, movementInbox,
+    parcelEncoder, IncomingProfiles, RemoveIntentions, identityCache, settings.ReconnectionSettings, selfProfile, realmData);
 pulseMultiplayerBus.SubscribeToIncomingMessages();
 
-pulseProfilePropagationBus = FeatureEnabled
+pulseProfilePropagationBus = pulseActivation.IsActive
     ? new PulseProfilePropagationBus(pulseMultiplayerService)
     : new IProfilePropagation.Dummy();
 ```


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Introduces a full fallback from Pulse to LiveKit so an **unreachable Pulse server can no longer block login**.

Based off the [conversation ](https://decentralandteam.slack.com/archives/C05T5G3E9SN/p1781786142311429)with the Chinese user behind the strict NAT that uses an xray tunnel without UDP support.

**Problem**
- `StartPulseMultiplayerStartupOperation` connected to Pulse with an unbounded retry (`RetryPolicy.WithRetries(int.MaxValue, …)`). If the Pulse server was unreachable, the start-up operation never returned and the login flow stalled (a sequential-loader failure could also abort login outright). After all the process was killed by the outer timeout.
- `LiveKitMessagesBroadcaster.backwardCompatibilityMode` (set once at construction from `FeatureId.PULSE`) gated **all** LiveKit traffic — movement, emotes **and** profiles — to only the wallets that announced over LiveKit. With Pulse enabled but dead, that traffic reached only a subset of peers (a silent partial outage).

**Solution**
- A single shared **`PulseActivation`** (`volatile bool`, one-way `Deactivate()`) is now the session-wide source of truth for "is Pulse the active transport". It is seeded once from `FeatureId.PULSE`, read **live** by the broadcaster, and threaded into the Pulse container and the start-up operation. It replaces the misnamed `backwardCompatibilityMode`.
- The start-up connect is **bounded to 5 attempts**. If Pulse is unreachable (the connection times out), the operation calls `PulseActivation.Deactivate()` and returns success — login continues and the client behaves exactly as if Pulse were never present (LiveKit broadcasts to all peers, no Pulse sends, no Pulse profile propagation). Only reachability (timeout) failures fall back; handshake/auth failures still surface as normal start-up errors.
- **Runtime** reconnection failures do **not** fall back — the existing `StartRouting` / `HandleDisconnect` loop is untouched.
- The **`--pulse`** arg now carries `true`/`false` and overrides the remote feature flag (`--pulse true` force-on, `--pulse false` force-off); when absent, the remote flag drives it. (Replaces the old presence-only `--pulse`.)

Docs updated: `docs/pulse.md`, `docs/multiplayer.md`, `docs/livekit-networking.md`, `docs/app-arguments.md`.
Verified locally: Unity batch compile clean (0 `error CS`) + 8/8 new EditMode unit tests pass (`PulseActivationShould`, `PulseMultiplayerServiceShould`, `StartPulseMultiplayerStartupOperationShould`).

## Test Instructions

> Get a build for this PR with `metaforge explorer run <this-PR-number>` (add `--clear` for a clean data dir). Tail logs with `metaforge explorer logs tail --filter "Pulse"`.

### Prerequisites
- [ ] A build/Editor where Pulse can be exercised (use the `--pulse true|false` arg below — no remote-FF setup needed).
- [ ] Admin rights to edit the OS hosts file (for the fallback test).
- [ ] At least one other player in the same realm/parcel to confirm movement, emotes and profiles still sync over LiveKit.

### Test Steps

**A — `--pulse` flag override**
1. Launch with `--pulse false` → Pulse is off. Verify no Pulse connection is attempted (no Pulse log activity) and that nearby players, movement and emotes still work over LiveKit.
2. Launch with `--pulse true` (Pulse server reachable) → verify Pulse connects and carries player movement.
3. Launch with **no** `--pulse` arg → Pulse is driven solely by the `pulse` remote feature flag.

**B — Fallback when Pulse is unreachable (the core change)**
1. Reroute the Pulse server hostname to a black-hole IP so the connection times out:
   - **Windows** — edit `C:\Windows\System32\drivers\etc\hosts` as Administrator and add:
     ```
     4.78.139.54   pulse-server.decentraland.org
     ```
   - **macOS** — `sudo nano /etc/hosts`, add the same line:
     ```
     4.78.139.54   pulse-server.decentraland.org
     ```
     then flush DNS:
     ```bash
     sudo dscacheutil -flushcache; sudo killall -HUP mDNSResponder
     ```
2. Launch with `--pulse true` (force Pulse on so it actually attempts to connect).
3. **Expected:** the client tries the Pulse connection 5 times (each bounded by the ~10 s transport timeout, ~50–65 s total), logs `Pulse unreachable at start-up; falling back to LiveKit-only`, then **login completes normally** over LiveKit — no hang, no aborted login. Movement, emotes and profiles sync with the other player over LiveKit (i.e. the session behaves as if Pulse were never present).
4. **Cleanup:** remove the hosts entry (and re-flush DNS on macOS).

### Additional Testing Notes
- Watch the sequence with `--filter "Pulse"` (or `MULTIPLAYER` category) in the logs.
- **Runtime = no fallback** (regression guard): with a reachable server, connect successfully, then mid-session add the hosts reroute and force a disconnect. The client should keep retrying Pulse per `ReconnectionSettings` and must **not** flip LiveKit into broadcast-to-all mode.
- Known trade-off (by design, agreed): when Pulse is down, login is delayed ~50–65 s by the 5 bounded attempts (existing 10 s per-attempt transport timeout) before falling back.

## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included
