### PR TITLE
fix: allow local-ab deep-link param for loopback realms, deriving the assets base from the realm

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -130,13 +130,12 @@ namespace Global.AppArgs
         public const string LSD_USE_REMOTE_AB = "lsd-use-remote-ab";
         public const string LSD_REMOTE_AB_SERVER = "lsd-remote-ab-server";
         public const string LSD_REMOTE_AB_WORLD = "lsd-remote-ab-world";
-        public const string LOCAL_AB = "local-ab";
-
         /// <summary>
-        ///     Overrides the port of the local asset-bundle server (implies <see cref="LOCAL_AB" />). Only the port is
-        ///     configurable — the host is always 127.0.0.1; a full-URL override requires <see cref="OPTIMIZED_ASSETS_URL" />.
+        ///     Local scene development only: load assets as asset bundles served by the preview server at
+        ///     {realm}/optimized-assets instead of raw GLTFs. Carries no URL or port — the base is derived
+        ///     from the realm the client already has.
         /// </summary>
-        public const string LOCAL_AB_PORT = "local-ab-port";
+        public const string LOCAL_AB = "local-ab";
 
         public const string OPTIMIZED_ASSETS_URL = "optimized-assets-url";
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -132,6 +132,12 @@ namespace Global.AppArgs
         public const string LSD_REMOTE_AB_WORLD = "lsd-remote-ab-world";
         public const string LOCAL_AB = "local-ab";
 
+        /// <summary>
+        ///     Overrides the port of the local asset-bundle server (implies <see cref="LOCAL_AB" />). Only the port is
+        ///     configurable — the host is always 127.0.0.1; a full-URL override requires <see cref="OPTIMIZED_ASSETS_URL" />.
+        /// </summary>
+        public const string LOCAL_AB_PORT = "local-ab-port";
+
         public const string OPTIMIZED_ASSETS_URL = "optimized-assets-url";
 
         public const string NO_LIVEKIT_MODE = "no-livekit-mode";

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
@@ -126,9 +126,9 @@ namespace Global.AppArgs
             }
 
             // Tier 2 (SEC-019/020): the local-development params Creator Hub / sdk-commands attach to preview deep
-            // links (local-scene, dclenv, hub, skip-auth-screen, landscape-terrain-enabled, multi-instance) are
-            // permitted only when the target realm is loopback — a remote-realm deep link from a web page cannot
-            // enable them. Everything not in either tier is dropped.
+            // links (DeepLinkAllowlist.LOOPBACK_REALM_PERMITTED_KEYS, with per-key rationale) are permitted only
+            // when the target realm is loopback — a remote-realm deep link from a web page cannot enable them.
+            // Everything not in either tier is dropped.
             bool realmIsLoopback = output.TryGetValue(AppArgsFlags.REALM, out string? loopbackRealm)
                                    && Uri.TryCreate(loopbackRealm, UriKind.Absolute, out Uri? loopbackRealmUri)
                                    && loopbackRealmUri.IsLoopback;

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -19,12 +19,14 @@ namespace Global.AppArgs
     ///         <item>
     ///             <b>Permitted only for a loopback realm</b> — the local-development params Creator Hub and the
     ///             SDK (<c>sdk-commands</c>) attach to their preview deep links: local-scene, dclenv, hub,
-    ///             skip-auth-screen, landscape-terrain-enabled, multi-instance, mcp, mcp-port. They are gated on
+    ///             skip-auth-screen, landscape-terrain-enabled, multi-instance, mcp, mcp-port, local-ab,
+    ///             local-ab-port. They are gated on
     ///             <c>Uri.IsLoopback</c> of the target realm (127.0.0.1 / localhost / [::1]) so a remote-realm deep
     ///             link from a web page can never enable them, while a legitimate local-dev launch (which always
     ///             targets loopback) works. All but the MCP pair are individually low-harm — an analytics tag, a
-    ///             cosmetic toggle, an instance count, an env enum, or a screen skip that still forces auth when no
-    ///             valid identity is cached; <c>mcp</c>/<c>mcp-port</c> start an unauthenticated loopback control
+    ///             cosmetic toggle, an instance count, an env enum, a screen skip that still forces auth when no
+    ///             valid identity is cached, or an asset-server toggle/port whose host is pinned to 127.0.0.1;
+    ///             <c>mcp</c>/<c>mcp-port</c> start an unauthenticated loopback control
     ///             port, so they lean on the gate plus the server's own 127.0.0.1 bind and Origin check — see the
     ///             per-key comment for what the gate does and does not cover.
     ///         </item>
@@ -110,6 +112,19 @@ namespace Global.AppArgs
             // Port the server above listens on. Presence alone also starts it (MCP_PORT implies MCP), so it carries
             // the same gate; the value is clamped to 1024-65535 and falls back to the default port (McpServerPlugin).
             AppArgsFlags.MCP_PORT,
+
+            // Local-scene development only: load the scene's asset bundles from a locally running abgen instead of
+            // raw GLTFs. Redirects the optimized-assets endpoints to a fixed 127.0.0.1 URL, so the worst case for a
+            // crafted link is asset loading pointed at a dead (or squatted) local port — a hostile process on the
+            // victim's own loopback is already past this trust boundary.
+            AppArgsFlags.LOCAL_AB,
+
+            // Port the local asset-bundle server above listens on (implies LOCAL_AB). The host stays pinned to
+            // 127.0.0.1 — the value is parsed as an int and must fall in 1024-65535, else abgen's default port is
+            // used (RealmLaunchSettings.ResolveLocalAssetBundlesUrl), so a crafted link cannot smuggle a remote
+            // host or a path through it. The full-URL variant (optimized-assets-url) points AB/LOD/registry
+            // endpoints at arbitrary infrastructure and stays never-permitted.
+            AppArgsFlags.LOCAL_AB_PORT,
         };
 
         public static bool IsPermitted(string key) =>

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -13,18 +13,19 @@ namespace Global.AppArgs
     ///     <list type="bullet">
     ///         <item>
     ///             <b>Always permitted</b> — benign navigation / share / login intents whose worst case is already
