### PR TITLE
fix(NT8): guard destroyed prop View in GliderPropControllerSystem

### DIFF
--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/GliderPropControllerSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/GliderPropControllerSystem.cs
@@ -169,6 +169,14 @@ namespace DCL.CharacterMotion.Systems
         [All(typeof(DeleteEntityIntention))]
         private void CleanUpDestroyedAvatarsProp(ref GliderProp gliderProp)
         {
+            // The prop View is parented to the avatar transform; if the avatar GameObject was
+            // destroyed by Unity directly, the child View is already destroyed (== null via Unity's
+            // overload) while the ECS component still references it. Guard before touching members,
+            // otherwise the throw escapes Update as EcsSystemException [GliderPropControllerSystem]
+            // (UNITY-EXPLORER-NT8).
+            if (gliderProp.View == null)
+                return;
+
             if (glidingSettings.EnablePropPooling)
             {
                 gliderProp.View.PrepareForNextActivation();


### PR DESCRIPTION
UNITY-EXPLORER-NT8 (824 evts/2 users): EcsSystemException [GliderPropControllerSystem]. The glider prop View is parented to the avatar transform; when the avatar GameObject is torn down by Unity, the child View is destroyed while the ECS GliderProp component still references it. CleanUpDestroyedAvatarsProp then dereferences the destroyed View (PrepareForNextActivation / .gameObject), throwing out of Update. Early-return on Unity-null View (overloaded ==), matching the codebase's SafeDestroy/null-guard idiom. Unverified (no Unity build).

fixes https://github.com/decentraland/unity-explorer/issues/8064

---
_Supersedes #9405: moved from the fork into the org repo so CI workflows receive repository secrets (fork PRs do not)._