### PR TITLE
fix: disposed-identity Sign throws ObjectDisposedException tracked

### DIFF
--- a/Explorer/Assets/DCL/Tests/Editor/DecentralandIdentityShould.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/DecentralandIdentityShould.cs
@@ -1,0 +1,80 @@
+using DCL.Web3;
+using DCL.Web3.Abstract;
+using DCL.Web3.Chains;
+using DCL.Web3.Identities;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+
+namespace DCL.Tests.Editor
+{
+    public class DecentralandIdentityShould
+    {
+        private const string ADDRESS = "0x0000000000000000000000000000000000000001";
+
+        private static DecentralandIdentity NewIdentity()
+        {
+            AuthChain authChain = AuthChain.Create();
+            authChain.SetSigner(ADDRESS);
+
+            authChain.Set(new AuthLink
+            {
+                type = AuthLinkType.ECDSA_EPHEMERAL,
+                payload = "ephemeral payload",
+                signature = "0xephemeralsignature",
+            });
+
+            IWeb3Account ephemeralAccount = Substitute.For<IWeb3Account>();
+            ephemeralAccount.Sign(Arg.Any<string>()).Returns("0xentitysignature");
+
+            return new DecentralandIdentity(new Web3Address(ADDRESS), ephemeralAccount, DateTime.UtcNow.AddDays(1), authChain, IWeb3Identity.Web3IdentitySource.None);
+        }
+
+        [Test]
+        public void SignEntityWhileAlive()
+        {
+            // Arrange
+            DecentralandIdentity identity = NewIdentity();
+
+            // Act
+            AuthChain signed = identity.Sign("entityId");
+
+            // Assert
+            Assert.IsTrue(signed.TryGet(AuthLinkType.ECDSA_SIGNED_ENTITY, out AuthLink link));
+            Assert.AreEqual("entityId", link.payload);
+
+            signed.Dispose();
+            identity.Dispose();
+        }
+
+        [Test]
+        public void ThrowObjectDisposedOnSignAfterDispose()
+        {
+            // Arrange
+            DecentralandIdentity identity = NewIdentity();
+
+            // Act
+            identity.Dispose();
+
+            // Assert
+            Assert.Throws<ObjectDisposedException>(() => identity.Sign("entityId"));
+        }
+
+        [Test]
+        public void ThrowObjectDisposedEvenAfterPoolReissuesItsAuthChain()
+        {
+            // Arrange
+            DecentralandIdentity identity = NewIdentity();
+            identity.Dispose();
+
+            // Act - the pool can re-issue the identity's released AuthChain instance with the
+            // disposed flag reset; the identity guard must not depend on that pooled state.
+            AuthChain reissued = AuthChain.Create();
+
+            // Assert
+            Assert.Throws<ObjectDisposedException>(() => identity.Sign("entityId"));
+
+            reissued.Dispose();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Tests/Editor/DecentralandIdentityShould.cs.meta
+++ b/Explorer/Assets/DCL/Tests/Editor/DecentralandIdentityShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca6f29b7ea2f469a82a653db411b47c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Web3/Chains/AuthChain.cs
+++ b/Explorer/Assets/DCL/Web3/Chains/AuthChain.cs
@@ -16,8 +16,16 @@ namespace DCL.Web3.Chains
 
         private bool disposed;
 
-        public static AuthChain Create() =>
-            POOL.Get()!;
+        public static AuthChain Create()
+        {
+            // Reset the recycled instance: a pooled AuthChain comes back with disposed == true
+            // (set by the Dispose that released it), which made its next Dispose a no-op — the
+            // instance never returned to the pool again and reads saw stale state.
+            AuthChain instance = POOL.Get()!;
+            instance.disposed = false;
+            instance.chain.Clear();
+            return instance;
+        }
 
         private AuthChain() { }
 

--- a/Explorer/Assets/DCL/Web3/Identities/DecentralandIdentity.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/DecentralandIdentity.cs
@@ -7,6 +7,8 @@ namespace DCL.Web3.Identities
 {
     public class DecentralandIdentity : IWeb3Identity
     {
+        private bool disposed;
+
         public Web3Address Address { get; }
         public DateTime Expiration { get; }
         public IWeb3Account EphemeralAccount { get; }
@@ -33,11 +35,22 @@ namespace DCL.Web3.Identities
 
         public void Dispose()
         {
+            if (disposed)
+                return;
+
+            disposed = true;
             AuthChain.Dispose();
         }
 
         public AuthChain Sign(string entityId)
         {
+            // Tracked on the identity itself: the pooled AuthChain's disposed flag is reset when the
+            // pool re-issues the instance, so it cannot be trusted after this identity released it.
+            // ObjectDisposedException (not OperationCanceledException) so the failure is not silently
+            // swallowed by the standard catch (OperationCanceledException) { } blocks.
+            if (disposed)
+                throw new ObjectDisposedException(nameof(DecentralandIdentity), $"Cannot sign, the identity for {Address} has been disposed");
+
             if (Expiration < DateTime.UtcNow)
                 throw new Web3IdentityException(this, $"Cannot sign, identity has expired: {Expiration:s}");
 

--- a/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
@@ -18,8 +18,10 @@ namespace DCL.Web3.Identities
         {
             private readonly IWeb3Identity? identity;
 
+#pragma warning disable CS0067
             public event Action? OnIdentityCleared;
             public event Action? OnIdentityChanged;
+#pragma warning restore CS0067
 
             public Fake() : this(new IWeb3Identity.Random()) { }
 


### PR DESCRIPTION
Not seen in prod


---
_Supersedes #9412: moved from the fork into the org repo so CI workflows receive repository secrets (fork PRs do not)._