-    ///             gated elsewhere (a consent prompt, a matching login token, or a plain coordinate): realm,
-    ///             position, community, signin, authRequestId, force-open-backpack, spawnpoint.
+    ///             gated elsewhere (a consent prompt, a matching login token, a plain coordinate, or a closed
+    ///             Decentraland-owned enum): realm, position, community, signin, authRequestId, force-open-backpack,
+    ///             spawnpoint, dclenv.
     ///         </item>
     ///         <item>
     ///             <b>Permitted only for a loopback realm</b> — the local-development params Creator Hub and the
-    ///             SDK (<c>sdk-commands</c>) attach to their preview deep links: local-scene, dclenv, hub,
+    ///             SDK (<c>sdk-commands</c>) attach to their preview deep links: local-scene, hub,
     ///             skip-auth-screen, landscape-terrain-enabled, multi-instance, mcp, mcp-port, local-ab.
     ///             They are gated on
     ///             <c>Uri.IsLoopback</c> of the target realm (127.0.0.1 / localhost / [::1]) so a remote-realm deep
     ///             link from a web page can never enable them, while a legitimate local-dev launch (which always
     ///             targets loopback) works. All but the MCP pair are individually low-harm — an analytics tag, a
-    ///             cosmetic toggle, an instance count, an env enum, a screen skip that still forces auth when no
+    ///             cosmetic toggle, an instance count, a screen skip that still forces auth when no
     ///             valid identity is cached, or an asset-server toggle whose base URL derives from the realm this
     ///             gate already checked; <c>mcp</c>/<c>mcp-port</c> start an unauthenticated loopback control
     ///             port, so they lean on the gate plus the server's own 127.0.0.1 bind and Origin check — see the
@@ -72,6 +73,14 @@ namespace Global.AppArgs
             // POSITION — it only picks where inside an already-permitted realm/position navigation the user arrives,
             // with no capability, infra, or exec impact.
             AppArgsFlags.SPAWN_POINT,
+
+            // Target environment (org|zone|today). Not realm-gated: the login callbacks and jump-in links that carry
+            // it have no realm at all, so the loopback-realm condition below could never pass for them and the session
+            // would silently fall back to the default environment. Safe on its own — a closed Decentraland-owned enum,
+            // parsed with Enum.TryParse where it is consumed and ignored when it does not match, never a URL, so it
+            // cannot point the client at attacker infrastructure. Worst case is a session in a Decentraland-owned test
+            // environment, strictly less capable than the attacker-supplied REALM above.
+            AppArgsFlags.ENVIRONMENT,
         };
 
         // Local-development params Creator Hub / sdk-commands attach to preview deep links. Permitted ONLY when the
@@ -83,9 +92,6 @@ namespace Global.AppArgs
             // Enables local-scene-development mode (opens an LSD websocket to the realm). Only meaningful against a
             // local server; loopback-gated so an attacker can't point LSD at a remote realm (SEC-020).
             AppArgsFlags.LOCAL_SCENE,
-
-            // Target environment (org/zone/today). A DCL-owned enum, not a URL — cannot point at attacker infra.
-            AppArgsFlags.ENVIRONMENT,
 
             // Marks the session as launched from the Creator Hub (analytics trait only — no capability unlock).
             AppArgsFlags.DCL_EDITOR,

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -19,14 +19,14 @@ namespace Global.AppArgs
     ///         <item>
     ///             <b>Permitted only for a loopback realm</b> — the local-development params Creator Hub and the
     ///             SDK (<c>sdk-commands</c>) attach to their preview deep links: local-scene, dclenv, hub,
-    ///             skip-auth-screen, landscape-terrain-enabled, multi-instance, mcp, mcp-port, local-ab,
-    ///             local-ab-port. They are gated on
+    ///             skip-auth-screen, landscape-terrain-enabled, multi-instance, mcp, mcp-port, local-ab.
+    ///             They are gated on
     ///             <c>Uri.IsLoopback</c> of the target realm (127.0.0.1 / localhost / [::1]) so a remote-realm deep
     ///             link from a web page can never enable them, while a legitimate local-dev launch (which always
     ///             targets loopback) works. All but the MCP pair are individually low-harm — an analytics tag, a
     ///             cosmetic toggle, an instance count, an env enum, a screen skip that still forces auth when no
-    ///             valid identity is cached, or an asset-server toggle/port whose host is pinned to 127.0.0.1;
-    ///             <c>mcp</c>/<c>mcp-port</c> start an unauthenticated loopback control
+    ///             valid identity is cached, or an asset-server toggle whose base URL derives from the realm this
+    ///             gate already checked; <c>mcp</c>/<c>mcp-port</c> start an unauthenticated loopback control
     ///             port, so they lean on the gate plus the server's own 127.0.0.1 bind and Origin check — see the
     ///             per-key comment for what the gate does and does not cover.
     ///         </item>
