### PR TITLE
fix: 9309-block-input-announcement-field

### DIFF
--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementCreationCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementCreationCardView.cs
@@ -26,14 +26,14 @@ namespace DCL.Communities.CommunitiesCard.Announcements
         [SerializeField] private TMP_Text characterCounterText = null!;
 
         [Header("Emoji Panel Configuration")]
-        [SerializeField] internal EmojiButtonView emojiButton = null!;
-        [SerializeField] internal EmojiPanelView emojiPanel = null!;
-        [SerializeField] internal EmojiPanelConfigurationSO emojiPanelConfiguration = null!;
-        [SerializeField] internal AudioClipConfig addEmojiAudio = null!;
-        [SerializeField] internal AudioClipConfig openEmojiPanelAudio = null!;
-        [SerializeField] internal InputSuggestionPanelView suggestionPanel = null!;
-        [SerializeField] internal Transform suggestionPanelParent = null!;
-        [SerializeField] internal ViewEventBus inputEventBus = null!;
+        [SerializeField] private EmojiButtonView emojiButton = null!;
+        [SerializeField] private EmojiPanelView emojiPanel = null!;
+        [SerializeField] private EmojiPanelConfigurationSO emojiPanelConfiguration = null!;
+        [SerializeField] private AudioClipConfig addEmojiAudio = null!;
+        [SerializeField] private AudioClipConfig openEmojiPanelAudio = null!;
+        [SerializeField] private InputSuggestionPanelView suggestionPanel = null!;
+        [SerializeField] private Transform suggestionPanelParent = null!;
+        [SerializeField] private ViewEventBus inputEventBus = null!;
 
         public event Action<string>? CreateAnnouncementButtonClicked;
         public event Action<bool>? InputFocusChanged;

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementCreationCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementCreationCardView.cs
@@ -36,6 +36,7 @@ namespace DCL.Communities.CommunitiesCard.Announcements
         [SerializeField] internal ViewEventBus inputEventBus = null!;
 
         public event Action<string>? CreateAnnouncementButtonClicked;
+        public event Action<bool>? InputFocusChanged;
 
         private string currentProfileThumbnailUrl = null!;
         private AnnouncementEmojiController? announcementEmojiController;
@@ -104,11 +105,17 @@ namespace DCL.Communities.CommunitiesCard.Announcements
             createAnnouncementButtonLoadingSpinner.SetActive(isLoading);
         }
 
-        private void OnAnnouncementInputSelected(string _) =>
+        private void OnAnnouncementInputSelected(string _)
+        {
             createAnnouncementInputOutline.SetActive(true);
+            InputFocusChanged?.Invoke(true);
+        }
 
-        private void OnAnnouncementInputDeselected(string _) =>
+        private void OnAnnouncementInputDeselected(string _)
+        {
             createAnnouncementInputOutline.SetActive(false);
+            InputFocusChanged?.Invoke(false);
+        }
 
         private void OnAnnouncementInputValueChanged(string text)
         {

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementsSectionController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementsSectionController.cs
@@ -1,6 +1,8 @@
 ﻿using Cysharp.Threading.Tasks;
 using DCL.Communities.CommunitiesDataProvider.DTOs;
 using DCL.Diagnostics;
+using DCL.Input;
+using DCL.Input.Component;
 using DCL.NotificationsBus;
 using DCL.NotificationsBus.NotificationTypes;
 using DCL.Profiles;
@@ -24,6 +26,7 @@ namespace DCL.Communities.CommunitiesCard.Announcements
 
         private readonly AnnouncementsSectionView view;
         private readonly CommunitiesDataProvider.CommunitiesDataProvider communitiesDataProvider;
+        private readonly IInputBlock inputBlock;
         private readonly SectionFetchData<CommunityPost> currentAnnouncementsFetchData = new (PAGE_SIZE);
 
         protected override SectionFetchData<CommunityPost> currentSectionFetchData => currentAnnouncementsFetchData;
@@ -32,6 +35,7 @@ namespace DCL.Communities.CommunitiesCard.Announcements
         private bool lastFetchSucceeded;
         private bool isCreationAllowed;
         private bool isPosting;
+        private bool isCreationInputBlocking;
         private readonly HashSet<string> announcementsUpdatingLikeStatus = new();
 
         public AnnouncementsSectionController(
@@ -39,10 +43,12 @@ namespace DCL.Communities.CommunitiesCard.Announcements
             CommunitiesDataProvider.CommunitiesDataProvider communitiesDataProvider,
             ProfileRepositoryWrapper profileRepositoryWrapper,
             IWeb3IdentityCache identityCache,
-            IProfileRepository profileRepository) : base (view, PAGE_SIZE)
+            IProfileRepository profileRepository,
+            IInputBlock inputBlock) : base (view, PAGE_SIZE)
         {
             this.view = view;
             this.communitiesDataProvider = communitiesDataProvider;
+            this.inputBlock = inputBlock;
 
             InitializeViewAsync(identityCache, profileRepository, profileRepositoryWrapper, cancellationToken).Forget();
 
@@ -50,6 +56,7 @@ namespace DCL.Communities.CommunitiesCard.Announcements
             view.LikeAnnouncementButtonClicked += LikeAnnouncement;
             view.UnlikeAnnouncementButtonClicked += UnlikeAnnouncement;
             view.DeleteAnnouncementButtonClicked += DeleteAnnouncement;
+            view.CreationInputFocusChanged += OnCreationInputFocusChanged;
         }
 
         public override void Dispose()
