### PR TITLE
fix: back off when a social-service subscription stream completes (stop re-subscribe flood)

### DIFF
--- a/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
+++ b/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
@@ -22,6 +22,18 @@ namespace DCL.SocialService
         /// </summary>
         private const int BASE_RETRY_DELAY_SECONDS = 2;
 
+        /// <summary>
+        ///     Maximum delay in seconds between retry attempts (caps the exponential backoff so it
+        ///     cannot grow without bound).
+        /// </summary>
+        private const int MAX_RETRY_DELAY_SECONDS = 60;
+
+        /// <summary>
+        ///     A stream that stayed open at least this long is treated as a genuine, established
+        ///     subscription rather than an immediate server-side rejection, so its backoff is reset.
+        /// </summary>
+        private const int STABLE_STREAM_SECONDS = 30;
+
         public class ServerStreamReportsDebouncer : FrameDebouncer
         {
             public ServerStreamReportsDebouncer() : base(1)
@@ -67,7 +79,22 @@ namespace DCL.SocialService
                 {
                     // It's an endless [background] loop
                     await socialServiceRPC.EnsureRpcConnectionAsync(int.MaxValue, ct);
+
+                    DateTime streamOpenedAt = DateTime.UtcNow;
                     await openStreamFunc().AttachExternalCancellation(ct);
+
+                    // Reaching this point means the stream completed WITHOUT throwing. For a
+                    // long-lived subscription that is not normal: the social service completes the
+                    // stream immediately when the subscription is a duplicate for this connection,
+                    // so re-opening with no delay hot-loops and hammers the server with
+                    // re-subscribes (the "Duplicate subscription detected" flood). Back off here
+                    // just like the error paths. If the stream actually stayed open for a meaningful
+                    // time, reset the backoff so a genuine reconnect is still prompt.
+                    if (DateTime.UtcNow - streamOpenedAt >= TimeSpan.FromSeconds(STABLE_STREAM_SECONDS))
+                        retryAttempt = 0;
+
+                    retryAttempt++;
+                    await WaitNextRetryAsync(retryAttempt, ct);
                 }
                 catch (OperationCanceledException) { break; }
                 catch (WebSocketException e)
@@ -98,6 +125,8 @@ namespace DCL.SocialService
                 }
                 catch (Exception e)
                 {
+                    retryAttempt++;
+
                     ReportHub.LogException(e, new ReportData(reportCategory, new ReportDebounce(serverStreamReportsDebouncer)));
 
                     try { await WaitNextRetryAsync(retryAttempt, ct); }
@@ -108,8 +137,9 @@ namespace DCL.SocialService
 
         private async UniTask WaitNextRetryAsync(int retryAttempt, CancellationToken ct)
         {
-            // Calculate exponential backoff delay
-            int delaySeconds = BASE_RETRY_DELAY_SECONDS * (int)Math.Pow(2, retryAttempt - 1);
+            // Exponential backoff, capped so it cannot grow without bound (computed in double to
+            // avoid int overflow once retryAttempt gets large).
+            int delaySeconds = (int)Math.Min(BASE_RETRY_DELAY_SECONDS * Math.Pow(2, retryAttempt - 1), MAX_RETRY_DELAY_SECONDS);
             ReportHub.Log(reportCategory, $"Retrying connection in {delaySeconds} seconds...");
 
             await UniTask.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken: ct);

--- a/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
+++ b/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
@@ -22,16 +22,9 @@ namespace DCL.SocialService
         /// </summary>
         private const int BASE_RETRY_DELAY_SECONDS = 2;
 
-        /// <summary>
-        ///     Maximum delay in seconds between retry attempts (caps the exponential backoff so it
-        ///     cannot grow without bound).
-        /// </summary>
         private const int MAX_RETRY_DELAY_SECONDS = 60;
 
-        /// <summary>
-        ///     A stream that stayed open at least this long is treated as a genuine, established
-        ///     subscription rather than an immediate server-side rejection, so its backoff is reset.
-        /// </summary>
+        // A stream open shorter than this was likely an instant server-side rejection (e.g. duplicate)
         private const int STABLE_STREAM_SECONDS = 30;
 
         public class ServerStreamReportsDebouncer : FrameDebouncer
@@ -83,13 +76,8 @@ namespace DCL.SocialService
                     DateTime streamOpenedAt = DateTime.UtcNow;
                     await openStreamFunc().AttachExternalCancellation(ct);
 
-                    // Reaching this point means the stream completed WITHOUT throwing. For a
-                    // long-lived subscription that is not normal: the social service completes the
-                    // stream immediately when the subscription is a duplicate for this connection,
-                    // so re-opening with no delay hot-loops and hammers the server with
-                    // re-subscribes (the "Duplicate subscription detected" flood). Back off here
-                    // just like the error paths. If the stream actually stayed open for a meaningful
-                    // time, reset the backoff so a genuine reconnect is still prompt.
+                    // A stream that completed instantly was likely rejected as a duplicate — back off.
+                    // If it stayed open long enough to be genuine, reset the backoff counter.
                     if (DateTime.UtcNow - streamOpenedAt >= TimeSpan.FromSeconds(STABLE_STREAM_SECONDS))
                         retryAttempt = 0;
 

--- a/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
+++ b/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
@@ -79,7 +79,6 @@ namespace DCL.SocialService
                     await openStreamFunc().AttachExternalCancellation(ct);
 
                     // A stream that completed instantly was likely rejected as a duplicate — back off.
-                    // If it stayed open long enough to be genuine, reset the backoff counter.
                     if (DateTime.UtcNow - streamOpenedAt >= TimeSpan.FromSeconds(STABLE_STREAM_SECONDS))
                         retryAttempt = 0;
 
@@ -127,8 +126,7 @@ namespace DCL.SocialService
 
         private async UniTask WaitNextRetryAsync(int retryAttempt, CancellationToken ct)
         {
-            // Exponential backoff, capped so it cannot grow without bound (computed in double to
-            // avoid int overflow once retryAttempt gets large).
+            // Exponential backoff capped at MAX_RETRY_DELAY_SECONDS; computed in double to avoid int overflow.
             int delaySeconds = (int)Math.Min(BASE_RETRY_DELAY_SECONDS * Math.Pow(2, retryAttempt - 1), MAX_RETRY_DELAY_SECONDS);
             ReportHub.Log(reportCategory, $"Retrying connection in {delaySeconds} seconds...");
 


### PR DESCRIPTION
## Problem

The social service was being flooded with `[DEBUG] (update-handler): Duplicate subscription detected, ignoring` for `communityMemberConnectivityUpdate` — **hundreds per minute from a single `wsConnectionId`**. The server's per-connection dedup guard is working correctly; the flood is a **client-side re-subscribe loop**.

## Root cause

`RPCSocialServiceBase.KeepServerStreamOpenAsync` only backs off on **exceptions**. When `openStreamFunc()` returns **normally**, the loop falls straight through and re-opens the stream **with zero delay**:

```csharp
await openStreamFunc().AttachExternalCancellation(ct);   // returns normally when the server completes the stream
// no catch hit → loop again immediately, no delay
```

The social service **completes a subscription stream immediately** when the subscribe is a *duplicate* for that connection (its per-connection dedup `return`s an empty, completed stream). So once a connection has a duplicate subscription — e.g. a second concurrent subscribe loop started by `OnTransportConnected` + `OnTransportReconnected`, the first of which holds the real subscription — the second loop hot-loops: open → server completes instantly → re-open → … as fast as the RPC round-trip allows. That is the flood.

## This affects ALL subscriptions, not just communities

The bug is in the **shared base method**, so every subscription that goes through `KeepServerStreamOpenAsync` has the same flaw — this fix protects all of them at once:

| Subscription | Service | Trigger pattern | Risk |
|---|---|---|---|
| `communityMemberConnectivityUpdate` | `RPCCommunitiesService` | self-wired `OnTransportConnected` + `OnTransportReconnected` + uncancellable `foreach` | **High** (the one that flooded in prod) |
| `privateVoiceChatUpdate` | `RPCPrivateVoiceChatService` | **identical** dual-trigger pattern | **High** |
| `communityVoiceChatUpdate` | `RPCCommunityVoiceChatService` | **identical** dual-trigger pattern | **High** |
| `friendshipUpdate` / `friendConnectivityUpdate` / `blockUpdate` | `RPCFriendsService` | started once from `FriendsContainer` (not on transport events) | Lower, but still vulnerable to the base flaw |

The two **voice** subscriptions in particular share the exact trigger setup that caused the community flood; production just happened to surface community member connectivity first.

## Fix

In `KeepServerStreamOpenAsync`:
- **Back off on normal completion.** A long-lived subscription stream completing on its own is abnormal — treat it like any other reconnect and `WaitNextRetryAsync` before re-opening, instead of hot-looping.
- **Reset-on-stable.** If the stream actually stayed open ≥ 30s (a genuine subscription that ended, not an instant duplicate-rejection), reset the backoff so a real reconnect is still prompt. The healthy path is unaffected — the first subscribe establishes and the `await foreach` blocks while updates flow, so the backoff code is never reached.
- **Cap the backoff** at 60s and compute it in `double` to avoid int overflow as `retryAttempt` grows.
- **Increment `retryAttempt` in the generic `catch (Exception)`** path too (it previously didn't, so its backoff never grew).

This converts the tight hot-loop into exponential backoff (2s → 4s → 8s … capped at 60s), so a connection that keeps getting duplicate-rejected quietly backs off instead of hammering the server — for every subscription above.

## Not addressed here (follow-up)

Superseded subscription loops can't be truly torn down — `AttachExternalCancellation` unblocks the wrapper but the underlying `await foreach` keeps running (see the `// cancellation doesn't work` comment in `RPCCommunitiesService.cs` and `RPCFriendsService.cs`). That's what lets a second concurrent loop see a duplicate in the first place. This same "multiple `OnTransport*` triggers + uncancellable `foreach`" pattern is duplicated in `RPCCommunitiesService` **and both voice services**, so a proper fix (RPC-client-level stream cancellation / a single-loop guarantee, ideally lifted into a shared helper) should cover all three. The backoff fix here makes the situation **harmless** (the duplicate-rejected loop backs off instead of flooding) and self-healing, so it's a good standalone first step.

## Testing

Not build-verified locally (no Unity build environment). The change is localized to `KeepServerStreamOpenAsync` / `WaitNextRetryAsync` and is logic-reviewed. The server-side log noise is being addressed separately as defense-in-depth in `social-service-ea`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)