### PR TITLE
chore: await or forget abandoned async calls

### DIFF
--- a/Explorer/Assets/DCL/Chat/Commands/SceneAdminsChatCommand.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/SceneAdminsChatCommand.cs
@@ -18,13 +18,13 @@ namespace DCL.Chat.Commands
 
         public string Description => $"<b>/{Command}</b>\n  Shows the list of admins of the scene";
 
-        public async UniTask<string> ExecuteCommandAsync(string[] parameters, CancellationToken ct)
+        public UniTask<string> ExecuteCommandAsync(string[] parameters, CancellationToken ct)
         {
             Result<IEnumerable<string>> result = RoomMetadataCurrentScene.Instance.CurrentAdmins();
 
             if (result.Success == false)
             {
-                return result.ErrorMessage;
+                return UniTask.FromResult(result.ErrorMessage);
             }
 
             StringBuilder sb = new StringBuilder();
@@ -37,7 +37,7 @@ namespace DCL.Chat.Commands
                 sb.AppendLine();
             }
 
-            return sb.ToString();
+            return UniTask.FromResult(sb.ToString());
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/Tests/GlobalWorldActionsShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/Tests/GlobalWorldActionsShould.cs
@@ -216,7 +216,7 @@ namespace CrdtEcsBridge.RestrictedActions.Tests
             int promiseEntitiesCount = world.CountEntities(in promiseOutcomeQuery);
             Assert.AreEqual(0, promiseEntitiesCount, $"Expected to find 0 promise entity but found {promiseEntitiesCount}.");
 
-            globalWorldActions.TriggerSceneEmoteAsync(mockSceneData, src, hash, loop, AvatarEmoteMask.AemFullBody, CancellationToken.None);
+            globalWorldActions.TriggerSceneEmoteAsync(mockSceneData, src, hash, loop, AvatarEmoteMask.AemFullBody, CancellationToken.None).Forget();
 
             promiseEntitiesCount = world.CountEntities(in promiseOutcomeQuery);
             Assert.AreEqual(1, promiseEntitiesCount, $"Expected to find 1 promise entity but found {promiseEntitiesCount}.");
@@ -237,7 +237,7 @@ namespace CrdtEcsBridge.RestrictedActions.Tests
             int promiseEntitiesCount = world.CountEntities(in promiseOutcomeQuery);
             Assert.AreEqual(0, promiseEntitiesCount, $"Expected to find 0 promise entity but found {promiseEntitiesCount}.");
 
-            globalWorldActions.TriggerSceneEmoteAsync(mockSceneData, src, hash, loop, AvatarEmoteMask.AemFullBody, CancellationToken.None);
+            globalWorldActions.TriggerSceneEmoteAsync(mockSceneData, src, hash, loop, AvatarEmoteMask.AemFullBody, CancellationToken.None).Forget();
 
             LogAssert.Expect(LogType.Error, $"'{src}' scene emote cannot be played. It must follow the naming convention ending in '_emote.glb'");
 
@@ -261,7 +261,7 @@ namespace CrdtEcsBridge.RestrictedActions.Tests
             int promiseEntitiesCount = world.CountEntities(in promiseOutcomeQuery);
             Assert.AreEqual(0, promiseEntitiesCount, $"Expected to find 0 promise entity but found {promiseEntitiesCount}.");
 
-            globalWorldActions.TriggerSceneEmoteAsync(mockSceneData, "ignored_src.glb", hash, loop, AvatarEmoteMask.AemFullBody, CancellationToken.None);
+            globalWorldActions.TriggerSceneEmoteAsync(mockSceneData, "ignored_src.glb", hash, loop, AvatarEmoteMask.AemFullBody, CancellationToken.None).Forget();
 
             promiseEntitiesCount = world.CountEntities(in promiseOutcomeQuery);
             Assert.AreEqual(1, promiseEntitiesCount, $"Expected to find 1 promise entity but found {promiseEntitiesCount}.");
