### PR TITLE
chore: combined QA build for the clean-* fix set (#9416–#9429)

### DIFF
--- a/Explorer/Assets/DCL/AssetsProvision/Contextual/ContextualImage.cs
+++ b/Explorer/Assets/DCL/AssetsProvision/Contextual/ContextualImage.cs
@@ -51,14 +51,16 @@ namespace DCL.AssetsProvision
 
         private void OnDisable()
         {
-            image.sprite = null!;
-            asset.Release();
+            if (image != null)
+                image.sprite = null!;
+            asset?.Release();
         }
 
         private void OnDestroy()
         {
-            image.sprite = null!;
-            asset.Dispose();
+            if (image != null)
+                image.sprite = null!;
+            asset?.Dispose();
         }
 
         public UniTask TriggerOrWaitReadyAsync(CancellationToken token) =>

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenAudio.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenAudio.cs
@@ -62,7 +62,7 @@ namespace DCL.AuthenticationScreenFlow
 
         private void OnContinuousAudioStarted(AudioClipConfig audioClipConfig)
         {
-            if (audioClipConfig.GetInstanceID() != backgroundMusic.GetInstanceID())
+            if (audioClipConfig.GetEntityId() != backgroundMusic.GetEntityId())
                 return;
 
             UIAudioEventsBus.Instance.PlayContinuousUIAudioEvent -= OnContinuousAudioStarted;

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/LobbyForExistingAccountAuthView.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/LobbyForExistingAccountAuthView.cs
@@ -46,13 +46,13 @@ namespace DCL.AuthenticationScreenFlow
             JumpIntoWorldButton.interactable = true;
             DiffAccountButton.interactable = true;
 
-            ShowAsync(CancellationToken.None).Forget();
+            ShowAsync(destroyCancellationToken).Forget();
         }
 
         public void Hide(int animHash)
         {
             hideAnimHash = animHash;
-            HideAsync(CancellationToken.None).Forget();
+            HideAsync(destroyCancellationToken).Forget();
         }
 
         public override async UniTask ShowAsync(CancellationToken ct)

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/LobbyForNewAccountAuthView.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/LobbyForNewAccountAuthView.cs
@@ -106,13 +106,13 @@ namespace DCL.AuthenticationScreenFlow
 
         public void Show()
         {
-            ShowAsync(CancellationToken.None).Forget();
+            ShowAsync(destroyCancellationToken).Forget();
         }
 
         public void Hide(int animHash)
         {
             hideAnimHash = animHash;
-            HideAsync(CancellationToken.None).Forget();
+            HideAsync(destroyCancellationToken).Forget();
         }
 
         public override async UniTask ShowAsync(CancellationToken ct)

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/LoginSelectionAuthView.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/LoginSelectionAuthView.cs
@@ -106,7 +106,7 @@ namespace DCL.AuthenticationScreenFlow
         public void Show(int animHash, bool moreOptionsExpanded)
         {
             showAnimHash = animHash;
-            ShowAsync(CancellationToken.None).Forget();
+            ShowAsync(destroyCancellationToken).Forget();
 
             areOptionsExpanded = moreOptionsExpanded;
             SetOptionsPanelVisibility(areOptionsExpanded);
@@ -120,7 +120,7 @@ namespace DCL.AuthenticationScreenFlow
             loadingSpinner.SetActive(false);
             SetEmailInputFieldSpinnerActive(false);
 
-            HideAsync(CancellationToken.None).Forget();
+            HideAsync(destroyCancellationToken).Forget();
         }
 
         public void SetLoadingSpinnerVisibility(bool isLoading)

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/ProfileFetchingAuthView.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/ProfileFetchingAuthView.cs
@@ -23,13 +23,13 @@ namespace DCL.AuthenticationScreenFlow
 
         public void Show()
         {
-            ShowAsync(CancellationToken.None).Forget();
+            ShowAsync(destroyCancellationToken).Forget();
         }
 
         public void Hide(int hideAnimHash)
         {
             this.hideAnimHash = hideAnimHash;
-            HideAsync(CancellationToken.None).Forget();
+            HideAsync(destroyCancellationToken).Forget();
         }
 
         public override async UniTask ShowAsync(CancellationToken ct)

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/VerificationDappAuthView.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/VerificationDappAuthView.cs
@@ -60,13 +60,13 @@ namespace DCL.AuthenticationScreenFlow
             code.text = dataCode.ToString();
             DoCountdownAsync(expiration).Forget();
 
-            ShowAsync(CancellationToken.None).Forget();
+            ShowAsync(destroyCancellationToken).Forget();
         }
 
         public void Hide(int hideAnimHash)
         {
             this.hideAnimHash = hideAnimHash;
-            HideAsync(CancellationToken.None).Forget();
+            HideAsync(destroyCancellationToken).Forget();
         }
 
         public override async UniTask ShowAsync(CancellationToken ct)

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/VerificationOTPAuthView.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/VerificationOTPAuthView.cs
@@ -33,14 +33,14 @@ namespace DCL.AuthenticationScreenFlow
         public void Show(string email)
         {
             InputField.Clear();
-            ShowAsync(CancellationToken.None).Forget();
+            ShowAsync(destroyCancellationToken).Forget();
             description.text = description.text.Replace("your@email.com", email); // Update description with user email
         }
 
         public void Hide(int hideAnimHash)
         {
             this.hideAnimHash = hideAnimHash;
-            HideAsync(CancellationToken.None).Forget();
+            HideAsync(destroyCancellationToken).Forget();
         }
 
         public override async UniTask ShowAsync(CancellationToken ct)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -1,15 +1,16 @@
 ﻿using DCL.AvatarRendering.AvatarShape.ComputeShader;
-using DCL.AvatarRendering.AvatarShape.Rendering.TextureArray;
 using DCL.AvatarRendering.AvatarShape.Helpers;
-using DCL.Optimization.Pools;
-using System.Collections.Generic;
+using DCL.AvatarRendering.AvatarShape.Rendering.TextureArray;
 using DCL.Diagnostics;
+using DCL.Optimization.Pools;
+using RichTypes;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Unity.Collections;
 using Unity.Mathematics;
 using UnityEngine;
-using UnityEngine.Pool;
 using UnityEngine.Assertions;
-using RichTypes;
+using UnityEngine.Pool;
 
 namespace DCL.AvatarRendering.AvatarShape.Components
 {
@@ -21,8 +22,8 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         public struct Buffers
         {
             // since it's impossible to guarantee initialization of structure in C# the case requires to provide an additional check
-            private ComputeSkinningBufferContainer computeSkinningBufferContainer;
-            private readonly ComputeBuffer bones; 
+            private ComputeSkinningBufferContainer? computeSkinningBufferContainer;
+            private readonly ComputeBuffer? bones;
             internal readonly int kernel;
 
             public Buffers(ComputeBuffer bones, int kernel) : this()
@@ -32,7 +33,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
                 this.kernel = kernel;
             }
 
-            public bool TryGetBones(out ComputeBuffer bones)
+            public bool TryGetBones([NotNullWhen(true)] out ComputeBuffer? bones)
             {
                 bones = this.bones;
                 return bones != null;
@@ -127,7 +128,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
                 return Result.ErrorResult("Attempt to process an invalid avatar");
             }
 
-            if (buffers.TryGetBones(out ComputeBuffer bones) == false)
+            if (buffers.TryGetBones(out ComputeBuffer? bones) == false)
             {
                 return Result.ErrorResult("ComputeSkinning error: Cannot get bones (ComputeBuffer)");
             }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -45,8 +45,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
             public void DisposeBuffers()
             {
-                computeSkinningBufferContainer.Dispose();
-                bones.Dispose();
+                // a default(Buffers) (empty avatar) owns nothing to dispose
+                computeSkinningBufferContainer?.Dispose();
+                bones?.Dispose();
             }
         }
 
