### PR TITLE
fix(ui): loading/panel/menu robustness - teardown guards

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterCamera/Systems/ControlCinemachineVirtualCameraSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Systems/ControlCinemachineVirtualCameraSystem.cs
@@ -117,6 +117,7 @@ namespace DCL.Character.CharacterCamera.Systems
                                            {
                                                ThirdPersonCameraShoulder.Right => ThirdPersonCameraShoulder.Left,
                                                ThirdPersonCameraShoulder.Left => ThirdPersonCameraShoulder.Right,
+                                               ThirdPersonCameraShoulder.Center => ThirdPersonCameraShoulder.Right,
                                            };
 
             ThirdPersonCameraShoulder thirdPersonCameraShoulder = cameraComponent.Shoulder;

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewAvatarContainer.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewAvatarContainer.cs
@@ -25,13 +25,13 @@ namespace DCL.CharacterPreview
         private bool isFOVTransitioning;
 
         [field: SerializeField] internal Vector3 previewPositionInScene { get; private set; }
-        [field: SerializeField] internal Transform avatarParent { get; private set; }
-        [field: SerializeField] internal Camera camera { get; private set; }
-        [field: SerializeField] internal Transform cameraTarget { get; private set; }
-        [field: SerializeField] internal Transform rotationTarget { get; private set; }
-        [field: SerializeField] internal CinemachineFreeLook freeLookCamera { get; private set; }
-        [field: SerializeField] internal GameObject previewPlatform { get; private set; }
-        [field: SerializeField] internal AvatarPreviewHeadIKSettings headIKSettings { get; private set; }
+        [field: SerializeField] internal Transform avatarParent { get; private set; } = null!;
+        [field: SerializeField] internal new Camera camera { get; private set; } = null!;
+        [field: SerializeField] internal Transform cameraTarget { get; private set; } = null!;
+        [field: SerializeField] internal Transform rotationTarget { get; private set; } = null!;
+        [field: SerializeField] internal CinemachineFreeLook freeLookCamera { get; private set; } = null!;
+        [field: SerializeField] internal GameObject previewPlatform { get; private set; } = null!;
+        [field: SerializeField] internal AvatarPreviewHeadIKSettings headIKSettings { get; private set; } = null!;
 
         internal float TargetFOV { get; set; }
         internal float RotationModifier { get; set; }

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/FriendPanelSectionControllerBase.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/FriendPanelSectionControllerBase.cs
@@ -19,6 +19,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections
         protected readonly U requestManager;
 
         private CancellationTokenSource friendListInitCts = new ();
+        private bool disposed;
 
         protected UniTaskCompletionSource? panelLifecycleTask { get; private set; }
 
@@ -40,6 +41,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections
             view.Disable -= Disable;
             requestManager.Dispose();
             friendListInitCts.SafeCancelAndDispose();
+            disposed = true;
         }
 
         public async UniTask InitAsync(CancellationToken ct)
@@ -51,6 +53,9 @@ namespace DCL.Friends.UI.FriendPanel.Sections
             EnumResult<TaskError> result = await requestManager.InitAsync(ct).SuppressToResultAsync(ReportCategory.FRIENDS);
 
             if (!result.Success)
+                return;
+
+            if (ct.IsCancellationRequested)
                 return;
 
             view.SetLoadingState(false);
@@ -73,6 +78,9 @@ namespace DCL.Friends.UI.FriendPanel.Sections
 
         protected void CheckShouldInit()
         {
+            if (disposed)
+                return;
+
             if (!requestManager.WasInitialised)
                 InitAsync(friendListInitCts.Token).Forget();
         }

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/SectionLoadingView.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/SectionLoadingView.cs
@@ -10,8 +10,11 @@ namespace DCL.Friends.UI.FriendPanel.Sections
         [field: SerializeField] public LoadingBrightView LoadingBright { get; private set; }
         [field: SerializeField] public float FadeDuration { get; private set; } = 0.3f;
 