@@ -58,12 +65,29 @@ namespace DCL.Communities.CommunitiesCard.Announcements
             view.LikeAnnouncementButtonClicked -= LikeAnnouncement;
             view.UnlikeAnnouncementButtonClicked -= UnlikeAnnouncement;
             view.DeleteAnnouncementButtonClicked -= DeleteAnnouncement;
+            view.CreationInputFocusChanged -= OnCreationInputFocusChanged;
+
+            OnCreationInputFocusChanged(false);
 
             base.Dispose();
         }
 
+        private void OnCreationInputFocusChanged(bool isFocused)
+        {
+            if (isFocused == isCreationInputBlocking)
+                return;
+
+            isCreationInputBlocking = isFocused;
+
+            if (isFocused)
+                inputBlock.Disable(InputMapComponent.BLOCK_USER_INPUT);
+            else
+                inputBlock.Enable(InputMapComponent.BLOCK_USER_INPUT);
+        }
+
         public override void Reset()
         {
+            OnCreationInputFocusChanged(false);
             communityData = null;
             currentAnnouncementsFetchData.Reset();
             view.SetAllowCreation(false);

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementsSectionController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementsSectionController.cs
@@ -230,14 +230,12 @@ namespace DCL.Communities.CommunitiesCard.Announcements
                 }
 
                 foreach (CommunityPost post in currentAnnouncementsFetchData.Items)
-                {
                     if (post.id == postId)
                     {
                         post.isLikedByUser = true;
                         post.likesCount++;
                         break;
                     }
-                }
 
                 RefreshGrid(true);
             }
@@ -268,14 +266,12 @@ namespace DCL.Communities.CommunitiesCard.Announcements
                 }
 
                 foreach (CommunityPost post in currentAnnouncementsFetchData.Items)
-                {
                     if (post.id == postId)
                     {
                         post.isLikedByUser = false;
                         post.likesCount--;
                         break;
                     }
-                }
 
                 RefreshGrid(true);
             }

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementsSectionView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementsSectionView.cs
@@ -29,7 +29,7 @@ namespace DCL.Communities.CommunitiesCard.Announcements
         private ProfileRepositoryWrapper profileRepositoryWrapper = null!;
         private bool isCreationAllowed;
         private CommunityMemberRole currentRole;
-        private AnnouncementCreationCardView? announcementCreationCardItem = null;
+        private AnnouncementCreationCardView? announcementCreationCardItem;
 
         private void Awake() =>
             loopListScrollRect.SetScrollSensitivityBasedOnPlatform();

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementsSectionView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementsSectionView.cs
@@ -19,6 +19,7 @@ namespace DCL.Communities.CommunitiesCard.Announcements
 
         public event Action? NewDataRequested;
         public event Action<string>? CreateAnnouncementButtonClicked;
+        public event Action<bool>? CreationInputFocusChanged;
         public event Action<string>? LikeAnnouncementButtonClicked;
         public event Action<string>? UnlikeAnnouncementButtonClicked;
         public event Action<string>? DeleteAnnouncementButtonClicked;
@@ -90,6 +91,8 @@ namespace DCL.Communities.CommunitiesCard.Announcements
                     announcementCreationCardItem.Configure(currentProfile, profileRepositoryWrapper);
                     announcementCreationCardItem.CreateAnnouncementButtonClicked -= OnCreateAnnouncementButtonClicked;
                     announcementCreationCardItem.CreateAnnouncementButtonClicked += OnCreateAnnouncementButtonClicked;
+                    announcementCreationCardItem.InputFocusChanged -= OnCreationInputFocusChanged;
+                    announcementCreationCardItem.InputFocusChanged += OnCreationInputFocusChanged;
                     return creationInputItem;
                 }
 
@@ -124,6 +127,9 @@ namespace DCL.Communities.CommunitiesCard.Announcements
 
         private void OnCreateAnnouncementButtonClicked(string announcementContent) =>
             CreateAnnouncementButtonClicked?.Invoke(announcementContent);