@@ -276,7 +276,7 @@ namespace CrdtEcsBridge.RestrictedActions.Tests
             var mockSceneData = new MockSceneData { SceneEntityDefinition = new SceneEntityDefinition("sceneInvisibleTest", new SceneMetadata()) };
             var hash = "emote_hash_invisible";
 
-            globalWorldActions.TriggerSceneEmoteAsync(mockSceneData, "any.glb", hash, false, AvatarEmoteMask.AemFullBody, CancellationToken.None);
+            globalWorldActions.TriggerSceneEmoteAsync(mockSceneData, "any.glb", hash, false, AvatarEmoteMask.AemFullBody, CancellationToken.None).Forget();
 
             Assert.IsFalse(world.Has<CharacterEmoteIntent>(playerEntity));
         }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Tests/LoadSystemBaseOngoingRequestRaceShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Tests/LoadSystemBaseOngoingRequestRaceShould.cs
@@ -15,7 +15,6 @@ using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace ECS.StreamableLoading.Tests
@@ -24,7 +23,7 @@ namespace ECS.StreamableLoading.Tests
     public class LoadSystemBaseOngoingRequestRaceShould
     {
         [Test]
-        public async Task CheckWhenMultipleWaitersRaceOnCancellation()
+        public void CheckWhenMultipleWaitersRaceOnCancellation()
         {
             // Arrange
             using var mockedReportScope = new MockedReportScope();

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Realm/IRealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Realm/IRealmController.cs
@@ -30,8 +30,8 @@ namespace ECS.SceneLifeCycle.Realm
                 //ignore
                 UniTask.CompletedTask;
 
-            public async UniTask<bool> IsReachableAsync(URLDomain realm, CancellationToken ct) =>
-                false;
+            public UniTask<bool> IsReachableAsync(URLDomain realm, CancellationToken ct) =>
+                UniTask.FromResult(false);
 
             public void DisposeGlobalWorld()
             {

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Categories/CategoryControllers/CategoryMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Categories/CategoryControllers/CategoryMarkersController.cs
@@ -108,10 +108,8 @@ namespace DCL.MapRenderer.MapLayers.Categories
             }
         }
 
-        public async UniTask InitializeAsync(CancellationToken cancellationToken)
-        {
-
-        }
+        public UniTask InitializeAsync(CancellationToken cancellationToken) =>
+            UniTask.CompletedTask;
 
         private void ShowPlaces(IReadOnlyList<PlacesData.PlaceInfo> places, CategoriesEnum mapLayer)
         {
@@ -181,7 +179,7 @@ namespace DCL.MapRenderer.MapLayers.Categories
             return UniTask.CompletedTask;
         }
 
-        public async UniTask EnableAsync(CancellationToken cancellationToken)
+        public UniTask EnableAsync(CancellationToken cancellationToken)
         {
             foreach (ICategoryMarker marker in markers.Values)
                 mapCullingController.StartTracking(marker, this);
@@ -193,6 +191,7 @@ namespace DCL.MapRenderer.MapLayers.Categories
             }
 
             isEnabled = true;
+            return UniTask.CompletedTask;
         }
 
         public void ResetToBaseScale()

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents/LiveEventsMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents/LiveEventsMarkersController.cs
@@ -68,9 +68,8 @@ namespace DCL.MapRenderer.MapLayers.Categories
             this.navmapBus = navmapBus;
         }
 
-        public async UniTask InitializeAsync(CancellationToken cancellationToken)
-        {
-        }
+        public UniTask InitializeAsync(CancellationToken cancellationToken) =>
+            UniTask.CompletedTask;
 
         public void ApplyCameraZoom(float baseZoom, float zoom, int zoomLevel)
         {

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
@@ -72,7 +72,7 @@ namespace DCL.MapRenderer.MapLayers.PointsOfInterest
             this.navmapBus = navmapBus;
         }
 
-        public async UniTask InitializeAsync(CancellationToken cancellationToken) { }
+        public UniTask InitializeAsync(CancellationToken cancellationToken) => UniTask.CompletedTask;
 
         protected override void DisposeImpl()
         {

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/SearchResults/SearchResultMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/SearchResults/SearchResultMarkersController.cs
@@ -79,7 +79,7 @@ namespace DCL.MapRenderer.MapLayers.SearchResults
             ReleaseMarkers();
         }
 
