### PR TITLE
fix(friends): OperationCanceledException-safe friends prewarm on reconnect

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/Global/FriendsContainer.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/FriendsContainer.cs
@@ -238,11 +238,15 @@ namespace DCL.PluginSystem.Global
 
             async UniTaskVoid PrewarmAsync(CancellationToken ct)
             {
-                await friendsPanelController.InitAsync(ct);
-                await PreWarmFriendsCacheAsync(ct);
+                try
+                {
+                    await friendsPanelController.InitAsync(ct);
+                    await PreWarmFriendsCacheAsync(ct);
 
-                // TODO should not unsubscribe as the user can re-login with another account, and thus, pre-warming will be skipped
-                loadingStatus.CurrentStage.Unsubscribe(PreWarmFriends);
+                    // TODO should not unsubscribe as the user can re-login with another account, and thus, pre-warming will be skipped
+                    loadingStatus.CurrentStage.Unsubscribe(PreWarmFriends);
+                }
+                catch (OperationCanceledException) { }
             }
         }
 


### PR DESCRIPTION

Production evidence (decentraland Sentry, archive snapshot 2026-07-17):
- UNITY-EXPLORER-PFR: 1 events / 1 users, last seen 2026-07-10
- UNITY-EXPLORER-PF9: 1 events / 1 users, last seen 2026-07-06
- UNITY-EXPLORER-PE6: 1 events / 1 users, last seen 2026-07-01
- UNITY-TEST-ENVIRONMENT-1CK: 1 events / 1 users, last seen 2026-07-08
- UNITY-TEST-ENVIRONMENT-1F2: 1 events / 1 users, last seen 2026-06-30
- UNITY-TEST-ENVIRONMENT-1EE: 1 events / 1 users, last seen 2026-06-19
