### PR TITLE
fix: livekit stream on first join

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -1001,7 +1001,8 @@ namespace Global.Dynamic
                 lodContainer.RoadAssetsPool,
                 staticContainer.SceneLoadingLimit,
                 dynamicWorldParams.StartParcel,
-                bootstrapContainer.Analytics.EntitiesAnalytics
+                bootstrapContainer.Analytics.EntitiesAnalytics,
+                commsContainer.RoomHub
             );
 
             var container = new DynamicWorldContainer(

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -1002,7 +1002,7 @@ namespace Global.Dynamic
                 staticContainer.SceneLoadingLimit,
                 dynamicWorldParams.StartParcel,
                 bootstrapContainer.Analytics.EntitiesAnalytics,
-                commsContainer.RoomHub
+                commsContainer.RoomHub.SceneRoom()
             );
 
             var container = new DynamicWorldContainer(

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -1000,7 +1000,6 @@ namespace Global.Dynamic
                 bootstrapContainer.UseRemoteAssetBundles,
                 lodContainer.RoadAssetsPool,
                 staticContainer.SceneLoadingLimit,
-                dynamicWorldParams.StartParcel,
                 bootstrapContainer.Analytics.EntitiesAnalytics,
                 commsContainer.RoomHub.SceneRoom()
             );

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/GlobalWorldFactory.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/GlobalWorldFactory.cs
@@ -11,6 +11,7 @@ using DCL.Interaction.Raycast;
 using DCL.Ipfs;
 using DCL.LOD;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.Optimization.Pools;
 using DCL.PerformanceAndDiagnostics.Analytics;
@@ -82,6 +83,7 @@ namespace Global.Dynamic
         private readonly StartParcel startParcel;
         private readonly EntitiesAnalytics entitiesAnalytics;
         private readonly bool isBuilderCollectionPreview;
+        private readonly IRoomHub roomHub;
 
         public GlobalWorldFactory(in StaticContainer staticContainer,
             CameraSamplingData cameraSamplingData,
@@ -103,7 +105,8 @@ namespace Global.Dynamic
             RoadAssetsPool roadAssetPool,
             SceneLoadingLimit sceneLoadingLimit,
             StartParcel startParcel,
-            EntitiesAnalytics entitiesAnalytics)
+            EntitiesAnalytics entitiesAnalytics,
+            IRoomHub roomHub)
         {
             partitionedWorldsAggregateFactory = staticContainer.SingletonSharedDependencies.AggregateFactory;
             componentPoolsRegistry = staticContainer.ComponentsContainer.ComponentPoolsRegistry;
@@ -125,6 +128,7 @@ namespace Global.Dynamic
             this.lodCache = lodCache;
             this.localSceneDevelopment = FeaturesRegistry.Instance.IsEnabled(FeatureId.LOCAL_SCENE_DEVELOPMENT);
             this.sceneReadinessReportQueue = sceneReadinessReportQueue;
+            this.roomHub = roomHub;
             this.world = world;
             this.profileRepository = profileRepository;
             this.roadCoordinates = roadCoordinates;
@@ -202,7 +206,8 @@ namespace Global.Dynamic
             //Removed, since we now have landscape surrounding the world
             //CreateEmptyPointersInFixedRealmSystem.InjectToWorld(ref builder, jobsMathHelper, realmPartitionSettings);
             ResolveStaticPointersSystem.InjectToWorld(ref builder);
-            ControlSceneUpdateLoopSystem.InjectToWorld(ref builder, realmPartitionSettings, destroyCancellationSource.Token, scenesCache, sceneReadinessReportQueue);
+            ControlSceneUpdateLoopSystem.InjectToWorld(ref builder, realmPartitionSettings, destroyCancellationSource.Token, scenesCache, sceneReadinessReportQueue,
+                realmData, roomHub.IsSceneRoomSettled);
 
             IComponentPool<PartitionComponent> partitionComponentPool = componentPoolsRegistry.GetReferenceTypePool<PartitionComponent>();
             PartitionSceneEntitiesSystem.InjectToWorld(ref builder, partitionComponentPool, partitionSettings, cameraSamplingData, staticContainer.PartitionDataContainer, staticContainer.RealmPartitionSettings);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/GlobalWorldFactory.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/GlobalWorldFactory.cs
@@ -11,7 +11,6 @@ using DCL.Interaction.Raycast;
 using DCL.Ipfs;
 using DCL.LOD;
 using DCL.Multiplayer.Connections.DecentralandUrls;
-using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.Optimization.Pools;
 using DCL.PerformanceAndDiagnostics.Analytics;
@@ -83,7 +82,7 @@ namespace Global.Dynamic
         private readonly StartParcel startParcel;
         private readonly EntitiesAnalytics entitiesAnalytics;
         private readonly bool isBuilderCollectionPreview;
-        private readonly IRoomHub roomHub;
+        private readonly ISceneRoomStatus sceneRoomStatus;
 
         public GlobalWorldFactory(in StaticContainer staticContainer,
             CameraSamplingData cameraSamplingData,
@@ -106,7 +105,7 @@ namespace Global.Dynamic
             SceneLoadingLimit sceneLoadingLimit,
             StartParcel startParcel,
             EntitiesAnalytics entitiesAnalytics,
-            IRoomHub roomHub)
+            ISceneRoomStatus sceneRoomStatus)
         {
             partitionedWorldsAggregateFactory = staticContainer.SingletonSharedDependencies.AggregateFactory;
             componentPoolsRegistry = staticContainer.ComponentsContainer.ComponentPoolsRegistry;
@@ -128,7 +127,7 @@ namespace Global.Dynamic
             this.lodCache = lodCache;
             this.localSceneDevelopment = FeaturesRegistry.Instance.IsEnabled(FeatureId.LOCAL_SCENE_DEVELOPMENT);
             this.sceneReadinessReportQueue = sceneReadinessReportQueue;
-            this.roomHub = roomHub;
+            this.sceneRoomStatus = sceneRoomStatus;
             this.world = world;
             this.profileRepository = profileRepository;
             this.roadCoordinates = roadCoordinates;
@@ -207,7 +206,7 @@ namespace Global.Dynamic
             //CreateEmptyPointersInFixedRealmSystem.InjectToWorld(ref builder, jobsMathHelper, realmPartitionSettings);
             ResolveStaticPointersSystem.InjectToWorld(ref builder);
             ControlSceneUpdateLoopSystem.InjectToWorld(ref builder, realmPartitionSettings, destroyCancellationSource.Token, scenesCache, sceneReadinessReportQueue,
-                realmData, roomHub.IsSceneRoomSettled);
+                realmData, sceneRoomStatus);
 
             IComponentPool<PartitionComponent> partitionComponentPool = componentPoolsRegistry.GetReferenceTypePool<PartitionComponent>();
             PartitionSceneEntitiesSystem.InjectToWorld(ref builder, partitionComponentPool, partitionSettings, cameraSamplingData, staticContainer.PartitionDataContainer, staticContainer.RealmPartitionSettings);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/GlobalWorldFactory.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/GlobalWorldFactory.cs
@@ -1,5 +1,4 @@
 using Arch.Core;
-using DCL.SceneRunner.Scene;
 using Arch.SystemGroups;
 using CommunicationData.URLHelpers;
 using CrdtEcsBridge.RestrictedActions;
@@ -79,7 +78,6 @@ namespace Global.Dynamic
         private readonly HashSet<Vector2Int> roadCoordinates;
         private readonly ILODSettingsAsset lodSettingsAsset;
         private readonly SceneLoadingLimit sceneLoadingLimit;
