### PR TITLE
fix: read warning baseline from S3 directly and refresh PR comment on failed lint

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -954,6 +954,14 @@ jobs:
           should_build='${{ needs.prebuild.outputs.should_build }}'
           prebuild_result='${{ needs.prebuild.result }}'
 
+          # Legit no-op: prebuild was skipped entirely (its 'if' was false — e.g. a labeled/unlabeled
+          # event, a draft without 'force-build', or the 'perf_test' label). That's a deliberate
+          # "don't build this event" decision, not a failure, so there is nothing to gate.
+          if [ "$prebuild_result" = "skipped" ]; then
+            echo "Gate not applicable (prebuild skipped — no build for this event). Passing."
+            exit 0
+          fi
+
           # Legit no-op: prebuild ran and decided no build is needed (no Explorer/ changes).
           # The Prebuild job's "Skip build and test checks" step already posts per-target success
           # statuses for this case, so the gate can safely pass.
@@ -962,8 +970,8 @@ jobs:
             exit 0
           fi
 
-          # Any other prebuild outcome (skipped/cancelled/failure) means no real build happened.
-          # Fail closed so an incidental PR event can't silently produce a green Build Gate.
+          # cancelled/failure => a build was expected but never completed. Fail closed so a real
+          # problem can't silently produce a green Build Gate.
           if [ "$prebuild_result" != "success" ]; then
             echo "::error::Prebuild did not succeed (result: $prebuild_result). No build produced for this commit; re-trigger the workflow (e.g. push a new commit or add the 'force-build' label)."
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,8 +280,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
           EXPLORER_TEAM_S3_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
         run: |
-          # Read straight from S3 (authenticated), NOT the public CDN URL: Cloudflare/CloudFront in
-          # front of the bucket can serve a stale baseline, producing inconsistent ratchet results.
+          # Read directly from s3 to avoid cache stales 
           baseline=$(aws s3 cp "s3://$EXPLORER_TEAM_S3_BUCKET/${{ env.WARNINGS_BASELINE_S3_KEY }}" - 2>/dev/null | jq -r '.count' 2>/dev/null || echo "")
           echo "baseline=$baseline" >> "$GITHUB_OUTPUT"
           echo "Baseline warnings: ${baseline:-<none>}"
@@ -323,7 +322,7 @@ jobs:
           EXPLORER_TEAM_S3_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
         run: |
           set -euo pipefail
-          # Read straight from S3 (authenticated) to avoid stale CDN reads when deciding whether to lower.
+          # Read directly from s3 to avoid cache stales 
           cur=$(aws s3 cp "s3://$EXPLORER_TEAM_S3_BUCKET/${{ env.WARNINGS_BASELINE_S3_KEY }}" - 2>/dev/null | jq -r '.count' 2>/dev/null || echo "")
           if [ -n "$cur" ] && [ "$COUNT" -ge "$cur" ]; then
             echo "No update: current count ($COUNT) is not less than existing baseline ($cur)."
@@ -337,7 +336,7 @@ jobs:
 
       # Hand the numbers to the trusted workflow_run companion that posts the PR comment.
       # Runs even when the gate above failed (!cancelled), so a failing run still refreshes the comment
-      # instead of leaving a stale "reduced" message from an earlier passing run.
+      # instead of leaving a stale message.
       - name: Write warning result for PR comment
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,9 +273,16 @@ jobs:
 
       - name: Read warnings baseline from S3
         id: baseline
+        env:
+          AWS_MAX_ATTEMPTS: 3
+          AWS_RETRY_MODE: standard
+          AWS_ACCESS_KEY_ID: ${{ secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY }}
+          EXPLORER_TEAM_S3_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
         run: |
