### PR TITLE
chore: allow scene-console deeplink param

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
@@ -213,8 +213,8 @@ namespace Global.AppArgs
             }
 
             // Tier 2 (SEC-019/020): the local-development params Creator Hub / sdk-commands attach to preview deep
-            // links (local-scene, dclenv, hub, skip-auth-screen, landscape-terrain-enabled, multi-instance,
-            // scene-console) are permitted only when the target realm is whitelisted — loopback, or a world listed in
+            // links (local-scene, hub, skip-auth-screen, landscape-terrain-enabled, multi-instance, local-ab, mcp,
+            // mcp-port) are permitted only when the target realm is whitelisted — loopback, or a world listed in
             // the deeplink-whitelisted-worlds feature flag. A remote-realm deep link from a web page cannot enable
             // them unless that exact world was explicitly whitelisted. Everything not in either tier is dropped.
             bool realmIsWhitelisted = output.TryGetValue(AppArgsFlags.REALM, out string? whitelistRealm)

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -7,7 +7,7 @@ namespace Global.AppArgs
     /// <summary>
     ///     Deny-by-default allowlist of query params a <c>decentraland://</c> deep link may inject into app-args.
     ///     Shared by the cold-start argv path and the runtime bridge path (both funnel through
-    ///     <see cref="ApplicationParametersParser.ProcessDeepLinkParameters" />).
+    ///     <see cref="ApplicationParametersParser.ProcessDeepLinkParameters(string,System.Collections.Generic.Dictionary{string,string})" />).
     ///     <para>
     ///     A deep link is fully attacker-controllable — anyone can craft one and get a victim to open it — so
     ///     params fall into three tiers:
@@ -15,24 +15,25 @@ namespace Global.AppArgs
     ///     <list type="bullet">
     ///         <item>
     ///             <b>Always permitted</b> — benign navigation / share / login intents whose worst case is already
-    ///             gated elsewhere (a consent prompt, a matching login token, a plain coordinate, or a closed
-    ///             Decentraland-owned enum): realm, position, community, signin, authRequestId, force-open-backpack,
-    ///             spawnpoint, dclenv, self-preview-builder-collections.
+    ///             gated elsewhere (a consent prompt, a matching login token, a plain coordinate, a closed
+    ///             Decentraland-owned enum, or a read-only log view): realm, position, community, signin,
+    ///             authRequestId, force-open-backpack, spawnpoint, dclenv, self-preview-builder-collections,
+    ///             scene-console.
     ///         </item>
     ///         <item>
     ///             <b>Permitted only for a whitelisted realm</b> — the local-development params Creator Hub and the
-    ///             SDK (<c>sdk-commands</c>) attach to their preview deep links: local-scene, dclenv, hub,
-    ///             skip-auth-screen, landscape-terrain-enabled, multi-instance, scene-console, mcp, mcp-port. A realm
-    ///             is "whitelisted" when it is loopback (127.0.0.1 / localhost / [::1]) OR its world matches the
+    ///             SDK (<c>sdk-commands</c>) attach to their preview deep links: local-scene, hub, skip-auth-screen,
+    ///             landscape-terrain-enabled, multi-instance, local-ab, mcp, mcp-port. A realm is "whitelisted" when
+    ///             it is loopback (127.0.0.1 / localhost / [::1]) OR its world matches the
     ///             <c>deeplink-whitelisted-worlds</c> feature flag (see <see cref="IsRealmWhitelisted" /> and
     ///             <see cref="SetWhitelistedWorlds" />). A remote-realm deep link from a web page can never enable
     ///             them unless that exact world was explicitly whitelisted. All but the MCP pair are individually
