### PR TITLE
feat: prioritize share-screen source and fix camera-off frozen frame

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/MediaPlayerPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/MediaPlayerPlugin.cs
@@ -36,7 +36,10 @@ namespace DCL.PluginSystem.World
             this.mediaFactory = mediaFactory;
         }
 
-        public void Dispose() { }
+        public void Dispose()
+        {
+            mediaPlayerPluginWrapper?.Dispose();
+        }
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in ECSWorldInstanceSharedDependencies sharedDependencies, in SystemsDependencies systemsDependencies, in PersistentEntities _, List<IFinalizeWorldSystem> finalizeWorldSystems, List<ISceneIsCurrentListener> sceneIsCurrentListeners) =>
             mediaPlayerPluginWrapper.InjectToWorld(ref builder, sharedDependencies, systemsDependencies.RoomHub, finalizeWorldSystems, sceneIsCurrentListeners);
@@ -49,7 +52,8 @@ namespace DCL.PluginSystem.World
                 settings.FadeSpeed,
                 settings.VideoPrioritizationSettings,
                 mediaFactory,
-                settings.FlipMaterial
+                settings.FlipMaterial,
+                settings.CameraOffPlaceholder
             );
 
             return UniTask.CompletedTask;
@@ -61,6 +65,9 @@ namespace DCL.PluginSystem.World
             [field: SerializeField] public float FadeSpeed { get; private set; } = 1f;
 
             [field: SerializeField] public Material FlipMaterial { get; private set; }
+
+            [field: SerializeField] [field: Tooltip("Shown on LiveKit screens when the streamer turns their camera off. Falls back to black if unset.")]
+            public Texture2D CameraOffPlaceholder { get; private set; }
 
             public VideoPrioritizationSettings VideoPrioritizationSettings;
         }

--- a/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
+++ b/Explorer/Assets/DCL/PluginSystem/World/World Plugins Container.asset
@@ -36,27 +36,6 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 7493825610294857301
-      type: {class: UIShellContainer/Settings, ns: Global.Dynamic, asm: DCL.Plugins}
-      data:
-        <CursorSettings>k__BackingField:
-          m_AssetGUID: 7382805fd18299d41925547efbad99f0
-          m_SubObjectName: 
-          m_SubObjectType: 
-          m_SubObjectGUID: 
-          m_EditorAssetChanged: 0
-        <PopupCloserView>k__BackingField:
-          m_AssetGUID: dbfb7e67a438449f9a887f820f733868
-          m_SubObjectName: 
-          m_SubObjectType: 
-          m_SubObjectGUID: 
-          m_EditorAssetChanged: 0
-        <MainUIView>k__BackingField:
-          m_AssetGUID: c7887090193b1ec4c994ad22169b86db
-          m_SubObjectName: 
-          m_SubObjectType: 
-          m_SubObjectGUID: 
-          m_EditorAssetChanged: 0
     - rid: 250124815058075745
       type: {class: PulseContainer/Settings, ns: DCL.Multiplayer.Movement, asm: DCL.Plugins}
       data:
@@ -253,6 +232,7 @@ MonoBehaviour:
       data:
         <FadeSpeed>k__BackingField: 1
         <FlipMaterial>k__BackingField: {fileID: 2100000, guid: d08e60223593f4abe8863c64316f3476, type: 2}
+        <CameraOffPlaceholder>k__BackingField: {fileID: 2800000, guid: e44cab49d5bd4474a04a45081ef16aeb, type: 3}
         VideoPrioritizationSettings: {fileID: 11400000, guid: 12f48d0297bd3f746b92a97878478086, type: 2}
     - rid: 4938242198007709791
       type: {class: ParticleSystemPlugin/ParticleSystemPluginSettings, ns: DCL.SDKComponents.ParticleSystem.Systems, asm: DCL.Plugins}
@@ -277,6 +257,27 @@ MonoBehaviour:
         <LoadingAttemptsCount>k__BackingField: 6
         <PoolInitialCapacity>k__BackingField: 256
         <PoolMaxSize>k__BackingField: 2048
+    - rid: 7493825610294857301
+      type: {class: UIShellContainer/Settings, ns: Global.Dynamic, asm: DCL.Plugins}
+      data:
+        <CursorSettings>k__BackingField:
+          m_AssetGUID: 7382805fd18299d41925547efbad99f0
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_SubObjectGUID: 
+          m_EditorAssetChanged: 0
+        <PopupCloserView>k__BackingField:
+          m_AssetGUID: dbfb7e67a438449f9a887f820f733868
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_SubObjectGUID: 
+          m_EditorAssetChanged: 0
+        <MainUIView>k__BackingField:
+          m_AssetGUID: c7887090193b1ec4c994ad22169b86db
+          m_SubObjectName: 
+          m_SubObjectType: 
+          m_SubObjectGUID: 
+          m_EditorAssetChanged: 0
     - rid: 7615904969758605314
       type: {class: NFTShapePluginSettings, ns: DCL.PluginSystem.Global, asm: DCL.Plugins}
       data:

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/LivekitPlayer.cs
@@ -67,6 +67,37 @@ namespace DCL.SDKComponents.MediaStream
 
         public bool IsVideoOpened => cvs.HasValue && cvs.Value.videoStream.Resource.Has;
 
