### PR TITLE
fix: authenticate chat sender identity before trusting ForwardedFrom

### DIFF
--- a/Explorer/Assets/DCL/Chat/MessageBus/LiveKitChatMessagesBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/LiveKitChatMessagesBus.cs
@@ -12,10 +12,10 @@ using DCL.Multiplayer.Connections.Messaging.Pipe;
 using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Multiplayer.Deduplication;
 using DCL.SceneBannedUsers;
+using DCL.Web3;
 using DCL.Web3.Identities;
 using Decentraland.Kernel.Comms.Rfc4;
 using DCL.LiveKit.Public;
-using LiveKit.Proto;
 using LiveKit.Rooms;
 using System;
 using System.Threading;
@@ -87,6 +87,9 @@ namespace DCL.Chat.MessageBus
                                    _ => "local",
                                };
 
+            // Must match the participant identity that comms-message-sfu joins the room under: it is the
+            // only signal that authenticates a relayed message's ForwardedFrom stamp. If the two ever
+            // diverge, relayed community messages are attributed to the router instead of their sender.
             routingUser = $"message-router-{serverEnv}-0";
 
             ConfigureMessagePipesHubAsync(setupExploreSectionsCts.Token).Forget();
@@ -121,9 +124,11 @@ namespace DCL.Chat.MessageBus
         {
             using (receivedMessage)
             {
-                string walletId = receivedMessage.Payload.HasForwardedFrom
-                    ? receivedMessage.Payload.ForwardedFrom
-                    : receivedMessage.FromWalletId;
+                // The island and scene pipes are peer-to-peer, so the message router is never in their
+                // path and a populated ForwardedFrom can only have been set by the publishing peer.
+                // Keying on it would let any peer publish under an arbitrary wallet and rotate the
+                // value to get a fresh slot for each of the checks below.
+                string walletId = receivedMessage.FromWalletId;
 
                 // If the user that sends the message is banned from the current scene, we ignore it
                 if (RoomMetadataCurrentScene.Instance.IsUserBanned(walletId)) return;
@@ -131,7 +136,7 @@ namespace DCL.Chat.MessageBus
                 // If the message was already received through the scene or island pipe, we ignore it
                 if (messageDeduplication.TryPass(walletId, receivedMessage.Payload.Timestamp) == false) return;
 
-                if (!TryCreateMessage(receivedMessage, out ChatMessage message)) return;
+                if (!TryCreateMessage(receivedMessage, walletId, out ChatMessage message)) return;
 
                 if (!isNearbyChannelBufferEnabled)
                 {
@@ -173,26 +178,43 @@ namespace DCL.Chat.MessageBus
                     return;
                 }
 
-                if (TryCreateMessage(receivedMessage, out ChatMessage newMessage))
+                string walletId = ResolveChatPipeSenderWalletId(receivedMessage);
+
+                if (TryCreateMessage(receivedMessage, walletId, out ChatMessage newMessage))
                     MessageAdded?.Invoke(parsedChannelId, channelType, newMessage);
             }
         }
 
