### PR TITLE
fix: asset-bundle-budget-null-safe

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs
@@ -96,7 +96,9 @@ namespace ECS.StreamableLoading.AssetBundles
             }
 
             // Release budget now to not hold it until dependencies are resolved to prevent a deadlock
-            state.AcquiredBudget!.Release();
+            // Null-safe: the pooled state can be recycled (budget disposed and nulled) if the promise is
+            // forgotten/cancelled while this detached flow is mid-await
+            state.AcquiredBudget?.Release();
 
             // if GetContent prints an error, null will be thrown
             if (assetBundle == null)

--- a/Explorer/Assets/DCL/WebRequests/ArtificialDelayWebRequestController.cs
+++ b/Explorer/Assets/DCL/WebRequests/ArtificialDelayWebRequestController.cs
@@ -29,7 +29,7 @@ namespace DCL.WebRequests
             (float delaySeconds, bool useDelay) = await options.GetOptionsAsync(envelope.Ct);
 
             if (useDelay)
-                await UniTask.Delay(TimeSpan.FromSeconds(delaySeconds));
+                await UniTask.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken: envelope.Ct);
 
             return await origin.SendAsync<TWebRequest, TWebRequestArgs, TWebRequestOp, TResult>(envelope, op, expectedContentLength, progressReporter);
         }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Two small robustness fixes in the streamable loading / web request path:

- **Null-safe budget release in `LoadAssetBundleSystem`.** The pooled `StreamableLoadingState` can be recycled (its budget disposed and nulled by the pool `actionOnRelease`) if the promise is forgotten or cancelled while the detached load flow is mid-await. Releasing the budget with `!.` would throw a `NullReferenceException` in that window. Switched to `?.` to match how the budget is treated everywhere else in the flow (`FlowAsync`'s ongoing-request path, `FinalizeLoading`, `IsWorldInvalid` all already null-check it).

- **Honor cancellation token in `ArtificialDelayWebRequestController`.** `UniTask.Delay` now receives `envelope.Ct`, so the artificial delay is cancelled together with the request instead of running to completion after the request is already gone.

## Test Instructions

Smoke test, nothing in particular. Run the app and confirm scenes/asset bundles load normally with no regressions or new errors in the console.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
