### PR TITLE
fix: restore AB visibility on finished loading

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Components/GltfContainerAsset.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Components/GltfContainerAsset.cs
@@ -94,6 +94,15 @@ namespace ECS.Unity.GLTFContainer.Asset.Components
                 Renderers[i].forceRenderingOff = !newState;
         }
 
+        /// <summary>
+        ///     Restores rendering on reuse: cached assets keep whatever renderer state the previous scene left (e.g. hidden via a VisibilityComponent).
+        /// </summary>
+        public void EnableRenderers()
+        {
+            foreach (var renderer in Renderers)
+                renderer.enabled = true;
+        }
+
         public void ToggleAnimationState(bool newState)
         {
             foreach (Animation animation in Animations)

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Components/GltfContainerAsset.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Components/GltfContainerAsset.cs
@@ -94,13 +94,10 @@ namespace ECS.Unity.GLTFContainer.Asset.Components
                 Renderers[i].forceRenderingOff = !newState;
         }
 
-        /// <summary>
-        ///     Restores rendering on reuse: cached assets keep whatever renderer state the previous scene left (e.g. hidden via a VisibilityComponent).
-        /// </summary>
-        public void EnableRenderers()
+        public void SetRenderersActive(bool active)
         {
             foreach (var renderer in Renderers)
-                renderer.enabled = true;
+                renderer.enabled = active;
         }
 
         public void ToggleAnimationState(bool newState)

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
@@ -95,6 +95,7 @@ namespace ECS.Unity.GLTFContainer.Systems
                 result.Asset.Root.transform.ResetLocalTRS();
                 result.Asset.Root.SetActive(true);
 
+                result.Asset.EnableRenderers();
                 result.Asset.ToggleAnimationState(true);
 
                 component.State = LoadingState.Finished;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
@@ -95,7 +95,7 @@ namespace ECS.Unity.GLTFContainer.Systems
                 result.Asset.Root.transform.ResetLocalTRS();
                 result.Asset.Root.SetActive(true);
 
-                result.Asset.EnableRenderers();
+                result.Asset.SetRenderersActive(true);
                 result.Asset.ToggleAnimationState(true);
 
                 component.State = LoadingState.Finished;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
@@ -147,8 +147,7 @@ namespace ECS.Unity.GLTFContainer.Tests
 
             GltfContainerAsset asset = world.Get<StreamableLoadingResult<GltfContainerAsset>>(component.Promise.Entity).Asset!;
 
-            foreach (Renderer renderer in asset.Renderers)
-                renderer.enabled = false;
+            asset.SetRenderersActive(false);
 
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.RENDERER_WITH_LEGACY_ANIM_HASH });
             AddTransformToEntity(e);

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
@@ -25,6 +25,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using UnityEngine;
 using UnityEngine.TestTools;
 using Utility;
 
@@ -69,8 +70,9 @@ namespace ECS.Unity.GLTFContainer.Tests
 
                 usedResources = false;
             }
-            catch (Exception e)
+            catch (Exception)
             {
+                // ignored
             }
         }
 
@@ -98,7 +100,7 @@ namespace ECS.Unity.GLTFContainer.Tests
 
             LogAssert.ignoreFailingMessages = true;
 
-            system.Update(0);
+            system!.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
             Assert.That(component.State, Is.EqualTo(LoadingState.FinishedWithError));
@@ -132,6 +134,33 @@ namespace ECS.Unity.GLTFContainer.Tests
         }
 
         [Test]