@@ -117,6 +118,10 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
         public Result ComputeSkinning(NativeArray<float4x4> bonesResult, GlobalJobArrayIndex indexInGlobalJobArray)
         {
+            // an empty avatar (no vertices) has nothing to skin
+            if (VertCount == 0)
+                return Result.SuccessResult();
+
             if (indexInGlobalJobArray.TryGetValue(out int validIndex) == false)
             {
                 return Result.ErrorResult("Attempt to process an invalid avatar");

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
@@ -28,6 +28,18 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
             (int vertCount, int totalBoneBufferCount) = SetupCounters(meshesData, boneCount);
 
+            if (vertCount == 0 || boneCount == 0)
+            {
+                ReportHub.LogWarning(ReportCategory.AVATAR,
+                    $"[ComputeShaderSkinning] Empty avatar mesh data (vertCount={vertCount}, boneCount={boneCount}); skipping skinning.");
+                ListPool<MeshData>.Release(meshesData);
+
+                // VertCount == 0 with default Buffers marks the component as empty: ComputeSkinning and
+                // DisposeBuffers no-op on it, and the materials list is pool-rented so Dispose's
+                // unconditional USED_SLOTS_POOL.Release stays balanced.
+                return new AvatarCustomSkinningComponent(0, 0, default, AvatarCustomSkinningComponent.USED_SLOTS_POOL.Get(), skinningShader, default);
+            }
+
             AvatarCustomSkinningComponent.Buffers buffers = SetupComputeShader(meshesData, skinningShader, vertCount, totalBoneBufferCount, boneCount);
             List<AvatarCustomSkinningComponent.MaterialSetup> materialSetups = SetupMeshRenderer(meshesData, avatarMaterialPool, avatarShapeComponent, facialFeatureTexture);
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/FixedComputeBufferHandler.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/FixedComputeBufferHandler.cs
@@ -93,6 +93,10 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
             // Merge the region with any adjacent free regions in the freeRegions list.
             // The freeRegions list should always be kept sorted. If you merge regions, make sure the result is still sorted.
 
+            // a zero-length slice was never rented (Rent rejects 0): nothing to release
+            if (slice.Length == 0)
+                return;
+
             if (!rentedRegions.Remove(slice))
             {
                 ReportHub.LogError(ReportCategory.AVATAR, "Trying to release a slice that was not rented");

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/DemoScripts/Systems/PlayableDirectorUpdatingSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/DemoScripts/Systems/PlayableDirectorUpdatingSystem.cs
@@ -31,7 +31,7 @@ namespace DCL.AvatarAnimation
         {
             // Just taking the one and only playable director from the scene is ok for now
             if (playableDirector == null)
-                playableDirector = GameObject.FindObjectOfType<PlayableDirector>();
+                playableDirector = Object.FindAnyObjectByType<PlayableDirector>();
 
             if (playableDirector != null)
             {

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Editor/BoneHider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Editor/BoneHider.cs
@@ -1,4 +1,5 @@
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.Animations.Rigging;
 using ScriptableWizard = UnityEditor.ScriptableWizard;
 
@@ -8,7 +9,7 @@ public class BoneHider : ScriptableWizard
     public static void ToggleBones()
     {
         // Find all instances of BoneRenderer in the scene.
-        BoneRenderer[] bones = FindObjectsOfType<BoneRenderer>();
+        BoneRenderer[] bones = Object.FindObjectsByType<BoneRenderer>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
     
         // Check if there are any bones to toggle. If not, simply return.
         if (bones.Length == 0) return;
@@ -27,7 +28,7 @@ public class BoneHider : ScriptableWizard
     public static void ToggleEffectors()
     {
         // Find all instances of Rig in the scene.
-        Rig[] rigs = FindObjectsOfType<Rig>();
+        Rig[] rigs = Object.FindObjectsByType<Rig>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
     
         // Initialize a flag to indicate if the valueToSet has been determined.
         bool valueDetermined = false;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarInstantiatorSystem.cs
@@ -287,7 +287,9 @@ namespace DCL.AvatarRendering.AvatarShape
                 foreach (var renderer in cachedAttachment.Renderers)
                     renderer.enabled = false;
 
-            skinningComponent.SetVertOutRegion(vertOutBuffer.Rent(skinningComponent.VertCount));
+            // an empty avatar (VertCount == 0) owns no region of the shared buffer (Rent rejects 0)
+            if (skinningComponent.VertCount > 0)
+                skinningComponent.SetVertOutRegion(vertOutBuffer.Rent(skinningComponent.VertCount));
             avatarBase.gameObject.SetActive(true);
             avatarBase.UpdateHeadWearableOffset(skinningComponent.LocalBounds, wearableIntention); // Update cached head wearable offset for nametag positioning
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/MakeVertsOutBufferDefragmentationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/MakeVertsOutBufferDefragmentationSystem.cs
@@ -35,6 +35,11 @@ namespace DCL.AvatarRendering.AvatarShape
         [Query]
         private void UpdateIndices([Data] IReadOnlyDictionary<int, FixedComputeBufferHandler.Slice> remapping, ref AvatarCustomSkinningComponent avatarCustomSkinningComponent)
         {
+            // a zero-length region owns no slice of the buffer; its default StartIndex (0) must not
+            // match a real region that starts at 0
+            if (avatarCustomSkinningComponent.VertsOutRegion.Length == 0)
+                return;
+
             if (remapping.TryGetValue(avatarCustomSkinningComponent.VertsOutRegion.StartIndex, out FixedComputeBufferHandler.Slice newRegion))
                 avatarCustomSkinningComponent.SetVertOutRegion(newRegion);
         }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarShapeVisibilitySystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarShapeVisibilitySystemShould.cs
@@ -421,10 +421,6 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             ref var shapeRef = ref world.Get<AvatarShapeComponent>(playerEntity);
             shapeRef.IsDirty = true;
 
-            // Add skinning component for dither test
-            var skinningMaterials = new List<AvatarCustomSkinningComponent.MaterialSetup>();
-            var skinningComponent = new AvatarCustomSkinningComponent();
-
             // Act - This update should trigger ResetDitherState due to IsDirty
             system.Update(0);
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
@@ -192,6 +192,8 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
 
         public void StartMaskedLegacyEmote(AnimationClip clip, AvatarMask avatarMask, bool loop)
         {
+            if (AvatarAnimator == null) return;
+
             // Keep the Animator enabled so locomotion stays driving the bones we restore each frame.
             AvatarAnimator.enabled = true;
             AddOrGetMaskedLegacyBlender().Play(clip, avatarMask, loop);
@@ -200,15 +202,22 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         public void StopMaskedLegacyEmote() =>
             maskedLegacyBlender?.Stop();
 
-        public void SetPointAtLayerWeight(float weight) =>
+        public void SetPointAtLayerWeight(float weight)
+        {
+            if (AvatarAnimator == null) return;
             AvatarAnimator.SetLayerWeight(rightPointAtLayerIndex, weight);
+        }
 
-        public void SetRotationLayerWeight(float weight) =>
+        public void SetRotationLayerWeight(float weight)
+        {
+            if (AvatarAnimator == null) return;
             AvatarAnimator.SetLayerWeight(rotationLayerIndex, weight);
+        }
 
         public void SetAnimatorFloat(int hash, float value)
         {
             if (IsLegacyAnimationPlaying) return;
+            if (AvatarAnimator == null) return;
             if (AvatarAnimator.GetFloat(hash).Equals(value)) return;
 
             AvatarAnimator.enabled = true;
@@ -218,6 +227,7 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         public void SetAnimatorInt(int hash, int value)
         {
             if (IsLegacyAnimationPlaying) return;
+            if (AvatarAnimator == null) return;
             if (AvatarAnimator.GetInteger(hash).Equals(value)) return;
 
             AvatarAnimator.enabled = true;
@@ -227,22 +237,28 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         public void SetAnimatorTrigger(int hash)
         {
             if (IsLegacyAnimationPlaying) return;
+            if (AvatarAnimator == null) return;
 
             AvatarAnimator.enabled = true;
             AvatarAnimator.SetTrigger(hash);
         }
 
         public bool IsAnimatorInTag(int hashTag) =>
-            AvatarAnimator.GetCurrentAnimatorStateInfo(0).tagHash == hashTag;
+            AvatarAnimator != null && AvatarAnimator.GetCurrentAnimatorStateInfo(0).tagHash == hashTag;
 
         public int GetAnimatorCurrentStateTag(string layerName)
         {
+            if (AvatarAnimator == null) return 0;
+
             int layerIndex = AvatarAnimator.GetLayerIndex(layerName);
             return AvatarAnimator.GetCurrentAnimatorStateInfo(layerIndex).tagHash;
         }
 
-        public void ResetAnimatorTrigger(int hash) =>
+        public void ResetAnimatorTrigger(int hash)
+        {
+            if (AvatarAnimator == null) return;
             AvatarAnimator.ResetTrigger(hash);
+        }
 
         public void ResetArmatureInclination()
         {
@@ -260,7 +276,7 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
             transform.localPosition = Vector3.zero;
             LegacyAnimation?.Stop();
             maskedLegacyBlender?.Stop();
-            AvatarAnimator.Rebind();
+            if (AvatarAnimator != null) AvatarAnimator.Rebind();
             HipsConstraint.data.offset = Vector3.zero;
             HipsConstraint.weight = 0;
             FeetIKRig.enabled = false;
@@ -268,16 +284,19 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
 
         public void SetLayerWeight(string layerName, float weight)
         {
+            if (AvatarAnimator == null) return;
+
             int index = AvatarAnimator.GetLayerIndex(layerName);
             AvatarAnimator.SetLayerWeight(index, weight);
         }
 
         public bool GetAnimatorBool(int hash) =>
-            AvatarAnimator.GetBool(hash);
+            AvatarAnimator != null && AvatarAnimator.GetBool(hash);
 
         public void SetAnimatorBool(int hash, bool value)
         {
             if (IsLegacyAnimationPlaying) return;
+            if (AvatarAnimator == null) return;
             if (AvatarAnimator.GetBool(hash) == value) return;
 
             AvatarAnimator.enabled = true;
@@ -285,11 +304,12 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         }
 
         public float GetAnimatorFloat(int hash) =>
-            AvatarAnimator.GetFloat(hash);
+            AvatarAnimator != null ? AvatarAnimator.GetFloat(hash) : 0f;
 
         public void ReplaceEmoteAnimation(AnimationClip animationClip)
         {
             if (lastEmote == animationClip) return;
+            if (AvatarAnimator == null) return;
 
             overrideController["Emote"] = animationClip;
             AvatarAnimator.runtimeAnimatorController = overrideController;

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Components/IAvatarAttachment.cs
@@ -149,6 +149,8 @@ namespace DCL.AvatarRendering.Loading.Components
                         return true;
                     }
             }
+            else if (string.IsNullOrEmpty(key))
+                ReportHub.LogWarning(ReportCategory.WEARABLE, $"Empty content key requested for wearable with ID: {DTO.Metadata.id}");
             else
                 ReportHub.LogError(ReportCategory.WEARABLE, $"No content found in DTO for wearable with ID: {DTO.Metadata.id}");
 

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/DTO/AvatarAttachmentDTO.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/DTO/AvatarAttachmentDTO.cs
@@ -42,8 +42,7 @@ namespace DCL.AvatarRendering.Loading.DTO
         [Serializable]
         public abstract class MetadataBase : TrimmedAvatarAttachmentDTO.TrimmedMetadataBase<DataBase>
         {
-            public string name;
-
+            // `name` is inherited from TrimmedMetadataBase<TDataBase>.
             public I18n[] i18n;
             public string thumbnail;
 

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Equipped/EquippedWearables.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Equipped/EquippedWearables.cs
@@ -19,19 +19,18 @@ namespace DCL.AvatarRendering.Wearables.Equipped
 
         public EquippedWearables()
         {
-            foreach (string category in WearableCategories.CATEGORIES_PRIORITY)
-                wearables.Add(category, null);
+            UnEquipAll();
         }
 
         public IWearable? Wearable(string category) =>
-            wearables[category];
+            wearables.TryGetValue(category, out IWearable? wearable) ? wearable : null;
 
         public (Color, Color, Color) GetColors() =>
             (hairColor, eyesColor, bodyshapeColor);
 
         public bool IsEquipped(ITrimmedWearable wearable)
         {
-            return wearables[wearable.GetCategory()]?.DTO.id == wearable.TrimmedDTO.id;
+            return Wearable(wearable.GetCategory())?.DTO.id == wearable.TrimmedDTO.id;
         }
 
         public void Equip(IWearable wearable) =>
@@ -48,8 +47,14 @@ namespace DCL.AvatarRendering.Wearables.Equipped
 
         public void UnEquipAll()
         {
+            // Re-seed instead of a bare Dictionary.Clear(): reads rely on every seeded category key
+            // surviving with a null value (Clear() made category reads throw KeyNotFoundException after
+            // an identity change), and Equip() can add non-priority category keys that must not keep
+            // the previous identity's wearables equipped.
+            wearables.Clear();
+
             foreach (string category in WearableCategories.CATEGORIES_PRIORITY)
-                wearables[category] = null;
+                wearables.Add(category, null);
         }
 
         public void SetHairColor(Color newColor) =>
@@ -69,7 +74,7 @@ namespace DCL.AvatarRendering.Wearables.Equipped
 
         public void Clear()
         {
-            wearables.Clear();
+            UnEquipAll();
             forceRenderCategories.Clear();
         }
 

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableStorage.cs
@@ -14,9 +14,6 @@ namespace DCL.AvatarRendering.Wearables.Helpers
     {
         private readonly LinkedList<(URN key, long lastUsedFrame)> listedCacheKeys = new ();
         private readonly Dictionary<URN, LinkedListNode<(URN key, long lastUsedFrame)>> cacheKeysDictionary = new (new Dictionary<URN, LinkedListNode<(URN key, long lastUsedFrame)>>(), URNIgnoreCaseEqualityComparer.Default);
-        private readonly Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>> ownedNftsRegistry = new (new Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>>(), URNIgnoreCaseEqualityComparer.Default);
-
-        private readonly object lockObject = new ();
 
         internal Dictionary<URN, IWearable> wearablesCache { get; } = new (new Dictionary<URN, IWearable>(), URNIgnoreCaseEqualityComparer.Default);
 

--- a/Explorer/Assets/DCL/Character/CharacterCamera/Systems/ControlCinemachineVirtualCameraSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterCamera/Systems/ControlCinemachineVirtualCameraSystem.cs
@@ -117,6 +117,7 @@ namespace DCL.Character.CharacterCamera.Systems
                                            {
                                                ThirdPersonCameraShoulder.Right => ThirdPersonCameraShoulder.Left,
                                                ThirdPersonCameraShoulder.Left => ThirdPersonCameraShoulder.Right,
+                                               ThirdPersonCameraShoulder.Center => ThirdPersonCameraShoulder.Right,
                                            };
 
             ThirdPersonCameraShoulder thirdPersonCameraShoulder = cameraComponent.Shoulder;

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/GliderPropControllerSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/GliderPropControllerSystem.cs
@@ -169,6 +169,14 @@ namespace DCL.CharacterMotion.Systems
         [All(typeof(DeleteEntityIntention))]
         private void CleanUpDestroyedAvatarsProp(ref GliderProp gliderProp)
         {
+            // The prop View is parented to the avatar transform; if the avatar GameObject was
+            // destroyed by Unity directly, the child View is already destroyed (== null via Unity's
+            // overload) while the ECS component still references it. Guard before touching members,
+            // otherwise the throw escapes Update as EcsSystemException [GliderPropControllerSystem]
+            // (UNITY-EXPLORER-NT8).
+            if (gliderProp.View == null)
+                return;
+
             if (glidingSettings.EnablePropPooling)
             {
                 gliderProp.View.PrepareForNextActivation();

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewAvatarContainer.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewAvatarContainer.cs
@@ -25,13 +25,13 @@ namespace DCL.CharacterPreview
         private bool isFOVTransitioning;
 
         [field: SerializeField] internal Vector3 previewPositionInScene { get; private set; }
-        [field: SerializeField] internal Transform avatarParent { get; private set; }
-        [field: SerializeField] internal Camera camera { get; private set; }
-        [field: SerializeField] internal Transform cameraTarget { get; private set; }
-        [field: SerializeField] internal Transform rotationTarget { get; private set; }
-        [field: SerializeField] internal CinemachineFreeLook freeLookCamera { get; private set; }
-        [field: SerializeField] internal GameObject previewPlatform { get; private set; }
-        [field: SerializeField] internal AvatarPreviewHeadIKSettings headIKSettings { get; private set; }
+        [field: SerializeField] internal Transform avatarParent { get; private set; } = null!;
+        [field: SerializeField] internal new Camera camera { get; private set; } = null!;
+        [field: SerializeField] internal Transform cameraTarget { get; private set; } = null!;
+        [field: SerializeField] internal Transform rotationTarget { get; private set; } = null!;
+        [field: SerializeField] internal CinemachineFreeLook freeLookCamera { get; private set; } = null!;
+        [field: SerializeField] internal GameObject previewPlatform { get; private set; } = null!;
+        [field: SerializeField] internal AvatarPreviewHeadIKSettings headIKSettings { get; private set; } = null!;
 
         internal float TargetFOV { get; set; }
         internal float RotationModifier { get; set; }

--- a/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
+++ b/Explorer/Assets/DCL/CommunicationData/URLHelpers/URN.cs
@@ -17,9 +17,12 @@ namespace CommunicationData.URLHelpers
 
         public URN(string urn)
         {
+            // A null/empty urn produces the same field state as default(URN), which IsNullOrEmpty and
+            // IsValid already treat as a first-class value; ToLower() on it crashed emote loading when
+            // a DTO carried no id.
             originalUrn = urn;
-            lowercaseUrn = originalUrn.ToLower();
-            hash = originalUrn != null ? lowercaseUrn.GetHashCode() : 0;
+            lowercaseUrn = string.IsNullOrEmpty(urn) ? urn : urn.ToLower();
+            hash = string.IsNullOrEmpty(urn) ? 0 : lowercaseUrn.GetHashCode();
         }
 
         private URN(URN urn, int shortenIndex)

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementCreationCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementCreationCardView.cs
@@ -1,5 +1,6 @@
 ﻿using DCL.Audio;
 using DCL.Chat;
+using DCL.Clipboard;
 using DCL.Emoji;
 using DCL.Profiles;
 using DCL.UI.CustomInputField;
@@ -40,6 +41,7 @@ namespace DCL.Communities.CommunitiesCard.Announcements
 
         private string currentProfileThumbnailUrl = null!;
         private AnnouncementEmojiController? announcementEmojiController;
+        private ClipboardManager? subscribedClipboardManager;
 
         private void Awake()
         {
@@ -50,17 +52,23 @@ namespace DCL.Communities.CommunitiesCard.Announcements
             announcementInput.onValueChanged.AddListener(OnAnnouncementInputValueChanged);
             announcementInput.PasteShortcutPerformed += OnAnnouncementInputPasteShortcut;
             createAnnouncementButton.onClick.AddListener(OnCreateAnnouncementButton);
-            ViewDependencies.ClipboardManager.OnPaste += OnPasteClipboardText;
+            subscribedClipboardManager = ViewDependencies.ClipboardManager;
+            subscribedClipboardManager.OnPaste += OnPasteClipboardText;
         }
 
         private void OnDestroy()
         {
-            announcementInput.onSelect.RemoveListener(OnAnnouncementInputSelected);
-            announcementInput.onDeselect.RemoveListener(OnAnnouncementInputDeselected);
-            announcementInput.onValueChanged.RemoveListener(OnAnnouncementInputValueChanged);
-            announcementInput.PasteShortcutPerformed -= OnAnnouncementInputPasteShortcut;
-            createAnnouncementButton.onClick.RemoveListener(OnCreateAnnouncementButton);
-            ViewDependencies.ClipboardManager.OnPaste -= OnPasteClipboardText;
+            if (announcementInput != null)
+            {
+                announcementInput.onSelect.RemoveListener(OnAnnouncementInputSelected);
+                announcementInput.onDeselect.RemoveListener(OnAnnouncementInputDeselected);
+                announcementInput.onValueChanged.RemoveListener(OnAnnouncementInputValueChanged);
+                announcementInput.PasteShortcutPerformed -= OnAnnouncementInputPasteShortcut;
+            }
+            if (createAnnouncementButton != null)
+                createAnnouncementButton.onClick.RemoveListener(OnCreateAnnouncementButton);
+            if (subscribedClipboardManager != null)
+                subscribedClipboardManager.OnPaste -= OnPasteClipboardText;
 
             announcementEmojiController?.Dispose();
         }

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListItemView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Events/EventListItemView.cs
@@ -91,10 +91,6 @@ namespace DCL.Communities.CommunitiesCard.Events
         {
             //Disabled because of https://github.com/decentraland/unity-explorer/issues/5154
             interestedContainer.SetActive(false);
-            return;
-
-            eventInterestedUsersText.text = eventData!.Value.Event.total_attendees.ToString();
-            interestedContainer.SetActive(eventData!.Value.Event is { live: false, total_attendees: > 0 });
         }
 
         public void SubscribeToInteractions(Action<PlaceAndEventDTO> mainAction,

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/FriendPanelSectionControllerBase.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/FriendPanelSectionControllerBase.cs
@@ -19,6 +19,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections
         protected readonly U requestManager;
 
         private CancellationTokenSource friendListInitCts = new ();
+        private bool disposed;
 
         protected UniTaskCompletionSource? panelLifecycleTask { get; private set; }
 
@@ -40,6 +41,7 @@ namespace DCL.Friends.UI.FriendPanel.Sections
             view.Disable -= Disable;
             requestManager.Dispose();
             friendListInitCts.SafeCancelAndDispose();
+            disposed = true;
         }
 
         public async UniTask InitAsync(CancellationToken ct)
@@ -51,6 +53,9 @@ namespace DCL.Friends.UI.FriendPanel.Sections
             EnumResult<TaskError> result = await requestManager.InitAsync(ct).SuppressToResultAsync(ReportCategory.FRIENDS);
 
             if (!result.Success)
+                return;
+
+            if (ct.IsCancellationRequested)
                 return;
 
             view.SetLoadingState(false);
@@ -73,6 +78,9 @@ namespace DCL.Friends.UI.FriendPanel.Sections
 
         protected void CheckShouldInit()
         {
+            if (disposed)
+                return;
+
             if (!requestManager.WasInitialised)
                 InitAsync(friendListInitCts.Token).Forget();
         }

--- a/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/SectionLoadingView.cs
+++ b/Explorer/Assets/DCL/Friends/UI/FriendPanel/Sections/SectionLoadingView.cs
@@ -10,8 +10,11 @@ namespace DCL.Friends.UI.FriendPanel.Sections
         [field: SerializeField] public LoadingBrightView LoadingBright { get; private set; }
         [field: SerializeField] public float FadeDuration { get; private set; } = 0.3f;
 
+        private Tweener? fadeTween;
+
         public void Show()
         {
+            fadeTween?.Kill();
             CanvasGroup.alpha = 1;
             CanvasGroup.blocksRaycasts = true;
             LoadingBright.StartLoadingAnimation(null);
@@ -19,8 +22,16 @@ namespace DCL.Friends.UI.FriendPanel.Sections
 
         public void Hide()
         {
-            CanvasGroup.DOFade(0, FadeDuration).OnComplete(() => CanvasGroup.blocksRaycasts = false);
+            fadeTween?.Kill();
+            fadeTween = CanvasGroup.DOFade(0, FadeDuration).OnComplete(() => CanvasGroup.blocksRaycasts = false);
             LoadingBright.FinishLoadingAnimation(null);
+        }
+
+        private void OnDestroy()
+        {
+            // Without this the fade outlives panel teardown and DOTween keeps driving the destroyed CanvasGroup.
+            fadeTween?.Kill();
+            fadeTween = null;
         }
     }
 }

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/Systems/InWorldCameraPlugin.cs
@@ -56,6 +56,7 @@ namespace DCL.PluginSystem.Global
         private readonly InWorldCameraFactory factory;
         private readonly ICameraReelStorageService cameraReelStorageService;
         private readonly ICameraReelScreenshotsStorage cameraReelScreenshotsStorage;
+        private readonly CancellationTokenSource pluginCts = new ();
         private readonly IMVCManager mvcManager;
         private readonly ISystemClipboard systemClipboard;
         private readonly IDecentralandUrlsSource decentralandUrlsSource;
@@ -133,6 +134,8 @@ namespace DCL.PluginSystem.Global
 
         public void Dispose()
         {
+            web3IdentityCache.OnIdentityChanged -= FetchCameraReelStorage;
+            pluginCts.SafeCancelAndDispose();
             factory.Dispose();
             dclInput.InWorldCamera.ToggleInWorldCamera.performed -= OnShortcutToggleInWorldCameraPressed;
         }
@@ -212,7 +215,7 @@ namespace DCL.PluginSystem.Global
             if (web3IdentityCache.Identity == null)
                 return;
 
-            cameraReelStorageService.GetUserGalleryStorageInfoAsync(web3IdentityCache.Identity.Address, CancellationToken.None).Forget();
+            cameraReelStorageService.GetUserGalleryStorageInfoAsync(web3IdentityCache.Identity.Address, pluginCts.Token).Forget();
         }
 
         [Serializable]

--- a/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/UI/InWorldCameraController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/InWorldCamera/UI/InWorldCameraController.cs
@@ -159,7 +159,7 @@ namespace DCL.InWorldCamera.UI
         {
             if (toOpen)
             {
-                viewInstance!.ShortcutsInfoPanel.ShowAsync(CancellationToken.None).Forget();
+                viewInstance!.ShortcutsInfoPanel.ShowAsync(ctx.Token).Forget();
                 viewInstance.ShortcutsInfoPanel.Closed += OnShortcutsInfoPanelClosed;
                 viewInstance.ShortcutsInfoButton.OnSelect(null);
                 shortcutPanelIsOpen = true;
@@ -169,7 +169,7 @@ namespace DCL.InWorldCamera.UI
                 if (viewInstance != null)
                 {
                     viewInstance.ShortcutsInfoPanel.Closed -= OnShortcutsInfoPanelClosed;
-                    viewInstance.ShortcutsInfoPanel.HideAsync(CancellationToken.None).Forget();
+                    viewInstance.ShortcutsInfoPanel.HideAsync(ctx.Token).Forget();
                     viewInstance.ShortcutsInfoButton.OnDeselect(null);
                 }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Systems/CreateGltfAssetFromAssetBundleSystem.cs
@@ -57,10 +57,21 @@ namespace ECS.Unity.GLTFContainer.Asset.Systems
 
             AssetBundleData assetBundleData = assetBundleResult.Asset!;
 
-            if (Utils.TryCreateGltfObject(assetBundleData, assetIntention.Hash, out GltfContainerAsset result))
-                World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(result));
-            else
-                World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(GetReportData(), new ArgumentException($"Failed to load {assetIntention.Hash} from AB")));
+            // Instantiation can throw if the AB's underlying Unity asset was destroyed/unloaded
+            // (ref-counted bundle evicted) leaving a "fake-null" object that TryGetAsset still returns.
+            // Convert to a failed result instead of letting it escape Update as an EcsSystemException
+            // (UNITY-EXPLORER-P76 — top crash, 4911 evts/68 users). Mirrors the else-branch failure path.
+            try
+            {
+                if (Utils.TryCreateGltfObject(assetBundleData, assetIntention.Hash, out GltfContainerAsset result))
+                    World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(result));
+                else
+                    World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(GetReportData(), new ArgumentException($"Failed to load {assetIntention.Hash} from AB")));
+            }
+            catch (Exception e)
+            {
+                World.Add(entity, new StreamableLoadingResult<GltfContainerAsset>(GetReportData(), new ArgumentException($"Failed to instantiate {assetIntention.Hash} from AB", e)));
+            }
 
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/ConfigureGltfContainerColliders.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/ConfigureGltfContainerColliders.cs
@@ -93,7 +93,7 @@ namespace ECS.Unity.GLTFContainer.Systems
                     MeshCollider newCollider = go.AddComponent<MeshCollider>();
 
                     // TODO Jobify: can be invoked from a worker thread
-                    Physics.BakeMesh(mesh.GetInstanceID(), false);
+                    Physics.BakeMesh(mesh.GetEntityId(), false);
 
                     newCollider.sharedMesh = mesh;
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/NFTShapes/LoadNFTTypeSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/NFTShapes/LoadNFTTypeSystem.cs
@@ -38,7 +38,11 @@ namespace ECS.StreamableLoading.NFTShapes
             StreamableLoadingState state, IPartitionComponent partition, CancellationToken ct)
         {
             string imageUrl = await ImageUrlAsync(intention.CommonArguments, ct);
-            string convertUrl = ktxEnabled ? string.Format(urlsSource.Url(DecentralandUrl.MediaConverter), Uri.EscapeDataString(imageUrl)) : imageUrl;
+
+            // Same guard as GetTextureWebRequest: non-publicly-routable URLs must not reach the hosted converter.
+            string convertUrl = ktxEnabled && !DCL.WebRequests.WebRequestUtils.IsNonPubliclyRoutable(imageUrl)
+                ? string.Format(urlsSource.Url(DecentralandUrl.MediaConverter), Uri.EscapeDataString(imageUrl))
+                : imageUrl;
             var contentInfo = await WebContentInfo.FetchAsync(convertUrl, ct);
 
             if (!ktxEnabled && contentInfo is { Type: WebContentInfo.ContentType.Image, SizeInBytes: > MAX_PREVIEW_SIZE })

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DebugSettings/DebugSettings.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DebugSettings/DebugSettings.cs
@@ -43,7 +43,7 @@ namespace Global.Dynamic.DebugSettings
         private string customGatekeeperUrl = string.Empty;
         [Space]
         [SerializeField]
-        private string[] appParameters;
+        private string[] appParameters = System.Array.Empty<string>();
 
         public static DebugSettings Release() =>
             new ()

--- a/Explorer/Assets/DCL/Infrastructure/Global/Versioning/DCLVersion.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Versioning/DCLVersion.cs
@@ -55,8 +55,9 @@ namespace Global.Versioning
 
                     return output.Trim();
                 }
-#endif
+#else
                 return null;
+#endif
             }
         }
     }

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/LoadSmartWearablePreviewSceneSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/LoadSmartWearablePreviewSceneSystem.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using Utility;
 
 namespace ECS.SceneLifeCycle.Systems
 {
@@ -31,10 +32,17 @@ namespace ECS.SceneLifeCycle.Systems
         private readonly IWebRequestController webRequestController;
         private readonly IDecentralandUrlsSource urlsSource;
 
+        private readonly CancellationTokenSource systemCts = new ();
+
         public LoadSmartWearablePreviewSceneSystem(World world, IWebRequestController webRequestController, IDecentralandUrlsSource urlsSource) : base(world)
         {
             this.webRequestController = webRequestController;
             this.urlsSource = urlsSource;
+        }
+
+        protected override void OnDispose()
+        {
+            systemCts.SafeCancelAndDispose();
         }
 
         protected override void Update(float t)
@@ -49,7 +57,7 @@ namespace ECS.SceneLifeCycle.Systems
         {
             World.Add(entity, new SmartWearablePreviewScene { Value = Entity.Null });
 
-            TryLoadPreviewSceneAsync(entity, realm.Ipfs, CancellationToken.None).Forget();
+            TryLoadPreviewSceneAsync(entity, realm.Ipfs, systemCts.Token).Forget();
         }
 
         [Query]

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/IGetHash.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Scene/HibridScene/IGetHash.cs
@@ -36,7 +36,11 @@ namespace SceneRunner.Scene
                 }
             }
             catch (OperationCanceledException) { throw; }
-            catch (Exception) { }
+            catch (Exception e)
+            {
+                ReportHub.LogError(reportCategory, $"Hybrid scene fetch failed at {coordinate}: {e.GetType().Name}: {e.Message}");
+                return (false, "");
+            }
 
             ReportHub.LogError(reportCategory, $"Trying to load hybrid scene with coordinates {coordinate} failed. You wont get the asset bundles");
             return (false, "");
@@ -77,7 +81,11 @@ namespace SceneRunner.Scene
                 }
             }
             catch (OperationCanceledException) { throw; }
-            catch (Exception) { }
+            catch (Exception e)
+            {
+                ReportHub.LogError(reportCategory, $"Hybrid scene fetch failed at {coordinate}: {e.GetType().Name}: {e.Message}");
+                return (false, "");
+            }
 
             ReportHub.LogError(reportCategory, $"Trying to load hybrid scene with coordinates {coordinate} failed. You wont get the asset bundles");
             return (false, "");
@@ -97,10 +105,11 @@ namespace SceneRunner.Scene
                 return (true, getSceneDefinition[0].id!);
             }
             catch (OperationCanceledException) { throw; }
-            catch (Exception) { }
-
-            ReportHub.LogError(reportCategory, $"Trying to load hybrid scene with coordinates {coordinate} failed. You wont get the asset bundles");
-            return (false, "");
+            catch (Exception e)
+            {
+                ReportHub.LogError(reportCategory, $"Hybrid scene fetch failed at {coordinate}: {e.GetType().Name}: {e.Message}");
+                return (false, "");
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/SceneFactory.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/SceneFactory.cs
@@ -198,6 +198,10 @@ namespace SceneRunner
             var engineAPIMutexOwner = new MultiThreadSync.Owner(nameof(EngineAPIImplementation));
             var ethereumApiImpl = new RestrictedEthereumApi(ethereumApi, permissionsProvider);
 
+            // ENABLE_SDK_OBSERVABLES is a deliberate compile-time toggle; the else branch is kept intact
+            // so the SDK-observables feature can be disabled by flipping the constant. Suppress the
+            // unreachable-code warning for the currently-disabled branch without removing it.
+#pragma warning disable CS0162
             if (ENABLE_SDK_OBSERVABLES)
             {
                 var sdkCommsControllerAPI = new SDKMessageBusCommsAPIImplementation(sceneData, messagePipesHub, sceneRuntime);
@@ -262,6 +266,7 @@ namespace SceneRunner
                     deps.RuntimeMetrics
                 );
             }
+#pragma warning restore CS0162
 
             try
             {

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/WebSocket/WebSocketApiWrapper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/WebSocket/WebSocketApiWrapper.cs
@@ -49,7 +49,11 @@ namespace SceneRuntime.Apis.Modules
                 if (!isLocalSceneDevelopment && !url.ToLower().StartsWith("wss://"))
                     throw new Exception("Can't start an unsafe ws connection, please upgrade to wss. url=" + url);
 
-                return api.ConnectAsync(websocketId, url, disposeCts.Token).ReportAndRethrowException(exceptionsHandler).ToDisconnectedPromise(this);
+                // A failed connection to a scene-supplied endpoint is a scene-content problem, not an
+                // explorer defect, so it must NOT be reported to Sentry as an error (it spammed
+                // UNITY-EXPLORER-P4K with thousands of events). ToDisconnectedPromise still rejects the
+                // scene's JS connect() promise, matching how SimpleFetchApiWrapper.Fetch surfaces failures.
+                return api.ConnectAsync(websocketId, url, disposeCts.Token).ToDisconnectedPromise(this);
             }
             catch (Exception e)
             {

--- a/Explorer/Assets/DCL/Landscape/Systems/CollideTerrainSystem.cs
+++ b/Explorer/Assets/DCL/Landscape/Systems/CollideTerrainSystem.cs
@@ -141,7 +141,7 @@ namespace DCL.Landscape.Systems
                 NativeArrayOptions.UninitializedMemory);
 
             for (int i = 0; i < dirtyParcels.Count; i++)
-                meshes[i] = dirtyParcels[i].Mesh.GetInstanceID();
+                meshes[i] = dirtyParcels[i].Mesh.GetEntityId();
 
             var bakeColliderMeshesJob = new BakeColliderMeshes() { Meshes = meshes };
             bakeColliderMeshesJob.Schedule(meshes.Length, 1).Complete();

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Categories/CategoryControllers/CategoryMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Categories/CategoryControllers/CategoryMarkersController.cs
@@ -108,10 +108,7 @@ namespace DCL.MapRenderer.MapLayers.Categories
             }
         }
 
