### PR TITLE
fix: align hiccup metrics window and threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ Explorer/.cursorignore
 
 # API Keys
 .env
+
+# ReSharper CLI download for local linting (scripts/lint/download-resharper.sh)
+/rsharp/
+rsharp.zip

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/PerformanceAnalyticsSystem.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/PerformanceAnalyticsSystem.cs
@@ -105,12 +105,19 @@ namespace DCL.Analytics.Systems
             jsonObjectBuilder.Set("total_gc_alloc", ((ulong)profiler.TotalGcAlloc).ByteToMB());
 
             // MainThread
-            (bool hasValue, long count, long sumTime, long min, long max, float avg) hiccups = profiler.CalculateMainThreadHiccups();
-            jsonObjectBuilder.Set("hiccups_in_thousand_frames", !hiccups.hasValue ? 0 : hiccups.count);
-            jsonObjectBuilder.Set("hiccups_time", !hiccups.hasValue ? 0 : hiccups.sumTime * NS_TO_MS);
-            jsonObjectBuilder.Set("hiccups_min", !hiccups.hasValue ? 0 : hiccups.min * NS_TO_MS);
-            jsonObjectBuilder.Set("hiccups_max", !hiccups.hasValue ? 0 : hiccups.max * NS_TO_MS);
-            jsonObjectBuilder.Set("hiccups_avg", !hiccups.hasValue ? 0 : hiccups.avg * NS_TO_MS);
+            HiccupStats hiccups = profiler.CalculateMainThreadHiccups();
+            jsonObjectBuilder.Set("hiccups_in_thousand_frames", !hiccups.HasValue ? 0 : hiccups.Count);
+            jsonObjectBuilder.Set("hiccups_time", !hiccups.HasValue ? 0 : hiccups.SumTimeNs * NS_TO_MS);
+            jsonObjectBuilder.Set("hiccups_excess_time", !hiccups.HasValue ? 0 : hiccups.ExcessTimeNs * NS_TO_MS);
+            jsonObjectBuilder.Set("hiccups_min", !hiccups.HasValue ? 0 : hiccups.MinNs * NS_TO_MS);
+            jsonObjectBuilder.Set("hiccups_max", !hiccups.HasValue ? 0 : hiccups.MaxNs * NS_TO_MS);
+            jsonObjectBuilder.Set("hiccups_avg", !hiccups.HasValue ? 0 : hiccups.AvgNs * NS_TO_MS);
+
+            // Frames the hiccup stats were measured over; below FRAME_BUFFER_SIZE during warm-up or at low framerate.
+            jsonObjectBuilder.Set("hiccups_samples_amount", !hiccups.HasValue ? 0 : hiccups.SampleCount);
+
+            // Threshold applied this report (scales with target frame rate). GPU hiccups use the same value.
+            jsonObjectBuilder.Set("hiccups_threshold", hiccups.ThresholdNs * NS_TO_MS);
 
             jsonObjectBuilder.Set("min_frame_time", profiler.MainThreadFrameTimes.Min * NS_TO_MS);
             jsonObjectBuilder.Set("max_frame_time", profiler.MainThreadFrameTimes.Max * NS_TO_MS);
@@ -129,11 +136,13 @@ namespace DCL.Analytics.Systems
 
             // GPU
             hiccups = profiler.CalculateGpuHiccups();
