### PR TITLE
feat(MediaStream): vendor open-source UnitedAV

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/ECS.Unity.asmdef
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/ECS.Unity.asmdef
@@ -31,7 +31,8 @@
         "GUID:40cc3d3e494162646bdb002eed05aeec",
         "GUID:d28a7e4beeca475418c15757abf1b6f1",
         "GUID:84651a3751eca9349aac36a66bba901b",
-        "GUID:9e24947de15b9834991c9d8411ea37cf"
+        "GUID:9e24947de15b9834991c9d8411ea37cf",
+        "GUID:839d16b917532fb4d9050bbc00e77cfd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/PluginSystem/DCL.Plugins.asmdef
+++ b/Explorer/Assets/DCL/PluginSystem/DCL.Plugins.asmdef
@@ -72,7 +72,8 @@
         "GUID:a42927d1d4a3b4cda9b076a7adecb9cc",
         "GUID:f8127c6ac263abf468221dcbccbde182",
         "GUID:63cde67b4a5d47449392dfc49fc0c3ed",
-        "GUID:267f743eefeddd44982a713909628102"
+        "GUID:267f743eefeddd44982a713909628102",
+        "GUID:839d16b917532fb4d9050bbc00e77cfd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -90,7 +91,7 @@
             "define": "GPUI_PRO_PRESENT"
         },
         {
-            "name": "com.renderheads.avpro.video-ultra",
+            "name": "org.unitedav",
             "expression": "",
             "define": "AV_PRO_PRESENT"
         }

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/MediaPlayerComponent.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Components/MediaPlayerComponent.cs
@@ -1,5 +1,5 @@
 using DCL.ECSComponents;
-using RenderHeads.Media.AVProVideo;
+using UnitedAV;
 using System;
 using System.Threading;
 using UnityEngine;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaFactory.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaFactory.cs
@@ -14,7 +14,7 @@ using ECS.Unity.GltfNodeModifiers.Components;
 using ECS.Unity.PrimitiveRenderer.Components;
 using ECS.Unity.Textures.Components;
 using LiveKit.Rooms;
-using RenderHeads.Media.AVProVideo;
+using UnitedAV;
 using SceneRunner.Scene;
 using System;
 using System.Collections.Generic;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerCustomPool.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerCustomPool.cs
@@ -1,6 +1,6 @@
 using Cysharp.Threading.Tasks;
 using ECS.Unity.AssetLoad.Cache;
-using RenderHeads.Media.AVProVideo;
+using UnitedAV;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -44,17 +44,17 @@ namespace DCL.SDKComponents.MediaStream
             else
             {
                 mediaPlayer = Object.Instantiate(mediaPlayerPrefab, rootContainerTransform);
-                mediaPlayer.PlatformOptionsWindows._audioMode = Windows.AudioOutput.Unity;
+                mediaPlayer.PlatformOptionsWindows._audioMode = UnitedAV.Windows.AudioOutput.Unity;
                 mediaPlayer.PlatformOptions_macOS.audioMode = MediaPlayer.PlatformOptions.AudioMode.Unity;
             }
 
             #if UNITY_EDITOR
                 if (UnityEditorInternal.RenderDoc.IsLoaded())
-                    mediaPlayer.PlatformOptionsWindows.videoApi = RenderHeads.Media.AVProVideo.Windows.VideoApi.MediaFoundation;
+                    mediaPlayer.PlatformOptionsWindows.videoApi = UnitedAV.Windows.VideoApi.MediaFoundation;
                 else
-                    mediaPlayer.PlatformOptionsWindows.videoApi = RenderHeads.Media.AVProVideo.Windows.VideoApi.WinRT;
+                    mediaPlayer.PlatformOptionsWindows.videoApi = UnitedAV.Windows.VideoApi.WinRT;
             #else
-                mediaPlayer.PlatformOptionsWindows.videoApi = RenderHeads.Media.AVProVideo.Windows.VideoApi.WinRT;
+                mediaPlayer.PlatformOptionsWindows.videoApi = UnitedAV.Windows.VideoApi.WinRT;
             #endif
             mediaPlayer.PlatformOptionsWindows.startWithHighestBitrate = true;
             mediaPlayer.PlatformOptionsWindows.useLowLiveLatency = false;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerExtensions.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MediaPlayerExtensions.cs
@@ -1,6 +1,6 @@
 using Cysharp.Threading.Tasks;
 using DCL.ECSComponents;
-using RenderHeads.Media.AVProVideo;
+using UnitedAV;
 using System;
 using UnityEngine;
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/MultiMediaPlayer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/MultiMediaPlayer.cs
@@ -1,6 +1,6 @@
 using Cysharp.Threading.Tasks;
 using DCL.ECSComponents;
-using RenderHeads.Media.AVProVideo;
+using UnitedAV;
 using REnum;
 using UnityEngine;
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/MediaFactoryBuilder.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/MediaFactoryBuilder.cs
@@ -6,7 +6,7 @@ using DCL.PluginSystem.World.Dependencies;
 using DCL.Utilities;
 using DCL.WebRequests;
 using ECS.Unity.AssetLoad.Cache;
-using RenderHeads.Media.AVProVideo;
+using UnitedAV;
 using UnityEngine;
 using UnityEngine.Pool;
 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/MediaPlayerContainer.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Systems/MediaPlayerContainer.cs
@@ -12,7 +12,7 @@ using DCL.ResourcesUnloading;
 using DCL.Utilities;
 using DCL.WebRequests;
 using ECS.Unity.AssetLoad.Cache;
-using RenderHeads.Media.AVProVideo;
+using UnitedAV;
 using System;
 using System.Threading;
 using UnityEngine;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Tests/CleanUpMediaPlayerShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Tests/CleanUpMediaPlayerShould.cs
@@ -1,4 +1,4 @@
-﻿#if AV_PRO_PRESENT
+#if AV_PRO_PRESENT
 using Arch.Core;
 using DCL.ECSComponents;
 using DCL.Optimization.Pools;
@@ -6,7 +6,7 @@ using ECS.TestSuite;
 using ECS.Unity.Textures.Components;
 using NSubstitute;
 using NUnit.Framework;
-using RenderHeads.Media.AVProVideo;
+using UnitedAV;
 using SceneRunner.Scene;
 using UnityEngine;
 using Utility;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Tests/CreateMediaPlayerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Tests/CreateMediaPlayerSystemShould.cs
@@ -1,4 +1,4 @@
-﻿#if AV_PRO_PRESENT
+#if AV_PRO_PRESENT
 using Arch.Core;
 using DCL.ECSComponents;
 using DCL.Optimization.PerformanceBudgeting;
@@ -9,7 +9,7 @@ using ECS.TestSuite;
 using ECS.Unity.Textures.Components;
 using NSubstitute;
 using NUnit.Framework;
-using RenderHeads.Media.AVProVideo;
+using UnitedAV;
 using SceneRunner.Scene;
 using UnityEngine;
 using Utility;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Tests/UpdateMediaPlayerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Tests/UpdateMediaPlayerSystemShould.cs
@@ -1,4 +1,4 @@
-﻿#if AV_PRO_PRESENT
+#if AV_PRO_PRESENT
 using Arch.Core;
 using DCL.ECSComponents;
 using DCL.Optimization.PerformanceBudgeting;
@@ -7,7 +7,7 @@ using ECS.Prioritization.Components;
 using ECS.TestSuite;
 using NSubstitute;
 using NUnit.Framework;
-using RenderHeads.Media.AVProVideo;
+using UnitedAV;
 using SceneRunner.Scene;
 using System.Threading;
 using UnityEngine;

--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -22,7 +22,7 @@
     "com.mackysoft.serializereference-extensions": "1.3.1",
     "com.nickkhalow.chrome-devtool-protocol-unity": "https://github.com/decentraland/chrome-devtool-protocol-unity.git?path=/Packages",
     "com.nickkhalow.richtypes": "https://github.com/NickKhalow/RichTypesUnity.git?path=/Packages/RichTypes",
-    "com.renderheads.avpro.video-ultra": "git@github.com:decentraland/unity-explorer-packages.git?path=/AVProVideo",
+    "org.unitedav": "file:org.unitedav",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "2.9.1",
     "com.unity.animation.rigging": "1.4.1",

