### PR TITLE
fix: restore EditMode test compilation broken by CommunitiesFeatureAccess warm-up token

### DIFF
--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests/LiveKitChatMessagesBusShould.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests/LiveKitChatMessagesBusShould.cs
@@ -19,6 +19,7 @@ using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using ChatMessage = DCL.Chat.History.ChatMessage;
 using ChatPacket = Decentraland.Kernel.Comms.Rfc4.Chat;
 
@@ -60,7 +61,7 @@ namespace DCL.Chat.MessageBus.Tests
             FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(FeatureFlagsResultDto.Empty));
             OfficialWalletsHelper.Initialize(new OfficialWalletsHelper());
             FeaturesRegistry.Initialize(new FeaturesRegistry(appArgs, false));
-            CommunitiesFeatureAccess.Initialize(new CommunitiesFeatureAccess(identityCache, appArgs));
+            CommunitiesFeatureAccess.Initialize(new CommunitiesFeatureAccess(identityCache, appArgs, CancellationToken.None));
             RoomMetadataCurrentScene.InitializeTest();
 
             pipesHub = new FakeMessagePipesHub();


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fixes an EditMode test **compilation error** currently on `dev`:

```
Assets/DCL/Chat/MessageBus/Tests/LiveKitChatMessagesBusShould.cs(63,53): error CS7036:
There is no argument given that corresponds to the required formal parameter 'warmUpCt'
of 'CommunitiesFeatureAccess.CommunitiesFeatureAccess(IWeb3IdentityCache, IAppArgs, CancellationToken)'
```

**Root cause — a semantic (logical) merge conflict between two PRs, neither of which is individually wrong:**

| PR | Merged | Change |
|----|--------|--------|
| #9472 (`feat: open Explorer UI from SDK scene`) | Jul 29 | Added a required 3rd param `CancellationToken warmUpCt` to the `CommunitiesFeatureAccess` constructor |
| #9501 (`fix: authenticate chat sender identity before trusting ForwardedFrom`) | Aug 3 | **Added** `LiveKitChatMessagesBusShould.cs`, which constructs `CommunitiesFeatureAccess` with **two** arguments |

`dev` compiled fine for the 5 days after #9472 because no two-arg call site existed yet. #9501's branch was cut from `dev` **before** #9472 landed, so on that branch the constructor still took two params and the new test compiled — its CI was green. #9501 was then merged **without being brought up to date with `dev`**. The two changes touch different files (`CommunitiesFeatureAccess.cs` vs. the new test), so git merged them with no textual conflict — but the combination does not compile. The broken call entered `dev` only when #9501 merged, which is why the failure appears now rather than 5 days ago.

**Fix:** Pass the third argument at that call site. Because this test does not set `disableForTests`, the constructor's warm-up short-circuits via `forceEnabledInEditor` and never suspends, so `CancellationToken.None` is the appropriate token — no cancellation-on-teardown plumbing is needed here (unlike `CommunitiesFeatureAccessShould`, which exercises the real gating path). The diff is a single call-site update plus the `System.Threading` using directive.

**Prevention (follow-up, not in this PR):** enabling GitHub's *"Require branches to be up to date before merging"* on `dev` would have caught this — it forces a PR's checks to run against a fresh merge with the current base, which would have compiled the 3-param constructor together with the 2-arg call and failed before merge.

## Test Instructions

### Test Steps
1. Open the project in Unity (or run CI EditMode tests).
2. Confirm the EditMode test assembly compiles (previously failed with CS7036).
3. Run `LiveKitChatMessagesBusShould` — all cases pass.

### Additional Testing Notes
- No production code changed; test-only fix.
- Verified `new CommunitiesFeatureAccess(` has no other stale call sites.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered (none — test-only)
- [ ] For SDK features: Test scene is included (N/A)