### PR TITLE
perf: fetch the Genesis world manifest concurrently with realm /about

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -135,6 +135,7 @@ namespace Global.Dynamic
             try
             {
                 serverAbout.Clear();
+                worldManifestProvider.PrefetchGenesisManifest(environment, ct);
 
                 GenericDownloadHandlerUtils.Adapter<GenericGetRequest, GenericGetArguments> genericGetRequest = webRequestController.GetAsync(new CommonArguments(url), ct, ReportCategory.REALM);
                 ServerAbout result = await genericGetRequest.OverwriteFromJsonAsync(serverAbout, WRJsonParser.Unity);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -135,7 +135,11 @@ namespace Global.Dynamic
             try
             {
                 serverAbout.Clear();
-                worldManifestProvider.PrefetchGenesisManifest(environment, ct);
+
+                // Local scene development runs against a local realm and must not reach out to
+                // the Genesis manifest host.
+                if (!isLocalSceneDevelopment)
+                    worldManifestProvider.PrefetchGenesisManifest(environment, ct);
 
                 GenericDownloadHandlerUtils.Adapter<GenericGetRequest, GenericGetArguments> genericGetRequest = webRequestController.GetAsync(new CommonArguments(url), ct, ReportCategory.REALM);
                 ServerAbout result = await genericGetRequest.OverwriteFromJsonAsync(serverAbout, WRJsonParser.Unity);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/WorldManifestProvider.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/WorldManifestProvider.cs
@@ -27,6 +27,13 @@ namespace Global.Dynamic
         private const string dclWorldName = "dcl.eth";
 
         private WorldManifest? cachedMainManifest;
+        private UniTask<WorldManifest>? inFlightMainManifest;
+
+        // Genesis manifest URLs are compile-time constants, so this runs concurrently with
+        // the realm /about request instead of waiting on realmName. Idempotent; Preserve()
+        // lets the Genesis branch await this same task rather than issue a second request.
+        public void PrefetchGenesisManifest(DecentralandEnvironment environment, CancellationToken ct) =>
+            inFlightMainManifest ??= FetchGenesisManifestAsync(environment, ct).Preserve();
 
         public WorldManifestProvider(IWebRequestController webRequestController)
         {
@@ -38,7 +45,10 @@ namespace Global.Dynamic
             try
             {
                 if(MAIN_REALM_NAMES.Contains(realmName))
-                    return await FetchGenesisManifestAsync(environment, ct);
+                {
+                    PrefetchGenesisManifest(environment, ct);
+                    return await inFlightMainManifest!.Value;
+                }
 
                 if(realmName.EndsWith(dclWorldName))
                     return await FetchNonGenesisManifestAsync(assetBundleRegistry, realmName, ct);


### PR DESCRIPTION
The Genesis manifest URL is a compile-time constant, so the fetch does not need `realmName` from the `/about` response. It now starts alongside that request, and the Genesis branch awaits the same task — keeping the manifest off the boot critical path.

`PrefetchGenesisManifest` is idempotent (`??=`), and the task is `Preserve()`d so the Genesis branch can await it rather than issue a second request. `FetchGenesisManifestAsync` already funnels every exception into `WorldManifest.Empty`, so a failed prefetch cannot fail the boot.

### Scope and cost

The prefetch starts before the realm type is known, so it is speculative:

- **Genesis** — the manifest is ready when the Genesis branch asks for it.
- **Worlds (`*.dcl.eth`) and custom realms** — resolve their manifest from `realmName` as before, and additionally pay one discarded Genesis fetch, once per provider lifetime. It is async and fail-soft, but it is network the entrypoint does not consume.
- **Local scene development** — skipped entirely, so an offline preview does not reach the Genesis manifest host.

`SetRealmAsync` also runs on realm changes, not only at boot; `??=` bounds the speculative fetch to one per session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwLgyC5zggzth1oggwnBd4