-        private readonly StartParcel startParcel;
         private readonly EntitiesAnalytics entitiesAnalytics;
         private readonly bool isBuilderCollectionPreview;
         private readonly ISceneRoomStatus sceneRoomStatus;
@@ -103,7 +101,6 @@ namespace Global.Dynamic
             bool useRemoteAssetBundles,
             RoadAssetsPool roadAssetPool,
             SceneLoadingLimit sceneLoadingLimit,
-            StartParcel startParcel,
             EntitiesAnalytics entitiesAnalytics,
             ISceneRoomStatus sceneRoomStatus)
         {
@@ -135,7 +132,6 @@ namespace Global.Dynamic
             this.useRemoteAssetBundles = useRemoteAssetBundles;
             this.roadAssetPool = roadAssetPool;
             this.sceneLoadingLimit = sceneLoadingLimit;
-            this.startParcel = startParcel;
             this.isBuilderCollectionPreview = FeaturesRegistry.Instance.IsEnabled(FeatureId.SELF_PREVIEW_BUILDER_COLLECTIONS);
             this.entitiesAnalytics = entitiesAnalytics;
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
@@ -55,7 +55,7 @@ namespace DCL.UserInAppInitializationFlow
             var loadPlayerAvatarStartupOperation = new LoadPlayerAvatarStartupOperation(loadingStatus, selfProfile, staticContainer.MainPlayerAvatarBaseProxy);
             var startPulseMultiplayerStartupOperation = new StartPulseMultiplayerStartupOperation(pulseMultiplayerService, profilePropagation, selfProfile, pulseActivation);
             var loadLandscapeStartupOperation = new LoadLandscapeStartupOperation(loadingStatus, terrainContainer.Landscape);
-            var teleportStartupOperation = new TeleportStartupOperation(loadingStatus, realmContainer.RealmController, staticContainer.ExposedGlobalDataContainer.ExposedCameraData.CameraEntityProxy, realmContainer.TeleportController, staticContainer.ExposedGlobalDataContainer.CameraSamplingData, dynamicWorldParams.StartParcel, appArgs, dynamicWorldParams.EditorPositionOverrideActive);
+            var teleportStartupOperation = new TeleportStartupOperation(loadingStatus, realmContainer.RealmController, staticContainer.ExposedGlobalDataContainer.ExposedCameraData.CameraEntityProxy, realmContainer.TeleportController, staticContainer.ExposedGlobalDataContainer.CameraSamplingData, dynamicWorldParams.StartParcel, appArgs, roomHub, dynamicWorldParams.EditorPositionOverrideActive);
 
             var loadingOperations = new List<IStartupOperation>
             {

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/InitializationFlowContainer.cs
@@ -3,7 +3,6 @@ using DCL.Audio;
 using DCL.Character.Plugin;
 using DCL.Chat.History;
 using DCL.Diagnostics;
-using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Multiplayer.Connections.Pulse;
 using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Multiplayer.HealthChecks;
@@ -48,7 +47,7 @@ namespace DCL.UserInAppInitializationFlow
             IWorldPermissionsService worldPermissionsService,
             IChatHistory chatHistory)
         {
-            ILoadingStatus? loadingStatus = staticContainer.LoadingStatus;
+            ILoadingStatus loadingStatus = staticContainer.LoadingStatus;
 
             var ensureLivekitConnectionStartupOperation = new EnsureLivekitConnectionStartupOperation(liveKitHealthCheck, roomHub);
             var blocklistCheckStartupOperation = new BlocklistCheckStartupOperation(staticContainer.WebRequestsContainer.WebRequestController, bootstrapContainer.IdentityCache!, bootstrapContainer.DecentralandUrlsSource, moderationDataProvider);
@@ -68,11 +67,9 @@ namespace DCL.UserInAppInitializationFlow
 
             // The Global PX operation is the 3rd most time-consuming loading stage and it's currently not needed in Local Scene Development
             // More loading stage measurements for Local Scene Development at https://github.com/decentraland/unity-explorer/pull/3630
+            // TODO review why loadGlobalPxOperation is invoked on recovery
             if (!localSceneDevelopment)
-            {
-                // TODO review why loadGlobalPxOperation is invoked on recovery
                 loadingOperations.Add(new LoadGlobalPortableExperiencesStartupOperation(loadingStatus, bootstrapContainer.DebugSettings, staticContainer.PortableExperiencesController));
-            }
 
             var startUpOps = new AnalyticsSequentialLoadingOperation<IStartupOperation.Params>(
                 loadingStatus,

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Reporting/ISceneReadinessReportQueue.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Reporting/ISceneReadinessReportQueue.cs
@@ -11,5 +11,10 @@ namespace ECS.SceneLifeCycle.Reporting
         bool TryDequeue(IReadOnlyList<Vector2Int> parcels, out PooledLoadReportList? report);
 
         bool TryDequeue(Vector2Int parcel, out PooledLoadReportList? report);
+
+        /// <summary>
+        ///     Non-consuming check: true when someone is waiting to land on any of the given parcels
+        /// </summary>
+        bool HasReport(IReadOnlyList<Vector2Int> parcels);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Reporting/SceneReadinessReportQueue.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Reporting/SceneReadinessReportQueue.cs
@@ -54,6 +54,20 @@ namespace ECS.SceneLifeCycle.Reporting
             return false;
         }
 
+        public bool HasReport(IReadOnlyList<Vector2Int> parcels)
+        {
+            if (queue.Count == 0)
+                return false;
+
+            for (var i = 0; i < parcels.Count; i++)
+            {
+                if (queue.ContainsKey(parcels[i]))
+                    return true;
+            }
+
+            return false;
+        }
+
         public bool TryDequeue(Vector2Int parcel, out PooledLoadReportList? report)
         {
             if (queue.TryGetValue(parcel, out PooledLoadReportList list))

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Reporting/SceneReadinessReportQueue.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Reporting/SceneReadinessReportQueue.cs
@@ -45,10 +45,8 @@ namespace ECS.SceneLifeCycle.Reporting
             }
 
             for (var i = 0; i < parcels.Count; i++)
-            {
                 if (TryDequeue(parcels[i], out report))
                     return true;
-            }
 
             report = null;
             return false;
@@ -60,10 +58,8 @@ namespace ECS.SceneLifeCycle.Reporting
                 return false;
 
             for (var i = 0; i < parcels.Count; i++)
-            {
                 if (queue.ContainsKey(parcels[i]))
                     return true;
-            }
 
             return false;
         }

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
@@ -3,7 +3,6 @@ using Arch.System;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
-using ECS;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
 using ECS.Prioritization;
@@ -35,7 +34,7 @@ namespace ECS.SceneLifeCycle.Systems
 
         private readonly IScenesCache scenesCache;
         private readonly IRealmData realmData;
-        private readonly Func<string, bool> isSceneRoomSettled;
+        private readonly ISceneRoomStatus sceneRoomStatus;
 
         internal ControlSceneUpdateLoopSystem(World world,
             IRealmPartitionSettings realmPartitionSettings,
@@ -43,14 +42,14 @@ namespace ECS.SceneLifeCycle.Systems
             IScenesCache scenesCache,
             ISceneReadinessReportQueue sceneReadinessReportQueue,
             IRealmData realmData,
-            Func<string, bool> isSceneRoomSettled) : base(world)
+            ISceneRoomStatus sceneRoomStatus) : base(world)
         {
             this.realmPartitionSettings = realmPartitionSettings;
             this.destroyCancellationToken = destroyCancellationToken;
             this.scenesCache = scenesCache;
             this.sceneReadinessReportQueue = sceneReadinessReportQueue;
             this.realmData = realmData;
-            this.isSceneRoomSettled = isSceneRoomSettled;
+            this.sceneRoomStatus = sceneRoomStatus;
         }
 
         protected override void Update(float t)