@@ -113,18 +113,14 @@ namespace Global.AppArgs
             // the same gate; the value is clamped to 1024-65535 and falls back to the default port (McpServerPlugin).
             AppArgsFlags.MCP_PORT,
 
-            // Local-scene development only: load the scene's asset bundles from a locally running abgen instead of
-            // raw GLTFs. Redirects the optimized-assets endpoints to a fixed 127.0.0.1 URL, so the worst case for a
-            // crafted link is asset loading pointed at a dead (or squatted) local port — a hostile process on the
-            // victim's own loopback is already past this trust boundary.
+            // Local-scene development only: load the scene's asset bundles from the preview server instead of raw
+            // GLTFs. A pure boolean — the optimized-assets base is derived from the realm itself
+            // ({realm}/optimized-assets, see RealmLaunchSettings.LocalAssetBundlesBaseUrl), the same value this
+            // gate already requires to be loopback, so the flag adds no attacker-controllable input: it can only
+            // point asset loading at the realm the link already targets. The full-URL variant
+            // (optimized-assets-url) points AB/LOD/registry endpoints at arbitrary infrastructure and stays
+            // never-permitted.
             AppArgsFlags.LOCAL_AB,
-
-            // Port the local asset-bundle server above listens on (implies LOCAL_AB). The host stays pinned to
-            // 127.0.0.1 — the value is parsed as an int and must fall in 1024-65535, else abgen's default port is
-            // used (RealmLaunchSettings.ResolveLocalAssetBundlesUrl), so a crafted link cannot smuggle a remote
-            // host or a path through it. The full-URL variant (optimized-assets-url) points AB/LOD/registry
-            // endpoints at arbitrary infrastructure and stays never-permitted.
-            AppArgsFlags.LOCAL_AB_PORT,
         };
 
         public static bool IsPermitted(string key) =>

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -127,11 +127,12 @@ namespace Global.AppArgs.Tests
         public void DeepLinkDropsExecAndInfraParamsEvenForLoopbackRealm()
         {
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=http://127.0.0.1:8000&creator-hub-bin-path=x&launch-cdp-monitor-on-start=true&comms-adapter=y");
+                "decentraland://?realm=http://127.0.0.1:8000&creator-hub-bin-path=x&launch-cdp-monitor-on-start=true&comms-adapter=y&optimized-assets-url=https://evil.example");
 
             Assert.IsFalse(output.ContainsKey("creator-hub-bin-path"), "creator-hub-bin-path must never be permitted (SEC-005), even for a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), "launch-cdp-monitor-on-start must never be permitted, even for a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.COMMS_ADAPTER), "comms-adapter must never be permitted, even for a loopback realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.OPTIMIZED_ASSETS_URL), "optimized-assets-url must never be permitted, even for a loopback realm — it points the AB/LOD/registry endpoints at arbitrary infrastructure for the whole session; only the host-pinned local-ab-port variant is deep-link reachable");
         }
 
         [Test]
@@ -161,6 +162,26 @@ namespace Global.AppArgs.Tests
 
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.MCP), "mcp must be dropped when the link carries no realm at all (drive-by link against the default realm)");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.MCP_PORT), "mcp-port must be dropped when the link carries no realm at all");
+        }
+
+        [Test]
+        public void DeepLinkKeepsLocalAbForLoopbackRealm()
+        {
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
+                "decentraland://?realm=http://127.0.0.1:8000&local-scene=true&local-ab=true&local-ab-port=5200");
+
+            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.LOCAL_AB), "local-ab must survive for a loopback (local dev) realm — Creator Hub forwards it into the preview deep link");
+            Assert.AreEqual("5200", output.GetValueOrDefault(AppArgsFlags.LOCAL_AB_PORT), "local-ab-port must survive for a loopback (local dev) realm");
+        }
+
+        [Test]
+        public void DeepLinkDropsLocalAbForRemoteRealm()
+        {
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
+                "decentraland://?realm=https://peer.decentraland.org&local-scene=true&local-ab=true&local-ab-port=5200");
+
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_AB), "local-ab must be dropped for a non-loopback (remote) realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_AB_PORT), "local-ab-port must be dropped for a non-loopback (remote) realm (it implies local-ab)");
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -66,7 +66,7 @@ namespace Global.AppArgs.Tests
         public void DeepLinkKeepsAllowlistedParams()
         {
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=https://peer.decentraland.org&position=10,20&community=abc&signin=id1&authRequestId=req1&force-open-backpack=true&spawnpoint=lobby");
+                "decentraland://?realm=https://peer.decentraland.org&position=10,20&community=abc&signin=id1&authRequestId=req1&force-open-backpack=true&spawnpoint=lobby&dclenv=zone");
 
             Assert.AreEqual("https://peer.decentraland.org", output.GetValueOrDefault(AppArgsFlags.REALM));
             Assert.AreEqual("10,20", output.GetValueOrDefault(AppArgsFlags.POSITION));
@@ -75,6 +75,22 @@ namespace Global.AppArgs.Tests
             Assert.AreEqual("req1", output.GetValueOrDefault(AppArgsFlags.AUTH_REQUEST_ID));
             Assert.IsTrue(output.ContainsKey(AppArgsFlags.FORCE_OPEN_BACKPACK), "force-open-backpack must survive (shipped feature #9398)");
             Assert.AreEqual("lobby", output.GetValueOrDefault(AppArgsFlags.SPAWN_POINT), "spawnpoint must survive (named scene spawn point #9369)");
