### PR TITLE
fix: honor command-line args in the editor for the optimized-assets sidecar

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -198,7 +198,11 @@ namespace Global.Dynamic
 
             IAppArgs applicationParametersParser = new ApplicationParametersParser(
 #if UNITY_EDITOR
-                debugSettings.AppParameters
+                // Debug Settings are the base; real command-line args (e.g. --optimized-assets-url
+                // for a local preview sidecar) are appended so they override, matching a build. The
+                // bare "--" resets the parser's pending key so the Unity executable path that leads
+                // GetCommandLineArgs() is not consumed as a trailing Debug Setting's value.
+                debugSettings.AppParameters.Append("--").Concat(Environment.GetCommandLineArgs()).ToArray()
 #else
                 Environment.GetCommandLineArgs()
 #endif


### PR DESCRIPTION
## What

Follow-up to #9361. That PR wired the `--optimized-assets-url` launch argument into `MainSceneLoader`, but in the **editor** the argument parser is fed only `debugSettings.AppParameters`:

```csharp
new ApplicationParametersParser(
#if UNITY_EDITOR
    debugSettings.AppParameters
#else
    Environment.GetCommandLineArgs()
#endif
);
```

So a developer who launches the editor with `--optimized-assets-url http://localhost:PORT` (the documented local-preview sidecar path, use case 4) sees it **silently ignored in play mode** — asset delivery falls back to the default `ab-cdn` / gateway path. The editor is exactly where that override is most used, and it only worked in a standalone build.

## Fix

In the editor, append the real command-line args on top of the Debug Settings, letting the command line win:

```csharp
debugSettings.AppParameters.Append("--").Concat(Environment.GetCommandLineArgs()).ToArray()
```

- Debug Settings remain the base, so existing editor workflows are unchanged when no launch arg is passed.
- Command-line args override (last-write-wins in the parser), which is the right precedence for a per-run override.
- The bare `--` resets the parser's pending key, so the Unity executable path that leads `GetCommandLineArgs()` can't be swallowed as a trailing Debug Setting's value.

Behavior is unchanged in standalone builds and in the editor with no launch args.

## Verification

Driven end-to-end against a live abgen origin: with the fix, an editor play session launched with `--optimized-assets-url http://<origin>` routes scene manifests, bundles, LODs and registry discovery to that origin (confirmed both in the Editor log URLs and the origin's request counters); without it, the same launch resolves to `gateway.decentraland.org/ab-cdn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