@@ -145,10 +144,10 @@ namespace ECS.SceneLifeCycle.Systems
 
             string sceneId = definitionComponent.Definition.id!;
 
-            if (isSceneRoomSettled(sceneId))
+            if (sceneRoomStatus.IsSceneRoomSettled(sceneId))
                 return;
 
-            try { await UniTask.WaitUntil(() => isSceneRoomSettled(sceneId), cancellationToken: destroyCancellationToken).Timeout(SCENE_ROOM_CONNECT_TIMEOUT); }
+            try { await UniTask.WaitUntil(() => sceneRoomStatus.IsSceneRoomSettled(sceneId), cancellationToken: destroyCancellationToken).Timeout(SCENE_ROOM_CONNECT_TIMEOUT); }
             catch (TimeoutException)
             {
                 ReportHub.LogWarning(GetReportData(), $"Scene '{definitionComponent.Definition.GetLogSceneName()}' started before its comms room connected");

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
@@ -3,6 +3,7 @@ using Arch.System;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
+using ECS;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
 using ECS.Prioritization;
@@ -25,22 +26,31 @@ namespace ECS.SceneLifeCycle.Systems
     [UpdateAfter(typeof(ResolveStaticPointersSystem))]
     public partial class ControlSceneUpdateLoopSystem : BaseUnityLoopSystem
     {
+        // Fallback so a scene whose comms room never connects still starts; the normal release is the room connecting
+        private static readonly TimeSpan SCENE_ROOM_CONNECT_TIMEOUT = TimeSpan.FromSeconds(15);
+
         private readonly IRealmPartitionSettings realmPartitionSettings;
         private readonly CancellationToken destroyCancellationToken;
         private readonly ISceneReadinessReportQueue sceneReadinessReportQueue;
 
         private readonly IScenesCache scenesCache;
+        private readonly IRealmData realmData;
+        private readonly Func<string, bool> isSceneRoomSettled;
 
         internal ControlSceneUpdateLoopSystem(World world,
             IRealmPartitionSettings realmPartitionSettings,
             CancellationToken destroyCancellationToken,
             IScenesCache scenesCache,
-            ISceneReadinessReportQueue sceneReadinessReportQueue) : base(world)
+            ISceneReadinessReportQueue sceneReadinessReportQueue,
+            IRealmData realmData,
+            Func<string, bool> isSceneRoomSettled) : base(world)
         {
             this.realmPartitionSettings = realmPartitionSettings;
             this.destroyCancellationToken = destroyCancellationToken;
             this.scenesCache = scenesCache;
             this.sceneReadinessReportQueue = sceneReadinessReportQueue;
+            this.realmData = realmData;
+            this.isSceneRoomSettled = isSceneRoomSettled;
         }
 
         protected override void Update(float t)
@@ -102,6 +112,9 @@ namespace ECS.SceneLifeCycle.Systems
                 else
                     scenesCache.Add(scene, definitionComponent.Parcels);
 
+                // Peer CRDT state must land before the scene runs: local state produced first wins the CRDT merge and the synced entities are dropped
+                await WaitForSceneRoomIfWorldAsync(definitionComponent);
+
                 ReportHub.LogProductionInfo($"Scene '{definitionComponent.Definition.GetLogSceneName()}' started");
 
                 await DCLTask.SwitchToThreadPool();
@@ -118,6 +131,28 @@ namespace ECS.SceneLifeCycle.Systems
             }
             catch (OperationCanceledException) { }
             catch (Exception e) { ReportHub.LogException(e, GetReportData()); }
