### PR TITLE
chore: scene runtime V8 engine configuration

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/V8Tests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/V8Tests.cs
@@ -9,8 +9,8 @@ namespace SceneRuntime.Tests
 {
     public class V8Tests
     {
-        private V8EngineFactory engineFactory;
-        private V8ScriptEngine engine;
+        private V8EngineFactory engineFactory = null!;
+        private V8ScriptEngine engine = null!;
 
         [SetUp]
         public void SetUp()
@@ -69,10 +69,10 @@ namespace SceneRuntime.Tests
         public void BlockReflectionFromSceneScript()
         {
             // Arrange
-            engine.AddHostObject("host", new ReflectionProbe());
+            engine.AddHostObject("host", new SampleHostObject());
 
-            // Act — normal host member access is bound via UseReflectionBindFallback and must still work.
-            var value = engine.Evaluate("host.Value");
+            // Act — ordinary host member access must still work.
+            object? value = engine.Evaluate("host.Value");
 
             // Assert
             Assert.AreEqual(42, value);
@@ -84,8 +84,9 @@ namespace SceneRuntime.Tests
             Assert.That(reflectionException.ToString(), Does.Contain("reflection").IgnoreCase);
         }
 
-        private class ReflectionProbe
+        public class SampleHostObject
         {
+            // ReSharper disable once UnusedMember.Local
             public int Value => 42;
         }
     }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/V8Tests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/V8Tests.cs
@@ -2,6 +2,7 @@
 using Microsoft.ClearScript;
 using Microsoft.ClearScript.V8;
 using NUnit.Framework;
+using System;
 using UnityEngine;
 
 namespace SceneRuntime.Tests
@@ -55,6 +56,37 @@ namespace SceneRuntime.Tests
             for (byte i = 0; i < 10; ++i) { data[i] = i; }
 
             sceneScriptObject!.InvokeAsFunction(data);
+        }
+
+        [Test]
+        public void DisableReflectionOnCreatedEngine()
+        {
+            // Assert — the factory keeps AllowReflection disabled on the scene engine.
+            Assert.IsFalse(engine.AllowReflection);
+        }
+
+        [Test]
+        public void BlockReflectionFromSceneScript()
+        {
+            // Arrange
+            engine.AddHostObject("host", new ReflectionProbe());
+
+            // Act — normal host member access is bound via UseReflectionBindFallback and must still work.
+            var value = engine.Evaluate("host.Value");
+
+            // Assert
+            Assert.AreEqual(42, value);
+
+            // Act — reflection members are not available to scene scripts.
+            Exception reflectionException = Assert.Catch(() => engine.Evaluate("host.GetType()"));
+
+            // Assert
+            Assert.That(reflectionException.ToString(), Does.Contain("reflection").IgnoreCase);
+        }
+
+        private class ReflectionProbe
+        {
+            public int Value => 42;
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/V8EngineFactory.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/V8EngineFactory.cs
@@ -17,7 +17,7 @@ namespace SceneRuntime
             // IL2CPP does not support dynamic bindings!
             engine.DisableDynamicBinding = true;
             engine.UseReflectionBindFallback = true;
-            engine.AllowReflection = true;
+            engine.AllowReflection = false;
 
             return engine;
         }


### PR DESCRIPTION
## Description

Adjusts the V8 script engine configuration used to run scenes and adds regression coverage for the engine's configuration and host-member binding behavior.

## Technical

- Sets `AllowReflection = false` on the scene V8 engine (`V8EngineFactory`).
- Host member access continues to resolve via `UseReflectionBindFallback`, unchanged.
- Adds `V8Tests` cases asserting the engine configuration and that normal host member access still works.