-            jsonObjectBuilder.Set("gpu_hiccups_in_thousand_frames", hiccups.count);
-            jsonObjectBuilder.Set("gpu_hiccups_time", hiccups.count == 0 ? 0 : hiccups.sumTime * NS_TO_MS);
-            jsonObjectBuilder.Set("gpu_hiccups_min", hiccups.count == 0 ? 0 : hiccups.min * NS_TO_MS);
-            jsonObjectBuilder.Set("gpu_hiccups_max", hiccups.count == 0 ? 0 : hiccups.max * NS_TO_MS);
-            jsonObjectBuilder.Set("gpu_hiccups_avg", hiccups.count == 0 ? 0 : hiccups.avg * NS_TO_MS);
+            jsonObjectBuilder.Set("gpu_hiccups_in_thousand_frames", hiccups.Count);
+            jsonObjectBuilder.Set("gpu_hiccups_time", hiccups.Count == 0 ? 0 : hiccups.SumTimeNs * NS_TO_MS);
+            jsonObjectBuilder.Set("gpu_hiccups_excess_time", hiccups.Count == 0 ? 0 : hiccups.ExcessTimeNs * NS_TO_MS);
+            jsonObjectBuilder.Set("gpu_hiccups_min", hiccups.Count == 0 ? 0 : hiccups.MinNs * NS_TO_MS);
+            jsonObjectBuilder.Set("gpu_hiccups_max", hiccups.Count == 0 ? 0 : hiccups.MaxNs * NS_TO_MS);
+            jsonObjectBuilder.Set("gpu_hiccups_avg", hiccups.Count == 0 ? 0 : hiccups.AvgNs * NS_TO_MS);
+            jsonObjectBuilder.Set("gpu_hiccups_samples_amount", !hiccups.HasValue ? 0 : hiccups.SampleCount);
 
             jsonObjectBuilder.Set("gpu_min_frame_time", profiler.GpuFrameTimes.Min * NS_TO_MS);
             jsonObjectBuilder.Set("gpu_max_frame_time", profiler.GpuFrameTimes.Max * NS_TO_MS);

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/IProfiler.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/IProfiler.cs
@@ -8,9 +8,9 @@
 
         FrameTimeStats? CalculateMainThreadFrameTimesNs();
 
-        (bool hasValue, long count, long sumTime, long min, long max, float avg) CalculateMainThreadHiccups();
+        HiccupStats CalculateMainThreadHiccups();
 
-        (bool hasValue, long count, long sumTime, long min, long max, float avg) CalculateGpuHiccups();
+        HiccupStats CalculateGpuHiccups();
 
         public ulong AllScenesTotalHeapSize { get; set; }
 
@@ -41,5 +41,46 @@
         void UpdateFrameTimings();
 
         void ClearFrameTimings();
+    }
+
+    /// <summary>
+    ///     Hiccup statistics over the current measurement window. All time fields are in nanoseconds.
+    /// </summary>
+    public readonly struct HiccupStats
+    {
+        /// <summary>False only when the window has no samples yet (before the first recorded frame).</summary>
+        public readonly bool HasValue;
+
+        /// <summary>Number of frames above <see cref="ThresholdNs" />.</summary>
+        public readonly long Count;
+
+        /// <summary>Sum of the full duration of every hiccup frame.</summary>
+        public readonly long SumTimeNs;
+
+        /// <summary>Sum of each hiccup frame's excess over <see cref="ThresholdNs" /> ("time lost" beyond the bar).</summary>
+        public readonly long ExcessTimeNs;
+
+        public readonly long MinNs;
+        public readonly long MaxNs;
+        public readonly float AvgNs;
+
+        /// <summary>Frames the stats were measured over (can be below the buffer size during warm-up or low framerate).</summary>
+        public readonly long SampleCount;
+
+        /// <summary>The hiccup threshold actually applied, derived from the target frame rate.</summary>
+        public readonly long ThresholdNs;
+
+        public HiccupStats(bool hasValue, long count, long sumTimeNs, long excessTimeNs, long minNs, long maxNs, float avgNs, long sampleCount, long thresholdNs)
+        {
+            HasValue = hasValue;
+            Count = count;
+            SumTimeNs = sumTimeNs;
+            ExcessTimeNs = excessTimeNs;
+            MinNs = minNs;
+            MaxNs = maxNs;
+            AvgNs = avgNs;
+            SampleCount = sampleCount;
+            ThresholdNs = thresholdNs;
+        }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/Profiler.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/Profiler.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Unity.Profiling;
+using UnityEngine;
 using static Unity.Mathematics.math;
 
 namespace DCL.Profiling
@@ -10,7 +11,9 @@ namespace DCL.Profiling
     /// </summary>
     public class Profiler : IProfiler
     {
-        private const int HICCUP_THRESHOLD_IN_NS = 50_000_000; // 50 ms ~ 20 FPS
+        private const int HICCUP_THRESHOLD_IN_NS = 50_000_000; // 50 ms ~ 20 FPS; also the lower floor for the target-relative threshold
+        private const long NS_PER_SECOND = 1_000_000_000;
+        private const float HICCUP_TARGET_FRAME_TIME_MULTIPLIER = 2f; // a frame counts as a hiccup above 2x the target frame time
         private const int FRAME_BUFFER_SIZE = 1_024; // 1000 samples: for 34 FPS it's 33 seconds gameplay, for 60 FPS it's 17 seconds
         private const int PHYS_SIM_BUFFER_SIZE = 10;
 
@@ -83,6 +86,9 @@ namespace DCL.Profiling
                 mainThreadTimeRecorder.Stop();
                 gpuFrameTimeRecorder.Stop();
             }
+
+            // Discard buffered samples so pre-transition hiccups aren't attributed to the next realm/scene on resume.
+            ResetHiccupRecorders();
         }
 
         public void StartFrameTimeDataCollection()
