### PR TITLE
chore: pin GameCI image tag that exists (3.2.0 -> 3.2.2)

### DIFF
--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -19,7 +19,7 @@ env:
   UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
   UNITY_LICENSE: ${{ secrets.UNITY_PERSONAL_LICENSE }}
   UNITY_IMAGE_FLAVOR: linux-il2cpp
-  UNITY_IMAGE_VERSION: 3.2.0
+  UNITY_IMAGE_VERSION: 3.2.2
   GHCR_IMAGE_NAME: unityci-editor
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ env:
   UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
   UNITY_LICENSE: ${{ secrets.UNITY_PERSONAL_LICENSE }}
   UNITY_IMAGE_FLAVOR: linux-il2cpp
-  UNITY_IMAGE_VERSION: 3.2.0
+  UNITY_IMAGE_VERSION: 3.2.2
   GHCR_IMAGE_NAME: unityci-editor
   INSPECT_REPORT_JSON_FILE_NAME: InspectCodeReport.json
   WARNINGS_BASELINE_S3_KEY: '@dcl/unity-explorer/ci/warnings-baseline.json'


### PR DESCRIPTION
`UNITY_IMAGE_VERSION: 3.2.0` (`test.yml`, `test-performance.yml`) names a GameCI image tag that **does not exist for any Unity version**. Docker Hub publishes only three tags per editor:

```
ubuntu-<editor>-linux-il2cpp-3
ubuntu-<editor>-linux-il2cpp-3.2
ubuntu-<editor>-linux-il2cpp-3.2.2
```

verified for `6000.4.0f1` (dev), `6000.5.2f1` and `6000.5.5f1`. The workflows compose `ubuntu-$version-$flavor-$imgVer`, so the upstream half of the GHCR-miss fallback — pull `unityci/editor:$tag`, retag, push to GHCR — has never been able to resolve.

It goes unnoticed because GHCR still holds `ubuntu-6000.4.0f1-linux-il2cpp-3.2.0`, seeded back when that tag existed upstream. Every PR against `dev` hits that cache and never exercises the fallback. The first PR to move the editor version misses the cache and the job dies in ~3 minutes with `manifest unknown`, before the test runner starts (`unity-test-runner` step: 0s) — currently blocking the Unity 6000.5 upgrade PR.

Pins `3.2.2`, which exists for every editor version in use, so both the cache hit and the upstream fallback resolve.

Not in scope: `Performance Test (PlayMode)` is *skipped*, not failing — it is gated behind `workflow_dispatch || contains(labels.*.name, 'perf_test')`, which is working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
