### PR TITLE
fix: don't pre-select owned NAME dropdown entry for an unclaimed matching display name

### DIFF
--- a/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/ProfileNameEditorController.cs
@@ -162,7 +162,13 @@ namespace DCL.UI.ProfileNames
 
                 config.claimedNameDropdown.options = dropdownOptions;
 
-                int selectedIndex = config.claimedNameDropdown.options.FindIndex(option => option.text == profile.Name);
+                // An unclaimed display name that matches an owned NFT name is not an equipped name:
+                // keep the dropdown unselected so the entry stays selectable (selecting the pre-selected
+                // entry never fires onValueChanged, which would leave Save permanently disabled)
+                int selectedIndex = profile.HasClaimedName
+                    ? config.claimedNameDropdown.options.FindIndex(option => option.text == profile.Name)
+                    : -1;
+
                 config.claimedNameDropdown.SetValueWithoutNotify(selectedIndex);
                 // Always start as disabled as it makes no sense save your own current name again..
                 config.saveButtonInteractable = false;

--- a/Explorer/Assets/DCL/UI/Profiles/Names/Tests.meta
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e1ff4c186764293a157e29c4bfc2982
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/UI/Profiles/Names/Tests/DCL.UI.Profiles.Names.Tests.asmref
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/Tests/DCL.UI.Profiles.Names.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/UI/Profiles/Names/Tests/DCL.UI.Profiles.Names.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/Tests/DCL.UI.Profiles.Names.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e84fa1ae4add455397d283e2de495f78
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/UI/Profiles/Names/Tests/ProfileNameEditorControllerShould.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/Tests/ProfileNameEditorControllerShould.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using System.Reflection;
+using DCL.Browser;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Profiles;
+using DCL.Profiles.Self;
+using ECS.TestSuite;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace DCL.UI.ProfileNames.Tests
+{
+    /// <summary>
+    ///     Regression coverage for https://github.com/decentraland/unity-explorer/issues/9550: a minted
+    ///     Name cannot be equipped when it is spelled the same as the current non-unique display name.
+    /// </summary>
+    [TestFixture]
+    public class ProfileNameEditorControllerShould
+    {
+        private const string PREFAB_PATH = "Assets/DCL/UI/Profiles/Names/Assets/ProfileNameEditor.prefab";
+        private const string OWNED_NAME = "test2000";
+
+        private GameObject viewGameObject;
+        private ProfileNameEditorView view;
+        private ProfileNameEditorController controller;
+        private Profile profile;
+
+        [SetUp]
+        public void SetUp()
+        {
+            EcsTestsUtils.SetUpFeaturesRegistry();
+
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(PREFAB_PATH);
+            Assert.IsNotNull(prefab, $"Could not load ProfileNameEditor prefab from {PREFAB_PATH}");
+
+            viewGameObject = Object.Instantiate(prefab);
+            view = viewGameObject.GetComponent<ProfileNameEditorView>();
+            Assert.IsNotNull(view, "ProfileNameEditorView component not found on the instantiated prefab");
+
+            controller = new ProfileNameEditorController(
+                () => view,
+                new UnityAppWebBrowser(Substitute.For<IDecentralandUrlsSource>()),
+                Substitute.For<ISelfProfile>(),
+                Substitute.For<INftNamesProvider>(),
+                Substitute.For<IDecentralandUrlsSource>(),
+                new ProfileChangesBus());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            profile?.Dispose();
+
+            if (viewGameObject != null)
+                Object.DestroyImmediate(viewGameObject);
+
+            EcsTestsUtils.TearDownFeaturesRegistry();
+        }
+
+        [Test]
+        public void NotPreSelectOwnedNameDropdownEntryWhenDisplayNameMatchesButIsNotClaimed()
+        {
+            // Arrange: the user's *non-unique* display name happens to be spelled the same as an
+            // owned NFT name they haven't equipped yet (HasClaimedName == false) - the #9550 repro.
+            profile = Profile.Create("0x1234567890123456789012345678901234abcd", OWNED_NAME, new DCL.Profiles.Avatar());
+            profile.HasClaimedName = false;
+
+            using INftNamesProvider.PaginatedNamesResponse names = new (1, new[] { OWNED_NAME });
+
+            ProfileNameEditorView.ClaimedNameConfig config = view.ClaimedNameContainer;
+
+            // Act: drive the same private setup routine the popup runs every time it's shown.
+            InvokeSetUpClaimed(config, profile, names);
+
+            // Assert: the dropdown must stay unselected (-1, placeholder) so the matching entry
+            // remains clickable and still fires onValueChanged. Pre-fix, FindIndex matches on the
+            // name string alone and pre-selects index 0; re-clicking the already-selected entry
+            // never fires TMP_Dropdown.onValueChanged, so Save stays disabled forever.
+            Assert.AreEqual(-1, config.claimedNameDropdown.value,
+                "the claimed-name dropdown must not pre-select an owned name that merely matches the " +
+                "current (unclaimed) display name, or Save can never be enabled (#9550)");
+        }
+
+        private void InvokeSetUpClaimed(ProfileNameEditorView.ClaimedNameConfig config, Profile profile, INftNamesProvider.PaginatedNamesResponse names)
+        {
+            // SetUpClaimed is a local function nested in OnBeforeViewShow/SetUpAsync; the compiler
+            // emits it as a private instance method on the controller (it closes over the
+            // `dropdownOptions` field), so it's reached via reflection instead of a direct call.
+            MethodInfo setUpClaimed = typeof(ProfileNameEditorController)
+                .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                .Single(m => m.Name.Contains("SetUpClaimed"));
+
+            setUpClaimed.Invoke(controller, new object[] { config, profile, names });
+        }
+    }
+}

--- a/Explorer/Assets/DCL/UI/Profiles/Names/Tests/ProfileNameEditorControllerShould.cs.meta
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/Tests/ProfileNameEditorControllerShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 133435dfd794464194204e5e47f7546b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
The claimed-name dropdown pre-selected an entry whenever its text matched profile.Name, even when profile.HasClaimedName was false. TMP_Dropdown never fires onValueChanged when re-clicking the already-selected entry, so Save could never be enabled for a user whose non-unique display name matched a newly minted NAME — a silent, 100% reproducible equip block.

Only pre-select when the profile actually has a claimed name; otherwise start on the placeholder (-1) so the matching entry stays selectable.

Fixes #9550

Includes a regression test that fails without this fix.

# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, copy-pasteable steps for testing these changes.

### Quick reference

# Run this PR (with cache)
metaforge explorer run <this-PR-number>

# Run this PR (without cache — clears Explorer data)
metaforge explorer run <this-PR-number> --clear

# Run this PR (fresh account — clears everything and creates a new account)
metaforge account create --clear
metaforge explorer run <this-PR-number>

# Tail logs while testing
metaforge explorer logs tail --filter "<relevant text>"

# Run automation tests against this PR
metaforge explorer test <this-PR-number>
-->

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