@@ -115,6 +121,9 @@ namespace DCL.Profiling
         {
             MainThreadFrameTimes.Clear();
             GpuFrameTimes.Clear();
+
+            // Reset the hiccup buffers too, so each report counts only its own interval's frames.
+            ResetHiccupRecorders();
         }
 
         /// <summary>
@@ -122,24 +131,23 @@ namespace DCL.Profiling
         /// </summary>
         public FrameTimeStats? CalculateMainThreadFrameTimesNs()
         {
-            int availableSamples = mainThreadTimeRecorder.Capacity;
+            samples.Clear();
+            mainThreadTimeRecorder.CopyTo(samples);
 
-            if (availableSamples == 0)
+            if (samples.Count == 0)
                 return null;
 
             long minFrameTime = long.MaxValue;
             long maxFrameTime = long.MinValue;
 
             long hiccupCount = 0;
-
-            samples.Clear();
-            mainThreadTimeRecorder.CopyTo(samples);
+            long thresholdNs = EffectiveHiccupThresholdNs();
 
             for (var i = 0; i < samples.Count; i++)
             {
                 long frameTime = samples[i].Value;
 
-                if (frameTime > HICCUP_THRESHOLD_IN_NS) hiccupCount++;
+                if (frameTime > thresholdNs) hiccupCount++;
                 if (frameTime < minFrameTime) minFrameTime = frameTime;
                 if (frameTime > maxFrameTime) maxFrameTime = frameTime;
             }
@@ -147,35 +155,39 @@ namespace DCL.Profiling
             return new FrameTimeStats(minFrameTime, maxFrameTime, hiccupCount);
         }
 
-        public (bool hasValue, long count, long sumTime, long min, long max, float avg) CalculateMainThreadHiccups() =>
+        public HiccupStats CalculateMainThreadHiccups() =>
             CalculateThreadHiccups(mainThreadTimeRecorder);
 
-        public (bool hasValue, long count, long sumTime, long min, long max, float avg) CalculateGpuHiccups() =>
+        public HiccupStats CalculateGpuHiccups() =>
             CalculateThreadHiccups(gpuFrameTimeRecorder);
 