-        public async UniTask InitializeAsync(CancellationToken cancellationToken) { }
+        public UniTask InitializeAsync(CancellationToken cancellationToken) => UniTask.CompletedTask;
 
         private void OnPlaceSearched(INavmapBus.SearchPlaceParams searchParams,
             IReadOnlyList<PlacesData.PlaceInfo> places, int totalResultCount)
@@ -148,7 +148,7 @@ namespace DCL.MapRenderer.MapLayers.SearchResults
             return UniTask.CompletedTask;
         }
 
-        public async UniTask EnableAsync(CancellationToken cancellationToken)
+        public UniTask EnableAsync(CancellationToken cancellationToken)
         {
             foreach (ISearchResultMarker marker in markers.Values)
                 mapCullingController.StartTracking(marker, this);
@@ -160,6 +160,7 @@ namespace DCL.MapRenderer.MapLayers.SearchResults
             }
 
             isEnabled = true;
+            return UniTask.CompletedTask;
         }
 
         public void ResetToBaseScale()

--- a/Explorer/Assets/DCL/PluginSystem/Global/FriendsContainer.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/FriendsContainer.cs
@@ -230,7 +230,7 @@ namespace DCL.PluginSystem.Global
 
             friendServiceSubscriptionCts = friendServiceSubscriptionCts.SafeRestart();
 
-            LaunchSubscriptionsAsync(friendServiceSubscriptionCts.Token);
+            LaunchSubscriptionsAsync(friendServiceSubscriptionCts.Token).Forget();
 
             prewarmFriendsCancellationToken = prewarmFriendsCancellationToken.SafeRestart();
             PrewarmAsync(prewarmFriendsCancellationToken.Token).Forget();

--- a/Explorer/Assets/DCL/PluginSystem/World/AudioAnalysisPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AudioAnalysisPlugin.cs
@@ -41,9 +41,8 @@ namespace DCL.PluginSystem.World
         {
         }
 
-        public async UniTask InitializeAsync(CancellationToken ct)
-        {
-        }
+        public UniTask InitializeAsync(CancellationToken ct) =>
+            UniTask.CompletedTask;
     }
 }
 

--- a/Explorer/Assets/DCL/PluginSystem/World/LightSourcePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/LightSourcePlugin.cs
@@ -80,11 +80,12 @@ namespace DCL.PluginSystem.World
             await CreateLightSourcePoolAsync(lightSourcePrefab, ct);
         }
 
-        private async UniTask CreateLightSourcePoolAsync(Light lightSourcePrefab, CancellationToken ct)
+        private UniTask CreateLightSourcePoolAsync(Light lightSourcePrefab, CancellationToken ct)
         {
             lightPoolRegistry = poolsRegistry.AddGameObjectPool(() => Object.Instantiate(lightSourcePrefab, Vector3.zero, quaternion.identity), onRelease: OnPoolRelease, onGet: OnPoolGet);
 
             cacheCleaner.Register(lightPoolRegistry);
+            return UniTask.CompletedTask;
         }
 
         private void OnPoolRelease(Light light)

--- a/Explorer/Assets/DCL/SceneLoadingScreens/UnityLocalizationSceneTipsProvider.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/UnityLocalizationSceneTipsProvider.cs
@@ -46,7 +46,7 @@ namespace DCL.SceneLoadingScreens
             fallbackTips = Get(tipsTable, imagesTable, ct);
         }
 
-        public async UniTask<SceneTips> GetAsync(CancellationToken ct) =>
+        public UniTask<SceneTips> GetAsync(CancellationToken ct) =>
 
             // TODO: we will need specific scene tips in the future, but its disabled at the moment
             /*StringTable tipsTable = await tipsDatabase.GetTableAsync($"LoadingSceneTips-{parcelCoord.x},{parcelCoord.y}").Task
@@ -60,7 +60,7 @@ namespace DCL.SceneLoadingScreens
             ct.ThrowIfCancellationRequested();
 
             return await Get(tipsTable, imagesTable, ct);*/