+        // True when the currently-shown video track is muted (e.g. the streamer turned their camera off).
+        // The track stays subscribed while muted, so DecodeLastFrame would otherwise return a frozen frame.
+        public bool IsCurrentVideoMuted
+        {
+            get
+            {
+                if (!cvs.HasValue) return false;
+
+                StreamKey key = cvs.Value.key;
+                var participant = room.Participants.RemoteParticipant(key.identity);
+                return participant != null
+                       && participant.Tracks.TryGetValue(key.sid, out TrackPublication track)
+                       && track.Muted;
+            }
+        }
+
+        // Display name of the participant whose video is currently shown, or null when unknown
+        // (no current stream, or the participant has no display name — the wallet identity is not shown).
+        public string? CurrentStreamerName
+        {
+            get
+            {
+                if (!cvs.HasValue) return null;
+
+                var participant = room.Participants.RemoteParticipant(cvs.Value.key.identity);
+                if (participant == null) return null;
+
+                return string.IsNullOrEmpty(participant.Name) ? null : participant.Name;
+            }
+        }
+
         private bool isAudioOpened => audioSources.Count > 0;
 
         public LivekitPlayer(IRoom streamingRoom)
@@ -150,13 +181,13 @@ namespace DCL.SDKComponents.MediaStream
             StreamKey? streamKey = livekitAddress.Match(
                 this,
                 onUserStream: static (self, userStream) => new StreamKey(userStream.Identity, userStream.Sid),
-                onCurrentStream: static self => self.FirstAvailableTrackSid(TrackKind.KindVideo)
+                onCurrentStream: static self => self.BestInitialVideoKey()
             );
 
             if (streamKey.HasValue)
             {
                 Weak<IVideoStream> stream = room.VideoStreams.ActiveStream(streamKey.Value);
-                cvs = CurrentVideoStreamInfo.New(streamKey.Value.identity, stream);
+                cvs = CurrentVideoStreamInfo.New(streamKey.Value, stream);
             }
             else
             {
@@ -209,11 +240,12 @@ namespace DCL.SDKComponents.MediaStream
 
             StreamKey? targetKey = BestFollowCandidate();
 
-            // switch if found
-            if (targetKey != null)
+            // Switch only if the best source actually changed; re-allocating cvs every frame would
+            // reset the speaker-hold timer and re-wrap a healthy stream (e.g. while a screen share holds it).
+            if (targetKey != null && cvs?.key.Equals(targetKey.Value) != true)
             {
                 var currentVideoStream = room.VideoStreams.ActiveStream(targetKey.Value);
-                cvs = CurrentVideoStreamInfo.New(targetKey.Value.identity, currentVideoStream);
+                cvs = CurrentVideoStreamInfo.New(targetKey.Value, currentVideoStream);
             }
         }
 
