### PR TITLE
fix: suppress invalid email exception logging

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/IdentityVerificationOTPAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/IdentityVerificationOTPAuthState.cs
@@ -75,7 +75,7 @@ namespace DCL.AuthenticationScreenFlow
                     Exception ex => new SpanErrorInfo("Unexpected error during authentication flow", ex),
                 };
 
-                if (loginException is not OperationCanceledException)
+                if (loginException is not OperationCanceledException && loginException is not InvalidEmailException)
                     ReportHub.LogException(loginException, new ReportData(ReportCategory.AUTHENTICATION));
             }
 
@@ -100,7 +100,7 @@ namespace DCL.AuthenticationScreenFlow
 
                 // awaits OTP code being entered
                 IWeb3Identity identity = await compositeWeb3Provider.LoginAsync(LoginPayload.ForOtpFlow(email), ct);
-                machine.Enter<ProfileFetchingAuthState, ProfileFetchingPayload>(new (email, identity, false, ct));
+                machine.Enter<ProfileFetchingAuthState, ProfileFetchingPayload>(new ProfileFetchingPayload(email, identity, false, ct));
             }
             catch (OperationCanceledException e)
             {


### PR DESCRIPTION
# Pull Request Description
Fixes #8360

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes sure that during OTP login flow `InvalidEmailException` is not logged (doesn't get to Sentry) as it's related to user input.


### Test Steps
1. Login with an email
2. write an invalid email on purpose (e.g. `skdfgjhn@sdfgkjn.dehfrgkjn`)
3. Verify that the UI correctly displays the invalid email message
4. Verify there's no `InvalidEmailException` in the logs
5. OTP login should operate as normal


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