-        private bool TryCreateMessage(ReceivedMessage<Decentraland.Kernel.Comms.Rfc4.Chat> receivedMessage, out ChatMessage newMessage)
+        /// <summary>
+        /// Resolves the author of a message received on the chat pipe.
+        /// </summary>
+        /// <remarks>
+        /// ForwardedFrom is stamped only by the trusted message router, which relays community messages
+        /// under the <see cref="routingUser"/> identity. Honoring it from any other sender would let a
+        /// peer publish under an arbitrary wallet, since the field is an ordinary payload string while
+        /// FromWalletId is the LiveKit-authenticated participant identity.
+        /// </remarks>
+        private string ResolveChatPipeSenderWalletId(ReceivedMessage<Decentraland.Kernel.Comms.Rfc4.Chat> receivedMessage)
+        {
+            if (receivedMessage.Payload.HasForwardedFrom
+                && string.Equals(receivedMessage.FromWalletId, routingUser, StringComparison.OrdinalIgnoreCase)
+                && Web3Address.IsValidWalletAddress(receivedMessage.Payload.ForwardedFrom))
+                return receivedMessage.Payload.ForwardedFrom;
+
+            return receivedMessage.FromWalletId;
+        }
+
+        private bool TryCreateMessage(ReceivedMessage<Decentraland.Kernel.Comms.Rfc4.Chat> receivedMessage, string senderWalletId, out ChatMessage newMessage)
         {
             newMessage = default(ChatMessage);
 
-            string walletId = receivedMessage.Payload.HasForwardedFrom
-                ? receivedMessage.Payload.ForwardedFrom
-                : receivedMessage.FromWalletId;
+            if (IsUserBlockedAndMessagesHidden(senderWalletId)) return false;
 
-            if (IsUserBlockedAndMessagesHidden(walletId)) return false;
+            if (isChatMessageRateLimiterEnabled && !messageRateLimiter!.TryAllow(senderWalletId)) return false;
 
-            if (isChatMessageRateLimiterEnabled && !messageRateLimiter!.TryAllow(walletId)) return false;
+            newMessage = messageFactory.CreateChatMessage(senderWalletId, false, receivedMessage.Payload.Message, null, receivedMessage.Payload.Timestamp);
 
-            newMessage = messageFactory.CreateChatMessage(walletId, false, receivedMessage.Payload.Message, null, receivedMessage.Payload.Timestamp);
-
-            ReportHub.Log(ReportCategory.CHAT_MESSAGES, $"[ChatMessageBus] RECEIVED message: protoTimestamp={receivedMessage.Payload.Timestamp} messageId={newMessage.MessageId} from={walletId}");
+            ReportHub.Log(ReportCategory.CHAT_MESSAGES, $"[ChatMessageBus] RECEIVED message: protoTimestamp={receivedMessage.Payload.Timestamp} messageId={newMessage.MessageId} from={senderWalletId}");
 
             return true;
         }