+        }
+
+        private async UniTask WaitForSceneRoomIfWorldAsync(SceneDefinitionComponent definitionComponent)
+        {
+            // Genesis exploration shouldn't pay comms-connect latency on every scene
+            if (definitionComponent.IsPortableExperience || !realmData.Configured || !realmData.IsWorld())
+                return;
+
+            // Only the teleport destination (marked by a pending readiness report) is gated: the room targets the player's scene only, so other scenes of the world would wait in vain
+            if (!sceneReadinessReportQueue.HasReport(definitionComponent.Parcels))
+                return;
+
+            string sceneId = definitionComponent.Definition.id!;
+
+            if (isSceneRoomSettled(sceneId))
+                return;
+
+            try { await UniTask.WaitUntil(() => isSceneRoomSettled(sceneId), cancellationToken: destroyCancellationToken).Timeout(SCENE_ROOM_CONNECT_TIMEOUT); }
+            catch (TimeoutException)
+            {
+                ReportHub.LogWarning(GetReportData(), $"Scene '{definitionComponent.Definition.GetLogSceneName()}' started before its comms room connected");
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
@@ -142,7 +142,8 @@ namespace ECS.SceneLifeCycle.Systems
             if (!sceneReadinessReportQueue.HasReport(definitionComponent.Parcels))
                 return;
 
-            string sceneId = definitionComponent.Definition.id!;
+            if (definitionComponent.Definition.id is not { } sceneId)
+                return;
 
             if (sceneRoomStatus.IsSceneRoomSettled(sceneId))
                 return;

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ControlSceneUpdateLoopSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ControlSceneUpdateLoopSystemShould.cs
@@ -27,7 +27,8 @@ namespace ECS.SceneLifeCycle.Tests
         public void SetUp()
         {
             realmPartitionSettings = Substitute.For<IRealmPartitionSettings>();
-            system = new ControlSceneUpdateLoopSystem(world, realmPartitionSettings, CancellationToken.None, Substitute.For<IScenesCache>(), Substitute.For<ISceneReadinessReportQueue>());
+            system = new ControlSceneUpdateLoopSystem(world, realmPartitionSettings, CancellationToken.None, Substitute.For<IScenesCache>(), Substitute.For<ISceneReadinessReportQueue>(),
+                Substitute.For<IRealmData>(), static _ => true);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ControlSceneUpdateLoopSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ControlSceneUpdateLoopSystemShould.cs
@@ -28,7 +28,7 @@ namespace ECS.SceneLifeCycle.Tests
         {
             realmPartitionSettings = Substitute.For<IRealmPartitionSettings>();
             system = new ControlSceneUpdateLoopSystem(world, realmPartitionSettings, CancellationToken.None, Substitute.For<IScenesCache>(), Substitute.For<ISceneReadinessReportQueue>(),
-                Substitute.For<IRealmData>(), static _ => true);
+                Substitute.For<IRealmData>(), Substitute.For<ISceneRoomStatus>());
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ControlSceneUpdateLoopSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ControlSceneUpdateLoopSystemShould.cs
@@ -1,5 +1,6 @@
 ﻿using Arch.Core;
 using DCL.Ipfs;
+using DCL.Utilities;
 using ECS.Prioritization;
 using ECS.Prioritization.Components;
 using ECS.SceneLifeCycle.Components;
@@ -12,6 +13,7 @@ using ECS.TestSuite;
 using NSubstitute;
 using NUnit.Framework;
 using SceneRunner.Scene;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -21,14 +23,21 @@ namespace ECS.SceneLifeCycle.Tests
 {
     public class ControlSceneUpdateLoopSystemShould : UnitySystemTestBase<ControlSceneUpdateLoopSystem>
     {
-        private IRealmPartitionSettings realmPartitionSettings;
+        private IRealmPartitionSettings realmPartitionSettings = null!;
+        private ISceneReadinessReportQueue sceneReadinessReportQueue = null!;
+        private IRealmData realmData = null!;
+        private ISceneRoomStatus sceneRoomStatus = null!;
 
         [SetUp]
         public void SetUp()
         {
             realmPartitionSettings = Substitute.For<IRealmPartitionSettings>();
-            system = new ControlSceneUpdateLoopSystem(world, realmPartitionSettings, CancellationToken.None, Substitute.For<IScenesCache>(), Substitute.For<ISceneReadinessReportQueue>(),
-                Substitute.For<IRealmData>(), Substitute.For<ISceneRoomStatus>());
+            sceneReadinessReportQueue = Substitute.For<ISceneReadinessReportQueue>();
+            realmData = Substitute.For<IRealmData>();
+            sceneRoomStatus = Substitute.For<ISceneRoomStatus>();
+
+            system = new ControlSceneUpdateLoopSystem(world, realmPartitionSettings, CancellationToken.None, Substitute.For<IScenesCache>(), sceneReadinessReportQueue,
+                realmData, sceneRoomStatus);
         }
 
         [Test]
@@ -89,6 +98,36 @@ namespace ECS.SceneLifeCycle.Tests
         }
 
         [Test]
+        public void HoldWorldSceneStartUntilSceneRoomIsSettled()
+        {
+            ISceneFacade scene = CreateWorldScenePendingStart(isRoomSettled: false, hasReadinessReport: true);
+
+            system.Update(0f);
+
+            scene.DidNotReceive().StartUpdateLoopAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        }
+
+        [Test]
+        public void StartWorldSceneWhenSceneRoomIsSettled()
+        {
+            ISceneFacade scene = CreateWorldScenePendingStart(isRoomSettled: true, hasReadinessReport: true);
+
+            system.Update(0f);
+
+            scene.Received(1).StartUpdateLoopAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        }
+
+        [Test]
+        public void StartWorldSceneWithoutReadinessReportRegardlessOfSceneRoom()
+        {
+            ISceneFacade scene = CreateWorldScenePendingStart(isRoomSettled: false, hasReadinessReport: false);
+
+            system.Update(0f);
+
+            scene.Received(1).StartUpdateLoopAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        }
+
+        [Test]
         public void ChangeSceneFPS()
         {
             ISceneFacade scene = Substitute.For<ISceneFacade>();
@@ -101,6 +140,33 @@ namespace ECS.SceneLifeCycle.Tests
             system.Update(0f);
 
             scene.Received(1).SetTargetFPS(15);
+        }
+
+        private ISceneFacade CreateWorldScenePendingStart(bool isRoomSettled, bool hasReadinessReport)
+        {
+            realmData.Configured.Returns(true);
+            realmData.RealmType.Returns(new ReactiveProperty<RealmKind>(RealmKind.World));
+            sceneReadinessReportQueue.HasReport(Arg.Any<IReadOnlyList<Vector2Int>>()).Returns(hasReadinessReport);
+            sceneRoomStatus.IsSceneRoomSettled(Arg.Any<string>()).Returns(isRoomSettled);
+
+            ISceneFacade scene = Substitute.For<ISceneFacade>();
+
+            var promise = AssetPromise<ISceneFacade, GetSceneFacadeIntention>.Create(world, new GetSceneFacadeIntention(), PartitionComponent.TOP_PRIORITY);
+
+            SceneDefinitionComponent sceneDefinitionComponent = SceneDefinitionComponentFactory.CreateFromDefinition(new SceneEntityDefinition
+            {
+                id = "test-scene",
+                metadata = new SceneMetadata
+                {
+                    scene = new SceneMetadataScene
+                        { DecodedParcels = new[] { Vector3.zero.ToParcel() } },
+                },
+            }, new IpfsPath());
+
+            world.Add(promise.Entity, new StreamableLoadingResult<ISceneFacade>(scene));
+            world.Create(promise, PartitionComponent.TOP_PRIORITY, sceneDefinitionComponent);
+
+            return scene;
         }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/ISceneRoomMetaDataSource.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/ISceneRoomMetaDataSource.cs
@@ -14,8 +14,6 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
         MetaData.Input GetMetadataInput();
 
         UniTask<Result<MetaData>> MetaDataAsync(MetaData.Input input, CancellationToken token);
-
-        bool MetadataIsDirty { get; }
     }
 
     public static class SceneRoomMetaDataSourceExtensions

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/LocalSceneDevelopmentSceneRoomMetaDataSource.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/LocalSceneDevelopmentSceneRoomMetaDataSource.cs
@@ -22,8 +22,6 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
 
         public bool ScenesCommunicationIsIsolated => false;
 
-        public bool MetadataIsDirty => false;
-
         public MetaData.Input GetMetadataInput() =>
             new ("LocalSceneDevelopment", Vector2Int.zero);
 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/SceneRoomLogMetaDataSource.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/SceneRoomLogMetaDataSource.cs
@@ -37,7 +37,5 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
 
             return result;
         }
-
-        public bool MetadataIsDirty => origin.MetadataIsDirty;
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/SceneRoomMetaDataSource.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Meta/SceneRoomMetaDataSource.cs
@@ -26,33 +26,7 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Meta
 
         private readonly bool forceSceneIsolation;
 
-        private Vector2Int previousParcel = new (int.MaxValue, int.MaxValue);
-
         public bool ScenesCommunicationIsIsolated => forceSceneIsolation || !realmData.SingleScene;
-
-        public bool MetadataIsDirty
-        {
-            get
-            {
-                if (!realmData.Configured)
-                    return false;
-
-                CanBeDirty<Vector3> characterPosition = characterTransform.Position;
-
-                bool positionIsDirty = !realmData.SingleScene && characterPosition.IsDirty;
-
-                if (!positionIsDirty)
-                    return false;
-
-                Vector2Int parcel = characterPosition.ToParcel();
-
-                if (parcel == previousParcel)
-                    return false;
-
-                previousParcel = parcel;
-                return true;
-            }
-        }
 
         public SceneRoomMetaDataSource(IRealmData realmData, IExposedTransform characterTransform, World world, bool forceSceneIsolation, IDecentralandUrlsSource urlsSource)
         {

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/GateKeeperSceneRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/GateKeeperSceneRoom.cs
@@ -41,6 +41,7 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
             public event Action? CurrentSceneRoomDisconnected;
             public event Action? CurrentSceneRoomForbiddenAccess;
             public MetaData? ConnectedScene => origin.ConnectedScene;
+            public bool IsCommsOffline => origin.options.IsCommsOffline;
 
             private void OnCurrentSceneRoomConnected() =>
                 CurrentSceneRoomConnected?.Invoke();
@@ -127,7 +128,9 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
 
             try
             {
-                var result = await options.SceneRoomMetaDataSource.MetaDataAsync(options.SceneRoomMetaDataSource.GetMetadataInput(), token);
+                // The waits below re-check the live input against this capture: a frame-scoped dirty flag would miss changes made while the cycle awaits, parking the room on a stale parcel
+                MetaData.Input input = options.SceneRoomMetaDataSource.GetMetadataInput();
+                var result = await options.SceneRoomMetaDataSource.MetaDataAsync(input, token);
 
                 if (result.Success == false)
                     return;
@@ -143,13 +146,13 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
                     CurrentSceneRoomDisconnected?.Invoke();
 
                     // After disconnection we need to wait for metadata to change
-                    waitForReconnectionRequiredTask = WaitForMetadataIsDirtyAsync(token);
+                    waitForReconnectionRequiredTask = WaitForMetadataInputChangedAsync(input, token);
 
                     currentMetaData = meta;
 
-                    async UniTask WaitForMetadataIsDirtyAsync(CancellationToken token)
+                    async UniTask WaitForMetadataInputChangedAsync(MetaData.Input usedInput, CancellationToken token)
                     {
-                        while (!options.SceneRoomMetaDataSource.MetadataIsDirty)
+                        while (options.SceneRoomMetaDataSource.GetMetadataInput().Equals(usedInput))
                             await UniTask.Yield(token);
                     }
                 }
@@ -176,14 +179,14 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
                         }
                     }
 
-                    waitForReconnectionRequiredTask = WaitForReconnectionRequiredAsync(token);
+                    waitForReconnectionRequiredTask = WaitForReconnectionRequiredAsync(input, token);
 
                     // Either room has disconnected or metadata has changed
-                    async UniTask WaitForReconnectionRequiredAsync(CancellationToken token)
+                    async UniTask WaitForReconnectionRequiredAsync(MetaData.Input usedInput, CancellationToken token)
                     {
                         while (CurrentState() is IConnectiveRoom.State.Running
                                && Room().Info.ConnectionState == LKConnectionState.ConnConnected
-                               && !options.SceneRoomMetaDataSource.MetadataIsDirty)
+                               && options.SceneRoomMetaDataSource.GetMetadataInput().Equals(usedInput))
                             await UniTask.Yield(token);
                     }
                 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/GateKeeperSceneRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/GateKeeperSceneRoom.cs