-        private (bool hasValue, long count, long sumTime, long min, long max, float avg) CalculateThreadHiccups(ProfilerRecorder recorder)
+        private HiccupStats CalculateThreadHiccups(ProfilerRecorder recorder)
         {
-            int availableSamples = recorder.Capacity;
-
-            if (availableSamples == 0)
-                return (false, 0, 0, 0, 0, 0);
-
-            long hiccupCount = 0;
-            long hiccupTotalTime = 0;
-            long hiccupMin = -1;
-            long hiccupMax = -1;
-
             samples.Clear();
             recorder.CopyTo(samples);
 
-            for (var i = 0; i < samples.Count; i++)
+            // Actual frames in the window; below FRAME_BUFFER_SIZE during warm-up or right after a reset.
+            int sampleCount = samples.Count;
+            long thresholdNs = EffectiveHiccupThresholdNs();
+
+            if (sampleCount == 0)
+                return new HiccupStats(false, 0, 0, 0, 0, 0, 0, 0, thresholdNs);
+
+            long hiccupCount = 0;
+            long hiccupTotalTime = 0;
+            long hiccupExcessTime = 0;
+            long hiccupMin = -1;
+            long hiccupMax = -1;
+
+            for (var i = 0; i < sampleCount; i++)
             {
                 long frameTime = samples[i].Value;
 
-                if (frameTime > HICCUP_THRESHOLD_IN_NS)
+                if (frameTime > thresholdNs)
                 {
                     hiccupCount++;
                     hiccupTotalTime += frameTime;
+                    hiccupExcessTime += frameTime - thresholdNs;
 
                     if (frameTime > hiccupMax) hiccupMax = frameTime;
 
@@ -184,25 +196,57 @@ namespace DCL.Profiling
                 }
             }
 
-            return (true, hiccupCount, hiccupTotalTime, hiccupMin, hiccupMax, hiccupCount == 0 ? 0 : hiccupTotalTime / (float)hiccupCount);
+            float avg = hiccupCount == 0 ? 0 : hiccupTotalTime / (float)hiccupCount;
+            return new HiccupStats(true, hiccupCount, hiccupTotalTime, hiccupExcessTime, hiccupMin, hiccupMax, avg, sampleCount, thresholdNs);
+        }
+
+        // Hiccup bar = 2x the target frame time, floored at 50 ms. Uncapped/vsync configs (>= 60 FPS)
+        // stay at the floor; capped configs (e.g. 30 FPS -> 67 ms) get a higher bar so their normal
+        // cadence isn't counted as hiccups.
+        private static long EffectiveHiccupThresholdNs()
+        {
+            int targetFps = Application.targetFrameRate;
+
+            // 0 (vsync) or -1 (uncapped): no cap set, so use the floor.
+            if (targetFps <= 0)
+                return HICCUP_THRESHOLD_IN_NS;
+
+            var relativeThresholdNs = (long)(HICCUP_TARGET_FRAME_TIME_MULTIPLIER * NS_PER_SECOND / targetFps);
+            return max(HICCUP_THRESHOLD_IN_NS, relativeThresholdNs);
         }
 
         private float GetRecorderSamplesSum(ProfilerRecorder recorder)
         {
-            int samplesCount = recorder.Capacity;
+            samples.Clear();
+            recorder.CopyTo(samples);
 
-            if (samplesCount == 0)
+            if (samples.Count == 0)
                 return 0;
 
             float r = 0;
-
-            samples.Clear();
-            recorder.CopyTo(samples);
 
             for (var i = 0; i < samples.Count; i++)
                 r += samples[i].Value;
 
             return r;
+        }
+
+        // ProfilerRecorder has no flush, so a fresh window means recreating the recorders (keeping run state).
+        private void ResetHiccupRecorders()
+        {
+            bool wasRunning = mainThreadTimeRecorder.IsRunning;
+
+            mainThreadTimeRecorder.Dispose();
+            gpuFrameTimeRecorder.Dispose();
+
+            mainThreadTimeRecorder = new ProfilerRecorder(ProfilerCategory.Internal, "Main Thread", FRAME_BUFFER_SIZE); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
+            gpuFrameTimeRecorder = new ProfilerRecorder(ProfilerCategory.Render, "GPU Frame Time", FRAME_BUFFER_SIZE);
+
+            if (wasRunning)
+            {
+                mainThreadTimeRecorder.Start();
+                gpuFrameTimeRecorder.Start();
+            }
         }
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Welcome to the official documentation for Unity Explorer — the Decentraland cl
 - **[LiveKit Networking](livekit-networking.md)** — LiveKit transport: dual-room architecture, messaging pipes, Archipelago/GateKeeper, voice and chat rooms
 - **[Pulse](pulse.md)** — Pulse transport: ENet peer transport, peer identity, protocol, feature-flag gating
 - **[Diagnostics](diagnostics.md)** — ReportHub logging system and Sentry integration
