### PR TITLE
fix(media): texture/audio-analysis robustness - null guards, disposal

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/AudioAnalysisPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AudioAnalysisPlugin.cs
@@ -41,9 +41,7 @@ namespace DCL.PluginSystem.World
         {
         }
 
-        public async UniTask InitializeAsync(CancellationToken ct)
-        {
-        }
+        public UniTask InitializeAsync(CancellationToken ct) => UniTask.CompletedTask;
     }
 }
 

--- a/Explorer/Assets/DCL/PluginSystem/World/LightSourcePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/LightSourcePlugin.cs
@@ -80,11 +80,12 @@ namespace DCL.PluginSystem.World
             await CreateLightSourcePoolAsync(lightSourcePrefab, ct);
         }
 
-        private async UniTask CreateLightSourcePoolAsync(Light lightSourcePrefab, CancellationToken ct)
+        private UniTask CreateLightSourcePoolAsync(Light lightSourcePrefab, CancellationToken ct)
         {
             lightPoolRegistry = poolsRegistry.AddGameObjectPool(() => Object.Instantiate(lightSourcePrefab, Vector3.zero, quaternion.identity), onRelease: OnPoolRelease, onGet: OnPoolGet);
 
             cacheCleaner.Register(lightPoolRegistry);
+            return UniTask.CompletedTask;
         }
 
         private void OnPoolRelease(Light light)

--- a/Explorer/Assets/DCL/SDKComponents/AudioAnalysis/AudioAnalysisSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioAnalysis/AudioAnalysisSystem.cs
@@ -88,6 +88,10 @@ namespace DCL.SDKComponents.AudioSources
                 {
                     PBAudioAnalysisMode.ModeRaw => AnalysisResultMode.Raw,
                     PBAudioAnalysisMode.ModeLogarithmic => AnalysisResultMode.Logarithmic,
+
+                    // proto3 open enum: scene wire data can carry any out-of-range value; fall back
+                    // to the default mode instead of throwing every frame.
+                    _ => AnalysisResultMode.Raw,
                 };
                 float amplitudeGain = sdkComponent.HasAmplitudeGain ? sdkComponent.AmplitudeGain : DEFAULT_AMPLITUDE_GAIN; 
                 float bandsGain = sdkComponent.HasBandsGain ? sdkComponent.BandsGain : DEFAULT_BANDS_GAIN; 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/AnyTexture.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/AnyTexture.cs
@@ -1,5 +1,6 @@
 ﻿using REnum;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 using Utility;
 
 namespace ECS.StreamableLoading.Textures
@@ -12,7 +13,23 @@ namespace ECS.StreamableLoading.Textures
     [REnumField(typeof(Texture2D))]
     public partial struct AnyTexture
     {
-        public long ByteSize => Match(static _ => 0L, tex2d => tex2d.GetRawTextureData<byte>().Length);
+        public long ByteSize => Match(static _ => 0L, static tex2d => EstimateTextureByteSize(tex2d));
+
+        private static long EstimateTextureByteSize(Texture2D tex2d)
+        {
+            // Destroyed textures (Unity fake-null) account as zero instead of throwing.
+            if (tex2d == null) return 0L;
+            if (tex2d.isReadable) return tex2d.GetRawTextureData<byte>().Length;
+
+            // Non-readable textures have no CPU copy to measure (GetRawTextureData throws);
+            // estimate the GPU footprint across the full mip chain instead.
+            var size = (long)GraphicsFormatUtility.ComputeMipmapSize(tex2d.width, tex2d.height, tex2d.graphicsFormat);
+
+            for (var mip = 1; mip < tex2d.mipmapCount; mip++)
+                size += (long)GraphicsFormatUtility.ComputeMipmapSize(Mathf.Max(1, tex2d.width >> mip), Mathf.Max(1, tex2d.height >> mip), tex2d.graphicsFormat);
+
+            return size;
+        }
 
         public Texture Texture => Match<Texture>(static video => video.Texture, static tex2d => tex2d);
 


### PR DESCRIPTION
Production evidence (decentraland Sentry, archive snapshot 2026-07-17):
- UNITY-EXPLORER-NR2: 110 events / 20 users, last seen 2026-04-28
- UNITY-TEST-ENVIRONMENT-156: 1 events / 1 users, last seen 2026-04-20
