### PR TITLE
feat: include worlds in the place search at the navmap

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Categories/CategoryControllers/CategoryMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Categories/CategoryControllers/CategoryMarkersController.cs
@@ -120,6 +120,10 @@ namespace DCL.MapRenderer.MapLayers.Categories
             clusterController.SetClusterIcon(categoryImage);
             foreach (PlacesData.PlaceInfo placeInfo in places)
             {
+                // Worlds don't live on the Genesis map (they all report base_position "0,0"), so they get no map marker.
+                if (placeInfo.IsWorld)
+                    continue;
+
                 if (markers.ContainsKey(placeInfo.base_position_processed))
                     continue;
 

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Categories/CategoryControllers/CategoryMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Categories/CategoryControllers/CategoryMarkersController.cs
@@ -120,7 +120,6 @@ namespace DCL.MapRenderer.MapLayers.Categories
             clusterController.SetClusterIcon(categoryImage);
             foreach (PlacesData.PlaceInfo placeInfo in places)
             {
-                // Worlds don't live on the Genesis map (they all report base_position "0,0"), so they get no map marker.
                 if (placeInfo.IsWorld)
                     continue;
 

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/SearchResults/SearchResultMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/SearchResults/SearchResultMarkersController.cs
@@ -91,6 +91,10 @@ namespace DCL.MapRenderer.MapLayers.SearchResults
 
             foreach (PlacesData.PlaceInfo placeInfo in places)
             {
+                // Worlds don't live on the Genesis map (they all report base_position "0,0"), so they get no map marker.
+                if (placeInfo.IsWorld)
+                    continue;
+
                 if (markers.ContainsKey(placeInfo.base_position_processed))
                     continue;
 

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/SearchResults/SearchResultMarkersController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/SearchResults/SearchResultMarkersController.cs
@@ -91,7 +91,6 @@ namespace DCL.MapRenderer.MapLayers.SearchResults
 
             foreach (PlacesData.PlaceInfo placeInfo in places)
             {
-                // Worlds don't live on the Genesis map (they all report base_position "0,0"), so they get no map marker.
                 if (placeInfo.IsWorld)
                     continue;
 

--- a/Explorer/Assets/DCL/Navmap/NavmapCommandBus.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapCommandBus.cs
@@ -54,7 +54,10 @@ namespace DCL.Navmap
             if (!isFromSearchResults)
                 ClearPlacesFromMap();
 
-            MoveCameraTo(place.Positions[0], CAMERA_MOVE_SPEED);
+            // Worlds have no Genesis parcels, so there is nothing to move the map camera to.
+            if (!place.IsWorld)
+                MoveCameraTo(place.Positions[0], CAMERA_MOVE_SPEED);
+
             await command.ExecuteAsync(new AdditionalParams(isFromSearchResults, originalParcel), ct);
 
             AddCommand(command);

--- a/Explorer/Assets/DCL/Navmap/NavmapCommandBus.cs
+++ b/Explorer/Assets/DCL/Navmap/NavmapCommandBus.cs
@@ -54,7 +54,6 @@ namespace DCL.Navmap
             if (!isFromSearchResults)
                 ClearPlacesFromMap();
 
-            // Worlds have no Genesis parcels, so there is nothing to move the map camera to.
             if (!place.IsWorld)
                 MoveCameraTo(place.Positions[0], CAMERA_MOVE_SPEED);
 

--- a/Explorer/Assets/DCL/Navmap/PlaceElementView.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceElementView.cs
@@ -40,6 +40,8 @@ namespace DCL.Navmap
 
         public Vector2Int coords;
 
+        public bool IsHoverEnabled = true;
+
         public event Action<bool, Vector2Int> OnMouseHover;
 
         public void ConfigurePlaceImageController(ImageControllerProvider imageControllerProvider)
@@ -52,13 +54,15 @@ namespace DCL.Navmap
 
         public void OnPointerEnter(PointerEventData eventData)
         {
-            OnMouseHover?.Invoke(true, coords);
+            if (IsHoverEnabled)
+                OnMouseHover?.Invoke(true, coords);
             arrowImage.gameObject.SetActive(true);
         }
 
         public void OnPointerExit(PointerEventData eventData)
         {
-            OnMouseHover?.Invoke(false, coords);
+            if (IsHoverEnabled)
+                OnMouseHover?.Invoke(false, coords);
             arrowImage.gameObject.SetActive(false);
         }
 

--- a/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
@@ -191,9 +191,14 @@ namespace DCL.Navmap
             view.PlayerCountLabel.text = place.user_count.ToString();
             view.DescriptionLabel.text = string.IsNullOrEmpty(place.description) ? "No description" : place.description;
             view.DescriptionLabel.ConvertUrlsToClickeableLinks(OpenUrl);
-            view.CoordinatesLabel.text = place.base_position;
+
+            bool isWorld = place.IsWorld;
+
+            view.CoordinatesLabel.text = isWorld ? place.world_name : place.base_position;
             view.ParcelCountLabel.text = place.Positions.Length.ToString();
-            view.StartNavigationButton.gameObject.SetActive(true);
+
+            // Worlds are not on the Genesis map, so on-map navigation doesn't apply to them.
+            view.StartNavigationButton.gameObject.SetActive(!isWorld);
             view.StopNavigationButton.gameObject.SetActive(false);
             view.DonateButton?.gameObject.SetActive(donationsService.DonationFeatureEnabled && !string.IsNullOrEmpty(place.creator_address));
 
@@ -304,7 +309,7 @@ namespace DCL.Navmap
 
             if (isHome)
             {
-                if (!string.IsNullOrEmpty(place.world_name))
+                if (place.IsWorld)
                 {
                     homePlaceEventBus.SetAsHome(place.world_name);
                 }
@@ -358,7 +363,18 @@ namespace DCL.Navmap
 
             navmapBus.JumpIn(place!);
 
-            Vector2Int? destinationParcel = TeleportUtils.IsRoad(place!.title) && originParcel != null ? originParcel : currentBaseParcel;
+            // Worlds live on a separate realm; the goto command teleports there by world name.
+            if (place!.IsWorld)
+            {
+                chatMessagesBus
+                   .SendWithUtcNowTimestamp(ChatChannel.NEARBY_CHANNEL,
+                        $"/{ChatCommandsUtils.COMMAND_GOTO} {place.world_name}",
+                        ChatMessageOrigin.JUMP_IN);
+
+                return;
+            }
+
+            Vector2Int? destinationParcel = TeleportUtils.IsRoad(place.title) && originParcel != null ? originParcel : currentBaseParcel;
 
             chatMessagesBus
                .SendWithUtcNowTimestamp(ChatChannel.NEARBY_CHANNEL,

--- a/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
@@ -187,7 +187,7 @@ namespace DCL.Navmap
             thumbnailImage.RequestImage(place.image);
             view.PlaceNameLabel.text = place.title;
             view.CreatorNameLabel.text = $"created by <b>{place.contact_name}</b>";
-            view.LikeRateLabel.text = $"{(place.like_rate_as_float ?? 0) * 100:F0}%";
+            view.LikeRateLabel.text = $"{(place.LikeRateAsFloat ?? 0) * 100:F0}%";
             view.PlayerCountLabel.text = place.user_count.ToString();
             view.DescriptionLabel.text = string.IsNullOrEmpty(place.description) ? "No description" : place.description;
             view.DescriptionLabel.ConvertUrlsToClickeableLinks(OpenUrl);

--- a/Explorer/Assets/DCL/Navmap/SearchForPlaceAndShowResultsCommand.cs
+++ b/Explorer/Assets/DCL/Navmap/SearchForPlaceAndShowResultsCommand.cs
@@ -109,12 +109,12 @@ namespace DCL.Navmap
 
                 if (@params.filter == NavmapSearchPlaceFilter.All)
                 {
+                    // Note: onlyPlaces is intentionally omitted so the destinations endpoint returns both Genesis City places and Worlds.
                     using PlacesData.IPlacesAPIResponse response = await placesAPIService.SearchDestinationsAsync(@params.page, @params.pageSize, ct,
                         searchText: @params.text,
                         sortBy: sort, sortDirection: sortDirection,
                         category: @params.category is "All" or "Favorites" ? string.Empty : @params.category,
-                        onlySdk7: true,
-                        onlyPlaces: true);
+                        onlySdk7: true);
                     places.AddRange(response.Data);
                     totalResultCount = response.Total;
                 }

--- a/Explorer/Assets/DCL/Navmap/SearchForPlaceAndShowResultsCommand.cs
+++ b/Explorer/Assets/DCL/Navmap/SearchForPlaceAndShowResultsCommand.cs
@@ -3,7 +3,6 @@ using DCL.EventsApi;
 using DCL.PlacesAPIService;
 using System.Collections.Generic;
 using System.Threading;
-using UnityEngine;
 using UnityEngine.Pool;
 
 namespace DCL.Navmap
@@ -124,8 +123,7 @@ namespace DCL.Navmap
                         ct,
                         pageNumber: @params.page, pageSize: @params.pageSize,
                         sortByBy: sort, sortDirection: sortDirection,
-                        onlySdk7: true,
-                        onlyPlaces: true);
+                        onlySdk7: true);
                     places.AddRange(response.Data);
                     totalResultCount = response.Total;
                 }

--- a/Explorer/Assets/DCL/Navmap/SearchResultPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/SearchResultPanelController.cs
@@ -54,6 +54,7 @@ namespace DCL.Navmap
         {
             foreach ((string _, PlaceElementView fullSearchResultsView) in usedPoolElements)
             {
+                fullSearchResultsView.IsHoverEnabled = true;
                 fullSearchResultsView.resultButton.onClick.RemoveAllListeners();
                 fullSearchResultsView.resultAnimator.Rebind();
                 fullSearchResultsView.resultAnimator.Update(0f);

--- a/Explorer/Assets/DCL/Navmap/SearchResultPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/SearchResultPanelController.cs
@@ -83,12 +83,19 @@ namespace DCL.Navmap
 
             foreach (PlacesData.PlaceInfo placeInfo in places)
             {
+                bool isWorld = placeInfo.IsWorld;
+
+                // Worlds have no Genesis coordinates and all report base_position "0,0", so they are keyed by their unique id.
+                string key = isWorld ? placeInfo.id : placeInfo.base_position;
+
                 // Why two places with the same base position comes in the list?
-                if (usedPoolElements.ContainsKey(placeInfo.base_position)) continue;
+                if (usedPoolElements.ContainsKey(key)) continue;
 
                 PlaceElementView placeElementView = resultsPool.Get();
-                usedPoolElements.Add(placeInfo.base_position, placeElementView);
+                usedPoolElements.Add(key, placeElementView);
                 placeElementView.transform.SetAsLastSibling();
+                // Worlds have no Genesis coordinates, so they must not drive map hover/selection.
+                placeElementView.IsHoverEnabled = !isWorld;
                 placeElementView.placeName.text = placeInfo.title;
                 placeElementView.coords = placeInfo.base_position_processed;
                 placeElementView.placeCreator.gameObject.SetActive(
@@ -102,7 +109,11 @@ namespace DCL.Navmap
                 placeElementView.resultButton.onClick.AddListener(() =>
                 {
                     showPlaceInfoCancellationToken = showPlaceInfoCancellationToken.SafeRestart();
-                    navmapBus.SelectPlaceFromResultsPanel(placeInfo.base_position_processed, false, true);
+
+                    // Worlds don't live on the Genesis map so there is no marker/parcel to select.
+                    if (!isWorld)
+                        navmapBus.SelectPlaceFromResultsPanel(placeInfo.base_position_processed, false, true);
+
                     navmapBus.SelectPlaceAsync(placeInfo, showPlaceInfoCancellationToken.Token, true).Forget();
                 });
 

--- a/Explorer/Assets/DCL/Places/PlaceCardView.cs
+++ b/Explorer/Assets/DCL/Places/PlaceCardView.cs
@@ -159,7 +159,7 @@ namespace DCL.Places
             int onlineMembers = placeInfo.connected_addresses?.Length ?? placeInfo.user_count;
             onlineMembersText.text = $"{onlineMembers}";
             onlineMembersContainer.SetActive(onlineMembers > 0);
-            likeRateText.text = $"{(placeInfo.like_rate_as_float ?? 0) * 100:F0}%";
+            likeRateText.text = $"{(placeInfo.LikeRateAsFloat ?? 0) * 100:F0}%";
             placeCoordsText.text = string.IsNullOrWhiteSpace(placeInfo.world_name) ? placeInfo.base_position : placeInfo.world_name;
             featuredTag.SetActive(placeInfo.highlighted);
 

--- a/Explorer/Assets/DCL/Places/PlaceDetailPanelView.cs
+++ b/Explorer/Assets/DCL/Places/PlaceDetailPanelView.cs
@@ -190,7 +190,7 @@ namespace DCL.Places
             creatorNameText.gameObject.SetActive(!string.IsNullOrEmpty(placeInfo.contact_name));
             creatorWalletText.text = !string.IsNullOrEmpty(placeInfo.owner) && placeInfo.owner.Length >= 10 ? $"{placeInfo.owner[..5]}...{placeInfo.owner[^5..]}" : "Unknown";
             creatorWalletText.gameObject.SetActive(string.IsNullOrEmpty(placeInfo.contact_name));
-            likeRateText.text = $"{(placeInfo.like_rate_as_float ?? 0) * 100:F0}%";
+            likeRateText.text = $"{(placeInfo.LikeRateAsFloat ?? 0) * 100:F0}%";
             visitsText.text = UIUtils.NumberToCompactString(placeInfo.user_visits);
             SilentlySetLikeToggle(placeInfo.user_like);
             SilentlySetDislikeToggle(placeInfo.user_dislike);

--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIResponse.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIResponse.cs
@@ -25,6 +25,7 @@ namespace DCL.PlacesAPIService
         {
             private const string EMPTY_PLACE_ID = "fake_id";
 
+            // ReSharper disable InconsistentNaming
             public string id;
             public string title;
             public string description;
@@ -66,6 +67,8 @@ namespace DCL.PlacesAPIService
             public string[]? connected_addresses;
 
             [SerializeField] private string[] positions;
+
+            // ReSharper restore InconsistentNaming
 
             public bool IsEmptyPlace => id == EMPTY_PLACE_ID;
 
@@ -122,7 +125,7 @@ namespace DCL.PlacesAPIService
             }
 
             [JsonIgnore]
-            public float? like_rate_as_float
+            public float? LikeRateAsFloat
             {
                 get
                 {
@@ -173,12 +176,14 @@ namespace DCL.PlacesAPIService
             [Serializable]
             public class Realm
             {
+                // ReSharper disable InconsistentNaming
                 public string serverName;
                 public string layer;
                 public string url;
                 public int usersCount;
                 public int maxUsers;
                 public Vector2Int[] userParcels;
+                // ReSharper restore InconsistentNaming
             }
         }
 
@@ -186,9 +191,11 @@ namespace DCL.PlacesAPIService
         [Serializable]
         public class PlacesAPIResponse : PaginatedResponse, IPlacesAPIResponse
         {
+            // ReSharper disable InconsistentNaming
             public bool ok;
             public int total;
             public List<PlaceInfo> data;
+            // ReSharper restore InconsistentNaming
 
             int IPlacesAPIResponse.Total => total;
             IReadOnlyList<PlaceInfo> IPlacesAPIResponse.Data => data;
@@ -213,8 +220,10 @@ namespace DCL.PlacesAPIService
         [Serializable]
         public class PlacesAPIGetParcelResponse
         {
+            // ReSharper disable InconsistentNaming
             public bool ok;
             public PlaceInfo data;
+            // ReSharper restore InconsistentNaming
         }
 
     }
@@ -222,7 +231,9 @@ namespace DCL.PlacesAPIService
     [Serializable]
     public class OptimizedPlaceInMapResponse
     {
+        // ReSharper disable InconsistentNaming
         public Vector2Int base_position;
         public string name;
+        // ReSharper restore InconsistentNaming
     }
 }

--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIResponse.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIResponse.cs
@@ -69,6 +69,9 @@ namespace DCL.PlacesAPIService
 
             public bool IsEmptyPlace => id == EMPTY_PLACE_ID;
 
+            [JsonIgnore]
+            public bool IsWorld => !string.IsNullOrEmpty(world_name);
+
             public PlaceInfo(Vector2Int position)
             {
                 id = EMPTY_PLACE_ID;


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/9397

## Test Instructions

1. Go to the navmap (M)
2. Use the search bar to search for any world (ie: lorux0, metadyne, ryumi, etc..)
3. The place should be displayed in the list with the scene name
4. The place should not be displayed as a marker in the Genesis City (because worlds dont live there)
5. Click JumpIn, it should take you to the selected world

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