+        public async Task ReEnableRenderersDisabledByPreviousScene()
+        {
+            var component = new GltfContainerComponent(ColliderLayer.ClPhysics, ColliderLayer.ClPointer,
+                AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(
+                    world, new GetGltfContainerAssetIntention(GltfContainerTestResources.RENDERER_WITH_LEGACY_ANIM_NAME, GltfContainerTestResources.RENDERER_WITH_LEGACY_ANIM_HASH, new CancellationTokenSource()), PartitionComponent.TOP_PRIORITY))
+                {
+                    State = LoadingState.Loading,
+                };
+
+            await InstantiateAssetBundle(GltfContainerTestResources.RENDERER_WITH_LEGACY_ANIM_HASH, component.Promise.Entity);
+
+            GltfContainerAsset asset = world.Get<StreamableLoadingResult<GltfContainerAsset>>(component.Promise.Entity).Asset!;
+
+            foreach (Renderer renderer in asset.Renderers)
+                renderer.enabled = false;
+
+            Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.RENDERER_WITH_LEGACY_ANIM_HASH });
+            AddTransformToEntity(e);
+
+            system!.Update(0);
+
+            Assert.That(world.Get<GltfContainerComponent>(e).State, Is.EqualTo(LoadingState.Finished));
+            Assert.That(asset.Renderers, Is.Not.Empty);
+            Assert.That(asset.Renderers.All(r => r.enabled), Is.True);
+        }
+
+        [Test]
         public async Task InstantiateVisibleMeshesColliders()
         {
             var component = new GltfContainerComponent(ColliderLayer.ClPointer, ColliderLayer.ClNone,
@@ -145,7 +174,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH, IsDirty = true });
             AddTransformToEntity(e);
 
-            system.Update(0);
+            system!.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
             GltfContainerAsset promiseAsset = component.Promise.Result.Value.Asset;
@@ -159,16 +188,17 @@ namespace ECS.Unity.GLTFContainer.Tests
         {
             var component = new GltfContainerComponent(ColliderLayer.ClNone, ColliderLayer.ClPointer,
                 AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(
-                    world, new GetGltfContainerAssetIntention(GltfContainerTestResources.SCENE_WITH_COLLIDER_NAME, GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH, new CancellationTokenSource()), PartitionComponent.TOP_PRIORITY));
-
-            component.State = LoadingState.Loading;
+                    world, new GetGltfContainerAssetIntention(GltfContainerTestResources.SCENE_WITH_COLLIDER_NAME, GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH, new CancellationTokenSource()), PartitionComponent.TOP_PRIORITY))
+                {
+                    State = LoadingState.Loading,
+                };
 
             await InstantiateAssetBundle(GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH, component.Promise.Entity);
 
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH });
             AddTransformToEntity(e);
 
-            system.Update(0);
+            system!.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Visibility/Systems/GltfContainerVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Visibility/Systems/GltfContainerVisibilitySystem.cs
@@ -4,8 +4,6 @@ using DCL.ECSComponents;
 using ECS.Abstract;
 using ECS.Unity.GLTFContainer;
 using ECS.Unity.GLTFContainer.Components;
-using System.Collections.Generic;
-using UnityEngine;
 
 namespace ECS.Unity.Visibility.Systems
 {
@@ -22,10 +20,7 @@ namespace ECS.Unity.Visibility.Systems
             // we have several states that are notified with events
             if (component.State != LoadingState.Finished) return;
 
-            List<Renderer> renderers = component.Promise.Result!.Value.Asset!.Renderers;
-
-            for (var i = 0; i < renderers.Count; i++)
-                renderers[i].enabled = visible;
+            component.Promise.Result!.Value.Asset!.SetRenderersActive(visible);
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description
Fixes #9074 

The client doesn't reset the AB's renderer visibility on teardown/usage.
`Genesis Plaza` and `dclexperience.dcl.eth` use some shared asset bundles but the latter hides some ABs.
The two things combined caused the apparent missing assets.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR makes sure that upon usage, an AB's renderers are reset so they all start from the correct state.

### Test Steps
1. Launch the explorer and upon landing in GP, verify all assets are there
2. Teleport to `dclexperience.dcl.eth`, verify all assets are there
3. Go back to GP and verify assets are still there

### Additional Testing Notes
- The linked issue reports incorrect repro steps: the culprit is visit `dclexperience.dcl.eth` first and then go to GP

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
