### PR TITLE
feat: unify asset delivery and make it configurable

### DIFF
--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -83,7 +83,7 @@ namespace DCL.FeatureFlags
         public const string FOUNDATION_COMMUNITY_ID = "alfa-foundation-community-id";
         public const string HARDWARE_FINGERPRINT = "alfa-hardware-fingerprint";
         public const string OPTIMIZED_ASSETS = "optimized-assets";
-        public const string OPTIMIZED_ASSETS_BASE_URL_VARIANT = "base-url";
+        public const string OPTIMIZED_ASSETS_BASE_URL_VARIANT = "assets-base-url";
 
         public static class Endpoints
         {

--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -82,6 +82,8 @@ namespace DCL.FeatureFlags
         public const string NEW_LODS = "new-lods";
         public const string FOUNDATION_COMMUNITY_ID = "alfa-foundation-community-id";
         public const string HARDWARE_FINGERPRINT = "alfa-hardware-fingerprint";
+        public const string OPTIMIZED_ASSETS = "optimized-assets";
+        public const string OPTIMIZED_ASSETS_BASE_URL_VARIANT = "base-url";
 
         public static class Endpoints
         {

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -112,6 +112,8 @@ namespace Global.AppArgs
         public const string LSD_REMOTE_AB_SERVER = "lsd-remote-ab-server";
         public const string LSD_REMOTE_AB_WORLD = "lsd-remote-ab-world";
 
+        public const string OPTIMIZED_ASSETS_URL = "optimized-assets-url";
+
         public const string NO_LIVEKIT_MODE = "no-livekit-mode";
 
         public const string NATIVE_SHUTDOWN_STOPWATCH = "native-shutdown-stopwatch";

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -234,6 +234,7 @@ namespace Global.Dynamic
             var realmData = new RealmData();
 
             applicationParametersParser.TryGetValue(AppArgsFlags.GATEKEEPER_URL, out string? cliGatekeeperUrl);
+            applicationParametersParser.TryGetValue(AppArgsFlags.OPTIMIZED_ASSETS_URL, out string? cliOptimizedAssetsUrl);
 
             var decentralandUrlsSource = new GatewayUrlsSource(
                 decentralandEnvironment,
@@ -241,7 +242,8 @@ namespace Global.Dynamic
                 launchSettings,
                 debugSettings.GatekeeperMode,
                 debugSettings.CustomGatekeeperUrl,
-                cliGatekeeperUrl);
+                cliGatekeeperUrl,
+                cliOptimizedAssetsUrl);
             DiagnosticInfoUtils.LogEnvironment(decentralandUrlsSource);
 
             var assetsProvisioner = new AddressablesProvisioner();

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -10,7 +10,6 @@ using UnityEngine.Pool;
 
 namespace DCL.Browser.DecentralandUrls
 {
-    //TODO test urls
     public class DecentralandUrlsSource : IDecentralandUrlsSource
     {
         protected enum CacheBehaviour
@@ -39,6 +38,8 @@ namespace DCL.Browser.DecentralandUrls
         private readonly ILaunchMode launchMode;
         private readonly string decentralandDomain;
         private readonly string? gatekeeperBaseOverride;
+        private readonly string? optimizedAssetsBaseOverride;
+        private readonly bool isTodayEnvironment;
 
         public DecentralandUrlsSource(
             DecentralandEnvironment environment,
@@ -46,15 +47,18 @@ namespace DCL.Browser.DecentralandUrls
             ILaunchMode launchMode,
             GatekeeperMode gatekeeperMode = GatekeeperMode.Org,
             string customGatekeeperUrl = "",
-            string? cliGatekeeperUrl = null)
+            string? cliGatekeeperUrl = null,
+            string? cliOptimizedAssetsUrl = null)
         {
             decentralandDomain = environment.ToString()!.ToLower();
+            isTodayEnvironment = environment == DecentralandEnvironment.Today;
             this.realmData = realmData;
             this.launchMode = launchMode;
             this.gatekeeperBaseOverride = ResolveGatekeeperOverride(gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl, out string source);
             ReportHub.Log(ReportCategory.STARTUP, $"Gatekeeper base override: {gatekeeperBaseOverride ?? "(default)"} (source: {source})");
+            this.optimizedAssetsBaseOverride = cliOptimizedAssetsUrl?.TrimEnd('/');
 
-            if (environment == DecentralandEnvironment.Today)
+            if (isTodayEnvironment)
             {
                 // The today environment is a mixture of the org and today environments.
                 // Asset delivery (registry and S3) are used with the `.today` extension
@@ -181,6 +185,35 @@ namespace DCL.Browser.DecentralandUrls
         private string ResolveGatekeeperBaseUrl(string defaultBaseUrl) =>
             gatekeeperBaseOverride ?? defaultBaseUrl;
 
+        /// <summary>
+        ///     The "--optimized-assets-url" arg or the flag variant payload override the base url, otherwise
+        ///     https://abcdn.decentraland.{ENV}. FEATURE_FLAGS_DEPENDENT means it is re-resolved (not cached) until flags load.
+        /// </summary>
+        private UrlData ResolveOptimizedAssetsUrl(string dedicatedHostUrl)
+        {
+            if (!string.IsNullOrEmpty(optimizedAssetsBaseOverride))
+                return new UrlData(CacheBehaviour.FEATURE_FLAGS_DEPENDENT, optimizedAssetsBaseOverride!);
+
+            FeatureFlagsConfiguration featureFlags = FeatureFlagsConfiguration.Instance;
+
+            if (featureFlags.IsEmpty)
+                return isTodayEnvironment
+                    ? dedicatedHostUrl
+                    : new UrlData(CacheBehaviour.FEATURE_FLAGS_DEPENDENT, dedicatedHostUrl.Replace(ENV, decentralandDomain));
+
+            if (!featureFlags.IsEnabled(FeatureFlagsStrings.OPTIMIZED_ASSETS))
+                return dedicatedHostUrl;
+
+            if (featureFlags.TryGetTextPayload(FeatureFlagsStrings.OPTIMIZED_ASSETS, FeatureFlagsStrings.OPTIMIZED_ASSETS_BASE_URL_VARIANT, out string? customBaseUrl) && !string.IsNullOrEmpty(customBaseUrl))
+                return new UrlData(CacheBehaviour.FEATURE_FLAGS_DEPENDENT, customBaseUrl!.TrimEnd('/'));
+
+            return new UrlData(CacheBehaviour.FEATURE_FLAGS_DEPENDENT, $"https://abcdn.decentraland.{ENV}");
+        }
+
+        /// <summary>Registry-composed endpoints inherit the registry base's caching so a flag-driven base is not cached early.</summary>
+        private UrlData ComposeRegistryUrl(string path) =>
+            new (RawUrl(DecentralandUrl.AssetBundleRegistry).Caching, $"{Url(DecentralandUrl.AssetBundleRegistry)}{path}");
+
         protected virtual UrlData RawUrl(DecentralandUrl decentralandUrl) =>
             decentralandUrl switch
             {
@@ -230,8 +263,8 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.Account => $"https://decentraland.{ENV}/account/",
                 DecentralandUrl.MinimumSpecs => $"https://docs.decentraland.{ENV}/player/FAQs/decentraland-101/#what-hardware-do-i-need-to-run-decentraland",
                 DecentralandUrl.Market => $"https://market.decentraland.{ENV}",
-                DecentralandUrl.AssetBundlesCDN => $"https://ab-cdn.decentraland.{ENV}",
-                DecentralandUrl.LodGeneratorCDN => $"https://lod-generator-unity-cdn.decentraland.{ENV}",
+                DecentralandUrl.AssetBundlesCDN => ResolveOptimizedAssetsUrl($"https://ab-cdn.decentraland.{ENV}"),
+                DecentralandUrl.LodGeneratorCDN => ResolveOptimizedAssetsUrl($"https://lod-generator-unity-cdn.decentraland.{ENV}"),
                 DecentralandUrl.ArchipelagoStatus => $"https://archipelago-ea-stats.decentraland.{ENV}/status",
                 DecentralandUrl.ArchipelagoHotScenes => $"https://archipelago-ea-stats.decentraland.{ENV}/hot-scenes",
                 DecentralandUrl.GatekeeperStatus => $"{RawUrl(DecentralandUrl.Gatekeeper).Url!}/status",
@@ -243,8 +276,9 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.CameraReelLink => $"https://reels.decentraland.{ENV}",
                 DecentralandUrl.Blocklist => $"https://config.decentraland.{ENV}/denylist.json",
                 DecentralandUrl.ApiFriends => $"wss://rpc-social-service-ea.decentraland.{ENV}",
-                DecentralandUrl.AssetBundleRegistry => $"https://asset-bundle-registry.decentraland.{ENV}",
-                DecentralandUrl.AssetBundleRegistryVersion => $"{Url(DecentralandUrl.AssetBundleRegistry)}/entities/versions",
+                DecentralandUrl.AssetBundleRegistry => ResolveOptimizedAssetsUrl($"https://asset-bundle-registry.decentraland.{ENV}"),
+
+                DecentralandUrl.AssetBundleRegistryVersion => ComposeRegistryUrl("/entities/versions"),
                 DecentralandUrl.MarketplaceClaimName => $"https://decentraland.{ENV}/marketplace/names/claim",
                 DecentralandUrl.WorldPermissions => $"https://worlds-content-server.decentraland.{ENV}/world/{{0}}/permissions",
                 DecentralandUrl.WorldComms => $"https://worlds-content-server.decentraland.{ENV}/worlds/{{0}}/comms",
@@ -274,15 +308,15 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.SceneAdmins => $"{RawUrl(DecentralandUrl.Gatekeeper).Url!}/scene-admin",
                 DecentralandUrl.Pulse => $"pulse-server.decentraland.{ENV}",
 
-                DecentralandUrl.Profiles => $"{Url(DecentralandUrl.AssetBundleRegistry)}/profiles",
-                DecentralandUrl.ProfilesMetadata => $"{Url(DecentralandUrl.AssetBundleRegistry)}/profiles/metadata",
+                DecentralandUrl.Profiles => ComposeRegistryUrl("/profiles"),
+                DecentralandUrl.ProfilesMetadata => ComposeRegistryUrl("/profiles/metadata"),
                 DecentralandUrl.WorldCommsAdapter => $"https://worlds-content-server.decentraland.{ENV}/worlds/{{0}}/scenes/{{1}}/comms",
 
                 DecentralandUrl.EntitiesActive => UrlData.RealmDependent(FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.ASSET_BUNDLE_FALLBACK) && launchMode.CurrentMode != LaunchMode.LocalSceneDevelopment ? $"{Url(DecentralandUrl.AssetBundleRegistry)}/entities/active" :
                     realmData.Configured ? realmData.Ipfs.EntitiesActiveEndpoint.Value : null),
 
                 // Meant for Wearables and Emotes since they always must be solved by the AB-Registry
-                DecentralandUrl.EntitiesActiveElements => $"{Url(DecentralandUrl.AssetBundleRegistry)}/entities/active",
+                DecentralandUrl.EntitiesActiveElements => ComposeRegistryUrl("/entities/active"),
 
                 DecentralandUrl.WorldEntitiesActive => UrlData.RealmDependent(FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.ASSET_BUNDLE_FALLBACK) && launchMode.CurrentMode != LaunchMode.LocalSceneDevelopment ? $"{Url(DecentralandUrl.AssetBundleRegistry)}/entities/active?world_name={{0}}" :
                     realmData.Configured ? realmData.Ipfs.EntitiesActiveEndpoint.Value : null),

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -191,8 +191,8 @@ namespace DCL.Browser.DecentralandUrls
         /// </summary>
         private UrlData ResolveOptimizedAssetsUrl(string dedicatedHostUrl)
         {
-            if (!string.IsNullOrEmpty(optimizedAssetsBaseOverride))
-                return new UrlData(CacheBehaviour.FEATURE_FLAGS_DEPENDENT, optimizedAssetsBaseOverride!);
+            if (optimizedAssetsBaseOverride is { Length: > 0 })
+                return new UrlData(CacheBehaviour.FEATURE_FLAGS_DEPENDENT, optimizedAssetsBaseOverride);
 
             FeatureFlagsConfiguration featureFlags = FeatureFlagsConfiguration.Instance;
 
@@ -204,8 +204,8 @@ namespace DCL.Browser.DecentralandUrls
             if (!featureFlags.IsEnabled(FeatureFlagsStrings.OPTIMIZED_ASSETS))
                 return dedicatedHostUrl;
 
-            if (featureFlags.TryGetTextPayload(FeatureFlagsStrings.OPTIMIZED_ASSETS, FeatureFlagsStrings.OPTIMIZED_ASSETS_BASE_URL_VARIANT, out string? customBaseUrl) && !string.IsNullOrEmpty(customBaseUrl))
-                return new UrlData(CacheBehaviour.FEATURE_FLAGS_DEPENDENT, customBaseUrl!.TrimEnd('/'));
+            if (featureFlags.TryGetTextPayload(FeatureFlagsStrings.OPTIMIZED_ASSETS, FeatureFlagsStrings.OPTIMIZED_ASSETS_BASE_URL_VARIANT, out string? customBaseUrl) && customBaseUrl is { Length: > 0 })
+                return new UrlData(CacheBehaviour.FEATURE_FLAGS_DEPENDENT, customBaseUrl.TrimEnd('/'));
 
             return new UrlData(CacheBehaviour.FEATURE_FLAGS_DEPENDENT, $"https://abcdn.decentraland.{ENV}");
         }

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
@@ -13,6 +13,7 @@ namespace DCL.Browser
     public class GatewayUrlsSource : DecentralandUrlsSource
     {
         private const string GATEWAY_SUBDOMAIN = "gateway";
+        private const string TRANSFORMABLE_DOMAIN_MARKER = ".decentraland.";
         private const int HTTPS_PREFIX_LENGTH = 8; // "https://".Length
 
         private static readonly DecentralandEnvironment[] SUPPORTED_ENVS = { DecentralandEnvironment.Org, DecentralandEnvironment.Zone };
@@ -92,8 +93,9 @@ namespace DCL.Browser
             ILaunchMode launchMode,
             GatekeeperMode gatekeeperMode = GatekeeperMode.Org,
             string customGatekeeperUrl = "",
-            string? cliGatekeeperUrl = null)
-            : base(environment, realmData, launchMode, gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl)
+            string? cliGatekeeperUrl = null,
+            string? cliOptimizedAssetsUrl = null)
+            : base(environment, realmData, launchMode, gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl, cliOptimizedAssetsUrl)
         {
             envSupported = SUPPORTED_ENVS.Contains(environment);
 
@@ -142,8 +144,36 @@ namespace DCL.Browser
             if (!enabled || serviceUrl.Url == null || !SUPPORTED_URLS.Contains(decentralandUrl))
                 return serviceUrl;
 
+            // Consolidated urls (FEATURE_FLAGS_DEPENDENT) and custom hosts pass through; only env-shaped hosts are reshaped
+            if (serviceUrl.Caching == CacheBehaviour.FEATURE_FLAGS_DEPENDENT || !IsGatewayTransformable(serviceUrl.Url))
+                return serviceUrl;
+
             // it is called only once and then cached in the base class
             return new UrlData(CacheBehaviour.FEATURE_FLAGS_DEPENDENT, TransformToGateway(serviceUrl.Url));
+        }
+
+        /// <summary>
+        ///     True only for a bare https://{subdomain}.decentraland.{tld} authority (single-label sub + tld, no port or
+        ///     userinfo); any custom host passes through untouched.
+        /// </summary>
+        private static bool IsGatewayTransformable(string url)
+        {
+            if (!url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            int hostEnd = url.IndexOf('/', HTTPS_PREFIX_LENGTH);
+            ReadOnlySpan<char> authority = url.AsSpan(HTTPS_PREFIX_LENGTH, (hostEnd < 0 ? url.Length : hostEnd) - HTTPS_PREFIX_LENGTH);
+
+            if (authority.IndexOfAny(':', '@') >= 0)
+                return false;
+
+            int marker = authority.IndexOf(TRANSFORMABLE_DOMAIN_MARKER.AsSpan(), StringComparison.OrdinalIgnoreCase);
+
+            if (marker <= 0 || authority.Slice(0, marker).IndexOf('.') >= 0)
+                return false;
+
+            ReadOnlySpan<char> tld = authority.Slice(marker + TRANSFORMABLE_DOMAIN_MARKER.Length);
+            return tld.Length > 0 && tld.IndexOf('.') < 0;
         }
 
         public override string GetOriginalUrl(string url)

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests.meta
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25bff873dc604cd09b3ff0b254c70981
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DCL.Network.Tests.asmref
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DCL.Network.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DCL.Network.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DCL.Network.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 618711965e2445e4b06ccb064c9ebef7
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
@@ -1,0 +1,241 @@
+using DCL.FeatureFlags;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Utility;
+using ECS;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace DCL.Browser.DecentralandUrls.Tests
+{
+    public class DecentralandUrlsSourceShould
+    {
+        // The feature-flag singleton takes one Initialize per Reset; clear it around every test
+        [SetUp]
+        public void SetUp() => FeatureFlagsConfiguration.Reset();
+
+        [TearDown]
+        public void TearDown() => FeatureFlagsConfiguration.Reset();
+
+        private static void InitializeFeatureFlags(bool optimizedAssets, string? customBaseUrl = null, bool useGateway = false, bool assetBundleFallback = false)
+        {
+            var dto = new FeatureFlagsResultDto
+            {
+                flags = new Dictionary<string, bool>
+                {
+                    [FeatureFlagsStrings.OPTIMIZED_ASSETS] = optimizedAssets,
+                    [FeatureFlagsStrings.USE_GATEWAY] = useGateway,
+                    [FeatureFlagsStrings.ASSET_BUNDLE_FALLBACK] = assetBundleFallback,
+                },
+                variants = new Dictionary<string, FeatureFlagVariantDto>(),
+            };
+
+            if (customBaseUrl != null)
+            {
+                dto.variants[FeatureFlagsStrings.OPTIMIZED_ASSETS] = new FeatureFlagVariantDto
+                {
+                    name = FeatureFlagsStrings.OPTIMIZED_ASSETS_BASE_URL_VARIANT,
+                    enabled = true,
+                    payload = new FeatureFlagPayload { type = "string", value = customBaseUrl },
+                };
+            }
+
+            FeatureFlagsConfiguration.Reset();
+            FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(dto));
+        }
+
+        [TestCase(DecentralandEnvironment.Org, "https://ab-cdn.decentraland.org", "https://lod-generator-unity-cdn.decentraland.org", "https://asset-bundle-registry.decentraland.org")]
+        [TestCase(DecentralandEnvironment.Zone, "https://ab-cdn.decentraland.zone", "https://lod-generator-unity-cdn.decentraland.zone", "https://asset-bundle-registry.decentraland.zone")]
+        public void UseDedicatedHostsWhenOptimizedAssetsDisabled(DecentralandEnvironment environment, string expectedAssetBundles, string expectedLods, string expectedRegistry)
+        {
+            InitializeFeatureFlags(optimizedAssets: false);
+            DecentralandUrlsSource urlsSource = DecentralandUrlsSource.CreateForTest(environment, ILaunchMode.PLAY);
+
+            Assert.AreEqual(expectedAssetBundles, urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual(expectedLods, urlsSource.Url(DecentralandUrl.LodGeneratorCDN));
+            Assert.AreEqual(expectedRegistry, urlsSource.Url(DecentralandUrl.AssetBundleRegistry));
+            Assert.AreEqual($"{expectedRegistry}/entities/versions", urlsSource.Url(DecentralandUrl.AssetBundleRegistryVersion));
+        }
+
+        [TestCase(DecentralandEnvironment.Org, "https://abcdn.decentraland.org")]
+        [TestCase(DecentralandEnvironment.Zone, "https://abcdn.decentraland.zone")]
+        public void UseSingleDomainWhenOptimizedAssetsEnabled(DecentralandEnvironment environment, string expectedBaseUrl)
+        {
+            InitializeFeatureFlags(optimizedAssets: true);
+            DecentralandUrlsSource urlsSource = DecentralandUrlsSource.CreateForTest(environment, ILaunchMode.PLAY);
+
+            Assert.AreEqual(expectedBaseUrl, urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual(expectedBaseUrl, urlsSource.Url(DecentralandUrl.LodGeneratorCDN));
+            Assert.AreEqual(expectedBaseUrl, urlsSource.Url(DecentralandUrl.AssetBundleRegistry));
+            Assert.AreEqual($"{expectedBaseUrl}/entities/versions", urlsSource.Url(DecentralandUrl.AssetBundleRegistryVersion));
+        }
+
+        [Test]
+        public void ApplyOptimizedAssetsInLocalSceneDevelopmentMode()
+        {
+            InitializeFeatureFlags(optimizedAssets: true);
+            DecentralandUrlsSource urlsSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, ILaunchMode.LOCAL_SCENE_DEVELOPMENT);
+
+            Assert.AreEqual("https://abcdn.decentraland.org", urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual("https://abcdn.decentraland.org", urlsSource.Url(DecentralandUrl.LodGeneratorCDN));
+            Assert.AreEqual("https://abcdn.decentraland.org", urlsSource.Url(DecentralandUrl.AssetBundleRegistry));
+        }
+
+        [Test]
+        public void ApplyCliOverrideForLocalPreviewSidecar()
+        {
+            // The flag variant is fleet-scoped, so a per-machine preview sidecar needs the CLI arg (forces on + overrides verbatim)
+            InitializeFeatureFlags(optimizedAssets: false);
+            var urlsSource = new DecentralandUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.LOCAL_SCENE_DEVELOPMENT, cliOptimizedAssetsUrl: "http://127.0.0.1:5147");
+
+            Assert.AreEqual("http://127.0.0.1:5147", urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual("http://127.0.0.1:5147", urlsSource.Url(DecentralandUrl.LodGeneratorCDN));
+            Assert.AreEqual("http://127.0.0.1:5147", urlsSource.Url(DecentralandUrl.AssetBundleRegistry));
+            Assert.AreEqual("http://127.0.0.1:5147/entities/versions", urlsSource.Url(DecentralandUrl.AssetBundleRegistryVersion));
+        }
+
+        [Test]
+        public void ComposeRegistryEndpointsForWearablesWorldsAndProfilesOffTheUnifiedBase()
+        {
+            InitializeFeatureFlags(optimizedAssets: true, assetBundleFallback: true);
+            DecentralandUrlsSource urlsSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, ILaunchMode.PLAY);
+
+            Assert.AreEqual("https://abcdn.decentraland.org/entities/active", urlsSource.Url(DecentralandUrl.EntitiesActiveElements));
+            Assert.AreEqual("https://abcdn.decentraland.org/profiles", urlsSource.Url(DecentralandUrl.Profiles));
+            Assert.AreEqual("https://abcdn.decentraland.org/profiles/metadata", urlsSource.Url(DecentralandUrl.ProfilesMetadata));
+
+            // Realm-dependent, so Url() gates them on a configured realm; probe to resolve without one
+            Assert.AreEqual("https://abcdn.decentraland.org/entities/active", urlsSource.Probe(DecentralandUrl.EntitiesActive));
+            Assert.AreEqual("https://abcdn.decentraland.org/entities/active?world_name={0}", urlsSource.Probe(DecentralandUrl.WorldEntitiesActive));
+        }
+
+        [Test]
+        public void UseCustomBaseUrlFromVariantPayload()
+        {
+            InitializeFeatureFlags(optimizedAssets: true, customBaseUrl: "https://assets.example.com");
+            DecentralandUrlsSource urlsSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, ILaunchMode.PLAY);
+
+            Assert.AreEqual("https://assets.example.com", urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual("https://assets.example.com", urlsSource.Url(DecentralandUrl.LodGeneratorCDN));
+            Assert.AreEqual("https://assets.example.com", urlsSource.Url(DecentralandUrl.AssetBundleRegistry));
+        }
+
+        [Test]
+        public void UseArbitrarySchemeAndHostFromVariantPayload()
+        {
+            InitializeFeatureFlags(optimizedAssets: true, customBaseUrl: "http://ab.internal:5147");
+            DecentralandUrlsSource urlsSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, ILaunchMode.PLAY);
+
+            Assert.AreEqual("http://ab.internal:5147", urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual("http://ab.internal:5147", urlsSource.Url(DecentralandUrl.LodGeneratorCDN));
+            Assert.AreEqual("http://ab.internal:5147/entities/versions", urlsSource.Url(DecentralandUrl.AssetBundleRegistryVersion));
+        }
+
+        [Test]
+        public void TrimTrailingSlashFromPayloadOverride()
+        {
+            InitializeFeatureFlags(optimizedAssets: true, customBaseUrl: "https://assets.example.com/");
+            DecentralandUrlsSource urlsSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, ILaunchMode.PLAY);
+
+            Assert.AreEqual("https://assets.example.com", urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual("https://assets.example.com/entities/versions", urlsSource.Url(DecentralandUrl.AssetBundleRegistryVersion));
+        }
+
+        [TestCase(DecentralandEnvironment.Org, "https://abcdn.decentraland.org")]
+        [TestCase(DecentralandEnvironment.Zone, "https://abcdn.decentraland.zone")]
+        public void ApplyFlagArrivingAfterConstructionTimeProbing(DecentralandEnvironment environment, string expectedBaseUrl)
+        {
+            // LogEnvironment probes every url at construction, before a realm is entered, so realm-dependent urls resolve
+            // to their <NOT_CONFIGURED> sentinel - an unconfigured realm models that
+            FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(FeatureFlagsResultDto.Empty));
+            var urlsSource = new DecentralandUrlsSource(environment, Substitute.For<IRealmData>(), ILaunchMode.PLAY);
+
+            foreach (DecentralandUrl url in Enum.GetValues(typeof(DecentralandUrl)))
+                urlsSource.Probe(url);
+
+            InitializeFeatureFlags(optimizedAssets: true);
+
+            Assert.AreEqual(expectedBaseUrl, urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual(expectedBaseUrl, urlsSource.Url(DecentralandUrl.LodGeneratorCDN));
+            Assert.AreEqual(expectedBaseUrl, urlsSource.Url(DecentralandUrl.AssetBundleRegistry));
+            Assert.AreEqual($"{expectedBaseUrl}/entities/versions", urlsSource.Url(DecentralandUrl.AssetBundleRegistryVersion));
+        }
+
+        [Test]
+        public void ApplyFlagArrivingAfterEarlyResolutionOfRegistryComposedUrls()
+        {
+            // An early consumer resolving registry-composed urls through Url() before the flag arrives must not pin the pre-flag base
+            FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(FeatureFlagsResultDto.Empty));
+            DecentralandUrlsSource urlsSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, ILaunchMode.PLAY);
+
+            Assert.AreEqual("https://asset-bundle-registry.decentraland.org/profiles", urlsSource.Url(DecentralandUrl.Profiles));
+            Assert.AreEqual("https://asset-bundle-registry.decentraland.org/entities/active", urlsSource.Url(DecentralandUrl.EntitiesActiveElements));
+
+            InitializeFeatureFlags(optimizedAssets: true);
+
+            Assert.AreEqual("https://abcdn.decentraland.org/profiles", urlsSource.Url(DecentralandUrl.Profiles));
+            Assert.AreEqual("https://abcdn.decentraland.org/entities/active", urlsSource.Url(DecentralandUrl.EntitiesActiveElements));
+        }
+
+        [Test]
+        public void KeepTodayConstructionPinsWhenFlagsArriveLater()
+        {
+            FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(FeatureFlagsResultDto.Empty));
+            DecentralandUrlsSource urlsSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Today, ILaunchMode.PLAY);
+
+            InitializeFeatureFlags(optimizedAssets: true);
+
+            Assert.AreEqual("https://ab-cdn.decentraland.today", urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual("https://asset-bundle-registry.decentraland.today", urlsSource.Url(DecentralandUrl.AssetBundleRegistry));
+            Assert.AreEqual("https://asset-bundle-registry.decentraland.today/profiles", urlsSource.Url(DecentralandUrl.Profiles));
+        }
+
+        [Test]
+        public void KeepOptimizedAssetsOutOfTheGateway()
+        {
+            InitializeFeatureFlags(optimizedAssets: true, useGateway: true);
+            GatewayUrlsSource urlsSource = GatewayUrlsSource.CreateForTest(DecentralandEnvironment.Org, ILaunchMode.PLAY);
+
+            Assert.AreEqual("https://abcdn.decentraland.org", urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual("https://abcdn.decentraland.org", urlsSource.Url(DecentralandUrl.AssetBundleRegistry));
+            Assert.AreEqual("https://abcdn.decentraland.org/entities/versions", urlsSource.Url(DecentralandUrl.AssetBundleRegistryVersion));
+            Assert.AreEqual("https://gateway.decentraland.org/auth-api", urlsSource.Url(DecentralandUrl.ApiAuth));
+        }
+
+        [Test]
+        public void KeepGatewayRoutingWhenOptimizedAssetsDisabled()
+        {
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: true);
+            GatewayUrlsSource urlsSource = GatewayUrlsSource.CreateForTest(DecentralandEnvironment.Org, ILaunchMode.PLAY);
+
+            Assert.AreEqual("https://gateway.decentraland.org/ab-cdn", urlsSource.Url(DecentralandUrl.AssetBundlesCDN));
+            Assert.AreEqual("https://gateway.decentraland.org/asset-bundle-registry", urlsSource.Url(DecentralandUrl.AssetBundleRegistry));
+            Assert.AreEqual("https://gateway.decentraland.org/asset-bundle-registry/entities/versions", urlsSource.Url(DecentralandUrl.AssetBundleRegistryVersion));
+        }
+
+        [Test]
+        public void KeepNonDecentralandHostsOffTheGateway()
+        {
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: true);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatekeeperUrl: "https://gatekeeper.example.com");
+
+            Assert.AreEqual("https://gatekeeper.example.com/get-scene-adapter", urlsSource.Url(DecentralandUrl.GateKeeperSceneAdapter));
+
+            GatewayUrlsSource defaultSource = GatewayUrlsSource.CreateForTest(DecentralandEnvironment.Org, ILaunchMode.PLAY);
+            Assert.AreEqual("https://gateway.decentraland.org/comms-gatekeeper/get-scene-adapter", defaultSource.Url(DecentralandUrl.GateKeeperSceneAdapter));
+        }
+
+        [TestCase("https://gk.decentraland.org:8443")]
+        [TestCase("https://sub.decentraland.org@evil.example.com")]
+        [TestCase("https://x.decentraland.evil.example.com")]
+        [TestCase("https://gk.decentraland.org.")]
+        public void KeepNonEnvShapedDecentralandHostsOffTheGateway(string customHost)
+        {
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: true);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatekeeperUrl: customHost);
+
+            Assert.AreEqual($"{customHost}/get-scene-adapter", urlsSource.Url(DecentralandUrl.GateKeeperSceneAdapter));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs.meta
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b517e9a227d34980ba552695b681a5a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What

