### PR TITLE
fix: update scene restriction toast copy

### DIFF
--- a/Explorer/Assets/DCL/Minimap/SceneRestrictionsController.cs
+++ b/Explorer/Assets/DCL/Minimap/SceneRestrictionsController.cs
@@ -18,7 +18,7 @@ namespace DCL.Minimap
         private readonly Dictionary<SceneRestrictions, string> restrictionsTexts = new()
         {
             { SceneRestrictions.CAMERA_LOCKED, "• Camera locked" },
-            { SceneRestrictions.AVATAR_HIDDEN, "• Avatars hidden"},
+            { SceneRestrictions.AVATAR_HIDDEN, "• Avatars hidden" },
             { SceneRestrictions.AVATAR_MOVEMENTS_BLOCKED, "• Avatar movement disabled" },
             { SceneRestrictions.PASSPORT_CANNOT_BE_OPENED, "• User Options Menu disabled" },
             { SceneRestrictions.EXPERIENCES_BLOCKED, "• Experiences disabled" },

--- a/Explorer/Assets/DCL/Minimap/SceneRestrictionsController.cs
+++ b/Explorer/Assets/DCL/Minimap/SceneRestrictionsController.cs
@@ -17,13 +17,13 @@ namespace DCL.Minimap
         private readonly Dictionary<SceneRestrictions, GameObject> restrictionsGameObjects = new();
         private readonly Dictionary<SceneRestrictions, string> restrictionsTexts = new()
         {
-            { SceneRestrictions.CAMERA_LOCKED, "• The camera is locked" },
-            { SceneRestrictions.AVATAR_HIDDEN, "• The avatars are hidden" },
-            { SceneRestrictions.AVATAR_MOVEMENTS_BLOCKED, "• Avatar movements are blocked" },
-            { SceneRestrictions.PASSPORT_CANNOT_BE_OPENED, "• Passports can not be opened" },
-            { SceneRestrictions.EXPERIENCES_BLOCKED, "• Experiences are blocked" },
-            { SceneRestrictions.SKYBOX_TIME_UI_BLOCKED, "• Skybox time controls are blocked"},
-            { SceneRestrictions.NEARBY_VOICE_CHAT_BLOCKED, "• Nearby voice"},
+            { SceneRestrictions.CAMERA_LOCKED, "• Camera locked" },
+            { SceneRestrictions.AVATAR_HIDDEN, "• Avatars hidden"},
+            { SceneRestrictions.AVATAR_MOVEMENTS_BLOCKED, "• Avatar movement disabled" },
+            { SceneRestrictions.PASSPORT_CANNOT_BE_OPENED, "• User Options Menu disabled" },
+            { SceneRestrictions.EXPERIENCES_BLOCKED, "• Experiences disabled" },
+            { SceneRestrictions.SKYBOX_TIME_UI_BLOCKED, "• Day/Night controller disabled"},
+            { SceneRestrictions.NEARBY_VOICE_CHAT_BLOCKED, "• Nearby Voice disabled"},
         };
 
         public SceneRestrictionsController(ISceneRestrictionsView restrictionsView, ISceneRestrictionBusController sceneRestrictionBusController)

--- a/Explorer/Assets/DCL/Minimap/SceneRestrictionsController.cs
+++ b/Explorer/Assets/DCL/Minimap/SceneRestrictionsController.cs
@@ -23,7 +23,7 @@ namespace DCL.Minimap
             { SceneRestrictions.PASSPORT_CANNOT_BE_OPENED, "• User Options Menu disabled" },
             { SceneRestrictions.EXPERIENCES_BLOCKED, "• Experiences disabled" },
             { SceneRestrictions.SKYBOX_TIME_UI_BLOCKED, "• Day/Night controller disabled"},
-            { SceneRestrictions.NEARBY_VOICE_CHAT_BLOCKED, "• Nearby Voice disabled"},
+            { SceneRestrictions.NEARBY_VOICE_CHAT_BLOCKED, "• Nearby voice disabled" },
         };
 
         public SceneRestrictionsController(ISceneRestrictionsView restrictionsView, ISceneRestrictionBusController sceneRestrictionBusController)

