### PR TITLE
chore: remove dead CI config and fix misleading contracts

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -5,8 +5,8 @@ inputs:
     description: 'Formatted version tag. If not set, it uses the latest version tag (v[0-9]*)'
     required: false
   commit_sha:
-    description: 'The commit SHA to use for versioning'
-    required: true
+    description: 'The commit SHA to use for versioning. Falls back to GITHUB_SHA when omitted.'
+    required: false
 outputs:
   latest_version:
     description: 'Latest available version tag in repo'

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,7 +1,6 @@
 name: 'Auto Assign Reviewers'
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [opened, ready_for_review]
 

--- a/.github/workflows/build-profile-nightly.yml
+++ b/.github/workflows/build-profile-nightly.yml
@@ -54,8 +54,8 @@ jobs:
     needs: check-commits
     if: needs.check-commits.outputs.should_build == 'true'
     outputs:
-      latest_version: ${{ steps.get_version.outputs.latest_version }}
-      full_version: ${{ steps.get_version.outputs.short_version }}
+      # short_version (no commit hash) is what the build consumes as its version
+      version: ${{ steps.get_version.outputs.short_version }}
       tag_version: ${{ steps.get_version.outputs.tag_version }}
     steps:
       - name: Checkout code
@@ -76,7 +76,7 @@ jobs:
       profile: profile
       clean_build: true
       cache_strategy: library
-      version: ${{ needs.get-info.outputs.full_version }}
+      version: ${{ needs.get-info.outputs.version }}
       sentry_enabled: true
       is_release_build: false
       install_source: launcher

--- a/.github/workflows/build-release-main-page.yml
+++ b/.github/workflows/build-release-main-page.yml
@@ -2,21 +2,20 @@ name: Create Page Weekly Release
 
 on:
   workflow_run:
+    # workflow_run matches by workflow *name* only — a file path here never
+    # matches anything.
     workflows:
       - Unity Cloud Build Release
-      - .github/workflows/build-release-main.yml
     types:
       - completed
 
-jobs:  
+jobs:
   get-info:
     name: Get Info
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      latest_version: ${{ steps.get_version.outputs.latest_version }}
-      full_version: ${{ steps.get_version.outputs.next_full_version }}
       tag_version: ${{ steps.get_version.outputs.next_tag_version }}
     steps:
       - name: Checkout code
@@ -65,8 +64,11 @@ jobs:
         with:
           generate_release_notes: true
           draft: true # Swap to auto-release!
+          # No target_commitish: the tag was created and pushed on main above,
+          # so the release resolves to it. github.sha here is the DEFAULT
+          # branch head (dev) — workflow_run events run in that context — and
+          # must not be used as the release target.
           tag_name: ${{ needs.get-info.outputs.tag_version }}
-          target_commitish: ${{ github.sha }}
           files: |
             ./Decentraland_windows64.zip
             ./Decentraland_macos.zip

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -93,21 +93,20 @@ on:
           - macos-only
   workflow_call:
     inputs:
+      # Required inputs carry no default — a default on a required input can
+      # never be used.
       profile:
         required: true
         type: string
-        default: 'none'
       compression:
         required: false
         type: string
         default: 'LZ4HC'
       clean_build:
         required: true
-        default: true
         type: boolean
       cache_strategy:
         required: true
-        default: 'library'
         type: string
       version:
         required: true
@@ -314,6 +313,8 @@ jobs:
         with:
           script: |
             const sha = context.payload.pull_request.head.sha;
