### PR TITLE
chore: add login-bridge-only arg to force deeplink bridge during login process

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -37,9 +37,11 @@ namespace Global.AppArgs
 
         // The opaque identity id delivered by the auth website's signin deep link (<c>decentraland://?signin={identityId}</c>).
         public const string SIGNIN = "signin";
-
         // The auth request id parameter echoed in the signin deep link, used to match a link to the login that minted it.
         public const string AUTH_REQUEST_ID = "authRequestId";
+        // See: https://github.com/decentraland/unity-explorer/issues/9524
+        // ReSharper disable once UnusedMember.Global (actually used on release build)
+        public const string AUTH_BRIDGE_ONLY = "login-bridge-only";
 
         public const string FORCED_EMOTES = "self-force-emotes";
         public const string SELF_PREVIEW_EMOTES = "self-preview-emotes";

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -40,7 +40,7 @@ namespace Global.AppArgs
         // The auth request id parameter echoed in the signin deep link, used to match a link to the login that minted it.
         public const string AUTH_REQUEST_ID = "authRequestId";
         // See: https://github.com/decentraland/unity-explorer/issues/9524
-        // ReSharper disable once UnusedMember.Global (actually used on release build)
+        // ReSharper disable once UnusedMember.Global (used on non-editor build only)
         public const string AUTH_BRIDGE_ONLY = "login-bridge-only";
 
         public const string FORCED_EMOTES = "self-force-emotes";

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
@@ -217,7 +217,12 @@ namespace Global.Dynamic
                 web3AccountFactory,
                 webRequestController,
                 deeplinkSigninIdentityId,
-                deeplinkLoginAwaitingSigninRequestId
+                deeplinkLoginAwaitingSigninRequestId,
+#if UNITY_EDITOR
+                true
+#else
+                appArgs.HasFlag(AppArgsFlags.AUTH_BRIDGE_ONLY)
+#endif
             );
 
             var dappAuth = new DappWeb3EthereumApi(

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappDeepLinkAuthenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappDeepLinkAuthenticator.cs
@@ -33,6 +33,7 @@ namespace DCL.Web3.Authenticators
         private readonly IWebRequestController webRequestController;
         private readonly ReactiveProperty<string?> deeplinkSigninIdentityId;
         private readonly ReactiveProperty<string?> loginAwaitingSigninRequestId;
+        private readonly bool forceBridgeOnly;
         private readonly URLBuilder urlBuilder = new ();
         private readonly DCLSemaphoreSlim loginMutex = new ();
 
@@ -43,7 +44,8 @@ namespace DCL.Web3.Authenticators
             IWeb3AccountFactory web3AccountFactory,
             IWebRequestController webRequestController,
             ReactiveProperty<string?> deeplinkSigninIdentityId,
-            ReactiveProperty<string?> loginAwaitingSigninRequestId)
+            ReactiveProperty<string?> loginAwaitingSigninRequestId,
+            bool forceBridgeOnly)
         {
             this.webBrowser = webBrowser;
             this.authApiUrl = authApiUrl;
@@ -52,6 +54,7 @@ namespace DCL.Web3.Authenticators
             this.webRequestController = webRequestController;
             this.deeplinkSigninIdentityId = deeplinkSigninIdentityId;
             this.loginAwaitingSigninRequestId = loginAwaitingSigninRequestId;
+            this.forceBridgeOnly = forceBridgeOnly;
         }
 
         public void Dispose()
@@ -74,12 +77,11 @@ namespace DCL.Web3.Authenticators
                 // Client-generated id embedded in the browser URL; no server round-trip needed before opening the browser.
                 var authRequestId = Guid.NewGuid().ToString();
                 var url = $"{signatureWebAppUrl}/{authRequestId}?loginMethod={payload.Method}&flow=deeplink";
-#if UNITY_EDITOR
 
-                // Without this flag the auth website also launches a standalone Explorer build,
-                // which would steal the signin from the editor.
-                url += "&bridgeOnly";
-#endif
+                // Forces the login to open in deeplink bridge only, so the launcher does not spawn a new explorer instance
+                // during the confirmation from the website
+                if (forceBridgeOnly)
+                    url += "&bridgeOnly";
 
                 webBrowser.OpenUrlMainThreadOnly(url);
 

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappDeepLinkAuthenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappDeepLinkAuthenticator.cs
@@ -172,6 +172,7 @@ namespace DCL.Web3.Authenticators
         }
 
         // Field names mirror the auth server's JSON payloads verbatim, so they intentionally break the naming rules.
+        // ReSharper disable InconsistentNaming
         [Serializable]
         private struct IdentityAuthResponseDto
         {
@@ -193,5 +194,6 @@ namespace DCL.Web3.Authenticators
                 public string publicKey;
             }
         }
+        // ReSharper restore InconsistentNaming
     }
 }

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -186,6 +186,18 @@ For embedded links you will need to place value after `=` sign, instead of space
 
 ---
 
+### `login-bridge-only`
+**Description:** Forces the dapp deep-link login to complete through the deep-link bridge only, by appending `&bridgeOnly` to the auth website URL. Without it, confirming the login on the website can make the launcher spawn a second Explorer instance. See [issue #9524](https://github.com/decentraland/unity-explorer/issues/9524).
+
+Only affects player builds — the Editor always behaves as if the flag were set.
+
+**Usage:**
+```bash
+--login-bridge-only
+```
+
+---
+
 ## Avatar & Profile Flags
 
 ### `self-force-emotes`


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/9524

## Test Instructions

1. Download the build
2. Execute it using `--login-bridge-only`
3. Logout from any account
4. Execute the login process
5. The login should work as expected in the running instance
6. The launcher should not spawn a new instance in the process

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