-    ///             low-harm — an analytics tag, a cosmetic toggle, an instance count, an env enum, a screen skip that
-    ///             still forces auth when no valid identity is cached, or the per-scene JS console — and the
-    ///             whitelisted-realm gate confines them to the dev context. <c>mcp</c>/<c>mcp-port</c> start an
-    ///             unauthenticated loopback control port and are the one non-low-harm pair in this set; they lean on
-    ///             the gate plus the server's own 127.0.0.1 bind and Origin check — see the per-key comment for what
-    ///             the gate does and does not cover.
+    ///             low-harm — an analytics tag, a cosmetic toggle, an instance count, a screen skip that still forces
+    ///             auth when no valid identity is cached, or asset loading pointed at the realm the link already
+    ///             targets — and the whitelisted-realm gate confines them to the dev context.
+    ///             <c>mcp</c>/<c>mcp-port</c> start an unauthenticated loopback control port and are the one
+    ///             non-low-harm pair in this set; they lean on the gate plus the server's own 127.0.0.1 bind and
+    ///             Origin check — see the per-key comment for what the gate does and does not cover.
     ///         </item>
     ///         <item>
     ///             <b>Never permitted</b> — everything else, in particular params that launch code
@@ -93,6 +94,15 @@ namespace Global.AppArgs
             // cannot point the client at attacker infrastructure. Worst case is a session in a Decentraland-owned test
             // environment, strictly less capable than the attacker-supplied REALM above.
             AppArgsFlags.ENVIRONMENT,
+
+            // Opens the per-scene JS console: a read-only view of the log lines the running scene already emits, and
+            // the debug menu that hosts it. Not realm-gated (product decision) — creators and QA need it against
+            // production realms and worlds to diagnose a deployed scene, which is exactly what the whitelisted-realm
+            // tier below forbids. It unlocks no capability of its own: it loads no content, changes no endpoint, and
+            // the menu it opens is restricted to the informational widget categories (see DebugUtilitiesContainer) —
+            // the full debug panel still needs the never-permitted "debug". Worst case is a session logging verbosely
+            // (ReportHub.EnforceUnconditionalVerboseLogs) with a log panel on screen.
+            AppArgsFlags.SCENE_CONSOLE,
         };
 
         // Local-development params Creator Hub / sdk-commands attach to preview deep links. Permitted ONLY when the
@@ -131,9 +141,6 @@ namespace Global.AppArgs
             // Port the server above listens on. Presence alone also starts it (MCP_PORT implies MCP), so it carries
             // the same gate; the value is clamped to 1024-65535 and falls back to the default port (McpServerPlugin).
             AppArgsFlags.MCP_PORT,
-
-            // Opens the per-scene JS console (dev tooling for inspecting a scene under development).
-            AppArgsFlags.SCENE_CONSOLE,
 
             // Local-scene development only: load the scene's asset bundles from the preview server instead of raw
             // GLTFs. A pure boolean — the optimized-assets base is derived from the realm itself

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -96,7 +96,8 @@ namespace Global.AppArgs
             AppArgsFlags.ENVIRONMENT,
 
             // Opens the per-scene JS console: a read-only view of the log lines the running scene already emits, and
-            // the debug menu that hosts it. Not realm-gated (product decision) — creators and QA need it against
+            // Opens the debug menu with its informational widget categories — scene logs, performance, memory,
+            // room and realm info, entity requests, analytics, and web request metrics. Not realm-gated (product
             // production realms and worlds to diagnose a deployed scene, which is exactly what the whitelisted-realm
             // tier below forbids. It unlocks no capability of its own: it loads no content, changes no endpoint, and
             // the menu it opens is restricted to the informational widget categories (see DebugUtilitiesContainer) —

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -97,7 +97,7 @@ namespace Global.AppArgs.Tests
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must still require a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.SKIP_AUTH_SCREEN), "skip-auth-screen must still require a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.MULTIPLE_RUNNING_INSTANCES), "multi-instance must still require a loopback realm");
-            Assert.IsFalse(output.ContainsKey(AppArgsFlags.SCENE_CONSOLE), "scene-console must stay dropped for every realm");
+            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.SCENE_CONSOLE), "scene-console must survive without a realm: it is not realm-gated");
         }
 
         [Test]
@@ -197,21 +197,18 @@ namespace Global.AppArgs.Tests
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.MCP_PORT), "mcp-port must be dropped when the link carries no realm at all");
         }
 
