### PR TITLE
fix: ui background image position ignores border inset offset

### DIFF
--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Classes/DCLImage.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Classes/DCLImage.cs
@@ -235,17 +235,7 @@ namespace DCL.SDKComponents.SceneUI.Classes
         private void GenerateStretched(MeshGenerationContext mgc)
         {
             // in local coords
-            var r = canvas.contentRect;
-
-            float left = 0;
-            float right = r.width;
-            float top = 0;
-            float bottom = r.height;
-
-            VERTICES[0].position = new Vector3(left, bottom, Vertex.nearZ);
-            VERTICES[1].position = new Vector3(left, top, Vertex.nearZ);
-            VERTICES[2].position = new Vector3(right, top, Vertex.nearZ);
-            VERTICES[3].position = new Vector3(right, bottom, Vertex.nearZ);
+            PopulateStretchedQuad(VERTICES, canvas.contentRect);
 
             MeshWriteData? mwd = mgc.Allocate(VERTICES.Length, INDICES.Length, texture);
 
@@ -312,6 +302,19 @@ namespace DCL.SDKComponents.SceneUI.Classes
         {
             for (var i = 0; i < VERTICES.Length; i++)
                 VERTICES[i].tint = color;
+        }
+
+        internal static void PopulateStretchedQuad(Vertex[] vertices, Rect contentRect)
+        {
+            float left = contentRect.x;
+            float right = contentRect.xMax;
+            float top = contentRect.y;
+            float bottom = contentRect.yMax;
+
+            vertices[0].position = new Vector3(left, bottom, Vertex.nearZ);
+            vertices[1].position = new Vector3(left, top, Vertex.nearZ);
+            vertices[2].position = new Vector3(right, top, Vertex.nearZ);
+            vertices[3].position = new Vector3(right, bottom, Vertex.nearZ);
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/DCLImageShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/DCLImageShould.cs
@@ -1,0 +1,44 @@
+using DCL.SDKComponents.SceneUI.Classes;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace DCL.SDKComponents.SceneUI.Tests
+{
+    public class DCLImageShould
+    {
+        [Test]
+        public void PopulateStretchedQuadSpanningContentRectWhenNoInset()
+        {
+            // Arrange
+            var vertices = new Vertex[4];
+            var contentRect = new Rect(0f, 0f, 100f, 50f);
+
+            // Act
+            DCLImage.PopulateStretchedQuad(vertices, contentRect);
+
+            // Assert
+            Assert.AreEqual(new Vector3(0f, 50f, Vertex.nearZ), vertices[0].position); // bottom-left
+            Assert.AreEqual(new Vector3(0f, 0f, Vertex.nearZ), vertices[1].position); // top-left
+            Assert.AreEqual(new Vector3(100f, 0f, Vertex.nearZ), vertices[2].position); // top-right
+            Assert.AreEqual(new Vector3(100f, 50f, Vertex.nearZ), vertices[3].position); // bottom-right
+        }
+
+        [Test]
+        public void PopulateStretchedQuadHonoringContentRectOffsetWhenInset()
+        {
+            // Arrange - contentRect is inset by the element's border/padding, so it carries an offset (x/y)
+            var vertices = new Vertex[4];
+            var contentRect = new Rect(10f, 20f, 100f, 50f);
+
+            // Act
+            DCLImage.PopulateStretchedQuad(vertices, contentRect);
+
+            // Assert - the quad must span the inset rect, not be anchored at the local origin
+            Assert.AreEqual(new Vector3(10f, 70f, Vertex.nearZ), vertices[0].position); // bottom-left
+            Assert.AreEqual(new Vector3(10f, 20f, Vertex.nearZ), vertices[1].position); // top-left
+            Assert.AreEqual(new Vector3(110f, 20f, Vertex.nearZ), vertices[2].position); // top-right
+            Assert.AreEqual(new Vector3(110f, 70f, Vertex.nearZ), vertices[3].position); // bottom-right
+        }
+    }
+}

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/DCLImageShould.cs.meta
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/DCLImageShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 458b865f81014155bd1ad0fff83b47f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Bug
For scene UI backgrounds using the **Stretch** scale mode, the generated quad was
sized from `contentRect` but anchored at the element's local origin `(0, 0)`.
`contentRect` is inset by the element's border/padding and carries that inset in
its `x`/`y`. Ignoring the offset shifted the stretched background toward the
top-left by the inset amount, so it no longer aligned with the content box.

The sibling `Center` mode was already offset-aware (it derives corners from
`contentRect.center`), which confirmed the intended behavior.

## Fix
`DCLImage.GenerateStretched` now spans the quad across the content rect's actual
bounds (`contentRect.x`/`.y` → `.xMax`/`.yMax`) instead of the local origin. The
quad positioning was extracted into `PopulateStretchedQuad` to make it testable.

## Tests
Added `DCLImageShould` covering `PopulateStretchedQuad`:
- quad spans the rect when there is no inset;
- quad honors the `contentRect` offset when inset (regression test for this bug).

## QA TEST INSTRUCTIONS

For this test IGNORE the GREEN rectangle in the top-left of the screen.

1. Download the build from this PR
2. Enter `pravus.dcl.eth` world
3. Confirm that you see the image at the center of the screen completely inside its YELLOW border (not displaced)

<img width="369" height="437" alt="Screenshot 2026-07-01 at 3 45 19 AM" src="https://github.com/user-attachments/assets/344d18da-4daa-4fa0-8679-cad8a176efa0" />

<img width="549" height="678" alt="Screenshot 2026-07-01 at 3 47 22 AM" src="https://github.com/user-attachments/assets/3c9f0416-6a8b-4e6d-b7da-727038e2644e" />