+        private Tweener? fadeTween;
+
         public void Show()
         {
+            fadeTween?.Kill();
             CanvasGroup.alpha = 1;
             CanvasGroup.blocksRaycasts = true;
             LoadingBright.StartLoadingAnimation(null);
@@ -19,8 +22,16 @@ namespace DCL.Friends.UI.FriendPanel.Sections
 
         public void Hide()
         {
-            CanvasGroup.DOFade(0, FadeDuration).OnComplete(() => CanvasGroup.blocksRaycasts = false);
+            fadeTween?.Kill();
+            fadeTween = CanvasGroup.DOFade(0, FadeDuration).OnComplete(() => CanvasGroup.blocksRaycasts = false);
             LoadingBright.FinishLoadingAnimation(null);
+        }
+
+        private void OnDestroy()
+        {
+            // Without this the fade outlives panel teardown and DOTween keeps driving the destroyed CanvasGroup.
+            fadeTween?.Kill();
+            fadeTween = null;
         }
     }
 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/UIBindings/ElementBinding.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/UIBindings/ElementBinding.cs
@@ -8,7 +8,7 @@ namespace DCL.DebugUtilities.UIBindings
     /// </summary>
     public class ElementBinding<T> : IElementBinding<T>
     {
-        private T tempValue;
+        private T tempValue = default!;
 
         private bool tempValueIsDirty;
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugElementBase.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugElementBase.cs
@@ -5,7 +5,7 @@ namespace DCL.DebugUtilities.Views
 {
     public abstract class DebugElementBase<TElement, TDef> : VisualElement where TElement: DebugElementBase<TElement, TDef> where TDef: IDebugElementDef
     {
-        protected TDef definition { get; private set; }
+        protected TDef definition { get; private set; } = default!;
 
         public void Initialize(TDef definition)
         {

--- a/Explorer/Assets/DCL/RealmNavigation/LoadingOperation/SequentialLoadingOperation.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/LoadingOperation/SequentialLoadingOperation.cs
@@ -55,13 +55,25 @@ namespace DCL.RealmNavigation.LoadingOperation
 
                         if (!lastOpResult.Success)
                         {
-                            ReportHub.LogError(
-                                reportData,
-                                $"Operation failed on {processName} attempt {attempt + 1}/{attemptsCount}: {lastOpResult.AsResult().ErrorMessage}"
-                            );
+                            // Do not log cancellation as an error (CLAUDE.md §9): on shutdown the inner op
+                            // converts its OperationCanceledException into a TaskError.Cancelled result.
+                            if (!ct.IsCancellationRequested && lastOpResult.Error?.State != TaskError.Cancelled)
+                                ReportHub.LogError(
+                                    reportData,
+                                    $"Operation failed on {processName} attempt {attempt + 1}/{attemptsCount}: {lastOpResult.AsResult().ErrorMessage}"
+                                );
 
                             break;
                         }
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        // Cancellation of the outer flow is not an error: convert to a cancelled result
+                        // (the check below exits the attempt loop). An OperationCanceledException from an
+                        // operation's internal token is NOT ours to absorb - it propagates as before, so
+                        // the attempt loop cannot re-run the whole chain on an inner timeout.
+                        lastOpResult = EnumResult<TaskError>.CancelledResult(TaskError.Cancelled);
+                        break;
                     }
                     catch (Exception e)
                     {

--- a/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
@@ -102,10 +102,12 @@ namespace DCL.SceneLoadingScreens.LoadingScreen
                                                      SceneLoadingScreenController.IssueCommand(new SceneLoadingScreenController.Params(loadReport)), ct)
                                                 .SuppressToResultAsync(ReportCategory.SCENE_LOADING);
 
-                if (loadReport.GetStatus().TaskStatus == UniTaskStatus.Pending)
+                // Both logs below are pure cancellation artifacts on ExitPlayMode (the outer ct cancels ShowAsync,
+                // leaving loadReport Pending and result as TaskError.Cancelled). Only log when not cancelled (CLAUDE.md §9).
+                if (!ct.IsCancellationRequested && loadReport.GetStatus().TaskStatus == UniTaskStatus.Pending)
                     ReportHub.LogError(ReportCategory.SCENE_LOADING, "Loading screen finished unexpectedly, but the loading process continues");
 
-                if (finalResult.HasValue && !result.Success)
+                if (!ct.IsCancellationRequested && finalResult.HasValue && !result.Success)
                     ReportHub.LogError(ReportCategory.SCENE_LOADING, $"Loading screen finished with an error after the flow has finished: {result.Error.AsMessage()}");
 
                 return result;

--- a/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenView.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenView.cs
@@ -72,11 +72,13 @@ namespace DCL.SceneLoadingScreens
 
         public void ClearTips()
         {
+            // Application/view teardown can destroy the tip objects (children of this view) before
+            // ClearTips runs; skip the already-destroyed entries.
             foreach (TipView tip in tips)
-                Destroy(tip.gameObject);
+                if (tip != null) Destroy(tip.gameObject);
 
             foreach (TipBreadcrumb? breadcrumb in tipsBreadcrumbs)
-                Destroy(breadcrumb.gameObject);
+                if (breadcrumb != null) Destroy(breadcrumb.gameObject);
 
             tips.Clear();
             tipsBreadcrumbs.Clear();

--- a/Explorer/Assets/DCL/SceneLoadingScreens/UnityLocalizationSceneTipsProvider.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/UnityLocalizationSceneTipsProvider.cs
@@ -46,7 +46,7 @@ namespace DCL.SceneLoadingScreens
             fallbackTips = Get(tipsTable, imagesTable, ct);
         }
 
-        public async UniTask<SceneTips> GetAsync(CancellationToken ct) =>
+        public UniTask<SceneTips> GetAsync(CancellationToken ct) =>
 
             // TODO: we will need specific scene tips in the future, but its disabled at the moment
             /*StringTable tipsTable = await tipsDatabase.GetTableAsync($"LoadingSceneTips-{parcelCoord.x},{parcelCoord.y}").Task
@@ -60,7 +60,7 @@ namespace DCL.SceneLoadingScreens
             ct.ThrowIfCancellationRequested();
 
             return await Get(tipsTable, imagesTable, ct);*/
-            fallbackTips;
+            UniTask.FromResult(fallbackTips);
 
         private SceneTips Get(StringTable tipsTable, AssetTable? imagesTable, CancellationToken ct)
         {

--- a/Explorer/Assets/DCL/UI/Controls/ControlsPanel.prefab
+++ b/Explorer/Assets/DCL/UI/Controls/ControlsPanel.prefab
@@ -671,7 +671,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 4974685691c134a35bcea75af1936381, type: 3}
+  m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controls/GenericContextMenuSubMenuButtonView.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controls/GenericContextMenuSubMenuButtonView.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.UI.Controls.Configs;
 using System;
 using System.Threading;
@@ -148,7 +149,8 @@ namespace DCL.UI.Controls
                 if (!isHovering)
                     ShowSubmenu(false);
             }
-            catch (Exception) { }
+            catch (OperationCanceledException) { }
+            catch (Exception e) { ReportHub.LogException(e, ReportCategory.UI); }
         }
     }
 }

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
@@ -410,7 +410,6 @@ namespace DCL.UI
 
             float bestOutOfBoundsPercent = adjustedOutOfBoundsPercent;
             float3 bestPosition = adjustedPosition;
-            var foundPerfectPosition = false;
 
             for (var i = 0; i < fallbackDirectionsCount; i++)
             {


### PR DESCRIPTION
Teardown guards and cancellation scopes

Production evidence (decentraland Sentry, archive snapshot 2026-07-17):
- UNITY-TEST-ENVIRONMENT-17Z: 33 events / 24 users, last seen 2026-06-26
- UNITY-TEST-ENVIRONMENT-1CK: 22 events / 5 users, last seen 2026-07-08
- UNITY-TEST-ENVIRONMENT-16D: 13 events / 1 users, last seen 2026-05-05
- UNITY-TEST-ENVIRONMENT-187: 5 events / 3 users, last seen 2026-05-20
- UNITY-TEST-ENVIRONMENT-15W: 1 events / 1 users, last seen 2026-04-23
- UNITY-TEST-ENVIRONMENT-WN: 1 events / 1 users, last seen 2026-02-18