-        public async UniTask InitializeAsync(CancellationToken cancellationToken)
-        {
-
-        }
+        public UniTask InitializeAsync(CancellationToken cancellationToken) => UniTask.CompletedTask;
 
         private void ShowPlaces(IReadOnlyList<PlacesData.PlaceInfo> places, CategoriesEnum mapLayer)
         {
@@ -181,7 +178,7 @@ namespace DCL.MapRenderer.MapLayers.Categories
             return UniTask.CompletedTask;
         }
 
-        public async UniTask EnableAsync(CancellationToken cancellationToken)
+        public UniTask EnableAsync(CancellationToken cancellationToken)
         {
             foreach (ICategoryMarker marker in markers.Values)
                 mapCullingController.StartTracking(marker, this);
@@ -193,6 +190,7 @@ namespace DCL.MapRenderer.MapLayers.Categories
             }
 
             isEnabled = true;
+            return UniTask.CompletedTask;
         }
 
         public void ResetToBaseScale()

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/HomeMarker/HomeMarkerController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/HomeMarker/HomeMarkerController.cs
@@ -183,7 +183,7 @@ namespace DCL.MapRenderer.MapLayers.HomeMarker
 		{
 			mapMarker = null;
 
-			if (gameObject.GetInstanceID() != homeMarker.MarkerObject.gameObject.GetInstanceID())
+			if (gameObject.GetEntityId() != homeMarker.MarkerObject.gameObject.GetEntityId())
 				return false;
 
 			mapMarker = homeMarker;
@@ -194,7 +194,7 @@ namespace DCL.MapRenderer.MapLayers.HomeMarker
 
 		public bool TryDeHighlightObject(GameObject gameObject)
 		{
-			if (gameObject.GetInstanceID() != homeMarker.MarkerObject.gameObject.GetInstanceID())
+			if (gameObject.GetEntityId() != homeMarker.MarkerObject.gameObject.GetEntityId())
 				return false;
 
 			deHighlightCt = deHighlightCt.SafeRestart();
@@ -206,7 +206,7 @@ namespace DCL.MapRenderer.MapLayers.HomeMarker
 		{
 			mapRenderMarker = null;
 
-			if (gameObject.GetInstanceID() != homeMarker.MarkerObject.gameObject.GetInstanceID())
+			if (gameObject.GetEntityId() != homeMarker.MarkerObject.gameObject.GetEntityId())
 				return false;
 
 			DisplayPlacesInfoPanelAsync(CurrentCoordinates).Forget();

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents/LiveEventsMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/LiveEvents/LiveEventsMarkersController.cs
@@ -68,9 +68,7 @@ namespace DCL.MapRenderer.MapLayers.Categories
             this.navmapBus = navmapBus;
         }
 
-        public async UniTask InitializeAsync(CancellationToken cancellationToken)
-        {
-        }
+        public UniTask InitializeAsync(CancellationToken cancellationToken) => UniTask.CompletedTask;
 
         public void ApplyCameraZoom(float baseZoom, float zoom, int zoomLevel)
         {

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/PointsOfInterest/ScenesOfInterestMarkersController.cs
@@ -72,7 +72,7 @@ namespace DCL.MapRenderer.MapLayers.PointsOfInterest
             this.navmapBus = navmapBus;
         }
 
-        public async UniTask InitializeAsync(CancellationToken cancellationToken) { }
+        public UniTask InitializeAsync(CancellationToken cancellationToken) => UniTask.CompletedTask;
 
         protected override void DisposeImpl()
         {

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/SearchResults/SearchResultMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/SearchResults/SearchResultMarkersController.cs
@@ -79,7 +79,7 @@ namespace DCL.MapRenderer.MapLayers.SearchResults
             ReleaseMarkers();
         }
 
-        public async UniTask InitializeAsync(CancellationToken cancellationToken) { }
+        public UniTask InitializeAsync(CancellationToken cancellationToken) => UniTask.CompletedTask;
 
         private void OnPlaceSearched(INavmapBus.SearchPlaceParams searchParams,
             IReadOnlyList<PlacesData.PlaceInfo> places, int totalResultCount)
@@ -148,7 +148,7 @@ namespace DCL.MapRenderer.MapLayers.SearchResults
             return UniTask.CompletedTask;
         }
 
-        public async UniTask EnableAsync(CancellationToken cancellationToken)
+        public UniTask EnableAsync(CancellationToken cancellationToken)
         {
             foreach (ISearchResultMarker marker in markers.Values)
                 mapCullingController.StartTracking(marker, this);
@@ -160,6 +160,7 @@ namespace DCL.MapRenderer.MapLayers.SearchResults
             }
 
             isEnabled = true;
+            return UniTask.CompletedTask;
         }
 
         public void ResetToBaseScale()

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/WebSocketArchipelagoLiveConnection.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/LiveConnections/WebSocketArchipelagoLiveConnection.cs
@@ -20,6 +20,14 @@ namespace DCL.Multiplayer.Connections.Archipelago.LiveConnections
     {
         private const int BUFFER_SIZE = 1024 * 1024; //1MB
 
+        /// <summary>
+        ///     Budget for the graceful close handshake before hard-dropping the socket. The server ack
+        ///     is only worth waiting for briefly: the receive loop that would read it is already
+        ///     cancelled when a room stops, so an unbounded CloseAsync hung the teleport pipeline
+        ///     into its 10s timeout.
+        /// </summary>
+        private static readonly TimeSpan CLOSE_HANDSHAKE_BUDGET = TimeSpan.FromSeconds(1);
+
         private readonly IMemoryPool memoryPool;
 
         private Current? current;
@@ -48,8 +56,22 @@ namespace DCL.Multiplayer.Connections.Archipelago.LiveConnections
         {
             try
             {
-                TryUpdateWebSocket();
-                await current!.Value.WebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, token);
+                if (current?.WebSocket.State is WebSocketState.Open or WebSocketState.Connecting)
+                {
+                    using var closeCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+                    closeCts.CancelAfter(CLOSE_HANDSHAKE_BUDGET);
+
+                    try { await current!.Value.WebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, closeCts.Token); }
+                    catch (OperationCanceledException) when (token.IsCancellationRequested) { throw; }
+                    catch (Exception)
+                    {
+                        // The handshake exceeded its budget or the socket errored out; hard-drop below.
+                    }
+                }
+
+                // Install a fresh socket so a subsequent ConnectAsync can never race the old instance.
+                current?.Dispose();
+                current = Current.New();
                 return Result.SuccessResult();
             }
             catch (Exception e) { return Result.ErrorResult($"Cannot disconnect: {e}"); }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ArchipelagoIslandRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ArchipelagoIslandRoom.cs
@@ -56,6 +56,20 @@ namespace DCL.Multiplayer.Connections.Archipelago.Rooms
             this.currentAdapterAddress = currentAdapterAddress;
         }
 
+        public override async UniTask StopAsync()
+        {
+            await base.StopAsync();
+
+            // Close the sign-flow ws on stop. Otherwise the next StartAsync reuses the
+            // still-open socket (EnsureConnectionAsync sees IsConnected and skips the
+            // handshake), the server keeps the old peer+island, never re-sends
+            // IslandChanged — and the restarted room waits for a connection string that
+            // never arrives (observed as 3x10s RestartRoom timeouts on every
+            // world->genesis realm change).
+            try { await signFlow.DisconnectAsync(CancellationToken.None); }
+            catch (Exception e) { ReportHub.LogWarning(ReportCategory.COMMS_SCENE_HANDLER, $"ArchipelagoIslandRoom stop: disconnect failed: {e.Message}"); }
+        }
+
         protected override async UniTask PrewarmAsync(CancellationToken token)
         {
             // Reset the per-session state: the room instance is reused across StopAsync/StartAsync (teleport, logout)

--- a/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/IGateKeeperSceneRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/GateKeeper/Rooms/IGateKeeperSceneRoom.cs
@@ -35,9 +35,9 @@ namespace DCL.Multiplayer.Connections.GateKeeper.Rooms
 
         class Fake : Null, IGateKeeperSceneRoom
         {
-            public event Action? CurrentSceneRoomConnected;
-            public event Action? CurrentSceneRoomDisconnected;
-            public event Action? CurrentSceneRoomForbiddenAccess;
+            public event Action? CurrentSceneRoomConnected { add { } remove { } }
+            public event Action? CurrentSceneRoomDisconnected { add { } remove { } }
+            public event Action? CurrentSceneRoomForbiddenAccess { add { } remove { } }
             public MetaData? ConnectedScene { get; } = new MetaData("Fake", Vector2Int.zero, new MetaData.Input());
 
             public bool Activated => true;

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/NullRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/NullRoom.cs
@@ -34,21 +34,21 @@ namespace DCL.Multiplayer.Connections.Rooms
         public IAudioStreams AudioStreams => NullAudioStreams.INSTANCE;
         public ILocalTracks LocalTracks => NullLocalTracks.INSTANCE;
 
-        public event LocalPublishDelegate? LocalTrackPublished;
-        public event LocalPublishDelegate? LocalTrackUnpublished;
-        public event PublishDelegate? TrackPublished;
-        public event PublishDelegate? TrackUnpublished;
-        public event SubscribeDelegate? TrackSubscribed;
-        public event SubscribeDelegate? TrackUnsubscribed;
-        public event MuteDelegate? TrackMuted;
-        public event MuteDelegate? TrackUnmuted;
+        public event LocalPublishDelegate? LocalTrackPublished { add { } remove { } }
+        public event LocalPublishDelegate? LocalTrackUnpublished { add { } remove { } }
+        public event PublishDelegate? TrackPublished { add { } remove { } }
+        public event PublishDelegate? TrackUnpublished { add { } remove { } }
+        public event SubscribeDelegate? TrackSubscribed { add { } remove { } }
+        public event SubscribeDelegate? TrackUnsubscribed { add { } remove { } }
+        public event MuteDelegate? TrackMuted { add { } remove { } }
+        public event MuteDelegate? TrackUnmuted { add { } remove { } }
 #endif
 
-        public event ConnectionQualityChangeDelegate? ConnectionQualityChanged;
-        public event ConnectionStateChangeDelegate? ConnectionStateChanged;
-        public event ConnectionDelegate? ConnectionUpdated;
-        public event Room.MetaDelegate? RoomMetadataChanged;
-        public event Room.SidDelegate? RoomSidChanged;
+        public event ConnectionQualityChangeDelegate? ConnectionQualityChanged { add { } remove { } }
+        public event ConnectionStateChangeDelegate? ConnectionStateChanged { add { } remove { } }
+        public event ConnectionDelegate? ConnectionUpdated { add { } remove { } }
+        public event Room.MetaDelegate? RoomMetadataChanged { add { } remove { } }
+        public event Room.SidDelegate? RoomSidChanged { add { } remove { } }
 
         public void UpdateLocalMetadata(string metadata)
         {

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullActiveSpeakers.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullActiveSpeakers.cs
@@ -11,7 +11,7 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
 
         public int Count => 0;
 
-        public event Action? Updated;
+        public event Action? Updated { add { } remove { } }
 
         public IEnumerator<string> GetEnumerator()
         {

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullDataPipe.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullDataPipe.cs
@@ -10,7 +10,7 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
     {
         public static readonly NullDataPipe INSTANCE = new ();
 
-        public event ReceivedDataDelegate? DataReceived;
+        public event ReceivedDataDelegate? DataReceived { add { } remove { } }
 
         public void PublishData(Span<byte> data, string topic, IReadOnlyCollection<string> destinationSids, LKDataPacketKind kind = LKDataPacketKind.KindLossy)
         {

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullParticipantsHub.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Rooms/Nulls/NullParticipantsHub.cs
@@ -12,7 +12,7 @@ namespace DCL.Multiplayer.Connections.Rooms.Nulls
         public static readonly LKParticipant NULL_PARTICIPANT = new ();
         public static readonly WeakReference<LKParticipant> WEAK_NULL_PARTICIPANT = new (NULL_PARTICIPANT);
 
-        public event ParticipantDelegate? UpdatesFromParticipant;
+        public event ParticipantDelegate? UpdatesFromParticipant { add { } remove { } }
 
         public LKParticipant LocalParticipant() =>
             NULL_PARTICIPANT;

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Systems/RoomIndicator.prefab
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Systems/RoomIndicator.prefab
@@ -9,7 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6615945845340605545}
-  - component: {fileID: 6145739770501069584}
   m_Layer: 5
   m_Name: RoomIndicator
   m_TagString: Untagged
@@ -39,33 +38,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0.45, y: 0.3}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &6145739770501069584
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2074114889938352466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d7d34f10598c4f638b94710f3b0ff918, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  colors:
-  - source: 0
-    indicator: N/A
-    color: {r: 0.41509432, g: 0.41509432, b: 0.41509432, a: 1}
-  - source: 1
-    indicator: G
-    color: {r: 0.07143695, g: 0.26501098, b: 0.5283019, a: 1}
-  - source: 2
-    indicator: I
-    color: {r: 0.07058824, g: 0.5294118, b: 0.22292237, a: 1}
-  - source: 3
-    indicator: I+G
-    color: {r: 0.55345905, g: 0.06787699, b: 0.48883247, a: 1}
-  background: {fileID: 2968721729092005038}
-  text: {fileID: 1326886004246566054}
 --- !u!1 &2433736487283086053
 GameObject:
   m_ObjectHideFlags: 0
@@ -123,6 +95,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -144,9 +118,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 10
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &1326886004246566054
 MonoBehaviour:
@@ -206,6 +182,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -280,6 +257,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!212 &544308281080233652
 SpriteRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -298,6 +276,8 @@ SpriteRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -319,9 +299,11 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
+  m_MaskInteraction: 0
   m_Sprite: {fileID: 21300000, guid: 37894a231569347e8b89612f29611b85, type: 3}
   m_Color: {r: 0.13836467, g: 0.13836467, b: 0.13836467, a: 1}
   m_FlipX: 0
@@ -331,7 +313,6 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!1 &3907013848479446928
 GameObject:
@@ -371,6 +352,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!212 &2968721729092005038
 SpriteRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -389,6 +371,8 @@ SpriteRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -410,9 +394,11 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_Sprite: {fileID: 21300000, guid: 12dd1efc4e826764f9b02be515a9a033, type: 3}
   m_Color: {r: 0.5529412, g: 0.06666667, b: 0.49019608, a: 1}
   m_FlipX: 0
@@ -422,5 +408,4 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
   m_SpriteSortPoint: 0

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/UIBindings/ElementBinding.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/UIBindings/ElementBinding.cs
@@ -8,7 +8,7 @@ namespace DCL.DebugUtilities.UIBindings
     /// </summary>
     public class ElementBinding<T> : IElementBinding<T>
     {
-        private T tempValue;
+        private T tempValue = default!;
 
         private bool tempValueIsDirty;
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugElementBase.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/DebugUtilities/Views/DebugElementBase.cs
@@ -5,7 +5,7 @@ namespace DCL.DebugUtilities.Views
 {
     public abstract class DebugElementBase<TElement, TDef> : VisualElement where TElement: DebugElementBase<TElement, TDef> where TDef: IDebugElementDef
     {
-        protected TDef definition { get; private set; }
+        protected TDef definition { get; private set; } = default!;
 
         public void Initialize(TDef definition)
         {

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChatPlugin.cs
@@ -193,6 +193,9 @@ namespace DCL.PluginSystem.Global
 
         public void Dispose()
         {
+            web3IdentityCache.OnIdentityCleared -= OnIdentityCleared;
+            web3IdentityCache.OnIdentityChanged -= OnIdentityChanged;
+
             if (messageReactionService != null && chatStorage != null)
                 messageReactionService.ReactionPersistenceRequested -= chatStorage.OnReactionPersistenceRequested;
 
@@ -448,7 +451,7 @@ namespace DCL.PluginSystem.Global
             commandRegistry?.ResetChat.Execute();
 
             if (chatSharedAreaController is { IsVisible: true })
-                chatSharedAreaController.HideViewAsync(CancellationToken.None).Forget();
+                chatSharedAreaController.HideViewAsync(pluginCts.Token).Forget();
         }
 
         private void OnIdentityChanged()

--- a/Explorer/Assets/DCL/PluginSystem/Global/FriendsContainer.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/FriendsContainer.cs
@@ -238,11 +238,15 @@ namespace DCL.PluginSystem.Global
 
             async UniTaskVoid PrewarmAsync(CancellationToken ct)
             {
-                await friendsPanelController.InitAsync(ct);
-                await PreWarmFriendsCacheAsync(ct);
+                try
+                {
+                    await friendsPanelController.InitAsync(ct);
+                    await PreWarmFriendsCacheAsync(ct);
 
-                // TODO should not unsubscribe as the user can re-login with another account, and thus, pre-warming will be skipped
-                loadingStatus.CurrentStage.Unsubscribe(PreWarmFriends);
+                    // TODO should not unsubscribe as the user can re-login with another account, and thus, pre-warming will be skipped
+                    loadingStatus.CurrentStage.Unsubscribe(PreWarmFriends);
+                }
+                catch (OperationCanceledException) { }
             }
         }
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/InputPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/InputPlugin.cs
@@ -93,6 +93,7 @@ namespace DCL.PluginSystem.Global
 
         public void Dispose()
         {
+            DCLInput.Instance.Disable();
             DCLInput.Reset();
         }
     }

--- a/Explorer/Assets/DCL/PluginSystem/World/AudioAnalysisPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AudioAnalysisPlugin.cs
@@ -41,9 +41,7 @@ namespace DCL.PluginSystem.World
         {
         }
 
-        public async UniTask InitializeAsync(CancellationToken ct)
-        {
-        }
+        public UniTask InitializeAsync(CancellationToken ct) => UniTask.CompletedTask;
     }
 }
 

--- a/Explorer/Assets/DCL/PluginSystem/World/LightSourcePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/LightSourcePlugin.cs
@@ -80,11 +80,12 @@ namespace DCL.PluginSystem.World
             await CreateLightSourcePoolAsync(lightSourcePrefab, ct);
         }
 
-        private async UniTask CreateLightSourcePoolAsync(Light lightSourcePrefab, CancellationToken ct)
+        private UniTask CreateLightSourcePoolAsync(Light lightSourcePrefab, CancellationToken ct)
         {
             lightPoolRegistry = poolsRegistry.AddGameObjectPool(() => Object.Instantiate(lightSourcePrefab, Vector3.zero, quaternion.identity), onRelease: OnPoolRelease, onGet: OnPoolGet);
 
             cacheCleaner.Register(lightPoolRegistry);
+            return UniTask.CompletedTask;
         }
 
         private void OnPoolRelease(Light light)

--- a/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.CompactInfo.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.CompactInfo.cs
@@ -284,7 +284,9 @@ namespace DCL.Profiles
                 PicturePromise?.LoadingIntention.CancellationTokenSource.Cancel();
                 PicturePromise = null;
 
+                // Nulling the reference keeps Dispose idempotent for any caller that reaches it twice.
                 ProfilePicture.TryDereference();
+                ProfilePicture = null;
             }
         }
     }