@@ -41,7 +41,15 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
             public event Action? CurrentSceneRoomDisconnected;
             public event Action? CurrentSceneRoomForbiddenAccess;
             public MetaData? ConnectedScene => origin.ConnectedScene;
-            public bool IsCommsOffline => origin.options.IsCommsOffline;
+
+            public bool IsSceneRoomSettled(string sceneId)
+            {
+                // States in which the room will never connect must not hold callers waiting
+                if (!Activated || origin.options.IsCommsOffline || AttemptToConnectState is AttemptToConnectState.FORBIDDEN_ACCESS)
+                    return true;
+
+                return IsSceneConnected(sceneId);
+            }
 
             private void OnCurrentSceneRoomConnected() =>
                 CurrentSceneRoomConnected?.Invoke();

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/GateKeeperSceneRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/GateKeeperSceneRoom.cs
@@ -3,9 +3,7 @@ using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.GateKeeper.Meta;
 using DCL.Multiplayer.Connections.GateKeeper.Rooms.Options;
 using DCL.Multiplayer.Connections.Rooms.Connective;
-using DCL.PrivateWorlds;
 using DCL.WebRequests;
-using LiveKit.Proto;
 using DCL.LiveKit.Public;
 using System;
 using System.Threading;
@@ -136,7 +134,7 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
 
             try
             {
-                // The waits below re-check the live input against this capture: a frame-scoped dirty flag would miss changes made while the cycle awaits, parking the room on a stale parcel
+                // Captured so the waits below can detect input changes that occur while this cycle is busy awaiting
                 MetaData.Input input = options.SceneRoomMetaDataSource.GetMetadataInput();
                 var result = await options.SceneRoomMetaDataSource.MetaDataAsync(input, token);
 
@@ -158,10 +156,10 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
 
                     currentMetaData = meta;
 
-                    async UniTask WaitForMetadataInputChangedAsync(MetaData.Input usedInput, CancellationToken token)
+                    async UniTask WaitForMetadataInputChangedAsync(MetaData.Input usedInput, CancellationToken ct)
                     {
                         while (options.SceneRoomMetaDataSource.GetMetadataInput().Equals(usedInput))
-                            await UniTask.Yield(token);
+                            await UniTask.Yield(ct);
                     }
                 }
                 else
@@ -182,20 +180,18 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
                         CurrentSceneRoomConnected?.Invoke();
 
                         if (roomSelection == RoomSelection.NEW)
-                        {
                             currentMetaData = meta;
-                        }
                     }
 
                     waitForReconnectionRequiredTask = WaitForReconnectionRequiredAsync(input, token);
 
                     // Either room has disconnected or metadata has changed
-                    async UniTask WaitForReconnectionRequiredAsync(MetaData.Input usedInput, CancellationToken token)
+                    async UniTask WaitForReconnectionRequiredAsync(MetaData.Input usedInput, CancellationToken ct)
                     {
                         while (CurrentState() is IConnectiveRoom.State.Running
                                && Room().Info.ConnectionState == LKConnectionState.ConnConnected
                                && options.SceneRoomMetaDataSource.GetMetadataInput().Equals(usedInput))
-                            await UniTask.Yield(token);
+                            await UniTask.Yield(ct);
                     }
                 }
 
@@ -213,7 +209,7 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
 
         private async UniTask<string> ConnectionStringAsync(MetaData meta, CancellationToken token)
         {
-            string url = options.GetAdapterURL(meta.sceneId);
+            string url = options.GetAdapterURL(meta.sceneId!);
             
             ReportHub.Log(ReportCategory.COMMS_SCENE_HANDLER,
                 $"[GateKeeperSceneRoom] Requesting adapter from '{url}' for scene '{meta.sceneId}' (secretLength={options.RealmData.WorldCommsSecret.Length})");

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/GateKeeperSceneRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/GateKeeperSceneRoom.cs
@@ -166,7 +166,7 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
                 {
                     if (!meta.Equals(currentMetaData.GetValueOrDefault()) || Room().Info.ConnectionState != LKConnectionState.ConnConnected)
                     {
-                        string connectionString = await ConnectionStringAsync(meta, token);
+                        string connectionString = await ConnectionStringAsync(meta.sceneId, meta, token);
 
                         if (Room().Info.ConnectionState != LKConnectionState.ConnConnected)
                             currentMetaData = null;
@@ -207,16 +207,16 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
             }
         }
 
-        private async UniTask<string> ConnectionStringAsync(MetaData meta, CancellationToken token)
+        private async UniTask<string> ConnectionStringAsync(string sceneId, MetaData meta, CancellationToken token)
         {
-            string url = options.GetAdapterURL(meta.sceneId!);
-            
+            string url = options.GetAdapterURL(sceneId);
+
             ReportHub.Log(ReportCategory.COMMS_SCENE_HANDLER,
-                $"[GateKeeperSceneRoom] Requesting adapter from '{url}' for scene '{meta.sceneId}' (secretLength={options.RealmData.WorldCommsSecret.Length})");
+                $"[GateKeeperSceneRoom] Requesting adapter from '{url}' for scene '{sceneId}' (secretLength={options.RealmData.WorldCommsSecret.Length})");
 
             if (!string.IsNullOrEmpty(options.RealmData.WorldCommsSecret))
                 ReportHub.LogWarning(ReportCategory.COMMS_SCENE_HANDLER,
-                    $"[GateKeeperSceneRoom] Non-empty WorldCommsSecret is being sent for scene '{meta.sceneId}'.");
+                    $"[GateKeeperSceneRoom] Non-empty WorldCommsSecret is being sent for scene '{sceneId}'.");
 
             AdapterResponse response = await webRequests
                                             .SignedFetchPostAsync(url, meta.BuildWithSecret(options.RealmData.WorldCommsSecret, options.HardwareFingerprint), token)

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/IGateKeeperSceneRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/IGateKeeperSceneRoom.cs
@@ -1,12 +1,13 @@
 using Cysharp.Threading.Tasks;
 using DCL.Multiplayer.Connections.GateKeeper.Meta;
 using DCL.Multiplayer.Connections.Rooms.Connective;