-            fallbackTips;
+            UniTask.FromResult(fallbackTips);
 
         private SceneTips Get(StringTable tipsTable, AssetTable? imagesTable, CancellationToken ct)
         {

--- a/Explorer/Assets/DCL/VoiceChat/Microphone/MicrophoneTrackPublisher.cs
+++ b/Explorer/Assets/DCL/VoiceChat/Microphone/MicrophoneTrackPublisher.cs
@@ -196,6 +196,10 @@ namespace DCL.VoiceChat
             microphoneTrack = null;
         }
 
+        // suppress CS1998 on other platforms.
+#if !UNITY_STANDALONE_OSX
+#pragma warning disable CS1998
+#endif
         private static async UniTask<MicrophoneRtcAudioSource> CreateMicrophoneSourceAsync(VoiceChatConfiguration configuration, CancellationToken ct)
         {
             if (Application.platform is RuntimePlatform.WindowsPlayer or RuntimePlatform.WindowsEditor)
@@ -223,5 +227,8 @@ namespace DCL.VoiceChat
 
             return result.Value;
         }
+#if !UNITY_STANDALONE_OSX
+#pragma warning restore CS1998
+#endif
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes abandoned / mislabeled async calls surfaced by the compiler warnings **CS4014** (call not awaited) and **CS1998** (async method without `await`). These are correctness/readability hazards: un-awaited tasks run detached with unobserved exceptions, and `async` methods with no `await` allocate a state machine while running synchronously and misleading the reader.

**CS4014 — un-awaited calls (now explicitly `.Forget()`):**
- `PluginSystem/Global/FriendsContainer.cs` — `LaunchSubscriptionsAsync(...)` was fire-and-forget without `.Forget()`; now matches the sibling `PrewarmAsync(...).Forget()` in the same method.
- `RestrictedActions/Tests/GlobalWorldActionsShould.cs` (×4) — `TriggerSceneEmoteAsync(...)` calls; the tests assert the synchronous side effects, so `.Forget()` makes the fire-and-forget intent explicit.

**CS1998 — `async` methods with no `await` (converted to non-async `UniTask`-returning):**
- Empty / synchronous `InitializeAsync` / `EnableAsync` in the MapRenderer layer controllers (`CategoryMarkersController`, `LiveEventsMarkersController`, `ScenesOfInterestMarkersController`, `SearchResultMarkersController`) and `AudioAnalysisPlugin` → `UniTask.CompletedTask`.
- `LightSourcePlugin.CreateLightSourcePoolAsync` → returns `UniTask.CompletedTask` (body is fully synchronous).
- `SceneAdminsChatCommand.ExecuteCommandAsync` and `IRealmController` null-object `IsReachableAsync` → `UniTask.FromResult(...)`.
- `UnityLocalizationSceneTipsProvider.GetAsync` → `UniTask.FromResult(fallbackTips)` (the real async body is currently commented out).
- `VoiceChat/Microphone/MicrophoneTrackPublisher.CreateMicrophoneSourceAsync` — the only `await` is behind `#if UNITY_STANDALONE_OSX`, so non-macOS builds legitimately have no `await`; wrapped in a scoped `#pragma warning disable/restore CS1998` rather than adding a no-op `await`.
- `StreamableLoading/Tests/LoadSystemBaseOngoingRequestRaceShould.cs` — the race test drives the system synchronously and never awaits; converted `async Task` → `void` and dropped the now-unused `System.Threading.Tasks` import.

No behavioral change is intended — every call site preserves its prior runtime semantics; the fixes only make intent explicit and remove the spurious async state machines.

## Test Instructions

This is a pure correctness/warnings cleanup with no expected behavioral change — primarily a sanity check that nothing regressed.

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
- App boots normally. Friends pre-warm/subscriptions still work, the map layers (categories, live events, points of interest, search results) still populate, light-source SDK components still load, voice chat microphone publishing still works, and the `/scene-admins` chat command still returns the admin list.

### Test Steps
1. Happy path, no behaviour should change against the dev branch

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included