--- a/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/Profile.cs
@@ -83,7 +83,8 @@ namespace DCL.Profiles
 
         public void Dispose()
         {
-            GetCompact().Dispose();
+            // POOL's actionOnRelease runs Clear(), which already disposes the compact info -
+            // disposing it here too made every pooled release a double-dispose.
             POOL.Release(this);
         }
 

--- a/Explorer/Assets/DCL/RealmNavigation/LoadingOperation/SequentialLoadingOperation.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/LoadingOperation/SequentialLoadingOperation.cs
@@ -55,13 +55,25 @@ namespace DCL.RealmNavigation.LoadingOperation
 
                         if (!lastOpResult.Success)
                         {
-                            ReportHub.LogError(
-                                reportData,
-                                $"Operation failed on {processName} attempt {attempt + 1}/{attemptsCount}: {lastOpResult.AsResult().ErrorMessage}"
-                            );
+                            // Do not log cancellation as an error (CLAUDE.md §9): on shutdown the inner op
+                            // converts its OperationCanceledException into a TaskError.Cancelled result.
+                            if (!ct.IsCancellationRequested && lastOpResult.Error?.State != TaskError.Cancelled)
+                                ReportHub.LogError(
+                                    reportData,
+                                    $"Operation failed on {processName} attempt {attempt + 1}/{attemptsCount}: {lastOpResult.AsResult().ErrorMessage}"
+                                );
 
                             break;
                         }
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        // Cancellation of the outer flow is not an error: convert to a cancelled result
+                        // (the check below exits the attempt loop). An OperationCanceledException from an
+                        // operation's internal token is NOT ours to absorb - it propagates as before, so
+                        // the attempt loop cannot re-run the whole chain on an inner timeout.
+                        lastOpResult = EnumResult<TaskError>.CancelledResult(TaskError.Cancelled);
+                        break;
                     }
                     catch (Exception e)
                     {

--- a/Explorer/Assets/DCL/Roads/Data/Editor/RoadAssetGenerator.cs
+++ b/Explorer/Assets/DCL/Roads/Data/Editor/RoadAssetGenerator.cs
@@ -56,7 +56,7 @@ namespace DCL.LOD.Data.Editor
 
                     if (child.name.Contains("_collider")) {
                         MeshFilter meshFilter = child.GetComponent<MeshFilter>();
-                        Physics.BakeMesh(meshFilter.sharedMesh.GetInstanceID(), false);
+                        Physics.BakeMesh(meshFilter.sharedMesh.GetEntityId(), false);
                         meshFilter.gameObject.AddComponent<MeshCollider>();
 
                         if (meshFilter != null)

--- a/Explorer/Assets/DCL/SDKComponents/AudioAnalysis/AudioAnalysisSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioAnalysis/AudioAnalysisSystem.cs
@@ -88,6 +88,10 @@ namespace DCL.SDKComponents.AudioSources
                 {
                     PBAudioAnalysisMode.ModeRaw => AnalysisResultMode.Raw,
                     PBAudioAnalysisMode.ModeLogarithmic => AnalysisResultMode.Logarithmic,
+
+                    // proto3 open enum: scene wire data can carry any out-of-range value; fall back
+                    // to the default mode instead of throwing every frame.
+                    _ => AnalysisResultMode.Raw,
                 };
                 float amplitudeGain = sdkComponent.HasAmplitudeGain ? sdkComponent.AmplitudeGain : DEFAULT_AMPLITUDE_GAIN; 
                 float bandsGain = sdkComponent.HasBandsGain ? sdkComponent.BandsGain : DEFAULT_BANDS_GAIN; 

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/AnyTexture.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/AnyTexture.cs
@@ -1,5 +1,6 @@
 ﻿using REnum;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 using Utility;
 
 namespace ECS.StreamableLoading.Textures
@@ -12,7 +13,23 @@ namespace ECS.StreamableLoading.Textures
     [REnumField(typeof(Texture2D))]
     public partial struct AnyTexture
     {
-        public long ByteSize => Match(static _ => 0L, tex2d => tex2d.GetRawTextureData<byte>().Length);
+        public long ByteSize => Match(static _ => 0L, static tex2d => EstimateTextureByteSize(tex2d));
+
+        private static long EstimateTextureByteSize(Texture2D tex2d)
+        {
+            // Destroyed textures (Unity fake-null) account as zero instead of throwing.
+            if (tex2d == null) return 0L;
+            if (tex2d.isReadable) return tex2d.GetRawTextureData<byte>().Length;
+
+            // Non-readable textures have no CPU copy to measure (GetRawTextureData throws);
+            // estimate the GPU footprint across the full mip chain instead.
+            var size = (long)GraphicsFormatUtility.ComputeMipmapSize(tex2d.width, tex2d.height, tex2d.graphicsFormat);
+
+            for (var mip = 1; mip < tex2d.mipmapCount; mip++)
+                size += (long)GraphicsFormatUtility.ComputeMipmapSize(Mathf.Max(1, tex2d.width >> mip), Mathf.Max(1, tex2d.height >> mip), tex2d.graphicsFormat);
+
+            return size;
+        }
 
         public Texture Texture => Match<Texture>(static video => video.Texture, static tex2d => tex2d);
 

--- a/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/LoadingScreen/LoadingScreen.cs
@@ -102,10 +102,12 @@ namespace DCL.SceneLoadingScreens.LoadingScreen
                                                      SceneLoadingScreenController.IssueCommand(new SceneLoadingScreenController.Params(loadReport)), ct)
                                                 .SuppressToResultAsync(ReportCategory.SCENE_LOADING);
 
-                if (loadReport.GetStatus().TaskStatus == UniTaskStatus.Pending)
+                // Both logs below are pure cancellation artifacts on ExitPlayMode (the outer ct cancels ShowAsync,
+                // leaving loadReport Pending and result as TaskError.Cancelled). Only log when not cancelled (CLAUDE.md §9).
+                if (!ct.IsCancellationRequested && loadReport.GetStatus().TaskStatus == UniTaskStatus.Pending)
                     ReportHub.LogError(ReportCategory.SCENE_LOADING, "Loading screen finished unexpectedly, but the loading process continues");
 
-                if (finalResult.HasValue && !result.Success)
+                if (!ct.IsCancellationRequested && finalResult.HasValue && !result.Success)
                     ReportHub.LogError(ReportCategory.SCENE_LOADING, $"Loading screen finished with an error after the flow has finished: {result.Error.AsMessage()}");
 
                 return result;

--- a/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenView.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenView.cs
@@ -72,11 +72,13 @@ namespace DCL.SceneLoadingScreens
 
         public void ClearTips()
         {
+            // Application/view teardown can destroy the tip objects (children of this view) before
+            // ClearTips runs; skip the already-destroyed entries.
             foreach (TipView tip in tips)
-                Destroy(tip.gameObject);
+                if (tip != null) Destroy(tip.gameObject);
 
             foreach (TipBreadcrumb? breadcrumb in tipsBreadcrumbs)
-                Destroy(breadcrumb.gameObject);
+                if (breadcrumb != null) Destroy(breadcrumb.gameObject);
 
             tips.Clear();
             tipsBreadcrumbs.Clear();

--- a/Explorer/Assets/DCL/SceneLoadingScreens/UnityLocalizationSceneTipsProvider.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/UnityLocalizationSceneTipsProvider.cs
@@ -46,7 +46,7 @@ namespace DCL.SceneLoadingScreens
             fallbackTips = Get(tipsTable, imagesTable, ct);
         }
 
-        public async UniTask<SceneTips> GetAsync(CancellationToken ct) =>
+        public UniTask<SceneTips> GetAsync(CancellationToken ct) =>
 
             // TODO: we will need specific scene tips in the future, but its disabled at the moment
             /*StringTable tipsTable = await tipsDatabase.GetTableAsync($"LoadingSceneTips-{parcelCoord.x},{parcelCoord.y}").Task
@@ -60,7 +60,7 @@ namespace DCL.SceneLoadingScreens
             ct.ThrowIfCancellationRequested();
 
             return await Get(tipsTable, imagesTable, ct);*/
-            fallbackTips;
+            UniTask.FromResult(fallbackTips);
 
         private SceneTips Get(StringTable tipsTable, AssetTable? imagesTable, CancellationToken ct)
         {

--- a/Explorer/Assets/DCL/Settings/Configuration/SettingsModuleBindings.cs
+++ b/Explorer/Assets/DCL/Settings/Configuration/SettingsModuleBindings.cs
@@ -49,9 +49,9 @@ namespace DCL.Settings.Configuration
         where TConfig : SettingsModuleViewConfiguration
         where TControllerType : Enum
     {
-        [field: SerializeField] public ViewRef View { get; private set; }
-        [field: SerializeField] public TConfig Config { get; private set; }
-        [field: SerializeField] public TControllerType Feature { get; private set; }
+        [field: SerializeField] public ViewRef View { get; private set; } = null!;
+        [field: SerializeField] public TConfig Config { get; private set; } = null!;
+        [field: SerializeField] public TControllerType Feature { get; private set; } = default!;
 
         [Serializable]
         public class ViewRef : ComponentReference<TView>

--- a/Explorer/Assets/DCL/SkyBox/SkyboxRenderController.cs
+++ b/Explorer/Assets/DCL/SkyBox/SkyboxRenderController.cs
@@ -55,26 +55,26 @@ public class SkyboxRenderController : MonoBehaviour
     private LensFlareDataSRP? activeLensFlareData;
 
     [Header("Skybox Color")]
-    [GradientUsage(true)] [SerializeField] private Gradient skyZenitColorRamp;
-    [GradientUsage(true)] [SerializeField] private Gradient skyHorizonColorRamp;
-    [GradientUsage(true)] [SerializeField] private Gradient skyNadirColorRamp;
+    [GradientUsage(true)] [SerializeField] private Gradient skyZenitColorRamp = null!;
+    [GradientUsage(true)] [SerializeField] private Gradient skyHorizonColorRamp = null!;
+    [GradientUsage(true)] [SerializeField] private Gradient skyNadirColorRamp = null!;
 
     [InspectorName("Rim Light Color")]
-    [GradientUsage(true)] [SerializeField] private Gradient rimColorRamp;
+    [GradientUsage(true)] [SerializeField] private Gradient rimColorRamp = null!;
 
     [Header("Indirect Lighting")]
     [InspectorName("Enabled")] [SerializeField] private bool indirectLight = true;
-    [GradientUsage(true)] [SerializeField] private Gradient indirectSkyRamp;
-    [GradientUsage(true)] [SerializeField] private Gradient indirectEquatorRamp;
-    [GradientUsage(true)] [SerializeField] private Gradient groundEquatorRamp;
+    [GradientUsage(true)] [SerializeField] private Gradient indirectSkyRamp = null!;
+    [GradientUsage(true)] [SerializeField] private Gradient indirectEquatorRamp = null!;
+    [GradientUsage(true)] [SerializeField] private Gradient groundEquatorRamp = null!;
 
     [Header("Clouds")]
-    [GradientUsage(true)] [SerializeField] private Gradient cloudsColorRamp;
-    [SerializeField] private AnimationCurve cloudsHighlightsIntensity;
+    [GradientUsage(true)] [SerializeField] private Gradient cloudsColorRamp = null!;
+    [SerializeField] private AnimationCurve cloudsHighlightsIntensity = null!;
 
     [Header("Fog")]
     [InspectorName("Enabled")] [SerializeField] private bool fog = true;
-    [GradientUsage(true)] [SerializeField] private Gradient fogColorRamp;
+    [GradientUsage(true)] [SerializeField] private Gradient fogColorRamp = null!;
 
     private Material skyboxMaterial;
 

--- a/Explorer/Assets/DCL/SmartWearables/Systems/SmartWearableSystem.cs
+++ b/Explorer/Assets/DCL/SmartWearables/Systems/SmartWearableSystem.cs
@@ -57,6 +57,7 @@ namespace DCL.SmartWearables
         /// </summary>
         private readonly Dictionary<string, ScenePromise> pendingScenes = new ();
 
+        private readonly CancellationTokenSource systemCts = new ();
         private CancellationTokenSource outfitEquipCts = new ();
 
         private bool currentSceneDirty;
@@ -95,6 +96,21 @@ namespace DCL.SmartWearables
             web3IdentityCache.OnIdentityCleared += OnIdentityCleared;
         }
 
+        protected override void OnDispose()
+        {
+            backpackEventBus.EquipWearableEvent -= OnEquipWearable;
+            backpackEventBus.UnEquipWearableEvent -= OnUnEquipWearable;
+            backpackEventBus.EquipOutfitEvent -= OnEquipOutfit;
+            portableExperiencesController.PortableExperienceUnloaded -= OnPortableExperienceUnloaded;
+            loadingStatus.CurrentStage.OnUpdate -= OnLoadingStatusChanged;
+            scenesCache.CurrentScene.OnUpdate -= OnCurrentSceneChanged;
+            web3IdentityCache.OnIdentityCleared -= OnIdentityCleared;
+
+            systemCts.Cancel();
+            systemCts.Dispose();
+            outfitEquipCts.SafeCancelAndDispose();
+        }
+
         private void OnEquipWearable(IWearable wearable, bool isManuallyEquipped)
         {
             if (!isManuallyEquipped) return;
@@ -104,7 +120,7 @@ namespace DCL.SmartWearables
 
         private async UniTask TryRunSmartWearableSceneAsync(IWearable wearable)
         {
-            bool isSmart = await smartWearableCache.IsSmartAsync(wearable, CancellationToken.None);
+            bool isSmart = await smartWearableCache.IsSmartAsync(wearable, systemCts.Token);
             if (!isSmart || !smartWearableCache.CurrentSceneAllowsSmartWearables) return;
 
             string id = SmartWearableCache.GetCacheId(wearable);
@@ -322,7 +338,7 @@ namespace DCL.SmartWearables
             if (smartWearablesAllowed)
                 // Notice scenes that are already running won't run again, so we can call this safely
                 // TODO consider cancelling a previous running task
-                RunScenesForEquippedWearablesAsync(AuthorizationAction.SkipAuthorization, CancellationToken.None).Forget();
+                RunScenesForEquippedWearablesAsync(AuthorizationAction.SkipAuthorization, systemCts.Token).Forget();
             else
                 UnloadAllSmartWearableScenes();
         }
@@ -348,7 +364,7 @@ namespace DCL.SmartWearables
             loadingStatus.CurrentStage.OnUpdate -= OnLoadingStatusChanged;
             scenesCache.CurrentScene.OnUpdate += OnCurrentSceneChanged;
 
-            RunScenesForEquippedWearablesAsync(AuthorizationAction.RequestAuthorization, CancellationToken.None).Forget();
+            RunScenesForEquippedWearablesAsync(AuthorizationAction.RequestAuthorization, systemCts.Token).Forget();
         }
 
         private async UniTask RunScenesForEquippedWearablesAsync(AuthorizationAction authorization, CancellationToken ct)

--- a/Explorer/Assets/DCL/Social/WebSocketRpcTransport.cs
+++ b/Explorer/Assets/DCL/Social/WebSocketRpcTransport.cs
@@ -94,6 +94,7 @@ namespace DCL.SocialService
                         }
                     }
                     catch (OperationCanceledException) { break; }
+                    catch (ObjectDisposedException) { break; }
                     catch (WebSocketException e)
                     {
                         OnErrorEvent?.Invoke(e);
@@ -119,6 +120,12 @@ namespace DCL.SocialService
             {
                 OnErrorEvent?.Invoke(e);
             }
+            // The socket can be disposed mid-send during teardown/reconnect (isDisposed was false at
+            // entry); surface it like a send failure so callers don't believe the message was delivered.
+            catch (ObjectDisposedException e)
+            {
+                OnErrorEvent?.Invoke(e);
+            }
         }
 
         public virtual async UniTask SendMessageAsync(string data, CancellationToken ct)
@@ -127,6 +134,10 @@ namespace DCL.SocialService
 
             try { await webSocket.SendAsync(Encoding.UTF8.GetBytes(data), WebSocketMessageType.Text, true, ct); }
             catch (WebSocketException e)
+            {
+                OnErrorEvent?.Invoke(e);
+            }
+            catch (ObjectDisposedException e)
             {
                 OnErrorEvent?.Invoke(e);
             }
@@ -141,7 +152,8 @@ namespace DCL.SocialService
 
             if (State is WebSocketState.Open or WebSocketState.CloseReceived)
             {
-                await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", ct);
+                try { await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", ct); }
+                catch (ObjectDisposedException) { return; }
                 OnCloseEvent?.Invoke();
             }
         }

--- a/Explorer/Assets/DCL/Tests/Editor/DecentralandIdentityShould.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/DecentralandIdentityShould.cs
@@ -1,0 +1,80 @@
+using DCL.Web3;
+using DCL.Web3.Abstract;
+using DCL.Web3.Chains;
+using DCL.Web3.Identities;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+
+namespace DCL.Tests.Editor
+{
+    public class DecentralandIdentityShould
+    {
+        private const string ADDRESS = "0x0000000000000000000000000000000000000001";
+
+        private static DecentralandIdentity NewIdentity()
+        {
+            AuthChain authChain = AuthChain.Create();
+            authChain.SetSigner(ADDRESS);
+
+            authChain.Set(new AuthLink
+            {
+                type = AuthLinkType.ECDSA_EPHEMERAL,
+                payload = "ephemeral payload",
+                signature = "0xephemeralsignature",
+            });
+
+            IWeb3Account ephemeralAccount = Substitute.For<IWeb3Account>();
+            ephemeralAccount.Sign(Arg.Any<string>()).Returns("0xentitysignature");
+
+            return new DecentralandIdentity(new Web3Address(ADDRESS), ephemeralAccount, DateTime.UtcNow.AddDays(1), authChain, IWeb3Identity.Web3IdentitySource.None);
+        }
+
+        [Test]
+        public void SignEntityWhileAlive()
+        {
+            // Arrange
+            DecentralandIdentity identity = NewIdentity();
+
+            // Act
+            AuthChain signed = identity.Sign("entityId");
+
+            // Assert
+            Assert.IsTrue(signed.TryGet(AuthLinkType.ECDSA_SIGNED_ENTITY, out AuthLink link));
+            Assert.AreEqual("entityId", link.payload);
+
+            signed.Dispose();
+            identity.Dispose();
+        }
+
+        [Test]
+        public void ThrowObjectDisposedOnSignAfterDispose()
+        {
+            // Arrange
+            DecentralandIdentity identity = NewIdentity();
+
+            // Act
+            identity.Dispose();
+
+            // Assert
+            Assert.Throws<ObjectDisposedException>(() => identity.Sign("entityId"));
+        }
+
+        [Test]
+        public void ThrowObjectDisposedEvenAfterPoolReissuesItsAuthChain()
+        {
+            // Arrange
+            DecentralandIdentity identity = NewIdentity();
+            identity.Dispose();
+
+            // Act - the pool can re-issue the identity's released AuthChain instance with the
+            // disposed flag reset; the identity guard must not depend on that pooled state.
+            AuthChain reissued = AuthChain.Create();
+
+            // Assert
+            Assert.Throws<ObjectDisposedException>(() => identity.Sign("entityId"));
+
+            reissued.Dispose();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Tests/Editor/DecentralandIdentityShould.cs.meta
+++ b/Explorer/Assets/DCL/Tests/Editor/DecentralandIdentityShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca6f29b7ea2f469a82a653db411b47c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/UI/Controls/ControlsPanel.prefab
+++ b/Explorer/Assets/DCL/UI/Controls/ControlsPanel.prefab
@@ -671,7 +671,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 4974685691c134a35bcea75af1936381, type: 3}
+  m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/Controls/GenericContextMenuSubMenuButtonView.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/Controls/GenericContextMenuSubMenuButtonView.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.UI.Controls.Configs;
 using System;
 using System.Threading;
@@ -148,7 +149,8 @@ namespace DCL.UI.Controls
                 if (!isHovering)
                     ShowSubmenu(false);
             }
-            catch (Exception) { }
+            catch (OperationCanceledException) { }
+            catch (Exception e) { ReportHub.LogException(e, ReportCategory.UI); }
         }
     }
 }

