### PR TITLE
fix: allow emailOTP only for epic store

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/Prefabs/LoginSelection.Screen.prefab
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/Prefabs/LoginSelection.Screen.prefab
@@ -3216,6 +3216,8 @@ MonoBehaviour:
   <CancelLoginButton>k__BackingField: {fileID: 9108319191272288200}
   <EmailOTPContainer>k__BackingField: {fileID: 5285033395635913484}
   <EmailInputField>k__BackingField: {fileID: 2001940849056367380}
+  <OtherLoginContainer>k__BackingField: {fileID: 5887702060069110797}
+  <ContinueWithTextContainer>k__BackingField: {fileID: 3844889584895123327}
   <LoginMetamaskButton>k__BackingField: {fileID: 4481630630708771614}
   <LoginGoogleButton>k__BackingField: {fileID: 9078712830092277137}
   <LoginDiscordButton>k__BackingField: {fileID: 8034867738283704265}

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -149,7 +149,7 @@ namespace DCL.AuthenticationScreenFlow
             audio = new AuthenticationScreenAudio(viewInstance, audioMixerVolumesController, backgroundMusic);
             characterPreviewController = new AuthenticationScreenCharacterPreviewController(viewInstance!.CharacterPreviewView, emotesSettings, characterPreviewFactory, world, characterPreviewEventBus);
 
-            bool isEpicBuild = installSource == EPIC_STORE_INSTALL_SOURCE;
+            bool isEpicBuild = string.Equals(installSource, EPIC_STORE_INSTALL_SOURCE, StringComparison.OrdinalIgnoreCase);
             // Epic builds only support emailOTP due to deeplink limitations
             // See: https://github.com/decentraland/unity-explorer/issues/9554
             bool enableEmailOTP = FeaturesRegistry.Instance.IsEnabled(FeatureId.EmailOTPAuth) || isEpicBuild;

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -12,19 +12,15 @@ using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.SceneLoadingScreens.SplashScreen;
-using DCL.Settings.Utils;
 using DCL.UI;
 using DCL.Utilities;
 using DCL.Utility;
 using DCL.Web3.Authenticators;
 using DCL.Web3.Identities;
 using DCL.WebRequests;
-using Global.AppArgs;
 using MVC;
 using System;
-using System.Collections.Generic;
 using System.Threading;
-using UnityEngine;
 using Utility;
 
 namespace DCL.AuthenticationScreenFlow
@@ -49,6 +45,7 @@ namespace DCL.AuthenticationScreenFlow
 
         internal const int ANIMATION_DELAY = 300;
         internal const string LOADING_TRANSACTION_NAME = "loading_process";
+        private const string EPIC_STORE_INSTALL_SOURCE = "epic";
 
         private readonly ICompositeWeb3Provider web3Authenticator;
         private readonly ISelfProfile selfProfile;
@@ -150,9 +147,13 @@ namespace DCL.AuthenticationScreenFlow
             base.OnViewInstantiated();
 
             audio = new AuthenticationScreenAudio(viewInstance, audioMixerVolumesController, backgroundMusic);
-            characterPreviewController = new AuthenticationScreenCharacterPreviewController(viewInstance.CharacterPreviewView, emotesSettings, characterPreviewFactory, world, characterPreviewEventBus);
+            characterPreviewController = new AuthenticationScreenCharacterPreviewController(viewInstance!.CharacterPreviewView, emotesSettings, characterPreviewFactory, world, characterPreviewEventBus);
 
-            bool enableEmailOTP = FeaturesRegistry.Instance.IsEnabled(FeatureId.EmailOTPAuth);
+            bool isEpicBuild = installSource == EPIC_STORE_INSTALL_SOURCE;
+            // Epic builds only support emailOTP due to deeplink limitations
+            // See: https://github.com/decentraland/unity-explorer/issues/9554
+            bool enableEmailOTP = FeaturesRegistry.Instance.IsEnabled(FeatureId.EmailOTPAuth) || isEpicBuild;
+            bool otherLoginMethodsEnabled = !isEpicBuild;
             viewInstance.LoginSelectionAuthView.EmailOTPContainer.SetActive(enableEmailOTP);
 
             viewInstance.DiscordButton.onClick.AddListener(OpenSupportUrl);