+using ECS;
 using System;
 using UnityEngine;
 
 namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
 {
-    public interface IGateKeeperSceneRoom : IActivatableConnectiveRoom
+    public interface IGateKeeperSceneRoom : IActivatableConnectiveRoom, ISceneRoomStatus
     {
         /// <summary>
         /// This event is triggered when the current scene room is successfully connected.
@@ -26,11 +27,6 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
         public MetaData? ConnectedScene { get; }
 
         /// <summary>
-        ///     True when the realm declares no comms adapter ("offline:offline"): the room will never connect.
-        /// </summary>
-        public bool IsCommsOffline { get; }
-
-        /// <summary>
         ///     Tells if no communication channel is attached to the given scene.
         /// </summary>
         /// <param name="sceneId"></param>
@@ -44,12 +40,13 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
             public event Action? CurrentSceneRoomForbiddenAccess;
             public MetaData? ConnectedScene { get; } = new MetaData("Fake", Vector2Int.zero, new MetaData.Input());
 
-            public bool IsCommsOffline => true;
-
             public bool Activated => true;
 
             public bool IsSceneConnected(string? sceneId) =>
                 false;
+
+            public bool IsSceneRoomSettled(string sceneId) =>
+                true;
 
             public UniTask ActivateAsync() =>
                 UniTask.CompletedTask;

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/IGateKeeperSceneRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/IGateKeeperSceneRoom.cs
@@ -26,6 +26,11 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
         public MetaData? ConnectedScene { get; }
 
         /// <summary>
+        ///     True when the realm declares no comms adapter ("offline:offline"): the room will never connect.
+        /// </summary>
+        public bool IsCommsOffline { get; }
+
+        /// <summary>
         ///     Tells if no communication channel is attached to the given scene.
         /// </summary>
         /// <param name="sceneId"></param>
@@ -38,6 +43,8 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
             public event Action? CurrentSceneRoomDisconnected;
             public event Action? CurrentSceneRoomForbiddenAccess;
             public MetaData? ConnectedScene { get; } = new MetaData("Fake", Vector2Int.zero, new MetaData.Input());
+
+            public bool IsCommsOffline => true;
 
             public bool Activated => true;
 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/IRoomHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/IRoomHub.cs
@@ -1,7 +1,6 @@
 using Cysharp.Threading.Tasks;
 using DCL.Multiplayer.Connections.Archipelago.Rooms.Chat;
 using DCL.Multiplayer.Connections.GateKeeper.Rooms;
-using DCL.Multiplayer.Connections.Rooms.Connective;
 using LiveKit.Proto;
 using LiveKit.Rooms;
 using LiveKit.Rooms.Participants;
@@ -31,20 +30,6 @@ namespace DCL.Multiplayer.Connections.RoomHubs
         public static bool HasAnyRoomConnected(this IRoomHub roomHub) =>
             roomHub.IslandRoom().Info.ConnectionState == LKConnectionState.ConnConnected ||
             roomHub.SceneRoom().Room().Info.ConnectionState == LKConnectionState.ConnConnected;
-
-        /// <summary>
-        ///     True when the scene comms for the given scene are settled: the room is connected for that scene,
-        ///     or it is in a state in which it will never connect (deactivated, offline realm comms, forbidden access)
-        /// </summary>
-        public static bool IsSceneRoomSettled(this IRoomHub roomHub, string sceneId)
-        {
-            IGateKeeperSceneRoom sceneRoom = roomHub.SceneRoom();
-
-            if (!sceneRoom.Activated || sceneRoom.IsCommsOffline || sceneRoom.AttemptToConnectState is AttemptToConnectState.FORBIDDEN_ACCESS)
-                return true;
-
-            return sceneRoom.IsSceneConnected(sceneId);
-        }
 
         public static int ParticipantsCount(this IRoomHub roomHub) =>
             roomHub.AllLocalRoomsRemoteParticipantIdentities().Count;

--- a/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/IRoomHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/RoomHubs/IRoomHub.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.Multiplayer.Connections.Archipelago.Rooms.Chat;
 using DCL.Multiplayer.Connections.GateKeeper.Rooms;
+using DCL.Multiplayer.Connections.Rooms.Connective;
 using LiveKit.Proto;
 using LiveKit.Rooms;
 using LiveKit.Rooms.Participants;
@@ -30,6 +31,20 @@ namespace DCL.Multiplayer.Connections.RoomHubs
         public static bool HasAnyRoomConnected(this IRoomHub roomHub) =>
             roomHub.IslandRoom().Info.ConnectionState == LKConnectionState.ConnConnected ||
             roomHub.SceneRoom().Room().Info.ConnectionState == LKConnectionState.ConnConnected;
+
+        /// <summary>
+        ///     True when the scene comms for the given scene are settled: the room is connected for that scene,
+        ///     or it is in a state in which it will never connect (deactivated, offline realm comms, forbidden access)
+        /// </summary>
+        public static bool IsSceneRoomSettled(this IRoomHub roomHub, string sceneId)
+        {
+            IGateKeeperSceneRoom sceneRoom = roomHub.SceneRoom();
+
+            if (!sceneRoom.Activated || sceneRoom.IsCommsOffline || sceneRoom.AttemptToConnectState is AttemptToConnectState.FORBIDDEN_ACCESS)
+                return true;
+
+            return sceneRoom.IsSceneConnected(sceneId);
+        }
 
         public static int ParticipantsCount(this IRoomHub roomHub) =>
             roomHub.AllLocalRoomsRemoteParticipantIdentities().Count;

--- a/Explorer/Assets/DCL/NetworkDefinitions/ISceneRoomStatus.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/ISceneRoomStatus.cs
@@ -1,0 +1,14 @@
+namespace ECS
+{
+    /// <summary>
+    ///     Connection status of the comms room backing scenes, exposed without a dependency on the comms assemblies
+    /// </summary>
+    public interface ISceneRoomStatus
+    {
+        /// <summary>
+        ///     True when the comms for the given scene are settled: the room is connected for that scene,
+        ///     or it is in a state in which it will never connect (deactivated, offline realm comms, forbidden access)
+        /// </summary>
+        bool IsSceneRoomSettled(string sceneId);
+    }
+}

--- a/Explorer/Assets/DCL/NetworkDefinitions/ISceneRoomStatus.cs.meta
+++ b/Explorer/Assets/DCL/NetworkDefinitions/ISceneRoomStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acfd550df25a42919835dc5e752a15b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/RealmNavigation/Container/RealmNavigationContainer.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/Container/RealmNavigationContainer.cs
@@ -86,7 +86,7 @@ namespace DCL.RealmNavigation
                     new LoadLandscapeTeleportOperation(landscape),
                     new PrewarmRoadAssetPoolsTeleportOperation(realmContainer.RealmController, lodContainer.RoadAssetsPool),
                     new UnloadCacheImmediateTeleportOperation(staticContainer.CacheCleaner, staticContainer.SingletonSharedDependencies.MemoryBudget),
-                    new MoveToParcelInNewRealmTeleportOperation(staticContainer.LoadingStatus, realmContainer.RealmController, exposedGlobalDataContainer.ExposedCameraData.CameraEntityProxy, realmContainer.TeleportController, exposedGlobalDataContainer.CameraSamplingData),
+                    new MoveToParcelInNewRealmTeleportOperation(staticContainer.LoadingStatus, realmContainer.RealmController, exposedGlobalDataContainer.ExposedCameraData.CameraEntityProxy, realmContainer.TeleportController, exposedGlobalDataContainer.CameraSamplingData, roomHub),
                     new RestartRoomAsyncTeleportOperation(roomHub, LIVEKIT_TIMEOUT),
                 },
                 ReportCategory.SCENE_LOADING,

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/MoveToParcelInNewRealmTeleportOperation.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/MoveToParcelInNewRealmTeleportOperation.cs
@@ -1,6 +1,7 @@
 using Arch.Core;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
+using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Utilities;
 using DCL.Utility.Types;
 using ECS.Prioritization.Components;
@@ -11,7 +12,7 @@ namespace DCL.RealmNavigation.TeleportOperations
     public class MoveToParcelInNewRealmTeleportOperation : TeleportToSpawnPointOperationBase<TeleportParams>, ITeleportOperation
     {
         public MoveToParcelInNewRealmTeleportOperation(ILoadingStatus loadingStatus, IGlobalRealmController realmController, ObjectProxy<Entity> cameraEntity, ITeleportController teleportController, CameraSamplingData cameraSamplingData,
-            string reportCategory = ReportCategory.SCENE_LOADING) : base(loadingStatus, realmController, cameraEntity, teleportController, cameraSamplingData, reportCategory) { }
+            IRoomHub roomHub, string reportCategory = ReportCategory.SCENE_LOADING) : base(loadingStatus, realmController, cameraEntity, teleportController, cameraSamplingData, roomHub, reportCategory) { }
 
         public override UniTask<EnumResult<TaskError>> ExecuteAsync(TeleportParams args, CancellationToken ct) =>
             InternalExecuteAsync(args, args.CurrentDestinationParcel, ct, args.AllowsWorldPositionOverride, args.LandOnParcel);

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/TeleportToSpawnPointOperationBase.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/TeleportToSpawnPointOperationBase.cs
@@ -2,6 +2,8 @@
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Ipfs;
+using DCL.Multiplayer.Connections.RoomHubs;
+using DCL.Multiplayer.Connections.Rooms.Connective;
 using DCL.RealmNavigation.LoadingOperation;
 using DCL.Utilities;
 using DCL.Utility.Types;
@@ -26,15 +28,17 @@ namespace DCL.RealmNavigation.TeleportOperations
         private readonly CameraSamplingData cameraSamplingData;
         private readonly string reportCategory;
         private readonly ITeleportController teleportController;
+        private readonly IRoomHub roomHub;
 
         protected TeleportToSpawnPointOperationBase(ILoadingStatus loadingStatus, IGlobalRealmController realmController, ObjectProxy<Entity> cameraEntity, ITeleportController teleportController, CameraSamplingData cameraSamplingData,
-            string reportCategory = ReportCategory.SCENE_LOADING)
+            IRoomHub roomHub, string reportCategory = ReportCategory.SCENE_LOADING)
         {
             this.loadingStatus = loadingStatus;
             this.realmController = realmController;
             this.cameraEntity = cameraEntity;
             this.teleportController = teleportController;
             this.cameraSamplingData = cameraSamplingData;
+            this.roomHub = roomHub;
             this.reportCategory = reportCategory;
         }
 