-          url="${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}/${{ env.WARNINGS_BASELINE_S3_KEY }}"
-          baseline=$(curl -fsSL "$url" | jq -r '.count' 2>/dev/null || echo "")
+          # Read straight from S3 (authenticated), NOT the public CDN URL: Cloudflare/CloudFront in
+          # front of the bucket can serve a stale baseline, producing inconsistent ratchet results.
+          baseline=$(aws s3 cp "s3://$EXPLORER_TEAM_S3_BUCKET/${{ env.WARNINGS_BASELINE_S3_KEY }}" - 2>/dev/null | jq -r '.count' 2>/dev/null || echo "")
           echo "baseline=$baseline" >> "$GITHUB_OUTPUT"
           echo "Baseline warnings: ${baseline:-<none>}"
 
@@ -316,8 +323,8 @@ jobs:
           EXPLORER_TEAM_S3_BUCKET: ${{ secrets.EXPLORER_TEAM_S3_BUCKET }}
         run: |
           set -euo pipefail
-          url="${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}/${{ env.WARNINGS_BASELINE_S3_KEY }}"
-          cur=$(curl -fsSL "$url" | jq -r '.count' 2>/dev/null || echo "")
+          # Read straight from S3 (authenticated) to avoid stale CDN reads when deciding whether to lower.
+          cur=$(aws s3 cp "s3://$EXPLORER_TEAM_S3_BUCKET/${{ env.WARNINGS_BASELINE_S3_KEY }}" - 2>/dev/null | jq -r '.count' 2>/dev/null || echo "")
           if [ -n "$cur" ] && [ "$COUNT" -ge "$cur" ]; then
             echo "No update: current count ($COUNT) is not less than existing baseline ($cur)."
             exit 0
@@ -329,12 +336,18 @@ jobs:
             --content-type application/json --cache-control no-cache
 
       # Hand the numbers to the trusted workflow_run companion that posts the PR comment.
+      # Runs even when the gate above failed (!cancelled), so a failing run still refreshes the comment
+      # instead of leaving a stale "reduced" message from an earlier passing run.
       - name: Write warning result for PR comment
-        if: github.event_name == 'pull_request'
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         env:
           COUNT: ${{ steps.warnings.outputs.count }}
           BASELINE: ${{ steps.baseline.outputs.baseline }}
         run: |
+          if [ -z "$COUNT" ]; then
+            echo "No warning count computed (lint produced no result) - skipping comment payload."
+            exit 0
+          fi
           jq -n \
             --argjson pr "${{ github.event.pull_request.number }}" \
             --argjson count "$COUNT" \
@@ -344,11 +357,12 @@ jobs:
           cat warning-result.json
 
       - name: Upload warning result
-        if: github.event_name == 'pull_request'
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: warning-result
           path: warning-result.json
+          if-no-files-found: ignore
 
       - name: Upload lint reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Three CI fixes to the lint warning-ratchet and the build gate, found while debugging a PR that flipped pass→fail on the same commit.

**1. Stale baseline via CDN (`test.yml`).** The warning baseline was read through the public URL (`explorer-artifacts.decentraland.org`), which is fronted by Cloudflare/CloudFront and served **cached** copies despite `cache-control: no-cache`. Two runs of the same commit read different baselines (`50351` stale vs `48555` real), making the gate non-deterministic. Both reads (the PR enforce path and the dev baseline-update path) now fetch **directly from S3** with the team AWS creds — no CDN in the path.

**2. Stale PR comment on failure (`test.yml`).** The `warning-result` artifact was only uploaded when the lint job succeeded, so a failing run left the previous passing run's "reduced" comment in place. The write/upload steps now run with `!cancelled()` (plus an empty-count guard and `if-no-files-found: ignore`), so a failing run refreshes the comment to "not reduced".

**3. Build Gate fails on a skipped build (`build-unitycloud.yml`).** The gate lumped a *skipped* prebuild in with cancelled/failure and failed closed, so CI/docs-only PRs (which don't trigger a build) went red and needed a `force-build` label. A skipped prebuild is a deliberate "don't build this event" decision, not a failure — the gate now passes on `skipped` and still fails closed on `cancelled`/`failure`.

The ratchet gate logic (strict reduction) is unchanged.

## Quality Checklist
- [x] Changes have been tested locally
- [x] CI-only change (no app code)