--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests.meta
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c986ac8e801244c0a6c1f7c97c363954
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests/DCL.Chat.MessageBus.Tests.asmref
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests/DCL.Chat.MessageBus.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests/DCL.Chat.MessageBus.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests/DCL.Chat.MessageBus.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b6324aafafbb4c49a39dae939ad16643
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests/LiveKitChatMessagesBusShould.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests/LiveKitChatMessagesBusShould.cs
@@ -1,0 +1,272 @@
+using DCL.Chat.History;
+using DCL.Communities;
+using DCL.FeatureFlags;
+using DCL.Friends.UserBlocking;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Multiplayer.Connections.Messaging;
+using DCL.Multiplayer.Connections.Messaging.Hubs;
+using DCL.Multiplayer.Connections.Messaging.Pipe;
+using DCL.Multiplayer.Connections.RoomHubs;
+using DCL.Multiplayer.Connections.Rooms;
+using DCL.Profiles;
+using DCL.SceneBannedUsers;
+using DCL.Web3.Identities;
+using Decentraland.Kernel.Comms.Rfc4;
+using Global.AppArgs;
+using Google.Protobuf;
+using LiveKit.Internal.FFIClients.Pools;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using ChatMessage = DCL.Chat.History.ChatMessage;
+using ChatPacket = Decentraland.Kernel.Comms.Rfc4.Chat;
+
+namespace DCL.Chat.MessageBus.Tests
+{
+    /// <summary>
+    /// Regression coverage for SEC-029: <c>Chat.ForwardedFrom</c> is a server-only stamp, so it must
+    /// only be honored when the authenticated LiveKit sender is the trusted message router. Otherwise
+    /// any co-located peer can impersonate a wallet and rotate the value to defeat ban, block, dedup
+    /// and rate-limiting, all of which key on the resolved sender.
+    /// </summary>
+    [TestFixture]
+    public class LiveKitChatMessagesBusShould
+    {
+        private const string ROUTING_USER = "message-router-dev-0";
+        private const string PEER_WALLET = "0x1111111111111111111111111111111111111111";
+        private const string VICTIM_WALLET = "0x2222222222222222222222222222222222222222";
+        private const string COMMUNITY_TOPIC = "community:1234";
+
+        private FakeMessagePipesHub pipesHub = null!;
+        private IMultiPool multiPool = null!;
+        private IUserBlockingCache userBlockingCache = null!;
+        private IWeb3IdentityCache identityCache = null!;
+        private List<ChatMessage> received = null!;
+        private LiveKitChatMessagesBus? bus;
+
+        [SetUp]
+        public void SetUp()
+        {
+            FeatureFlagsConfiguration.Reset();
+            OfficialWalletsHelper.Reset();
+            FeaturesRegistry.Reset();
+            CommunitiesFeatureAccess.Reset();
+            RoomMetadataCurrentScene.Reset();
+
+            IAppArgs appArgs = Substitute.For<IAppArgs>();
+            identityCache = Substitute.For<IWeb3IdentityCache>();
+
+            FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(FeatureFlagsResultDto.Empty));
+            OfficialWalletsHelper.Initialize(new OfficialWalletsHelper());
+            FeaturesRegistry.Initialize(new FeaturesRegistry(appArgs, false));
+            CommunitiesFeatureAccess.Initialize(new CommunitiesFeatureAccess(identityCache, appArgs));
+            RoomMetadataCurrentScene.InitializeTest();
+
+            pipesHub = new FakeMessagePipesHub();
+            multiPool = Substitute.For<IMultiPool>();
+            userBlockingCache = Substitute.For<IUserBlockingCache>();
+            received = new List<ChatMessage>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            bus?.Dispose();
+            bus = null;
+
+            RoomMetadataCurrentScene.Reset();
+            CommunitiesFeatureAccess.Reset();
+            FeaturesRegistry.Reset();
+            OfficialWalletsHelper.Reset();
+            FeatureFlagsConfiguration.Reset();
+        }
+
+        [Test]
+        public void AttributeNearbyMessageToAuthenticatedSenderIgnoringForwardedFrom()
+        {
+            // Arrange — Island and Scene are peer-to-peer pipes, so no router is ever in their path.
+            CreateBus();
+
+            // Act — a peer forges the author of its own nearby message.
+            DeliverNearby(fromWallet: PEER_WALLET, forwardedFrom: VICTIM_WALLET, timestamp: 1d);
+
+            // Assert
+            Assert.That(received.Count, Is.EqualTo(1));
+            Assert.That(received[0].SenderWalletAddress, Is.EqualTo(PEER_WALLET));
+        }
+
+        [Test]
+        public void IgnoreForwardedFromWhenChatPipeSenderIsNotTheMessageRouter()
+        {
+            // Arrange
+            CreateBus();
+
+            // Act — the same forgery on the pipe that does have a legitimate router path.
+            DeliverOnChatPipe(fromWallet: PEER_WALLET, forwardedFrom: VICTIM_WALLET, timestamp: 1d);
+
+            // Assert
+            Assert.That(received.Count, Is.EqualTo(1));
+            Assert.That(received[0].SenderWalletAddress, Is.EqualTo(PEER_WALLET));
+        }
+
+        [Test]
+        public void HonorForwardedFromWhenChatPipeSenderIsTheMessageRouter()
+        {
+            // Arrange — a genuinely relayed community message arrives AS the router participant.
+            // Requires the Communities shape to be included, which it is in the Editor.
+            CreateBus();
+
+            // Act
+            DeliverOnChatPipe(fromWallet: ROUTING_USER, forwardedFrom: VICTIM_WALLET, timestamp: 1d);
+
+            // Assert — real forwarding still resolves to the original sender.
+            Assert.That(received.Count, Is.EqualTo(1));
+            Assert.That(received[0].SenderWalletAddress, Is.EqualTo(VICTIM_WALLET));
+        }
+
+        [Test]
+        public void FallBackToRouterIdentityWhenForwardedFromIsMalformed()
+        {
+            // Arrange
+            CreateBus();
+
+            // Act — a malformed or rogue value from the router itself.
+            DeliverOnChatPipe(fromWallet: ROUTING_USER, forwardedFrom: "not-a-wallet-address", timestamp: 1d);
+
+            // Assert
+            Assert.That(received.Count, Is.EqualTo(1));
+            Assert.That(received[0].SenderWalletAddress, Is.EqualTo(ROUTING_USER));
+        }
+
+        [Test]
+        public void NotGrantFreshDedupSlotsWhenNearbyForwardedFromRotates()
+        {
+            // Arrange — dedup keys on (sender, timestamp), so a rotating author used to hand one peer
+            // an unlimited supply of unused keys at a single timestamp.
+            CreateBus();
+
+            // Act
+            DeliverNearby(PEER_WALLET, forwardedFrom: VICTIM_WALLET, timestamp: 1d);
+            DeliverNearby(PEER_WALLET, forwardedFrom: "0x3333333333333333333333333333333333333333", timestamp: 1d);
+            DeliverNearby(PEER_WALLET, forwardedFrom: "0x4444444444444444444444444444444444444444", timestamp: 1d);
+
+            // Assert — all three collapse onto the one authenticated wallet.
+            Assert.That(received.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void DeduplicateAcrossNearbyPipesWhenForwardedFromDiffers()
+        {
+            // Arrange — the same message reaches the client over both nearby pipes.
+            CreateBus();
+
+            // Act — a forged author on the second copy used to defeat the cross-pipe dedup.
+            DeliverNearby(PEER_WALLET, forwardedFrom: null, timestamp: 1d);
+            Deliver(pipesHub.Scene, PEER_WALLET, VICTIM_WALLET, 1d, RoomSource.Gatekeeper, string.Empty);
+
+            // Assert
+            Assert.That(received.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void KeepNearbyMessageOfBlockedPeerHiddenWhenForwardedFromRotates()
+        {
+            // Arrange — the local user blocks the peer and hides its messages.
+            userBlockingCache.HideChatMessages.Returns(true);
+            userBlockingCache.UserIsBlocked(PEER_WALLET).Returns(true);
+            CreateBus();
+
+            // Act — the blocked peer claims to be somebody the local user has not blocked.
+            DeliverNearby(PEER_WALLET, forwardedFrom: VICTIM_WALLET, timestamp: 1d);
+
+            // Assert
+            Assert.That(received, Is.Empty);
+        }
+
+        [Test]
+        public void AttributeNearbyMessageToAuthenticatedSenderWhenForwardedFromIsAbsent()
+        {
+            // Arrange
+            CreateBus();
+
+            // Act
+            DeliverNearby(PEER_WALLET, forwardedFrom: null, timestamp: 1d);
+
+            // Assert
+            Assert.That(received.Count, Is.EqualTo(1));
+            Assert.That(received[0].SenderWalletAddress, Is.EqualTo(PEER_WALLET));
+        }
+
+        // ── Test helpers ─────────────────────────────────────────
+
+        private void CreateBus()
+        {
+            var messageFactory = new ChatMessageFactory(Substitute.For<IProfileCache>(), identityCache);
+
+            // Zone resolves the routing user to "message-router-dev-0".
+            var newBus = new LiveKitChatMessagesBus(pipesHub,
+                messageFactory,
+                userBlockingCache,
+                DecentralandEnvironment.Zone,
+                identityCache,
+                Substitute.For<IRoomHub>());
+
+            newBus.MessageAdded += (_, _, message) => received.Add(message);
+            bus = newBus;
+        }
+
+        private void DeliverNearby(string fromWallet, string? forwardedFrom, double timestamp) =>
+            Deliver(pipesHub.Island, fromWallet, forwardedFrom, timestamp, RoomSource.Island, string.Empty);
+
+        private void DeliverOnChatPipe(string fromWallet, string? forwardedFrom, double timestamp) =>
+            Deliver(pipesHub.Chat, fromWallet, forwardedFrom, timestamp, RoomSource.Island, COMMUNITY_TOPIC);
+
+        private void Deliver(FakeMessagePipe pipe, string fromWallet, string? forwardedFrom, double timestamp,
+            RoomSource roomSource, string topic)
+        {
+            var payload = new ChatPacket { Message = "hello", Timestamp = timestamp };
+
+            if (forwardedFrom != null)
+                payload.ForwardedFrom = forwardedFrom;
+
+            pipe.Deliver(Packet.MessageOneofCase.Chat,
+                new ReceivedMessage<ChatPacket>(payload, new Packet(), fromWallet, multiPool, roomSource, topic));
+        }
+
+        private sealed class FakeMessagePipesHub : IMessagePipesHub
+        {
+            public readonly FakeMessagePipe Island = new ();
+            public readonly FakeMessagePipe Scene = new ();
+            public readonly FakeMessagePipe Chat = new ();
+
+            public IMessagePipe ScenePipe() => Scene;
+
+            public IMessagePipe IslandPipe() => Island;
+
+            public IMessagePipe ChatPipe() => Chat;
+
+            public void Dispose() { }
+        }
+
+        private sealed class FakeMessagePipe : IMessagePipe
+        {
+            private readonly Dictionary<Packet.MessageOneofCase, object> handlers = new ();
+
+            public MessageWrap<T> NewMessage<T>(string topic = "") where T: class, IMessage, new() =>
+                throw new NotSupportedException("Receive-only fake");
+
+            public void Subscribe<T>(Packet.MessageOneofCase ofCase, Action<ReceivedMessage<T>> onMessageReceived,
+                IMessagePipe.ThreadStrict threadStrict = IMessagePipe.ThreadStrict.MainThreadOnly) where T: class, IMessage, new() =>
+                handlers[ofCase] = onMessageReceived;
+
+            public void Deliver<T>(Packet.MessageOneofCase ofCase, ReceivedMessage<T> message) where T: class, IMessage, new()
+            {
+                if (handlers.TryGetValue(ofCase, out object? handler))
+                    ((Action<ReceivedMessage<T>>)handler).Invoke(message);
+            }
+
+            public void Dispose() { }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests/LiveKitChatMessagesBusShould.cs.meta
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests/LiveKitChatMessagesBusShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e863e9991812413bbfd451b9431bcccb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Web3/Abstract/Web3Address.cs
+++ b/Explorer/Assets/DCL/Web3/Abstract/Web3Address.cs
@@ -22,6 +22,25 @@ namespace DCL.Web3
             this.address = address.ToLower();
         }
 
+        /// <summary>
+        /// Checks that a value is shaped like an Ethereum wallet address: "0x" followed by 40 hex digits.
+        /// </summary>
+        /// <param name="walletAddress">The value to check. Null and malformed values return false.</param>
+        public static bool IsValidWalletAddress(string? walletAddress)
+        {
+            if (walletAddress == null || walletAddress.Length != ETH_ADDRESS_LENGTH) return false;
+
+            if (walletAddress[0] != '0' || (walletAddress[1] != 'x' && walletAddress[1] != 'X')) return false;
+
+            for (int i = 2; i < walletAddress.Length; i++)
+            {
+                if (walletAddress[i] is not (>= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F'))
+                    return false;
+            }
+
+            return true;
+        }
+
         public override string ToString() =>
             address;
 

--- a/Explorer/Assets/DCL/Web3/Tests.meta
+++ b/Explorer/Assets/DCL/Web3/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f6e9d00f4a94d8d82917d13c7d20119
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Web3/Tests/DCL.Web3.Tests.asmref
+++ b/Explorer/Assets/DCL/Web3/Tests/DCL.Web3.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/Web3/Tests/DCL.Web3.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/Web3/Tests/DCL.Web3.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9879ee20282746d0885cd8f040420ea1
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Web3/Tests/Web3AddressShould.cs
+++ b/Explorer/Assets/DCL/Web3/Tests/Web3AddressShould.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+
+namespace DCL.Web3.Tests
+{
+    [TestFixture]
+    public class Web3AddressShould
+    {
+        private const string VALID_ADDRESS = "0x1111111111111111111111111111111111111111";
+
+        [TestCase("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd", TestName = "lowercase hex")]
+        [TestCase("0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD", TestName = "uppercase hex")]
+        [TestCase("0x71C7656EC7ab88b098defB751B7401B5f6d8976F", TestName = "checksummed mixed case")]
+        [TestCase("0X1111111111111111111111111111111111111111", TestName = "uppercase X prefix")]
+        [TestCase("0x0000000000000000000000000000000000000000", TestName = "zero address")]
+        public void AcceptWellFormedWalletAddress(string candidate)
+        {
+            Assert.That(Web3Address.IsValidWalletAddress(candidate), Is.True);
+        }
+
+        [TestCase(null, TestName = "null")]
+        [TestCase("", TestName = "empty")]
+        [TestCase("0x111111111111111111111111111111111111111", TestName = "one hex digit short")]
+        [TestCase("0x11111111111111111111111111111111111111111", TestName = "one hex digit long")]
+        [TestCase("1111111111111111111111111111111111111111111", TestName = "no 0x prefix")]
+        [TestCase("111111111111111111111111111111111111111111", TestName = "42 chars but no prefix")]
+        [TestCase("0x111111111111111111111111111111111111111g", TestName = "non hex digit")]
+        [TestCase("0x1111111111111111111111111111111111111 11", TestName = "embedded space")]
+        [TestCase("not-a-wallet-address", TestName = "arbitrary text")]
+        public void RejectMalformedWalletAddress(string? candidate)
+        {
+            Assert.That(Web3Address.IsValidWalletAddress(candidate), Is.False);
+        }
+
+        [Test]
+        public void ValidateAgainstItsOwnLengthConstant()
+        {
+            // Arrange / Act / Assert — the validator and the constant must not drift apart.
+            Assert.That(VALID_ADDRESS.Length, Is.EqualTo(Web3Address.ETH_ADDRESS_LENGTH));
+            Assert.That(Web3Address.IsValidWalletAddress(VALID_ADDRESS), Is.True);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Web3/Tests/Web3AddressShould.cs.meta
+++ b/Explorer/Assets/DCL/Web3/Tests/Web3AddressShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1844b760f60469cb52006f22f7a40f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes **SEC-029** (High, remote): any co-located LiveKit peer could post nearby-chat messages attributed to **any** wallet, and bypass scene-ban, block, dedup and rate-limiting at the same time.

`Chat.ForwardedFrom` is a server-only stamp — the message router (`comms-message-sfu`) writes it when it relays a community message. The client preferred it over the LiveKit-authenticated `FromWalletId` **with no check that the packet actually came from that router**:

```csharp
string walletId = receivedMessage.Payload.HasForwardedFrom
    ? receivedMessage.Payload.ForwardedFrom   // arbitrary attacker-supplied payload string
    : receivedMessage.FromWalletId;           // authenticated participant identity
```

That block was duplicated in `HandleNearbyPipesMessage` and `TryCreateMessage`, and its result was the key for the scene ban, the cross-pipe dedup, the user block, the rate limiter **and** the rendered author. One forgery therefore bought both impersonation (posing as a moderator, running scams) and a full bypass of all four controls — each forged identity got its own dedup slot and a full rate-limit budget, enabling a sustained flood. No scene authoring and no victim interaction required: it lands on people standing in legitimate public spaces.

**The fix** resolves the sender once per pipe, from the authenticated identity:

- **Island/Scene (nearby)** now always use `FromWalletId`. These pipes are peer-to-peer, so the router is never in their path and a populated `ForwardedFrom` can only have come from the publishing peer. They deliberately do *not* consult `routingUser`, so nearby chat stays safe even if participant identities were ever forgeable at join time.
- **Chat pipe** honors `ForwardedFrom` only when the authenticated sender **is** `routingUser` and the value is a well-formed wallet address. Genuine community relay keeps working; a peer forging the field is attributed to its real wallet.
- `TryCreateMessage` now takes the resolved sender rather than resolving it a second time, so the author and all four controls share one authenticated key.

A rejected `ForwardedFrom` is intentionally **not** logged — the attacker controls the message rate, so per-message logging would be a flood amplifier on the very path this fixes.

`IsValidWalletAddress` lives on `Web3Address`, which already owns `ETH_ADDRESS_LENGTH`, so the constant and the check that enforces it stay together. It is allocation-free (no regex, no LINQ).

### Scope

Client-side only, and that is authoritative: **nearby chat is peer-to-peer and has no server backstop**, so the client must ignore `ForwardedFrom` there regardless of any backend change. Two complementary items remain open in other repos and do not block this:

- `comms-gatekeeper` — never mint a room token letting an ordinary participant join under the reserved `message-router-{env}-0` identity.
- `comms-message-sfu` — confirm it strips/overwrites any client-supplied `ForwardedFrom` before relaying; optionally HMAC-sign relayed messages so provenance is verifiable cryptographically rather than by identity string.

### Note for reviewers

The chat-pipe path depends on the client's `routingUser` string (`message-router-{env}-0`) exactly matching the SFU's participant identity per environment. If they ever diverge, relayed community messages would be attributed to the router instead of their sender. There is a comment at the construction site; a constant shared with `comms-message-sfu` would be the durable fix and is out of scope here.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 9501
```

**Expected result**: Nearby and community chat behave exactly as before — messages show the correct author, community messages relayed through the router are attributed to the original sender (not to `message-router-*`), blocking a user still hides their messages, and DMs land in the right conversation.

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run 9501
```

**Expected result**: Same as above on a clean profile — no regression in first-run chat.

### Prerequisites
- [ ] Two accounts (or two clients) able to stand in the same island
- [ ] For the community path: both accounts in the same community, with the Communities feature available to them
- [ ] To exercise the rate-limit key, run with the chat rate-limit flag enabled

### Test Steps
1. Stand both clients in the same parcel and send nearby messages in each direction. Both render under the correct sender names.
2. Block one account from the other and enable "hide chat messages". The blocked account's nearby messages stop appearing.
3. Unblock, then send the same nearby message while both the island and scene rooms are connected. The message appears **once**, not twice (cross-pipe dedup still works).
4. Open a community channel from both accounts and exchange messages. Each message is attributed to the sender who typed it — **not** to `message-router-prd-0`/`message-router-dev-0`. This is the main regression risk in this PR.
5. Send a DM between the two accounts. It arrives in the correct conversation with the correct author.

### Additional Testing Notes
- **Step 4 is the highest-value check.** The community relay is the one legitimate producer of `ForwardedFrom`; if the client's `routingUser` did not match the SFU identity in the target environment, community messages would show the router as the author. Please verify in `zone` **and** `org`, since the identity is environment-derived.
- Spoofing itself is not reproducible from a stock client (the send path always clears `ForwardedFrom`); it requires a modified client publishing a crafted packet. The behaviour is covered by automated tests instead — see below.
- Automated coverage: `LiveKitChatMessagesBusShould` (8 cases) proves a forged `ForwardedFrom` is ignored on nearby pipes and on the chat pipe from a non-router sender, that genuine router relay is still honored, that a malformed value falls back, and that rotating the field no longer grants fresh dedup slots or unhides a blocked peer. `Web3AddressShould` (15 cases) pins the address validator. Full `DCL.Chat.*` EditMode suite: 1366/1366 pass. ReSharper InspectCode (same rules as CI): no findings in the changed files.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
