### PR TITLE
fix(profile): profile/attachment/URN data robustness - null guards

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
@@ -149,6 +149,8 @@ namespace DCL.AvatarRendering.Loading.Components
                         return true;
                     }
             }
+            else if (string.IsNullOrEmpty(key))
+                ReportHub.LogWarning(ReportCategory.WEARABLE, $"Empty content key requested for wearable with ID: {DTO.Metadata.id}");
             else
                 ReportHub.LogError(ReportCategory.WEARABLE, $"No content found in DTO for wearable with ID: {DTO.Metadata.id}");
 

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/DTO/AvatarAttachmentDTO.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/DTO/AvatarAttachmentDTO.cs
@@ -42,8 +42,7 @@ namespace DCL.AvatarRendering.Loading.DTO
         [Serializable]
         public abstract class MetadataBase : TrimmedAvatarAttachmentDTO.TrimmedMetadataBase<DataBase>
         {
-            public string name;
-
+            // `name` is inherited from TrimmedMetadataBase<TDataBase>.
             public I18n[] i18n;
             public string thumbnail;
 

--- a/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
+++ b/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
@@ -17,9 +17,12 @@ namespace CommunicationData.URLHelpers
 
         public URN(string urn)
         {
+            // A null/empty urn produces the same field state as default(URN), which IsNullOrEmpty and
+            // IsValid already treat as a first-class value; ToLower() on it crashed emote loading when
+            // a DTO carried no id.
             originalUrn = urn;
-            lowercaseUrn = originalUrn.ToLower();
-            hash = originalUrn != null ? lowercaseUrn.GetHashCode() : 0;
+            lowercaseUrn = string.IsNullOrEmpty(urn) ? urn : urn.ToLower();
+            hash = string.IsNullOrEmpty(urn) ? 0 : lowercaseUrn.GetHashCode();
         }
 
         private URN(URN urn, int shortenIndex)

--- a/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.CompactInfo.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.CompactInfo.cs
@@ -284,7 +284,9 @@ namespace DCL.Profiles
                 PicturePromise?.LoadingIntention.CancellationTokenSource.Cancel();
                 PicturePromise = null;
 
+                // Nulling the reference keeps Dispose idempotent for any caller that reaches it twice.
                 ProfilePicture.TryDereference();
+                ProfilePicture = null;
             }
         }
     }

--- a/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
@@ -83,7 +83,8 @@ namespace DCL.Profiles
 
         public void Dispose()
         {
-            GetCompact().Dispose();
+            // POOL's actionOnRelease runs Clear(), which already disposes the compact info -
+            // disposing it here too made every pooled release a double-dispose.
             POOL.Release(this);
         }
 

--- a/Explorer/Assets/DCL/SmartWearables/Systems/SmartWearableSystem.cs
+++ b/Explorer/Assets/DCL/SmartWearables/Systems/SmartWearableSystem.cs
@@ -57,6 +57,7 @@ namespace DCL.SmartWearables
         /// </summary>
         private readonly Dictionary<string, ScenePromise> pendingScenes = new ();
 
+        private readonly CancellationTokenSource systemCts = new ();
         private CancellationTokenSource outfitEquipCts = new ();
 
         private bool currentSceneDirty;
@@ -95,6 +96,21 @@ namespace DCL.SmartWearables
             web3IdentityCache.OnIdentityCleared += OnIdentityCleared;
         }
 
+        protected override void OnDispose()
+        {
+            backpackEventBus.EquipWearableEvent -= OnEquipWearable;
+            backpackEventBus.UnEquipWearableEvent -= OnUnEquipWearable;
+            backpackEventBus.EquipOutfitEvent -= OnEquipOutfit;
+            portableExperiencesController.PortableExperienceUnloaded -= OnPortableExperienceUnloaded;
+            loadingStatus.CurrentStage.OnUpdate -= OnLoadingStatusChanged;
+            scenesCache.CurrentScene.OnUpdate -= OnCurrentSceneChanged;
+            web3IdentityCache.OnIdentityCleared -= OnIdentityCleared;
+
+            systemCts.Cancel();
+            systemCts.Dispose();
+            outfitEquipCts.SafeCancelAndDispose();
+        }
+
         private void OnEquipWearable(IWearable wearable, bool isManuallyEquipped)
         {
             if (!isManuallyEquipped) return;
@@ -104,7 +120,7 @@ namespace DCL.SmartWearables
 
         private async UniTask TryRunSmartWearableSceneAsync(IWearable wearable)
         {
-            bool isSmart = await smartWearableCache.IsSmartAsync(wearable, CancellationToken.None);
+            bool isSmart = await smartWearableCache.IsSmartAsync(wearable, systemCts.Token);
             if (!isSmart || !smartWearableCache.CurrentSceneAllowsSmartWearables) return;
 
             string id = SmartWearableCache.GetCacheId(wearable);
@@ -322,7 +338,7 @@ namespace DCL.SmartWearables
             if (smartWearablesAllowed)
                 // Notice scenes that are already running won't run again, so we can call this safely
                 // TODO consider cancelling a previous running task
-                RunScenesForEquippedWearablesAsync(AuthorizationAction.SkipAuthorization, CancellationToken.None).Forget();
+                RunScenesForEquippedWearablesAsync(AuthorizationAction.SkipAuthorization, systemCts.Token).Forget();
             else
                 UnloadAllSmartWearableScenes();
         }
@@ -348,7 +364,7 @@ namespace DCL.SmartWearables
             loadingStatus.CurrentStage.OnUpdate -= OnLoadingStatusChanged;
             scenesCache.CurrentScene.OnUpdate += OnCurrentSceneChanged;
 
-            RunScenesForEquippedWearablesAsync(AuthorizationAction.RequestAuthorization, CancellationToken.None).Forget();
+            RunScenesForEquippedWearablesAsync(AuthorizationAction.RequestAuthorization, systemCts.Token).Forget();
         }
 
         private async UniTask RunScenesForEquippedWearablesAsync(AuthorizationAction authorization, CancellationToken ct)


### PR DESCRIPTION
Production evidence (decentraland Sentry, archive snapshot 2026-07-17):
- UNITY-TEST-ENVIRONMENT-137: 61 events / 3 users, last seen 2026-05-21
- UNITY-EXPLORER-P5K: 35 events / 3 users, last seen 2026-05-30
- UNITY-EXPLORER-P3N: 10 events / 2 users, last seen 2026-05-16
- UNITY-TEST-ENVIRONMENT-TA: 8 events / 1 users, last seen 2026-02-10
- UNITY-EXPLORER-NMN: 6 events / 3 users, last seen 2026-04-24
- UNITY-EXPLORER-PCA: 3 events / 1 users, last seen 2026-07-12

fixes https://github.com/decentraland/unity-explorer/issues/8846
fixes https://github.com/decentraland/unity-explorer/issues/8722
fixes https://github.com/decentraland/unity-explorer/issues/7544
fixes https://github.com/decentraland/unity-explorer/issues/9029

---
_Supersedes #9403: moved from the fork into the org repo so CI workflows receive repository secrets (fork PRs do not)._