--- a/Explorer/Assets/DCL/SceneRestrictionBusController/SceneRestriction/Assets/SceneRestrictionsToast.prefab
+++ b/Explorer/Assets/DCL/SceneRestrictionBusController/SceneRestriction/Assets/SceneRestrictionsToast.prefab
@@ -152,7 +152,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 219, y: 34}
+  m_SizeDelta: {x: 230, y: 34}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8374687070976786852
 CanvasRenderer:

--- a/Explorer/Assets/DCL/SceneRestrictionBusController/SceneRestriction/Assets/SceneRestrictionsToast.prefab
+++ b/Explorer/Assets/DCL/SceneRestrictionBusController/SceneRestriction/Assets/SceneRestrictionsToast.prefab
@@ -149,8 +149,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1159939997348515854}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 219, y: 34}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -396,7 +396,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4966924927682336045}
   m_Enabled: 1
-  m_Alpha: 0
+  m_Alpha: 1
   m_Interactable: 0
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0

--- a/Explorer/Assets/DCL/SceneRestrictionBusController/SceneRestriction/Assets/SceneRestrictionsToast.prefab
+++ b/Explorer/Assets/DCL/SceneRestrictionBusController/SceneRestriction/Assets/SceneRestrictionsToast.prefab
@@ -396,7 +396,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4966924927682336045}
   m_Enabled: 1
-  m_Alpha: 1
+  m_Alpha: 0
   m_Interactable: 0
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0

--- a/Explorer/Assets/DCL/SceneRestrictionBusController/SceneRestriction/Assets/SceneRestrictionsToast.prefab
+++ b/Explorer/Assets/DCL/SceneRestrictionBusController/SceneRestriction/Assets/SceneRestrictionsToast.prefab
@@ -54,8 +54,8 @@ MonoBehaviour:
   m_Padding:
     m_Left: 0
     m_Right: 0
-    m_Top: 14
-    m_Bottom: 14
+    m_Top: 18
+    m_Bottom: 18
   m_ChildAlignment: 1
   m_Spacing: 1
   m_ChildForceExpandWidth: 1
@@ -149,8 +149,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1159939997348515854}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 219, y: 34}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -182,7 +182,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: This scene is restricting the use of some features
+  m_text: This scene is restricting the use of the following features
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
   m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
@@ -220,6 +220,7 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -386,6 +387,7 @@ MonoBehaviour:
   <ToastCanvasGroup>k__BackingField: {fileID: 4631154171231165118}
   <ToastTextParent>k__BackingField: {fileID: 2680132346790437763}
   <FadeTime>k__BackingField: 0.3
+  <CycleDurationTime>k__BackingField: 3
 --- !u!225 &4631154171231165118
 CanvasGroup:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## What does this PR change?
This PR updates the wording and style of the restriction toasts and replaces some outdated terminology. For example, "Skybox" has been updated to "Night/Day" controller, and references to the "Passport" have been replaced with the user's Options menu.
<img width="627" height="260" alt="Screenshot 2026-06-23 at 13 54 58" src="https://github.com/user-attachments/assets/93bc6b7c-0e93-4900-b076-f15499b9382b" />



### Test Steps
1. launch the explorer.
2. Go to water some plans, or feed pigeons so you can see the movements disable message.
3. Go to the clock elevator so you can see the camera lock message.
4. Since you won't be able to validate all the message in the client please confirm the copy updates within the script [here](https://github.com/decentraland/unity-explorer/pull/9054/changes) 
<img width="860" height="486" alt="Screenshot 2026-06-23 at 16 28 18" src="https://github.com/user-attachments/assets/4d837a90-d4fe-4ce2-bf49-56f3b046662c" />