@@ -90,6 +94,11 @@ namespace DCL.RealmNavigation.TeleportOperations
             // add camera sampling data to the camera entity to start partitioning
             Assert.IsTrue(cameraEntity.Configured);
             realmController.GlobalWorld.EcsWorld.Add(cameraEntity.Object, cameraSamplingData);
+
+            // The destination scene gates its start on this room (see ControlSceneUpdateLoopSystem) and the readiness wait below needs the scene running, so the connection must be kicked off first
+            if (isWorld)
+                roomHub.SceneRoom().StartIfNotAsync().Forget();
+
             return await waitForSceneReadiness.ToUniTask();
         }
 

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/TeleportToSpawnPointOperationBase.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/TeleportToSpawnPointOperationBase.cs
@@ -95,11 +95,23 @@ namespace DCL.RealmNavigation.TeleportOperations
             Assert.IsTrue(cameraEntity.Configured);
             realmController.GlobalWorld.EcsWorld.Add(cameraEntity.Object, cameraSamplingData);
 
-            // The destination scene gates its start on this room (see ControlSceneUpdateLoopSystem) and the readiness wait below needs the scene running, so the connection must be kicked off first
+            // Detached: connecting can take seconds and must not delay enqueueing the readiness report below
             if (isWorld)
-                roomHub.SceneRoom().StartIfNotAsync().Forget();
+                StartSceneRoomAsync().Forget();
 
             return await waitForSceneReadiness.ToUniTask();
+        }
+
+        private async UniTaskVoid StartSceneRoomAsync()
+        {
+            try
+            {
+                bool started = await roomHub.SceneRoom().StartIfNotAsync();
+
+                if (!started)
+                    ReportHub.LogWarning(reportCategory, "Scene room connection attempt failed on world teleport");
+            }
+            catch (Exception e) { ReportHub.LogException(e, reportCategory); }
         }
 
         private async UniTask<WaitForSceneReadiness?> TeleportToWorldSpawnPointAsync(
@@ -128,16 +140,14 @@ namespace DCL.RealmNavigation.TeleportOperations
             }
             else
             {
-                bool isSceneContained = false;
+                var isSceneContained = false;
                 // Check if result contains the requested parcel.
                 foreach (var sceneEntityDefinition in scenes)
-                {
                     if (sceneEntityDefinition.Contains(parcelToTeleport))
                     {
                         isSceneContained = true;
                         break;
                     }
-                }
 
                 // If no parcel is present on any scene, teleport to the first Decoded Base
                 if (!isSceneContained)

--- a/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/TeleportToSpawnPointOperationBase.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportOperations/TeleportToSpawnPointOperationBase.cs
@@ -111,6 +111,7 @@ namespace DCL.RealmNavigation.TeleportOperations
                 if (!started)
                     ReportHub.LogWarning(reportCategory, "Scene room connection attempt failed on world teleport");
             }
+            catch (OperationCanceledException) { }
             catch (Exception e) { ReportHub.LogException(e, reportCategory); }
         }
 

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/TeleportStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/TeleportStartupOperation.cs
@@ -2,6 +2,7 @@ using Arch.Core;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Ipfs;
+using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.RealmNavigation;
 using DCL.RealmNavigation.TeleportOperations;
 using DCL.Utilities;
@@ -28,9 +29,10 @@ namespace DCL.UserInAppInitializationFlow
             CameraSamplingData cameraSamplingData,
             StartParcel startParcel,
             IAppArgs appArgs,
+            IRoomHub roomHub,
             bool editorPositionOverrideActive = false,
             string reportCategory = ReportCategory.SCENE_LOADING)
-            : base(loadingStatus, realmController, cameraEntity, teleportController, cameraSamplingData, reportCategory)
+            : base(loadingStatus, realmController, cameraEntity, teleportController, cameraSamplingData, roomHub, reportCategory)
         {
             this.startParcel = startParcel;
             this.appArgs = appArgs;

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/TeleportStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/TeleportStartupOperation.cs
@@ -1,13 +1,11 @@
 using Arch.Core;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
-using DCL.Ipfs;
 using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.RealmNavigation;
 using DCL.RealmNavigation.TeleportOperations;
 using DCL.Utilities;
 using DCL.Utility.Types;
-using ECS;
 using ECS.Prioritization.Components;
 using Global.AppArgs;
 using System.Threading;

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/TeleportStartupOperationShould.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/TeleportStartupOperationShould.cs
@@ -1,6 +1,8 @@
 using Arch.Core;
 using Cysharp.Threading.Tasks;
 using DCL.Ipfs;
+using DCL.Multiplayer.Connections.GateKeeper.Rooms;
+using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.RealmNavigation;
 using DCL.Utilities;
 using ECS;
@@ -28,6 +30,7 @@ namespace DCL.UserInAppInitializationFlow.Tests
         private ITeleportController teleportController;
         private ILoadingStatus loadingStatus;
         private IAppArgs appArgs;
+        private IRoomHub roomHub;
         private CancellationTokenSource cts;
         private CancellationTokenSource globalWorldCts;
         private WorldManifest worldManifest;
@@ -64,6 +67,10 @@ namespace DCL.UserInAppInitializationFlow.Tests
                 .Returns(UniTask.FromResult<WaitForSceneReadiness?>(null));
 
             appArgs = Substitute.For<IAppArgs>();
+
+            roomHub = Substitute.For<IRoomHub>();
+            roomHub.SceneRoom().Returns(Substitute.For<IGateKeeperSceneRoom>());
+
             cts = new CancellationTokenSource();
         }
 
