### PR TITLE
fix(P76): guard GLTF instantiation from asset bundle

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
@@ -57,10 +57,21 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
 
             AssetBundleData assetBundleData = assetBundleResult.Asset!;
 
-            if (Utils.TryCreateGltfObject(assetBundleData, assetIntention.Hash, out GltfContainerAsset result))
-                World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(result));
-            else
-                World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(GetReportData(), new ArgumentException($"Failed to load {assetIntention.Hash} from AB")));
+            // Instantiation can throw if the AB's underlying Unity asset was destroyed/unloaded
+            // (ref-counted bundle evicted) leaving a "fake-null" object that TryGetAsset still returns.
+            // Convert to a failed result instead of letting it escape Update as an EcsSystemException
+            // (UNITY-EXPLORER-P76 — top crash, 4911 evts/68 users). Mirrors the else-branch failure path.
+            try
+            {
+                if (Utils.TryCreateGltfObject(assetBundleData, assetIntention.Hash, out GltfContainerAsset result))
+                    World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(result));
+                else
+                    World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(GetReportData(), new ArgumentException($"Failed to load {assetIntention.Hash} from AB")));
+            }
+            catch (Exception e)
+            {
+                World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(GetReportData(), new ArgumentException($"Failed to instantiate {assetIntention.Hash} from AB", e)));
+            }
 
         }
 


### PR DESCRIPTION
UNITY-EXPLORER-P76 (4911 evts/68 users — #1 issue): EcsSystemException [CreateGltfAssetFromAssetBundleSystem]. The success branch of ConvertFromAssetBundle calls Utils.TryCreateGltfObject (Object.Instantiate + GetComponentsInChildren), which can throw when the asset bundle's underlying Unity object was destroyed/unloaded (ref-counted bundle evicted) — TryGetAsset only checks the C# list, not Unity-liveness, so it hands back a fake-null object. The throw escaped Update and surfaced as a wrapped EcsSystemException. Wrap in try/catch and emit a failed StreamableLoadingResult (mirroring the existing else-branch), which downstream finalize systems already handle. Uses only symbols already in scope (no new usings). Unverified (no Unity build).

fixes https://github.com/decentraland/unity-explorer/issues/8845

---
_Supersedes #9402: moved from the fork into the org repo so CI workflows receive repository secrets (fork PRs do not)._