-        public void DeepLinkKeepsSceneConsoleForLoopbackRealm()
+        // scene-console is always permitted: creators and QA need the scene log console against production realms and
+        // worlds, and it unlocks no capability (read-only view of logs the scene already emits; the full debug panel
+        // still needs the never-permitted `debug`).
+        [TestCase("decentraland://?realm=http://127.0.0.1:8000&scene-console=true", TestName = "loopback realm")]
+        [TestCase("decentraland://?realm=https://peer.decentraland.org&scene-console=true", TestName = "production catalyst realm")]
+        [TestCase("decentraland://?realm=other-world.dcl.eth&scene-console=true", TestName = "non-whitelisted world realm")]
+        [TestCase("decentraland://?scene-console=true", TestName = "no realm")]
+        public void DeepLinkKeepsSceneConsoleForEveryRealm(string deepLink)
         {
-            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=http://127.0.0.1:8000&scene-console=true");
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(deepLink);
 
-            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.SCENE_CONSOLE), "scene-console must survive for a loopback (local dev) realm");
-        }
-
-        [Test]
-        public void DeepLinkDropsSceneConsoleForRemoteRealm()
-        {
-            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=https://peer.decentraland.org&scene-console=true");
-
-            Assert.IsFalse(output.ContainsKey(AppArgsFlags.SCENE_CONSOLE), "scene-console must be dropped for a non-whitelisted remote realm");
+            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.SCENE_CONSOLE), "scene-console must survive for every realm");
         }
 
         [Test]
@@ -222,12 +219,12 @@ namespace Global.AppArgs.Tests
 
             // Act
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=test-world.dcl.eth&local-scene=true&dclenv=zone&scene-console=true");
+                "decentraland://?realm=test-world.dcl.eth&local-scene=true&dclenv=zone&mcp=true");
 
             // Assert
             Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.LOCAL_SCENE), "local-scene must survive for a whitelisted world realm");
             Assert.AreEqual("zone", output.GetValueOrDefault(AppArgsFlags.ENVIRONMENT), "dclenv must survive for a whitelisted world realm");
-            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.SCENE_CONSOLE), "scene-console must survive for a whitelisted world realm");
+            Assert.AreEqual("true", output.GetValueOrDefault(AppArgsFlags.MCP), "mcp must survive for a whitelisted world realm");
         }
 
         [Test]
@@ -252,11 +249,11 @@ namespace Global.AppArgs.Tests
 
             // Act
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=other-world.dcl.eth&local-scene=true&scene-console=true");
+                "decentraland://?realm=other-world.dcl.eth&local-scene=true&mcp=true");
 
             // Assert
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must be dropped for a world that is not whitelisted");
-            Assert.IsFalse(output.ContainsKey(AppArgsFlags.SCENE_CONSOLE), "scene-console must be dropped for a world that is not whitelisted");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.MCP), "mcp must be dropped for a world that is not whitelisted");
         }
 
         // IsRealmWhitelisted gates BOTH the whitelisted-realm dev params and skipping the realm-change consent prompt

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -86,7 +86,7 @@ For embedded links you will need to place value after `=` sign, instead of space
 ## Scene & Environment Flags
 
 ### `scene-console`
-**Description:** Enables the scene console for debugging and development. Only available in debug mode or when running local scenes.
+**Description:** Enables the scene console (the debug menu's log view of the scene's own output) for debugging and development. Works for any realm — local scene development enables it implicitly, and the flag itself is accepted from deep links against production realms and worlds too, so creators and QA can inspect a deployed scene.
 
 **Usage:**
 ```bash


### PR DESCRIPTION
### WHY

Since the resent big drop of deep link parameters, creators can no longer debug on their deployed scenes using `&scene-console=true` that was very useful specially for multiplayer server scenes...

### WHAT

Added scene-console param to the allow list.

### QA TEST STEPS

1. Replace the launcher latest build with the one from this PR
2. Open a deep link going to production containing the `scene-console=true` param and confirm that that param doesn't appear in the deep link confirmation dialog (only skip-version-check does) AND that once you are inside the world, you can open the SCENE DEBUG CONSOLE.

Deep link: `decentraland://?realm=pravus.dcl.eth&skip-version-check=true&scene-console=true`