--- a/Explorer/Packages/org.unitedav/Runtime.meta
+++ b/Explorer/Packages/org.unitedav/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07f0fa3aa3355bd3fbe56736ebb9357a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9a5bc25a529b2d8e2b256ba50af28ca5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/README.md
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/README.md
@@ -1,0 +1,33 @@
+# UnitedAV native plugins
+
+The C# runtime (`UnitedAV.Runtime`) P/Invokes a native library whose base name is
+`UnitedAV` (see `Runtime/UnitedAV/Internal/UnitedAVNative.cs`). At load time Mono /
+IL2CPP resolve the platform-specific file name from that base name:
+
+| Platform        | Resolved file name     |
+|-----------------|------------------------|
+| Linux x86_64    | `libUnitedAV.so`       |
+| Windows x86_64  | `UnitedAV.dll`         |
+| macOS universal | `libUnitedAV.dylib`    |
+
+## Build from source
+
+The native plugin is **not committed** — build it and place the artifact under a
+per-platform folder, each with a Unity `PluginImporter` `.meta` that enables it for
+exactly the platforms it targets:
+
+```
+Runtime/Plugins/
+  Linux/x86_64/libUnitedAV.so        # Editor + Standalone Linux x86_64
+  Windows/x86_64/UnitedAV.dll        # Editor + Standalone Windows x86_64
+  macOS/UnitedAV.dylib               # Editor + Standalone macOS
+```
+
+Built binaries are git-ignored. To produce the Linux artifact:
+
+```sh
+cmake -S native -B native/build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build native/build
+mkdir -p unity/Runtime/Plugins/Linux/x86_64
+cp native/build/libUnitedAV.so unity/Runtime/Plugins/Linux/x86_64/libUnitedAV.so
+```

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/README.md.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d4e5f60718293a4b5c6d7e8f90a1b2c3
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22a31b7308ce4cd6a6163291159a7e55
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b46bc3c5827f48438c9820b490b13a33
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/UnitedAV.dll
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/UnitedAV.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64db4d46e0ac23759ddea9b7ca324c826fb1baa8f823c68012c8c8821c31b320
+size 543369

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/UnitedAV.dll.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/UnitedAV.dll.meta
@@ -1,0 +1,47 @@
+fileFormatVersion: 2
+guid: 03f23534796243a0a7d21672faa15510
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 0
+        Exclude WindowsStoreApps: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Windows
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avcodec-61.dll
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avcodec-61.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dce4437b5926d836d77af41b14b09eaf1b1692355528fc24b807e4a27a50ae96
+size 15180288

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avcodec-61.dll.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avcodec-61.dll.meta
@@ -1,0 +1,47 @@
+fileFormatVersion: 2
+guid: 3bb89dc6dcbf42fda9139a0f887cfbfc
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 0
+        Exclude WindowsStoreApps: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Windows
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avformat-61.dll
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avformat-61.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddb4b5158d67a89ef55834c19fecf41ab0ef555ccc9f4fccee3d25298a6a2f17
+size 2595328

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avformat-61.dll.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avformat-61.dll.meta
@@ -1,0 +1,47 @@
+fileFormatVersion: 2
+guid: 1ab86ec0b1ec45db8b8af7e23bb04ac0
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 0
+        Exclude WindowsStoreApps: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Windows
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avutil-59.dll
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avutil-59.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b981d16c310371cdce1b0292aebd386d4532eb35cdf6f2567351e4b1a318f901
+size 1064960

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avutil-59.dll.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/avutil-59.dll.meta
@@ -1,0 +1,47 @@
+fileFormatVersion: 2
+guid: 373d1d676dfb4b10aefbad0f741e1c4a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 0
+        Exclude WindowsStoreApps: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Windows
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/libmcfgthread-2.dll
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/libmcfgthread-2.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcae43f9fa65c11527306d92bfe99ae5e6487eeec878a48816c5d5faa2fcd80d
+size 86267

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/libmcfgthread-2.dll.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/libmcfgthread-2.dll.meta
@@ -1,0 +1,47 @@
+fileFormatVersion: 2
+guid: 7b3700aa667c4346a8b2eed99da6d04e
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 0
+        Exclude WindowsStoreApps: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Windows
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/swresample-5.dll
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/swresample-5.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7112b9be7550471cc1cf43a4305171e312bd497736024b6e217901fedb4e6624
+size 124928

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/swresample-5.dll.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/swresample-5.dll.meta
@@ -1,0 +1,47 @@
+fileFormatVersion: 2
+guid: 90d503ce5075455ab41f17ea08fa497a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 0
+        Exclude WindowsStoreApps: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Windows
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/swscale-8.dll
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/swscale-8.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c81078c6bca6431de306ce23edb77eedf8cb4a25cda6bc1295d8fa817006e73f
+size 671232

