### PR TITLE
chore: enable shared UBA cache for release/hotfix/main builds

### DIFF
--- a/.github/workflows/build-release-main.yml
+++ b/.github/workflows/build-release-main.yml
@@ -31,7 +31,10 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "> ⚠️ If some artefacts are missing please take a look at previous attempts" >> $GITHUB_STEP_SUMMARY
 
-  # Run a clean build (no cache)
+  # Enable cache reuse for release builds: cache_strategy=library turns on the remote
+  # library/shader cache and clean_build=false lets the build consume it. The shared,
+  # dev-isolated release/hotfix/main cache pool (cold genesis) is wired in build.py's
+  # clone_current_target.
   build:
     name: Build Unity Cloud
     needs: get-info
@@ -41,8 +44,8 @@ jobs:
     uses: ./.github/workflows/build-unitycloud.yml
     with:
       profile: none
-      clean_build: true
-      cache_strategy: none
+      clean_build: false
+      cache_strategy: library
       version: ${{ needs.get-info.outputs.version }}
       sentry_enabled: true
       is_release_build: true

--- a/docs/build-and-ci.md
+++ b/docs/build-and-ci.md
@@ -6,13 +6,13 @@ The Unity project is built automatically on certain triggers by a combination of
 
 There are two main workflows that handle all major builds:
 - `build-unitycloud`
-- `build-release-weekly`
+- `build-release-main`
 
-The main workflow is `build-unitycloud`, which will be automatically triggered by commits and PRs to `main`, or by a manual workflow dispatch call.
+The main workflow is `build-unitycloud`, which is automatically triggered by pushes to `dev`, by pull requests, by the merge queue, or by a manual workflow dispatch call.
 By default, PRs marked as draft will not trigger the build. If this is something you want, you need to add a label `force-build` to this PR.
 