+
+        private void OnCreationInputFocusChanged(bool isFocused) =>
+            CreationInputFocusChanged?.Invoke(isFocused);
 
         private void OnLikeAnnouncementButtonClicked(string announcementId) =>
             LikeAnnouncementButtonClicked?.Invoke(announcementId);

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
@@ -30,7 +30,6 @@ using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.UI;
 using DCL.UI.Profiles.Helpers;
-using DCL.Utilities;
 using DCL.Utilities.Extensions;
 using DCL.Utility.Types;
 using DCL.VoiceChat;
@@ -74,7 +73,7 @@ namespace DCL.Communities.CommunitiesCard
         private readonly CommunitiesDataProvider.CommunitiesDataProvider communitiesDataProvider;
         private readonly IWebRequestController webRequestController;
         private readonly ProfileRepositoryWrapper profileRepositoryWrapper;
-        private readonly IPlacesAPIService placesAPIService;
+        private readonly IPlacesAPIService placesApiService;
         private readonly IRealmNavigator realmNavigator;
         private readonly ISystemClipboard clipboard;
         private readonly IWebBrowser webBrowser;
@@ -118,7 +117,7 @@ namespace DCL.Communities.CommunitiesCard
             CommunitiesDataProvider.CommunitiesDataProvider communitiesDataProvider,
             IWebRequestController webRequestController,
             ProfileRepositoryWrapper profileDataProvider,
-            IPlacesAPIService placesAPIService,
+            IPlacesAPIService placesApiService,
             IRealmNavigator realmNavigator,
             ISystemClipboard clipboard,
             IWebBrowser webBrowser,
@@ -144,7 +143,7 @@ namespace DCL.Communities.CommunitiesCard
             this.communitiesDataProvider = communitiesDataProvider;
             this.webRequestController = webRequestController;
             this.profileRepositoryWrapper = profileDataProvider;
-            this.placesAPIService = placesAPIService;
+            this.placesApiService = placesApiService;
             this.realmNavigator = realmNavigator;
             this.clipboard = clipboard;
             this.webBrowser = webBrowser;
@@ -387,7 +386,7 @@ namespace DCL.Communities.CommunitiesCard
             placesSectionController = new PlacesSectionController(viewInstance.PlacesSectionView,
                 thumbnailLoader,
                 communitiesDataProvider,
-                placesAPIService,
+                placesApiService,
                 realmNavigator,
                 mvcManager,
                 clipboard,
@@ -399,7 +398,7 @@ namespace DCL.Communities.CommunitiesCard
 
             eventListController = new EventListController(viewInstance.EventListView,
                 eventsApiService,
-                placesAPIService,
+                placesApiService,
                 thumbnailLoader,
                 mvcManager,
                 clipboard,
@@ -408,7 +407,6 @@ namespace DCL.Communities.CommunitiesCard
                 decentralandUrlsSource);
 
             if (FeaturesRegistry.Instance.IsEnabled(FeatureId.COMMUNITIES_ANNOUNCEMENTS))
-            {
                 announcementsSectionController = new AnnouncementsSectionController(
                     viewInstance.AnnouncementsSectionView,
                     communitiesDataProvider,
@@ -416,7 +414,6 @@ namespace DCL.Communities.CommunitiesCard
                     web3IdentityCache,
                     profileRepository,
                     inputBlock);
-            }
 
             viewInstance.SetCardBackgroundColor(viewInstance.BackgroundColor, BG_SHADER_COLOR_1);
         }
@@ -482,10 +479,8 @@ namespace DCL.Communities.CommunitiesCard
                 if (!communityData.IsAccessAllowed())
                 {
                     if (!existsInvitation)
-                    {
                         // Check if we have a pending request to join the community
                         await CheckUserInviteOrRequestAsync(InviteRequestAction.request_to_join, ct);
-                    }
                 }
                 else
                     communityPlaceIds = (await communitiesDataProvider.GetCommunityPlacesAsync(communityId, ct)).ToArray();
@@ -684,9 +679,7 @@ namespace DCL.Communities.CommunitiesCard
                     return;
 
                 if (!result.Success)
-                {
                     NotificationsBusController.Instance.AddNotification(new ServerErrorNotification(REQUEST_TO_JOIN_COMMUNITY_ERROR_MESSAGE));
-                }
 
                 communityData.SetPendingInviteOrRequestId(result.Value);
                 communityData.SetPendingAction(InviteRequestAction.request_to_join);
@@ -709,9 +702,7 @@ namespace DCL.Communities.CommunitiesCard
                     return;
 
                 if (!result.Success || !result.Value)
-                {
                     NotificationsBusController.Instance.AddNotification(new ServerErrorNotification(CANCEL_REQUEST_TO_JOIN_COMMUNITY_ERROR_MESSAGE));
-                }
 
                 communityData.SetPendingInviteOrRequestId(null);
                 communityData.SetPendingAction(InviteRequestAction.none);
