### PR TITLE
fix: survive media player destroyed during hot reload

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastDownloadProviderBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastDownloadProviderBase.cs
@@ -26,7 +26,8 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
     {
         protected const int ATTEMPTS_COUNT = 6;
 
-        protected readonly IAcquiredBudget acquiredBudget;
+        // Nullable: StreamableLoadingState can null its budget on teardown/cancellation.
+        protected readonly IAcquiredBudget? acquiredBudget;
         protected readonly World world;
         protected readonly IPartitionComponent partitionComponent;
         protected readonly IWebRequestController webRequestController;
@@ -43,7 +44,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
 
         public void Dispose()
         {
-            acquiredBudget.Release();
+            acquiredBudget?.Release();
         }
 
         public virtual void SetContentMappings(ContentDefinition[] contentMappings)
@@ -84,7 +85,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
             finally
             {
                 if (ShouldReleaseBudget(uri))
-                    acquiredBudget.Release();
+                    acquiredBudget?.Release();
                 success = string.IsNullOrEmpty(error);
                 downloadHandler?.Dispose();
             }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastDownloadProviderBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastDownloadProviderBase.cs
@@ -33,7 +33,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
         protected readonly IWebRequestController webRequestController;
         protected readonly ReportData reportData;
 
-        protected GltFastDownloadProviderBase(World world, IPartitionComponent partitionComponent, ReportData reportData, IWebRequestController webRequestController, IAcquiredBudget acquiredBudget)
+        protected GltFastDownloadProviderBase(World world, IPartitionComponent partitionComponent, ReportData reportData, IWebRequestController webRequestController, IAcquiredBudget? acquiredBudget)
         {
             this.world = world;
             this.partitionComponent = partitionComponent;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastDownloadStrategy.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastDownloadStrategy.cs
@@ -9,7 +9,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
 {
     public interface IGltFastDownloadStrategy
     {
-        IGLTFastDisposableDownloadProvider CreateDownloadProvider(World world, GetGLTFIntention intention, IPartitionComponent partitionComponent, ReportData reportData, IWebRequestController webRequestController, IAcquiredBudget acquiredBudget);
+        IGLTFastDisposableDownloadProvider CreateDownloadProvider(World world, GetGLTFIntention intention, IPartitionComponent partitionComponent, ReportData reportData, IWebRequestController webRequestController, IAcquiredBudget? acquiredBudget);
     }
 
     public struct GltFastSceneDownloadStrategy : IGltFastDownloadStrategy
@@ -21,7 +21,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
             this.sceneData = sceneData;
         }
 
-        public IGLTFastDisposableDownloadProvider CreateDownloadProvider(World world, GetGLTFIntention intention, IPartitionComponent partitionComponent, ReportData reportData, IWebRequestController webRequestController, IAcquiredBudget acquiredBudget) =>
+        public IGLTFastDisposableDownloadProvider CreateDownloadProvider(World world, GetGLTFIntention intention, IPartitionComponent partitionComponent, ReportData reportData, IWebRequestController webRequestController, IAcquiredBudget? acquiredBudget) =>
             new GltFastSceneDownloadProvider(world, sceneData, partitionComponent, intention.Name!, reportData, webRequestController, acquiredBudget);
     }
 
@@ -34,7 +34,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
             this.contentDownloadUrl = contentDownloadUrl;
         }
 
-        public IGLTFastDisposableDownloadProvider CreateDownloadProvider(World world, GetGLTFIntention intention, IPartitionComponent partitionComponent, ReportData reportData, IWebRequestController webRequestController, IAcquiredBudget acquiredBudget) =>
+        public IGLTFastDisposableDownloadProvider CreateDownloadProvider(World world, GetGLTFIntention intention, IPartitionComponent partitionComponent, ReportData reportData, IWebRequestController webRequestController, IAcquiredBudget? acquiredBudget) =>
             new GltFastGlobalDownloadProvider(world, contentDownloadUrl, partitionComponent, reportData, webRequestController, acquiredBudget);
     }
 
@@ -47,7 +47,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
             this.realmData = realmData;
         }
 
-        public IGLTFastDisposableDownloadProvider CreateDownloadProvider(World world, GetGLTFIntention intention, IPartitionComponent partitionComponent, ReportData reportData, IWebRequestController webRequestController, IAcquiredBudget acquiredBudget) =>
+        public IGLTFastDisposableDownloadProvider CreateDownloadProvider(World world, GetGLTFIntention intention, IPartitionComponent partitionComponent, ReportData reportData, IWebRequestController webRequestController, IAcquiredBudget? acquiredBudget) =>
             new GltFastGlobalDownloadProvider(world, realmData.Ipfs.ContentBaseUrl.Value, partitionComponent, reportData, webRequestController, acquiredBudget);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastGlobalDownloadProvider.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastGlobalDownloadProvider.cs
