### PR TITLE
fix: WearableStorage locks on the shared base-registry monitor

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Equipped/EquippedWearables.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Equipped/EquippedWearables.cs
@@ -19,19 +19,18 @@ namespace DCL.AvatarRendering.Wearables.Equipped
 
         public EquippedWearables()
         {
-            foreach (string category in WearableCategories.CATEGORIES_PRIORITY)
-                wearables.Add(category, null);
+            UnEquipAll();
         }
 
         public IWearable? Wearable(string category) =>
-            wearables[category];
+            wearables.TryGetValue(category, out IWearable? wearable) ? wearable : null;
 
         public (Color, Color, Color) GetColors() =>
             (hairColor, eyesColor, bodyshapeColor);
 
         public bool IsEquipped(ITrimmedWearable wearable)
         {
-            return wearables[wearable.GetCategory()]?.DTO.id == wearable.TrimmedDTO.id;
+            return Wearable(wearable.GetCategory())?.DTO.id == wearable.TrimmedDTO.id;
         }
 
         public void Equip(IWearable wearable) =>
@@ -48,8 +47,14 @@ namespace DCL.AvatarRendering.Wearables.Equipped
 
         public void UnEquipAll()
         {
+            // Re-seed instead of a bare Dictionary.Clear(): reads rely on every seeded category key
+            // surviving with a null value (Clear() made category reads throw KeyNotFoundException after
+            // an identity change), and Equip() can add non-priority category keys that must not keep
+            // the previous identity's wearables equipped.
+            wearables.Clear();
+
             foreach (string category in WearableCategories.CATEGORIES_PRIORITY)
-                wearables[category] = null;
+                wearables.Add(category, null);
         }
 
         public void SetHairColor(Color newColor) =>
@@ -69,7 +74,7 @@ namespace DCL.AvatarRendering.Wearables.Equipped
 
         public void Clear()
         {
-            wearables.Clear();
+            UnEquipAll();
             forceRenderCategories.Clear();
         }
 

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableStorage.cs
@@ -14,9 +14,6 @@ namespace DCL.AvatarRendering.Wearables.Helpers
     {
         private readonly LinkedList<(URN key, long lastUsedFrame)> listedCacheKeys = new ();
         private readonly Dictionary<URN, LinkedListNode<(URN key, long lastUsedFrame)>> cacheKeysDictionary = new (new Dictionary<URN, LinkedListNode<(URN key, long lastUsedFrame)>>(), URNIgnoreCaseEqualityComparer.Default);
-        private readonly Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>> ownedNftsRegistry = new (new Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>>(), URNIgnoreCaseEqualityComparer.Default);
-
-        private readonly object lockObject = new ();
 
         internal Dictionary<URN, IWearable> wearablesCache { get; } = new (new Dictionary<URN, IWearable>(), URNIgnoreCaseEqualityComparer.Default);
 


### PR DESCRIPTION
Identity swap fully unequips

Production evidence (decentraland Sentry, archive snapshot 2026-07-17):
- UNITY-EXPLORER-PF3: 17 events / 1 users, last seen 2026-07-06
- UNITY-EXPLORER-KW0: 5 events / 2 users, last seen 2026-07-13
- UNITY-TEST-ENVIRONMENT-TT: 4 events / 2 users, last seen 2026-03-26
- UNITY-EXPLORER-NJ1: 3 events / 3 users, last seen 2026-04-19
- UNITY-EXPLORER-NJ0: 3 events / 3 users, last seen 2026-03-17
- UNITY-EXPLORER-MBC: 3 events / 1 users, last seen 2026-02-16

fixes https://github.com/decentraland/unity-explorer/issues/9304
fixes https://github.com/decentraland/unity-explorer/issues/9303
fixes https://github.com/decentraland/unity-explorer/issues/7397
fixes https://github.com/decentraland/unity-explorer/issues/7396

---
_Supersedes #9410: moved from the fork into the org repo so CI workflows receive repository secrets (fork PRs do not)._