--- a/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
+++ b/Explorer/Assets/DCL/UI/GenericContextMenu/GenericContextMenuController.cs
@@ -410,7 +410,6 @@ namespace DCL.UI
 
             float bestOutOfBoundsPercent = adjustedOutOfBoundsPercent;
             float3 bestPosition = adjustedPosition;
-            var foundPerfectPosition = false;
 
             for (var i = 0; i < fallbackDirectionsCount; i++)
             {

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/RealUserInAppInitializationFlow.cs
@@ -233,8 +233,13 @@ namespace DCL.UserInAppInitializationFlow
                 if (result.Success == false)
                 {
                     //Fail straight away
-                    string message = result.Error.AsMessage();
-                    ReportHub.LogError(ReportCategory.AUTHENTICATION, message);
+                    // Do not log cancellation as an error (CLAUDE.md §9): on shutdown the loading result
+                    // is a propagated TaskError.Cancelled, not a genuine auth failure.
+                    if (result.Error?.State != TaskError.Cancelled && !ct.IsCancellationRequested)
+                    {
+                        string message = result.Error.AsMessage();
+                        ReportHub.LogError(ReportCategory.AUTHENTICATION, message);
+                    }
                 }
             }
             while (result.Success == false && parameters.ShowAuthentication);

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadPlayerAvatarStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadPlayerAvatarStartupOperation.cs
@@ -33,6 +33,12 @@ namespace DCL.UserInAppInitializationFlow
             Profile? profile = await selfProfile.ProfileAsync(ct);
             args.Report.SetProgress(finalizationProgress);
 
