### PR TITLE
fix: deduplicate social service streams to stop reconnection spam

### DIFF
--- a/Explorer/Assets/DCL/Communities/RPCCommunitiesService.cs
+++ b/Explorer/Assets/DCL/Communities/RPCCommunitiesService.cs
@@ -12,8 +12,6 @@ namespace DCL.Communities
     public class RPCCommunitiesService : RPCSocialServiceBase
     {
         private const string SUBSCRIBE_TO_CONNECTIVITY_UPDATES = "SubscribeToCommunityMemberConnectivityUpdates";
-        // Increase the default number of retries because once it consumes all, it will not receive updates for the rest of the session
-        private const int MAX_CONNECTION_RETRIES = 20;
 
         private readonly CommunitiesEventBus communitiesEventBus;
         private readonly ISocialServiceEventBus socialServiceEventBus;
@@ -24,7 +22,7 @@ namespace DCL.Communities
             IRPCSocialServices socialServiceRPC,
             CommunitiesEventBus communitiesEventBus,
             ISocialServiceEventBus socialServiceEventBus,
-            IWeb3IdentityCache identityCache) : base(socialServiceRPC, ReportCategory.COMMUNITIES, MAX_CONNECTION_RETRIES)
+            IWeb3IdentityCache identityCache) : base(socialServiceRPC, ReportCategory.COMMUNITIES)
         {
             this.communitiesEventBus = communitiesEventBus;
             this.socialServiceEventBus = socialServiceEventBus;

--- a/Explorer/Assets/DCL/Communities/RPCCommunitiesService.cs
+++ b/Explorer/Assets/DCL/Communities/RPCCommunitiesService.cs
@@ -3,7 +3,6 @@ using DCL.Diagnostics;
 using DCL.SocialService;
 using DCL.Web3.Identities;
 using Decentraland.SocialService.V2;
-using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Threading;
 using Utility;
@@ -32,24 +31,27 @@ namespace DCL.Communities
             this.identityCache = identityCache;
 
             socialServiceEventBus.TransportClosed += OnTransportClosed;
-            socialServiceEventBus.RPCClientReconnected += OnTransportReconnected;
-            socialServiceEventBus.WebSocketConnectionEstablished += OnTransportConnected;
+            socialServiceEventBus.RPCClientReconnected += SubscribeToConnectivityStatus;
+            socialServiceEventBus.WebSocketConnectionEstablished += SubscribeToConnectivityStatus;
         }
 
         public override void Dispose()
         {
             socialServiceEventBus.TransportClosed -= OnTransportClosed;
-            socialServiceEventBus.RPCClientReconnected -= OnTransportReconnected;
-            socialServiceEventBus.WebSocketConnectionEstablished -= OnTransportConnected;
+            socialServiceEventBus.RPCClientReconnected -= SubscribeToConnectivityStatus;
+            socialServiceEventBus.WebSocketConnectionEstablished -= SubscribeToConnectivityStatus;
             subscriptionCts.SafeCancelAndDispose();
             base.Dispose();
         }
 
-        private void OnTransportConnected()
+        /// <summary>
+        ///     Starts the connectivity updates subscription. A call while the subscription is already
+        ///     active is a no-op, enforced by <see cref="RPCSocialServiceBase.KeepServerStreamOpenAsync{T}" />.
+        /// </summary>
+        public void SubscribeToConnectivityStatus()
         {
             if (identityCache.Identity == null) return;
 
-            subscriptionCts = subscriptionCts.SafeRestart();
             TrySubscribeToConnectivityStatusAsync(subscriptionCts.Token).Forget();
         }
 
@@ -58,25 +60,14 @@ namespace DCL.Communities
             subscriptionCts = subscriptionCts.SafeRestart();
         }
 
-        private void OnTransportReconnected()
+        private async UniTask TrySubscribeToConnectivityStatusAsync(CancellationToken ct)
         {
-            if (identityCache.Identity == null) return;
-
-            subscriptionCts = subscriptionCts.SafeRestart();
-            TrySubscribeToConnectivityStatusAsync(subscriptionCts.Token).Forget();
-        }
-
-        public async UniTask TrySubscribeToConnectivityStatusAsync(CancellationToken ct)
-        {
-            await KeepServerStreamOpenAsync(OpenStreamAndProcessUpdatesAsync, ct);
+            await KeepServerStreamOpenAsync<CommunityMemberConnectivityUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_TO_CONNECTIVITY_UPDATES, ct);
 
             return;
 
-            async UniTask OpenStreamAndProcessUpdatesAsync()
+            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<CommunityMemberConnectivityUpdate> stream)
             {
-                IUniTaskAsyncEnumerable<CommunityMemberConnectivityUpdate> stream =
-                    socialServiceRPC.Module().CallServerStream<CommunityMemberConnectivityUpdate>(SUBSCRIBE_TO_CONNECTIVITY_UPDATES, new Empty());
-
                 await foreach (CommunityMemberConnectivityUpdate? response in EnumerateWithCancellationAsync(stream, ct))
                 {
                     try

--- a/Explorer/Assets/DCL/Communities/RPCCommunitiesService.cs
+++ b/Explorer/Assets/DCL/Communities/RPCCommunitiesService.cs
@@ -62,11 +62,11 @@ namespace DCL.Communities
 
         private async UniTask TrySubscribeToConnectivityStatusAsync(CancellationToken ct)
         {
-            await KeepServerStreamOpenAsync<CommunityMemberConnectivityUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_TO_CONNECTIVITY_UPDATES, ct);
+            await KeepServerStreamOpenAsync<CommunityMemberConnectivityUpdate>(ProcessUpdatesAsync, SUBSCRIBE_TO_CONNECTIVITY_UPDATES, ct);
 
             return;
 
-            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<CommunityMemberConnectivityUpdate> stream)
+            async UniTask ProcessUpdatesAsync(IUniTaskAsyncEnumerable<CommunityMemberConnectivityUpdate> stream)
             {
                 await foreach (CommunityMemberConnectivityUpdate? response in EnumerateWithCancellationAsync(stream, ct))
                 {

--- a/Explorer/Assets/DCL/Friends/FriendsConnectivityStatusTracker.cs
+++ b/Explorer/Assets/DCL/Friends/FriendsConnectivityStatusTracker.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using DCL.Profiles;
+using UnityEngine.Pool;
 using Utility;
 
 namespace DCL.Friends
@@ -44,11 +45,31 @@ namespace DCL.Friends
             friendEventBus.OnYouRemovedFriend -= FriendRemoved;
             friendEventBus.OnOtherUserRemovedTheFriendship -= FriendRemoved;
 
-            // Cancel all pending debounce operations
-            foreach (var info in debounceInfo.Values)
-                info.CancellationTokenSource.SafeCancelAndDispose();
+            CancelPendingDebounces();
+        }
 
+        /// <summary>
+        ///     Forgets every cached status and cancels pending debounces, so subsequent updates
+        ///     are evaluated against an empty state and always raise their corresponding event.
+        /// </summary>
+        public void Reset()
+        {
+            friendsOnlineStatus.Clear();
+            CancelPendingDebounces();
+        }
+
+        private void CancelPendingDebounces()
+        {
+            if (debounceInfo.Count == 0) return;
+
+            using PooledObject<List<FriendStatusDebounceInfo>> scope = ListPool<FriendStatusDebounceInfo>.Get(out List<FriendStatusDebounceInfo> pendingDebounces);
+            pendingDebounces.AddRange(debounceInfo.Values);
+
+            // Empty the map before cancelling: cancellation continuations run synchronously and mutate it
             debounceInfo.Clear();
+
+            foreach (FriendStatusDebounceInfo info in pendingDebounces)
+                info.CancellationTokenSource.SafeCancelAndDispose();
         }
 
         private void FriendRemoved(string userid)

--- a/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
+++ b/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
@@ -1,10 +1,8 @@
-using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.SocialService;
-using DCL.Utilities;
 using DCL.Web3;
 using Decentraland.SocialService.V2;
 using Google.Protobuf.Collections;
@@ -174,7 +172,7 @@ namespace DCL.Friends
                 },
             };
 
