### PR TITLE
feat(mcp): report who wrote each scene component

### DIFF
--- a/.claude/skills/mcp-scene-iteration/SKILL.md
+++ b/.claude/skills/mcp-scene-iteration/SKILL.md
@@ -91,6 +91,8 @@ Repeat until **every requirement has proof**: a screenshot or state read demonst
 
 **Cross-examine** every conclusion: confirm each visual claim with a state read (ECS values via `get_entity_details`, logs, `get_player_state` position), and each state claim with pixels. One channel lies routinely — colliders exist that pixels don't show, entities render invisible while their state looks healthy, animations silently don't play. The reference files call out where cross-examination is mandatory.
 
+**For a networked scene, also ask who wrote the state you are reading.** `get_scene_state` → `scene.networkWriters` lists every address that has written to the scene, and `get_entity_details` → `networkWrites` names the address behind each component of an entity. When `scene.authoritativeMultiplayer` is true, a component whose last write has `isAuthoritativeServer: false` and `viaStateSync: false` was set by a peer the server did not authorise — the scene looking correct is not the same as the scene being driven correctly. Two readings are *not* evidence of a rogue client: a component absent from `networkWrites` was written locally by the scene's own code (the ordinary case for a single-player scene), and a row with `viaStateSync: true` was replayed to you in a peer's state dump when you joined, so it names who handed it over, not who wrote it.
+
 **MANDATORY — camera cleanup before finishing.** NEVER leave the camera in `free` mode when you stop working (end of task, handing back to the user, or pausing for their input): always restore it with `set_camera_mode third_person` as your last camera action, and confirm via `get_player_state` → `camera.mode` if anything in between could have failed.
 
 ## Screenshot frequency & cost

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution.meta
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cbcf8d09f15f4e0e8d0effa8952e157d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution/CrdtWriterLog.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution/CrdtWriterLog.cs
@@ -56,7 +56,7 @@ namespace CRDT.Attribution
             lock (scenes)
             {
                 SceneWrites sceneWrites = SceneOf(sceneId, nowMs);
-                Walk(batch, fromWalletId ?? string.Empty, isTrustedSource, viaStateSync, sceneWrites, nowMs);
+                Walk(batch, fromWalletId, isTrustedSource, viaStateSync, sceneWrites, nowMs);
             }
         }
 
@@ -213,9 +213,14 @@ namespace CRDT.Attribution
             return created;
         }
 
+        /// <summary>
+        ///     Reached only from <see cref="SceneOf" /> with the table at <see cref="MAX_SCENES" />, and every
+        ///     recorded timestamp is below the seed, so the first entry compared already replaces it: the search
+        ///     always names a scene that is in the table.
+        /// </summary>
         private void EvictLeastRecentlyWritten()
         {
-            string? oldest = null;
+            string oldest = string.Empty;
             long oldestAtMs = long.MaxValue;
 
             foreach (KeyValuePair<string, SceneWrites> entry in scenes)
@@ -225,8 +230,7 @@ namespace CRDT.Attribution
                     oldest = entry.Key;
                 }
 