+            Assert.AreEqual("zone", output.GetValueOrDefault(AppArgsFlags.ENVIRONMENT), "dclenv must survive for any realm: it is the only channel that carries the environment into a launched client");
+        }
+
+        [Test]
+        public void DeepLinkKeepsEnvironmentForRealmlessLoginCallback()
+        {
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
+                "decentraland://open?signin=id1&dclenv=zone&authRequestId=req1&local-scene=true&skip-auth-screen=true&multi-instance=true&scene-console=true");
+
+            Assert.AreEqual("zone", output.GetValueOrDefault(AppArgsFlags.ENVIRONMENT), "dclenv must survive a realm-less login callback, otherwise the client falls back to the default environment");
+            Assert.AreEqual("id1", output.GetValueOrDefault(AppArgsFlags.SIGNIN));
+            Assert.AreEqual("req1", output.GetValueOrDefault(AppArgsFlags.AUTH_REQUEST_ID));
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must still require a loopback realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.SKIP_AUTH_SCREEN), "skip-auth-screen must still require a loopback realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.MULTIPLE_RUNNING_INSTANCES), "multi-instance must still require a loopback realm");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.SCENE_CONSOLE), "scene-console must stay dropped for every realm");
         }
 
         [Test]
@@ -99,10 +115,9 @@ namespace Global.AppArgs.Tests
         public void DeepLinkKeepsSdkAndCreatorHubDevParamsForLoopbackRealm()
         {
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=http://127.0.0.1:8000&position=10,20&local-scene=true&dclenv=zone&hub=true&skip-auth-screen=true&landscape-terrain-enabled=true&multi-instance=true");
+                "decentraland://?realm=http://127.0.0.1:8000&position=10,20&local-scene=true&hub=true&skip-auth-screen=true&landscape-terrain-enabled=true&multi-instance=true");
 
             Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.LOCAL_SCENE), "local-scene");
-            Assert.AreEqual("zone", output.GetValueOrDefault(AppArgsFlags.ENVIRONMENT), "dclenv");
             Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.DCL_EDITOR), "hub");
             Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.SKIP_AUTH_SCREEN), "skip-auth-screen");
             Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.LANDSCAPE_TERRAIN_ENABLED), "landscape-terrain-enabled");
@@ -113,10 +128,9 @@ namespace Global.AppArgs.Tests
         public void DeepLinkDropsSdkAndCreatorHubDevParamsForRemoteRealm()
         {
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=https://peer.decentraland.org&local-scene=true&dclenv=zone&hub=true&skip-auth-screen=true&landscape-terrain-enabled=true&multi-instance=true");
+                "decentraland://?realm=https://peer.decentraland.org&local-scene=true&hub=true&skip-auth-screen=true&landscape-terrain-enabled=true&multi-instance=true");
 
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must be dropped for a remote realm");
-            Assert.IsFalse(output.ContainsKey(AppArgsFlags.ENVIRONMENT), "dclenv must be dropped for a remote realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.DCL_EDITOR), "hub must be dropped for a remote realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.SKIP_AUTH_SCREEN), "skip-auth-screen must be dropped for a remote realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LANDSCAPE_TERRAIN_ENABLED), "landscape-terrain-enabled must be dropped for a remote realm");

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -132,7 +132,7 @@ namespace Global.AppArgs.Tests
             Assert.IsFalse(output.ContainsKey("creator-hub-bin-path"), "creator-hub-bin-path must never be permitted (SEC-005), even for a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), "launch-cdp-monitor-on-start must never be permitted, even for a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.COMMS_ADAPTER), "comms-adapter must never be permitted, even for a loopback realm");
-            Assert.IsFalse(output.ContainsKey(AppArgsFlags.OPTIMIZED_ASSETS_URL), "optimized-assets-url must never be permitted, even for a loopback realm — it points the AB/LOD/registry endpoints at arbitrary infrastructure for the whole session; only the host-pinned local-ab-port variant is deep-link reachable");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.OPTIMIZED_ASSETS_URL), "optimized-assets-url must never be permitted, even for a loopback realm — it points the AB/LOD/registry endpoints at arbitrary infrastructure for the whole session; local-ab derives the base from the realm instead");
         }
 
         [Test]
@@ -168,20 +168,18 @@ namespace Global.AppArgs.Tests
         public void DeepLinkKeepsLocalAbForLoopbackRealm()
         {
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=http://127.0.0.1:8000&local-scene=true&local-ab=true&local-ab-port=5200");
+                "decentraland://?realm=http://127.0.0.1:8000&local-scene=true&local-ab=true");
 
             Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.LOCAL_AB), "local-ab must survive for a loopback (local dev) realm — Creator Hub forwards it into the preview deep link");
-            Assert.AreEqual("5200", output.GetValueOrDefault(AppArgsFlags.LOCAL_AB_PORT), "local-ab-port must survive for a loopback (local dev) realm");
         }
 
         [Test]
         public void DeepLinkDropsLocalAbForRemoteRealm()
         {
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=https://peer.decentraland.org&local-scene=true&local-ab=true&local-ab-port=5200");
+                "decentraland://?realm=https://peer.decentraland.org&local-scene=true&local-ab=true");
 
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_AB), "local-ab must be dropped for a non-loopback (remote) realm");
-            Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_AB_PORT), "local-ab-port must be dropped for a non-loopback (remote) realm (it implies local-ab)");
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -233,7 +233,7 @@ namespace Global.Dynamic
             applicationParametersParser.TryGetValue(AppArgsFlags.OPTIMIZED_ASSETS_URL, out string? cliOptimizedAssetsUrl);
 
             if (string.IsNullOrEmpty(cliOptimizedAssetsUrl) && launchSettings.useLocalAssetBundles)