-            GetBlockedUsersResponse? response = await socialServiceRPC.Module()!
+            GetBlockedUsersResponse? response = await socialServiceRPC.Module()
                                                                       .CallUnaryProcedure<GetBlockedUsersResponse>(GET_BLOCKED_USERS, payload)
                                                                       .AttachExternalCancellation(ct)
                                                                       .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -196,7 +194,7 @@ namespace DCL.Friends
                 },
             };
 
-            BlockUserResponse? response = await socialServiceRPC.Module()!
+            BlockUserResponse? response = await socialServiceRPC.Module()
                                                                 .CallUnaryProcedure<BlockUserResponse>(BLOCK_USER, payload)
                                                                 .AttachExternalCancellation(ct)
                                                                 .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -222,7 +220,7 @@ namespace DCL.Friends
                 },
             };
 
-            UnblockUserResponse? response = await socialServiceRPC.Module()!
+            UnblockUserResponse? response = await socialServiceRPC.Module()
                                                                   .CallUnaryProcedure<UnblockUserResponse>(UNBLOCK_USER, payload)
                                                                   .AttachExternalCancellation(ct)
                                                                   .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -240,7 +238,7 @@ namespace DCL.Friends
         {
             await socialServiceRPC.EnsureRpcConnectionAsync(ct);
 
-            GetBlockingStatusResponse? response = await socialServiceRPC.Module()!
+            GetBlockingStatusResponse? response = await socialServiceRPC.Module()
                                                                         .CallUnaryProcedure<GetBlockingStatusResponse>(GET_BLOCKING_STATUS, new Empty())
                                                                         .AttachExternalCancellation(ct)
                                                                         .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -261,7 +259,7 @@ namespace DCL.Friends
                 },
             };
 
-            PaginatedFriendsProfilesResponse? response = await socialServiceRPC.Module()!
+            PaginatedFriendsProfilesResponse? response = await socialServiceRPC.Module()
                                                                                .CallUnaryProcedure<PaginatedFriendsProfilesResponse>(GET_FRIENDS_PROCEDURE_NAME, payload)
                                                                                .AttachExternalCancellation(ct)
                                                                                .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -292,7 +290,7 @@ namespace DCL.Friends
                 },
             };
 
-            PaginatedFriendsProfilesResponse? response = await socialServiceRPC.Module()!
+            PaginatedFriendsProfilesResponse? response = await socialServiceRPC.Module()
                                                                                .CallUnaryProcedure<PaginatedFriendsProfilesResponse>(GET_MUTUAL_FRIENDS_PROCEDURE_NAME, payload)
                                                                                .AttachExternalCancellation(ct)
                                                                                .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -317,7 +315,7 @@ namespace DCL.Friends
                 },
             };
 
-            GetFriendshipStatusResponse response = await socialServiceRPC.Module()!
+            GetFriendshipStatusResponse response = await socialServiceRPC.Module()
                                                                          .CallUnaryProcedure<GetFriendshipStatusResponse>(GET_FRIENDSHIP_STATUS_PROCEDURE_NAME, payload)
                                                                          .AttachExternalCancellation(ct)
                                                                          .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -364,7 +362,7 @@ namespace DCL.Friends
                 },
             };
 
-            PaginatedFriendshipRequestsResponse response = await socialServiceRPC.Module()!
+            PaginatedFriendshipRequestsResponse response = await socialServiceRPC.Module()
                                                                                  .CallUnaryProcedure<PaginatedFriendshipRequestsResponse>(GET_RECEIVED_FRIEND_REQUESTS_PROCEDURE_NAME,
                                                                                       payload)
                                                                                  .AttachExternalCancellation(ct)
@@ -412,7 +410,7 @@ namespace DCL.Friends
                 },
             };
 
-            PaginatedFriendshipRequestsResponse response = await socialServiceRPC.Module()!
+            PaginatedFriendshipRequestsResponse response = await socialServiceRPC.Module()
                                                                                  .CallUnaryProcedure<PaginatedFriendshipRequestsResponse>(GET_SENT_FRIEND_REQUESTS_PROCEDURE_NAME,
                                                                                       payload)
                                                                                  .AttachExternalCancellation(ct)
@@ -554,7 +552,7 @@ namespace DCL.Friends
             UpsertFriendshipPayload payload,
             CancellationToken ct)
         {
-            UpsertFriendshipResponse response = await socialServiceRPC.Module()!
+            UpsertFriendshipResponse response = await socialServiceRPC.Module()
                                                                       .CallUnaryProcedure<UpsertFriendshipResponse>(UPDATE_FRIENDSHIP_PROCEDURE_NAME, payload)
                                                                       .AttachExternalCancellation(ct)
                                                                       .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));