+            // Must match this workflow's "Build (<target>)" job names and the
+            // "Test (<mode>)" job names in test.yml — keep in sync on rename.
             const checks = [
               'Build (macos)',
               'Build (windows64)',

--- a/.github/workflows/claude-pr-review-require.yml
+++ b/.github/workflows/claude-pr-review-require.yml
@@ -1,6 +1,5 @@
 name: Require Claude Review
 on:
-  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,9 +1,6 @@
 name: Claude Review
 on:
-  workflow_dispatch:
   issue_comment:
-    types: [created]
-  pull_request_review_comment:
     types: [created]
   pull_request:
     types: [opened, synchronize, ready_for_review, labeled]

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -9,7 +9,6 @@ jobs:
   close-issues:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Needed to allow deletion of stale state files
       issues: write
       pull-requests: write
 

--- a/.github/workflows/enforce-group-approvals.yml
+++ b/.github/workflows/enforce-group-approvals.yml
@@ -1,7 +1,6 @@
 name: Enforce QA and DEV Approvals
 
 on:
-  workflow_dispatch:
   pull_request:
     branches: [dev]
     types:

--- a/.github/workflows/on-delete-release.yml
+++ b/.github/workflows/on-delete-release.yml
@@ -24,8 +24,11 @@ jobs:
           DELETED_RELEASE_TAG=$(jq -r .release.tag_name "$GITHUB_EVENT_PATH")
           echo "Deleted Release Tag: $DELETED_RELEASE_TAG"
 
-          # Fetch the current latest release from the API
-          LATEST_RELEASE=$(curl -H "Authorization: Bearer $GITHUB_TOKEN" -s "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)
+          # Fetch the current latest release from the API. '// empty' keeps the
+          # output blank when no release remains (the API returns 404 JSON with
+          # no tag_name) — otherwise the literal string "null" would be written
+          # to latest.json as the version.
+          LATEST_RELEASE=$(curl -H "Authorization: Bearer $GITHUB_TOKEN" -s "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r '.tag_name // empty')
           echo "Latest Release Tag: $LATEST_RELEASE"
 
           echo "latest_release=$LATEST_RELEASE" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -30,6 +30,6 @@ jobs:
           API_KEY: ${{ secrets.UNITY_CLOUD_API_KEY }}
           ORG_ID: ${{ secrets.UNITY_CLOUD_ORG_ID }}
           PROJECT_ID: ${{ secrets.UNITY_CLOUD_PROJECT_ID }}
-          TARGET: t_${{ matrix.target }}
+          # --delete derives the target names for every platform from BRANCH_NAME
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: python -u scripts/cloudbuild/build.py --delete

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -10,7 +10,6 @@ on:
       - "Unity Cloud Build"
     branches-ignore:
       - "main"
-  workflow_dispatch:
 permissions:
   contents: read  
   pull-requests: write

--- a/.github/workflows/pr-comment-delete-artifact-url.yml
+++ b/.github/workflows/pr-comment-delete-artifact-url.yml
@@ -1,4 +1,4 @@
-# pr-comment-artifact-url.yml
+# pr-comment-delete-artifact-url.yml
 ---
 name: Delete Artifact URL in PR
 

--- a/.github/workflows/pr-comment-warnings.yml
+++ b/.github/workflows/pr-comment-warnings.yml
@@ -11,7 +11,6 @@ on:
       - "completed"
     workflows:
       - "Unity Test"
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,42 +224,7 @@ jobs:
             exit 1
           fi
 
-      # - name: Activate Unity license
-      #   run: |
-      #     docker run --rm \
-      #       -v /tmp/unity-home/.local/share/unity3d:/root/.local/share/unity3d \
-      #       -v /tmp/unity-home/.cache/unity3d:/root/.cache/unity3d \
-      #       -v /tmp/unity-home/.config/unity3d:/root/.config/unity3d \
-      #       -e UNITY_EMAIL="$UNITY_EMAIL" \
-      #       -e UNITY_PASSWORD="$UNITY_PASSWORD" \
-      #       -e UNITY_LICENSE="$UNITY_LICENSE" \
-      #       ${{ steps.img-lint.outputs.ghcr }} \
-      #       /bin/bash -lc 'source /opt/unity/activate.sh 2>/dev/null || true; unity-editor -batchmode -nographics -quit -logFile /dev/stdout'
-
-      # # C# Linting using JetBrains ReSharper CLI
-
-      # - name: Generate solution inside Unity Docker container
-      #   run: |
-      #     docker run --rm \
-      #       -v "${{ github.workspace }}:/workspace" \
-      #       -v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK \
-      #       -v /tmp/ssh-unity:/root/.ssh:ro \
-      #       -v /tmp/unity-home/.local/share/unity3d:/root/.local/share/unity3d \
-      #       -v /tmp/unity-home/.cache/unity3d:/root/.cache/unity3d \
-      #       -v /tmp/unity-home/.config/unity3d:/root/.config/unity3d \
-      #       -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK \
-      #       -e UNITY_EMAIL="$UNITY_EMAIL" \
-      #       -e UNITY_PASSWORD="$UNITY_PASSWORD" \
-      #       -e UNITY_LICENSE="$UNITY_LICENSE" \
-      #       -w /workspace \
-      #       ${{ steps.img-lint.outputs.ghcr }} \
-      #       unity-editor \
-      #       -batchmode \
-      #       -nographics \
-      #       -projectPath /workspace/Explorer \
-      #       -executeMethod UnityEditor.SyncVS.SyncSolution \
-      #       -quit \
-      #       -logFile -
+      # BEGIN: C# Linting using JetBrains ReSharper CLI
 
       - name: Rewrite GitHub SSH URLs to HTTPS
         run: |
@@ -466,6 +431,9 @@ jobs:
           contains(fromJSON('["force-build", "clean-build"]'), github.event.label.name)
         )
       )
+    # The resulting check names "Test (editmode)" / "Test (playmode)" are
+    # posted as skip statuses by build-unitycloud.yml ("Skip build and test
+    # checks" step) — keep both places in sync when renaming.
     name: Test (${{ matrix.testMode }})
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Second PR of the CI pipeline audit — **stacked on #9312** (base is `fix/ci-workflow-bugs`; it retargets to `dev` automatically when #9312 merges). Pure dead-config removal and contract fixes; no pipeline behavior changes.

- **Dead triggers removed.** `workflow_dispatch` in claude-pr-review, claude-pr-review-require, enforce-group-approvals, auto-assign, pr-comment-artifact-url and pr-comment-warnings: no job can run under it — every job's condition or payload access requires a PR/comment/workflow_run event (in claude-pr-review-require and auto-assign the github-script would throw on the missing payload). Same for the `pull_request_review_comment` trigger in claude-pr-review, which no job reads.
- **pr-closure.yml**: dropped `TARGET: t_${{ matrix.target }}` — the job has no matrix (it evaluated to `t_`), and `build.py --delete` derives all platform targets from `BRANCH_NAME` (verified in `scripts/cloudbuild/build.py::delete_current_target`).
- **on-delete-release.yml**: deleting the last remaining release wrote `{"version": "null"}` to `latest.json` (jq stringifies the missing `tag_name` of the 404 body). Now the update is skipped.
- **build-release-main-page.yml**: `workflow_run.workflows` matches by workflow *name* only — the `.github/workflows/build-release-main.yml` path entry never matched anything. Also removed `target_commitish: github.sha`, which points at the **dev** head in workflow_run context (harmless only because the manually pushed tag takes precedence), and trimmed unused job outputs.
- **build-unitycloud.yml**: removed defaults on `required: true` workflow_call inputs (a default on a required input can never be used — actionlint `events` finding); documented that the hardcoded check names in the skip step must stay in sync with test.yml (and vice versa in test.yml).
- **test.yml**: deleted ~35 lines of long-dead commented-out lint steps (git history keeps them).
- **close-inactive-issues.yml**: removed `contents: write` — actions/stale doesn't need it; the comment claiming it did was wrong.
- **version action**: `commit_sha` is now declared `required: false` — composite actions never enforced it, three callers omit it, and the script already falls back to `GITHUB_SHA`. The declaration now matches reality.
- **build-profile-nightly.yml**: the `full_version` job output actually carried `short_version`; renamed to `version` (its only consumer updated).

**Deliberately not included:** the audit's B5 finding (Dependency Security Review's MEDIUM-RISK `pending` status has no human resolution path) — any fix weakens a security gate, so the mechanism needs an explicit maintainer decision first.

## Test Instructions

CI-only change; nothing to run in the client.

**Steps (standard run)**: N/A

### Prerequisites
- [ ] #9312 merged first (this PR is stacked on it)

### Test Steps
1. Confirm all still-triggered workflows parse: actionlint reports no new findings on touched files.
2. After merge, the nightly profile build must still pass its version to Unity Cloud (`get-info.outputs.version` — renamed from `full_version`).
3. Deleting a non-latest release must still refresh `latest.json`; deleting the only release must skip the S3 update instead of writing `"null"`.

### Additional Testing Notes
- Removing dead `workflow_dispatch` triggers makes those workflows disappear from the manual "Run workflow" dropdown — that is intended; dispatching them never did anything.

## Quality Checklist
- [x] Changes have been tested locally (actionlint on all touched files)
- [x] Documentation has been updated (if required) — N/A, inline comments added
- [x] Performance impact has been considered — none
- [ ] For SDK features: Test scene is included — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)