+- **[Performance Analytics](performance-analytics.md)** — `performance_report` telemetry: hiccup/frame-time metrics, measurement window, and target-relative threshold
 
 ## Avatar System
 - **[Avatar Rendering](avatar-rendering.md)** — GPU skinning, compute shaders, and cel-shading

--- a/docs/performance-analytics.md
+++ b/docs/performance-analytics.md
@@ -1,0 +1,77 @@
+# Performance Analytics (`performance_report`)
+
+The client periodically emits a `performance_report` analytics event (via Segment) describing CPU/GPU frame timing, hiccups, and memory. It is produced by [`PerformanceAnalyticsSystem`](../Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/Systems/PerformanceAnalyticsSystem.cs) from data collected by [`Profiler`](../Explorer/Assets/DCL/PerformanceAndDiagnostics/Profiling/Profiler.cs).
+
+> This is runtime telemetry sent from real sessions. It is **not** the local [Performance Benchmark](performance-benchmark.md) PDF tool, and it is separate from [Diagnostics](diagnostics.md) (ReportHub/Sentry logging).
+
+## Reporting pipeline
+
+- `PerformanceAnalyticsSystem` runs in the `InitializationSystemGroup` (after `DebugViewProfilingSystem`).
+- The event fires every `PerformanceReportInterval` seconds of **played** time. The shipped `AnalyticsConfiguration.asset` uses **15 s**; the code default and the Playground asset use 1 s.
+- Collection is **paused** whenever the realm is not configured, the loading stage is not `Completed`, or the app is unfocused. Loading screens and backgrounded time are intentionally excluded.
+
+## Data source
+
+Both frame-time families read from Unity `ProfilerRecorder` ring buffers (near-zero overhead, consistent with the Unity Profiler):
+
+- **Main thread** (`ProfilerCategory.Internal`, "Main Thread"): CPU main-thread time. This is *not* full presented-frame time and *not* GPU time. Feeds the `hiccups_*` and `*_frame_time` fields.
+- **GPU** (`ProfilerCategory.Render`, "GPU Frame Time"): feeds the `gpu_*` fields.
+
+The buffer holds up to 1024 frames (`FRAME_BUFFER_SIZE`).
+
+## What a hiccup is
+
+A hiccup is any single frame whose sampled thread time exceeds the **effective threshold**:
+
+```
+threshold = max(50 ms, HICCUP_TARGET_FRAME_TIME_MULTIPLIER x targetFrameTime)
+```
+
+with `HICCUP_TARGET_FRAME_TIME_MULTIPLIER = 2` and the target frame time derived from `Application.targetFrameRate`.
+
+- `targetFrameRate <= 0` (vsync or uncapped, which run at >= 60 FPS in practice) → the target-relative bar is below the floor, so the threshold stays at the **50 ms floor**.
+- Explicitly capped configs raise the bar so their normal cadence is not counted as hiccups.
+
+| Target | 2x target | Applied threshold (50 ms floor) |
+|---|---|---|
+| 120 / 90 / 60 fps | <= 33 ms | **50 ms** |
+| 40 fps | 50 ms | **50 ms** |
+| 30 fps | 67 ms | **67 ms** |
+
+The threshold applied to each report is emitted as `hiccups_threshold`, so counts can be interpreted and compared across cohorts. The same threshold is used for CPU and GPU hiccups.
+
+## Measurement window
+
+Each report describes exactly its own `PerformanceReportInterval`. After every report (and whenever collection stops on a teleport/unfocus), both the custom frame-time buffers and the hiccup `ProfilerRecorder`s are reset. `ProfilerRecorder` has no public flush, so the recorders are disposed and recreated (see `Profiler.ResetHiccupRecorders`). Consequences:
+
+- No frame is counted in more than one report.
+- Stale pre-transition frames are not attributed to the next realm/scene.
+- The on-screen debug HUD reads the same recorders, so its hiccup counter reflects the current (post-reset) window rather than a trailing 1024 frames.
+
+Because the window can be shorter than 1024 frames (warm-up, or low framerate), `hiccups_samples_amount` reports the actual frame count so consumers can normalize (e.g. per-1000-frames or per-second) themselves.
+
+## Emitted fields
+
+Main-thread hiccups (all times in ms):
+
+| Field | Meaning |
+|---|---|
+| `hiccups_in_thousand_frames` | Count of hiccup frames in the window (not normalized to 1000; see `hiccups_samples_amount`). |
+| `hiccups_time` | Sum of the **full** duration of each hiccup frame. |
+| `hiccups_excess_time` | Sum of each hiccup frame's **excess over the threshold** ("time lost" beyond the bar). |
+| `hiccups_min` / `hiccups_max` / `hiccups_avg` | Duration stats of hiccup frames. |
+| `hiccups_samples_amount` | Frames the window was measured over. |
+| `hiccups_threshold` | The threshold actually applied this report. |
+
+Frame-time family: `min_frame_time`, `max_frame_time`, `mean_frame_time`, `frame_time_percentile_{5,10,20,50,75,80,90,95}`, `samples`, `samples_amount`.
+
+GPU family: the same fields with a `gpu_` prefix (including `gpu_hiccups_excess_time` and `gpu_hiccups_samples_amount`). GPU hiccups use the same threshold as the main thread, so there is no separate `gpu_hiccups_threshold`.
+
+Plus quality/memory context: `quality_level`, `player_count`, `total_time`, JS heap (`jsheap_*`, `running_v8_engines`), and process memory (`total_used_memory`, `system_used_memory`, `gc_used_memory`, `total_gc_alloc`).
+
+## Interpretation notes
+
+- `hiccups_in_thousand_frames` is a **count**, not a rate. Normalize with `hiccups_samples_amount` before comparing windows or cohorts.
+- `hiccups_time` includes the whole hiccup frame; use `hiccups_excess_time` for "time lost to hiccups".
+- Because the threshold scales with the target frame rate, hiccup counts on intentionally capped configs are lower than a fixed 50 ms bar would produce. This is deliberate: it measures stalls relative to each config's expected cadence. Use `hiccups_threshold` when comparing across cohorts.
+- `hiccups_max` remains a good "did the client freeze" signal.