Behind the `optimized-assets` feature flag, asset delivery is routed to a single origin — `https://abcdn.decentraland.{ENV}` — instead of the separate `ab-cdn`, `lod-generator-unity-cdn`, and `asset-bundle-registry` hosts. The flag's `assets-base-url` variant can repoint that origin to any scheme/host/port. For per-machine local development, the `--optimized-assets-url` launch argument forces the feature on and overrides the base verbatim (e.g. a developer's local preview sidecar), taking precedence over the flag. With the flag off and no argument, URL resolution is byte-for-byte unchanged.

## The five delivery paths it covers

| Path | Resolves through | Flag on → |
|---|---|---|
| **1. Scenes** | `AssetBundlesCDN` (manifests + bundles), `LodGeneratorCDN` (LOD + ISS — LODs are asset bundles too) | `https://abcdn.decentraland.{ENV}` |
| **2. Wearables & emotes** | `AssetBundleRegistry` → `/entities/active` | `…/entities/active` |
| **3. Worlds** | `AssetBundleRegistry` → `/entities/active?world_name=` | `…/entities/active?world_name=` |
| **4. Preview / local scene development** | `--optimized-assets-url` per-machine override, else the flag resolution | the sidecar host verbatim, else `https://abcdn.decentraland.{ENV}` |
| **5. Non-`decentraland.*` hosts** | `assets-base-url` variant + gateway pass-through | the variant host verbatim |