@@ -734,9 +725,7 @@ namespace DCL.Communities.CommunitiesCard
                     return;
 
                 if (!result.Success || !result.Value)
-                {
                     NotificationsBusController.Instance.AddNotification(new ServerErrorNotification(ACCEPT_COMMUNITY_INVITATION_ERROR_MESSAGE));
-                }
 
                 if (communityData.privacy == CommunityPrivacy.@public)
                 {
@@ -768,9 +757,7 @@ namespace DCL.Communities.CommunitiesCard
                     return;
 
                 if (!result.Success || !result.Value)
-                {
                     NotificationsBusController.Instance.AddNotification(new ServerErrorNotification(REJECT_COMMUNITY_INVITATION_ERROR_MESSAGE));
-                }
 
                 CloseController();
             }

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/CommunityCardController.cs
@@ -414,7 +414,8 @@ namespace DCL.Communities.CommunitiesCard
                     communitiesDataProvider,
                     profileRepositoryWrapper,
                     web3IdentityCache,
-                    profileRepository);
+                    profileRepository,
+                    inputBlock);
             }
 
             viewInstance.SetCardBackgroundColor(viewInstance.BackgroundColor, BG_SHADER_COLOR_1);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes #9309: in-world keyboard input was not blocked while typing in the community announcement field.

**Problem:** When the announcement creation field (community card, Announcements section) was focused, world input stayed active, so typing leaked into gameplay: `W/A/S/D` moved the avatar, `Space` jumped, `V` switched camera POV, `T` toggled nearby voice chat, and `Enter` focused the main chat.

**Root cause:** The field's `onSelect`/`onDeselect` handlers only toggled a visual outline; they never blocked input. The `CommunityCardController` blocks just `SHORTCUTS` + `IN_WORLD_CAMERA` at the card level, leaving `PLAYER`, `CAMERA`, and `VOICE_CHAT` active while the card is open. (This is why the issue only reproduced
when the card was opened from the chat sidebar: that path doesn't re-block the rest.)

**Fix:** The announcement field's focus/blur is now wired through the section view to `AnnouncementsSectionController`, which disables/enables the full `InputMapComponent.BLOCK_USER_INPUT` set (`PLAYER, CAMERA, IN_WORLD_CAMERA, SHORTCUTS, VOICE_CHAT`) via the existing `IInputBlock` service, the same mechanism the chat input
and the backpack/navmap search bars use. A guard flag keeps the reference counters balanced, and the block is released on `Reset`/`Dispose` so it can't leak if the card closes while the field is focused.

A second commit clears the trivial, mechanical ReSharper findings in the touched files (unused `using`, redundant braces/initializer, `placesAPIService` to `placesApiService` rename, `internal` to `private` on emoji fields). No behavioural change; verified against a full-solution InspectCode run.

Files changed:
- `AnnouncementCreationCardView.cs`: raises an `InputFocusChanged` event on focus/blur
- `AnnouncementsSectionView.cs`: re-exposes the event and re-subscribes per pooled-item rebind
- `AnnouncementsSectionController.cs`: blocks/restores input on focus/blur
- `CommunityCardController.cs`: passes `IInputBlock` into the section controller

## Test Instructions

**Expected result:** While the announcement field is focused, `W/A/S/D`, `Space`, `V`, `T`, and `Enter` must not trigger any in-world action. After clicking away from the field, movement, camera, voice chat, and chat focus work normally again.

### Prerequisites
- [ ] Account must be a `moderator` or `owner` of a community (creation input is only shown to those roles)
- [ ] Community announcements feature flag enabled (`COMMUNITIES_ANNOUNCEMENTS`)

### Test Steps
1. Launch the Explorer.
2. Open a community card **from the chat sidebar** (the original repro path).
3. Click the announcement input field and start typing.
4. While focused, press `W` `A` `S` `D`, `Space`, `V`, `T`, and `Enter`, then verify the avatar does not move/jump, camera POV does not change, nearby voice chat does not activate, and chat is not focused; the characters type into the field instead.
5. Click elsewhere to blur the field, then verify `W/A/S/D` move the avatar and `V`/`T`/`Enter` work again.
6. Close the card while the field is still focused, then verify world input is fully restored (no stuck-blocked movement/camera).

### Additional Testing Notes
- Verify on both Windows and Mac (issue reproduced on both).
- Edge case: repeatedly focus/blur the field and confirm input never gets stuck blocked or double-unblocked (reference-counter balance).
- The announcement card is recycled through a pooled loop list, so confirm the block still works after scrolling the announcements list and re-showing the creation card.

## Quality Checklist
- [X] Changes have been tested locally
- [ ] Documentation has been updated (if required): n/a
- [ ] Performance impact has been considered: n/a (event-driven, no per-frame work)
- [ ] For SDK features: Test scene is included: n/a

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting.
