### PR TITLE
fix: allow new emote intent to override previous emote

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -282,8 +282,10 @@ namespace DCL.AvatarRendering.Emotes.Play
             {
                 // we wait until the avatar finishes moving to trigger the emote,
                 // avoid the case where: you stop moving, trigger the emote, the emote gets triggered and next frame it gets cancelled because inertia keeps moving the avatar
-                //We also avoid triggering the emote while the character is jumping or landing, as the landing animation breaks the emote flow if they have props
+                // We also avoid triggering the emote while the character is jumping or landing, as the landing animation breaks the emote flow if they have props
+                // Skipped while an emote plays: the disabled CharacterController makes grounded/blend readings stale, parking the intent forever and soft-locking movement.
                 if (emoteIntent.Mask == AvatarEmoteMask.AemFullBody &&
+                    !emoteComponent.IsPlayingEmote &&
                     (avatarView.IsAnimatorInTag(AnimationHashes.JUMPING_TAG) ||
                      !avatarView.GetAnimatorBool(AnimationHashes.GROUNDED) ||
                      avatarView.GetAnimatorFloat(AnimationHashes.MOVEMENT_BLEND) > 0.1f))


### PR DESCRIPTION
# Pull Request Description

Fixes #9115 (suspected root cause analysis is incorrect)

After catching a fish in the Genesis Plaza pond game, the player can't walk until they jump. The scene leaves the "hold fish" scene emote looping and fires `triggerEmote('fistpump')` in the same tick it unlocks input. In the explorer, a playing emote disables the `CharacterController` (so the avatar can't move), and the fistpump's `CharacterEmoteIntent` can get stuck unconsumed. `ConsumeEmoteIntent's` grounded/movement guard reads stale animator values (also affected by the teleport for the rotation set) while the controller is disabled. A pending intent also disables all cancel-by-input queries `([None(CharacterEmoteIntent)])`, so walking can neither move the avatar nor cancel the loop. Only jump escapes, because air jumps fire the unconditional `JUMP` animator trigger that forces the animator out of the emote state..

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

(`CharacterEmoteSystem.ConsumeEmoteIntent`): skip the grounded/movement guard when an emote is already playing. The avatar can't be in locomotion mid-emote and the readings are invalid, so the new emote replaces the current one immediately instead of parking and soft-locking movement.


### Test Steps
1. Full regression on the emotes: test all possible combinations with wheel emotes, scene emotes etc...
2. Verify in the fishing pond game that catching a fish never gets you stuck in the last frame of the "showing the catch" emote


## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