@@ -222,7 +254,10 @@ namespace DCL.SDKComponents.MediaStream
         {
             StreamKey? targetKey = PresentationBotVideoKey();
 
-            // try pick up another key if PresentationBot is unavailable
+            // Screen share ranks below the presentation bot but above speaker cameras.
+            targetKey ??= FirstScreenShareVideoKey();
+
+            // try pick up another key if presentation bot and screen share are unavailable
             if (targetKey == null)
             {
                 float lastSwitch = cvs?.switchedAtTime ?? 0;
@@ -246,6 +281,10 @@ namespace DCL.SDKComponents.MediaStream
             return targetKey;
         }
 
+        // Pure. Initial selection priority: presentation bot, then screen share, then first available track.
+        private StreamKey? BestInitialVideoKey() =>
+            PresentationBotVideoKey() ?? FirstScreenShareVideoKey() ?? FirstAvailableTrackSid(TrackKind.KindVideo);
+
         private StreamKey? FindVideoTrackForParticipant(string identity)
         {
             // See: solved https://github.com/decentraland/unity-explorer/issues/3796
@@ -258,6 +297,25 @@ namespace DCL.SDKComponents.MediaStream
             {
                 if (track.Kind == TrackKind.KindVideo)
                     return new StreamKey(identity, sid);
+            }
+
+            return null;
+        }
+
+        private StreamKey? FirstScreenShareVideoKey()
+        {
+            foreach ((string identity, _) in room.Participants.RemoteParticipantIdentities())
+            {
+                var participant = room.Participants.RemoteParticipant(identity);
+
+                if (participant == null)
+                    continue;
+
+                foreach ((string sid, TrackPublication track) in participant.Tracks)
+                {
+                    if (track.Kind == TrackKind.KindVideo && track.Source == TrackSource.SourceScreenshare)
+                        return new StreamKey(identity, sid);
+                }
             }
 
             return null;
@@ -474,35 +532,36 @@ namespace DCL.SDKComponents.MediaStream
 
         private readonly struct CurrentVideoStreamInfo
         {
-            public readonly string fromIdentity;
+            public readonly StreamKey key;
             public readonly Weak<IVideoStream> videoStream;
             public readonly float switchedAtTime;
 
+            public string fromIdentity => key.identity;
+
             private CurrentVideoStreamInfo(
-                    string fromIdentity,
+                    StreamKey key,
                     Weak<IVideoStream> videoStream,
                     float switchedAtTime)
             {
-                this.fromIdentity = fromIdentity;
+                this.key = key;
                 this.videoStream = videoStream;
                 this.switchedAtTime = switchedAtTime;
             }
 
             public static CurrentVideoStreamInfo New(
-                    string fromIdentity,
+                    StreamKey key,
                     Weak<IVideoStream> videoStream)
             {
                 return new (
-                        fromIdentity,
+                        key,
                         videoStream,
                         UnityEngine.Time.realtimeSinceStartup
                         );
             }
 
-            // add "IsFromPresentationBot"?
             public bool IsFromPresentationBot()
             {
-                return fromIdentity.IsPresentationBotIdentity();
+                return key.identity.IsPresentationBotIdentity();
             }
         }
     }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Settings/CameraOffPlaceholder.png
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Settings/CameraOffPlaceholder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19d4f97ea65f8ad1a36cb7bbe4dd8d103017a00200178282775776f6b918d2ab
+size 28820

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Settings/CameraOffPlaceholder.png.meta
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Settings/CameraOffPlaceholder.png.meta
@@ -1,0 +1,104 @@
+fileFormatVersion: 2
+guid: e44cab49d5bd4474a04a45081ef16aeb
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    customData:
+    physicsShape: []
+    bones: []
+    spriteID:
+    internalID: 0
+    vertices: []
+    indices:
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName:
+  pSDRemoveMatte: 0
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CameraOffScreenComposer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CameraOffScreenComposer.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
+
+namespace DCL.SDKComponents.MediaStream
+{
+    /// <summary>
+    ///     Composites the static "camera off" background with the streamer's display name into a texture,
+    ///     used by <see cref="UpdateMediaPlayerSystem" /> when a LiveKit video track is muted so the screen
+    ///     shows "&lt;avatar&gt; &lt;name&gt;" (like a video call) instead of the frozen last frame.
+    ///     The offscreen rig (camera + canvas) is built lazily on first use and shared across scenes;
+    ///     composites are cached per name so each one is rendered only once.
+    ///     NOTE: the visual result (text size, vertical position, color space) must be verified in the
+    ///     Unity editor — it cannot be validated headlessly.
+    /// </summary>
+    public sealed class CameraOffScreenComposer : IDisposable
+    {
+        // The background PNG is authored at 1024x1024 (power-of-two); the rig matches it.
+        private const int WIDTH = 1024;
+        private const int HEIGHT = 1024;
+        private const int UI_LAYER = 5; // Unity built-in "UI" layer.
+        private const int MAX_CACHED = 16;
+
+        // Placed far from any scene geometry so the offscreen camera only ever renders its own canvas.
+        private static readonly Vector3 RIG_POSITION = new (0f, 100000f, 0f);
+        private static readonly Color BACKGROUND_COLOR = new (0x20 / 255f, 0x21 / 255f, 0x24 / 255f, 1f);
+        private static readonly Color32 LABEL_COLOR = new (0x9a, 0xa0, 0xa6, 0xff);
+
+        private readonly Texture? background;
+        private readonly Dictionary<string, RenderTexture> cache = new ();
+
+        private GameObject? rig;
+        private Camera? camera;
+        private TextMeshProUGUI? label;
+        private bool rigCreationFailed;
+
+        public CameraOffScreenComposer(Texture? background)
+        {
+            this.background = background;
+        }
+
+        public void Dispose()
+        {
+            ClearCache();
+
+            if (rig != null)
+                Object.Destroy(rig);
+
+            rig = null;
+            camera = null;
+            label = null;
+        }
+
+        /// <summary>
+        ///     Returns a texture showing the camera-off background plus the streamer name. Falls back to the
+        ///     plain background when the name is empty or text rendering is unavailable, and to null when no
+        ///     background was configured (the caller then renders black).
+        /// </summary>
+        public Texture? Compose(string? streamerName)
+        {
+            // No background configured — caller renders black.
+            if (background == null)
+                return null;
+
+            if (string.IsNullOrEmpty(streamerName))
+                return background;
+
+            if (cache.TryGetValue(streamerName, out RenderTexture cached) && cached != null)
+                return cached;
+
+            EnsureRig();
+
+            if (camera == null || label == null)
+                return background;
+
+            if (cache.Count >= MAX_CACHED)
+                ClearCache();
+
+            var composite = new RenderTexture(WIDTH, HEIGHT, 0, RenderTextureFormat.BGRA32) { name = "CameraOffComposite" };
+            composite.Create();
+
+            // Target texture first so the screen-space canvas sizes to it, then build and render.
+            camera.targetTexture = composite;
+            label.text = streamerName;
+            Canvas.ForceUpdateCanvases();
+            camera.Render();
+            camera.targetTexture = null;
+
+            cache[streamerName] = composite;
+            return composite;
+        }
+
+        private void EnsureRig()
+        {
+            if (rig != null || rigCreationFailed) return;
+
+            TMP_FontAsset font = TMP_Settings.defaultFontAsset;
+
+            if (font == null)
+            {
+                // No default TMP font configured — fall back to the plain background.
+                rigCreationFailed = true;
+                return;
+            }
+
+            rig = new GameObject("CameraOffComposerRig") { hideFlags = HideFlags.HideAndDontSave };
+            Object.DontDestroyOnLoad(rig);
+            // Far from any scene geometry so the offscreen camera only renders its own canvas.
+            rig.transform.position = RIG_POSITION;
+
+            var cameraObject = new GameObject("Camera") { layer = UI_LAYER };
+            cameraObject.transform.SetParent(rig.transform, false);
+
+            camera = cameraObject.AddComponent<Camera>();
+            camera.orthographic = true;
+            camera.cullingMask = 1 << UI_LAYER;
+            camera.clearFlags = CameraClearFlags.SolidColor;
+            camera.backgroundColor = BACKGROUND_COLOR;
+            camera.nearClipPlane = 0.1f;
+            camera.farClipPlane = 100f;
+            camera.enabled = false; // rendered manually via camera.Render().
+
+            // Screen-space-camera canvas always faces the camera and fills its target texture, so the
+            // layout maps 1:1 to the baked WIDTH x HEIGHT regardless of camera placement/orientation.
+            var canvasObject = new GameObject("Canvas", typeof(RectTransform), typeof(Canvas)) { layer = UI_LAYER };
+            canvasObject.transform.SetParent(rig.transform, false);
+
+            var canvas = canvasObject.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceCamera;
+            canvas.worldCamera = camera;
+            canvas.planeDistance = 1f;
+
+            var backgroundObject = new GameObject("Background", typeof(RawImage)) { layer = UI_LAYER };
+            backgroundObject.transform.SetParent(canvasObject.transform, false);
+            var backgroundImage = backgroundObject.GetComponent<RawImage>();
+            backgroundImage.texture = background;
+            Stretch(backgroundImage.rectTransform, Vector2.zero, Vector2.one);
+
+            var labelObject = new GameObject("Label", typeof(TextMeshProUGUI)) { layer = UI_LAYER };
+            labelObject.transform.SetParent(canvasObject.transform, false);
+            label = labelObject.GetComponent<TextMeshProUGUI>();
+            label.font = font;
+            label.color = LABEL_COLOR;
+            label.fontSize = 64;
+            label.alignment = TextAlignmentOptions.Center;
+            label.overflowMode = TextOverflowModes.Ellipsis;
+            // Below the avatar circle (which sits in the upper-middle of the background).
+            Stretch(label.rectTransform, new Vector2(0.06f, 0.18f), new Vector2(0.94f, 0.34f));
+        }
+
+        private static void Stretch(RectTransform rectTransform, Vector2 anchorMin, Vector2 anchorMax)
+        {
+            rectTransform.anchorMin = anchorMin;
+            rectTransform.anchorMax = anchorMax;
+            rectTransform.offsetMin = Vector2.zero;
+            rectTransform.offsetMax = Vector2.zero;
+        }
+
+        private void ClearCache()
+        {
+            foreach (RenderTexture renderTexture in cache.Values)
+            {
+                if (renderTexture == null) continue;
+                renderTexture.Release();
+                Object.Destroy(renderTexture);
+            }
+
+            cache.Clear();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CameraOffScreenComposer.cs.meta
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/CameraOffScreenComposer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6baa0bda315b40d3954924282c6e7b43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/MediaPlayerPluginWrapper.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/MediaPlayerPluginWrapper.cs
@@ -8,12 +8,13 @@ using DCL.PluginSystem.World.Dependencies;
 using DCL.SDKComponents.MediaStream.Settings;
 using DCL.WebRequests;
 using ECS.LifeCycle;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace DCL.SDKComponents.MediaStream
 {
-    public class MediaPlayerPluginWrapper
+    public class MediaPlayerPluginWrapper : IDisposable
     {
         private readonly IPerformanceBudget frameTimeBudget;
         private readonly IExposedCameraData exposedCameraData;
@@ -21,6 +22,7 @@ namespace DCL.SDKComponents.MediaStream
         private readonly VideoPrioritizationSettings videoPrioritizationSettings;
         private readonly MediaFactoryBuilder mediaFactory;
         private readonly Material flipMaterial;
+        private readonly CameraOffScreenComposer cameraOffComposer;
 
         public MediaPlayerPluginWrapper(
             IPerformanceBudget frameTimeBudget,
@@ -28,13 +30,15 @@ namespace DCL.SDKComponents.MediaStream
             float audioFadeSpeed,
             VideoPrioritizationSettings videoPrioritizationSettings,
             MediaFactoryBuilder mediaFactory,
-            Material flipMaterial)
+            Material flipMaterial,
+            Texture2D cameraOffPlaceholder)
         {
             this.exposedCameraData = exposedCameraData;
             this.audioFadeSpeed = audioFadeSpeed;
             this.videoPrioritizationSettings = videoPrioritizationSettings;
             this.mediaFactory = mediaFactory;
             this.flipMaterial = flipMaterial;
+            this.cameraOffComposer = new CameraOffScreenComposer(cameraOffPlaceholder);
 
 #if AV_PRO_PRESENT && !UNITY_EDITOR_LINUX && !UNITY_STANDALONE_LINUX
             this.frameTimeBudget = frameTimeBudget;
@@ -48,7 +52,7 @@ namespace DCL.SDKComponents.MediaStream
             MediaFactory mediaFactory = this.mediaFactory.CreateForScene(builder.World, sceneDeps, roomHub);
 
             CreateMediaPlayerSystem.InjectToWorld(ref builder, sceneDeps.SceneStateProvider, mediaFactory);
-            sceneIsCurrentListeners.Add(UpdateMediaPlayerSystem.InjectToWorld(ref builder, sceneDeps.SceneData, sceneDeps.SceneStateProvider, frameTimeBudget, mediaFactory, audioFadeSpeed, flipMaterial, videoPrioritizationSettings));
+            sceneIsCurrentListeners.Add(UpdateMediaPlayerSystem.InjectToWorld(ref builder, sceneDeps.SceneData, sceneDeps.SceneStateProvider, frameTimeBudget, mediaFactory, audioFadeSpeed, flipMaterial, cameraOffComposer, videoPrioritizationSettings));
 
             if (FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.VIDEO_PRIORITIZATION))
                 UpdateMediaPlayerPrioritizationSystem.InjectToWorld(ref builder, exposedCameraData, videoPrioritizationSettings);
@@ -57,6 +61,11 @@ namespace DCL.SDKComponents.MediaStream
 
             finalizeWorldSystems.Add(CleanUpMediaPlayerSystem.InjectToWorld(ref builder));
 #endif
+        }
+
+        public void Dispose()
+        {
+            cameraOffComposer.Dispose();
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -32,6 +32,7 @@ namespace DCL.SDKComponents.MediaStream
 
         private readonly float audioFadeSpeed;
         private readonly Material flipMaterial;
+        private readonly CameraOffScreenComposer cameraOffComposer;
         private readonly VideoPrioritizationSettings videoPrioritizationSettings;
 
         private static float lastOpenMediaTime;
@@ -51,6 +52,7 @@ namespace DCL.SDKComponents.MediaStream
             MediaFactory mediaFactory,
             float audioFadeSpeed,
             Material flipMaterial,
+            CameraOffScreenComposer cameraOffComposer,
             VideoPrioritizationSettings videoPrioritizationSettings
         ) : base(world)
         {
@@ -60,6 +62,7 @@ namespace DCL.SDKComponents.MediaStream
             this.mediaFactory = mediaFactory;
             this.audioFadeSpeed = audioFadeSpeed;
             this.flipMaterial = flipMaterial;
+            this.cameraOffComposer = cameraOffComposer;
             this.videoPrioritizationSettings = videoPrioritizationSettings;
         }
 
@@ -231,6 +234,27 @@ namespace DCL.SDKComponents.MediaStream
                 if (!livekitPlayer.IsVideoOpened)
                 {
                     RenderBlackTexture(ref assignedTexture);
+                    return;
+                }
+
+                // The track stays subscribed while muted, so LastTexture would return a frozen frame.
+                // Show the camera-off placeholder (avatar + streamer name) instead, like a video call.
+                if (livekitPlayer.IsCurrentVideoMuted)
+                {
+                    Texture? placeholder = cameraOffComposer.Compose(livekitPlayer.CurrentStreamerName);
+
+                    if (placeholder != null)
+                    {
+                        // Size the target to the placeholder so a stream that starts muted isn't blitted
+                        // onto the pool's initial 1x1 texture (which would show a single sampled color).
+                        if (assignedTexture.Texture.width != placeholder.width || assignedTexture.Texture.height != placeholder.height)
+                            assignedTexture.Resize(placeholder.width, placeholder.height);
+
+                        Graphics.Blit(placeholder, assignedTexture.Texture);
+                    }
+                    else
+                        RenderBlackTexture(ref assignedTexture);
+
                     return;
                 }
             }

--- a/docs/cast.md
+++ b/docs/cast.md
@@ -27,7 +27,7 @@ The `MultiMediaPlayer` REnum wraps both behind a unified interface so the ECS sy
 livekit-video://current-stream
 ```
 
-Picks the first available video track in the room — and then **follows the active speaker** (see [Active Speaker Tracking](#active-speaker-tracking-video-follows-voice) below). If a presentation bot is present, it takes priority over all other participants. This is the default mode for streaming theatre screens.
+Picks the highest-priority available video track in the room — and then **follows the active speaker** (see [Active Speaker Tracking](#active-speaker-tracking-video-follows-voice) below). The priority order is **presentation bot → screen share → active-speaker camera**. This is the default mode for streaming theatre screens.
 
 ### UserStream
 
@@ -49,43 +49,48 @@ Defined in `LivekitAddress.cs`. Helper extensions in `LiveKitMediaExtensions.cs`
 
 When `OpenMedia()` is called:
 
-- **CurrentStream** → `FirstAvailableTrackSid()` iterates all remote participants (under lock). If a **presentation bot** is found (identity starts with `presentation-bot:`), its video track is returned first. Otherwise the first available video track is used. The participant's identity is stored in `currentVideoIdentity`.
+- **CurrentStream** → `BestInitialVideoKey()` selects in priority order: a **presentation bot** track (identity starts with `presentation-bot:`), then a **screen share** track (`TrackSource.SourceScreenshare`), then the first available video track (`FirstAvailableTrackSid()`). The selected `(identity, sid)` is stored as the current stream key.
 - **UserStream** → Directly opens the stream for the specified `(identity, sid)`.
 
 ### Active Speaker Tracking (video-follows-voice)
 
-In `CurrentStream` mode, the video automatically switches to whoever is speaking. This is driven by `TryFollowActiveSpeaker()`, which runs every frame inside `EnsureVideoIsPlaying()`.
+In `CurrentStream` mode, the video automatically switches to whoever is speaking. This is driven by `TryFollowVideoStreamToActiveSpeaker()`, which runs every frame inside `EnsureVideoIsPlaying()` and picks the best source via `BestFollowCandidate()`.
 
 **How it works:**
 
 1. `room.ActiveSpeakers` (provided by the LiveKit SDK) is an ordered collection of participant identities currently speaking — first element = highest audio level.
-2. Each frame, `TryFollowActiveSpeaker()` first checks for a **presentation bot** (`TrySwitchToPresentationBot()`). If one is found, the video locks to the bot and never auto-switches away.
-3. If no presentation bot is present, the dominant speaker is read. If it differs from the current video identity **and** enough time has passed since the last switch, the video stream is swapped.
+2. Each frame, `BestFollowCandidate()` resolves the best source in priority order: **presentation bot** (`PresentationBotVideoKey()`), then **screen share** (`FirstScreenShareVideoKey()`), then the **dominant active speaker** with a video track (`FindVideoTrackForParticipant()`).
+3. The video switches only when the chosen `(identity, sid)` differs from the current one. While a presentation bot or screen share is available, it holds the stream and the active-speaker tier is skipped. Active-speaker switches are also debounced (see below).
 
-**Debounce:** A minimum hold time of **1.5 seconds** (`MIN_SPEAKER_HOLD_SECONDS`) prevents flickering during rapid speaker changes.
+**Debounce:** A minimum hold time of **1.5 seconds** (`MIN_SPEAKER_HOLD_SECONDS`) prevents flickering during rapid speaker changes. It applies only to the active-speaker tier.
 
-**Presentation bot:** Any participant whose identity starts with `presentation-bot:` (`PRESENTATION_BOT_PREFIX`) is treated as the authoritative video source. Once the player locks onto a presentation bot, it stays there regardless of active speakers.
+**Presentation bot:** Any participant whose identity starts with `presentation-bot:` (`PRESENTATION_BOT_IDENTITY_PREFIX`) is treated as the authoritative video source. While a presentation bot is present, it holds the stream regardless of active speakers.
+
+**Screen share:** Any video track published with `TrackSource.SourceScreenshare` ranks above active-speaker cameras and below the presentation bot. While a screen share is available, it holds the stream; the player falls back to active-speaker tracking only once it ends.
 
 **Fallback rules:**
 
 | Scenario | Behavior |
 |----------|----------|
-| Presentation bot present | Always switch to bot, stay locked |
+| Presentation bot present | Hold on bot (highest priority) |
+| Screen share present (no bot) | Hold on screen share |
 | Active speaker has no video track | Keep current video |
 | No one is speaking | Keep current video |
 | Rapid speaker changes (<1.5s) | Debounced — stays on current |
 | UserStream mode | No auto-switching (early return) |
 
-**Video muted state:** Each frame, `CheckVideoTrackMuted()` reads the current video track's `TrackPublication.Muted` flag. The `IsVideoTrackMuted` property is exposed so the system can render a black texture when the track is muted.
+**Camera-off (muted) state:** `IsCurrentVideoMuted` reads the current video track's `TrackPublication.Muted` flag. Muting a camera does not unpublish the track, so the last decoded frame would otherwise stay frozen on screen. When the current track is muted, `UpdateMediaPlayerSystem` shows a **camera-off placeholder** (an avatar silhouette plus the streamer's name, like a video call) instead of the frozen frame. `CameraOffScreenComposer` composites the static `CameraOffPlaceholder` texture (configured on `MediaPlayerPluginSettings`) with the streamer name (`LivekitPlayer.CurrentStreamerName`) into a per-name cached texture via an offscreen camera; it falls back to the plain placeholder when no name is known, and to black when no placeholder texture is set. Audio is unaffected, so muted participants are still heard.
 
 **Key methods in `LivekitPlayer.cs`:**
 
-- `FirstAvailableTrackSid()` — Selects first video track, prioritizing presentation bot
-- `TryFollowActiveSpeaker()` — Core speaker-tracking logic with debounce
-- `TrySwitchToPresentationBot()` — Searches for and locks onto presentation bot
+- `BestInitialVideoKey()` — Initial selection: presentation bot → screen share → first available
+- `BestFollowCandidate()` — Per-frame source selection in the same priority order
+- `TryFollowVideoStreamToActiveSpeaker()` — Applies `BestFollowCandidate()`, switching only when the source changed
+- `FirstScreenShareVideoKey()` — Finds the first screen-share video track in the room
+- `PresentationBotVideoKey()` / `PresentationBotIdentity()` — Find the presentation bot's video track / identity
 - `FindVideoTrackForParticipant(identity)` — Looks up a participant's video track by identity
-- `FindPresentationBotVideoTrack()` — Finds the presentation bot's video track
-- `CheckVideoTrackMuted()` — Reads muted state from track publication
+- `FirstAvailableTrackSid(kind)` — Returns the first available track of a kind (final fallback)
+- `IsCurrentVideoMuted` — Reads the current track's muted state from its publication
 
 ---
 
@@ -140,7 +145,7 @@ No dead sources + within interval → No action
 
 LiveKit video textures are capped at **1920x1080** (`MAX_LIVEKIT_VIDEO_WIDTH` / `MAX_LIVEKIT_VIDEO_HEIGHT` in `UpdateMediaPlayerSystem`). If a video frame exceeds these dimensions, it's scaled down via `Graphics.Blit()` before being copied to the render target. This prevents GPU stalls from unexpectedly large incoming video.
 
-When the video track is muted or no texture is available, the system renders a black texture instead.
+When no texture is available (no stream is open), the system renders a black texture. When the current LiveKit track is muted (camera off), it renders the camera-off placeholder (avatar silhouette plus the streamer name) instead.
 
 ---
 
@@ -151,7 +156,7 @@ When the video track is muted or no texture is available, the system renders a b
 | System | Group | Responsibility |
 |--------|-------|---------------|
 | `CreateMediaPlayerSystem` | ComponentInstantiation | Detects new `PBVideoPlayer`/`PBAudioStream` components, creates `MediaPlayerComponent` with appropriate backend |
-| `UpdateMediaPlayerSystem` | SyncedPresentation | Drives playback each frame — calls `EnsureVideoIsPlaying()`, `EnsureAudioIsPlaying()`, handles volume crossfading, texture updates |
+| `UpdateMediaPlayerSystem` | SyncedPresentation | Drives playback each frame — calls `EnsureVideoIsPlaying()`, `EnsureAudioIsPlaying()`, handles volume crossfading, texture updates, and renders the camera-off placeholder when the current track is muted |
 | `CleanUpMediaPlayerSystem` | CleanUp | Disposes players when entities/components are removed |
 
 ### Factory
@@ -227,9 +232,11 @@ Metadata is a JSON string parsed at query time.
 | `SDKComponents/MediaStream/MultiMediaPlayer.cs` | Unified wrapper over AvPro and Livekit backends |
 | `SDKComponents/MediaStream/MediaPlayerComponent.cs` | ECS component holding the player |
 | `SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs` | Per-frame system driving playback |
+| `SDKComponents/MediaStream/Systems/CameraOffScreenComposer.cs` | Composites the avatar placeholder + streamer name shown when a track is muted |
 | `SDKComponents/MediaStream/Systems/CreateMediaPlayerSystem.cs` | System creating players from SDK components |
 | `SDKComponents/MediaStream/Systems/CleanUpMediaPlayerSystem.cs` | Disposal system |
 | `SDKComponents/MediaStream/MediaFactory.cs` | Factory choosing backend by URL |
+| `PluginSystem/World/MediaPlayerPlugin.cs` | Plugin settings — `FlipMaterial`, `CameraOffPlaceholder` |
 | `SDKComponents/MediaStream/LiveKitMediaExtensions.cs` | URL parsing helpers |
 | `Infrastructure/.../CommsApi/CommsApiWrap.cs` | `getActiveVideoStreams` API |
 | `Infrastructure/.../CommsApi/GetActiveVideoStreamsResponse.cs` | Response builder with display name resolution |


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Two changes to the Cast / LiveKit in-world streaming feature:

**1. Screen-share prioritization.** In `current-stream` auto-follow mode the priority was only `presentation bot → active-speaker cameras`, so a participant sharing their screen was treated like any camera. This adds a **screen-share tier in the middle**: `presentation bot → screen share → active-speaker cameras`. While a screen share is available it holds the stream (yielding only to a presentation bot) and falls back to active-speaker tracking once it ends. Implemented in `LivekitPlayer` by detecting `TrackSource.SourceScreenshare` (`FirstScreenShareVideoKey`) and inserting it into `BestFollowCandidate`/`BestInitialVideoKey`, mirroring the existing presentation-bot helpers.

**2. Camera-off no longer freezes the last frame.** Muting a camera in LiveKit keeps the track *subscribed* (the SDK only sets `TrackPublication.Muted`), so the in-world screen kept displaying the last decoded frame. The current track's muted state is now detected (`LivekitPlayer.IsCurrentVideoMuted`), and instead of the frozen frame the screen shows a **camera-off placeholder** — a static avatar silhouette composited with the streamer's name (`CameraOffScreenComposer`, an offscreen TMP→RenderTexture bake cached per name). It degrades gracefully: no name → plain silhouette; no placeholder texture assigned → black. Audio is unaffected, so muted participants are still heard.

Docs: `docs/cast.md` updated to match (corrected stale method names, documented the new tier and the placeholder behavior).

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
With a scene showing a `livekit-video://current-stream` screen and a LiveKit room:
- A participant starts screen sharing → the screen switches to the screen share and stays on it even while another (non-bot) participant speaks.
- The screen share stops → the screen falls back to active-speaker camera tracking.
- A presentation bot joins while screen sharing → the bot takes over (highest priority).
- The shown participant turns their camera **off** → the screen shows the avatar + their name (not a frozen frame); audio keeps playing. Turning the camera back on resumes video.

### Prerequisites
- [ ] A LiveKit room with at least two participants (camera + screen share capable).

### Test Steps
1. Open a scene with a streaming screen pointed at `livekit-video://current-stream`.
2. Have one participant share their screen → verify the screen prioritizes it over speaking cameras.
3. Stop the screen share → verify it returns to active-speaker tracking.
4. Turn the shown participant's camera off → verify the avatar + name placeholder appears instead of a frozen frame, and audio continues.

### Additional Testing Notes
- Camera-off placeholder distorts slightly on non-square screens (square 1024×1024 source stretched onto a widescreen quad) — expected.
- The `CameraOffPlaceholder` texture is wired in `World Plugins Container.asset`; if unset, the camera-off state falls back to black.

## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.