-                cliOptimizedAssetsUrl = RealmLaunchSettings.DEFAULT_LOCAL_ASSET_BUNDLES_URL;
+                cliOptimizedAssetsUrl = RealmLaunchSettings.ResolveLocalAssetBundlesUrl(applicationParametersParser);
 
             var decentralandUrlsSource = new GatewayUrlsSource(
                 decentralandEnvironment,

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -233,7 +233,7 @@ namespace Global.Dynamic
             applicationParametersParser.TryGetValue(AppArgsFlags.OPTIMIZED_ASSETS_URL, out string? cliOptimizedAssetsUrl);
 
             if (string.IsNullOrEmpty(cliOptimizedAssetsUrl) && launchSettings.useLocalAssetBundles)
-                cliOptimizedAssetsUrl = RealmLaunchSettings.ResolveLocalAssetBundlesUrl(applicationParametersParser);
+                cliOptimizedAssetsUrl = launchSettings.LocalAssetBundlesBaseUrl();
 
             var decentralandUrlsSource = new GatewayUrlsSource(
                 decentralandEnvironment,

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
@@ -25,6 +25,9 @@ namespace Global.Dynamic
         /// </summary>
         public const string DEFAULT_LOCAL_ASSET_BUNDLES_URL = "http://127.0.0.1:5147";
 
+        private const int MIN_LOCAL_AB_PORT = 1024;
+        private const int MAX_LOCAL_AB_PORT = 65535;
+
         [Serializable]
         public struct PredefinedScenes
         {
@@ -42,8 +45,8 @@ namespace Global.Dynamic
         [SerializeField] internal HybridSceneContentServer remoteHybridSceneContentServer = HybridSceneContentServer.Goerli;
         [SerializeField] internal bool useRemoteAssetsBundles;
         [SerializeField] [Tooltip("Local scene development only: load the scene's asset bundles from a locally running abgen instead of loading "
-                                  + "raw GLTFs. The server URL comes from --optimized-assets-url, defaulting to " + DEFAULT_LOCAL_ASSET_BUNDLES_URL
-                                  + " (abgen's default port) when not provided")] internal bool useLocalAssetBundles;
+                                  + "raw GLTFs. The server URL comes from --optimized-assets-url, or 127.0.0.1 on the --local-ab-port port, defaulting to "
+                                  + DEFAULT_LOCAL_ASSET_BUNDLES_URL + " (abgen's default port) when neither is provided")] internal bool useLocalAssetBundles;
         [SerializeField] [Tooltip("In Worlds there is one LiveKit room for all scenes so it's possible to communicate changes outside of the scene. "
                                   + "In Genesis City there are individual LiveKit rooms and only one connection at a time is maintained. "
                                   + "Toggle this flag to equalize this behavior")] internal bool isolateSceneCommunication;
@@ -96,6 +99,19 @@ namespace Global.Dynamic
             return new HybridSceneParams();
         }
 