@@ -163,7 +164,8 @@ namespace DCL.AuthenticationScreenFlow
 
             fsm.AddStates(
                 new InitAuthState(viewInstance, installSource),
-                new LoginSelectionAuthState(fsm, viewInstance, this, CurrentState, splashScreen, web3Authenticator, webBrowser, enableEmailOTP),
+                new LoginSelectionAuthState(fsm, viewInstance, this, CurrentState, splashScreen, web3Authenticator, webBrowser,
+                    enableEmailOTP, otherLoginMethodsEnabled),
                 new ProfileFetchingAuthState(fsm, viewInstance, this, CurrentState, selfProfile, storedIdentityProvider),
                 new IdentityVerificationDappDeepLinkAuthState(fsm, viewInstance, this, CurrentState, web3Authenticator),
                 new LobbyForExistingAccountAuthState(fsm, viewInstance, this, splashScreen, CurrentState, characterPreviewController),

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LoginSelectionAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LoginSelectionAuthState.cs
@@ -24,11 +24,14 @@ namespace DCL.AuthenticationScreenFlow
         private readonly ICompositeWeb3Provider compositeWeb3Provider;
         private readonly UnityAppWebBrowser webBrowser;
         private readonly bool enableEmailOTP;
+        private readonly bool otherLoginMethodsEnabled;
 
         public LoginSelectionAuthState(MVCStateMachine<AuthStateBase> machine,
             AuthenticationScreenView viewInstance, AuthenticationScreenController controller,
             ReactiveProperty<AuthStatus> currentState, SplashScreen splashScreen,
-            ICompositeWeb3Provider compositeWeb3Provider, UnityAppWebBrowser webBrowser, bool enableEmailOTP) : base(viewInstance)
+            ICompositeWeb3Provider compositeWeb3Provider, UnityAppWebBrowser webBrowser,
+            bool enableEmailOTP,
+            bool otherLoginMethodsEnabled) : base(viewInstance)
         {
             view = viewInstance.LoginSelectionAuthView;
 
@@ -39,6 +42,7 @@ namespace DCL.AuthenticationScreenFlow
             this.compositeWeb3Provider = compositeWeb3Provider;
             this.webBrowser = webBrowser;
             this.enableEmailOTP = enableEmailOTP;
+            this.otherLoginMethodsEnabled = otherLoginMethodsEnabled;
 
             // Cancel button persists in the Verification state (until code is shown)
             view.CancelLoginButton.onClick.AddListener(OnCancelBeforeVerification);
@@ -136,7 +140,7 @@ namespace DCL.AuthenticationScreenFlow
             if (splashScreen != null) // it can be destroyed after first login
                 splashScreen.FadeOutAndHide();
 
-            view.Show(animHash, moreOptionsExpanded: !enableEmailOTP);
+            view.Show(animHash, moreOptionsExpanded: !enableEmailOTP, otherLoginMethodsEnabled);
             Enter();
         }
 

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/LoginSelectionAuthView.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/LoginSelectionAuthView.cs
@@ -24,6 +24,12 @@ namespace DCL.AuthenticationScreenFlow
 
         [field: Header("SECONDARY LOGINS")]
         [field: SerializeField]
+        public GameObject OtherLoginContainer { get; private set; } = null!;
+
+        [field: SerializeField]
+        public GameObject ContinueWithTextContainer { get; private set; } = null!;
+
+        [field: SerializeField]
         public Button LoginMetamaskButton { get; private set; } = null!;
 
         [field: SerializeField]
@@ -103,13 +109,15 @@ namespace DCL.AuthenticationScreenFlow
             moreOptionsPanel.SetActive(isExpanded);
         }
 
-        public void Show(int animHash, bool moreOptionsExpanded)
+        public void Show(int animHash, bool moreOptionsExpanded, bool otherLoginMethodsEnabled)
         {
             showAnimHash = animHash;
             ShowAsync(CancellationToken.None).Forget();
 
             areOptionsExpanded = moreOptionsExpanded;
-            SetOptionsPanelVisibility(areOptionsExpanded);
+            OtherLoginContainer.SetActive(otherLoginMethodsEnabled);
+            ContinueWithTextContainer.SetActive(otherLoginMethodsEnabled && !moreOptionsExpanded);
+            SetOptionsPanelVisibility(areOptionsExpanded && otherLoginMethodsEnabled);
 
             SetLoadingSpinnerVisibility(false);
         }


### PR DESCRIPTION
## What does this PR change?

Fixes https://github.com/decentraland/unity-explorer/issues/9554
Works as mitigation change, not final solution.

## Test instructions

1. Download epic store build
2. Check that you only have one login option: emailOTP
3. Go through the login and check is OK
4. Download the normal build
5. Check you have all of the login options enabled

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