### PR DESCRIPTION
## What does this PR change?

The `performance_report` hiccup metrics recomputed over a rolling 1024-frame `ProfilerRecorder` buffer that was never reset, so hiccups were double-counted across reports and survived teleports/unfocus. The 50ms bar also ignored the target frame rate, and the `Capacity`-based guard left dead code.

- **Reset the hiccup recorders after each report and on collection stop**, so each report covers only its own interval. `ProfilerRecorder` has no flush, so the recorders are disposed and recreated (run state preserved). No frame is counted in more than one report, and stale pre-transition frames are not attributed to the next realm/scene.
- **Make the threshold target-relative**: `max(50ms, 2x target frame time)`. Uncapped/vsync configs stay at the 50ms floor; explicitly capped configs (e.g. 30 FPS -> 67ms) get a higher bar so their normal cadence is not counted as hiccups.
- **Add `hiccups_excess_time`, `hiccups_samples_amount` and `hiccups_threshold` fields** (plus `gpu_` twins) so counts can be normalized and compared across cohorts.
- **Fix the `Capacity` vs valid-sample-count guard** (it read buffer capacity instead of the actual sample count) and replace the return tuple with a `HiccupStats` struct.
- **Document the `performance_report` event** in `docs/performance-analytics.md`.

Also adds the local-lint ReSharper CLI download paths (`/rsharp/`, `rsharp.zip`) to `.gitignore`.

## Test Instructions

**Expected result**: An overall smoke check of the app. Launch the client, sign in, and move around a few scenes. Everything should behave as before with no regressions in frame timing, teleporting, or focus/unfocus behavior. The change is confined to how the `performance_report` telemetry event is computed and emitted, so there should be no visible change to gameplay.

## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does, especially useful for first-time contributors.