+            // A null profile must fail the operation: adding it to the world poisons every
+            // Profile-querying system with a per-frame NRE (observed when the profiles endpoint
+            // returns no avatars for the signed-in wallet).
+            if (profile == null)
+                throw new System.InvalidOperationException("Self profile could not be resolved (profiles endpoint returned no avatar for the signed-in wallet) — cannot create the player avatar.");
+
             // Add the profile into the player entity so it will create the avatar in world
 
             World world = args.FlowParameters.World;

--- a/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChat/VoiceChatParticipantEntryPresenter.cs
+++ b/Explorer/Assets/DCL/VoiceChat/CommunityVoiceChat/VoiceChatParticipantEntryPresenter.cs
@@ -75,6 +75,8 @@ namespace DCL.VoiceChat.CommunityVoiceChat
         {
             if (string.IsNullOrEmpty(currentParticipantState.WalletId)) return;
 
+            // deliberately not tied to this pooled entry's cts: the open passport must survive
+            // the entry being recycled (participant leaves, list rebuild)
             OpenPassportAsync(currentParticipantState.WalletId, CancellationToken.None).Forget();
             return;
 

--- a/Explorer/Assets/DCL/VoiceChat/PrivateVoiceChat/PrivateVoiceChatCallStatusServiceNull.cs
+++ b/Explorer/Assets/DCL/VoiceChat/PrivateVoiceChat/PrivateVoiceChatCallStatusServiceNull.cs
@@ -7,7 +7,7 @@ namespace DCL.VoiceChat
     public class PrivateVoiceChatCallStatusServiceNull : IPrivateVoiceChatCallStatusService
     {
         public string CurrentTargetWallet { get; }
-        public event Action<PrivateVoiceChatUpdate>? PrivateVoiceChatUpdateReceived;
+        public event Action<PrivateVoiceChatUpdate>? PrivateVoiceChatUpdateReceived { add { } remove { } }
         public IReadonlyReactiveProperty<VoiceChatStatus> Status { get; } = new ReactiveProperty<VoiceChatStatus>(VoiceChatStatus.DISCONNECTED);
         public IReadonlyReactiveProperty<string> CallId { get; } = new ReactiveProperty<string>(string.Empty);
         public string ConnectionUrl { get; }

--- a/Explorer/Assets/DCL/Web3/Chains/AuthChain.cs
+++ b/Explorer/Assets/DCL/Web3/Chains/AuthChain.cs
@@ -16,8 +16,16 @@ namespace DCL.Web3.Chains
 
         private bool disposed;
 
-        public static AuthChain Create() =>
-            POOL.Get()!;
+        public static AuthChain Create()
+        {
+            // Reset the recycled instance: a pooled AuthChain comes back with disposed == true
+            // (set by the Dispose that released it), which made its next Dispose a no-op — the
+            // instance never returned to the pool again and reads saw stale state.
+            AuthChain instance = POOL.Get()!;
+            instance.disposed = false;
+            instance.chain.Clear();
+            return instance;
+        }
 
         private AuthChain() { }
 

--- a/Explorer/Assets/DCL/Web3/Identities/DecentralandIdentity.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/DecentralandIdentity.cs
@@ -7,6 +7,8 @@ namespace DCL.Web3.Identities
 {
     public class DecentralandIdentity : IWeb3Identity
     {
+        private bool disposed;
+
         public Web3Address Address { get; }
         public DateTime Expiration { get; }
         public IWeb3Account EphemeralAccount { get; }
@@ -33,11 +35,22 @@ namespace DCL.Web3.Identities
 
         public void Dispose()
         {
+            if (disposed)
+                return;
+
+            disposed = true;
             AuthChain.Dispose();
         }
 
         public AuthChain Sign(string entityId)
         {
+            // Tracked on the identity itself: the pooled AuthChain's disposed flag is reset when the
+            // pool re-issues the instance, so it cannot be trusted after this identity released it.
+            // ObjectDisposedException (not OperationCanceledException) so the failure is not silently
+            // swallowed by the standard catch (OperationCanceledException) { } blocks.
+            if (disposed)
+                throw new ObjectDisposedException(nameof(DecentralandIdentity), $"Cannot sign, the identity for {Address} has been disposed");
+
             if (Expiration < DateTime.UtcNow)
                 throw new Web3IdentityException(this, $"Cannot sign, identity has expired: {Expiration:s}");
 

--- a/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
@@ -18,8 +18,10 @@ namespace DCL.Web3.Identities
         {
             private readonly IWeb3Identity? identity;
 
+#pragma warning disable CS0067
             public event Action? OnIdentityCleared;
             public event Action? OnIdentityChanged;
+#pragma warning restore CS0067
 
             public Fake() : this(new IWeb3Identity.Random()) { }
 

--- a/Explorer/Assets/DCL/WebRequests/Dumper/EnvelopeJsonConverter.cs
+++ b/Explorer/Assets/DCL/WebRequests/Dumper/EnvelopeJsonConverter.cs
@@ -143,8 +143,8 @@ namespace DCL.WebRequests.Dumper
                 }
             }
 
-            if (!commonArguments.HasValue || argsType == null)
-                throw new JsonSerializationException("Required properties 'commonArguments' or 'argsType' are missing");
+            if (!commonArguments.HasValue || argsType == null || requestType == null || args == null)
+                throw new JsonSerializationException("Required properties 'commonArguments', 'requestType', 'argsType', or 'args' are missing");
 
             var envelope = new WebRequestDump.Envelope(requestType, commonArguments.Value, argsType, args, headersInfo, startTime, effectiveUrl);
             envelope.Conclude(statusKind, endTime);

--- a/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
@@ -322,6 +322,10 @@ namespace DCL.WebRequests
 
                             using var textReader = new StreamReader(stream, Encoding.UTF8);
                             using var jsonReader = new JsonTextReader(textReader);
+
+                            if (Target == null)
+                                throw new InvalidOperationException($"{nameof(OverwriteFromJsonAsyncOp<T, TRequest>)} requires a non-null {nameof(Target)} to populate");
+
                             serializer.Populate(jsonReader, Target);
                         }
                     }

--- a/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
@@ -37,7 +37,9 @@ namespace DCL.WebRequests
 
         internal static GetTextureWebRequest Initialize(string url, GetTextureArguments textureArguments, IDecentralandUrlsSource urlsSource, bool ktxEnabled)
         {
-            bool useKtx = textureArguments.UseKtx && ktxEnabled && !WebRequestUtils.IsLocalhost(url);
+            // Never hand a non-publicly-routable content URL to the hosted converter: its workers
+            // cannot reach the host, so the job hangs until TCP timeout and clogs the converter queue.
+            bool useKtx = textureArguments.UseKtx && ktxEnabled && !WebRequestUtils.IsNonPubliclyRoutable(url);
             string requestUrl = useKtx ? string.Format(urlsSource.Url(DecentralandUrl.MediaConverter), Uri.EscapeDataString(url)) : url;
             UnityWebRequest webRequest = UnityWebRequest.Get(requestUrl);
 

--- a/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
@@ -177,6 +177,50 @@ namespace DCL.WebRequests
             || url.StartsWith("https://[::1]", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
+        ///     True when the URL's host is syntactically recognizable as non-publicly-routable and
+        ///     therefore unreachable from hosted Decentraland services (the media converter, etc.):
+        ///     loopback, RFC1918, CGNAT (100.64/10), link-local, unique-local IPv6 and the
+        ///     .local/.internal/.lan suffixes. It does NOT resolve DNS, so a public hostname that
+        ///     resolves to a private address still passes.
+        /// </summary>
+        public static bool IsNonPubliclyRoutable(string url)
+        {
+            if (IsLocalhost(url)) return true;
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri)) return false;
+
+            string host = uri.Host;
+
+            if (uri.IsLoopback
+                || host.EndsWith(".local", StringComparison.OrdinalIgnoreCase)
+                || host.EndsWith(".internal", StringComparison.OrdinalIgnoreCase)
+                || host.EndsWith(".lan", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (System.Net.IPAddress.TryParse(host.Trim('[', ']'), out System.Net.IPAddress? ip))
+            {
+                if (System.Net.IPAddress.IsLoopback(ip)) return true;
+
+                Span<byte> b = stackalloc byte[16];
+
+                if (!ip.TryWriteBytes(b, out int written)) return false;
+
+                if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork && written == 4)
+                {
+                    return b[0] == 10
+                           || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
+                           || (b[0] == 192 && b[1] == 168)
+                           || (b[0] == 100 && b[1] >= 64 && b[1] <= 127)
+                           || (b[0] == 169 && b[1] == 254);
+                }
+
+                if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
+                    return ip.IsIPv6LinkLocal || ip.IsIPv6SiteLocal || (b[0] & 0xFE) == 0xFC;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         ///     Does nothing with the web request
         /// </summary>
         public readonly struct NoOp<TWebRequest> : IWebRequestOp<TWebRequest, NoResult> where TWebRequest: struct, ITypedWebRequest

--- a/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
+++ b/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
@@ -49,9 +49,6 @@ namespace Plugins.RustSegment.SegmentServerWrap
         private long trackId;
         private long flushId;
 
-        // temportal sentry budget fix. TODO remove once the core issue solved
-        private static bool ONCE_PATTERN_ALREADY_CAUGHT = false;
-
         public RustSegmentAnalyticsService(string writerKey, string? anonId)
         {
             using Mutex<RustSegmentAnalyticsService>.Guard instanceGuard = CURRENT.Lock(); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
@@ -234,18 +231,17 @@ namespace Plugins.RustSegment.SegmentServerWrap
                 string marshaled = Marshal.PtrToStringUTF8(msg) ?? "cannot parse message";
                 bool isCaught = marshaled.Contains(ONCE_PATTERN);
 
-                if (isCaught && ONCE_PATTERN_ALREADY_CAUGHT)
+                if (isCaught)
                 {
-                    // Don't log if already was
+                    // Transient, self-recovering analytics-upload failure (the SDK retries): this is
+                    // report-noise, not a hard error. Route to the local debug log only — never Sentry —
+                    // so it stops generating Sentry errors (UNITY-EXPLORER-P13: 637 events / 242 users).
+                    ReportHub.LogWarning(ReportCategory.ANALYTICS, $"Segment error: {marshaled}", ReportHandler.DebugLog);
                     return;
                 }
 
+                // Genuine, non-transient Segment errors keep full Sentry reporting.
                 ReportHub.LogException(new Exception($"Segment error: {marshaled}"), ReportCategory.ANALYTICS);
-
-                if (isCaught)
-                {
-                    ONCE_PATTERN_ALREADY_CAUGHT = true;
-                }
             }
             catch
             {

--- a/Explorer/Assets/StreamingAssets/Js/Modules/WebSocketApi.js
+++ b/Explorer/Assets/StreamingAssets/Js/Modules/WebSocketApi.js
@@ -47,6 +47,14 @@ class WebSocket {
         const thisReadyState = this.readyState;
         // console.log("WebSocket.send is called", data.constructor.name, `State is ${thisReadyState}`);
 
+        // Per the WHATWG WebSocket spec, send() on a CLOSING/CLOSED socket must NOT throw — the data is
+        // silently discarded. Throwing on CLOSED bubbled out of the scene update loop and was reported to
+        // Sentry once per tick by misbehaving scenes (UNITY-EXPLORER-NQE: "WebSocket state is 3, cannot
+        // send data"). Only a still-CONNECTING socket remains an error.
+        if (thisReadyState === WebSocket.CLOSING || thisReadyState === WebSocket.CLOSED) {
+            return;
+        }
+
         if (thisReadyState !== WebSocket.OPEN) {
             const errorMessage = `WebSocket state is ${thisReadyState}, cannot send data`;
             throw new Error(errorMessage);


### PR DESCRIPTION
Compound PR for the `chore/clean-*` fix set — **this is the review and merge unit** (team decision; the 14 individual PRs #9416–#9429 are closed and all further fixes for this set land here). Each fix is its own signed merge commit, so per-fix review works commit-by-commit.

Constituents (each independently rebased on `dev`, mutually conflict-free):

- chore/clean-gltf-ab-instantiate-guard — guard GLTF instantiation from asset bundle (top crash) (was #9416)
- chore/clean-profile-data-robustness — profile/attachment/URN data robustness (was #9417)
- chore/clean-ws-send-closed-noop — WebSocketApi.js send() no-ops on CLOSING/CLOSED (was #9418)
- chore/clean-glider-prop-nullguard — guard destroyed prop View in GliderPropControllerSystem (was #9419)
- chore/clean-segment-noise — route transient Segment send-loop errors off Sentry (was #9420)
- chore/clean-ws-connect-noreport — don't report scene websocket connect failures to Sentry (was #9421)
- chore/clean-friends-reconnect-cancel — OperationCanceledException-safe friends prewarm (was #9422)
- chore/clean-findobjectsbytype — two-argument FindObjectsByType overload (was #9423)
- chore/clean-wearable-storage-lock — WearableStorage locks on shared base-registry monitor (was #9424)
- chore/clean-media-robustness — texture/audio-analysis robustness (was #9425)
- chore/clean-identity-dispose — disposed-identity Sign throws ObjectDisposedException (was #9426)
- chore/clean-ui-loading-robustness — loading/panel/menu teardown guards (was #9427)
- chore/clean-core-misc-robustness — scattered null/dispose/cancellation robustness (was #9428)
- chore/clean-network-robustness — WebRequestUtils guards, NFT URL routing, comms hangs (was #9429)

Each merge commit's message carries the production-error evidence (Sentry issue ids + event/user counts) motivating that fix.

QA focus areas: avatar/wearable loading, friends panel across reconnects, loading screens & teleports, media scenes, profile edits. The rest are Sentry-noise/defensive changes with no expected behavior delta.

92 files, +602/−182 vs dev. Compile-verified green (216 assemblies, 0 errors) on Unity 6000.4.11f1.