--- a/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/swscale-8.dll.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/Plugins/Windows/x86_64/swscale-8.dll.meta
@@ -1,0 +1,47 @@
+fileFormatVersion: 2
+guid: e9fb09b8c6cd4c889c827bc89211e528
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 0
+        Exclude WindowsStoreApps: 1
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: Windows
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV.Runtime.asmdef
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV.Runtime.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "UnitedAV.Runtime",
+    "rootNamespace": "UnitedAV",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV.Runtime.asmdef.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV.Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 839d16b917532fb4d9050bbc00e77cfd
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ba4dc5c799477ebecbe47ba3f3ca2010
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Enums.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Enums.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+namespace UnitedAV
+{
+    public enum MediaPathType
+    {
+        AbsolutePathOrURL = 0,
+        RelativeToProjectFolder = 1,
+        RelativeToStreamingAssetsFolder = 2,
+        RelativeToDataFolder = 3,
+        RelativeToPersistentDataFolder = 4,
+    }
+
+    public enum ErrorCode
+    {
+        None = 0,
+        LoadFailed = 100,
+        DecodeFailed = 200,
+        InvalidPermissions = 300,
+        InvalidOperation = 400,
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Enums.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Enums.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9d4dafa4a49397090a3a009deb1f3dd3

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Interfaces.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Interfaces.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UnitedAV
+{
+    public interface IMediaControl
+    {
+        bool Play();
+        bool Pause();
+        bool Stop();
+
+        bool Seek(double timeSeconds);
+
+        void SetLooping(bool looping);
+        bool IsLooping();
+
+        void SetPlaybackRate(float rate);
+        float GetPlaybackRate();
+
+        bool IsPlaying();
+        bool IsPaused();
+        bool IsFinished();
+        bool IsSeeking();
+        bool IsBuffering();
+
+        double GetCurrentTime();
+        TimeRanges GetBufferedTimes();
+        ErrorCode GetLastError();
+    }
+
+    public interface IMediaInfo
+    {
+        // double.PositiveInfinity for live streams or unknown duration.
+        double GetDuration();
+
+        int GetVideoWidth();
+        int GetVideoHeight();
+        float GetVideoFrameRate();
+
+        bool HasVideo();
+        bool HasAudio();
+    }
+
+    public interface ITextureProducer
+    {
+        // Null while loading; the reference may change across videos or device loss.
+        Texture GetTexture();
+
+        // True when rows are top-down and need a vertical flip in Unity's bottom-up UV space.
+        bool RequiresVerticalFlip();
+    }
+
+    public struct TimeRange
+    {
+        public double startTime;
+        public double duration;
+
+        public TimeRange(double start, double dur)
+        {
+            startTime = start;
+            duration = dur;
+        }
+
+        public double EndTime => startTime + duration;
+    }
+
+    public sealed class TimeRanges
+    {
+        private readonly List<TimeRange> _ranges;
+
+        public TimeRanges()
+        {
+            _ranges = new List<TimeRange>();
+        }
+
+        public TimeRanges(List<TimeRange> ranges)
+        {
+            _ranges = ranges ?? new List<TimeRange>();
+        }
+
+        public int Count => _ranges.Count;
+
+        public TimeRange this[int index] => _ranges[index];
+
+        public IReadOnlyList<TimeRange> Ranges => _ranges;
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Interfaces.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Interfaces.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c6b311a0c879f8fc9bda3424a086c68

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Internal.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Internal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 30b8f5ab0fbd3598db7174b711b7639c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Internal/UnitedAVNative.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Internal/UnitedAVNative.cs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// P/Invoke layer over the native C ABI. cdecl, library "UnitedAV".
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace UnitedAV.Internal
+{
+    internal enum UAVState
+    {
+        Idle      = 0,
+        Opening   = 1,
+        Ready     = 2,
+        Playing   = 3,
+        Paused    = 4,
+        Buffering = 5,
+        Finished  = 6,
+        Error     = 7,
+    }
+
+    internal enum UAVResult
+    {
+        Ok            = 0,
+        ErrInvalid    = -1,
+        ErrOpenFailed = -2,
+        ErrNoStream   = -3,
+        ErrDecode     = -4,
+        ErrUnsupported = -5,
+        ErrNoMem      = -6,
+    }
+
+    internal enum UAVPixelFormat
+    {
+        Rgba32 = 0,
+        Nv12   = 1,
+    }
+
+    // data is owned by the native player and valid only until the matching uav_release_frame.
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct UAVVideoFrame
+    {
+        public IntPtr data;
+        public int    width;
+        public int    height;
+        public int    stride;
+        public int    format;
+        public long   frame_id;
+        public double pts;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct UAVMediaInfo
+    {
+        public int    has_video;
+        public int    has_audio;
+        public int    width;
+        public int    height;
+        public double frame_rate;
+        public double duration;
+        public int    audio_channels;
+        public int    audio_sample_rate;
+    }
+
+    internal static class UnitedAVNative
+    {
+        public const string Lib = "UnitedAV";
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint uav_abi_version();
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr uav_create();
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void uav_destroy(IntPtr p);
+
+        // BestFitMapping/ThrowOnUnmappableChar disabled so URL bytes pass through unmodified.
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi,
+            BestFitMapping = false, ThrowOnUnmappableChar = false)]
+        public static extern int uav_open(IntPtr p, [MarshalAs(UnmanagedType.LPStr)] string url);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_close(IntPtr p);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_play(IntPtr p);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_pause(IntPtr p);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_stop(IntPtr p);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_seek(IntPtr p, double seconds);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_set_looping(IntPtr p, int loop);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_set_rate(IntPtr p, float rate);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_set_volume(IntPtr p, float volume);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_set_muted(IntPtr p, int muted);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_get_state(IntPtr p);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern double uav_get_position(IntPtr p);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_get_info(IntPtr p, out UAVMediaInfo outInfo);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_last_error(IntPtr p);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_acquire_frame(IntPtr p, long last_frame_id, out UAVVideoFrame outFrame);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void uav_release_frame(IntPtr p);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_read_audio(IntPtr p, IntPtr dst, int frames, int channels, int sample_rate);
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Internal/UnitedAVNative.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Internal/UnitedAVNative.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a6f77f82e03ce89db0235bd5f627c1a

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Internal/UnitedAVWebGL.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Internal/UnitedAVWebGL.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// P/Invoke layer over the Unity WebGL backend (Plugins/WebGL/UnitedAV.jslib). On
+// WebGL the native FFmpeg plugin is unavailable; this drives the browser's own
+// HTMLVideoElement and uploads frames into Unity GL textures. Counterpart of
+// UnitedAVNative.cs (which targets the native "UnitedAV" library elsewhere).
+#if UNITY_WEBGL && !UNITY_EDITOR
+using System.Runtime.InteropServices;
+
+namespace UnitedAV.Internal
+{
+    internal static class UnitedAVWebGL
+    {
+        [DllImport("__Internal")] public static extern int   UAV_Web_Create(string url);
+        [DllImport("__Internal")] public static extern void  UAV_Web_Play(int h);
+        [DllImport("__Internal")] public static extern void  UAV_Web_Pause(int h);
+        [DllImport("__Internal")] public static extern void  UAV_Web_Seek(int h, double t);
+        [DllImport("__Internal")] public static extern void  UAV_Web_SetLooping(int h, int on);
+        [DllImport("__Internal")] public static extern void  UAV_Web_SetVolume(int h, float vol);
+        [DllImport("__Internal")] public static extern void  UAV_Web_SetMuted(int h, int on);
+        [DllImport("__Internal")] public static extern int   UAV_Web_GetWidth(int h);
+        [DllImport("__Internal")] public static extern int   UAV_Web_GetHeight(int h);
+        [DllImport("__Internal")] public static extern double UAV_Web_GetDuration(int h);
+        [DllImport("__Internal")] public static extern double UAV_Web_GetPosition(int h);
+        [DllImport("__Internal")] public static extern int   UAV_Web_HasVideo(int h);
+        [DllImport("__Internal")] public static extern int   UAV_Web_GetState(int h);
+        [DllImport("__Internal")] public static extern int   UAV_Web_HasNewFrame(int h);
+        [DllImport("__Internal")] public static extern int   UAV_Web_UploadTexture(int h, int glTex);
+        // WebGPU upload path (design-only; only meaningful in a Unity WebGPU player
+        // build). wgpuTex is the GPUTexture handle from Texture.GetNativeTexturePtr().
+        [DllImport("__Internal")] public static extern int   UAV_Web_UploadTextureWGPU(int h, int wgpuTex);
+        [DllImport("__Internal")] public static extern void  UAV_Web_Destroy(int h);
+
+        // Mirrors the native C ABI UAVState.
+        public enum State { Idle = 0, Opening = 1, Ready = 2, Playing = 3, Paused = 4, Buffering = 5, Finished = 6, Error = 7 }
+    }
+}
+#endif

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Internal/UnitedAVWebGL.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Internal/UnitedAVWebGL.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a43fade92bf6dbf418c41fbce356a96f

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaControlImpl.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaControlImpl.cs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using UnitedAV.Internal;
+
+namespace UnitedAV
+{
+    internal sealed class MediaControlImpl : IMediaControl
+    {
+        private readonly MediaPlayer _player;
+
+        public MediaControlImpl(MediaPlayer player)
+        {
+            _player = player;
+        }
+
+        private System.IntPtr H => _player.NativeHandle;
+        private bool Valid => H != System.IntPtr.Zero;
+
+        public bool Play()
+        {
+            if (!Valid) return false;
+            return UnitedAVNative.uav_play(H) == (int)UAVResult.Ok;
+        }
+
+        public bool Pause()
+        {
+            if (!Valid) return false;
+            return UnitedAVNative.uav_pause(H) == (int)UAVResult.Ok;
+        }
+
+        public bool Stop()
+        {
+            if (!Valid) return false;
+            return UnitedAVNative.uav_stop(H) == (int)UAVResult.Ok;
+        }
+
+        public bool Seek(double timeSeconds)
+        {
+            if (!Valid) return false;
+            _player.NotifySeekRequested();
+            return UnitedAVNative.uav_seek(H, timeSeconds) == (int)UAVResult.Ok;
+        }
+
+        public void SetLooping(bool looping)
+        {
+            _player.LoopingFlag = looping;
+            if (Valid)
+                UnitedAVNative.uav_set_looping(H, looping ? 1 : 0);
+        }
+
+        public bool IsLooping()
+        {
+            return _player.LoopingFlag;
+        }
+
+        public void SetPlaybackRate(float rate)
+        {
+            if (Valid)
+            {
+                UnitedAVNative.uav_set_rate(H, rate);
+                _player.PlaybackRateValue = rate;
+            }
+        }
+
+        public float GetPlaybackRate()
+        {
+            return _player.PlaybackRateValue;
+        }
+
+        public bool IsPlaying()
+        {
+            return Valid && (UAVState)UnitedAVNative.uav_get_state(H) == UAVState.Playing;
+        }
+
+        public bool IsPaused()
+        {
+            return Valid && (UAVState)UnitedAVNative.uav_get_state(H) == UAVState.Paused;
+        }
+
+        public bool IsFinished()
+        {
+            return Valid && (UAVState)UnitedAVNative.uav_get_state(H) == UAVState.Finished;
+        }
+
+        public bool IsSeeking()
+        {
+            if (!Valid) return false;
+            return _player.IsSeekingInternal;
+        }
+
+        public bool IsBuffering()
+        {
+            return Valid && (UAVState)UnitedAVNative.uav_get_state(H) == UAVState.Buffering;
+        }
+
+        public double GetCurrentTime()
+        {
+            return Valid ? UnitedAVNative.uav_get_position(H) : 0.0;
+        }
+
+        public TimeRanges GetBufferedTimes()
+        {
+            var ranges = new List<TimeRange>();
+            if (Valid)
+            {
+                double pos = UnitedAVNative.uav_get_position(H);
+                if (pos > 0.0)
+                    ranges.Add(new TimeRange(0.0, pos));
+            }
+            return new TimeRanges(ranges);
+        }
+
+        public ErrorCode GetLastError()
+        {
+            if (!Valid)
+                return ErrorCode.None;
+            return MediaPlayer.MapError(UnitedAVNative.uav_last_error(H));
+        }
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaControlImpl.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaControlImpl.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ae3531904767a861a2f5ba2cc98dd2b

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaInfoImpl.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaInfoImpl.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+using UnitedAV.Internal;
+
+namespace UnitedAV
+{
+    internal sealed class MediaInfoImpl : IMediaInfo
+    {
+        private readonly MediaPlayer _player;
+
+        public MediaInfoImpl(MediaPlayer player)
+        {
+            _player = player;
+        }
+
+        private System.IntPtr H => _player.NativeHandle;
+
+        private bool TryGetInfo(out UAVMediaInfo info)
+        {
+            info = default;
+            if (H == System.IntPtr.Zero)
+                return false;
+            return UnitedAVNative.uav_get_info(H, out info) == (int)UAVResult.Ok;
+        }
+
+        public double GetDuration()
+        {
+            if (!TryGetInfo(out var info))
+                return double.PositiveInfinity;
+
+            return info.duration > 0.0 ? info.duration : double.PositiveInfinity;
+        }
+
+        public int GetVideoWidth()
+        {
+            return TryGetInfo(out var info) ? info.width : 0;
+        }
+
+        public int GetVideoHeight()
+        {
+            return TryGetInfo(out var info) ? info.height : 0;
+        }
+
+        public float GetVideoFrameRate()
+        {
+            return TryGetInfo(out var info) ? (float)info.frame_rate : 0f;
+        }
+
+        public bool HasVideo()
+        {
+            return TryGetInfo(out var info) && info.has_video != 0;
+        }
+
+        public bool HasAudio()
+        {
+            return TryGetInfo(out var info) && info.has_audio != 0;
+        }
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaInfoImpl.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaInfoImpl.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d21452a8e4aabe9d8a96c4c54c811820

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Audio.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Audio.cs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Runtime.InteropServices;
+using UnityEngine;
+using UnitedAV.Internal;
+
+namespace UnitedAV
+{
+    public partial class MediaPlayer
+    {
+        private AudioClip _audioClip;
+        private int _audioChannels;
+        private int _audioSampleRate;
+
+        private float[] _audioScratch;
+        private GCHandle _audioScratchHandle;
+        private bool _audioScratchPinned;
+
+        // Snapshot for the audio thread; the main thread may zero _native during teardown.
+        private IntPtr _audioNative = IntPtr.Zero;
+
+        private const int StreamClipLengthSamples = 16384;
+
+        private void SetupAudioIfNeeded()
+        {
+            if (_native == IntPtr.Zero)
+                return;
+            if (_audioClip != null)
+                return;
+
+            UAVMediaInfo info;
+            if (UnitedAVNative.uav_get_info(_native, out info) != (int)UAVResult.Ok)
+                return;
+            if (info.has_audio == 0 || info.audio_channels <= 0)
+                return;
+
+            _audioChannels = info.audio_channels;
+            _audioSampleRate = AudioSettings.outputSampleRate > 0
+                ? AudioSettings.outputSampleRate
+                : (info.audio_sample_rate > 0 ? info.audio_sample_rate : 48000);
+
+            _audioScratch = new float[8192 * _audioChannels];
+            _audioScratchHandle = GCHandle.Alloc(_audioScratch, GCHandleType.Pinned);
+            _audioScratchPinned = true;
+
+            _audioNative = _native;
+
+            _audioClip = AudioClip.Create(
+                name: "UnitedAV_AudioClip",
+                lengthSamples: StreamClipLengthSamples,
+                channels: _audioChannels,
+                frequency: _audioSampleRate,
+                stream: true,
+                pcmreadercallback: PcmReader);
+
+            if (_audioSource == null)
+            {
+                if (!TryGetComponent(out _audioSource))
+                    _audioSource = gameObject.AddComponent<AudioSource>();
+            }
+
+            _audioSource.clip = _audioClip;
+            _audioSource.loop = true;
+            _audioSource.volume = _audioVolume;
+            _audioSource.playOnAwake = false;
+        }
+
+        // Audio-thread callback. Always fills the whole span (zero-pad on underrun)
+        // so the streaming clip never reports "finished".
+        private void PcmReader(float[] data)
+        {
+            IntPtr native = _audioNative;
+            if (native == IntPtr.Zero || !_audioScratchPinned || _audioChannels <= 0)
+            {
+                Array.Clear(data, 0, data.Length);
+                return;
+            }
+
+            int channels = _audioChannels;
+            int framesRequested = data.Length / channels;
+            int framesFilled = 0;
+
+            IntPtr scratchPtr = _audioScratchHandle.AddrOfPinnedObject();
+            int scratchFrames = _audioScratch.Length / channels;
+
+            while (framesFilled < framesRequested)
+            {
+                int chunkFrames = Math.Min(scratchFrames, framesRequested - framesFilled);
+
+                int got = UnitedAVNative.uav_read_audio(
+                    native, scratchPtr, chunkFrames, channels, _audioSampleRate);
+
+                if (got <= 0)
+                    break;
+
+                Array.Copy(_audioScratch, 0, data, framesFilled * channels, got * channels);
+                framesFilled += got;
+
+                if (got < chunkFrames)
+                    break;
+            }
+
+            int filledSamples = framesFilled * channels;
+            if (filledSamples < data.Length)
+                Array.Clear(data, filledSamples, data.Length - filledSamples);
+        }
+
+        private void EnsureAudioPlaying()
+        {
+            if (_audioSource != null && _audioClip != null && !_audioSource.isPlaying)
+                _audioSource.Play();
+        }
+
+        private void EnsureAudioPaused()
+        {
+            if (_audioSource != null && _audioSource.isPlaying)
+                _audioSource.Pause();
+        }
+
+        private void TeardownAudio()
+        {
+            // Stop the audio thread from touching native before destroying anything.
+            _audioNative = IntPtr.Zero;
+
+            if (_audioSource != null)
+            {
+                if (_audioSource.isPlaying)
+                    _audioSource.Stop();
+                if (_audioSource.clip == _audioClip)
+                    _audioSource.clip = null;
+            }
+
+            if (_audioClip != null)
+            {
+                Destroy(_audioClip);
+                _audioClip = null;
+            }
+
+            if (_audioScratchPinned)
+            {
+                _audioScratchHandle.Free();
+                _audioScratchPinned = false;
+            }
+            _audioScratch = null;
+            _audioChannels = 0;
+            _audioSampleRate = 0;
+        }
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Audio.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Audio.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 09d1d02a54a6036228048091f1c35431

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Internal.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Internal.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// The native ABI is set-only for looping/rate, so the last value set is cached here.
+
+namespace UnitedAV
+{
+    public partial class MediaPlayer
+    {
+        internal bool LoopingFlag { get; set; }
+        internal float PlaybackRateValue { get; set; } = 1f;
+
+        internal bool IsSeekingInternal => _wasSeekRequested && _wasSeeking;
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Internal.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Internal.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 731a5b6b84d21e183b3199746e6c6904

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Video.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Video.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// CPU video upload path. Textures are RGBA32 sRGB and require a vertical flip.
+
+using System;
+using UnityEngine;
+using UnitedAV.Internal;
+
+namespace UnitedAV
+{
+    public partial class MediaPlayer
+    {
+        private Texture2D _texture;
+        private int _texWidth;
+        private int _texHeight;
+
+        private long _lastFrameId = -1;
+
+        private void UpdateVideoTexture()
+        {
+            if (!_mediaOpened || _native == IntPtr.Zero)
+                return;
+
+            UAVVideoFrame frame;
+            int rc = UnitedAVNative.uav_acquire_frame(_native, _lastFrameId, out frame);
+
+            if (rc != (int)UAVResult.Ok)
+                return;
+
+            try
+            {
+                if (frame.data == IntPtr.Zero || frame.width <= 0 || frame.height <= 0)
+                    return;
+
+                if (frame.format != (int)UAVPixelFormat.Rgba32)
+                    return;
+
+                EnsureTexture(frame.width, frame.height);
+                if (_texture == null)
+                    return;
+
+                // ABI contract: RGBA32 is tightly packed (stride == width*4).
+                int expected = frame.width * frame.height * 4;
+                _texture.LoadRawTextureData(frame.data, expected);
+                _texture.Apply(false);
+
+                _lastFrameId = frame.frame_id;
+
+                if (!_firstFrameFired)
+                {
+                    _firstFrameFired = true;
+                    FireEvent(MediaPlayerEvent.EventType.FirstFrameReady, ErrorCode.None);
+                }
+            }
+            finally
+            {
+                // Native frame buffer is valid only until release.
+                UnitedAVNative.uav_release_frame(_native);
+            }
+        }
+
+        private void EnsureTexture(int width, int height)
+        {
+            if (_texture != null && _texWidth == width && _texHeight == height)
+                return;
+
+            if (_texture != null)
+            {
+                Destroy(_texture);
+                _texture = null;
+            }
+
+            // linear:false => sRGB texture, matching the sRGB-encoded decoded color.
+            _texture = new Texture2D(width, height, TextureFormat.RGBA32, mipChain: false, linear: false)
+            {
+                name = "UnitedAV_VideoTexture",
+                wrapMode = TextureWrapMode.Clamp,
+                filterMode = FilterMode.Bilinear,
+            };
+
+            _texWidth = width;
+            _texHeight = height;
+
+            _textureProducer?.SetTexture(_texture);
+
+            FireEvent(MediaPlayerEvent.EventType.ResolutionChanged, ErrorCode.None);
+        }
+
+        internal Texture2D CurrentTexture => _texture;
+
+        internal void DestroyTextureInternal()
+        {
+            if (_texture != null)
+            {
+                Destroy(_texture);
+                _texture = null;
+            }
+            _texWidth = 0;
+            _texHeight = 0;
+            _lastFrameId = -1;
+        }
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Video.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.Video.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: adb613b59968233d78319bc504f4eeaa

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.cs
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using UnityEngine;
+using UnitedAV.Internal;
+
+namespace UnitedAV
+{
+    [AddComponentMenu("UnitedAV/Media Player")]
+    public partial class MediaPlayer : MonoBehaviour
+    {
+        private IntPtr _native = IntPtr.Zero;
+
+        private MediaControlImpl _control;
+        private MediaInfoImpl _info;
+        private TextureProducerImpl _textureProducer;
+
+        [SerializeField] private MediaPlayerEvent _events = new MediaPlayerEvent();
+
+        [SerializeField] private bool _autoOpen = false;
+        [SerializeField, Range(0f, 1f)] private float _audioVolume = 1f;
+        [SerializeField] private string _mediaPath = string.Empty;
+        [SerializeField] private MediaPathType _mediaPathType = MediaPathType.AbsolutePathOrURL;
+
+        [SerializeField] private PlatformOptionsWindows _platformOptionsWindows = new PlatformOptionsWindows();
+        [SerializeField] private PlatformOptions_macOS _platformOptions_macOS = new PlatformOptions_macOS();
+
+        [SerializeField] private AudioSource _audioSource;
+
+        private bool _mediaOpened;
+        private UAVState _lastState = UAVState.Idle;
+        private bool _firstFrameFired;
+        private bool _metaDataFired;
+        private bool _startedFired;
+        private bool _wasSeeking;
+        private bool _wasBuffering;
+        private ErrorCode _lastReportedError = ErrorCode.None;
+
+        public IMediaControl Control => _control;
+        public IMediaInfo Info => _info;
+        public ITextureProducer TextureProducer => _textureProducer;
+        public MediaPlayerEvent Events => _events;
+
+        public float AudioVolume
+        {
+            get => _audioVolume;
+            set
+            {
+                _audioVolume = Mathf.Clamp01(value);
+                if (_native != IntPtr.Zero)
+                    UnitedAVNative.uav_set_volume(_native, _audioVolume);
+                if (_audioSource != null)
+                    _audioSource.volume = _audioVolume;
+            }
+        }
+
+        public AudioSource AudioSource
+        {
+            get => _audioSource;
+            set => SetAudioSource(value);
+        }
+
+        public bool AutoOpen
+        {
+            get => _autoOpen;
+            set => _autoOpen = value;
+        }
+
+        public PlatformOptionsWindows PlatformOptionsWindows
+        {
+            get => _platformOptionsWindows;
+            set => _platformOptionsWindows = value;
+        }
+
+        public PlatformOptions_macOS PlatformOptions_macOS
+        {
+            get => _platformOptions_macOS;
+            set => _platformOptions_macOS = value;
+        }
+
+        public bool MediaOpened => _mediaOpened;
+
+        internal IntPtr NativeHandle => _native;
+
+        private void Awake()
+        {
+            EnsureNativeCreated();
+
+            _control = new MediaControlImpl(this);
+            _info = new MediaInfoImpl(this);
+            _textureProducer = new TextureProducerImpl(this);
+
+            if (_audioSource == null)
+                TryGetComponent(out _audioSource);
+        }
+
+        private void Start()
+        {
+            if (_autoOpen && !string.IsNullOrEmpty(_mediaPath))
+                OpenMedia(_mediaPathType, _mediaPath, autoPlay: true);
+        }
+
+        private void Update()
+        {
+            if (_native == IntPtr.Zero)
+                return;
+
+            PollStateAndFireEvents();
+            UpdateVideoTexture();
+        }
+
+        private void OnDestroy()
+        {
+            TeardownAudio();
+            _textureProducer?.Dispose();
+
+            if (_native != IntPtr.Zero)
+            {
+                UnitedAVNative.uav_destroy(_native);
+                _native = IntPtr.Zero;
+            }
+        }
+
+        private void EnsureNativeCreated()
+        {
+            if (_native == IntPtr.Zero)
+            {
+                _native = UnitedAVNative.uav_create();
+                if (_native == IntPtr.Zero)
+                {
+                    Debug.LogError("[UnitedAV] uav_create() returned null; native plugin missing or failed to init.");
+                    return;
+                }
+
+                UnitedAVNative.uav_set_volume(_native, _audioVolume);
+            }
+        }
+
+        public bool OpenMedia(MediaPathType pathType, string path, bool autoPlay)
+        {
+            EnsureNativeCreated();
+            if (_native == IntPtr.Zero || string.IsNullOrEmpty(path))
+                return false;
+
+            if (_mediaOpened)
+                CloseMedia();
+
+            _mediaPathType = pathType;
+            _mediaPath = path;
+
+            string resolved = ResolvePath(pathType, path);
+
+            int rc = UnitedAVNative.uav_open(_native, resolved);
+            if (rc != (int)UAVResult.Ok)
+            {
+                _lastReportedError = MapError(rc);
+                FireEvent(MediaPlayerEvent.EventType.Error, _lastReportedError);
+                return false;
+            }
+
+            _mediaOpened = true;
+            _lastState = UAVState.Idle;
+            _firstFrameFired = false;
+            _metaDataFired = false;
+            _startedFired = false;
+            _wasSeeking = false;
+            _wasBuffering = false;
+            _lastReportedError = ErrorCode.None;
+
+            UnitedAVNative.uav_set_volume(_native, _audioVolume);
+
+            if (autoPlay)
+                UnitedAVNative.uav_play(_native);
+
+            return true;
+        }
+
+        public void Stop()
+        {
+            if (_native != IntPtr.Zero)
+                UnitedAVNative.uav_stop(_native);
+        }
+
+        public void CloseMedia()
+        {
+            if (_native != IntPtr.Zero && _mediaOpened)
+            {
+                FireEvent(MediaPlayerEvent.EventType.Closing, ErrorCode.None);
+                UnitedAVNative.uav_close(_native);
+            }
+
+            _mediaOpened = false;
+            _lastState = UAVState.Idle;
+            _firstFrameFired = false;
+            _metaDataFired = false;
+            _startedFired = false;
+            _lastFrameId = -1;
+
+            TeardownAudio();
+            _textureProducer?.ClearTexture();
+            DestroyTextureInternal();
+        }
+
+        public void SetAudioSource(AudioSource audioSource)
+        {
+            _audioSource = audioSource;
+            if (_audioClip != null && _audioSource != null)
+            {
+                _audioSource.clip = _audioClip;
+                _audioSource.loop = true;
+                _audioSource.volume = _audioVolume;
+                if (!_audioSource.isPlaying)
+                    _audioSource.Play();
+            }
+        }
+
+        private static string ResolvePath(MediaPathType pathType, string path)
+        {
+            switch (pathType)
+            {
+                case MediaPathType.AbsolutePathOrURL:
+                    return path;
+
+                case MediaPathType.RelativeToProjectFolder:
+                    return CombineUnder(GetProjectFolder(), path);
+
+                case MediaPathType.RelativeToStreamingAssetsFolder:
+                    return CombineUnder(Application.streamingAssetsPath, path);
+
+                case MediaPathType.RelativeToDataFolder:
+                    return CombineUnder(Application.dataPath, path);
+
+                case MediaPathType.RelativeToPersistentDataFolder:
+                    return CombineUnder(Application.persistentDataPath, path);
+
+                default:
+                    return path;
+            }
+        }
+
+        private static string GetProjectFolder()
+        {
+            string data = Application.dataPath;
+            try
+            {
+                string parent = System.IO.Path.GetDirectoryName(data);
+                return string.IsNullOrEmpty(parent) ? data : parent;
+            }
+            catch
+            {
+                return data;
+            }
+        }
+
+        private static string CombineUnder(string root, string relative)
+        {
+            if (string.IsNullOrEmpty(root))
+                return relative;
+            return System.IO.Path.Combine(root, relative);
+        }
+
+        internal static ErrorCode MapError(int nativeResult)
+        {
+            switch ((UAVResult)nativeResult)
+            {
+                case UAVResult.Ok:
+                    return ErrorCode.None;
+                case UAVResult.ErrOpenFailed:
+                case UAVResult.ErrNoStream:
+                    return ErrorCode.LoadFailed;
+                case UAVResult.ErrDecode:
+                    return ErrorCode.DecodeFailed;
+                case UAVResult.ErrUnsupported:
+                    return ErrorCode.DecodeFailed;
+                case UAVResult.ErrInvalid:
+                    return ErrorCode.InvalidOperation;
+                case UAVResult.ErrNoMem:
+                    return ErrorCode.LoadFailed;
+                default:
+                    return nativeResult < 0 ? ErrorCode.LoadFailed : ErrorCode.None;
+            }
+        }
+
+        private void FireEvent(MediaPlayerEvent.EventType et, ErrorCode code)
+        {
+            _events?.Invoke(this, et, code);
+        }
+
+        private void PollStateAndFireEvents()
+        {
+            if (!_mediaOpened)
+                return;
+
+            var state = (UAVState)UnitedAVNative.uav_get_state(_native);
+
+            if (!_metaDataFired && state >= UAVState.Ready && state != UAVState.Error)
+            {
+                _metaDataFired = true;
+                FireEvent(MediaPlayerEvent.EventType.MetaDataReady, ErrorCode.None);
+
+                SetupAudioIfNeeded();
+
+                FireEvent(MediaPlayerEvent.EventType.ReadyToPlay, ErrorCode.None);
+            }
+
+            bool seeking = state == UAVState.Buffering && _wasSeekRequested;
+            if (seeking && !_wasSeeking)
+                FireEvent(MediaPlayerEvent.EventType.StartedSeeking, ErrorCode.None);
+            if (!seeking && _wasSeeking)
+            {
+                FireEvent(MediaPlayerEvent.EventType.FinishedSeeking, ErrorCode.None);
+                _wasSeekRequested = false;
+            }
+            _wasSeeking = seeking;
+
+            bool buffering = state == UAVState.Buffering && !_wasSeekRequested;
+            if (buffering && !_wasBuffering)
+            {
+                FireEvent(MediaPlayerEvent.EventType.StartedBuffering, ErrorCode.None);
+                FireEvent(MediaPlayerEvent.EventType.Stalled, ErrorCode.None);
+            }
+            if (!buffering && _wasBuffering)
+            {
+                FireEvent(MediaPlayerEvent.EventType.FinishedBuffering, ErrorCode.None);
+                FireEvent(MediaPlayerEvent.EventType.Unstalled, ErrorCode.None);
+            }
+            _wasBuffering = buffering;
+
+            if (state != _lastState)
+            {
+                switch (state)
+                {
+                    case UAVState.Playing:
+                        if (!_startedFired)
+                        {
+                            FireEvent(MediaPlayerEvent.EventType.Started, ErrorCode.None);
+                            _startedFired = true;
+                        }
+                        if (_lastState == UAVState.Paused)
+                            FireEvent(MediaPlayerEvent.EventType.Unpaused, ErrorCode.None);
+                        EnsureAudioPlaying();
+                        break;
+
+                    case UAVState.Paused:
+                        FireEvent(MediaPlayerEvent.EventType.Paused, ErrorCode.None);
+                        EnsureAudioPaused();
+                        break;
+
+                    case UAVState.Finished:
+                        FireEvent(MediaPlayerEvent.EventType.FinishedPlaying, ErrorCode.None);
+                        EnsureAudioPaused();
+                        break;
+
+                    case UAVState.Error:
+                        _lastReportedError = MapError(UnitedAVNative.uav_last_error(_native));
+                        if (_lastReportedError == ErrorCode.None)
+                            _lastReportedError = ErrorCode.DecodeFailed;
+                        FireEvent(MediaPlayerEvent.EventType.Error, _lastReportedError);
+                        break;
+                }
+
+                _lastState = state;
+            }
+        }
+
+        // Set by Seek() so the poll loop distinguishes seek-buffering from network stalls.
+        private bool _wasSeekRequested;
+        internal void NotifySeekRequested() => _wasSeekRequested = true;
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a724e69d05979ac77982cf7237d436d1

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayerEvent.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayerEvent.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using UnityEngine.Events;
+
+namespace UnitedAV
+{
+    [Serializable]
+    public class MediaPlayerEvent : UnityEvent<MediaPlayer, MediaPlayerEvent.EventType, ErrorCode>
+    {
+        public enum EventType
+        {
+            MetaDataReady,
+            ReadyToPlay,
+            Started,
+            FirstFrameReady,
+            FinishedPlaying,
+            Closing,
+            Error,
+            SubtitleChange,
+            Stalled,
+            Unstalled,
+            ResolutionChanged,
+            StartedSeeking,
+            FinishedSeeking,
+            StartedBuffering,
+            FinishedBuffering,
+            PropertiesChanged,
+            PlaylistItemChanged,
+            PlaylistFinished,
+            TextTracksChanged,
+            TextCueChanged,
+            Paused,
+            Unpaused,
+        }
+
+        // UnityEvent exposes no runtime listener count, so track it ourselves for HasListeners().
+        private int _runtimeListenerCount;
+
+        public new void AddListener(UnityAction<MediaPlayer, EventType, ErrorCode> call)
+        {
+            base.AddListener(call);
+            _runtimeListenerCount++;
+        }
+
+        public new void RemoveListener(UnityAction<MediaPlayer, EventType, ErrorCode> call)
+        {
+            base.RemoveListener(call);
+            if (_runtimeListenerCount > 0)
+                _runtimeListenerCount--;
+        }
+
+        public new void RemoveAllListeners()
+        {
+            base.RemoveAllListeners();
+            _runtimeListenerCount = 0;
+        }
+
+        /// <summary>True if any listener (runtime-added or editor-persistent) is attached.</summary>
+        public bool HasListeners()
+        {
+            return _runtimeListenerCount > 0 || GetPersistentEventCount() > 0;
+        }
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayerEvent.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/MediaPlayerEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c7e815a71e9c01d3fa2c3a9a49c0fe17

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/PlatformOptions.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/PlatformOptions.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using UnitedAV.Windows;
+
+namespace UnitedAV
+{
+    public partial class MediaPlayer
+    {
+        public class PlatformOptions
+        {
+            public enum AudioMode
+            {
+                SystemDirect = 0,
+                Unity = 1,
+                FacebookAudio360 = 2,
+            }
+        }
+    }
+
+    [Serializable]
+    public class PlatformOptionsWindows
+    {
+        public VideoApi videoApi = VideoApi.WinRT;
+        public AudioOutput _audioMode = AudioOutput.System;
+        public bool startWithHighestBitrate = false;
+        public bool useLowLiveLatency = false;
+    }
+
+    [Serializable]
+    public class PlatformOptions_macOS
+    {
+        public MediaPlayer.PlatformOptions.AudioMode audioMode = MediaPlayer.PlatformOptions.AudioMode.SystemDirect;
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/PlatformOptions.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/PlatformOptions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bbe4b378c70cfdc32bbcedb81bdfc528

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Streaming.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Streaming.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 353611c27cd4447ba37f0d76b9d1f8db
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Streaming/MediaSender.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Streaming/MediaSender.cs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+// Managed binding for the upstream sender. cdecl, library "UnitedAV". A sender is
+// not internally synchronized: serialize all calls for a given handle on one thread.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace UnitedAV.Streaming
+{
+    /// <summary>Video encoder selection.</summary>
+    public enum UAVVideoCodec
+    {
+        None = 0,
+        VP9  = 1,
+        VP8  = 2,
+        AV1  = 3,
+    }
+
+    /// <summary>Audio encoder selection.</summary>
+    public enum UAVAudioCodec
+    {
+        None = 0,
+        Opus = 1,
+    }
+
+    /// <summary>Sender result / error codes. 0 == OK.</summary>
+    public enum UAVSendResult
+    {
+        Ok            = 0,
+        ErrInvalid    = -1,
+        ErrOpenFailed = -2,
+        ErrNoStream   = -3,
+        ErrEncode     = -4,
+        ErrUnsupported = -5,
+        ErrNoMem      = -6,
+    }
+
+    /// <summary>Sender configuration; zero-init then fill the fields you need (codec None disables that media).</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct UAVSendConfig
+    {
+        public int video_codec;
+        public int width;
+        public int height;
+        public int fps;
+        public int video_bitrate;
+
+        public int audio_codec;
+        public int sample_rate;
+        public int channels;
+        public int audio_bitrate;
+
+        /// <summary>VP9 video + Opus audio, geometry/fps from the first pushed frame.</summary>
+        public static UAVSendConfig Default()
+        {
+            return new UAVSendConfig
+            {
+                video_codec = (int)UAVVideoCodec.VP9,
+                width = 0,
+                height = 0,
+                fps = 30,
+                video_bitrate = 0,
+                audio_codec = (int)UAVAudioCodec.Opus,
+                sample_rate = 48000,
+                channels = 2,
+                audio_bitrate = 0,
+            };
+        }
+    }
+
+    internal static class UnitedAVSendNative
+    {
+        public const string Lib = "UnitedAV";
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint uav_send_abi_version();
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr uav_send_create();
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void uav_send_destroy(IntPtr s);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi,
+            BestFitMapping = false, ThrowOnUnmappableChar = false)]
+        public static extern int uav_send_open(IntPtr s,
+            [MarshalAs(UnmanagedType.LPStr)] string url, ref UAVSendConfig cfg);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_send_push_video(IntPtr s, IntPtr rgba,
+            int w, int h, int stride, double pts_seconds);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_send_push_audio(IntPtr s, IntPtr interleaved,
+            int frames, int channels, int sample_rate, double pts_seconds);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_send_close(IntPtr s);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int uav_send_last_error(IntPtr s);
+
+        [DllImport(Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int uav_send_get_sdp(IntPtr s, byte[] buf, int buflen);
+    }
+
+    /// <summary>Managed wrapper over the upstream sender; one instance owns one native handle, serialize pushes on a single thread.</summary>
+    public sealed class MediaSender : IDisposable
+    {
+        private IntPtr _native = IntPtr.Zero;
+        private bool _open;
+
+        public static uint AbiVersion => UnitedAVSendNative.uav_send_abi_version();
+
+        public bool IsOpen => _open;
+
+        public MediaSender()
+        {
+            _native = UnitedAVSendNative.uav_send_create();
+            if (_native == IntPtr.Zero)
+                throw new InvalidOperationException(
+                    "[UnitedAV] uav_send_create() returned null; native plugin missing or out of memory.");
+        }
+
+        /// <summary>Open the output URL with the given config; call once before any push.</summary>
+        public UAVSendResult Open(string url, UAVSendConfig config)
+        {
+            if (_native == IntPtr.Zero)
+                return UAVSendResult.ErrInvalid;
+            if (string.IsNullOrEmpty(url))
+                return UAVSendResult.ErrInvalid;
+
+            int rc = UnitedAVSendNative.uav_send_open(_native, url, ref config);
+            _open = rc == (int)UAVSendResult.Ok;
+            return (UAVSendResult)rc;
+        }
+
+        /// <summary>Push one RGBA8888 frame from a managed array (stride bytes/row, monotonic ptsSeconds).</summary>
+        public UAVSendResult PushVideo(byte[] rgba, int w, int h, int stride, double ptsSeconds)
+        {
+            if (rgba == null)
+                return UAVSendResult.ErrInvalid;
+            int needed = (stride > 0 ? stride : w * 4) * h;
+            if (rgba.Length < needed)
+                return UAVSendResult.ErrInvalid;
+
+            GCHandle handle = GCHandle.Alloc(rgba, GCHandleType.Pinned);
+            try
+            {
+                return PushVideo(handle.AddrOfPinnedObject(), w, h, stride, ptsSeconds);
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+        /// <summary>Push one RGBA8888 frame from a native pointer (no managed copy).</summary>
+        public UAVSendResult PushVideo(IntPtr rgba, int w, int h, int stride, double ptsSeconds)
+        {
+            if (_native == IntPtr.Zero || !_open || rgba == IntPtr.Zero)
+                return UAVSendResult.ErrInvalid;
+
+            int rc = UnitedAVSendNative.uav_send_push_video(_native, rgba, w, h, stride, ptsSeconds);
+            return (UAVSendResult)rc;
+        }
+
+        /// <summary>Push interleaved float audio (~[-1,1]) from a managed array; frames is samples-per-channel.</summary>
+        public UAVSendResult PushAudio(float[] interleaved, int frames, int channels, int sampleRate, double ptsSeconds)
+        {
+            if (interleaved == null || frames <= 0 || channels <= 0)
+                return UAVSendResult.ErrInvalid;
+            if (interleaved.Length < frames * channels)
+                return UAVSendResult.ErrInvalid;
+
+            GCHandle handle = GCHandle.Alloc(interleaved, GCHandleType.Pinned);
+            try
+            {
+                return PushAudio(handle.AddrOfPinnedObject(), frames, channels, sampleRate, ptsSeconds);
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+        /// <summary>Push interleaved float audio from a native pointer.</summary>
+        public UAVSendResult PushAudio(IntPtr interleaved, int frames, int channels, int sampleRate, double ptsSeconds)
+        {
+            if (_native == IntPtr.Zero || !_open || interleaved == IntPtr.Zero)
+                return UAVSendResult.ErrInvalid;
+
+            int rc = UnitedAVSendNative.uav_send_push_audio(
+                _native, interleaved, frames, channels, sampleRate, ptsSeconds);
+            return (UAVSendResult)rc;
+        }
+
+        /// <summary>Flush encoders, write the trailer, close the output; the handle can be reopened afterward.</summary>
+        public UAVSendResult Close()
+        {
+            if (_native == IntPtr.Zero)
+                return UAVSendResult.ErrInvalid;
+            int rc = UnitedAVSendNative.uav_send_close(_native);
+            _open = false;
+            return (UAVSendResult)rc;
+        }
+
+        /// <summary>Last error code recorded by an open/push/close on this handle.</summary>
+        public UAVSendResult LastError()
+        {
+            if (_native == IntPtr.Zero)
+                return UAVSendResult.ErrInvalid;
+            return (UAVSendResult)UnitedAVSendNative.uav_send_last_error(_native);
+        }
+
+        /// <summary>SDP for the current RTP session (only meaningful for rtp:// URLs), or null if unavailable.</summary>
+        public string GetSdp()
+        {
+            if (_native == IntPtr.Zero)
+                return null;
+
+            int needed = UnitedAVSendNative.uav_send_get_sdp(_native, null, 0);
+            if (needed <= 0)
+                return null;
+
+            byte[] buf = new byte[needed + 1];
+            int written = UnitedAVSendNative.uav_send_get_sdp(_native, buf, buf.Length);
+            if (written <= 0)
+                return null;
+
+            int len = Math.Min(written, buf.Length);
+            if (len > 0 && buf[len - 1] == 0)
+                len--;
+            return System.Text.Encoding.ASCII.GetString(buf, 0, len);
+        }
+
+        /// <summary>Close (if open) and destroy the native handle; safe to call twice.</summary>
+        public void Dispose()
+        {
+            if (_native != IntPtr.Zero)
+            {
+                if (_open)
+                    UnitedAVSendNative.uav_send_close(_native);
+                _open = false;
+                UnitedAVSendNative.uav_send_destroy(_native);
+                _native = IntPtr.Zero;
+            }
+            GC.SuppressFinalize(this);
+        }
+
+        ~MediaSender()
+        {
+            if (_native != IntPtr.Zero)
+            {
+                UnitedAVSendNative.uav_send_destroy(_native);
+                _native = IntPtr.Zero;
+            }
+        }
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Streaming/MediaSender.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/Streaming/MediaSender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d0a2cdf85414565a2d75d4c4b060ec9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/TextureProducerImpl.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/TextureProducerImpl.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+using UnityEngine;
+
+namespace UnitedAV
+{
+    internal sealed class TextureProducerImpl : ITextureProducer
+    {
+        private readonly MediaPlayer _player;
+        private Texture2D _texture;
+
+        public TextureProducerImpl(MediaPlayer player)
+        {
+            _player = player;
+        }
+
+        public Texture GetTexture()
+        {
+            return _texture;
+        }
+
+        public bool RequiresVerticalFlip()
+        {
+            // CPU path delivers top-down RGBA rows; Unity samples bottom-up.
+            return true;
+        }
+
+        internal void SetTexture(Texture2D texture)
+        {
+            _texture = texture;
+        }
+
+        internal void ClearTexture()
+        {
+            _texture = null;
+        }
+
+        internal void Dispose()
+        {
+            _texture = null;
+            _player?.DestroyTextureInternal();
+        }
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/TextureProducerImpl.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/TextureProducerImpl.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7d53f4fd262d15d11ab0da060b3c9750

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/WebGLMediaSource.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/WebGLMediaSource.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Unity WebGL media source: the browser decodes the video (HTMLVideoElement) and
+// each Tick() uploads the current frame into a Texture2D's underlying GL texture
+// via the jslib. Implements the same IMediaControl/IMediaInfo/ITextureProducer
+// surface as the native player so consumer code is unchanged on WebGL.
+//
+// MediaPlayer can select this backend under `#if UNITY_WEBGL && !UNITY_EDITOR`.
+// The browser handles audio itself (HTMLVideoElement); there is no PCM tap.
+#if UNITY_WEBGL && !UNITY_EDITOR
+using UnityEngine;
+using UnitedAV.Internal;
+
+namespace UnitedAV
+{
+    public sealed class WebGLMediaSource : IMediaControl, IMediaInfo, ITextureProducer
+    {
+        int _h;
+        Texture2D _tex;
+        int _w, _hgt;
+        bool _looping;
+        float _rate = 1f;
+        ErrorCode _err = ErrorCode.None;
+
+        public bool Open(string url)
+        {
+            Close();
+            _h = UnitedAVWebGL.UAV_Web_Create(url);
+            return _h != 0;
+        }
+
+        // Call once per frame (e.g. from MonoBehaviour.Update) to (re)size the
+        // texture once dimensions are known and upload the latest decoded frame.
+        public void Tick()
+        {
+            if (_h == 0) return;
+            int w = UnitedAVWebGL.UAV_Web_GetWidth(_h);
+            int hh = UnitedAVWebGL.UAV_Web_GetHeight(_h);
+            if (w <= 0 || hh <= 0) return;
+            if (_tex == null || _w != w || _hgt != hh)
+            {
+                if (_tex != null) Object.Destroy(_tex);
+                _tex = new Texture2D(w, hh, TextureFormat.RGBA32, false, false);
+                _tex.wrapMode = TextureWrapMode.Clamp;
+                _tex.Apply(false, false);   // realize the GL texture so GetNativeTexturePtr is valid
+                _w = w; _hgt = hh;
+            }
+            if (UnitedAVWebGL.UAV_Web_HasNewFrame(_h) != 0)
+            {
+                int tex = (int)_tex.GetNativeTexturePtr();
+                if (tex != 0)
+                {
+                    // Dispatch on the active graphics backend: WebGPU player builds use
+                    // the GPUTexture copyExternalImageToTexture path; WebGL builds use
+                    // texImage2D. (Design-only: the WebGPU jslib branch has a
+                    // runtime-verify TODO for the GPUTexture-registry name.)
+                    if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.WebGPU)
+                        UnitedAVWebGL.UAV_Web_UploadTextureWGPU(_h, tex);
+                    else
+                        UnitedAVWebGL.UAV_Web_UploadTexture(_h, tex);
+                }
+            }
+        }
+
+        UnitedAVWebGL.State St => _h != 0 ? (UnitedAVWebGL.State)UnitedAVWebGL.UAV_Web_GetState(_h)
+                                          : UnitedAVWebGL.State.Idle;
+
+        // IMediaControl
+        public bool Play()  { if (_h == 0) return false; UnitedAVWebGL.UAV_Web_Play(_h); return true; }
+        public bool Pause() { if (_h == 0) return false; UnitedAVWebGL.UAV_Web_Pause(_h); return true; }
+        public bool Stop()  { if (_h == 0) return false; UnitedAVWebGL.UAV_Web_Pause(_h); UnitedAVWebGL.UAV_Web_Seek(_h, 0); return true; }
+        public bool Seek(double t) { if (_h == 0) return false; UnitedAVWebGL.UAV_Web_Seek(_h, t); return true; }
+        public void SetLooping(bool on) { _looping = on; if (_h != 0) UnitedAVWebGL.UAV_Web_SetLooping(_h, on ? 1 : 0); }
+        public bool IsLooping() => _looping;
+        public void SetPlaybackRate(float r) { _rate = r; }   // HTMLVideoElement.playbackRate could be wired if needed
+        public float GetPlaybackRate() => _rate;
+        public bool IsPlaying()   => St == UnitedAVWebGL.State.Playing;
+        public bool IsPaused()    => St == UnitedAVWebGL.State.Paused;
+        public bool IsFinished()  => St == UnitedAVWebGL.State.Finished;
+        public bool IsSeeking()   => St == UnitedAVWebGL.State.Buffering;
+        public bool IsBuffering() => St == UnitedAVWebGL.State.Opening || St == UnitedAVWebGL.State.Buffering;
+        public double GetCurrentTime() => _h != 0 ? UnitedAVWebGL.UAV_Web_GetPosition(_h) : 0.0;
+        public TimeRanges GetBufferedTimes() => new TimeRanges();
+        public ErrorCode GetLastError() => St == UnitedAVWebGL.State.Error ? ErrorCode.LoadFailed : _err;
+
+        public void SetVolume(float v) { if (_h != 0) UnitedAVWebGL.UAV_Web_SetVolume(_h, v); }
+        public void SetMuted(bool m)   { if (_h != 0) UnitedAVWebGL.UAV_Web_SetMuted(_h, m ? 1 : 0); }
+
+        // IMediaInfo
+        public double GetDuration() { double d = _h != 0 ? UnitedAVWebGL.UAV_Web_GetDuration(_h) : 0.0; return d < 0 ? double.PositiveInfinity : d; }
+        public int GetVideoWidth()  => _w;
+        public int GetVideoHeight() => _hgt;
+        public float GetVideoFrameRate() => 0f;   // not exposed by HTMLVideoElement
+        public bool HasVideo() => _h != 0 && UnitedAVWebGL.UAV_Web_HasVideo(_h) != 0;
+        public bool HasAudio() => false;          // audio plays through the browser, not a PCM tap
+
+        // ITextureProducer
+        public Texture GetTexture() => _tex;
+        public bool RequiresVerticalFlip() => false;   // jslib uploads with UNPACK_FLIP_Y
+
+        public void Close()
+        {
+            if (_h != 0) { UnitedAVWebGL.UAV_Web_Destroy(_h); _h = 0; }
+            if (_tex != null) { Object.Destroy(_tex); _tex = null; }
+            _w = _hgt = 0;
+        }
+    }
+}
+#endif

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/WebGLMediaSource.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/WebGLMediaSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 10380c245a60acd42ae8bcb1b0081ea8

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/WindowsEnums.cs
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/WindowsEnums.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+namespace UnitedAV.Windows
+{
+    public enum VideoApi
+    {
+        WinRT = 0,
+        MediaFoundation = 1,
+        DirectShow = 2,
+    }
+
+    public enum AudioOutput
+    {
+        System = 0,
+        Unity = 1,
+        FacebookAudio360 = 2,
+    }
+}

--- a/Explorer/Packages/org.unitedav/Runtime/UnitedAV/WindowsEnums.cs.meta
+++ b/Explorer/Packages/org.unitedav/Runtime/UnitedAV/WindowsEnums.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 54fae33a28bbf603da841983c086e33f

--- a/Explorer/Packages/org.unitedav/package.json
+++ b/Explorer/Packages/org.unitedav/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "org.unitedav",
+  "version": "0.0.1",
+  "displayName": "UnitedAV",
+  "description": "UnitedAV — an open-source (Apache-2.0) FFmpeg-based audio/video plugin for Unity. A C# API (namespace UnitedAV) wrapping a native libav backend (P/Invoke into the 'UnitedAV' native plugin): CPU + hardware video decode, audio, and an upstream sender (UnitedAV.Streaming).",
+  "unity": "2021.3",
+  "keywords": [
+    "video",
+    "audio",
+    "streaming",
+    "media",
+    "ffmpeg"
+  ],
+  "author": {
+    "name": "UnitedAV"
+  },
+  "license": "Apache-2.0",
+  "samples": [
+    {
+      "displayName": "Basic Playback",
+      "description": "A minimal MonoBehaviour that opens a URL and shows the video on a material.",
+      "path": "Samples~/BasicPlayback"
+    },
+    {
+      "displayName": "End To End",
+      "description": "A scene that displays a MediaPlayer onto a RawImage and runs a headless self-test battery (open/play/pause/seek/loop/volume/mute/events/texture/HW-backend). The standalone Player writes a JSON report and sets its exit code, so it self-tests when launched.",
+      "path": "Samples~/EndToEnd"
+    },
+    {
+      "displayName": "Showcase (video gallery)",
+      "description": "A ring of screens, each playing a different video stream through its own MediaPlayer, with a camera orbiting around them. Procedurally built; supports headless frame capture for a recorded fly-through (UAV_SHOWCASE_CAPTURE).",
+      "path": "Samples~/Showcase"
+    }
+  ]
+}

--- a/Explorer/Packages/org.unitedav/package.json.meta
+++ b/Explorer/Packages/org.unitedav/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c574b95b3f4532484a7b22b4700116cc
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -186,13 +186,6 @@
       "dependencies": {},
       "hash": "00cbf100acd16a024c6fb1acd2ba9a439dfa358b"
     },
-    "com.renderheads.avpro.video-ultra": {
-      "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/AVProVideo",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {},
-      "hash": "f79125eff7607f6d0e2665cb31eb313779908d55"
-    },
     "com.unity.2d.sprite": {
       "version": "1.0.0",
       "depth": 0,
@@ -557,6 +550,12 @@
         "com.unity.nuget.newtonsoft-json": "3.2.1"
       },
       "hash": "5f385df93c2d1e4a9aed3dd0aad62c247c684a4b"
+    },
+    "org.unitedav": {
+      "version": "file:org.unitedav",
+      "depth": 0,
+      "source": "embedded",
+      "dependencies": {}
     },
     "superscrollview": {
       "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/SuperScrollView",


### PR DESCRIPTION
Replace the commercial AVPro Video Ultra plugin with the open-source UnitedAV plugin (Apache-2.0, eordano/unitedav), vendored as an embedded UPM package.

- Add embedded package Packages/org.unitedav: UnitedAV.Runtime asmdef + the Windows x64 native UnitedAV.dll (cross-built against LGPL FFmpeg, dynamically linked). Bundles the FFmpeg av*/sw* runtime DLLs + mingw thread runtime, with Windows-x64-only PluginImporter metas.
- manifest.json: drop com.renderheads.avpro.video-ultra git dep; add org.unitedav (file:org.unitedav).
- Swap namespace RenderHeads.Media.AVProVideo -> UnitedAV across the 10 MediaStream consumer files; fully-qualify UnitedAV.Windows.* enums in MediaPlayerCustomPool (Windows is a namespace in UnitedAV, not a type).
- DCL.Plugins.asmdef: versionDefine com.renderheads.avpro.video-ultra ->
  org.unitedav (keep define AV_PRO_PRESENT) + reference UnitedAV.Runtime.
- ECS.Unity.asmdef: reference UnitedAV.Runtime (AVPro was an auto-referenced precompiled DLL; UnitedAV ships as a source asmdef -> needs explicit refs).
