### PR TITLE
fix(P4K): don't report scene websocket connect failures to Sentry

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/WebSocket/WebSocketApiWrapper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/WebSocket/WebSocketApiWrapper.cs
@@ -49,7 +49,11 @@ namespace SceneRuntime.Apis.Modules
                 if (!isLocalSceneDevelopment && !url.ToLower().StartsWith("wss://"))
                     throw new Exception("Can't start an unsafe ws connection, please upgrade to wss. url=" + url);
 
-                return api.ConnectAsync(websocketId, url, disposeCts.Token).ReportAndRethrowException(exceptionsHandler).ToDisconnectedPromise(this);
+                // A failed connection to a scene-supplied endpoint is a scene-content problem, not an
+                // explorer defect, so it must NOT be reported to Sentry as an error (it spammed
+                // UNITY-EXPLORER-P4K with thousands of events). ToDisconnectedPromise still rejects the
+                // scene's JS connect() promise, matching how SimpleFetchApiWrapper.Fetch surfaces failures.
+                return api.ConnectAsync(websocketId, url, disposeCts.Token).ToDisconnectedPromise(this);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
UNITY-EXPLORER-P4K (3010 evts/7 users): Utility.Networking.WebSocketException from scene JS connect(). WebSocketApiWrapper.ConnectAsync wrapped the call in .ReportAndRethrowException(exceptionsHandler), so every failed connection to a scene-supplied (dead/invalid) endpoint became a Sentry error — a scene retry loop produced thousands. The sibling SimpleFetchApiWrapper.Fetch deliberately does not report. Drop the report from connect only; ToDisconnectedPromise still rejects the scene's JS promise so its catch handler runs. Send/Receive/Close keep reporting. Report-noise reduction, not a functional bug. Unverified (no build).