Registry-composed endpoints (`entities/versions`, `entities/active`, `profiles`, `profiles/metadata`) follow the resolved base automatically.

## Gateway

`use-gateway` reshapes only bare `https://{subdomain}.decentraland.{tld}` authorities into the gateway domain. URLs consolidated by optimized-assets, and any custom host (a port, userinfo, a deep domain, or a non-`decentraland` tld), pass through untouched instead of being rewritten into a non-existent gateway URL.

## Changes

- `FeatureFlagsStrings` — the `optimized-assets` flag and its `assets-base-url` variant.
- `DecentralandUrlsSource` — `AssetBundlesCDN`, `LodGeneratorCDN`, `AssetBundleRegistry` and the registry-composed endpoints resolve through the flag; they stay uncached while feature flags are unfetched, so a flag arriving after startup still applies.
- `GatewayUrlsSource` — the host-shape guard so only environment-shaped hosts are gateway-transformed.
- `AppArgsFlags` / `MainSceneLoader` — the `--optimized-assets-url` launch argument, wired in as a base-URL override that forces the feature on.

## Rollout

Land with the flag off — resolution is unchanged. Enable per environment once the `abcdn.decentraland.{ENV}` deployment is live; the `assets-base-url` variant targets a specific deployment for canary/QA. Do not enable for `today` sessions — the construction pre-warm pins the dedicated `.today` hosts, the same limitation as `use-gateway`. For local development against a preview sidecar, pass `--optimized-assets-url http://host:port` — no flag or dashboard change needed.