+        /// <summary>
+        ///     Base URL of the local asset-bundle server: always 127.0.0.1, on the port from
+        ///     <see cref="AppArgsFlags.LOCAL_AB_PORT" /> when it parses to a valid non-system port (1024-65535),
+        ///     otherwise abgen's default (<see cref="DEFAULT_LOCAL_ASSET_BUNDLES_URL" />). The host is deliberately
+        ///     not configurable here: this arg is deep-link reachable, so only the loopback port may vary.
+        /// </summary>
+        public static string ResolveLocalAssetBundlesUrl(IAppArgs appArgs) =>
+            appArgs.TryGetValue(AppArgsFlags.LOCAL_AB_PORT, out string? portValue)
+            && int.TryParse(portValue, out int parsedPort)
+            && parsedPort is >= MIN_LOCAL_AB_PORT and <= MAX_LOCAL_AB_PORT
+                ? $"http://127.0.0.1:{parsedPort}"
+                : DEFAULT_LOCAL_ASSET_BUNDLES_URL;
+
         public void ApplyConfig(IAppArgs applicationParameters)
         {
             if (applicationParameters.TryGetValue(AppArgsFlags.REALM, out string? realm))
@@ -121,7 +137,7 @@ namespace Global.Dynamic
                 // The serialized checkbox is an Editor convenience only: player builds opt in
                 // exclusively through the app arg, so a box ticked (and accidentally committed)
                 // in the scene asset cannot ship enabled.
-                bool useLocalAB = appParameters.HasFlag(AppArgsFlags.LOCAL_AB) || (Application.isEditor && useLocalAssetBundles);
+                bool useLocalAB = appParameters.HasFlag(AppArgsFlags.LOCAL_AB) || appParameters.HasFlag(AppArgsFlags.LOCAL_AB_PORT) || (Application.isEditor && useLocalAssetBundles);
                 bool useRemoteAB = appParameters.HasFlag(AppArgsFlags.LSD_USE_REMOTE_AB) || useRemoteAssetsBundles;
 
                 if (useLocalAB && useRemoteAB)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmLaunchSettings.cs
@@ -21,12 +21,11 @@ namespace Global.Dynamic
     public class RealmLaunchSettings : ILaunchMode
     {
         /// <summary>
-        ///     abgen's default port; used for local asset bundles when no explicit --optimized-assets-url is given.
+        ///     Path under the local-scene-development realm where the preview server proxies its abgen sidecar
+        ///     (decentraland/js-sdk-toolchain#1504) — the client derives the optimized-assets base from the realm
+        ///     origin it already has instead of being told a second origin.
         /// </summary>
-        public const string DEFAULT_LOCAL_ASSET_BUNDLES_URL = "http://127.0.0.1:5147";
-
-        private const int MIN_LOCAL_AB_PORT = 1024;
-        private const int MAX_LOCAL_AB_PORT = 65535;
+        public const string OPTIMIZED_ASSETS_PATH = "/optimized-assets";
 
         [Serializable]
         public struct PredefinedScenes
@@ -44,9 +43,9 @@ namespace Global.Dynamic
         [SerializeField] internal string remoteHibridWorld = "MetadyneLabs.dcl.eth";
         [SerializeField] internal HybridSceneContentServer remoteHybridSceneContentServer = HybridSceneContentServer.Goerli;
         [SerializeField] internal bool useRemoteAssetsBundles;
-        [SerializeField] [Tooltip("Local scene development only: load the scene's asset bundles from a locally running abgen instead of loading "
-                                  + "raw GLTFs. The server URL comes from --optimized-assets-url, or 127.0.0.1 on the --local-ab-port port, defaulting to "
-                                  + DEFAULT_LOCAL_ASSET_BUNDLES_URL + " (abgen's default port) when neither is provided")] internal bool useLocalAssetBundles;
+        [SerializeField] [Tooltip("Local scene development only: load the scene's asset bundles from the preview server instead of loading "
+                                  + "raw GLTFs. The assets base is derived from the realm ({realm}" + OPTIMIZED_ASSETS_PATH + "); "
+                                  + "an explicit --optimized-assets-url overrides it")] internal bool useLocalAssetBundles;
         [SerializeField] [Tooltip("In Worlds there is one LiveKit room for all scenes so it's possible to communicate changes outside of the scene. "
                                   + "In Genesis City there are individual LiveKit rooms and only one connection at a time is maintained. "
                                   + "Toggle this flag to equalize this behavior")] internal bool isolateSceneCommunication;
@@ -100,17 +99,21 @@ namespace Global.Dynamic
         }
 
         /// <summary>
-        ///     Base URL of the local asset-bundle server: always 127.0.0.1, on the port from
-        ///     <see cref="AppArgsFlags.LOCAL_AB_PORT" /> when it parses to a valid non-system port (1024-65535),
-        ///     otherwise abgen's default (<see cref="DEFAULT_LOCAL_ASSET_BUNDLES_URL" />). The host is deliberately
-        ///     not configurable here: this arg is deep-link reachable, so only the loopback port may vary.
+        ///     Base URL for local asset bundles: the local-scene-development realm plus
+        ///     <see cref="OPTIMIZED_ASSETS_PATH" />. No value other than the realm itself — which the deep-link
+        ///     allowlist already gates on being loopback — feeds the result, so a deep link cannot point it
+        ///     anywhere the realm doesn't already reach. Null outside local scene development.
         /// </summary>
-        public static string ResolveLocalAssetBundlesUrl(IAppArgs appArgs) =>
-            appArgs.TryGetValue(AppArgsFlags.LOCAL_AB_PORT, out string? portValue)
-            && int.TryParse(portValue, out int parsedPort)
-            && parsedPort is >= MIN_LOCAL_AB_PORT and <= MAX_LOCAL_AB_PORT
-                ? $"http://127.0.0.1:{parsedPort}"
-                : DEFAULT_LOCAL_ASSET_BUNDLES_URL;
+        public string? LocalAssetBundlesBaseUrl()
+        {
+            if (isLocalSceneDevelopmentRealm)
+                return customRealm.TrimEnd('/') + OPTIMIZED_ASSETS_PATH;
+
+            if (initialRealm == InitialRealm.Localhost)
+                return IRealmNavigator.LOCALHOST + OPTIMIZED_ASSETS_PATH;
+
+            return null;
+        }
 
         public void ApplyConfig(IAppArgs applicationParameters)
         {
@@ -137,7 +140,7 @@ namespace Global.Dynamic
                 // The serialized checkbox is an Editor convenience only: player builds opt in
                 // exclusively through the app arg, so a box ticked (and accidentally committed)
                 // in the scene asset cannot ship enabled.
-                bool useLocalAB = appParameters.HasFlag(AppArgsFlags.LOCAL_AB) || appParameters.HasFlag(AppArgsFlags.LOCAL_AB_PORT) || (Application.isEditor && useLocalAssetBundles);
+                bool useLocalAB = appParameters.HasFlag(AppArgsFlags.LOCAL_AB) || (Application.isEditor && useLocalAssetBundles);
                 bool useRemoteAB = appParameters.HasFlag(AppArgsFlags.LSD_USE_REMOTE_AB) || useRemoteAssetsBundles;
 
                 if (useLocalAB && useRemoteAB)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/RealmLaunchSettingsShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/RealmLaunchSettingsShould.cs
@@ -183,44 +183,44 @@ namespace Global.Tests.EditMode
             Assert.AreEqual(world, realmLaunchSettings.TargetWorld);
         }
 
-        [TestCase("5200", "http://127.0.0.1:5200")]
-        [TestCase("80", RealmLaunchSettings.DEFAULT_LOCAL_ASSET_BUNDLES_URL)] // below the non-system port range
-        [TestCase("70000", RealmLaunchSettings.DEFAULT_LOCAL_ASSET_BUNDLES_URL)] // above the max port
-        [TestCase("evil.example", RealmLaunchSettings.DEFAULT_LOCAL_ASSET_BUNDLES_URL)] // non-numeric: cannot smuggle a host
-        [TestCase("5147/path", RealmLaunchSettings.DEFAULT_LOCAL_ASSET_BUNDLES_URL)] // non-numeric: cannot smuggle a path
-        public void ResolveLocalAssetBundlesUrlOnlyFromValidPort(string portValue, string expectedUrl)
-        {
-            //Arrange
-            ApplicationParametersParser applicationParametersParser = new (new[]
-            {
-                "--local-ab-port",
-                portValue,
-            });
-
-            //Act
-            string url = RealmLaunchSettings.ResolveLocalAssetBundlesUrl(applicationParametersParser);
-
-            //Assert
-            Assert.AreEqual(expectedUrl, url);
-        }
-
-        [Test]
-        public void EnableLocalAssetBundlesWhenLocalAbPortProvidedViaDeeplink()
+        [TestCase("http://127.0.0.1:8000", "http://127.0.0.1:8000/optimized-assets")]
+        [TestCase("http://127.0.0.1:8000/", "http://127.0.0.1:8000/optimized-assets")] // trailing slash must not double up
+        [TestCase("http://localhost:8001", "http://localhost:8001/optimized-assets")]
+        public void DeriveLocalAssetBundlesBaseUrlFromRealm(string realm, string expectedUrl)
         {
             //Arrange
             var realmLaunchSettings = new RealmLaunchSettings();
 
             ApplicationParametersParser applicationParametersParser = new (new[]
             {
-                "decentraland://?realm=http://127.0.0.1:8000&position=100,100&local-scene=true&local-ab-port=5200"
+                $"decentraland://?realm={realm}&position=100,100&local-scene=true&local-ab=true",
             });
 
             //Act
             realmLaunchSettings.ApplyConfig(applicationParametersParser);
 
             //Assert
-            Assert.IsTrue(realmLaunchSettings.useLocalAssetBundles, "local-ab-port must imply local-ab");
-            Assert.AreEqual("http://127.0.0.1:5200", RealmLaunchSettings.ResolveLocalAssetBundlesUrl(applicationParametersParser));
+            Assert.IsTrue(realmLaunchSettings.useLocalAssetBundles, "local-ab must enable local asset bundles");
+            Assert.AreEqual(expectedUrl, realmLaunchSettings.LocalAssetBundlesBaseUrl());
+        }
+
+        [Test]
+        public void NotDeriveLocalAssetBundlesBaseUrlOutsideLocalSceneDevelopment()
+        {
+            //Arrange
+            var realmLaunchSettings = new RealmLaunchSettings();
+
+            ApplicationParametersParser applicationParametersParser = new (new[]
+            {
+                "--realm",
+                "https://peer.decentraland.org",
+            });
+
+            //Act
+            realmLaunchSettings.ApplyConfig(applicationParametersParser);
+
+            //Assert
+            Assert.IsNull(realmLaunchSettings.LocalAssetBundlesBaseUrl());
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/RealmLaunchSettingsShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/RealmLaunchSettingsShould.cs
@@ -183,6 +183,46 @@ namespace Global.Tests.EditMode
             Assert.AreEqual(world, realmLaunchSettings.TargetWorld);
         }
 
+        [TestCase("5200", "http://127.0.0.1:5200")]
+        [TestCase("80", RealmLaunchSettings.DEFAULT_LOCAL_ASSET_BUNDLES_URL)] // below the non-system port range
+        [TestCase("70000", RealmLaunchSettings.DEFAULT_LOCAL_ASSET_BUNDLES_URL)] // above the max port
+        [TestCase("evil.example", RealmLaunchSettings.DEFAULT_LOCAL_ASSET_BUNDLES_URL)] // non-numeric: cannot smuggle a host
+        [TestCase("5147/path", RealmLaunchSettings.DEFAULT_LOCAL_ASSET_BUNDLES_URL)] // non-numeric: cannot smuggle a path
+        public void ResolveLocalAssetBundlesUrlOnlyFromValidPort(string portValue, string expectedUrl)
+        {
+            //Arrange
+            ApplicationParametersParser applicationParametersParser = new (new[]
+            {
+                "--local-ab-port",
+                portValue,
+            });
+
+            //Act
+            string url = RealmLaunchSettings.ResolveLocalAssetBundlesUrl(applicationParametersParser);
+
+            //Assert
+            Assert.AreEqual(expectedUrl, url);
+        }
+
+        [Test]
+        public void EnableLocalAssetBundlesWhenLocalAbPortProvidedViaDeeplink()
+        {
+            //Arrange
+            var realmLaunchSettings = new RealmLaunchSettings();
+
+            ApplicationParametersParser applicationParametersParser = new (new[]
+            {
+                "decentraland://?realm=http://127.0.0.1:8000&position=100,100&local-scene=true&local-ab-port=5200"
+            });
+
+            //Act
+            realmLaunchSettings.ApplyConfig(applicationParametersParser);
+
+            //Assert
+            Assert.IsTrue(realmLaunchSettings.useLocalAssetBundles, "local-ab-port must imply local-ab");
+            Assert.AreEqual("http://127.0.0.1:5200", RealmLaunchSettings.ResolveLocalAssetBundlesUrl(applicationParametersParser));
+        }
+
         [Test]
         [TestCase("127.0.0.1:8000")]
         [TestCase("localhost:8000")]


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Creator Hub / `sdk-commands` preview deep links need to enable local asset bundles, but `local-ab` was not yet allowlisted and the full-URL override (`optimized-assets-url`) is deliberately never-permitted for deep links: it rewrites the `AssetBundlesCDN`, `LodGeneratorCDN`, and `AssetBundleRegistry` endpoints globally for the whole session, and the loopback-realm gate only checks the `realm` param — which an attacker also controls — so allowlisting it would let a crafted link point asset loading at arbitrary remote infrastructure.

This PR implements the explorer side of [decentraland/js-sdk-toolchain#1504](https://github.com/decentraland/js-sdk-toolchain/pull/1504): the preview server proxies its abgen sidecar at `{realm}/optimized-assets`, so the client derives the assets base from the single origin it already has — no URL, port, or any other attacker-controllable value travels in the link.

- Adds **`local-ab`** to `DeepLinkAllowlist.LOOPBACK_REALM_PERMITTED_KEYS` (with the per-key security rationale the set requires). It is a pure boolean: the optimized-assets base becomes `{realm}/optimized-assets` (`RealmLaunchSettings.LocalAssetBundlesBaseUrl`), the same realm the loopback gate already validated, so the flag can only point asset loading at the realm the link already targets.
- The Editor `InitialRealm.Localhost` path derives from `IRealmNavigator.LOCALHOST` the same way, so the deeplink-less Editor dev loop keeps working.
- An explicit `--optimized-assets-url` CLI arg still takes precedence (CLI args are trusted and not allowlist-filtered); the param stays never-permitted for deep links, now pinned by a test.
- Retires the `http://127.0.0.1:5147` default-port convention — with the proxy, the sidecar's port is private to sdk-commands (it moves back to `getPort(0)`), so there is nothing to guess.
- Path-prefix audit (the base now carries `/optimized-assets`): all consumers compose verbatim — `URLBuilder.AppendDomain` (manifest loads), `URLDomain.Append`/`URLBuilder.Combine` (bundle URLs), and `ComposeRegistryUrl` string interpolation (registry endpoints). The path-stripping `AppendDomainWithReplacedPath` is only used with the Lambdas URL, never with the optimized-assets endpoints.

Note: per `DeepLinkAllowlist`'s class doc, changes to the permitted sets are a SEC-019/020 product decision — flagging for that sign-off in review.

⚠️ **Dependency**: the deep-link `local-ab` flow requires decentraland/js-sdk-toolchain#1504 (the `/optimized-assets` proxy route) to be released.

## Test Instructions

### Easiest way to run this build: swap it into the launcher's `latest` folder

The SDK/Creator Hub deeplink flow always launches whatever build sits in the launcher's `latest` folder, so the most straightforward way to test end-to-end is to put this PR's build there:

- macOS: `~/Library/Application Support/DecentralandLauncherLight/latest/Decentraland.app`
- Windows: `%APPDATA%\DecentralandLauncherLight\latest\`

1. **Rename the original — do not delete it** (e.g. `Decentraland.app` → `Decentraland.original.app`) so the released build is not lost.
2. Copy this PR's build in under the original name (`Decentraland.app`) — the deeplink flow now opens it transparently, no App Parameters needed.
3. **When you finish testing, rename things back.** Otherwise every preview keeps launching the PR build until the launcher's next self-update replaces `latest`.

### Prerequisites
- [x] An SDK7 scene using [js-sdk-toolchain#1498](https://github.com/decentraland/js-sdk-toolchain/pull/1498)'s branch build — install the two tarballs from the **"Test this pull request" bot comment** on that PR (URLs change per push; current example):
```bash
cd path/to/your-scene
npm install "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/abgen-proxied-assets/dcl-sdk-commands-7.25.1-30488513888.commit-1d09bd1.tgz"
```
- [ ] The scene running with the asset-bundles sidecar:
```bash
npm run start -- --asset-bundles
```
No abgen installation or `ABGEN_*` configuration is needed — the SDK downloads a pinned, sha256-verified abgen binary (v0.11.7) on first run and wires it automatically. E

### Test Steps
1. **Launch the explorer:** swap this build into the launcher's `latest` folder (see above) and just run the scene — the deeplink flow opens it with all parameters set. 
2. **Confirm you are on the right build:** the Authentication screen reports the branch on the bottom left — it should read `feat/lsd-local-ab-allowlist`.
3. **Confirm bundles are actually being built:** the scene's terminal shows the sidecar converting (manifest GET, per-asset build lines, then one bundle GET per asset). 
4. **Compare memory:** open the debug panel → **Memory** tab. Loading the same scene with `--asset-bundles` should sit noticeably **lower** than without it (Genesis Plaza used as the reference scene). Please report any inconsistency between flag on and off.
5. **Degrade path:** run the scene without `--asset-bundles` (or kill the sidecar and reload) → the scene still renders via raw GLTFs, no exception spam.
6. **Hot reload:** with the sidecar running, overwrite a `.glb` in the scene → the scene reloads, only that asset reconverts, and the updated model appears.
7. **Wearable caching:** avatars/wearables render normally (streamed from the production ab-cdn through the sidecar) and stay disk-cached — exit and enter again: wearables/emotes load near-instantly with no re-downloads in the sidecar log, while the scene's own bundles are re-requested fresh.

### Additional Testing Notes
- **First load of a large scene may time out before every asset converts** (Genesis Plaza reproduces this) — re-run the scene and it completes; conversions are cached in `.dcl-optimized-assets/`, so any subsequent run is fine. Known issue, still to be addressed.

## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