@@ -22,7 +22,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
             IPartitionComponent partitionComponent,
             ReportData reportData,
             IWebRequestController webRequestController,
-            IAcquiredBudget acquiredBudget)
+            IAcquiredBudget? acquiredBudget)
             : base(world, partitionComponent, reportData, webRequestController, acquiredBudget)
         {
             this.contentSourceUrl = contentSourceUrl;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastSceneDownloadProvider.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastSceneDownloadProvider.cs
@@ -17,7 +17,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
         private readonly ISceneData sceneData;
 
         public GltFastSceneDownloadProvider(World world, ISceneData sceneData, IPartitionComponent partitionComponent, string targetGltfOriginalPath, ReportData reportData,
-            IWebRequestController webRequestController, IAcquiredBudget acquiredBudget)
+            IWebRequestController webRequestController, IAcquiredBudget? acquiredBudget)
             : base(world, partitionComponent, reportData, webRequestController, acquiredBudget)
         {
             this.sceneData = sceneData;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastSceneDownloadProvider.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastSceneDownloadProvider.cs
@@ -31,7 +31,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
 
             if (!sceneData.SceneContent.TryGetContentUrl(originalFilePath, out URLAddress tryGetContentUrlResult))
             {
-                if (isBaseGltfFetch) acquiredBudget.Release();
+                if (isBaseGltfFetch) acquiredBudget?.Release();
                 throw new Exception($"Error on GLTF download ({targetGltfOriginalPath} - {originalFilePath}): NOT FOUND");
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/LoadGLTFSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/LoadGLTFSystem.cs
@@ -65,7 +65,7 @@ namespace ECS.StreamableLoading.GLTF
 
             // Acquired budget is released inside GLTFastDownloadedProvider once the GLTF has been fetched
             // Cannot inject DownloadProvider from outside, because it needs the AcquiredBudget and PartitionComponent
-            using IGLTFastDisposableDownloadProvider gltFastDownloadProvider = downloadStrategy.CreateDownloadProvider(World, intention, partition, reportData, webRequestController, state.AcquiredBudget!);
+            using IGLTFastDisposableDownloadProvider gltFastDownloadProvider = downloadStrategy.CreateDownloadProvider(World, intention, partition, reportData, webRequestController, state.AcquiredBudget);
             gltFastDownloadProvider.SetContentMappings(intention.ContentMappings);
 
             GltfImport? gltfImport = null;

--- a/Explorer/Assets/DCL/SDKComponents/AudioAnalysis/AudioAnalysisSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioAnalysis/AudioAnalysisSystem.cs
@@ -47,10 +47,13 @@ namespace DCL.SDKComponents.AudioSources
         [Query]
         private void HandleMediaPlayerComponent(
             CRDTEntity entity,
-            ref MediaPlayerComponent mediaPlayerComponent, 
+            ref MediaPlayerComponent mediaPlayerComponent,
             ref PBAudioAnalysis sdkComponent
         )
         {
+            // Skip players whose AVPro object was destroyed; UpdateMediaPlayerSystem tears them down.
+            if (!mediaPlayerComponent.MediaPlayer.IsValid) return;
+
             HandleComponent(entity, ref mediaPlayerComponent, ref sdkComponent);
         }
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerCustomPool.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerCustomPool.cs
@@ -99,6 +99,9 @@ namespace DCL.SDKComponents.MediaStream
             //On quit, Unity may have already detroyed the MediaPlayer; so we might get a null-ref
             if (UnityObjectUtils.IsQuitting) return;
 
+            // Already destroyed (pool eviction / scene teardown): nothing left to stop or re-pool.
+            if (mediaPlayer == null) return;
+
             mediaPlayer.Stop();
             mediaPlayer.CloseMedia();
             mediaPlayer.AudioVolume = 0f;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MultiMediaPlayer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MultiMediaPlayer.cs
@@ -80,6 +80,12 @@ namespace DCL.SDKComponents.MediaStream
             static _ => false
         );
 
+        // False when the AVPro MediaPlayer GameObject was destroyed (pool eviction / scene teardown). LiveKit is always valid.
+        public bool IsValid => Match(
+            static avPro => avPro.AvProMediaPlayer != null,
+            static _ => true
+        );
+
         public bool IsReady => Match(
             static avPro => avPro.AvProMediaPlayer.TextureProducer != null,
             static _ => true

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/UpdateMediaPlayerSystem.cs
@@ -10,6 +10,7 @@ using DCL.Utilities.Extensions;
 using ECS.Abstract;
 using ECS.Groups;
 using ECS.LifeCycle;
+using ECS.LifeCycle.Components;
 using ECS.Unity.Textures.Components;
 using ECS.Unity.Transforms.Components;
 using SceneRunner.Scene;
@@ -65,6 +66,7 @@ namespace DCL.SDKComponents.MediaStream
 
         protected override void Update(float t)
         {
+            RemoveDeadMediaPlayersQuery(World);
             UpdateMediaPlayerPositionQuery(World);
             UpdateAudioStreamQuery(World, t);
             UpdateVideoStreamQuery(World, t);
@@ -75,6 +77,17 @@ namespace DCL.SDKComponents.MediaStream
         public void OnSceneIsCurrentChanged(bool enteredScene)
         {
             ToggleCurrentStreamsStateQuery(World, enteredScene);
+        }
+
+        // Drops players whose AVPro object was destroyed under them (pool eviction / scene teardown). Runs first so no
+        // later query dereferences the stale ref; recreated from the SDK component next frame.
+        [Query]
+        [None(typeof(DeleteEntityIntention))]
+        private void RemoveDeadMediaPlayers(Entity entity, ref MediaPlayerComponent mediaPlayer)
+        {
+            if (mediaPlayer.MediaPlayer.IsValid) return;
+
+            RemoveAndForceReInitialization(ref mediaPlayer, entity);
         }
 
         [Query]

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/VideoEventsSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/VideoEventsSystem.cs
@@ -40,6 +40,9 @@ namespace DCL.SDKComponents.MediaStream
         {
             if (!frameTimeBudget.TrySpendBudget()) return;
 
+            // Skip players whose AVPro object was destroyed; UpdateMediaPlayerSystem tears them down.
+            if (!mediaPlayer.MediaPlayer.IsValid) return;
+
             VideoState state = GetVideoStateForPropagation(mediaPlayer);
             PropagateStateInVideoEvent(in sdkEntity, ref mediaPlayer, state);
         }


### PR DESCRIPTION
## What does this PR change?

Fixes #8795

A pooled AVPro `MediaPlayer` GameObject can be destroyed (pool eviction, or scene teardown after a hot reload) while a stale `MediaPlayerComponent` still references it. Dereferencing the destroyed Unity object threw a null-reference error that escalated to a `SceneExecutionException` and killed the whole scene, the symptom reported in #8795 after 3-4 local hot reloads.

- `MultiMediaPlayer.IsValid` detects a destroyed underlying AVPro player (LiveKit is always valid).
- `UpdateMediaPlayerSystem` drops dead players each frame *before* any dereference (runs first), recreating them from their SDK component the next frame.
- `VideoEventsSystem` and `AudioAnalysisSystem` skip dead players.
- `MediaPlayerCustomPool.ReleaseMediaPlayer` is null-safe, so tearing down an already-destroyed player cannot throw.

Also hardens the GLTF download provider against the same shape of teardown crash: `StreamableLoadingState.AcquiredBudget` can become null during cancellation. `IAcquiredBudget?` is now propagated honestly through the whole chain (`GltFastDownloadProviderBase`, `GltFastSceneDownloadProvider`, `GltFastGlobalDownloadProvider`, the `IGltFastDownloadStrategy` interface and its three impls), the null-forgiving operator at the `LoadGLTFSystem` call site is removed, and the budget is released null-safely.

## Test Instructions

### What this fix does
Keeps local scenes working after many hot reloads. Before the fix, a scene that plays video or audio would stop responding after only a few reloads.

### Setup
- Run the Explorer build generated for this PR (#9069).
- Have a local scene running with hot reload enabled. Make sure the scene includes a video or audio screen that is playing. Genesis Plaza works for this.

### Steps
1. Open the local scene and confirm the video or audio is playing.
2. Make a small change to the scene so it reloads, and wait for the reload to finish.
3. Repeat step 2 several times, at least 5 or 6 reloads in a row.
4. Between a couple of the reloads, walk out of the scene and back into it.

### Expected result
- After every reload the scene keeps working: the video or audio screen comes back and plays, and avatars and interactions still respond.
- The scene never freezes or stops responding, no matter how many times it is reloaded.

### Note for reviewers
This fix only covers the scene staying alive through hot reloads. Unrelated messages may still appear in the logs and are out of scope here; please judge the result by whether the scene keeps working after repeated reloads, not by whether the log is completely clean.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does, especially useful for first-time contributors.