--- a/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
+++ b/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
@@ -58,15 +58,10 @@ namespace DCL.Friends
 
         public UniTask SubscribeToIncomingFriendshipEventsAsync(CancellationToken ct)
         {
-            return KeepServerStreamOpenAsync(OpenStreamAndProcessUpdatesAsync, ct);
+            return KeepServerStreamOpenAsync<FriendshipUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_FRIENDSHIP_UPDATES_PROCEDURE_NAME, ct);
 
-            async UniTask OpenStreamAndProcessUpdatesAsync()
+            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<FriendshipUpdate> stream)
             {
-                IUniTaskAsyncEnumerable<FriendshipUpdate> stream =
-                    socialServiceRPC.Module()
-                                    .CallServerStream<FriendshipUpdate>(SUBSCRIBE_FRIENDSHIP_UPDATES_PROCEDURE_NAME,
-                                         new Empty());
-
                 await foreach (FriendshipUpdate? response in EnumerateWithCancellationAsync(stream, ct))
                 {
                     try
@@ -116,13 +111,10 @@ namespace DCL.Friends
 
         public UniTask SubscribeToConnectivityStatusAsync(CancellationToken ct)
         {
-            return KeepServerStreamOpenAsync(OpenStreamAndProcessUpdatesAsync, ct);
+            return KeepServerStreamOpenAsync<FriendConnectivityUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_TO_CONNECTIVITY_UPDATES, ct);
 
-            async UniTask OpenStreamAndProcessUpdatesAsync()
+            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<FriendConnectivityUpdate> stream)
             {
-                IUniTaskAsyncEnumerable<FriendConnectivityUpdate> stream =
-                    socialServiceRPC.Module()!.CallServerStream<FriendConnectivityUpdate>(SUBSCRIBE_TO_CONNECTIVITY_UPDATES, new Empty());
-
                 await foreach (FriendConnectivityUpdate? response in EnumerateWithCancellationAsync(stream, ct))
                 {
                     try
@@ -149,13 +141,10 @@ namespace DCL.Friends
 
         public UniTask SubscribeToUserBlockUpdatersAsync(CancellationToken ct)
         {
-            return KeepServerStreamOpenAsync(OpenStreamAndProcessUpdatesAsync, ct);
+            return KeepServerStreamOpenAsync<BlockUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_TO_BLOCK_STATUS_UPDATES, ct);
 
-            async UniTask OpenStreamAndProcessUpdatesAsync()
+            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<BlockUpdate> stream)
             {
-                IUniTaskAsyncEnumerable<BlockUpdate> stream =
-                    socialServiceRPC.Module()!.CallServerStream<BlockUpdate>(SUBSCRIBE_TO_BLOCK_STATUS_UPDATES, new Empty());
-
                 await foreach (BlockUpdate? response in EnumerateWithCancellationAsync(stream, ct))
                 {
                     try

--- a/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
+++ b/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
@@ -58,9 +58,9 @@ namespace DCL.Friends
 
         public UniTask SubscribeToIncomingFriendshipEventsAsync(CancellationToken ct)
         {
-            return KeepServerStreamOpenAsync<FriendshipUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_FRIENDSHIP_UPDATES_PROCEDURE_NAME, ct);
+            return KeepServerStreamOpenAsync<FriendshipUpdate>(ProcessUpdatesAsync, SUBSCRIBE_FRIENDSHIP_UPDATES_PROCEDURE_NAME, ct);
 
-            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<FriendshipUpdate> stream)
+            async UniTask ProcessUpdatesAsync(IUniTaskAsyncEnumerable<FriendshipUpdate> stream)
             {
                 await foreach (FriendshipUpdate? response in EnumerateWithCancellationAsync(stream, ct))
                 {
@@ -111,9 +111,9 @@ namespace DCL.Friends
 
         public UniTask SubscribeToConnectivityStatusAsync(CancellationToken ct)
         {
-            return KeepServerStreamOpenAsync<FriendConnectivityUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_TO_CONNECTIVITY_UPDATES, ct);
+            return KeepServerStreamOpenAsync<FriendConnectivityUpdate>(ProcessUpdatesAsync, SUBSCRIBE_TO_CONNECTIVITY_UPDATES, ct);
 
-            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<FriendConnectivityUpdate> stream)
+            async UniTask ProcessUpdatesAsync(IUniTaskAsyncEnumerable<FriendConnectivityUpdate> stream)
             {
                 await foreach (FriendConnectivityUpdate? response in EnumerateWithCancellationAsync(stream, ct))
                 {
@@ -141,9 +141,9 @@ namespace DCL.Friends
 
         public UniTask SubscribeToUserBlockUpdatersAsync(CancellationToken ct)
         {
-            return KeepServerStreamOpenAsync<BlockUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_TO_BLOCK_STATUS_UPDATES, ct);
+            return KeepServerStreamOpenAsync<BlockUpdate>(ProcessUpdatesAsync, SUBSCRIBE_TO_BLOCK_STATUS_UPDATES, ct);
 
-            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<BlockUpdate> stream)
+            async UniTask ProcessUpdatesAsync(IUniTaskAsyncEnumerable<BlockUpdate> stream)
             {
                 await foreach (BlockUpdate? response in EnumerateWithCancellationAsync(stream, ct))
                 {

--- a/Explorer/Assets/DCL/Friends/Tests.meta
+++ b/Explorer/Assets/DCL/Friends/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ee52a8e70c84baeb714f65f60382d79
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Friends/Tests/DCL.Friends.Tests.asmref
+++ b/Explorer/Assets/DCL/Friends/Tests/DCL.Friends.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/Friends/Tests/DCL.Friends.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/Friends/Tests/DCL.Friends.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e39cae10a790e3e4da01d7d5ae6d1915
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Friends/Tests/FriendsConnectivityStatusTrackerShould.cs
+++ b/Explorer/Assets/DCL/Friends/Tests/FriendsConnectivityStatusTrackerShould.cs
@@ -17,8 +17,12 @@ namespace DCL.Friends.Tests
         private FriendsConnectivityStatusTracker tracker = null!;
 
         [OneTimeSetUp]
-        public void OneTimeSetUp() =>
+        public void OneTimeSetUp()
+        {
+            // The editor domain may still hold an initialized registry from a play-mode session
+            EcsTestsUtils.TearDownFeaturesRegistry();
             EcsTestsUtils.SetUpFeaturesRegistry();
+        }
 
         [OneTimeTearDown]
         public void OneTimeTearDown() =>

--- a/Explorer/Assets/DCL/Friends/Tests/FriendsConnectivityStatusTrackerShould.cs
+++ b/Explorer/Assets/DCL/Friends/Tests/FriendsConnectivityStatusTrackerShould.cs
@@ -1,0 +1,93 @@
+using Cysharp.Threading.Tasks;
+using DCL.Profiles;
+using DCL.UI;
+using ECS.TestSuite;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace DCL.Friends.Tests
+{
+    public class FriendsConnectivityStatusTrackerShould
+    {
+        // The tracker debounces status changes for 2000ms; the margin absorbs editor loop jitter
+        private const int DEBOUNCE_WAIT_MS = 2500;
+        private const string FRIEND_ID = "0x79fdd6f8ba257bda1d5a2a413ae0b43ec300ed10";
+
+        private DefaultFriendsEventBus eventBus = null!;
+        private FriendsConnectivityStatusTracker tracker = null!;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp() =>
+            EcsTestsUtils.SetUpFeaturesRegistry();
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown() =>
+            EcsTestsUtils.TearDownFeaturesRegistry();
+
+        [SetUp]
+        public void SetUp()
+        {
+            eventBus = new DefaultFriendsEventBus();
+            tracker = new FriendsConnectivityStatusTracker(eventBus, isConnectivityStatusEnabled: true);
+        }
+
+        [TearDown]
+        public void TearDown() =>
+            tracker.Dispose();
+
+        [Test]
+        public async Task RaiseOnlineEventWhenSameStatusIsRebroadcastAfterReset()
+        {
+            //Arrange
+            var friendProfile = new Profile.CompactInfo(FRIEND_ID, "TestFriend");
+            var onlineEventsCount = 0;
+            tracker.OnFriendBecameOnline += _ => onlineEventsCount++;
+
+            eventBus.BroadcastFriendConnected(friendProfile);
+            await UniTask.Delay(DEBOUNCE_WAIT_MS);
+
+            //Act
+            tracker.Reset();
+            eventBus.BroadcastFriendConnected(friendProfile);
+            await UniTask.Delay(DEBOUNCE_WAIT_MS);
+
+            //Assert
+            Assert.AreEqual(2, onlineEventsCount);
+            Assert.AreEqual(OnlineStatus.ONLINE, tracker.GetFriendStatus(friendProfile.UserId));
+        }
+
+        [Test]
+        public async Task ReportFriendAsOfflineAfterReset()
+        {
+            //Arrange
+            var friendProfile = new Profile.CompactInfo(FRIEND_ID, "TestFriend");
+            eventBus.BroadcastFriendConnected(friendProfile);
+            await UniTask.Delay(DEBOUNCE_WAIT_MS);
+            Assert.AreEqual(OnlineStatus.ONLINE, tracker.GetFriendStatus(friendProfile.UserId));
+
+            //Act
+            tracker.Reset();
+
+            //Assert
+            Assert.AreEqual(OnlineStatus.OFFLINE, tracker.GetFriendStatus(friendProfile.UserId));
+        }
+
+        [Test]
+        public async Task CancelPendingDebounceOnReset()
+        {
+            //Arrange
+            var friendProfile = new Profile.CompactInfo(FRIEND_ID, "TestFriend");
+            var onlineEventsCount = 0;
+            tracker.OnFriendBecameOnline += _ => onlineEventsCount++;
+            eventBus.BroadcastFriendConnected(friendProfile);
+
+            //Act
+            tracker.Reset();
+            await UniTask.Delay(DEBOUNCE_WAIT_MS);
+
+            //Assert
+            Assert.AreEqual(0, onlineEventsCount);
+            Assert.AreEqual(OnlineStatus.OFFLINE, tracker.GetFriendStatus(friendProfile.UserId));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Friends/Tests/FriendsConnectivityStatusTrackerShould.cs.meta
+++ b/Explorer/Assets/DCL/Friends/Tests/FriendsConnectivityStatusTrackerShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 454e41be2d2a09841b2daba68ef1f883
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/PluginSystem/Global/CommunitiesPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/CommunitiesPlugin.cs
@@ -197,7 +197,7 @@ namespace DCL.PluginSystem.Global
                 profileRepository);
             mvcManager.RegisterController(communityCreationEditionController);
 
-            rpcCommunitiesService.TrySubscribeToConnectivityStatusAsync(ct).Forget();
+            rpcCommunitiesService.SubscribeToConnectivityStatus();
         }
 
         private void OnInputShortcutsEventsPerformedAsync(InputAction.CallbackContext _) =>

--- a/Explorer/Assets/DCL/PluginSystem/Global/FriendsContainer.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/FriendsContainer.cs
@@ -230,7 +230,7 @@ namespace DCL.PluginSystem.Global
 
             friendServiceSubscriptionCts = friendServiceSubscriptionCts.SafeRestart();
 
-            LaunchSubscriptionsAsync(friendServiceSubscriptionCts.Token);
+            LaunchSubscriptionsAsync(friendServiceSubscriptionCts.Token).Forget();
 
             prewarmFriendsCancellationToken = prewarmFriendsCancellationToken.SafeRestart();
             PrewarmAsync(prewarmFriendsCancellationToken.Token).Forget();
@@ -276,16 +276,15 @@ namespace DCL.PluginSystem.Global
         private void OnRPCClientReconnected()
         {
             friendServiceSubscriptionCts = friendServiceSubscriptionCts.SafeRestart();
-            ReconnectFriendServiceAsync(friendServiceSubscriptionCts.Token).Forget();
-            return;
 
-            async UniTaskVoid ReconnectFriendServiceAsync(CancellationToken ct)
-            {
-                await LaunchSubscriptionsAsync(ct);
-                await PreWarmFriendsCacheAsync(ct);
+            // Reset before re-subscribing: statuses cached for the previous identity would otherwise
+            // suppress the connectivity snapshot the new subscription delivers
+            friendsConnectivityStatusTracker.Reset();
+            friendsPanelController.Reset();
 
-                friendsPanelController.Reset();
-            }
+            // Subscriptions stay open until the next disconnect, so they must not gate the prewarm
+            LaunchSubscriptionsAsync(friendServiceSubscriptionCts.Token).Forget();
+            PreWarmFriendsCacheAsync(friendServiceSubscriptionCts.Token).Forget();
         }
 
         private async UniTask LaunchSubscriptionsAsync(CancellationToken ct)

--- a/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
+++ b/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
@@ -19,11 +19,6 @@ namespace DCL.SocialService
     public abstract class RPCSocialServiceBase : IDisposable
     {
         /// <summary>
-        ///     Maximum number of retry attempts for server stream connection
-        /// </summary>
-        private const int MAX_RETRY_ATTEMPTS = 5;
-
-        /// <summary>
         ///     Base delay in seconds between retry attempts (will be exponentially increased)
         /// </summary>
         private const int BASE_RETRY_DELAY_SECONDS = 2;
@@ -44,15 +39,12 @@ namespace DCL.SocialService
 
         protected readonly IRPCSocialServices socialServiceRPC;
         protected readonly string reportCategory;
-        private readonly int maxRetries;
         private readonly HashSet<Type> activeStreamTypes = new ();
 
-        protected RPCSocialServiceBase(IRPCSocialServices rpcSocialServices, string reportCategory,
-            int maxRetries = MAX_RETRY_ATTEMPTS)
+        protected RPCSocialServiceBase(IRPCSocialServices rpcSocialServices, string reportCategory)
         {
             socialServiceRPC = rpcSocialServices;
             this.reportCategory = reportCategory;
-            this.maxRetries = maxRetries;
         }
 
         public virtual void Dispose()

--- a/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
+++ b/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
@@ -79,6 +79,7 @@ namespace DCL.SocialService
                         await socialServiceRPC.EnsureRpcConnectionAsync(int.MaxValue, ct);
                         IUniTaskAsyncEnumerable<T>? stream = socialServiceRPC.Module().CallServerStream<T>(procedureName, new Empty());
                         await processUpdatesAsync(stream).AttachExternalCancellation(ct);
+                        retryAttempt = 0;
                     }
                     catch (OperationCanceledException) { break; }
                     catch (WebSocketException e)

--- a/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
+++ b/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
@@ -1,11 +1,15 @@
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 using Sentry;
+using Sentry.Unity;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Utility.Networking;
+using Type = System.Type;
 
 namespace DCL.SocialService
 {
@@ -24,7 +28,7 @@ namespace DCL.SocialService
         /// </summary>
         private const int BASE_RETRY_DELAY_SECONDS = 2;
 
-        public class ServerStreamReportsDebouncer : FrameDebouncer
+        protected class ServerStreamReportsDebouncer : FrameDebouncer
         {
             public ServerStreamReportsDebouncer() : base(1)
             {
@@ -41,6 +45,7 @@ namespace DCL.SocialService
         protected readonly IRPCSocialServices socialServiceRPC;
         protected readonly string reportCategory;
         private readonly int maxRetries;
+        private readonly HashSet<Type> activeStreamTypes = new ();
 
         protected RPCSocialServiceBase(IRPCSocialServices rpcSocialServices, string reportCategory,
             int maxRetries = MAX_RETRY_ATTEMPTS)
@@ -55,56 +60,73 @@ namespace DCL.SocialService
             lifeTimeCts.Cancel();
         }
 
-        protected async UniTask KeepServerStreamOpenAsync(Func<UniTask> openStreamFunc, CancellationToken ct)
+        /// <summary>
+        ///     Keeps the server stream of <typeparamref name="T" /> updates open until cancellation is requested.
+        ///     At most one stream per update type can be active at a time: a call for an already active type is a no-op.
+        ///     The active stream must never be torn down to make room for a new one — rpc-csharp sends no close message
+        ///     for a cancelled stream, so the server would keep the old subscription alive and reject the new one as a duplicate.
+        /// </summary>
+        protected async UniTask KeepServerStreamOpenAsync<T>(Func<IUniTaskAsyncEnumerable<T>, UniTask> openStreamFunc, string procedureName, CancellationToken ct) where T: IMessage, new()
         {
-            ct = CancellationTokenSource.CreateLinkedTokenSource(ct, lifeTimeCts.Token).Token;
+            if (!activeStreamTypes.Add(typeof(T)))
+                return;
 
-            var retryAttempt = 0;
-
-            // We try to keep the stream open until cancellation is requested
-            // If for any reason the rpc connection has a problem, we need to wait until it is restored, so we re-open the stream
-            while (!ct.IsCancellationRequested)
+            try
             {
-                try
+                ct = CancellationTokenSource.CreateLinkedTokenSource(ct, lifeTimeCts.Token).Token;
+
+                var retryAttempt = 0;
+
+                // We try to keep the stream open until cancellation is requested
+                // If for any reason the rpc connection has a problem, we need to wait until it is restored, so we re-open the stream
+                while (!ct.IsCancellationRequested)
                 {
-                    // It's an endless [background] loop
-                    await socialServiceRPC.EnsureRpcConnectionAsync(int.MaxValue, ct);
-                    await openStreamFunc().AttachExternalCancellation(ct);
-                }
-                catch (OperationCanceledException) { break; }
-                catch (WebSocketException e)
-                {
-                    retryAttempt++;
+                    try
+                    {
+                        // It's an endless [background] loop
+                        await socialServiceRPC.EnsureRpcConnectionAsync(int.MaxValue, ct);
+                        IUniTaskAsyncEnumerable<T>? stream = socialServiceRPC.Module().CallServerStream<T>(procedureName, new Empty());
+                        await openStreamFunc(stream).AttachExternalCancellation(ct);
+                    }
+                    catch (OperationCanceledException) { break; }
+                    catch (WebSocketException e)
+                    {
+                        retryAttempt++;
 
-                    Sentry.Unity.SentrySdk.AddBreadcrumb($"WebSocketException reason was WebSocketErrorCode: {e.WebSocketErrorCode.ToString()} "
-                                                         + $"ErrorCode: {e.ErrorCode.ToString()}", reportCategory, level: BreadcrumbLevel.Info);
+                        SentrySdk.AddBreadcrumb($"WebSocketException reason was WebSocketErrorCode: {e.WebSocketErrorCode.ToString()} "
+                                                + $"ErrorCode: {e.ErrorCode.ToString()}", reportCategory, level: BreadcrumbLevel.Info);
 
-                    var webSocketErrorCode = (WebSocketError)e.ErrorCode;
+                        var webSocketErrorCode = (WebSocketError)e.ErrorCode;
 
-                    if (webSocketErrorCode is WebSocketError.Faulted
-                        or WebSocketError.ConnectionClosedPrematurely
-                        or WebSocketError.NativeError
-                        or WebSocketError.HeaderError)
-                        ReportHub.LogWarning(new ReportData(reportCategory, new ReportDebounce(serverStreamReportsDebouncer)),
-                            $"WebSocketException {webSocketErrorCode} occurred while trying to keep rpc connection open, retrying..");
-                    else
+                        if (webSocketErrorCode is WebSocketError.Faulted
+                            or WebSocketError.ConnectionClosedPrematurely
+                            or WebSocketError.NativeError
+                            or WebSocketError.HeaderError)
+                            ReportHub.LogWarning(new ReportData(reportCategory, new ReportDebounce(serverStreamReportsDebouncer)),
+                                $"WebSocketException {webSocketErrorCode} occurred while trying to keep rpc connection open, retrying..");
+                        else
+                            ReportHub.LogException(e, new ReportData(reportCategory, new ReportDebounce(serverStreamReportsDebouncer)));
+
+                        try { await WaitNextRetryAsync(retryAttempt, ct); }
+                        catch (OperationCanceledException) { break; }
+                    }
+                    catch (InvalidOperationException e) when (IsExpectedDisconnectException(e))
+                    {
+                        // Expected during sign-out or transport close, exit gracefully
+                        break;
+                    }
+                    catch (Exception e)
+                    {
                         ReportHub.LogException(e, new ReportData(reportCategory, new ReportDebounce(serverStreamReportsDebouncer)));
 
-                    try { await WaitNextRetryAsync(retryAttempt, ct); }
-                    catch (OperationCanceledException) { break; }
+                        try { await WaitNextRetryAsync(retryAttempt, ct); }
+                        catch (OperationCanceledException) { break; }
+                    }
                 }
-                catch (InvalidOperationException e) when (IsExpectedDisconnectException(e))
-                {
-                    // Expected during sign-out or transport close, exit gracefully
-                    break;
-                }
-                catch (Exception e)
-                {
-                    ReportHub.LogException(e, new ReportData(reportCategory, new ReportDebounce(serverStreamReportsDebouncer)));
-
-                    try { await WaitNextRetryAsync(retryAttempt, ct); }
-                    catch (OperationCanceledException) { break; }
-                }
+            }
+            finally
+            {
+                activeStreamTypes.Remove(typeof(T));
             }
         }
 

--- a/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
+++ b/Explorer/Assets/DCL/Social/RPCSocialServiceBase.cs
@@ -66,7 +66,7 @@ namespace DCL.SocialService
         ///     The active stream must never be torn down to make room for a new one — rpc-csharp sends no close message
         ///     for a cancelled stream, so the server would keep the old subscription alive and reject the new one as a duplicate.
         /// </summary>
-        protected async UniTask KeepServerStreamOpenAsync<T>(Func<IUniTaskAsyncEnumerable<T>, UniTask> openStreamFunc, string procedureName, CancellationToken ct) where T: IMessage, new()
+        protected async UniTask KeepServerStreamOpenAsync<T>(Func<IUniTaskAsyncEnumerable<T>, UniTask> processUpdatesAsync, string procedureName, CancellationToken ct) where T: IMessage, new()
         {
             if (!activeStreamTypes.Add(typeof(T)))
                 return;
@@ -86,7 +86,7 @@ namespace DCL.SocialService
                         // It's an endless [background] loop
                         await socialServiceRPC.EnsureRpcConnectionAsync(int.MaxValue, ct);
                         IUniTaskAsyncEnumerable<T>? stream = socialServiceRPC.Module().CallServerStream<T>(procedureName, new Empty());
-                        await openStreamFunc(stream).AttachExternalCancellation(ct);
+                        await processUpdatesAsync(stream).AttachExternalCancellation(ct);
                     }
                     catch (OperationCanceledException) { break; }
                     catch (WebSocketException e)

--- a/Explorer/Assets/DCL/VoiceChat/Services/RPCCommunityVoiceChatService.cs
+++ b/Explorer/Assets/DCL/VoiceChat/Services/RPCCommunityVoiceChatService.cs
@@ -254,9 +254,9 @@ namespace DCL.VoiceChat.Services
 
         public UniTask SubscribeToCommunityVoiceChatUpdatesAsync(CancellationToken ct)
         {
-            return KeepServerStreamOpenAsync<CommunityVoiceChatUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_TO_COMMUNITY_VOICE_CHAT_UPDATES, ct);
+            return KeepServerStreamOpenAsync<CommunityVoiceChatUpdate>(ProcessUpdatesAsync, SUBSCRIBE_TO_COMMUNITY_VOICE_CHAT_UPDATES, ct);
 
-            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<CommunityVoiceChatUpdate> stream)
+            async UniTask ProcessUpdatesAsync(IUniTaskAsyncEnumerable<CommunityVoiceChatUpdate> stream)
             {
                 ReportHub.Log(ReportCategory.COMMUNITY_VOICE_CHAT, "Attempting to open community voice chat updates stream");
 

--- a/Explorer/Assets/DCL/VoiceChat/Services/RPCCommunityVoiceChatService.cs
+++ b/Explorer/Assets/DCL/VoiceChat/Services/RPCCommunityVoiceChatService.cs
@@ -5,7 +5,6 @@ using DCL.SocialService;
 using DCL.Web3.Identities;
 using Decentraland.SocialService.V2;
 using DCL.WebRequests;
-using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Threading;
 using Utility;

--- a/Explorer/Assets/DCL/VoiceChat/Services/RPCCommunityVoiceChatService.cs
+++ b/Explorer/Assets/DCL/VoiceChat/Services/RPCCommunityVoiceChatService.cs
@@ -35,6 +35,7 @@ namespace DCL.VoiceChat.Services
         private readonly IWeb3IdentityCache identityCache;
         private readonly string activeCommunityVoiceChatsUrl;
         private CancellationTokenSource subscriptionCts = new ();
+        private CancellationTokenSource fetchActiveChatsCts = new ();
 
         public event Action<CommunityVoiceChatUpdate>? CommunityVoiceChatUpdateReceived;
         public event Action<ActiveCommunityVoiceChatsResponse>? ActiveCommunityVoiceChatsFetched;
@@ -52,16 +53,17 @@ namespace DCL.VoiceChat.Services
             activeCommunityVoiceChatsUrl = urlsSource.Url(DecentralandUrl.ActiveCommunityVoiceChats);
 
             socialServiceEventBus.TransportClosed += OnTransportClosed;
-            socialServiceEventBus.RPCClientReconnected += OnTransportReconnected;
+            socialServiceEventBus.RPCClientReconnected += OnTransportConnected;
             socialServiceEventBus.WebSocketConnectionEstablished += OnTransportConnected;
         }
 
         public override void Dispose()
         {
             socialServiceEventBus.TransportClosed -= OnTransportClosed;
-            socialServiceEventBus.RPCClientReconnected -= OnTransportReconnected;
+            socialServiceEventBus.RPCClientReconnected -= OnTransportConnected;
             socialServiceEventBus.WebSocketConnectionEstablished -= OnTransportConnected;
             subscriptionCts.SafeCancelAndDispose();
+            fetchActiveChatsCts.SafeCancelAndDispose();
             base.Dispose();
         }
 
@@ -69,23 +71,16 @@ namespace DCL.VoiceChat.Services
         {
             if (identityCache.Identity == null) return;
 
-            subscriptionCts = subscriptionCts.SafeRestart();
             SubscribeToCommunityVoiceChatUpdatesAsync(subscriptionCts.Token).Forget();
-            FetchActiveCommunityVoiceChatsAsync(subscriptionCts.Token).Forget();
+
+            fetchActiveChatsCts = fetchActiveChatsCts.SafeRestart();
+            FetchActiveCommunityVoiceChatsAsync(fetchActiveChatsCts.Token).Forget();
         }
 
         private void OnTransportClosed()
         {
             subscriptionCts = subscriptionCts.SafeRestart();
-        }
-
-        private void OnTransportReconnected()
-        {
-            if (identityCache.Identity == null) return;
-
-            subscriptionCts = subscriptionCts.SafeRestart();
-            SubscribeToCommunityVoiceChatUpdatesAsync(subscriptionCts.Token).Forget();
-            FetchActiveCommunityVoiceChatsAsync(subscriptionCts.Token).Forget();
+            fetchActiveChatsCts = fetchActiveChatsCts.SafeRestart();
         }
 
         public async UniTask<StartCommunityVoiceChatResponse> StartCommunityVoiceChatAsync(string communityId, CancellationToken ct)
@@ -259,13 +254,10 @@ namespace DCL.VoiceChat.Services
 
         public UniTask SubscribeToCommunityVoiceChatUpdatesAsync(CancellationToken ct)
         {
-            return KeepServerStreamOpenAsync(OpenStreamAndProcessUpdatesAsync, ct);
+            return KeepServerStreamOpenAsync<CommunityVoiceChatUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_TO_COMMUNITY_VOICE_CHAT_UPDATES, ct);
 
-            async UniTask OpenStreamAndProcessUpdatesAsync()
+            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<CommunityVoiceChatUpdate> stream)
             {
-                IUniTaskAsyncEnumerable<CommunityVoiceChatUpdate> stream =
-                    socialServiceRPC.Module().CallServerStream<CommunityVoiceChatUpdate>(SUBSCRIBE_TO_COMMUNITY_VOICE_CHAT_UPDATES, new Empty());
-
                 ReportHub.Log(ReportCategory.COMMUNITY_VOICE_CHAT, "Attempting to open community voice chat updates stream");
 
                 try

--- a/Explorer/Assets/DCL/VoiceChat/Services/RPCPrivateVoiceChatService.cs
+++ b/Explorer/Assets/DCL/VoiceChat/Services/RPCPrivateVoiceChatService.cs
@@ -187,11 +187,11 @@ namespace DCL.VoiceChat.Services
 
         private async UniTaskVoid TrySubscribeToPrivateVoiceChatUpdatesAsync(CancellationToken ct)
         {
-            await KeepServerStreamOpenAsync<PrivateVoiceChatUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_TO_PRIVATE_VOICE_CHAT_UPDATES, ct);
+            await KeepServerStreamOpenAsync<PrivateVoiceChatUpdate>(ProcessUpdatesAsync, SUBSCRIBE_TO_PRIVATE_VOICE_CHAT_UPDATES, ct);
 
             return;
 
-            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<PrivateVoiceChatUpdate> stream)
+            async UniTask ProcessUpdatesAsync(IUniTaskAsyncEnumerable<PrivateVoiceChatUpdate> stream)
             {
                 ReportHub.Log(ReportCategory.VOICE_CHAT, $"{TAG} Successfully opened private voice chat updates stream");
 

--- a/Explorer/Assets/DCL/VoiceChat/Services/RPCPrivateVoiceChatService.cs
+++ b/Explorer/Assets/DCL/VoiceChat/Services/RPCPrivateVoiceChatService.cs
@@ -7,7 +7,6 @@ using System;
 using System.Threading;
 using Decentraland.SocialService.V2;
 using Google.Protobuf.WellKnownTypes;
-using Sentry;
 using Utility;
 
 namespace DCL.VoiceChat.Services
@@ -34,7 +33,7 @@ namespace DCL.VoiceChat.Services
         private readonly ISocialServiceEventBus socialServiceEventBus;
         private readonly IWeb3IdentityCache identityCache;
         private CancellationTokenSource subscriptionCts = new ();
-        private bool isServiceDisabled;
+        private readonly bool isServiceDisabled;
 
         public RPCPrivateVoiceChatService(
             IRPCSocialServices socialServiceRPC,
@@ -106,7 +105,7 @@ namespace DCL.VoiceChat.Services
                 },
             };
 
-            StartPrivateVoiceChatResponse? response = await socialServiceRPC.Module()!
+            StartPrivateVoiceChatResponse? response = await socialServiceRPC.Module()
                                                                             .CallUnaryProcedure<StartPrivateVoiceChatResponse>(START_PRIVATE_VOICE_CHAT, payload)
                                                                             .AttachExternalCancellation(ct)
                                                                             .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -125,7 +124,7 @@ namespace DCL.VoiceChat.Services
                 CallId = callId,
             };
 
-            AcceptPrivateVoiceChatResponse? response = await socialServiceRPC.Module()!
+            AcceptPrivateVoiceChatResponse? response = await socialServiceRPC.Module()
                                                                              .CallUnaryProcedure<AcceptPrivateVoiceChatResponse>(ACCEPT_PRIVATE_VOICE_CHAT, payload)
                                                                              .AttachExternalCancellation(ct)
                                                                              .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -144,7 +143,7 @@ namespace DCL.VoiceChat.Services
                 CallId = callId,
             };
 
-            RejectPrivateVoiceChatResponse? response = await socialServiceRPC.Module()!
+            RejectPrivateVoiceChatResponse? response = await socialServiceRPC.Module()
                                                                              .CallUnaryProcedure<RejectPrivateVoiceChatResponse>(REJECT_PRIVATE_VOICE_CHAT, payload)
                                                                              .AttachExternalCancellation(ct)
                                                                              .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -163,7 +162,7 @@ namespace DCL.VoiceChat.Services
                 CallId = callId,
             };
 
-            EndPrivateVoiceChatResponse? response = await socialServiceRPC.Module()!
+            EndPrivateVoiceChatResponse? response = await socialServiceRPC.Module()
                                                                           .CallUnaryProcedure<EndPrivateVoiceChatResponse>(END_PRIVATE_VOICE_CHAT, payload)
                                                                           .AttachExternalCancellation(ct)
                                                                           .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
@@ -177,7 +176,7 @@ namespace DCL.VoiceChat.Services
 
             await socialServiceRPC.EnsureRpcConnectionAsync(ct);
 
-            GetIncomingPrivateVoiceChatRequestResponse? response = await socialServiceRPC.Module()!
+            GetIncomingPrivateVoiceChatRequestResponse? response = await socialServiceRPC.Module()
                                                                                          .CallUnaryProcedure<GetIncomingPrivateVoiceChatRequestResponse>(GET_INCOMING_PRIVATE_VOICE_CHAT_REQUEST, new Empty())
                                                                                          .AttachExternalCancellation(ct)
                                                                                          .Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));

--- a/Explorer/Assets/DCL/VoiceChat/Services/RPCPrivateVoiceChatService.cs
+++ b/Explorer/Assets/DCL/VoiceChat/Services/RPCPrivateVoiceChatService.cs
@@ -35,7 +35,6 @@ namespace DCL.VoiceChat.Services
         private readonly IWeb3IdentityCache identityCache;
         private CancellationTokenSource subscriptionCts = new ();
         private bool isServiceDisabled;
-        private bool isListeningUpdatesFromServer;
 
         public RPCPrivateVoiceChatService(
             IRPCSocialServices socialServiceRPC,
@@ -188,22 +187,12 @@ namespace DCL.VoiceChat.Services
 
         private async UniTaskVoid TrySubscribeToPrivateVoiceChatUpdatesAsync(CancellationToken ct)
         {
-            if (isListeningUpdatesFromServer) return;
-
-            try
-            {
-                isListeningUpdatesFromServer = true;
-                await KeepServerStreamOpenAsync(OpenStreamAndProcessUpdatesAsync, ct);
-            }
-            finally { isListeningUpdatesFromServer = false; }
+            await KeepServerStreamOpenAsync<PrivateVoiceChatUpdate>(OpenStreamAndProcessUpdatesAsync, SUBSCRIBE_TO_PRIVATE_VOICE_CHAT_UPDATES, ct);
 
             return;
 
-            async UniTask OpenStreamAndProcessUpdatesAsync()
+            async UniTask OpenStreamAndProcessUpdatesAsync(IUniTaskAsyncEnumerable<PrivateVoiceChatUpdate> stream)
             {
-                IUniTaskAsyncEnumerable<PrivateVoiceChatUpdate> stream =
-                    socialServiceRPC.Module().CallServerStream<PrivateVoiceChatUpdate>(SUBSCRIBE_TO_PRIVATE_VOICE_CHAT_UPDATES, new Empty());
-
                 ReportHub.Log(ReportCategory.VOICE_CHAT, $"{TAG} Successfully opened private voice chat updates stream");
 
                 await foreach (PrivateVoiceChatUpdate? response in EnumerateWithCancellationAsync(stream, ct))


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Two fixes in the social service stream layer and its friends-panel consumer:

**1. Stream deduplication (reconnection spam).** `SubscribeToCommunityMemberConnectivityUpdates` could enter an infinite, delay-free reconnect loop that spammed the social service for the whole session. `RPCCommunitiesService` had an ungated subscribe entry point next to two event-gated ones; the server allows a single connectivity subscription per connection and instantly closes the duplicate, which the client treated as "reopen now". On top of that, rpc-csharp never tells the server a cancelled stream is closed, so "cancel and resubscribe" leaves a zombie subscription server-side that rejects any replacement.

`KeepServerStreamOpenAsync<T>` now owns the `CallServerStream` call and structurally enforces at most one active stream per update type; all subscribe entry points are idempotent and never restart a healthy loop. Subscription CTSs are cancelled only on transport close/dispose, and retry backoff resets after a successful stream session. Follow-up (upstream): patch rpc-csharp so cancellation sends `CloseStreamMessage`.

**2. Friends "Online" section empty after account switch (visual bug).** Logging out and into a different account in the same app session left online friends stuck in the Offline section, and re-logging never recovered:
- `FriendsConnectivityStatusTracker` kept the previous session's statuses, so the new account's initial connectivity snapshot looked like "no change" and never raised `OnFriendBecameOnline`.
- `FriendsContainer.OnRPCClientReconnected` awaited the never-completing stream subscriptions, so the friends cache prewarm and panel reset ran one logout too late.

The tracker now exposes `Reset()` (clears cached statuses and pending debounces), and the reconnect flow resets the tracker and panel synchronously before re-subscribing, then fire-and-forgets the subscriptions and the cache prewarm. Covered by new `FriendsConnectivityStatusTrackerShould` EditMode tests.

## Test Instructions

```bash
metaforge explorer run 9351
```

### Prerequisites
- [ ] Two accounts (A and B) that are friends with each other and members of the same community
- [ ] Optional log check: `metaforge explorer logs tail --filter "updates stream"` — each stream should open once per (re)connection, no rapid re-open spam

### Test Steps
1. **Communities member connectivity**: with A viewing the community members list, log B in and out -> A sees B's online/offline status change in real time.
2. **Friends**: B goes online/offline -> A's friends panel updates live; friend requests and block/unblock arrive without reopening the panel.
3. **Voice chat**: community voice chat (start/join/request-to-speak/mute) and private calls (call/accept/end) update live on both sides.
4. **Account switch (visual bug fix)**: log in as A with B online -> B appears in the Online section; log out and switch to another account that is also friends with B -> B must appear in the Online section again (previously it stayed in Offline forever). Repeat the switch a couple of times.
5. **Reconnects**: sign out/in on A, then briefly drop and restore A's network; repeat steps 1-3 after each -> updates still arrive, no stream spam in logs.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