-The `build-release-weekly` workflow mostly wraps & handles `build-unitycloud` for release, and currently it's triggered manually with a workflow dispatch call.
-The release build would create a new target based on the version, which means that this does not block `main` branch and merging to main can continue.
+The `build-release-main` workflow wraps `build-unitycloud` for releases; it is triggered by pushes to `main` and by manual workflow dispatch.
+Release, hotfix, and `main` builds share a single stable cache target per platform — the *release pool* — instead of a per-version target, so the cache is reused across releases without blocking `main`. See [Cache](#cache).
 
 ## GitHub Workflow
 
@@ -35,7 +35,7 @@ These are all currently set by the workflow:
 - `TARGET`: Template build config to use for builds
 - `BRANCH_NAME`: Name of the branch that triggered this build
 - `CLEAN_BUILD`: Triggers a clean build that forces a reimport of library folder, and not using any caching
-- `CACHE_STRATEGY`: Defines what strategy we want to use for caching (available options: `none`, `library`, `workspace`, `inherit`). This affects the speed of next build. By default it's set to `workspace`
+- `CACHE_STRATEGY`: Sets the target's `remoteCacheStrategy` — whether a target reuses **its own** cache between builds (options: `none`, `library`, `workspace`, `inherit`). The `build-unitycloud` workflow defaults it to `library`; release builds use `library`. See [Cache](#cache)
 - `COMMIT_SHA`: The SHA value of the commit that this build is triggered on
 - `BUILD_OPTIONS`: Any Unity BuildOptions to define for the build
 - `PARAM_<NAME>`: Any ENV variables starting with `PARAM_` will be passed to Unity without the prefix to be used with `Editor.CloudBuild.Parameters[]`
@@ -67,8 +67,9 @@ The Unity Cloud Build (Unity Cloud DevOps) is the environment where builds execu
 
 Only one build config can run at the same time. Therefore a "template" config build (named `@T_<TARGET_NAME>`) must be created for each target.
 
-Each build currently clones this template and renames it using the format `TARGET_NAME-BRANCH`.
-If a build is already triggered for the same target and a new commit is applied, it will cancel the previous build automatically.
+Each build clones this template and renames it based on the branch (see [Cache](#cache) for the full naming scheme). If a build is already running for the same target and a new commit is applied, the previous build is cancelled automatically.
+
+Because `main`, `release/*`, and `hotfix/*` builds all share one *release pool* target per platform, builds on those branches serialize against each other — a new one cancels a pending one on the same target. This is fine for the sequential release/hotfix cadence, but two of them running at once on the same platform will contend.
 
 ### Storage
 
@@ -76,8 +77,59 @@ All build artefacts are stored in the GitHub workflow run after the build is fin
 
 ### Cache
 
-Cache usage and level can be controlled by the template config build or by the `CACHE_STRATEGY` param.
-To update the cache or change settings of the template, the template itself must be run manually in the Unity Cloud Build UI.
+Caching is what keeps build times down: the bulk of a cold build is shader-variant compilation (historically ~55 min of an ~82 min release build). Two **independent** Unity Cloud mechanisms control it — don't confuse them:
+
+| Mechanism | Scope | What it does |
+|---|---|---|
+| `remoteCacheStrategy` (set via `CACHE_STRATEGY`) | one target, across its own builds | Whether a target keeps and reuses **its own** Library/shader cache between consecutive builds. Options: `none`, `library`, `workspace`, `inherit`. |
+| `buildTargetCopyCache` | one-time copy **from another target** | The **only** way cache crosses targets: a one-shot copy of a source target's cache into a target when it is created/updated. Not a live mirror — after the copy the two targets diverge. |
+
+**There is no implicit cross-target sharing.** Targets do not share cache because they have the same Unity version, the same platform, or belong to the same Unity Cloud **build-target group** (groups are organizational only — they carry no cache semantics). The single cross-target channel is the explicit `buildTargetCopyCache` copy in `build.py`.
+
+#### Target naming *is* cache identity
+
+Cache lives per target, so the target a build uses determines the cache it uses. `clone_current_target` derives the name from the branch:
+
+| Branch | Target name | Cache source |
+|---|---|---|
+| `dev` | `{platform}-dev` (e.g. `windows64-dev`) | its own |
+| feature / PR | `{platform}-{sanitized-branch}` | seeded once from `{platform}-dev` |
+| `main`, `release/*`, `hotfix/*` | `{platform}-release[-{install_source}]` — the **shared release pool** | its own, shared across all release/hotfix/main builds |
+
+`{install_source}` is appended only when it is not `launcher` (e.g. `-epic`), so each distinct artifact gets its own pool: `windows64-release`, `windows64-release-epic`, `macos-release`, …
+
+#### The shared release pool
+
+`main`, `release/*`, and `hotfix/*` builds all resolve to **one stable target per platform + install source**, so the Library + shader cache is **maintained and reused across releases** instead of compiled cold every time. Properties:
+
+- **Keyed on the branch, not on `IS_RELEASE_BUILD`.** Release builds run with that flag unset, so the branch name is the reliable discriminator. dev and feature branches are deliberately *not* in the pool.
+- **Cold genesis, isolated from dev.** The pool target is created with **no** `buildTargetCopyCache`, so it never copies dev's cache. Its first build is cold (and populates the cache); every later release reuses the pool's own cache. dev/feature targets keep their own caches and never reference the pool — isolation is bidirectional.
+- **Protected from deletion.** `pr-closure.yml` runs `build.py --delete` on every closed PR; `delete_current_target` refuses to delete the pool targets so the cross-release cache is never wiped.
+
+Turned on from `build-release-main.yml` via `cache_strategy: library` + `clean_build: false`.
+
+#### Where `buildTargetCopyCache` is applied
+
+`generate_body` strips it from every request body first; `clone_current_target` then re-adds it in only two cases — and only one of those copies from a *different* target:
+
+| Situation | `buildTargetCopyCache` |
+|---|---|
+| New target, release pool (cold genesis) | *not set* — no copy |
+| New target, dev / feature | `{platform}-dev` — **copy from dev** (the only cross-target copy) |
+| Existing target (any branch) | the target **itself** — a self-reference ("reuse my own"), not a cross-target pull |
+
+So the one line that copies *from another target* is the dev seed for a fresh dev/feature target; the release pool never reaches it.
+
+#### Confirming cache behavior from CI
+
+Two signals per build, no extra tooling:
+
+- **Which pool a build used** — `build.py` logs `Updated name for target: <target>` in the *Execute Unity Cloud build* step. The same target name across branches means the same cache.
+- **Whether cache was actually reused** — the *Generate Shader Compilation Report* step (and its uploaded artifact) prints `Remote Cache Hits: N` and `Total Variants Compiled: N`. Non-zero hits with ~0 variants compiled = warm; `0` hits with many variants = cold.
+
+A new pool target whose **first** build shows `Remote Cache Hits: 0` and whose **next** build shows non-zero hits is simultaneously the proof of reuse and the proof of isolation (it can only reuse what it built itself).
+
+To change the template defaults, run the template config (`@T_<TARGET_NAME>`) manually in the Unity Cloud Build UI.
 
 ### Rebuilding
 

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -117,17 +117,10 @@ def clone_current_target(use_cache):
     # Append the install source to the target name only if it's not 'launcher'
     install_suffix = f"-{install_source}" if install_source and install_source != 'launcher' else ''
 
-    # The shared release cache pool is keyed on the BRANCH, not IS_RELEASE_BUILD: release builds
-    # run with IS_RELEASE_BUILD unset and carry the branch in the target name (e.g.
-    # 'release/2026-06-29'), so the release flag can't identify them. release/*, hotfix/* and main
-    # all share the pool; dev and feature branches do not.
+    # Release/hotfix/main share a single stable pool target; all other branches use branch-derived names.
     is_release_pool = branch_name == 'main' or branch_name.startswith(('release/', 'hotfix/'))
 
     if is_release_pool:
-        # Release/hotfix branches and main share ONE stable cache target per (platform, install
-        # source), independent of the specific branch/date, so the Library + shader cache is
-        # maintained and reused across releases. dev and feature branches use the branch-derived
-        # name below and never reference this target, keeping the release cache isolated from them.
         new_target_name = f"{platform}-release{install_suffix}".lower()
     else:
         # Branch-derived target (one cache per branch), without commit SHA.
@@ -156,7 +149,7 @@ def clone_current_target(use_cache):
             # release cache lineage stays fully isolated from dev/feature branches. The first
             # release compiles cold but populates the library cache; later releases reuse it via
             # the existing-target branch below (buildTargetCopyCache = the pool target itself).
-            print(f"Release pool: cold genesis, not seeding cache from another target")
+            print("Release pool: cold genesis, not seeding cache from another target")
         elif use_cache:
             cache_source = resolve_cache_source(template_target)
             body['settings']['buildTargetCopyCache'] = cache_source

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -109,26 +109,30 @@ def clone_current_target(use_cache):
         
         return body
 
-    # Set target name based on branch, without commit SHA
-    base_target_name  = f'{re.sub(r'^t_', '', os.getenv('TARGET'))}-{re.sub('[^A-Za-z0-9]+', '-', os.getenv('BRANCH_NAME'))}'.lower()
+    platform = re.sub(r'^t_', '', os.getenv('TARGET')).lower()
+    branch_name = os.getenv('BRANCH_NAME', '')
 
     # Get the install source from the environment variable
     install_source = os.getenv('PARAM_INSTALL_SOURCE', 'launcher')
+    # Append the install source to the target name only if it's not 'launcher'
+    install_suffix = f"-{install_source}" if install_source and install_source != 'launcher' else ''
 
-    # Include install_source in the target name only if it's not 'launcher'
-    if install_source and install_source != 'launcher':
-        base_target_name = f"{base_target_name}-{install_source}"
+    # The shared release cache pool is keyed on the BRANCH, not IS_RELEASE_BUILD: release builds
+    # run with IS_RELEASE_BUILD unset and carry the branch in the target name (e.g.
+    # 'release/2026-06-29'), so the release flag can't identify them. release/*, hotfix/* and main
+    # all share the pool; dev and feature branches do not.
+    is_release_pool = branch_name == 'main' or branch_name.startswith(('release/', 'hotfix/'))
 
-    print(f"Start clone_current_target for {base_target_name}")
-
-    if is_release_workflow:
-         # Use the tag version in the target name if it's a release workflow
-        tag_version = os.getenv('TAG_VERSION', 'unknown-version')
-        # Remove dots from the tag version, as unity API does not allow . in the request
-        sanitized_tag_version = re.sub(r'\.', '-', tag_version)
-        new_target_name = f"{base_target_name}-{sanitized_tag_version}"
+    if is_release_pool:
+        # Release/hotfix branches and main share ONE stable cache target per (platform, install
+        # source), independent of the specific branch/date, so the Library + shader cache is
+        # maintained and reused across releases. dev and feature branches use the branch-derived
+        # name below and never reference this target, keeping the release cache isolated from them.
+        new_target_name = f"{platform}-release{install_suffix}".lower()
     else:
-        new_target_name = base_target_name
+        # Branch-derived target (one cache per branch), without commit SHA.
+        sanitized_branch = re.sub('[^A-Za-z0-9]+', '-', branch_name)
+        new_target_name = f"{platform}-{sanitized_branch}{install_suffix}".lower()
 
     print(f"Updated name for target: {new_target_name}")
 
@@ -147,7 +151,13 @@ def clone_current_target(use_cache):
     if 'error' in existing_target:
         print(f"New target found")
         # Create new target with template cache
-        if use_cache:
+        if is_release_pool:
+            # Cold genesis for the shared release/main pool: never seed from another target so the
+            # release cache lineage stays fully isolated from dev/feature branches. The first
+            # release compiles cold but populates the library cache; later releases reuse it via
+            # the existing-target branch below (buildTargetCopyCache = the pool target itself).
+            print(f"Release pool: cold genesis, not seeding cache from another target")
+        elif use_cache:
             cache_source = resolve_cache_source(template_target)
             body['settings']['buildTargetCopyCache'] = cache_source
             print(f"Using cache from: {cache_source}")
@@ -494,9 +504,17 @@ def delete_current_target():
     # List of targets to delete
     targets = ['macos', 'windows64']
     
+    # Shared release/main cache pool targets. pr-closure calls this on every PR close, so it must
+    # never delete these — doing so would wipe the cross-release cache. Kept in sync with the pool
+    # naming in clone_current_target ({platform}-release[-{install_source}]).
+    protected = {f'{t}-release' for t in targets} | {f'{t}-release-epic' for t in targets}
+
     # Loop through each target
     for target in targets:
         base_target_name = f'{target}-{re.sub("[^A-Za-z0-9]+", "-", os.getenv("BRANCH_NAME"))}'.lower()
+        if base_target_name in protected:
+            print(f'Refusing to delete shared release cache target: "{base_target_name}"')
+            continue
         response = requests.delete(f'{URL}/buildtargets/{base_target_name}', headers=HEADERS)
         
         if response.status_code == 204:

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -16,6 +16,10 @@ import utils
 
 RETRYABLE_EXIT_CODE = 99  # nick-fields/retry only retries on this code
 
+# All install sources used in build-release-main.yml's matrix. Used to build the set of
+# protected release-pool target names in delete_current_target.
+_RELEASE_INSTALL_SOURCES = ['launcher', 'epic']
+
 from zipfile import ZipFile, ZipInfo
 
 class ZipFileWithPermissions(zipfile.ZipFile):
@@ -497,10 +501,11 @@ def delete_current_target():
     # List of targets to delete
     targets = ['macos', 'windows64']
     
-    # Shared release/main cache pool targets. pr-closure calls this on every PR close, so it must
-    # never delete these — doing so would wipe the cross-release cache. Kept in sync with the pool
-    # naming in clone_current_target ({platform}-release[-{install_source}]).
-    protected = {f'{t}-release' for t in targets} | {f'{t}-release-epic' for t in targets}
+    protected = set()
+    for t in targets:
+        for src in _RELEASE_INSTALL_SOURCES:
+            suffix = f'-{src}' if src != 'launcher' else ''
+            protected.add(f'{t}-release{suffix}')
 
     # Loop through each target
     for target in targets:


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Enables remote build-cache reuse for Unity Build Automation (UBA) release builds, so shader-variant compilation is no longer recompiled from scratch on every release.

### Current scheme (before this PR)

- Releases are cut as separate branches (`release/YYYY-MM-DD`, `hotfix/*`). `scripts/cloudbuild/build.py` derives the UBA build-target name from the branch, so **every release branch gets its own target** (e.g. `macos-release-2026-06-29`) — nothing is reused release-to-release.
- The release caller `build-release-main.yml` passed `cache_strategy: none` + `clean_build: true`, so the remote library/shader cache was off and the build ran clean regardless.
- Net: release builds were **fully cold**. ~55 min of an ~82 min build was shader-variant compilation logging `remote cache hits 0`, recompiled from scratch each release.

### Goal

One cache pool that is:
- **Maintained across releases** (release → release reuse).
- **Shared by `release/*`, `hotfix/*`, and `main` only.**
- **Isolated from `dev` and feature branches**, bidirectionally — `dev` must not pull the release cache, and the release pool must not seed from `dev`.

### How it was implemented

**`.github/workflows/build-release-main.yml`**
- `cache_strategy: none → library` (turn on the remote library/shader cache).
- `clean_build: true → false` (let the build actually consume it).

**`scripts/cloudbuild/build.py`**
- **Branch-gated pool** in `clone_current_target`: membership is keyed on the **branch name** — `branch == 'main' or branch.startswith(('release/', 'hotfix/'))` — *not* on `IS_RELEASE_BUILD`. Pool builds use a **stable** target name `{platform}-release[-{install_source}]`, dropping the branch and tag-version suffix, so all release/hotfix/main builds share one cache target per platform + install source. `dev`/feature branches keep their branch-derived names and `*-dev` seed and never reference the pool target.
- **Cold genesis**: the pool target is created with **no** `buildTargetCopyCache` seed, so it never ingests `dev` cache. The first build is cold but populates the library cache; release #2+ reuse the pool's own cache (self-referential).
- **Delete guard** in `delete_current_target`: refuses to delete the pool targets, so the `pull_request: closed` cleanup can't wipe the cross-release cache.

### Why gate on the branch and not `IS_RELEASE_BUILD`

An existing release target (`macos-release-2026-06-29`, SCM branch `release/2026-06-29`) had **no version suffix** in its name → it was produced by the non-release-flag naming path, which means `IS_RELEASE_BUILD` does not reliably identify release builds. The branch name is the dependable discriminator. (The env-var values shown in the UBA target UI are unreliable and were not used as evidence.)

### Tradeoff

A single shared pool serializes builds per target, so concurrent `release/*` / `hotfix/*` / `main` builds on the same platform + install source contend (UBA cancels the pending one). Acceptable for the sequential release/hotfix cadence.

## Test Instructions

This is a CI / build-infra change with **no in-client behavior**, so the standard `metaforge explorer run` flow does not apply. Verification is done by reading the Unity Cloud build logs.

### Prerequisites
- [ ] Ability to trigger a release/hotfix build (push to `main` or a `release/*` / `hotfix/*` branch).

### Test Steps
1. **First release build after merge** — expect it **cold by design**: `build.py` logs `Release pool: cold genesis, not seeding cache from another target`; the target is named `{platform}-release`; shader passes log `remote cache hits 0`.
2. **Second release/hotfix build** — expect it **warm**: `build.py` logs `Using existing cache build target: {platform}-release`; shader passes log **non-zero** `remote cache hits` with `compiled 0 variants`; total wall time drops well below the ~82 min / ~55 min-shader baseline.
3. Confirm a `dev` or feature-branch build still uses its own branch-derived target seeded from `*-dev` and is unaffected.

### Additional Testing Notes
- Unity 6 has had shader-cache-reuse bugs — treat the non-zero `remote cache hits` check in step 2 as mandatory, not assumed.
- The benefit only appears from the **second** qualifying build onward; the first is cold.

## Quality Checklist
- [ ] Changes have been tested locally — `python -m py_compile scripts/cloudbuild/build.py` passes; full runtime behavior is only verifiable on real UBA builds (see Test Instructions).
- [x] Documentation has been updated — `docs/build-and-ci.md` now documents the UBA cache model, the release pool, and how to confirm cache behavior from CI.
- [x] Performance impact has been considered — this PR is the performance change (targets the ~55 min cold shader segment).
- [ ] For SDK features: Test scene is included — N/A (not an SDK feature).
