### PR TITLE
fix: repair CI workflow bugs found in pipeline audit

### DIFF
--- a/.github/workflows/auto-sync-main-to-dev.yml
+++ b/.github/workflows/auto-sync-main-to-dev.yml
@@ -22,9 +22,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr create \
-            --base dev \
-            --head chore/sync \
-            --title "chore: sync main to dev" \
-            --body ":crown: *An automated PR*" \
-            --label auto-pr \
+          # Create the PR only if none is open — a second create fails and would
+          # turn every subsequent push to main into a red run.
+          PR_NUMBER=$(gh pr list --head chore/sync --base dev --state open --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            gh pr create \
+              --base dev \
+              --head chore/sync \
+              --title "chore: sync main to dev" \
+              --body ":crown: *An automated PR*"
+            PR_NUMBER=$(gh pr list --head chore/sync --base dev --state open --json number --jq '.[0].number')
+          fi
+
+          # Always ensure the label is applied (handles 502 / retry scenarios)
+          gh pr edit "$PR_NUMBER" --add-label auto-pr

--- a/.github/workflows/build-game-ci-image.yml
+++ b/.github/workflows/build-game-ci-image.yml
@@ -1,9 +1,9 @@
 name: Build GameCI Image
 
+# workflow_dispatch only: a push trigger cannot supply the required inputs —
+# on push every ${{ inputs.* }} is empty, producing a malformed image tag and
+# empty docker build args.
 on:
-  push:
-    branches:
-      - dev-game-ci-docker-image
   workflow_dispatch:
     inputs:
       editor_version:

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -9,7 +9,6 @@ on:
       - ready_for_review
       - labeled
       - unlabeled
-  merge_group: {}
   push:
     branches:
       - dev
@@ -176,7 +175,6 @@ concurrency:
     ${{
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'merge_group' ||
       (
         github.event_name == 'pull_request' &&
         (
@@ -995,4 +993,3 @@ jobs:
           fi
 
           echo "Both Windows and macOS builds passed."
-# Test change

--- a/.github/workflows/enforce-group-approvals.yml
+++ b/.github/workflows/enforce-group-approvals.yml
@@ -88,7 +88,16 @@ jobs:
 
           echo "🔍 Fetching PR reviews..."
           PR_REVIEWS_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO_OWNER/$REPO_NAME" --json reviews -q '.reviews')
-          PR_REVIEWS=$(jq -r '.[] | select(.state == "APPROVED") | .author.login' <<< "$PR_REVIEWS_JSON")
+          # Only the latest state-changing review per user counts: an approval
+          # later replaced by a changes-requested review (or dismissed) must not
+          # satisfy the gate. COMMENTED reviews are ignored — they do not
+          # supersede an approval.
+          PR_REVIEWS=$(jq -r '
+            [ .[] | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED") ]
+            | group_by(.author.login)
+            | map(max_by(.submittedAt))
+            | .[] | select(.state == "APPROVED")
+            | .author.login' <<< "$PR_REVIEWS_JSON")
           echo "✅ Approved Reviews (before filtering): ${PR_REVIEWS:-None}"
 
           echo "🔍 Fetching pending review requests..."

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -70,6 +70,9 @@ jobs:
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
+          # Without a body filter this matches the FIRST bot comment of any kind
+          # (warning-ratchet, ext-contribution marker, ...) and overwrites it.
+          body-includes: 'img.shields.io/badge/Build'
 
       - name: Post skipped comment
         uses: peter-evans/create-or-update-comment@v3
@@ -200,6 +203,9 @@ jobs:
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
+          # Without a body filter this matches the FIRST bot comment of any kind
+          # (warning-ratchet, ext-contribution marker, ...) and overwrites it.
+          body-includes: 'img.shields.io/badge/Build'
 
       - name: Update Comment
         env:
@@ -265,6 +271,9 @@ jobs:
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
+          # Without a body filter this matches the FIRST bot comment of any kind
+          # (warning-ratchet, ext-contribution marker, ...) and overwrites it.
+          body-includes: 'img.shields.io/badge/Build'
 
       - name: Update Comment
         uses: peter-evans/create-or-update-comment@v3

--- a/.github/workflows/pr-comment-delete-artifact-url.yml
+++ b/.github/workflows/pr-comment-delete-artifact-url.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           issue-number: ${{ needs.pre-validation.outputs.pr-number }}
           comment-author: 'github-actions[bot]'
+          # Without a body filter this matches the FIRST bot comment of any kind
+          # (warning-ratchet, ext-contribution marker, ...) and overwrites it.
+          body-includes: 'img.shields.io/badge/Build'
       - name: Update Comment
         uses: peter-evans/create-or-update-comment@v3
         with:

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -82,7 +82,10 @@ jobs:
         uses: actions/cache@v5
         with:
           path: Explorer/Library
-          key: Library-Explorer-Ubuntu
+          # Same key scheme as test.yml — cache entries are immutable, so a
+          # constant key would pin the very first Library forever.
+          key: Library-Explorer-Ubuntu-${{ hashFiles('Explorer/Packages/packages-lock.json', 'Explorer/ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: Library-Explorer-Ubuntu-
 
       # --- Detect Unity version from the project ---
       - name: Read Unity version from ProjectVersion.txt
@@ -160,7 +163,6 @@ jobs:
           sshAgent: ${{ env.SSH_AUTH_SOCK }}
           customImage: ${{ steps.img.outputs.ghcr }}
           customParameters: -buildTarget StandaloneLinux64 -testCategory "Performance" -perfTestResults ./PerformanceTestResults.json -DCLBenchmarkCIPKey ${{ secrets.DCL_BENCHMARK_CIP_KEY }}
-          githubToken: ${{ env.GITHUB_TOKEN }}
 
       # Generate PDF report
       - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,36 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Only cancel an in-flight run when the new event will actually produce a new
+  # useful run. Otherwise an incidental 'labeled' event (bots add labels like
+  # 'new-dependency', 'claude-approved' or 'no QA needed' mid-run) would cancel
+  # real in-progress tests and replace them with a run that skips every job.
+  cancel-in-progress: >-
+    ${{
+      github.event_name != 'pull_request' ||
+      github.event.action == 'opened' ||
+      github.event.action == 'reopened' ||
+      github.event.action == 'synchronize' ||
+      github.event.action == 'ready_for_review' ||
+      (
+        github.event.action == 'labeled' &&
+        contains(fromJSON('["force-build", "clean-build", "force-lint"]'), github.event.label.name)
+      )
+    }}
 
 jobs:
 
   changes:
-    if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) || (github.event.pull_request.draft == false) || (github.event.label.name == 'force-build') || (github.event.label.name == 'clean-build') || (github.event.label.name == 'force-lint')
+    # Non-PR events (push to dev, merge_group, workflow_dispatch) always run.
+    # PR events run for non-draft PRs, except 'labeled', which only counts for
+    # the trigger labels — any other label add must not start a redundant run.
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.pull_request.draft == false) ||
+      (
+        github.event.action == 'labeled' &&
+        contains(fromJSON('["force-build", "clean-build", "force-lint"]'), github.event.label.name)
+      )
     name: Detect C# changes
     runs-on: ubuntu-latest
     outputs:
@@ -431,13 +455,16 @@ jobs:
 
 
   test:
-    # Skip when PR has 'perf_test' label (performance tests run in separate workflow)
+    # Skip when PR has 'perf_test' label (performance tests run in separate workflow).
+    # Same event gating as the 'changes' job, minus 'force-lint' (lint-only label).
     if: |
       !contains(github.event.pull_request.labels.*.name, 'perf_test') && (
-        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        (github.event.pull_request.draft == false) ||
-        (github.event.label.name == 'force-build') ||
-        (github.event.label.name == 'clean-build')
+        github.event_name != 'pull_request' ||
+        (github.event.action != 'labeled' && github.event.pull_request.draft == false) ||
+        (
+          github.event.action == 'labeled' &&
+          contains(fromJSON('["force-build", "clean-build"]'), github.event.label.name)
+        )
       )
     name: Test (${{ matrix.testMode }})
     runs-on: ubuntu-latest
@@ -590,7 +617,6 @@ jobs:
           sshAgent: ${{ env.SSH_AUTH_SOCK }}
           customImage: ${{ matrix.testMode == 'editmode' && steps.rg-img.outputs.image || steps.img.outputs.ghcr }}
           customParameters: -buildTarget StandaloneLinux64 -testCategory "!Performance" -burst-disable-compilation -accept-apiupdate
-          githubToken: ${{ env.GITHUB_TOKEN }}
 
       - name: Dump Unity Editor log on failure
         if: always() && steps.testRunner.outcome != 'success'
@@ -653,8 +679,13 @@ jobs:
   watchdog:
     runs-on: ubuntu-latest
     needs: [lint, test]
+    # always() is required: without a status-check function GitHub wraps the
+    # condition in an implicit success(), which is false whenever a needed job
+    # fails — the exact case this job exists for — so it never ran at all.
     if: |
-      needs.lint.result == 'failure' ||
-      needs.test.result == 'failure'
+      always() && (
+        needs.lint.result == 'failure' ||
+        needs.test.result == 'failure'
+      )
     steps:
       - run: exit 1


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes ten defects found in a full audit of the CI pipelines. No behavior is added — each change makes a workflow do what its code already claims to do.

1. **`test.yml` watchdog never ran** (verified on real runs, e.g. run 28808093323: Lint `failure`, watchdog `skipped`). Its `if` had no status-check function, so GitHub wrapped it in an implicit `success()` — false exactly when a needed job fails. Now `always() && (…)`.
2. **Any label add cancelled in-flight test runs.** `on: pull_request: types: [labeled]` + unconditional `cancel-in-progress: true` meant bot labels added mid-run (`new-dependency` at the start of Dependency Security Review, `claude-approved`, `no QA needed`) killed a running 80-minute test job and replaced it with a run that skips everything. Cancellation and job conditions are now gated the same way `build-unitycloud.yml` already does it.
3. **`test.yml` push/merge_group runs only worked by accident.** The explicit clause checked `refs/heads/main`, which the dev-only push trigger can never produce; dev pushes (which seed the warning baseline) passed only because `null == false` coerces to true in Actions expressions. Event handling is now explicit.
4. **`build-unitycloud.yml` dead `merge_group` trigger removed.** Prebuild's `if` never matched the event, so merge-queue runs would skip every job and report green without building. If a merge queue is ever adopted, proper support must be added instead.
5. **`auto-sync-main-to-dev.yml`** failed on every push to main while a sync PR was already open (`gh pr create` errors on duplicates); also removed a dangling `\` line continuation.
6. **`enforce-group-approvals.yml` counted stale approvals.** A reviewer who approved and later requested changes still satisfied the gate. Only each user's latest state-changing review (APPROVED / CHANGES_REQUESTED / DISMISSED) counts now; COMMENTED reviews don't supersede an approval.
7. **`pr-comment-artifact-url.yml` / `pr-comment-delete-artifact-url.yml`** matched the *first* `github-actions[bot]` comment of any kind and overwrote it — the warning-ratchet and ext-contribution comments share that author. Now scoped with `body-includes: img.shields.io/badge/Build` (present in all badge bodies, so existing PR comments keep working).
8. **`test-performance.yml` Library cache never updated** — constant key `Library-Explorer-Ubuntu` on an immutable cache pinned the first-ever entry forever. Now uses the same `hashFiles(...)` key + restore-keys as `test.yml` (and shares its cache).
9. **`githubToken: ${{ env.GITHUB_TOKEN }}`** in both test workflows referenced an env var that is never defined — removed the dead config (check reporting already goes through dorny/test-reporter).
10. **`build-game-ci-image.yml` push trigger removed** — on push all `inputs.*` are empty, producing image tag `…:--` and empty build args.

**Flagged, not changed** (needs a maintainer decision): `build-unitycloud.yml` declares **12 `workflow_dispatch` inputs**; GitHub documents a limit of 10. No dispatch runs exist in the last 100 runs to confirm whether manual dispatch still works. If it is broken, two inputs need to be merged or dropped (e.g. the two delta thresholds).

All changed files pass `actionlint` (only pre-existing findings remain repo-wide).

## Test Instructions

CI-only change — there is no client behavior to run; verification is on the workflows themselves.

**Steps (standard run)**: N/A (no Explorer/ changes; the build/test pipelines will skip or run unchanged on this PR).

### Prerequisites
- [ ] None

### Test Steps
1. On this PR, confirm Unity Test triggers normally and the `watchdog` job appears (it should be `skipped` when lint+tests pass).
2. Add any unrelated label (e.g. `no QA needed`) while a Unity Test run is in flight → the run must NOT be cancelled.
3. Add `force-lint` → lint re-runs; tests are not restarted.
4. After merge, push to `dev` → Unity Test still runs (baseline update path) — this exercises the explicit non-PR event condition.
5. On a PR with an approval that was later superseded by "request changes" from the same reviewer, `QA and DEV Approvals` must report the approval as missing.

### Additional Testing Notes
- The find-comment scoping keeps matching pre-existing badge comments (they all contain `img.shields.io/badge/Build`), so no duplicate badge comments should appear on open PRs.
- Merge-queue is not currently enabled; removing the dead `merge_group` trigger changes nothing observable.

## Quality Checklist
- [x] Changes have been tested locally (actionlint on all touched workflows; watchdog bug verified against live run history)
- [x] Documentation has been updated (if required) — N/A, comments added inline
- [x] Performance impact has been considered (fewer cancelled/redundant CI runs; perf tests stop re-importing from a stale Library)
- [ ] For SDK features: Test scene is included — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)