### PR TITLE
fix: use scene spawn point when Events jump-in targets the scene base

### DIFF
--- a/Explorer/Assets/DCL/RealmNavigation/TeleportController.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/TeleportController.cs
@@ -78,6 +78,11 @@ namespace DCL.RealmNavigation
 
             if (sceneDef != null && !TeleportUtils.IsRoad(sceneDef.metadata.OriginalJson.AsSpan()))
             {
+                // Landing on the scene's base parcel has no sub-parcel to target, so take the
+                // spawn-point path: the landing then matches map/chat teleports to the same scene.
+                if (landOnParcel && parcel == sceneDef.metadata.scene.DecodedBase)
+                    landOnParcel = false;
+
                 // When landing on the exact parcel, keep the requested parcel; otherwise snap to the
                 // scene base so the spawn point is used.
                 if (!landOnParcel)

--- a/Explorer/Assets/DCL/RealmNavigation/Tests.meta
+++ b/Explorer/Assets/DCL/RealmNavigation/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d51e15d52654ed9bcbbf64a627ac9a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/RealmNavigation/Tests/RealmNavigation.Tests.asmref
+++ b/Explorer/Assets/DCL/RealmNavigation/Tests/RealmNavigation.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/RealmNavigation/Tests/RealmNavigation.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/RealmNavigation/Tests/RealmNavigation.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 487c3c73685e4b18b888926705e04199
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/RealmNavigation/Tests/TeleportControllerShould.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/Tests/TeleportControllerShould.cs
@@ -1,0 +1,108 @@
+﻿using Arch.Core;
+using Cysharp.Threading.Tasks;
+using DCL.Character.Components;
+using DCL.CharacterMotion.Components;
+using DCL.Ipfs;
+using DCL.Utilities;
+using ECS.SceneLifeCycle.Reporting;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace DCL.RealmNavigation.Tests
+{
+    public class TeleportControllerShould
+    {
+        private World world;
+        private Entity playerEntity;
+        private TeleportController controller;
+        private IRetrieveScene retrieveScene;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = World.Create();
+            playerEntity = world.Create(new PlayerComponent());
+
+            retrieveScene = Substitute.For<IRetrieveScene>();
+
+            controller = new TeleportController(Substitute.For<ISceneReadinessReportQueue>())
+            {
+                World = world,
+                SceneProviderStrategy = retrieveScene,
+            };
+        }
+
+        [TearDown]
+        public void TearDown() =>
+            world.Dispose();
+
+        // Regression test for #9546: the Discover -> Events page jump-in ("BBQ Sauce Recipe" @ -148,141)
+        // targets coordinates that ARE the scene's own base parcel, yet EventCardActionsController still
+        // passes landOnParcel: true. That flag must not survive when there is no sub-parcel to single out,
+        // otherwise TeleportPositionCalculationSystem takes the raw parcel-center branch instead of the
+        // authored spawn point ("SpawnArea1") that every other teleport entry point (chat/map) resolves to.
+        [Test]
+        public async Task ClearLandOnParcelWhenTargetParcelIsTheSceneBase()
+        {
+            var baseParcel = new Vector2Int(-148, 141);
+
+            SceneEntityDefinition sceneDef = BuildSceneDefWithDefaultSpawnPoint(baseParcel);
+
+            retrieveScene.ByParcelAsync(baseParcel, Arg.Any<CancellationToken>())
+                         .Returns(UniTask.FromResult<SceneEntityDefinition?>(sceneDef));
+
+            AsyncLoadProcessReport loadReport = AsyncLoadProcessReport.Create(CancellationToken.None);
+
+            await controller.TeleportToSceneSpawnPointAsync(baseParcel, loadReport, CancellationToken.None, landOnParcel: true);
+
+            Assert.That(world.Has<PlayerTeleportIntent>(playerEntity), Is.True, "A PlayerTeleportIntent should have been queued on the player entity");
+
+            var intent = world.Get<PlayerTeleportIntent>(playerEntity);
+
+            // Unpatched: LandOnParcel stays true, so the position system takes the parcel-center path.
+            // Patched: base-parcel targets have no sub-parcel to single out, so the flag is cleared and
+            // spawn-point resolution (incl. the spawn's cameraTarget) runs instead - matching map/chat.
+            Assert.That(intent.LandOnParcel, Is.False,
+                "landOnParcel must be cleared when the requested parcel equals the scene's base parcel, so spawn-point resolution is used instead of the raw parcel center");
+        }
+
+        private static SceneEntityDefinition BuildSceneDefWithDefaultSpawnPoint(Vector2Int baseParcel)
+        {
+            var sceneSection = new SceneMetadataScene
+            {
+                DecodedBase = baseParcel,
+                DecodedParcels = new[] { baseParcel },
+            };
+
+            var spawnPoint = new SceneMetadata.SpawnPoint
+            {
+                name = "SpawnArea1",
+                @default = true,
+                position = new SceneMetadata.SpawnPoint.Position
+                {
+                    x = new SceneMetadata.SpawnPoint.Coordinate { MultiValue = new[] { 0f, 3f } },
+                    y = new SceneMetadata.SpawnPoint.Coordinate { SingleValue = 0f },
+                    z = new SceneMetadata.SpawnPoint.Coordinate { MultiValue = new[] { 0f, 3f } },
+                },
+                cameraTarget = new SceneMetadata.SpawnPoint.Position
+                {
+                    x = new SceneMetadata.SpawnPoint.Coordinate { SingleValue = 8f },
+                    y = new SceneMetadata.SpawnPoint.Coordinate { SingleValue = 1f },
+                    z = new SceneMetadata.SpawnPoint.Coordinate { SingleValue = 8f },
+                },
+            };
+
+            var metadata = new SceneMetadata
+            {
+                scene = sceneSection,
+                spawnPoints = new List<SceneMetadata.SpawnPoint> { spawnPoint },
+            };
+
+            return new SceneEntityDefinition("grill-master-week-2", metadata);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/RealmNavigation/Tests/TeleportControllerShould.cs.meta
+++ b/Explorer/Assets/DCL/RealmNavigation/Tests/TeleportControllerShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee6491e6957d499d96cd23b3176fa3ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
EventCardActionsController.JumpInEvent unconditionally passes landOnParcel: true, which targets the raw parcel center instead of the scene's authored scene.json spawn point. This was intentional for sub-parcel targeting in multi-parcel scenes (PR #8942, e.g. a Theatre inside Genesis Plaza), but it also fires when the event's coordinates equal the scene's own base parcel, where the sub-parcel rationale doesn't apply, causing map/chat and Events-page jump-ins to the same scene to land at different positions.

Clear landOnParcel in TeleportController.TeleportAsync when the requested parcel equals sceneDef.metadata.scene.DecodedBase, so the flow falls through to the same spawn-point resolution (including the cameraTarget look-at) used by every other teleport entry point. Sub-parcel jump-ins are untouched.

Fixes #9546
Related: #9368

Includes a regression test that fails without this fix.

# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, copy-pasteable steps for testing these changes.

### Quick reference

# Run this PR (with cache)
metaforge explorer run <this-PR-number>

# Run this PR (without cache — clears Explorer data)
metaforge explorer run <this-PR-number> --clear

# Run this PR (fresh account — clears everything and creates a new account)
metaforge account create --clear
metaforge explorer run <this-PR-number>

# Tail logs while testing
metaforge explorer logs tail --filter "<relevant text>"

# Run automation tests against this PR
metaforge explorer test <this-PR-number>
-->

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
