### PR TITLE
fix(ui): guard manual Animator.Update against inactive objects

### DIFF
--- a/Explorer/Assets/DCL/UI/ButtonWithAnimationView.cs
+++ b/Explorer/Assets/DCL/UI/ButtonWithAnimationView.cs
@@ -23,8 +23,14 @@ namespace DCL.UI
         {
             Button.onClick.AddListener(OnClick);
             ButtonAnimator.enabled = true;
-            ButtonAnimator.Rebind();
-            ButtonAnimator.Update(0);
+
+            // Animator.Update is only legal on an active-in-hierarchy object; these buttons
+            // are often enabled while their panel is still hidden during UI bootstrap.
+            if (ButtonAnimator.gameObject.activeInHierarchy)
+            {
+                ButtonAnimator.Rebind();
+                ButtonAnimator.Update(0);
+            }
         }
 
         private void OnDisable()

--- a/Explorer/Assets/DCL/UI/SectionSelectorController.cs
+++ b/Explorer/Assets/DCL/UI/SectionSelectorController.cs
@@ -38,7 +38,9 @@ namespace DCL.UI
 
             if (isOn)
                 selectorToggle.tabAnimator.SetTrigger(UIAnimationHashes.ACTIVE);
-            else
+            // Animator.Update is only legal on an active-in-hierarchy object; non-selected
+            // tabs are frequently snapped to their resting frame while still hidden.
+            else if (selectorToggle.tabAnimator.gameObject.activeInHierarchy)
             {
                 selectorToggle.tabAnimator.Rebind();
                 selectorToggle.tabAnimator.Update(0);

--- a/Explorer/Assets/DCL/UI/TabSelectorView.cs
+++ b/Explorer/Assets/DCL/UI/TabSelectorView.cs
@@ -39,7 +39,9 @@ namespace DCL.UI
         {
             tabAnimator.enabled = true;
 
-            if (tabAnimator != null)
+            // Animator.Update is only legal on an active-in-hierarchy object; tabs are
+            // frequently enabled while their panel is still hidden during UI bootstrap.
+            if (tabAnimator != null && tabAnimator.gameObject.activeInHierarchy)
             {
                 tabAnimator.Rebind();
                 tabAnimator.Update(0);


### PR DESCRIPTION
### Testing Instructions

1. This is a very internal change. Start the client and let it reach the world. Watch the Player.log during startup: before this PR, UI bootstrap logged Animator.Update / Rebind errors from panels whose tabs and animated buttons get initialized while still hidden. After this PR the console should have no Animator errors at startup.
2. Tab switching still animates: Open each panel: Backpack, Settings, Communities, Events, Places, Map/Navmap, Camera Reel, and click through every tab. The newly selected tab should play its ACTIVE animation; deselected tabs should snap back to their resting frame (not freeze mid-animation).
3. Reopen on a non-default tab ("emotes" in the backpack, sub-sections of settings, etc). In a couple of those panels, select a non-default tab, close the panel, and reopen it. This is the main regression risk: the resting-frame snap is now skipped while the panel is hidden, so we rely on OnEnable re-running the snap when it becomes visible. Verify tabs show the correct selected/unselected visuals on reopen, with no tab stuck in a hover or active pose.
4. Animated buttons. Hover and click buttons using ButtonWithAnimationView (e.g. panel header buttons, sidebar). Verify hover/click animations still play, and still play after the panel has been closed and reopened.
5. Rapid toggling. Open/close a panel quickly several times while switching tabs. No console errors, no desynced tab visuals.

<img width="1280" height="720" alt="wallshot3" src="https://github.com/user-attachments/assets/828a7735-0d42-4033-8461-21d173c93f38" />