-            if (oldest != null)
-                scenes.Remove(oldest);
+            scenes.Remove(oldest);
         }
 
         private static double SecondsSince(long atMs, long nowMs) =>

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution/CrdtWriterLog.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution/CrdtWriterLog.cs
@@ -1,0 +1,314 @@
+#nullable enable
+
+using CRDT.Protocol;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Utility;
+
+namespace CRDT.Attribution
+{
+    /// <summary>
+    ///     Keeps the last network writer of every component of every entity, per scene.
+    ///     <para>
+    ///         Fed from the scene-room ingress, which runs off the main thread, and read from tool calls on the main
+    ///         thread, so every access takes the same lock. The walk over the batch is read-only and independent of
+    ///         the one <see cref="CRDTFilter" /> performs on the way to the scene; it applies the same drop rule
+    ///         (<see cref="CRDTFilter.ShouldDropIncoming" />) so the log never claims a write the scene never saw.
+    ///     </para>
+    ///     Bounded on three axes: a scene keeps at most <see cref="MAX_WRITES_PER_SCENE" /> component rows and
+    ///     <see cref="MAX_WRITERS_PER_SCENE" /> distinct addresses, and the log at most <see cref="MAX_SCENES" />
+    ///     scenes, evicting the least recently written one. Every write either budget refuses is counted rather than
+    ///     silently forgotten, so a reader can tell a quiet component from a truncated log.
+    /// </summary>
+    public sealed class CrdtWriterLog : ICrdtWriterLog
+    {
+        private const int MAX_SCENES = 8;
+        private const int MAX_WRITES_PER_SCENE = 4096;
+        private const int MAX_WRITERS_PER_SCENE = 128;
+
+        /// <summary>
+        ///     Monotonic and thread-safe, unlike <c>Time.realtimeSinceStartup</c>, which the ingress thread cannot read.
+        /// </summary>
+        private static readonly Stopwatch CLOCK = Stopwatch.StartNew();
+
+        private readonly Dictionary<string, SceneWrites> scenes = new ();
+
+        private volatile bool enabled;
+
+        public bool IsEnabled => enabled;
+
+        public void Enable()
+        {
+            enabled = true;
+        }
+
+        public void RecordInbound(string sceneId, string fromWalletId, bool isTrustedSource, ReadOnlySpan<byte> sdkMessage)
+        {
+            if (!enabled || string.IsNullOrEmpty(sceneId) || sdkMessage.Length < 2)
+                return;
+
+            if (!TryFindBatch(sdkMessage, out ReadOnlySpan<byte> batch, out bool viaStateSync))
+                return;
+
+            long nowMs = CLOCK.ElapsedMilliseconds;
+
+            lock (scenes)
+            {
+                SceneWrites sceneWrites = SceneOf(sceneId, nowMs);
+                Walk(batch, fromWalletId ?? string.Empty, isTrustedSource, viaStateSync, sceneWrites, nowMs);
+            }
+        }
+
+        public void EntityWrites(string sceneId, int entityId, List<CrdtWrite> destination)
+        {
+            lock (scenes)
+            {
+                if (!scenes.TryGetValue(sceneId, out SceneWrites sceneWrites))
+                    return;
+
+                long nowMs = CLOCK.ElapsedMilliseconds;
+
+                foreach (KeyValuePair<long, Write> entry in sceneWrites.Writes)
+                {
+                    if (EntityOf(entry.Key) != entityId)
+                        continue;
+
+                    Write write = entry.Value;
+
+                    destination.Add(new CrdtWrite(entityId, ComponentOf(entry.Key), write.Writer, write.IsTrustedSource,
+                        write.ViaStateSync, write.MessageType, write.CrdtTimestamp, SecondsSince(write.AtMs, nowMs)));
+                }
+            }
+        }
+
+        public void SceneWriters(string sceneId, List<CrdtWriterSummary> destination)
+        {
+            lock (scenes)
+            {
+                if (!scenes.TryGetValue(sceneId, out SceneWrites sceneWrites))
+                    return;
+
+                long nowMs = CLOCK.ElapsedMilliseconds;
+
+                foreach (KeyValuePair<string, Writer> entry in sceneWrites.Writers)
+                    destination.Add(new CrdtWriterSummary(entry.Key, entry.Value.IsTrustedSource, entry.Value.Writes,
+                        entry.Value.StateSyncWrites, SecondsSince(entry.Value.LastAtMs, nowMs)));
+            }
+        }
+
+        public int DroppedWrites(string sceneId)
+        {
+            lock (scenes) { return scenes.TryGetValue(sceneId, out SceneWrites sceneWrites) ? sceneWrites.Dropped : 0; }
+        }
+
+        /// <summary>
+        ///     Locates the CRDT batch inside an SDK scene-room message, or reports that the message carries none.
+        ///     Encoding at https://github.com/decentraland/js-sdk-toolchain/blob/f122eaa2acaaed80db7ee0302e8d60ca7d2337bf/packages/@dcl/sdk/src/network/message-bus-sync.ts#L177-L208
+        /// </summary>
+        private static bool TryFindBatch(ReadOnlySpan<byte> sdkMessage, out ReadOnlySpan<byte> batch, out bool viaStateSync)
+        {
+            switch ((SdkCommsMessageType)sdkMessage[0])
+            {
+                case SdkCommsMessageType.CRDT:
+                    batch = sdkMessage[1..];
+                    viaStateSync = false;
+                    return true;
+
+                // [message type][1 byte: address length][address][CRDT messages]. This is a peer answering someone's
+                // request for the scene's state, so it replays writes it did not necessarily author — the rows are
+                // marked so a reader testing authorship can exclude them.
+                case SdkCommsMessageType.ResCRDTState:
+                    int addressLength = sdkMessage[1];
+
+                    if (sdkMessage.Length < 2 + addressLength)
+                        break;
+
+                    batch = sdkMessage[(2 + addressLength)..];
+                    viaStateSync = true;
+                    return true;
+            }
+
+            batch = default(ReadOnlySpan<byte>);
+            viaStateSync = false;
+            return false;
+        }
+
+        private static void Walk(ReadOnlySpan<byte> batch, string writer, bool isTrustedSource, bool viaStateSync, SceneWrites sceneWrites, long nowMs)
+        {
+            while (batch.Length > CRDTConstants.MESSAGE_HEADER_LENGTH)
+            {
+                uint messageLength = batch.ReadConst<uint>();
+                var messageType = (CRDTMessageType)batch[4..].ReadConst<uint>();
+
+                if (messageLength <= CRDTConstants.MESSAGE_HEADER_LENGTH)
+                    break;
+
+                if (messageType is CRDTMessageType.NONE or >= CRDTMessageType.MAX_MESSAGE_TYPE)
+                    break;
+
+                ReadOnlySpan<byte> body = batch[CRDTConstants.MESSAGE_HEADER_LENGTH..];
+
+                if (body.Length < HeaderLength(messageType))
+                    break;
+
+                uint bodyLength = CRDTMessageTypeUtils.TypeLengthBytes(messageType, body);
+
+                if (bodyLength == 0 || bodyLength > body.Length)
+                    break;
+
+                if (CarriesComponent(messageType))
+                {
+                    int entityId = body.ReadConst<int>();
+                    int componentId = body[4..].ReadConst<int>();
+                    int crdtTimestamp = body[8..].ReadConst<int>();
+
+                    if (!CRDTFilter.ShouldDropIncoming(messageType, unchecked((uint)componentId), isTrustedSource))
+                        sceneWrites.Record(entityId, componentId, writer, isTrustedSource, viaStateSync, messageType, crdtTimestamp, nowMs);
+                }
+
+                batch = body[(int)bodyLength..];
+            }
+        }
+
+        /// <summary>Bytes of fixed header the type has before <see cref="CRDTMessageTypeUtils.TypeLengthBytes" /> may read it.</summary>
+        private static int HeaderLength(CRDTMessageType messageType) =>
+            messageType switch
+            {
+                CRDTMessageType.PUT_COMPONENT => CRDTConstants.CRDT_PUT_COMPONENT_HEADER_LENGTH,
+                CRDTMessageType.APPEND_COMPONENT => CRDTConstants.CRDT_APPEND_COMPONENT_HEADER_LENGTH,
+                CRDTMessageType.AUTHORITATIVE_PUT_COMPONENT => CRDTConstants.CRDT_AUTHORITATIVE_PUT_COMPONENT_HEADER_LENGTH,
+                CRDTMessageType.DELETE_COMPONENT => CRDTConstants.CRDT_DELETE_COMPONENT_HEADER_LENGTH,
+                CRDTMessageType.DELETE_ENTITY => CRDTConstants.CRDT_DELETE_ENTITY_HEADER_LENGTH,
+
+                // The network variants repeat the same fields plus a 4-byte network id.
+                CRDTMessageType.PUT_COMPONENT_NETWORK => CRDTConstants.CRDT_PUT_COMPONENT_HEADER_LENGTH + 4,
+                CRDTMessageType.DELETE_COMPONENT_NETWORK => CRDTConstants.CRDT_DELETE_COMPONENT_HEADER_LENGTH + 4,
+                CRDTMessageType.DELETE_ENTITY_NETWORK => CRDTConstants.CRDT_DELETE_ENTITY_HEADER_LENGTH + 4,
+                _ => int.MaxValue,
+            };
+
+        /// <summary>Whether the body names a component, i.e. whether the write is attributable to one row.</summary>
+        private static bool CarriesComponent(CRDTMessageType messageType) =>
+            messageType is CRDTMessageType.PUT_COMPONENT
+                or CRDTMessageType.APPEND_COMPONENT
+                or CRDTMessageType.AUTHORITATIVE_PUT_COMPONENT
+                or CRDTMessageType.DELETE_COMPONENT
+                or CRDTMessageType.PUT_COMPONENT_NETWORK
+                or CRDTMessageType.DELETE_COMPONENT_NETWORK;
+
+        private SceneWrites SceneOf(string sceneId, long nowMs)
+        {
+            if (scenes.TryGetValue(sceneId, out SceneWrites existing))
+            {
+                existing.LastWriteAtMs = nowMs;
+                return existing;
+            }
+
+            if (scenes.Count >= MAX_SCENES)
+                EvictLeastRecentlyWritten();
+
+            var created = new SceneWrites { LastWriteAtMs = nowMs };
+            scenes[sceneId] = created;
+            return created;
+        }
+
+        private void EvictLeastRecentlyWritten()
+        {
+            string? oldest = null;
+            long oldestAtMs = long.MaxValue;
+
+            foreach (KeyValuePair<string, SceneWrites> entry in scenes)
+                if (entry.Value.LastWriteAtMs < oldestAtMs)
+                {
+                    oldestAtMs = entry.Value.LastWriteAtMs;
+                    oldest = entry.Key;
+                }
+
+            if (oldest != null)
+                scenes.Remove(oldest);
+        }
+
+        private static double SecondsSince(long atMs, long nowMs) =>
+            Math.Max(0, nowMs - atMs) / 1000d;
+
+        private static int EntityOf(long key) =>
+            unchecked((int)(key >> 32));
+
+        private static int ComponentOf(long key) =>
+            unchecked((int)key);
+
+        private static long KeyOf(int entityId, int componentId) =>
+            ((long)entityId << 32) | unchecked((uint)componentId);
+
+        private sealed class SceneWrites
+        {
+            public readonly Dictionary<long, Write> Writes = new ();
+            public readonly Dictionary<string, Writer> Writers = new ();
+
+            public long LastWriteAtMs;
+            public int Dropped;
+
+            /// <summary>
+            ///     Both budgets are checked before either table is touched, so a component row and the summary of the
+            ///     address behind it are always both present or both absent — otherwise an entity could name a writer
+            ///     the scene-level report never mentions. Whichever budget refuses, the write is counted as dropped.
+            /// </summary>
+            public void Record(int entityId, int componentId, string writer, bool isTrustedSource, bool viaStateSync, CRDTMessageType messageType, int crdtTimestamp, long nowMs)
+            {
+                long key = KeyOf(entityId, componentId);
+                bool knownWriter = Writers.TryGetValue(writer, out Writer summary);
+
+                if ((!Writes.ContainsKey(key) && Writes.Count >= MAX_WRITES_PER_SCENE)
+                    || (!knownWriter && Writers.Count >= MAX_WRITERS_PER_SCENE))
+                {
+                    Dropped++;
+                    return;
+                }
+
+                Writes[key] = new Write(writer, isTrustedSource, viaStateSync, messageType, crdtTimestamp, nowMs);
+
+                int writes = (knownWriter ? summary.Writes : 0) + (viaStateSync ? 0 : 1);
+                int stateSyncWrites = (knownWriter ? summary.StateSyncWrites : 0) + (viaStateSync ? 1 : 0);
+
+                Writers[writer] = new Writer(writes, stateSyncWrites, nowMs, isTrustedSource);
+            }
+        }
+
+        private readonly struct Write
+        {
+            public readonly string Writer;
+            public readonly bool IsTrustedSource;
+            public readonly bool ViaStateSync;
+            public readonly CRDTMessageType MessageType;
+            public readonly int CrdtTimestamp;
+            public readonly long AtMs;
+
+            public Write(string writer, bool isTrustedSource, bool viaStateSync, CRDTMessageType messageType, int crdtTimestamp, long atMs)
+            {
+                Writer = writer;
+                IsTrustedSource = isTrustedSource;
+                ViaStateSync = viaStateSync;
+                MessageType = messageType;
+                CrdtTimestamp = crdtTimestamp;
+                AtMs = atMs;
+            }
+        }
+
+        private readonly struct Writer
+        {
+            public readonly int Writes;
+            public readonly int StateSyncWrites;
+            public readonly long LastAtMs;
+            public readonly bool IsTrustedSource;
+
+            public Writer(int writes, int stateSyncWrites, long lastAtMs, bool isTrustedSource)
+            {
+                Writes = writes;
+                StateSyncWrites = stateSyncWrites;
+                LastAtMs = lastAtMs;
+                IsTrustedSource = isTrustedSource;
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution/CrdtWriterLog.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution/CrdtWriterLog.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 361edb7c194c469f9009d7fb910b09a7
+timeCreated: 1780000000

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution/ICrdtWriterLog.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution/ICrdtWriterLog.cs
@@ -1,0 +1,160 @@
+#nullable enable
+
+using CRDT.Protocol;
+using System;
+using System.Collections.Generic;
+
+namespace CRDT.Attribution
+{
+    /// <summary>
+    ///     Records which address authored each component write that reached a scene over the scene room, so tools
+    ///     can answer "who wrote this" and not only "what does it say".
+    ///     <para>
+    ///         A scene's CRDT state is the merge of writes from its own JavaScript and from every peer in the scene
+    ///         room — including, for an authoritative game, its server. Once merged, the rows are indistinguishable:
+    ///         a position the server set and a position a modified client asserted read exactly the same. Scenes
+    ///         built on <c>@dcl/sdk/network</c> guard against that themselves (<c>validateBeforeChange</c> comparing
+    ///         the sender against <see cref="AUTHORITATIVE_SERVER_ADDRESS" />), but nothing outside the scene could
+    ///         see the provenance those guards act on. This log keeps it.
+    ///     </para>
+    ///     <para>
+    ///         Only inbound network writes are recorded. A component the scene's own JavaScript wrote locally never
+    ///         appears here, so "absent from the log" means "not written by a peer", not "not written".
+    ///     </para>
+    ///     Disabled until <see cref="Enable" /> is called, so the recording costs nothing in a normal session.
+    /// </summary>
+    public interface ICrdtWriterLog
+    {
+        /// <summary>The identity the authoritative server of a scene connects to the scene room under.</summary>
+        public const string AUTHORITATIVE_SERVER_ADDRESS = "authoritative-server";
+
+        bool IsEnabled { get; }
+
+        /// <summary>Starts recording. Called by the consumer that needs the attribution (the MCP server).</summary>
+        void Enable();
+
+        /// <summary>
+        ///     Records the component writes carried by one inbound scene-room message.
+        /// </summary>
+        /// <param name="sceneId">Scene definition id the message was addressed to.</param>
+        /// <param name="fromWalletId">Address of the peer that sent it, as the transport reports it.</param>
+        /// <param name="isTrustedSource">Whether the sender is the local participant or a scene admin.</param>
+        /// <param name="sdkMessage">
+        ///     The payload after the Explorer routing byte, i.e. starting at the SDK's own message type
+        ///     (<see cref="SdkCommsMessageType" />). Messages that carry no CRDT batch are ignored.
+        /// </param>
+        void RecordInbound(string sceneId, string fromWalletId, bool isTrustedSource, ReadOnlySpan<byte> sdkMessage);
+
+        /// <summary>Appends the last network write of every component of <paramref name="entityId" /> to <paramref name="destination" />.</summary>
+        void EntityWrites(string sceneId, int entityId, List<CrdtWrite> destination);
+
+        /// <summary>Appends one entry per address that has written to <paramref name="sceneId" /> to <paramref name="destination" />.</summary>
+        void SceneWriters(string sceneId, List<CrdtWriterSummary> destination);
+
+        /// <summary>Number of writes the log refused for <paramref name="sceneId" /> because one of its budgets was full.</summary>
+        int DroppedWrites(string sceneId);
+
+        /// <summary>The log a client that does not want attribution gets; every call is a no-op.</summary>
+        public class Null : ICrdtWriterLog
+        {
+            public static readonly Null INSTANCE = new ();
+
+            public bool IsEnabled => false;
+
+            public void Enable() { }
+
+            public void RecordInbound(string sceneId, string fromWalletId, bool isTrustedSource, ReadOnlySpan<byte> sdkMessage) { }
+
+            public void EntityWrites(string sceneId, int entityId, List<CrdtWrite> destination) { }
+
+            public void SceneWriters(string sceneId, List<CrdtWriterSummary> destination) { }
+
+            public int DroppedWrites(string sceneId) =>
+                0;
+        }
+    }
+
+    /// <summary>
+    ///     The last network write observed for one component of one entity.
+    /// </summary>
+    public readonly struct CrdtWrite
+    {
+        public readonly int EntityId;
+        public readonly int ComponentId;
+
+        /// <summary>
+        ///     Address the write came from, or <see cref="ICrdtWriterLog.AUTHORITATIVE_SERVER_ADDRESS" />.
+        ///     Read together with <see cref="ViaStateSync" />: on a state-sync row this is the peer that handed the
+        ///     state over, which is not necessarily the peer that authored it.
+        /// </summary>
+        public readonly string Writer;
+
+        public readonly bool IsTrustedSource;
+
+        /// <summary>
+        ///     True when the row came out of a peer's answer to a CRDT state request rather than a live write — a
+        ///     client that joins mid-game hydrates this way. The dump replays state whoever originally wrote it,
+        ///     including the authoritative server, under the identity of the peer that supplied it, so
+        ///     <see cref="Writer" /> on such a row does not identify the author.
+        /// </summary>
+        public readonly bool ViaStateSync;
+
+        public readonly CRDTMessageType MessageType;
+
+        /// <summary>The CRDT Lamport timestamp of the write, which orders it against other writes to the same component.</summary>
+        public readonly int CrdtTimestamp;
+
+        public readonly double AgeSeconds;
+
+        public CrdtWrite(int entityId, int componentId, string writer, bool isTrustedSource, bool viaStateSync, CRDTMessageType messageType, int crdtTimestamp, double ageSeconds)
+        {
+            EntityId = entityId;
+            ComponentId = componentId;
+            Writer = writer;
+            IsTrustedSource = isTrustedSource;
+            ViaStateSync = viaStateSync;
+            MessageType = messageType;
+            CrdtTimestamp = crdtTimestamp;
+            AgeSeconds = ageSeconds;
+        }
+
+        /// <summary>
+        ///     True only when the authoritative server itself sent this write live. A state-sync row never qualifies,
+        ///     however it was originally authored, so this stays safe to test a scene's authority assumption against.
+        /// </summary>
+        public bool IsAuthoritativeServer =>
+            !ViaStateSync && Writer == ICrdtWriterLog.AUTHORITATIVE_SERVER_ADDRESS;
+    }
+
+    /// <summary>
+    ///     What one address has written to a scene since the log was enabled.
+    /// </summary>
+    public readonly struct CrdtWriterSummary
+    {
+        public readonly string Address;
+        public readonly bool IsTrustedSource;
+
+        /// <summary>Live writes this address made itself.</summary>
+        public readonly int Writes;
+
+        /// <summary>
+        ///     Rows this address supplied by answering a CRDT state request. Counted apart from <see cref="Writes" />
+        ///     because relaying a state dump is not the same claim as authoring the state in it.
+        /// </summary>
+        public readonly int StateSyncWrites;
+
+        public readonly double LastWriteAgeSeconds;
+
+        public CrdtWriterSummary(string address, bool isTrustedSource, int writes, int stateSyncWrites, double lastWriteAgeSeconds)
+        {
+            Address = address;
+            IsTrustedSource = isTrustedSource;
+            Writes = writes;
+            StateSyncWrites = stateSyncWrites;
+            LastWriteAgeSeconds = lastWriteAgeSeconds;
+        }
+
+        public bool IsAuthoritativeServer =>
+            Address == ICrdtWriterLog.AUTHORITATIVE_SERVER_ADDRESS;
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution/ICrdtWriterLog.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/Attribution/ICrdtWriterLog.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a27f980f9d4d4361a58dec250d08e076
+timeCreated: 1780000000

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/CRDTFilter.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/CRDTFilter.cs
@@ -90,6 +90,22 @@ namespace CRDT
             componentId is VIDEO_CONTROL_STATE or PHYSICS_COMBINED_IMPULSE or PHYSICS_COMBINED_FORCE;
 
         /// <summary>
+        /// Whether a CRDT message is withheld from the scene: a component that must not be synced between clients,
+        /// or a video component asserted by a source that is neither the local participant nor a scene admin.
+        /// Exposed so observers of the same traffic (writer attribution) apply the rule the scene is actually subject to,
+        /// instead of a copy of it that can drift.
+        /// </summary>
+        public static bool ShouldDropIncoming(CRDTMessageType messageType, uint componentId, bool isTrustedSource)
+        {
+            if (messageType is CRDTMessageType.PUT_COMPONENT_NETWORK or CRDTMessageType.DELETE_COMPONENT_NETWORK
+                && IsNoSyncComponent(componentId))
+                return true;
+
+            // Drop video components from untrusted sources
+            return isTrustedSource == false && componentId == VIDEO_PLAYER_COMPONENT_ID;
+        }
+
+        /// <summary>
         /// Filters CRDT messages from a span, removing messages with no-sync component IDs.
         /// Handles PUT_COMPONENT_NETWORK, DELETE_COMPONENT_NETWORK, and APPEND_COMPONENT.
         /// This is the core filtering logic shared by both FilterSceneMessageBatch and FilterCRDTState.
@@ -117,16 +133,7 @@ namespace CRDT
                 uint componentId = ReadComponentId(crdtMessages);
                 uint bodyLength = CRDTMessageTypeUtils.TypeLengthBytes(messageType, crdtMessages);
 
-                bool shouldDrop = messageType is CRDTMessageType.PUT_COMPONENT_NETWORK or CRDTMessageType.DELETE_COMPONENT_NETWORK
-                    && IsNoSyncComponent(componentId);
-
-                // Drop video components from untrusted sources
-                if (isTrustedSource == false && componentId == VIDEO_PLAYER_COMPONENT_ID)
-                {
-                    shouldDrop = true;
-                }
-
-                if (!shouldDrop)
+                if (!ShouldDropIncoming(messageType, componentId, isTrustedSource))
                 {
                     output.Write(messageLength);
                     output.Write((uint)messageType);

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/CRDTTests/CrdtWriterLogShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/CRDTTests/CrdtWriterLogShould.cs
@@ -1,0 +1,321 @@
+using CRDT.Attribution;
+using CRDT.Protocol;
+using DCL.ECS7;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+
+namespace CRDT.CRDTTests
+{
+    [TestFixture]
+    public class CrdtWriterLogShould
+    {
+        private const string SCENE = "bafkscene";
+        private const string SERVER = ICrdtWriterLog.AUTHORITATIVE_SERVER_ADDRESS;
+        private const string PEER = "0xdeadbeef";
+
+        private const int TRANSFORM = ComponentID.TRANSFORM;
+
+        private CrdtWriterLog log = null!;
+        private List<CrdtWrite> writes = null!;
+        private List<CrdtWriterSummary> writers = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            log = new CrdtWriterLog();
+            writes = new List<CrdtWrite>();
+            writers = new List<CrdtWriterSummary>();
+        }
+
+        [Test]
+        public void RecordNothingUntilEnabled()
+        {
+            // Act
+            log.RecordInbound(SCENE, SERVER, true, Batch(PutNetwork(entity: 512, component: TRANSFORM, timestamp: 1)));
+            log.EntityWrites(SCENE, 512, writes);
+
+            // Assert
+            Assert.That(log.IsEnabled, Is.False);
+            Assert.That(writes, Is.Empty);
+        }
+
+        [Test]
+        public void AttributeAWriteToThePeerThatSentIt()
+        {
+            // Arrange
+            log.Enable();
+
+            // Act
+            log.RecordInbound(SCENE, SERVER, true, Batch(PutNetwork(entity: 512, component: TRANSFORM, timestamp: 7)));
+            log.EntityWrites(SCENE, 512, writes);
+
+            // Assert
+            Assert.That(writes.Count, Is.EqualTo(1));
+            Assert.That(writes[0].Writer, Is.EqualTo(SERVER));
+            Assert.That(writes[0].IsAuthoritativeServer, Is.True);
+            Assert.That(writes[0].ComponentId, Is.EqualTo(TRANSFORM));
+            Assert.That(writes[0].CrdtTimestamp, Is.EqualTo(7));
+            Assert.That(writes[0].MessageType, Is.EqualTo(CRDTMessageType.PUT_COMPONENT_NETWORK));
+        }
+
+        /// <summary>
+        ///     The question an authoritative game asks: the last write to a component came from a client, not the server.
+        /// </summary>
+        [Test]
+        public void ReportTheLatestWriterOfAComponent()
+        {
+            // Arrange
+            log.Enable();
+            log.RecordInbound(SCENE, SERVER, true, Batch(PutNetwork(entity: 512, component: TRANSFORM, timestamp: 1)));
+
+            // Act
+            log.RecordInbound(SCENE, PEER, false, Batch(PutNetwork(entity: 512, component: TRANSFORM, timestamp: 2)));
+            log.EntityWrites(SCENE, 512, writes);
+
+            // Assert
+            Assert.That(writes.Count, Is.EqualTo(1));
+            Assert.That(writes[0].Writer, Is.EqualTo(PEER));
+            Assert.That(writes[0].IsAuthoritativeServer, Is.False);
+            Assert.That(writes[0].IsTrustedSource, Is.False);
+        }
+
+        [Test]
+        public void KeepWritesOfDifferentEntitiesApart()
+        {
+            // Arrange
+            log.Enable();
+
+            // Act
+            log.RecordInbound(SCENE, SERVER, true, Batch(PutNetwork(entity: 512, component: TRANSFORM, timestamp: 1)));
+            log.RecordInbound(SCENE, PEER, false, Batch(PutNetwork(entity: 513, component: TRANSFORM, timestamp: 1)));
+            log.EntityWrites(SCENE, 513, writes);
+
+            // Assert
+            Assert.That(writes.Count, Is.EqualTo(1));
+            Assert.That(writes[0].EntityId, Is.EqualTo(513));
+            Assert.That(writes[0].Writer, Is.EqualTo(PEER));
+        }
+
+        [Test]
+        public void ReadThroughTheAddressPrefixOfAStateResponse()
+        {
+            // Arrange
+            log.Enable();
+            byte[] batch = StateResponse(PEER, PutNetwork(entity: 512, component: TRANSFORM, timestamp: 3));
+
+            // Act
+            log.RecordInbound(SCENE, PEER, false, batch);
+            log.EntityWrites(SCENE, 512, writes);
+
+            // Assert
+            Assert.That(writes.Count, Is.EqualTo(1));
+            Assert.That(writes[0].CrdtTimestamp, Is.EqualTo(3));
+        }
+
+        /// <summary>
+        ///     A state dump replays writes its sender did not necessarily author — a client hydrating mid-game gets
+        ///     the server's writes handed to it by whichever peer answered. Crediting them to that peer would make
+        ///     every authorship test wrong, so the rows are marked and never read as authoritative.
+        /// </summary>
+        [Test]
+        public void NotCreditAuthorshipToThePeerThatRelayedAStateDump()
+        {
+            // Arrange
+            log.Enable();
+
+            // Act — the peer answers our state request with state the server originally wrote
+            log.RecordInbound(SCENE, PEER, false, StateResponse(PEER, PutNetwork(entity: 512, component: TRANSFORM, timestamp: 3)));
+            log.EntityWrites(SCENE, 512, writes);
+
+            // Assert
+            Assert.That(writes[0].ViaStateSync, Is.True);
+            Assert.That(writes[0].IsAuthoritativeServer, Is.False);
+        }
+
+        /// <summary>
+        ///     Even when the authoritative server is the peer answering the request, a replayed row is not a live
+        ///     assertion by it, so IsAuthoritativeServer stays false and only the flag distinguishes the two.
+        /// </summary>
+        [Test]
+        public void NotReadAStateDumpFromTheServerAsALiveServerWrite()
+        {
+            // Arrange
+            log.Enable();
+
+            // Act
+            log.RecordInbound(SCENE, SERVER, true, StateResponse(SERVER, PutNetwork(entity: 512, component: TRANSFORM, timestamp: 3)));
+            log.EntityWrites(SCENE, 512, writes);
+
+            // Assert
+            Assert.That(writes[0].Writer, Is.EqualTo(SERVER));
+            Assert.That(writes[0].ViaStateSync, Is.True);
+            Assert.That(writes[0].IsAuthoritativeServer, Is.False);
+        }
+
+        [Test]
+        public void CountRelayedRowsApartFromLiveWrites()
+        {
+            // Arrange
+            log.Enable();
+
+            // Act
+            log.RecordInbound(SCENE, PEER, false, Batch(PutNetwork(entity: 512, component: TRANSFORM, timestamp: 1)));
+            log.RecordInbound(SCENE, PEER, false, StateResponse(PEER, PutNetwork(entity: 513, component: TRANSFORM, timestamp: 1)));
+            log.SceneWriters(SCENE, writers);
+
+            // Assert
+            Assert.That(writers.Count, Is.EqualTo(1));
+            Assert.That(writers[0].Writes, Is.EqualTo(1));
+            Assert.That(writers[0].StateSyncWrites, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        ///     A component row must never name an address the scene-level summary omits, or the two tools would
+        ///     contradict each other. When the writer budget is full the write is refused outright and counted.
+        /// </summary>
+        [Test]
+        public void NeverNameAWriterTheSceneSummaryOmits()
+        {
+            // Arrange — more distinct addresses than a scene may summarise
+            log.Enable();
+            const int OVERSHOOT = 200;
+
+            for (var i = 0; i < OVERSHOOT; i++)
+                log.RecordInbound(SCENE, $"0x{i:x8}", false, Batch(PutNetwork(entity: 512 + i, component: TRANSFORM, timestamp: 1)));
+
+            log.SceneWriters(SCENE, writers);
+
+            // Assert — the budget held, and the overflow was counted rather than dropped silently
+            Assert.That(writers.Count, Is.LessThan(OVERSHOOT));
+            Assert.That(log.DroppedWrites(SCENE), Is.GreaterThan(0));
+
+            // Assert — every recorded component row resolves to a summarised address
+            var summarised = new HashSet<string>();
+
+            foreach (CrdtWriterSummary writer in writers)
+                summarised.Add(writer.Address);
+
+            for (var i = 0; i < OVERSHOOT; i++)
+            {
+                writes.Clear();
+                log.EntityWrites(SCENE, 512 + i, writes);
+
+                foreach (CrdtWrite write in writes)
+                    Assert.That(summarised, Does.Contain(write.Writer));
+            }
+        }
+
+        /// <summary>
+        ///     A write the CRDT filter withholds from the scene never reached the scene's state, so attributing it
+        ///     would describe a change the agent cannot observe.
+        /// </summary>
+        [Test]
+        public void NotAttributeAWriteTheSceneNeverReceives()
+        {
+            // Arrange
+            log.Enable();
+
+            // Act
+            log.RecordInbound(SCENE, PEER, isTrustedSource: false,
+                Batch(PutNetwork(entity: 512, component: ComponentID.VIDEO_PLAYER, timestamp: 1)));
+
+            log.EntityWrites(SCENE, 512, writes);
+
+            // Assert
+            Assert.That(writes, Is.Empty);
+        }
+
+        [Test]
+        public void SummariseEveryWriterOfAScene()
+        {
+            // Arrange
+            log.Enable();
+
+            // Act
+            log.RecordInbound(SCENE, SERVER, true, Batch(PutNetwork(entity: 512, component: TRANSFORM, timestamp: 1)));
+            log.RecordInbound(SCENE, SERVER, true, Batch(PutNetwork(entity: 513, component: TRANSFORM, timestamp: 1)));
+            log.RecordInbound(SCENE, PEER, false, Batch(PutNetwork(entity: 514, component: TRANSFORM, timestamp: 1)));
+            log.SceneWriters(SCENE, writers);
+
+            // Assert
+            Assert.That(writers.Count, Is.EqualTo(2));
+            Assert.That(writers.Find(writer => writer.Address == SERVER).Writes, Is.EqualTo(2));
+            Assert.That(writers.Find(writer => writer.Address == PEER).Writes, Is.EqualTo(1));
+            Assert.That(writers.Find(writer => writer.Address == SERVER).IsAuthoritativeServer, Is.True);
+        }
+
+        [Test]
+        public void ReportNothingForAnUnknownScene()
+        {
+            // Arrange
+            log.Enable();
+            log.RecordInbound(SCENE, SERVER, true, Batch(PutNetwork(entity: 512, component: TRANSFORM, timestamp: 1)));
+
+            // Act
+            log.EntityWrites("other-scene", 512, writes);
+            log.SceneWriters("other-scene", writers);
+
+            // Assert
+            Assert.That(writes, Is.Empty);
+            Assert.That(writers, Is.Empty);
+        }
+
+        [Test]
+        public void SurviveATruncatedBatch()
+        {
+            // Arrange
+            log.Enable();
+            byte[] truncated = Batch(PutNetwork(entity: 512, component: TRANSFORM, timestamp: 1))[..^6];
+
+            // Act & Assert
+            Assert.DoesNotThrow(() => log.RecordInbound(SCENE, SERVER, true, truncated));
+        }
+
+        /// <summary>A CRDT batch as the SDK sends it: the message type byte followed by the messages.</summary>
+        private static byte[] Batch(params byte[][] messages)
+        {
+            var stream = new MemoryStream();
+            stream.WriteByte((byte)SdkCommsMessageType.CRDT);
+
+            foreach (byte[] message in messages)
+                stream.Write(message, 0, message.Length);
+
+            return stream.ToArray();
+        }
+
+        /// <summary>A RES_CRDT_STATE payload: the type byte, the subject's address, then the messages.</summary>
+        private static byte[] StateResponse(string address, params byte[][] messages)
+        {
+            var stream = new MemoryStream();
+            stream.WriteByte((byte)SdkCommsMessageType.ResCRDTState);
+            stream.WriteByte((byte)address.Length);
+
+            foreach (char character in address)
+                stream.WriteByte((byte)character);
+
+            foreach (byte[] message in messages)
+                stream.Write(message, 0, message.Length);
+
+            return stream.ToArray();
+        }
+
+        /// <summary>[length][type][entity][component][timestamp][network id][data length][data]</summary>
+        private static byte[] PutNetwork(int entity, int component, int timestamp, int dataLength = 4)
+        {
+            var writer = new BinaryWriter(new MemoryStream());
+            writer.Write(CRDTConstants.MESSAGE_HEADER_LENGTH + 20 + dataLength);
+            writer.Write((int)CRDTMessageType.PUT_COMPONENT_NETWORK);
+            writer.Write(entity);
+            writer.Write(component);
+            writer.Write(timestamp);
+            writer.Write(0); // network id
+            writer.Write(dataLength);
+
+            for (var i = 0; i < dataLength; i++)
+                writer.Write((byte)0);
+
+            return ((MemoryStream)writer.BaseStream).ToArray();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/CRDTTests/CrdtWriterLogShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/CRDTTests/CrdtWriterLogShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f0a9a105d2fb4104b207162b4696e6aa
+timeCreated: 1780000000

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/Protocol/SdkCommsMessageType.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/Protocol/SdkCommsMessageType.cs
@@ -1,0 +1,18 @@
+namespace CRDT.Protocol
+{
+    /// <summary>
+    ///     First byte of a scene-room payload, written by the SDK runtime rather than by the Explorer.
+    ///     Must be aligned with the SDK runtime's values at:
+    ///     https://github.com/decentraland/js-sdk-toolchain/blob/c8695cd9b94e87ad567520089969583d9d36637f/packages/@dcl/sdk/src/network/binary-message-bus.ts#L3-L7
+    /// </summary>
+    public enum SdkCommsMessageType
+    {
+        CRDT = 1,
+
+        /// <summary>Special signal to receive CRDT State from a peer.</summary>
+        ReqCRDTState = 2,
+
+        /// <summary>Special signal to send CRDT State to a peer.</summary>
+        ResCRDTState = 3,
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/CRDT/Protocol/SdkCommsMessageType.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/CRDT/Protocol/SdkCommsMessageType.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6e76c7ae1305499b95d99c04fc5e903a
+timeCreated: 1780000000

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/CommunicationsControllerAPIImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/CommunicationsControllerAPIImplementation.cs
@@ -1,4 +1,5 @@
-﻿using CrdtEcsBridge.PoolsProviders;
+﻿using CRDT.Protocol;
+using CrdtEcsBridge.PoolsProviders;
 using SceneRunner.Scene;
 using SceneRuntime;
 using System;
@@ -40,7 +41,7 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
             // At this point data is already without MsgType (Explorer routing is truncated a step above).
 
             // read first byte as SDK routing
-            CommsMessageType commsMessageType = (CommsMessageType)message.Data[0];
+            SdkCommsMessageType commsMessageType = (SdkCommsMessageType)message.Data[0];
             // Copy and filter batch
             ReadOnlySpan<byte> sourceData = message.Data;
             bool isTrustedSource = message.IsTrustedSource;
@@ -49,13 +50,13 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
 
             // TODO This logic mostly duplicates CommunicationsControllerAPIImplementationBase.SendBinary we should standardise it later
             // Filter CRDT messages before receiving
-            if (commsMessageType == CommsMessageType.CRDT)
+            if (commsMessageType == SdkCommsMessageType.CRDT)
             {
                 int filteredLength = FilterCRDTMessage(sourceData, filteredUnbounded, isTrustedSource);
                 totalLength += filteredLength;
             }
             // Filter RES_CRDT_STATE messages before receiving
-            else if (commsMessageType == CommsMessageType.ResCRDTState)
+            else if (commsMessageType == SdkCommsMessageType.ResCRDTState)
             {
                 int filteredLength = FilterCRDTStateMessage(sourceData, filteredUnbounded, isTrustedSource);
                 totalLength += filteredLength;

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/CommunicationsControllerAPIImplementationBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/CommunicationsControllerAPIImplementationBase.cs
@@ -1,4 +1,5 @@
 ﻿using CRDT;
+using CRDT.Protocol;
 using CrdtEcsBridge.PoolsProviders;
 using DCL.Multiplayer.Profiles.BroadcastProfiles;
 using Microsoft.ClearScript;
@@ -15,14 +16,6 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
 {
     public abstract class CommunicationsControllerAPIImplementationBase : ICommunicationsControllerAPI
     {
-        // Must be aligned with SDK runtime 1st-byte values at:
-        // https://github.com/decentraland/js-sdk-toolchain/blob/c8695cd9b94e87ad567520089969583d9d36637f/packages/@dcl/sdk/src/network/binary-message-bus.ts#L3-L7
-        protected enum CommsMessageType {
-          CRDT = 1,
-          ReqCRDTState = 2,   // Special signal to receive CRDT State from a peer
-          ResCRDTState = 3    // Special signal to send CRDT State to a peer
-        }
-
         private readonly List<PoolableByteArray> eventsToProcess = new ();
         private readonly CancellationTokenSource cancellationTokenSource = new ();
         private readonly ISceneCommunicationPipe sceneCommunicationPipe;
@@ -71,12 +64,12 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
                 {
                     byte firstByte = poolable.Span[0];
 
-                    ISceneCommunicationPipe.ConnectivityAssertiveness assertiveness = firstByte == (int)CommsMessageType.ReqCRDTState
+                    ISceneCommunicationPipe.ConnectivityAssertiveness assertiveness = firstByte == (int)SdkCommsMessageType.ReqCRDTState
                         ? ISceneCommunicationPipe.ConnectivityAssertiveness.DeliveryAsserted
                         : ISceneCommunicationPipe.ConnectivityAssertiveness.DropIfNotConnected;
 
                     // Filter CRDT messages before sending
-                    if (firstByte == (int)CommsMessageType.CRDT)
+                    if (firstByte == (int)SdkCommsMessageType.CRDT)
                     {
                         Span<byte> filtered = stackalloc byte[poolable.Memory.Span.Length];
                         int filteredLength = FilterCRDTMessage(poolable.Memory.Span, filtered, isTrustedSource: true);
@@ -85,7 +78,7 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
                     }
 
                     // Filter RES_CRDT_STATE messages before sending
-                    if (firstByte == (int)CommsMessageType.ResCRDTState)
+                    if (firstByte == (int)SdkCommsMessageType.ResCRDTState)
                     {
                         Span<byte> filtered = stackalloc byte[poolable.Memory.Span.Length];
                         int filteredLength = FilterCRDTStateMessage(poolable.Memory.Span, filtered, isTrustedSource: true);

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/SceneCommunicationPipe.cs
@@ -1,4 +1,5 @@
-﻿using DCL.Multiplayer.Connections.GateKeeper.Rooms;
+﻿using CRDT.Attribution;
+using DCL.Multiplayer.Connections.GateKeeper.Rooms;
 using DCL.Multiplayer.Connections.Messaging;
 using DCL.Multiplayer.Connections.Messaging.Hubs;
 using DCL.Multiplayer.Connections.Messaging.Pipe;
@@ -23,10 +24,12 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
 
         private readonly IGateKeeperSceneRoom sceneRoom;
         private readonly IMessagePipe messagePipe;
+        private readonly ICrdtWriterLog writerLog;
 
-        public SceneCommunicationPipe(IMessagePipesHub messagePipesHub, IGateKeeperSceneRoom sceneRoom)
+        public SceneCommunicationPipe(IMessagePipesHub messagePipesHub, IGateKeeperSceneRoom sceneRoom, ICrdtWriterLog? writerLog = null)
         {
             this.sceneRoom = sceneRoom;
+            this.writerLog = writerLog ?? ICrdtWriterLog.Null.INSTANCE;
             messagePipe = messagePipesHub.ScenePipe();
             messagePipe.Subscribe<Scene>(Packet.MessageOneofCase.Scene, InvokeSubscriber, IMessagePipe.ThreadStrict.OriginThread);
         }
@@ -59,6 +62,11 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
                     message.FromWalletId,
                     isTrustedSource
                 );
+
+                // Attribution is taken from the message the scene is about to receive, so it names the peer the
+                // transport authenticated rather than anything the CRDT payload claims about itself.
+                if (msgType == ISceneCommunicationPipe.MsgType.Uint8Array)
+                    writerLog.RecordInbound(message.Payload.SceneId, message.FromWalletId, isTrustedSource, decodedMessage);
 
                 handler(dm);
             }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -865,6 +865,7 @@ namespace Global.Dynamic
                     staticContainer.EntityCollidersGlobalCache,
                     coroutineRunner,
                     globalWorld,
+                    staticContainer.CrdtWriterLog,
                     localSceneDevelopment));
 
             if (FeaturesRegistry.Instance.IsEnabled(FeatureId.LocalSceneDevelopment) || FeaturesRegistry.Instance.IsEnabled(FeatureId.SelfPreviewBuilderCollections))

--- a/Explorer/Assets/DCL/Infrastructure/Global/SceneSharedContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/SceneSharedContainer.cs
@@ -83,7 +83,7 @@ namespace Global
                     realmData,
                     staticContainer.PortableExperiencesController,
                     staticContainer.StaticSettings.SkyboxSettings,
-                    new SceneCommunicationPipe(messagePipesHub, roomHub.SceneRoom()),
+                    new SceneCommunicationPipe(messagePipesHub, roomHub.SceneRoom(), staticContainer.CrdtWriterLog),
                     remoteMetadata,
                     dclEnvironment,
                     systemClipboard,

--- a/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
@@ -1,6 +1,7 @@
 using Arch.Core;
 using DCL.SceneRunner.Scene;
 using CommunicationData.URLHelpers;
+using CRDT.Attribution;
 using CrdtEcsBridge.Components;
 using Cysharp.Threading.Tasks;
 using DCL.AssetsProvision;
@@ -85,6 +86,12 @@ namespace Global
         public readonly ObjectProxy<AvatarBase> MainPlayerAvatarBaseProxy = new ();
         public readonly PartitionDataContainer PartitionDataContainer = new ();
         public readonly IMapPinsEventBus MapPinsEventBus = new MapPinsEventBus();
+
+        /// <summary>
+        ///     Records who wrote each networked component of a scene. Inert until a consumer enables it — today only
+        ///     the MCP server does, so a normal session pays a single branch per inbound scene-room message.
+        /// </summary>
+        public readonly ICrdtWriterLog CrdtWriterLog = new CrdtWriterLog();
 
         private IAssetsProvisioner assetsProvisioner;
         public Entity PlayerEntity { get; set; }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Debugging/IWorldInfo.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Debugging/IWorldInfo.cs
@@ -7,5 +7,13 @@ namespace SceneRunner.Debugging
         string EntityComponentsInfo(int entityId);
 
         IReadOnlyList<int> EntityIds();
+
+        /// <summary>
+        ///     The CRDT id of the entity <paramref name="entityId" /> names. That is the id the scene's own code and
+        ///     the scene-room traffic address entities by, unlike <paramref name="entityId" />, which is the index of
+        ///     the entity in the ECS world.
+        /// </summary>
+        /// <returns>Null when the entity does not exist or is not backed by a CRDT entity.</returns>
+        int? CrdtEntityId(int entityId);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Debugging/IWorldInfo.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Debugging/IWorldInfo.cs
@@ -9,11 +9,11 @@ namespace SceneRunner.Debugging
         IReadOnlyList<int> EntityIds();
 
         /// <summary>
-        ///     The CRDT id of the entity <paramref name="entityId" /> names. That is the id the scene's own code and
-        ///     the scene-room traffic address entities by, unlike <paramref name="entityId" />, which is the index of
-        ///     the entity in the ECS world.
+        ///     Resolves the entity <paramref name="entityId" /> names into <paramref name="crdtEntityId" />, the id the
+        ///     scene's own code and the scene-room traffic address entities by, unlike <paramref name="entityId" />,
+        ///     which is the index of the entity in the ECS world.
         /// </summary>
-        /// <returns>Null when the entity does not exist or is not backed by a CRDT entity.</returns>
-        int? CrdtEntityId(int entityId);
+        /// <returns>False when the entity does not exist or is not backed by a CRDT entity.</returns>
+        bool TryGetCrdtEntityId(int entityId, out int crdtEntityId);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Debugging/WorldInfo.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Debugging/WorldInfo.cs
@@ -1,4 +1,5 @@
 using Arch.Core;
+using CRDT;
 using DCL.Diagnostics;
 using System.Collections.Generic;
 using System.Text;
@@ -48,6 +49,22 @@ namespace SceneRunner.Debugging
             var result = sb.ToString();
             ReportHub.Log(ReportCategory.DEBUG, result);
             return result;
+        }
+
+        public int? CrdtEntityId(int entityId)
+        {
+            int? crdtEntityId = null;
+
+            world.Query(
+                new QueryDescription().WithAll<CRDTEntity>().WithNone<FindMarker>(),
+                entity =>
+                {
+                    if (entity.Id == entityId && world.TryGet<CRDTEntity>(entity, out CRDTEntity crdtEntity))
+                        crdtEntityId = crdtEntity.Id;
+                }
+            );
+
+            return crdtEntityId;
         }
 
         public IReadOnlyList<int> EntityIds()

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/Debugging/WorldInfo.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/Debugging/WorldInfo.cs
@@ -51,20 +51,25 @@ namespace SceneRunner.Debugging
             return result;
         }
 
-        public int? CrdtEntityId(int entityId)
+        public bool TryGetCrdtEntityId(int entityId, out int crdtEntityId)
         {
-            int? crdtEntityId = null;
+            var found = false;
+            var id = 0;
 
             world.Query(
                 new QueryDescription().WithAll<CRDTEntity>().WithNone<FindMarker>(),
                 entity =>
                 {
                     if (entity.Id == entityId && world.TryGet<CRDTEntity>(entity, out CRDTEntity crdtEntity))
-                        crdtEntityId = crdtEntity.Id;
+                    {
+                        id = crdtEntity.Id;
+                        found = true;
+                    }
                 }
             );
 
-            return crdtEntityId;
+            crdtEntityId = id;
+            return found;
         }
 
         public IReadOnlyList<int> EntityIds()

--- a/Explorer/Assets/DCL/McpServer/Core/McpJsonSchema.cs
+++ b/Explorer/Assets/DCL/McpServer/Core/McpJsonSchema.cs
@@ -72,6 +72,21 @@ namespace DCL.McpServer.Core
             return AddField(name, field, isRequired);
         }
 
+        /// <summary>Adds an array field whose items are all objects of the shape <paramref name="items" /> describes.</summary>
+        public McpJsonSchema ObjectArray(string name, McpJsonSchema items, string? description = null, bool isRequired = false)
+        {
+            var field = new JObject
+            {
+                ["type"] = "array",
+                ["items"] = items.Build(),
+            };
+
+            if (description != null)
+                field["description"] = description;
+
+            return AddField(name, field, isRequired);
+        }
+
         /// <summary>Materializes the accumulated fields into the JSON Schema object.</summary>
         public JObject Build()
         {

--- a/Explorer/Assets/DCL/McpServer/DCL.McpServer.asmdef
+++ b/Explorer/Assets/DCL/McpServer/DCL.McpServer.asmdef
@@ -14,6 +14,7 @@
         "GUID:286980af24684da6acc1caa413039811",
         "GUID:809870cbfd80a7b46bcf72b178ab210b",
         "GUID:1b8e1e1bd01505f478f0369c04a4fb2f",
+        "GUID:0f4c0f120707fb74497f5d581b9858f8",
         "GUID:571dc9f8bded0034f98595106462e3d0",
         "GUID:0df5180c0c3a0594fbfa11f83736de9f",
         "GUID:3c7b57a14671040bd8c549056adc04f5",

--- a/Explorer/Assets/DCL/McpServer/Systems/McpServerPlugin.cs
+++ b/Explorer/Assets/DCL/McpServer/Systems/McpServerPlugin.cs
@@ -1,4 +1,5 @@
 using Arch.SystemGroups;
+using CRDT.Attribution;
 using CrdtEcsBridge.RestrictedActions;
 using Cysharp.Threading.Tasks;
 using DCL.CharacterCamera;
@@ -50,6 +51,7 @@ namespace DCL.McpServer.Systems
         private readonly IScenesCache scenesCache;
         private readonly ICurrentSceneInfo currentSceneInfo;
         private readonly ECSReloadScene reloadSceneController;
+        private readonly ICrdtWriterLog writerLog;
         private readonly bool localSceneDevelopment;
 
         private readonly SceneLogBuffer logBuffer;
@@ -74,6 +76,7 @@ namespace DCL.McpServer.Systems
             IEntityCollidersGlobalCache entityCollidersGlobalCache,
             ICoroutineRunner coroutineRunner,
             Arch.Core.World globalWorld,
+            ICrdtWriterLog writerLog,
             bool localSceneDevelopment)
         {
             port = appArgs.TryGetValue(AppArgsFlags.MCP_PORT, out string? portValue)
@@ -93,7 +96,11 @@ namespace DCL.McpServer.Systems
             this.entityCollidersGlobalCache = entityCollidersGlobalCache;
             this.coroutineRunner = coroutineRunner;
             this.globalWorld = globalWorld;
+            this.writerLog = writerLog;
             this.localSceneDevelopment = localSceneDevelopment;
+
+            // Attribution is only recorded while something asks for it, and the MCP server is that something.
+            writerLog.Enable();
 
             logBuffer = new SceneLogBuffer();
             logEntryBus = new DebugMenuConsoleLogEntryBus();
@@ -119,7 +126,7 @@ namespace DCL.McpServer.Systems
             var toolsRegistry = new McpToolsRegistry()
                           .Add(screenshotTool)
                           .Add(new GetPlayerStateTool(globalWorld, arguments.PlayerEntity, exposedCameraData, currentSceneInfo))
-                          .Add(new GetSceneStateTool(scenesCache, currentSceneInfo, loadingStatus, localSceneDevelopment))
+                          .Add(new GetSceneStateTool(scenesCache, currentSceneInfo, loadingStatus, writerLog, localSceneDevelopment))
                           .Add(new GetSceneLogsTool(logBuffer))
                           .Add(new TeleportTool(chatMessagesBus, scenesCache, loadingStatus))
                           .Add(new MoveToTool(globalWorldActions, globalWorld, arguments.PlayerEntity))
@@ -130,7 +137,7 @@ namespace DCL.McpServer.Systems
                           .Add(new SendChatTool(chatMessagesBus))
                           .Add(new ReloadSceneTool(reloadSceneController, scenesCache, globalWorld, arguments.PlayerEntity, arguments.SkyboxEntity))
                           .Add(new ListSceneEntitiesTool(worldInfoHub))
-                          .Add(new GetEntityDetailsTool(worldInfoHub))
+                          .Add(new GetEntityDetailsTool(worldInfoHub, scenesCache, writerLog))
                           .Add(new TriggerEmoteTool(globalWorldActions))
                           .Add(new ClickEntityTool(globalWorld, arguments.PlayerEntity))
                           .Build();

--- a/Explorer/Assets/DCL/McpServer/Tests/GetEntityDetailsToolShould.cs
+++ b/Explorer/Assets/DCL/McpServer/Tests/GetEntityDetailsToolShould.cs
@@ -1,10 +1,17 @@
+using CRDT.Attribution;
+using CRDT.Protocol;
+using DCL.Ipfs;
 using DCL.McpServer.Core;
 using DCL.McpServer.Tools;
+using DCL.Utilities;
+using ECS.SceneLifeCycle;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NUnit.Framework;
 using SceneRunner.Debugging;
 using SceneRunner.Debugging.Hub;
+using SceneRunner.Scene;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace DCL.McpServer.Tests
@@ -12,9 +19,13 @@ namespace DCL.McpServer.Tests
     public class GetEntityDetailsToolShould
     {
         private const string CURRENT_SCENE = "CURRENT";
+        private const string SCENE_ID = "scene-abc";
+        private const int CRDT_ENTITY = 512;
 
         private IWorldInfoHub worldInfoHub = null!;
         private IWorldInfo worldInfo = null!;
+        private IScenesCache scenesCache = null!;
+        private ICrdtWriterLog writerLog = null!;
         private GetEntityDetailsTool tool = null!;
 
         [SetUp]
@@ -23,7 +34,18 @@ namespace DCL.McpServer.Tests
             worldInfo = Substitute.For<IWorldInfo>();
             worldInfoHub = Substitute.For<IWorldInfoHub>();
             worldInfoHub.WorldInfo(CURRENT_SCENE).Returns(worldInfo);
-            tool = new GetEntityDetailsTool(worldInfoHub);
+            worldInfo.CrdtEntityId(5).Returns(CRDT_ENTITY);
+
+            // Built before the Returns() call, never inside its argument: configuring one substitute while another
+            // one's call is pending loses NSubstitute's record of which call it was meant to configure.
+            ISceneFacade scene = SceneWithId(SCENE_ID);
+
+            scenesCache = Substitute.For<IScenesCache>();
+            scenesCache.CurrentScene.Returns(new ReactiveProperty<ISceneFacade?>(scene));
+
+            writerLog = Substitute.For<ICrdtWriterLog>();
+
+            tool = new GetEntityDetailsTool(worldInfoHub, scenesCache, writerLog);
         }
 
         [Test]
@@ -37,7 +59,7 @@ namespace DCL.McpServer.Tests
             string text = TextOf(Execute(5));
 
             // Assert
-            Assert.That(text, Is.EqualTo(DUMP));
+            Assert.That(text, Does.StartWith(DUMP));
             Assert.That(text, Does.Not.Contain("truncated"));
         }
 
@@ -77,6 +99,87 @@ namespace DCL.McpServer.Tests
 
             // Assert
             Assert.That(result.Payload["isError"]!.Value<bool>(), Is.True);
+        }
+
+        /// <summary>
+        ///     The reading an authoritative game is after: the component the agent is looking at was last set by a
+        ///     player, not by the server that is supposed to own it.
+        /// </summary>
+        [Test]
+        public void NameTheAddressThatLastWroteEachComponent()
+        {
+            // Arrange
+            worldInfo.EntityComponentsInfo(5).Returns("Components of entity 5, total count: 1\n1) PBTransform");
+
+            writerLog.When(log => log.EntityWrites(SCENE_ID, CRDT_ENTITY, Arg.Any<List<CrdtWrite>>()))
+                     .Do(call => call.Arg<List<CrdtWrite>>()
+                                     .Add(new CrdtWrite(CRDT_ENTITY, 1, "0xabc", false, false, CRDTMessageType.PUT_COMPONENT_NETWORK, 9, 1.5)));
+
+            // Act
+            McpToolResult result = Execute(5);
+
+            // Assert
+            var writes = (JArray)result.Payload["structuredContent"]!["networkWrites"]!;
+            Assert.That(writes.Count, Is.EqualTo(1));
+            Assert.That(writes[0]!["writer"]!.Value<string>(), Is.EqualTo("0xabc"));
+            Assert.That(writes[0]!["isAuthoritativeServer"]!.Value<bool>(), Is.False);
+            Assert.That(writes[0]!["componentId"]!.Value<int>(), Is.EqualTo(1));
+            Assert.That(writes[0]!["crdtTimestamp"]!.Value<int>(), Is.EqualTo(9));
+
+            // Assert — the text mirror carries the same claim, for clients that do not read structured content
+            Assert.That(TextOf(result), Does.Contain("component 1 ← 0xabc"));
+        }
+
+        [Test]
+        public void SayExplicitlyWhenNoPeerHasWrittenTheEntity()
+        {
+            // Arrange
+            worldInfo.EntityComponentsInfo(5).Returns("Components of entity 5, total count: 1\n1) PBTransform");
+
+            // Act
+            McpToolResult result = Execute(5);
+
+            // Assert
+            Assert.That(((JArray)result.Payload["structuredContent"]!["networkWrites"]!).Count, Is.Zero);
+            Assert.That(TextOf(result), Does.Contain("none — every component of this entity was written by the scene's own code"));
+        }
+
+        [Test]
+        public void ReportANullCrdtEntityForAnEntityTheSceneNeverRegistered()
+        {
+            // Arrange
+            worldInfo.EntityComponentsInfo(7).Returns("Entity not found: 7");
+            worldInfo.CrdtEntityId(7).Returns((int?)null);
+
+            // Act
+            McpToolResult result = Execute(7);
+
+            // Assert
+            Assert.That(result.Payload["structuredContent"]!["crdtEntityId"]!.Type, Is.EqualTo(JTokenType.Null));
+            writerLog.DidNotReceive().EntityWrites(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<List<CrdtWrite>>());
+        }
+
+        [Test]
+        public void KeepTheOutputSchemaInSyncWithTheStructuredPayload()
+        {
+            // Arrange
+            worldInfo.EntityComponentsInfo(5).Returns("Components of entity 5, total count: 0");
+
+            // Act
+            var structured = (JObject)Execute(5).Payload["structuredContent"]!;
+
+            // Assert
+            McpSchemaAssert.KeysMatch(tool.OutputSchema, structured);
+        }
+
+        private static ISceneFacade SceneWithId(string sceneId)
+        {
+            ISceneData sceneData = Substitute.For<ISceneData>();
+            sceneData.SceneEntityDefinition.Returns(new SceneEntityDefinition { id = sceneId });
+
+            ISceneFacade scene = Substitute.For<ISceneFacade>();
+            scene.SceneData.Returns(sceneData);
+            return scene;
         }
 
         private McpToolResult Execute(int entityId) =>

--- a/Explorer/Assets/DCL/McpServer/Tests/GetEntityDetailsToolShould.cs
+++ b/Explorer/Assets/DCL/McpServer/Tests/GetEntityDetailsToolShould.cs
@@ -34,7 +34,12 @@ namespace DCL.McpServer.Tests
             worldInfo = Substitute.For<IWorldInfo>();
             worldInfoHub = Substitute.For<IWorldInfoHub>();
             worldInfoHub.WorldInfo(CURRENT_SCENE).Returns(worldInfo);
-            worldInfo.CrdtEntityId(5).Returns(CRDT_ENTITY);
+            worldInfo.TryGetCrdtEntityId(5, out Arg.Any<int>())
+                     .Returns(call =>
+                      {
+                          call[1] = CRDT_ENTITY;
+                          return true;
+                      });
 
             // Built before the Returns() call, never inside its argument: configuring one substitute while another
             // one's call is pending loses NSubstitute's record of which call it was meant to configure.
@@ -149,7 +154,7 @@ namespace DCL.McpServer.Tests
         {
             // Arrange
             worldInfo.EntityComponentsInfo(7).Returns("Entity not found: 7");
-            worldInfo.CrdtEntityId(7).Returns((int?)null);
+            worldInfo.TryGetCrdtEntityId(7, out Arg.Any<int>()).Returns(false);
 
             // Act
             McpToolResult result = Execute(7);

--- a/Explorer/Assets/DCL/McpServer/Tests/GetSceneStateToolShould.cs
+++ b/Explorer/Assets/DCL/McpServer/Tests/GetSceneStateToolShould.cs
@@ -1,3 +1,4 @@
+using CRDT.Attribution;
 using DCL.Diagnostics;
 using DCL.Ipfs;
 using DCL.McpServer.Core;
@@ -11,6 +12,7 @@ using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NUnit.Framework;
 using SceneRunner.Scene;
+using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using Utility.Multithreading;
@@ -22,6 +24,7 @@ namespace DCL.McpServer.Tests
         private IScenesCache scenesCache = null!;
         private ICurrentSceneInfo currentSceneInfo = null!;
         private ILoadingStatus loadingStatus = null!;
+        private ICrdtWriterLog writerLog = null!;
         private GetSceneStateTool tool = null!;
 
         [SetUp]
@@ -30,12 +33,13 @@ namespace DCL.McpServer.Tests
             scenesCache = Substitute.For<IScenesCache>();
             currentSceneInfo = Substitute.For<ICurrentSceneInfo>();
             loadingStatus = Substitute.For<ILoadingStatus>();
+            writerLog = Substitute.For<ICrdtWriterLog>();
 
             scenesCache.CurrentParcel.Returns(new ReactiveProperty<Vector2Int>(new Vector2Int(1, 2)));
             scenesCache.CurrentScene.Returns(new ReactiveProperty<ISceneFacade?>(null));
             loadingStatus.CurrentStage.Returns(new ReactiveProperty<LoadingStatus.LoadingStage>(default));
 
-            tool = new GetSceneStateTool(scenesCache, currentSceneInfo, loadingStatus, localSceneDevelopment: false);
+            tool = new GetSceneStateTool(scenesCache, currentSceneInfo, loadingStatus, writerLog, localSceneDevelopment: false);
         }
 
         [Test]
@@ -78,21 +82,7 @@ namespace DCL.McpServer.Tests
         public void KeepTheOutputSchemaInSyncWithTheStructuredPayload()
         {
             // Arrange — a populated scene so the nested "scene" object is covered, not just the top level.
-            ISceneStateProvider sceneStateProvider = Substitute.For<ISceneStateProvider>();
-            sceneStateProvider.State.Returns(new Atomic<SceneState>(SceneState.Running));
-
-            ISceneData sceneData = Substitute.For<ISceneData>();
-            sceneData.SceneLoadingConcluded.Returns(true);
-            sceneData.SceneEntityDefinition.Returns(new SceneEntityDefinition { id = "scene-abc" });
-
-            ISceneFacade scene = Substitute.For<ISceneFacade>();
-            scene.Info.Returns(new SceneShortInfo(new Vector2Int(1, 2), "Test scene", "7"));
-            scene.SceneStateProvider.Returns(sceneStateProvider);
-            scene.SceneData.Returns(sceneData);
-            scene.IsSceneReady().Returns(true);
-
-            scenesCache.CurrentScene.Returns(new ReactiveProperty<ISceneFacade?>(scene));
-            currentSceneInfo.SceneStatus.Returns(new ReactiveProperty<ICurrentSceneInfo.RunningStatus?>(null));
+            ArrangeScene(authoritativeMultiplayer: false);
 
             // Act
             var structured = (JObject)Execute().Payload["structuredContent"]!;
@@ -102,6 +92,75 @@ namespace DCL.McpServer.Tests
 
             // Assert — the definition id is what click_entity's sceneId pin expects
             Assert.That(structured["scene"]!["sceneId"]!.Value<string>(), Is.EqualTo("scene-abc"));
+        }
+
+        [Test]
+        public void NameTheAddressesThatWroteTheSceneState()
+        {
+            // Arrange — an authoritative scene the server and one player have both written to
+            ArrangeScene(authoritativeMultiplayer: true);
+
+            writerLog.When(log => log.SceneWriters("scene-abc", Arg.Any<List<CrdtWriterSummary>>()))
+                     .Do(call =>
+                      {
+                          var writers = call.Arg<List<CrdtWriterSummary>>();
+                          writers.Add(new CrdtWriterSummary(ICrdtWriterLog.AUTHORITATIVE_SERVER_ADDRESS, true, 12, 0, 4.5));
+                          writers.Add(new CrdtWriterSummary("0xabc", false, 1, 0, 0.25));
+                      });
+
+            // Act
+            var scene = (JObject)Execute().Payload["structuredContent"]!["scene"]!;
+
+            // Assert
+            Assert.That(scene["authoritativeMultiplayer"]!.Value<bool>(), Is.True);
+
+            var writers = (JArray)scene["networkWriters"]!;
+            Assert.That(writers.Count, Is.EqualTo(2));
+
+            // Assert — most recent first, so the peer that just wrote to an authoritative scene reads first
+            Assert.That(writers[0]!["address"]!.Value<string>(), Is.EqualTo("0xabc"));
+            Assert.That(writers[0]!["isAuthoritativeServer"]!.Value<bool>(), Is.False);
+            Assert.That(writers[1]!["address"]!.Value<string>(), Is.EqualTo(ICrdtWriterLog.AUTHORITATIVE_SERVER_ADDRESS));
+            Assert.That(writers[1]!["isAuthoritativeServer"]!.Value<bool>(), Is.True);
+        }
+
+        [Test]
+        public void ReportNoWritersForASceneNobodyHasWrittenTo()
+        {
+            // Arrange
+            ArrangeScene(authoritativeMultiplayer: false);
+
+            // Act
+            var scene = (JObject)Execute().Payload["structuredContent"]!["scene"]!;
+
+            // Assert
+            Assert.That(scene["authoritativeMultiplayer"]!.Value<bool>(), Is.False);
+            Assert.That(((JArray)scene["networkWriters"]!).Count, Is.Zero);
+            Assert.That(scene["droppedWriteRecords"]!.Value<int>(), Is.Zero);
+        }
+
+        private void ArrangeScene(bool authoritativeMultiplayer)
+        {
+            ISceneStateProvider sceneStateProvider = Substitute.For<ISceneStateProvider>();
+            sceneStateProvider.State.Returns(new Atomic<SceneState>(SceneState.Running));
+
+            ISceneData sceneData = Substitute.For<ISceneData>();
+            sceneData.SceneLoadingConcluded.Returns(true);
+
+            sceneData.SceneEntityDefinition.Returns(new SceneEntityDefinition
+            {
+                id = "scene-abc",
+                metadata = new SceneMetadata { authoritativeMultiplayer = authoritativeMultiplayer },
+            });
+
+            ISceneFacade scene = Substitute.For<ISceneFacade>();
+            scene.Info.Returns(new SceneShortInfo(new Vector2Int(1, 2), "Test scene", "7"));
+            scene.SceneStateProvider.Returns(sceneStateProvider);
+            scene.SceneData.Returns(sceneData);
+            scene.IsSceneReady().Returns(true);
+
+            scenesCache.CurrentScene.Returns(new ReactiveProperty<ISceneFacade?>(scene));
+            currentSceneInfo.SceneStatus.Returns(new ReactiveProperty<ICurrentSceneInfo.RunningStatus?>(null));
         }
 
         private McpToolResult Execute() =>

--- a/Explorer/Assets/DCL/McpServer/Tools/GetEntityDetailsTool.cs
+++ b/Explorer/Assets/DCL/McpServer/Tools/GetEntityDetailsTool.cs
@@ -63,9 +63,12 @@ namespace DCL.McpServer.Tools
                 return UniTask.FromResult(McpToolResult.Error("No scene world found at the current parcel."));
 
             string dump = worldInfo.EntityComponentsInfo(entityId);
-            int? crdtEntityId = worldInfo.CrdtEntityId(entityId);
+            bool isCrdtEntity = worldInfo.TryGetCrdtEntityId(entityId, out int crdtEntityId);
 
-            CollectWrites(crdtEntityId);
+            writesBuffer.Clear();
+
+            if (isCrdtEntity)
+                CollectWrites(crdtEntityId);
 
             var output = new StringBuilder(MAX_CHARS + 512);
 
@@ -85,7 +88,7 @@ namespace DCL.McpServer.Tools
             var structured = new JObject
             {
                 ["entityId"] = entityId,
-                ["crdtEntityId"] = crdtEntityId.HasValue ? new JValue(crdtEntityId.Value) : JValue.CreateNull(),
+                ["crdtEntityId"] = isCrdtEntity ? new JValue(crdtEntityId) : JValue.CreateNull(),
                 ["networkWrites"] = CrdtAttributionJson.Writes(writesBuffer),
             };
 
@@ -93,19 +96,15 @@ namespace DCL.McpServer.Tools
         }
 
         /// <summary>
-        ///     Attribution is keyed by CRDT entity, so an entity the scene never registered as one — and every entity
-        ///     while no scene is current — has no rows rather than borrowing another entity's.
+        ///     Attribution is keyed by CRDT entity within one scene, so while no scene is current an entity has no
+        ///     rows rather than borrowing another scene's.
         /// </summary>
-        private void CollectWrites(int? crdtEntityId)
+        private void CollectWrites(int crdtEntityId)
         {
-            writesBuffer.Clear();
-
-            string? sceneId = scenesCache.CurrentScene.Value?.SceneData.SceneEntityDefinition.id;
-
-            if (sceneId == null || !crdtEntityId.HasValue)
+            if (scenesCache.CurrentScene.Value?.SceneData.SceneEntityDefinition.id is not { } sceneId)
                 return;
 
-            writerLog.EntityWrites(sceneId, crdtEntityId.Value, writesBuffer);
+            writerLog.EntityWrites(sceneId, crdtEntityId, writesBuffer);
             writesBuffer.Sort(static (left, right) => left.AgeSeconds.CompareTo(right.AgeSeconds));
         }
     }

--- a/Explorer/Assets/DCL/McpServer/Tools/GetEntityDetailsTool.cs
+++ b/Explorer/Assets/DCL/McpServer/Tools/GetEntityDetailsTool.cs
@@ -1,9 +1,12 @@
+using CRDT.Attribution;
 using Cysharp.Threading.Tasks;
 using DCL.McpServer.Core;
 using DCL.McpServer.Utils;
+using ECS.SceneLifeCycle;
 using Newtonsoft.Json.Linq;
 using SceneRunner.Debugging;
 using SceneRunner.Debugging.Hub;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 
@@ -15,20 +18,38 @@ namespace DCL.McpServer.Tools
         private const string CURRENT_SCENE = "CURRENT";
 
         private readonly IWorldInfoHub worldInfoHub;
+        private readonly IScenesCache scenesCache;
+        private readonly ICrdtWriterLog writerLog;
+
+        private readonly List<CrdtWrite> writesBuffer = new ();
 
         public override string Name => "get_entity_details";
 
         public override string Description =>
-            "Dump all components of one entity in the current scene's ECS world (ids come from list_scene_entities).";
+            "Dump all components of one entity in the current scene's ECS world (ids come from list_scene_entities), "
+            + "and report which address last wrote each of its networked components. A component absent from that report was "
+            + "written by the scene's own code and never asserted by a peer; a row flagged viaStateSync was relayed in a peer's "
+            + "state dump and does not identify an author.";
 
         protected override McpJsonSchema DescribeInput(McpJsonSchema schema) =>
             schema.Integer("entityId", "Entity id within the current scene world.", isRequired: true);
 
+        public override JObject OutputSchema =>
+            McpJsonSchema.Object()
+                          .Integer("entityId", "The entity that was asked for, as an index into the scene's ECS world.")
+                          .Integer("crdtEntityId", "The same entity as the scene's own code and the scene room address it, or null when it is not backed by a CRDT entity.", nullable: true)
+                          .ObjectArray("networkWrites", CrdtAttributionJson.WriteSchema(),
+                               "Last observed write per component of this entity that arrived over the scene room, most recent first. "
+                               + "Empty when nothing about this entity came from a peer. The component dump itself is in the text content.")
+                          .Build();
+
         public override McpToolAnnotations Annotations => McpToolAnnotations.ReadOnly();
 
-        public GetEntityDetailsTool(IWorldInfoHub worldInfoHub)
+        public GetEntityDetailsTool(IWorldInfoHub worldInfoHub, IScenesCache scenesCache, ICrdtWriterLog writerLog)
         {
             this.worldInfoHub = worldInfoHub;
+            this.scenesCache = scenesCache;
+            this.writerLog = writerLog;
         }
 
         public override UniTask<McpToolResult> ExecuteAsync(JObject arguments, CancellationToken ct)
@@ -42,20 +63,50 @@ namespace DCL.McpServer.Tools
                 return UniTask.FromResult(McpToolResult.Error("No scene world found at the current parcel."));
 
             string dump = worldInfo.EntityComponentsInfo(entityId);
+            int? crdtEntityId = worldInfo.CrdtEntityId(entityId);
+
+            CollectWrites(crdtEntityId);
+
+            var output = new StringBuilder(MAX_CHARS + 512);
 
             if (dump.Length <= MAX_CHARS)
-                return UniTask.FromResult(McpToolResult.Text(dump));
+                output.Append(dump);
+            else
+                output.Append(dump, 0, MAX_CHARS)
+                      .AppendLine()
+                      .Append("... output truncated at ")
+                      .Append(MAX_CHARS)
+                      .Append('/')
+                      .Append(dump.Length)
+                      .Append(" chars");
 
-            var output = new StringBuilder(MAX_CHARS + 64);
-            output.Append(dump, 0, MAX_CHARS);
-            output.AppendLine();
-            output.Append("... output truncated at ")
-                  .Append(MAX_CHARS)
-                  .Append('/')
-                  .Append(dump.Length)
-                  .Append(" chars");
+            CrdtAttributionJson.AppendWrites(output, writesBuffer);
 
-            return UniTask.FromResult(McpToolResult.Text(output.ToString()));
+            var structured = new JObject
+            {
+                ["entityId"] = entityId,
+                ["crdtEntityId"] = crdtEntityId.HasValue ? new JValue(crdtEntityId.Value) : JValue.CreateNull(),
+                ["networkWrites"] = CrdtAttributionJson.Writes(writesBuffer),
+            };
+
+            return UniTask.FromResult(McpToolResult.TextWithStructured(output.ToString(), structured));
+        }
+
+        /// <summary>
+        ///     Attribution is keyed by CRDT entity, so an entity the scene never registered as one — and every entity
+        ///     while no scene is current — has no rows rather than borrowing another entity's.
+        /// </summary>
+        private void CollectWrites(int? crdtEntityId)
+        {
+            writesBuffer.Clear();
+
+            string? sceneId = scenesCache.CurrentScene.Value?.SceneData.SceneEntityDefinition.id;
+
+            if (sceneId == null || !crdtEntityId.HasValue)
+                return;
+
+            writerLog.EntityWrites(sceneId, crdtEntityId.Value, writesBuffer);
+            writesBuffer.Sort(static (left, right) => left.AgeSeconds.CompareTo(right.AgeSeconds));
         }
     }
 }

--- a/Explorer/Assets/DCL/McpServer/Tools/GetSceneStateTool.cs
+++ b/Explorer/Assets/DCL/McpServer/Tools/GetSceneStateTool.cs
@@ -70,14 +70,15 @@ namespace DCL.McpServer.Tools
         {
             Vector2Int currentParcel = scenesCache.CurrentParcel.Value;
             ISceneFacade? scene = scenesCache.CurrentScene.Value;
-            string? sceneId = scene?.SceneData.SceneEntityDefinition.id;
 
             writersBuffer.Clear();
+            var droppedWriteRecords = 0;
 
-            if (sceneId != null)
+            if (scene?.SceneData.SceneEntityDefinition.id is { } sceneId)
             {
                 writerLog.SceneWriters(sceneId, writersBuffer);
                 writersBuffer.Sort(static (left, right) => left.LastWriteAgeSeconds.CompareTo(right.LastWriteAgeSeconds));
+                droppedWriteRecords = writerLog.DroppedWrites(sceneId);
             }
 
             var state = new JObject
@@ -100,7 +101,7 @@ namespace DCL.McpServer.Tools
                         ["runningStatus"] = currentSceneInfo.SceneStatus.Value?.ToString() ?? "Unknown",
                         ["authoritativeMultiplayer"] = scene.SceneData.SceneEntityDefinition.metadata?.authoritativeMultiplayer ?? false,
                         ["networkWriters"] = CrdtAttributionJson.Writers(writersBuffer),
-                        ["droppedWriteRecords"] = sceneId == null ? 0 : writerLog.DroppedWrites(sceneId),
+                        ["droppedWriteRecords"] = droppedWriteRecords,
                     },
             };
 

--- a/Explorer/Assets/DCL/McpServer/Tools/GetSceneStateTool.cs
+++ b/Explorer/Assets/DCL/McpServer/Tools/GetSceneStateTool.cs
@@ -1,3 +1,4 @@
+using CRDT.Attribution;
 using Cysharp.Threading.Tasks;
 using DCL.McpServer.Core;
 using DCL.McpServer.Utils;
@@ -6,6 +7,7 @@ using ECS.SceneLifeCycle;
 using ECS.SceneLifeCycle.CurrentScene;
 using Newtonsoft.Json.Linq;
 using SceneRunner.Scene;
+using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 
@@ -16,13 +18,19 @@ namespace DCL.McpServer.Tools
         private readonly IScenesCache scenesCache;
         private readonly ICurrentSceneInfo currentSceneInfo;
         private readonly ILoadingStatus loadingStatus;
+        private readonly ICrdtWriterLog writerLog;
         private readonly bool localSceneDevelopment;
+
+        private readonly List<CrdtWriterSummary> writersBuffer = new ();
 
         public override string Name => "get_scene_state";
 
         public override string Description =>
             "Read the state of the scene at the player's current parcel: name, base parcel, runtime state (including JavaScript/ECS errors), "
-            + "readiness, asset loading progress and the global loading-screen stage. Call this after teleporting or reloading before interacting.";
+            + "readiness, asset loading progress and the global loading-screen stage. Call this after teleporting or reloading before interacting. "
+            + "For a networked scene it also reports which addresses have written to its state — for an authoritative game "
+            + "(authoritativeMultiplayer), an address other than 'authoritative-server' with a non-zero 'writes' count is a peer "
+            + "asserting state the server did not.";
 
         public override JObject OutputSchema =>
             McpJsonSchema.Object()
@@ -38,17 +46,23 @@ namespace DCL.McpServer.Tools
                                                          .String("state")
                                                          .Boolean("isReady")
                                                          .Boolean("assetsLoadingConcluded")
-                                                         .String("runningStatus"),
+                                                         .String("runningStatus")
+                                                         .Boolean("authoritativeMultiplayer", "True when the scene declares an authoritative server as the only legitimate author of its synced state.")
+                                                         .ObjectArray("networkWriters", CrdtAttributionJson.WriterSchema(),
+                                                              "Addresses that have written to this scene's synced state since this client started observing, most recent first. "
+                                                              + "Empty for a scene nobody writes to over the scene room; writes the scene's own code makes locally never appear here.")
+                                                         .Integer("droppedWriteRecords", "Writes the client could not record because a per-scene budget was full (4096 components or 128 distinct addresses); above zero, both networkWriters and get_entity_details undercount."),
                               "The scene at the player's current parcel, or null when no scene is loaded there.", nullable: true)
                           .Build();
 
         public override McpToolAnnotations Annotations => McpToolAnnotations.ReadOnly();
 
-        public GetSceneStateTool(IScenesCache scenesCache, ICurrentSceneInfo currentSceneInfo, ILoadingStatus loadingStatus, bool localSceneDevelopment)
+        public GetSceneStateTool(IScenesCache scenesCache, ICurrentSceneInfo currentSceneInfo, ILoadingStatus loadingStatus, ICrdtWriterLog writerLog, bool localSceneDevelopment)
         {
             this.scenesCache = scenesCache;
             this.currentSceneInfo = currentSceneInfo;
             this.loadingStatus = loadingStatus;
+            this.writerLog = writerLog;
             this.localSceneDevelopment = localSceneDevelopment;
         }
 
@@ -56,6 +70,15 @@ namespace DCL.McpServer.Tools
         {
             Vector2Int currentParcel = scenesCache.CurrentParcel.Value;
             ISceneFacade? scene = scenesCache.CurrentScene.Value;
+            string? sceneId = scene?.SceneData.SceneEntityDefinition.id;
+
+            writersBuffer.Clear();
+
+            if (sceneId != null)
+            {
+                writerLog.SceneWriters(sceneId, writersBuffer);
+                writersBuffer.Sort(static (left, right) => left.LastWriteAgeSeconds.CompareTo(right.LastWriteAgeSeconds));
+            }
 
             var state = new JObject
             {
@@ -75,6 +98,9 @@ namespace DCL.McpServer.Tools
                         ["isReady"] = scene.IsSceneReady(),
                         ["assetsLoadingConcluded"] = scene.SceneData.SceneLoadingConcluded,
                         ["runningStatus"] = currentSceneInfo.SceneStatus.Value?.ToString() ?? "Unknown",
+                        ["authoritativeMultiplayer"] = scene.SceneData.SceneEntityDefinition.metadata?.authoritativeMultiplayer ?? false,
+                        ["networkWriters"] = CrdtAttributionJson.Writers(writersBuffer),
+                        ["droppedWriteRecords"] = sceneId == null ? 0 : writerLog.DroppedWrites(sceneId),
                     },
             };
 

--- a/Explorer/Assets/DCL/McpServer/Utils/CrdtAttributionJson.cs
+++ b/Explorer/Assets/DCL/McpServer/Utils/CrdtAttributionJson.cs
@@ -1,0 +1,116 @@
+using CRDT.Attribution;
+using DCL.McpServer.Core;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace DCL.McpServer.Utils
+{
+    /// <summary>
+    ///     Renders <see cref="ICrdtWriterLog" /> readings into the shapes the state tools report, so the two tools
+    ///     that surface writer attribution describe the same row the same way.
+    /// </summary>
+    public static class CrdtAttributionJson
+    {
+        /// <summary>Schema of one entry of a tool's per-address summary.</summary>
+        public static McpJsonSchema WriterSchema() =>
+            McpJsonSchema.Object()
+                          .String("address", "Address of the peer, as the transport authenticated it.")
+                          .Boolean("isAuthoritativeServer", "True when the address is the scene's authoritative server rather than a player.")
+                          .Boolean("isTrustedSource", "True when the writer is the local participant or a scene admin; untrusted writers are subject to component filtering.")
+                          .Integer("writes", "Live component writes this address made itself.")
+                          .Integer("stateSyncWrites", "Rows this address supplied by answering a request for the scene's CRDT state. It relayed them; it did not necessarily author them.")
+                          .Number("lastWriteAgeSeconds");
+
+        /// <summary>Schema of one entry of a tool's per-component attribution.</summary>
+        public static McpJsonSchema WriteSchema() =>
+            McpJsonSchema.Object()
+                          .Integer("componentId")
+                          .String("writer", "Address the last observed write of this component came from. When viaStateSync is true this is the peer that handed the state over, NOT necessarily its author.")
+                          .Boolean("isAuthoritativeServer", "True only when the authoritative server itself sent this write live; never true for a state-sync row, however it was originally authored.")
+                          .Boolean("isTrustedSource")
+                          .Boolean("viaStateSync", "True when the row came from a peer's answer to a CRDT state request (how a client joining mid-game hydrates) rather than a live write. Exclude these rows when testing who authored a component.")
+                          .String("messageType", "CRDT message type of the write, e.g. PUT_COMPONENT_NETWORK.")
+                          .Integer("crdtTimestamp", "Lamport timestamp that orders this write against other writes of the same component.")
+                          .Number("ageSeconds");
+
+        public static JArray Writers(IReadOnlyList<CrdtWriterSummary> writers)
+        {
+            var array = new JArray();
+
+            foreach (CrdtWriterSummary writer in writers)
+                array.Add(new JObject
+                {
+                    ["address"] = writer.Address,
+                    ["isAuthoritativeServer"] = writer.IsAuthoritativeServer,
+                    ["isTrustedSource"] = writer.IsTrustedSource,
+                    ["writes"] = writer.Writes,
+                    ["stateSyncWrites"] = writer.StateSyncWrites,
+                    ["lastWriteAgeSeconds"] = Rounded(writer.LastWriteAgeSeconds),
+                });
+
+            return array;
+        }
+
+        public static JArray Writes(IReadOnlyList<CrdtWrite> writes)
+        {
+            var array = new JArray();
+
+            foreach (CrdtWrite write in writes)
+                array.Add(new JObject
+                {
+                    ["componentId"] = write.ComponentId,
+                    ["writer"] = write.Writer,
+                    ["isAuthoritativeServer"] = write.IsAuthoritativeServer,
+                    ["isTrustedSource"] = write.IsTrustedSource,
+                    ["viaStateSync"] = write.ViaStateSync,
+                    ["messageType"] = write.MessageType.ToString(),
+                    ["crdtTimestamp"] = write.CrdtTimestamp,
+                    ["ageSeconds"] = Rounded(write.AgeSeconds),
+                });
+
+            return array;
+        }
+
+        /// <summary>
+        ///     The human-readable mirror of <see cref="Writes" />, appended to a tool's text content. States the
+        ///     "no rows" case explicitly, because an empty section reads as an error while "written only locally"
+        ///     is the ordinary answer for a single-player scene.
+        /// </summary>
+        public static void AppendWrites(StringBuilder output, IReadOnlyList<CrdtWrite> writes)
+        {
+            output.AppendLine();
+            output.AppendLine("Network writers (last write per component, from the scene room):");
+
+            if (writes.Count == 0)
+            {
+                output.AppendLine("  none — every component of this entity was written by the scene's own code, not by a peer");
+                return;
+            }
+
+            foreach (CrdtWrite write in writes)
+            {
+                output.Append("  component ").Append(write.ComponentId);
+
+                // A state-sync row is phrased as a relay, never as authorship, so the text cannot be misread the way
+                // "← <address>" would be: the peer that answered the state request may not have written any of it.
+                if (write.ViaStateSync)
+                    output.Append(" ← state sync via ").Append(write.Writer).Append(" (author unknown)");
+                else
+                    output.Append(" ← ")
+                          .Append(write.Writer)
+                          .Append(write.IsAuthoritativeServer ? " (authoritative server)" : write.IsTrustedSource ? " (trusted)" : " (untrusted peer)");
+
+                output.Append(", ")
+                      .Append(write.MessageType)
+                      .Append(", ")
+                      .Append(Rounded(write.AgeSeconds).ToString(CultureInfo.InvariantCulture))
+                      .AppendLine("s ago");
+            }
+        }
+
+        private static double Rounded(double seconds) =>
+            System.Math.Round(seconds, 2);
+    }
+}

--- a/Explorer/Assets/DCL/McpServer/Utils/CrdtAttributionJson.cs.meta
+++ b/Explorer/Assets/DCL/McpServer/Utils/CrdtAttributionJson.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1714b52ff3aa4ff79fa65b9a7a7a3468
+timeCreated: 1780000000

--- a/Explorer/Assets/DCL/Multiplayer/Profiles/BroadcastProfiles/LiveKitMessagesBroadcaster.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Profiles/BroadcastProfiles/LiveKitMessagesBroadcaster.cs
@@ -1,4 +1,5 @@
-﻿using DCL.LiveKit.Public;
+﻿using CRDT.Attribution;
+using DCL.LiveKit.Public;
 using DCL.Multiplayer.Connections.GateKeeper.Rooms;
 using DCL.Multiplayer.Connections.Messaging;
 using DCL.Multiplayer.Connections.Messaging.Hubs;
@@ -23,7 +24,7 @@ namespace DCL.Multiplayer.Profiles.BroadcastProfiles
         /// <summary>
         ///     Hardcoded identity for the authoritative server in the LiveKit network.
         /// </summary>
-        public const string AUTH_SERVER_IDENTITY = "authoritative-server";
+        public const string AUTH_SERVER_IDENTITY = ICrdtWriterLog.AUTHORITATIVE_SERVER_ADDRESS;
 
         private readonly IGateKeeperSceneRoom sceneRoom;
         private readonly IMessagePipesHub messagePipesHub;

--- a/docs/mcp-automation.md
+++ b/docs/mcp-automation.md
@@ -62,10 +62,10 @@ The tables below are a human-readable overview. The authoritative argument contr
 |---|---|---|
 | `screenshot` | `maxWidth?` (default 1280), `quality?`, `worldOnly?` (exclude UI; post-processing still applied) | Downscaled image of the current view (UI included by default) + caption |
 | `get_player_state` | — | Player position/rotation/parcel/velocity/grounded + camera position/rotation/mode + wallet address |
-| `get_scene_state` | — | Current parcel, scene name/state (incl. `JavaScriptError`/`EcsError`), readiness, loading stage |
+| `get_scene_state` | — | Current parcel, scene name/state (incl. `JavaScriptError`/`EcsError`), readiness, loading stage, `authoritativeMultiplayer`, and `networkWriters` — every address that has written to the scene's synced state |
 | `get_scene_logs` | `limit?`, `severity?`, `sinceSeq?` | Scene JS console output with monotonic sequence numbers for incremental polling |
 | `list_scene_entities` | `limit?` | Entity ids of the current scene's ECS world |
-| `get_entity_details` | `entityId` | All components of one scene entity |
+| `get_entity_details` | `entityId` | All components of one scene entity, plus `networkWrites` — the address that last wrote each of its networked components |
 
 ### Controlling
 
@@ -84,7 +84,42 @@ The tables below are a human-readable overview. The authoritative argument contr
 
 ## Structured output
 
-`get_player_state`, `get_scene_state` and `list_scene_entities` also return `structuredContent` mirroring their text payload and declare a matching `outputSchema` in `tools/list` (MCP 2025-06-18). This is done **only as an example on the read-only state tools that benefit from it now** — every other tool returns text content only. A tool opts in by overriding `McpTool.OutputSchema` (default `null`); the same `McpJsonSchema` builder produces the schema.
+`get_player_state`, `get_scene_state`, `list_scene_entities` and `get_entity_details` also return `structuredContent` mirroring their text payload and declare a matching `outputSchema` in `tools/list` (MCP 2025-06-18). This is done **only as an example on the read-only state tools that benefit from it now** — every other tool returns text content only. A tool opts in by overriding `McpTool.OutputSchema` (default `null`); the same `McpJsonSchema` builder produces the schema.
+
+## Writer attribution
+
+The scene tools report the state of a scene, and for a networked scene that state is a merge: the scene's own
+JavaScript writes to it, and so does every peer in the scene room — including, for an authoritative game, its
+server. Once merged the rows are indistinguishable, so "the crate moved" cannot by itself answer "did the server
+move it, or did a client assert that it had?". Scenes built on `@dcl/sdk/network` decide exactly that question
+themselves, in `validateBeforeChange` comparing the sender against `authoritative-server`.
+
+The client records the same provenance those guards act on. Every CRDT write that arrives over the scene room is
+attributed to the address the transport authenticated it from, keyed by entity and component, and surfaced by:
+
+- `get_scene_state` → `scene.networkWriters`, one entry per address with its write count and how long ago it last
+  wrote, plus `scene.authoritativeMultiplayer`. On an authoritative scene, an address other than
+  `authoritative-server` with a non-zero `writes` count is a peer writing state the server did not.
+- `get_entity_details` → `networkWrites`, the last write per component of one entity: `writer`,
+  `isAuthoritativeServer`, `isTrustedSource`, `viaStateSync`, the CRDT `messageType` and Lamport `crdtTimestamp`,
+  and `ageSeconds`.
+
+Three limits are worth stating plainly:
+
+- **Only inbound network writes are recorded.** A component the scene's own code wrote locally never appears, so an
+  empty `networkWrites` means "no peer asserted this", not "nothing wrote this".
+- **A state-sync row names a relay, not an author.** A client joining mid-game hydrates by asking a peer for the
+  scene's CRDT state, and that peer's answer replays writes it did not necessarily make — including the server's.
+  Those rows carry `viaStateSync: true`, count into `stateSyncWrites` rather than `writes`, and never report
+  `isAuthoritativeServer: true` however they were originally authored. **Exclude them when testing authorship:**
+  `isAuthoritativeServer` alone is already safe, and "a peer wrote this" means `!isAuthoritativeServer &&
+  !viaStateSync`.
+- **Attribution starts when the client does.** Counts and ages cover this session only, and a scene's rows are
+  bounded (4096 components, 128 distinct addresses, 8 scenes); `scene.droppedWriteRecords` above zero means the log
+  undercounts. A write refused by either budget is dropped whole, so an entity never names an address that
+  `networkWriters` omits.
+
+Recording is off until the MCP server starts, so a session without `--mcp` pays one branch per inbound message.
 
 ## The scene-iteration loop
 


### PR DESCRIPTION
The scene tools report what a scene's state says, never who put it there. For a networked scene that state is a merge — the scene's own JavaScript writes to it, and so does every peer in the scene room, including an authoritative game's server — and once merged the rows are indistinguishable. So "the crate moved" cannot answer "did the server move it, or did a client assert that it had?". Scenes on @dcl/sdk/network decide exactly that in validateBeforeChange, comparing the sender against 'authoritative-server'; nothing outside the scene could see the provenance those guards act on.

Record it at the scene-room ingress, where the transport has already authenticated the sender, and surface it on the two tools that answer questions about scene state:

- get_scene_state -> scene.networkWriters and scene.authoritativeMultiplayer
- get_entity_details -> networkWrites, the last writer per component

CrdtWriterLog walks the inbound CRDT batch read-only, applying CRDTFilter.ShouldDropIncoming (extracted from the existing filter, no behaviour change) so it never attributes a write the scene never received. It is inert until a consumer enables it — only the MCP server does — so a normal session pays one branch per inbound message.

Two things the log must not claim:

An answer to a CRDT state request replays writes its sender did not necessarily author, including the server's — which is how a client joining mid-game hydrates. Crediting those rows to the relaying peer would break the authorship test this feature exists for, so they carry viaStateSync, count into stateSyncWrites rather than writes, and never report isAuthoritativeServer.

Both per-scene budgets (4096 components, 128 addresses) are checked before either table is written, so an entity can never name an address the scene-level summary omits, and every refused write is counted into droppedWriteRecords rather than silently forgotten.

Only inbound network writes are recorded: a component absent from the report was written locally by the scene, not never written.