@@ -174,6 +181,6 @@ namespace DCL.UserInAppInitializationFlow.Tests
 
         private TeleportStartupOperation CreateOperation(StartParcel startParcel, bool editorPositionOverrideActive = false) =>
             new TeleportStartupOperation(loadingStatus, realmController, cameraEntityProxy,
-                teleportController, new CameraSamplingData(), startParcel, appArgs, editorPositionOverrideActive);
+                teleportController, new CameraSamplingData(), startParcel, appArgs, roomHub, editorPositionOverrideActive);
     }
 }

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/TeleportStartupOperationShould.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/TeleportStartupOperationShould.cs
@@ -22,17 +22,17 @@ namespace DCL.UserInAppInitializationFlow.Tests
     [TestFixture]
     public class TeleportStartupOperationShould
     {
-        private World world;
-        private ObjectProxy<Entity> cameraEntityProxy;
-        private GlobalWorld globalWorld;
-        private IGlobalRealmController realmController;
-        private IRealmData realmData;
-        private ITeleportController teleportController;
-        private ILoadingStatus loadingStatus;
-        private IAppArgs appArgs;
-        private IRoomHub roomHub;
-        private CancellationTokenSource cts;
-        private CancellationTokenSource globalWorldCts;
+        private World world = null!;
+        private ObjectProxy<Entity> cameraEntityProxy = null!;
+        private GlobalWorld globalWorld = null!;
+        private IGlobalRealmController realmController = null!;
+        private IRealmData realmData = null!;
+        private ITeleportController teleportController = null!;
+        private ILoadingStatus loadingStatus = null!;
+        private IAppArgs appArgs = null!;
+        private IRoomHub roomHub = null!;
+        private CancellationTokenSource cts = null!;
+        private CancellationTokenSource globalWorldCts = null!;
         private WorldManifest worldManifest;
 
         [SetUp]
@@ -165,6 +165,36 @@ namespace DCL.UserInAppInitializationFlow.Tests
             Assert.IsTrue(startParcel.IsConsumed());
         }
 
+        [Test]
+        public void StartsSceneRoomConnectionOnWorldTeleport()
+        {
+            worldManifest = WorldManifest.Create(new WorldManifestDto
+            {
+                occupied = new[] { "5,7" },
+                spawn_coordinate = new SpawnCoordinateData(5, 7),
+                total = 1,
+            });
+            realmData.WorldManifest.Returns(worldManifest);
+            appArgs.HasFlag(AppArgsFlags.POSITION).Returns(false);
+
+            CreateOperation(new StartParcel(new Vector2Int(5, 7)))
+                .ExecuteAsync(MakeParams(), cts.Token).GetAwaiter().GetResult();
+
+            roomHub.SceneRoom().Received(1).StartAsync();
+        }
+
+        [Test]
+        public void DoesNotStartSceneRoomOnNonWorldTeleport()
+        {
+            realmData.RealmType.Returns(new ReactiveProperty<RealmKind>(RealmKind.GenesisCity));
+            appArgs.HasFlag(AppArgsFlags.POSITION).Returns(false);
+
+            CreateOperation(new StartParcel(new Vector2Int(10, 20)))
+                .ExecuteAsync(MakeParams(), cts.Token).GetAwaiter().GetResult();
+
+            roomHub.SceneRoom().DidNotReceive().StartAsync();
+        }
+
         private IStartupOperation.Params MakeParams()
         {
             Entity playerEntity = world.Create();
@@ -180,7 +210,7 @@ namespace DCL.UserInAppInitializationFlow.Tests
         }
 
         private TeleportStartupOperation CreateOperation(StartParcel startParcel, bool editorPositionOverrideActive = false) =>
-            new TeleportStartupOperation(loadingStatus, realmController, cameraEntityProxy,
+            new (loadingStatus, realmController, cameraEntityProxy,
                 teleportController, new CameraSamplingData(), startParcel, appArgs, roomHub, editorPositionOverrideActive);
     }
 }

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/TeleportStartupOperationShould.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/TeleportStartupOperationShould.cs
@@ -3,6 +3,7 @@ using Cysharp.Threading.Tasks;
 using DCL.Ipfs;
 using DCL.Multiplayer.Connections.GateKeeper.Rooms;
 using DCL.Multiplayer.Connections.RoomHubs;
+using DCL.Multiplayer.Connections.Rooms.Connective;
 using DCL.RealmNavigation;
 using DCL.Utilities;
 using ECS;
@@ -176,6 +177,9 @@ namespace DCL.UserInAppInitializationFlow.Tests
             });
             realmData.WorldManifest.Returns(worldManifest);
             appArgs.HasFlag(AppArgsFlags.POSITION).Returns(false);
+
+            // StartIfNotAsync is an extension NSubstitute can't intercept; from Stopped it delegates to StartAsync, which the assertion observes
+            roomHub.SceneRoom().CurrentState().Returns(IConnectiveRoom.State.Stopped);
 
             CreateOperation(new StartParcel(new Vector2Int(5, 7)))
                 .ExecuteAsync(MakeParams(), cts.Token).GetAwaiter().GetResult();


### PR DESCRIPTION
# Pull Request Description
Fixes #8697 

The problem is that when user A starts a livekit stream using admin tool in a scene and user B teleport/switch realm and join the scene, he is not able to see it unless he reloads the scene.

This happens because when teleporting, the scene loop is started before the livekit room is actually connected (connection is fire&forget). Since its code is running but cannot detect the stream because livekit is currently connecting, it fallback to whatever default video is on the screen in its `src` property.
When the connection is established, the RES_CRDT_STATE received is dropped due to LWW synchronization mechanism and the timestamp from both the local and incoming CRDT state.

Reloading works because the room is already connected so the scene is able to detect the stream so the user correctly resolves the CRDT message and presents the stream.

Worth noting: a change in how the admin tools works in that path would completely eliminate the issue (e.g. moving it to auth-server, so the CRDT message comes from an authority and cannot be discarded by the client during handshake)

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

The teleport now kicks off the scene-room connection early (`TeleportToSpawnPointOperationBase`), the gatekeeper connection cycle now converges race-free on the player's current parcel by comparing live metadata input instead of a frame-scoped dirty flag (`GateKeeperSceneRoom`), and `ControlSceneUpdateLoopSystem` holds the teleport-destination scene's start (worlds only, identified by its pending readiness report) until the room is connected for that scene via the new `ISceneRoomStatus.IsSceneRoomSettled(sceneId)`, with a 15s fallback so offline/denied worlds still load.

All teleport cases are covered (they all reach `TeleportToSceneSpawnPointAsync`). The only hole is walk in scenes: we are loading and starting neighbouring scenes while walking, but we connect to the current scene livekit's room only (those scenes will run without a livekit connection unless you walk inside, but at that point it's too late -> they were not able to detect such streams).

This trade-off is acceptable for two reasons:
- very few livekit streams happening (if any) on LANDs
- this problem will be eventually naturally removed when we transition to single scenes only


### Prerequisites
- Use 2 users: user A and B
- Have a world where you can stream

### Test Steps
1. With user A, reach the world and start streaming using OBS and admin tools
2. With user B, launch the explorer and teleport first to Genesis Plaza (this is mandatory, don't go directly into the world)
3. with user B, teleport to the world where the stream is happening
4. verify that user B is able to see the streaming without reloading
5. Generic smoke test: verify you are able to walk around/teleport and different scenes behaves correctly


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
