### PR TITLE
feat: buy collection store mints with credits

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -440,6 +440,7 @@ namespace Global.Dynamic
                 new CreditsManagerMetaTxRelayer(dynamicWorldDependencies.CompositeWeb3Provider, staticContainer.WebRequestsContainer.WebRequestController, bootstrapContainer.DecentralandUrlsSource, creditsChainConfig),
                 new PolygonSettlementPoller(dynamicWorldDependencies.CompositeWeb3Provider, creditsChainConfig),
                 new ManaUsdRateReader(dynamicWorldDependencies.CompositeWeb3Provider, creditsChainConfig),
+                creditsChainConfig,
                 identityCache,
                 CreditsFeatureAccess.Instance,
                 FeaturesRegistry.Instance.IsEnabled(FeatureId.CreditsWearablePurchase) && FeaturesRegistry.Instance.IsEnabled(FeatureId.UserCredits));

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/AuthorizeCreditResponse.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/AuthorizeCreditResponse.cs
@@ -27,24 +27,37 @@ namespace DCL.MarketplaceCredits
     }
 
     [Serializable]
+    /// <summary>
+    ///     A TRADE-backed purchase: identified by its trade.
+    ///     <para>
+    ///         Deliberately a separate shape from the mint body below rather than one struct with every field.
+    ///         `JsonUtility` cannot omit a field — it serialises every public member — and the server validates
+    ///         `contractAddress`/`itemId` as a pair the moment EITHER key is present. An empty string counts as
+    ///         present and fails the address check, which is exactly how a trade purchase came back 400 while the
+    ///         mint went through. Two shapes make "absent" expressible.
+    ///     </para>
+    ///     <para>
+    ///         Note what is NOT here: nothing identifying is part of what the server SIGNS. The authorization is
+    ///         a voucher for an AMOUNT (value + expiry + salt + signature) plus the caps the CreditsManager
+    ///         enforces on-chain against whatever MANA the external call actually moves. The identifiers are
+    ///         recorded on the intent so the buyer's purchase history can name what was bought.
+    ///     </para>
+    /// </summary>
     public struct AuthorizeUsdCreditBody
     {
         public int usdPriceCents;
-
-        /// <summary>
-        ///     Empty for a CollectionStore mint, which has no trade.
-        ///     <para>
-        ///         Neither this nor the item pair below is part of what the server SIGNS: the authorization is a
-        ///         voucher for an AMOUNT (value + expiry + salt + signature) and the caps the CreditsManager
-        ///         enforces on-chain against whatever MANA the external call actually moves. These fields are
-        ///         recorded on the intent so the buyer's purchase history can name what was bought — and for a
-        ///         mint they are the only identity it has, since there is no trade to resolve a name from.
-        ///     </para>
-        /// </summary>
         public string tradeId;
+    }
 
+    /// <summary>
+    ///     A COLLECTIONSTORE MINT: it has no trade, so it is identified by what is being bought. The server takes
+    ///     the pair only as a pair — half of it resolves to nothing.
+    /// </summary>
+    [Serializable]
+    public struct AuthorizeUsdMintCreditBody
+    {
+        public int usdPriceCents;
         public string contractAddress;
-
         public string itemId;
     }
 

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/AuthorizeCreditResponse.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/AuthorizeCreditResponse.cs
@@ -30,7 +30,22 @@ namespace DCL.MarketplaceCredits
     public struct AuthorizeUsdCreditBody
     {
         public int usdPriceCents;
+
+        /// <summary>
+        ///     Empty for a CollectionStore mint, which has no trade.
+        ///     <para>
+        ///         Neither this nor the item pair below is part of what the server SIGNS: the authorization is a
+        ///         voucher for an AMOUNT (value + expiry + salt + signature) and the caps the CreditsManager
+        ///         enforces on-chain against whatever MANA the external call actually moves. These fields are
+        ///         recorded on the intent so the buyer's purchase history can name what was bought — and for a
+        ///         mint they are the only identity it has, since there is no trade to resolve a name from.
+        ///     </para>
+        /// </summary>
         public string tradeId;
+
+        public string contractAddress;
+
+        public string itemId;
     }
 
     [Serializable]

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/MarketplaceCreditsAPIClient.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/MarketplaceCreditsAPIClient.cs
@@ -101,17 +101,37 @@ namespace DCL.MarketplaceCredits
         public virtual async UniTask<AuthorizeCreditResponse> AuthorizeUsdCreditAsync(int usdPriceCents, string tradeId, string contractAddress, string itemId, CancellationToken ct)
         {
             var url = $"{marketplaceCreditsBaseUrl}/credits/authorize";
-
-            string jsonBody = JsonUtility.ToJson(new AuthorizeUsdCreditBody
-            {
-                usdPriceCents = usdPriceCents,
-                tradeId = tradeId,
-                contractAddress = contractAddress,
-                itemId = itemId,
-            });
+            string jsonBody = BuildAuthorizeBody(usdPriceCents, tradeId, contractAddress, itemId);
 
             return await webRequestController.SignedFetchPostAsync(url, GenericPostArguments.CreateJson(jsonBody), string.Empty, ct)
                                              .CreateFromJson<AuthorizeCreditResponse>(WRJsonParser.Unity);
+        }
+
+        /// <summary>
+        ///     The authorize body, carrying ONLY the keys that apply to the rail being bought.
+        ///     <para>
+        ///         The server validates `contractAddress`/`itemId` as a pair the moment either key is present, and
+        ///         an empty string counts as present: sending `""` for both on a trade purchase fails its address
+        ///         check with a 400. `JsonUtility` cannot omit a field, so the shape is chosen here instead — which
+        ///         is also why this is a static, directly testable function rather than an inline serialise.
+        ///     </para>
+        /// </summary>
+        internal static string BuildAuthorizeBody(int usdPriceCents, string? tradeId, string? contractAddress, string? itemId)
+        {
+            bool hasItem = !string.IsNullOrEmpty(contractAddress) && !string.IsNullOrEmpty(itemId);
+
+            return hasItem
+                ? JsonUtility.ToJson(new AuthorizeUsdMintCreditBody
+                {
+                    usdPriceCents = usdPriceCents,
+                    contractAddress = contractAddress,
+                    itemId = itemId,
+                })
+                : JsonUtility.ToJson(new AuthorizeUsdCreditBody
+                {
+                    usdPriceCents = usdPriceCents,
+                    tradeId = tradeId ?? string.Empty,
+                });
         }
 
         public virtual async UniTask ReleaseUsdIntentsAsync(string[] salts, CancellationToken ct)

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/MarketplaceCreditsAPIClient.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/MarketplaceCreditsAPIClient.cs
@@ -90,10 +90,25 @@ namespace DCL.MarketplaceCredits
                                              .CreateFromJson<CreditPacksResponse>(WRJsonParser.Unity);
         }
 
-        public virtual async UniTask<AuthorizeCreditResponse> AuthorizeUsdCreditAsync(int usdPriceCents, string tradeId, CancellationToken ct)
+        /// <summary>
+        ///     Reserves the dollars and signs the credit for ONE purchase.
+        ///     <para>
+        ///         `tradeId` is empty for a CollectionStore mint, which is identified by the
+        ///         (contractAddress, itemId) pair instead — the server accepts either, and signs neither: what it
+        ///         signs is a voucher for an amount, and the caps the CreditsManager enforces on-chain.
+        ///     </para>
+        /// </summary>
+        public virtual async UniTask<AuthorizeCreditResponse> AuthorizeUsdCreditAsync(int usdPriceCents, string tradeId, string contractAddress, string itemId, CancellationToken ct)
         {
             var url = $"{marketplaceCreditsBaseUrl}/credits/authorize";
-            string jsonBody = JsonUtility.ToJson(new AuthorizeUsdCreditBody { usdPriceCents = usdPriceCents, tradeId = tradeId });
+
+            string jsonBody = JsonUtility.ToJson(new AuthorizeUsdCreditBody
+            {
+                usdPriceCents = usdPriceCents,
+                tradeId = tradeId,
+                contractAddress = contractAddress,
+                itemId = itemId,
+            });
 
             return await webRequestController.SignedFetchPostAsync(url, GenericPostArguments.CreateJson(jsonBody), string.Empty, ct)
                                              .CreateFromJson<AuthorizeCreditResponse>(WRJsonParser.Unity);

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Api/ShopListingDto.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Api/ShopListingDto.cs
@@ -9,6 +9,19 @@ namespace DCL.MarketplaceCredits.Purchase
     public class ShopListingDto
     {
         public string tradeId = null!;
+
+        /// <summary>
+        ///     How the row is BOUGHT — "trade" (an offchain signed order, fetched via /v1/trades/:id) or "store"
+        ///     (a CollectionStore mint, which has no trade and no order: nothing was ever signed or listed, so
+        ///     there is no id to fetch and the item is minted straight from the store contract).
+        ///     <para>
+        ///         This, not the presence of a tradeId, is what decides the purchase rail. Treating a null
+        ///         tradeId as "not for sale" is what made the web shop show NOT FOR SALE on items its own browse
+        ///         grid was selling.
+        ///     </para>
+        /// </summary>
+        public string? acquisition;
+
         public string listingType = null!;
         public string source = null!;
         public string contractAddress = null!;

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Chain/CreditsChainConfig.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Chain/CreditsChainConfig.cs
@@ -13,6 +13,17 @@ namespace DCL.MarketplaceCredits.Purchase
         private const string POLYGON_CREDITS_MANAGER_ADDRESS = "0x8b3a40ca1b6f5cafc99d112a4d02e897d1fd8cc5";
         private const string AMOY_CREDITS_MANAGER_ADDRESS = "0x8052a560e6e6ac86eeb7e711a4497f639b322fb3";
 
+        // CollectionStore — where a PRIMARY item with no trade is minted from (useCredits' external call target
+        // for a mint, the way the marketplace is for a trade).
+        private const string POLYGON_COLLECTION_STORE_ADDRESS = "0x214ffc0f0103735728dc66b61a22e4f163e275ae";
+        private const string AMOY_COLLECTION_STORE_ADDRESS = "0xe36abc9ec616c83caaa386541380829106149d68";
+
+        // The offchain marketplace. Not used to buy a mint — it is the contract that exposes
+        // `manaUsdAggregator()`, so it is the address the MANA/USD rate is read THROUGH. A trade already names
+        // its own marketplace; a mint has none, and a collection contract does not expose that method at all.
+        private const string POLYGON_OFFCHAIN_MARKETPLACE_ADDRESS = "0xa40b1d129b8906888720686f3a01921ddf37716f";
+        private const string AMOY_OFFCHAIN_MARKETPLACE_ADDRESS = "0x1b67d0e31eeb6b52d8eeed71d3616c2f5b33b8e7";
+
         private const string CREDITS_MANAGER_EIP712_NAME = "Decentraland Credits";
         private const string CREDITS_MANAGER_EIP712_VERSION = "1.0.0";
 
@@ -21,6 +32,10 @@ namespace DCL.MarketplaceCredits.Purchase
         public string ReadonlyNetwork { get; }
 
         public string CreditsManagerAddress { get; }
+
+        public string CollectionStoreAddress { get; }
+
+        public string OffChainMarketplaceAddress { get; }
 
         public string CreditsManagerEip712Name => CREDITS_MANAGER_EIP712_NAME;
 
@@ -33,12 +48,16 @@ namespace DCL.MarketplaceCredits.Purchase
                 ChainId = POLYGON_CHAIN_ID;
                 ReadonlyNetwork = POLYGON_READONLY_NETWORK;
                 CreditsManagerAddress = POLYGON_CREDITS_MANAGER_ADDRESS;
+                CollectionStoreAddress = POLYGON_COLLECTION_STORE_ADDRESS;
+                OffChainMarketplaceAddress = POLYGON_OFFCHAIN_MARKETPLACE_ADDRESS;
             }
             else
             {
                 ChainId = AMOY_CHAIN_ID;
                 ReadonlyNetwork = AMOY_READONLY_NETWORK;
                 CreditsManagerAddress = AMOY_CREDITS_MANAGER_ADDRESS;
+                CollectionStoreAddress = AMOY_COLLECTION_STORE_ADDRESS;
+                OffChainMarketplaceAddress = AMOY_OFFCHAIN_MARKETPLACE_ADDRESS;
             }
         }
     }

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/CreditsPurchaseService.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/CreditsPurchaseService.cs
@@ -24,6 +24,7 @@ namespace DCL.MarketplaceCredits.Purchase
         private readonly CreditsManagerMetaTxRelayer metaTxRelayer;
         private readonly PolygonSettlementPoller settlementPoller;
         private readonly ManaUsdRateReader manaUsdRateReader;
+        private readonly CreditsChainConfig chainConfig;
         private readonly IWeb3IdentityCache identityCache;
         private readonly CreditsFeatureAccess creditsFeatureAccess;
         private readonly bool isFeatureEnabled;
@@ -36,6 +37,7 @@ namespace DCL.MarketplaceCredits.Purchase
             CreditsManagerMetaTxRelayer metaTxRelayer,
             PolygonSettlementPoller settlementPoller,
             ManaUsdRateReader manaUsdRateReader,
+            CreditsChainConfig chainConfig,
             IWeb3IdentityCache identityCache,
             CreditsFeatureAccess creditsFeatureAccess,
             bool isFeatureEnabled)
@@ -45,12 +47,21 @@ namespace DCL.MarketplaceCredits.Purchase
             this.metaTxRelayer = metaTxRelayer;
             this.settlementPoller = settlementPoller;
             this.manaUsdRateReader = manaUsdRateReader;
+            this.chainConfig = chainConfig;
             this.identityCache = identityCache;
             this.creditsFeatureAccess = creditsFeatureAccess;
             this.isFeatureEnabled = isFeatureEnabled;
         }
 
-        public async UniTask<CreditsQuoteResult> QuoteAsync(string tradeId, CancellationToken ct)
+        /// <summary>
+        ///     Quotes the LISTING, not a trade id.
+        ///     <para>
+        ///         The row from /v3/catalog/unified already says how the item is acquired, what it costs and how
+        ///         much is left; passing only its tradeId threw that away and forced everything to be re-derived
+        ///         from a trade — which a CollectionStore mint does not have, so it could not be bought at all.
+        ///     </para>
+        /// </summary>
+        public async UniTask<CreditsQuoteResult> QuoteAsync(ShopListingDto listing, CancellationToken ct)
         {
             if (!isFeatureEnabled || !creditsFeatureAccess.IsUserAllowed())
                 return new CreditsQuoteResult(CreditsPurchaseError.FeatureDisabled);
@@ -62,7 +73,12 @@ namespace DCL.MarketplaceCredits.Purchase
 
             SetState(CreditsPurchaseState.ResolvingListing);
 
-            try { return await QuoteInternalAsync(tradeId, identity.Address, ct); }
+            try
+            {
+                return IsStoreMint(listing)
+                    ? await QuoteStoreMintInternalAsync(listing, ct)
+                    : await QuoteInternalAsync(listing.tradeId, identity.Address, ct);
+            }
             catch (OperationCanceledException)
             {
                 return new CreditsQuoteResult(CreditsPurchaseError.Cancelled);
@@ -94,6 +110,60 @@ namespace DCL.MarketplaceCredits.Purchase
                 ReportHub.LogException(e, new ReportData(ReportCategory.CREDITS_PURCHASE));
                 return new CreditsPurchaseResult(CreditsPurchaseError.UnknownError, message: e.Message);
             }
+        }
+
+        /// <summary>
+        ///     A CollectionStore mint is FOR SALE when it has stock, not when it has a trade.
+        ///     <para>
+        ///         `acquisition` is the server's own discriminator. A missing value means an older server that did
+        ///         not send it, and back then every row was a trade — so the absence must read as "trade", never
+        ///         as "mint".
+        ///     </para>
+        /// </summary>
+        private static bool IsStoreMint(ShopListingDto listing) =>
+            string.Equals(listing.acquisition, "store", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        ///     Quotes a mint entirely from the listing row: there is no trade to fetch and never will be.
+        ///     <para>
+        ///         A mint is always MANA-priced, so its credit price exists only through the oracle — the same
+        ///         path a legacy MANA trade takes. The rate is read through the marketplace contract because that
+        ///         is what exposes `manaUsdAggregator()`; a collection contract does not.
+        ///     </para>
+        /// </summary>
+        private async UniTask<CreditsQuoteResult> QuoteStoreMintInternalAsync(ShopListingDto listing, CancellationToken ct)
+        {
+            if (string.IsNullOrEmpty(listing.itemId))
+                return new CreditsQuoteResult(CreditsPurchaseError.ListingNotAvailable, "Mint listing has no itemId");
+
+            // Stock, not a trade, is what "still on sale" means here. A sold-out mint would otherwise be carried
+            // all the way to an on-chain revert.
+            if (listing.available <= 0)
+                return new CreditsQuoteResult(CreditsPurchaseError.ListingNotAvailable, "Mint is sold out");
+
+            if (string.IsNullOrEmpty(listing.manaWei))
+                return new CreditsQuoteResult(CreditsPurchaseError.ListingNotAvailable, "Mint listing has no price");
+
+            ManaUsdRate rate;
+
+            try { rate = await manaUsdRateReader.ReadAsync(chainConfig.OffChainMarketplaceAddress, ct); }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception e)
+            {
+                ReportHub.LogWarning(ReportCategory.CREDITS_PURCHASE,
+                    $"MANA/USD rate unavailable for mint {listing.contractAddress}-{listing.itemId}: {e.Message}");
+
+                return new CreditsQuoteResult(CreditsPurchaseError.PriceUnavailable, e.Message);
+            }
+
+            int usdCents = CreditsTradeEncoder.RoundUpToWholeCredit(CreditsTradeEncoder.ManaWeiToUsdCents(listing.manaWei!, rate), CENTS_PER_CREDIT);
+            BigInteger requiredManaWei = CreditsTradeEncoder.AmountOrZero(listing.manaWei!);
+
+            if (usdCents <= 0 || requiredManaWei <= BigInteger.Zero)
+                return new CreditsQuoteResult(CreditsPurchaseError.ListingNotAvailable, "Mint has no price");
+
+            var target = new StoreMintTarget(listing.contractAddress, listing.itemId!, listing.manaWei!);
+            return CreditsQuoteResult.Ok(CreditsPurchaseQuote.ForMint(target, usdCents, usdCents / CENTS_PER_CREDIT, requiredManaWei));
         }
 
         private async UniTask<CreditsQuoteResult> QuoteInternalAsync(string tradeId, string buyer, CancellationToken ct)
@@ -161,28 +231,59 @@ namespace DCL.MarketplaceCredits.Purchase
             if (usdCents <= 0)
                 return new CreditsQuoteResult(CreditsPurchaseError.ListingNotAvailable, "Trade has no price");
 
-            return CreditsQuoteResult.Ok(new CreditsPurchaseQuote(trade, usdCents, usdCents / CENTS_PER_CREDIT, requiredManaWei, isLegacyMana));
+            return CreditsQuoteResult.Ok(CreditsPurchaseQuote.ForTrade(trade, usdCents, usdCents / CENTS_PER_CREDIT, requiredManaWei, isLegacyMana));
         }
 
         private async UniTask<CreditsPurchaseResult> PurchaseInternalAsync(CreditsPurchaseQuote quote, string buyer, CancellationToken ct)
         {
             BigInteger requiredManaWei = quote.RequiredManaWei;
+            StoreMintTarget mint = quote.Mint;
 
-            if (!quote.IsLiveRatePrice)
+            // A mint's price is an ARGUMENT to CollectionStore.buy and the contract re-validates it against the
+            // item's live price, reverting if the creator moved it — so it is re-read here, as late as possible,
+            // instead of trusting the quote. A trade cannot fail this way: its price is signed into the order.
+            if (quote.Kind == CreditsListingKind.StoreMint)
+            {
+                SetState(CreditsPurchaseState.ResolvingListing);
+
+                ShopListingDto? fresh;
+
+                try { fresh = await shopAPIClient.GetShopListingForItemAsync(mint.CollectionAddress, mint.ItemId, ct); }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception e)
+                {
+                    ReportHub.LogWarning(ReportCategory.CREDITS_PURCHASE,
+                        $"Mint {mint.CollectionAddress}-{mint.ItemId} could not be re-read before buying: {e.Message}");
+
+                    return Fail(CreditsPurchaseError.ListingNotAvailable, message: e.Message);
+                }
+
+                if (fresh == null || !IsStoreMint(fresh) || fresh.available <= 0 || string.IsNullOrEmpty(fresh.manaWei))
+                    return Fail(CreditsPurchaseError.ListingNotAvailable, message: "The mint is no longer available");
+
+                mint = new StoreMintTarget(mint.CollectionAddress, mint.ItemId, fresh.manaWei!);
+                requiredManaWei = CreditsTradeEncoder.AmountOrZero(fresh.manaWei!);
+
+                // A price that moved UP past what the buyer confirmed must not be charged silently. The cap check
+                // below catches it too, but failing here names the reason.
+                if (requiredManaWei > quote.RequiredManaWei)
+                    return Fail(CreditsPurchaseError.PriceChanged, message: "The mint price changed");
+            }
+            else if (!quote.IsLiveRatePrice)
             {
                 SetState(CreditsPurchaseState.ResolvingListing);
 
                 ManaUsdRate rate;
 
-                try { rate = await manaUsdRateReader.ReadAsync(quote.Trade.contract, ct); }
+                try { rate = await manaUsdRateReader.ReadAsync(quote.Trade!.contract, ct); }
                 catch (OperationCanceledException) { throw; }
                 catch (Exception e)
                 {
-                    ReportHub.LogWarning(ReportCategory.CREDITS_PURCHASE, $"MANA/USD rate unavailable at purchase for trade {quote.Trade.id}: {e.Message}");
+                    ReportHub.LogWarning(ReportCategory.CREDITS_PURCHASE, $"MANA/USD rate unavailable at purchase for trade {quote.Trade!.id}: {e.Message}");
                     return Fail(CreditsPurchaseError.PriceUnavailable, message: e.Message);
                 }
 
-                requiredManaWei = CreditsTradeEncoder.UsdWeiToManaWei(quote.Trade.received[0].amount, rate);
+                requiredManaWei = CreditsTradeEncoder.UsdWeiToManaWei(quote.Trade!.received[0].amount, rate);
 
                 if (requiredManaWei <= BigInteger.Zero)
                     return Fail(CreditsPurchaseError.PriceUnavailable, message: "Trade draws no MANA");
@@ -192,7 +293,7 @@ namespace DCL.MarketplaceCredits.Purchase
 
             AuthorizeCreditResponse authorization;
 
-            try { authorization = await creditsAPIClient.AuthorizeUsdCreditAsync(quote.UsdCents, quote.Trade.id, ct); }
+            try { authorization = await creditsAPIClient.AuthorizeUsdCreditAsync(quote.UsdCents, quote.TradeId, quote.ContractAddress, quote.ItemId, ct); }
             catch (OperationCanceledException) { throw; }
             catch (UnityWebRequestException e)
             {
@@ -221,10 +322,18 @@ namespace DCL.MarketplaceCredits.Purchase
                 authorizedCap = BigInteger.Parse(authorization.maxCreditedValue)
                                 + CreditsTradeEncoder.UncreditedValue(authorization.maxCreditedValue, authorization.credit.availableAmount);
 
-                useCreditsCalldata = CreditsTradeEncoder.BuildUseCreditsCalldata(
-                    quote.Trade, buyer, authorization.credit, authorization.maxCreditedValue,
-                    DateTimeOffset.UtcNow.ToUnixTimeSeconds() + EXTERNAL_CALL_TTL_SECONDS,
-                    RandomSalt());
+                long externalCallExpiresAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + EXTERNAL_CALL_TTL_SECONDS;
+
+                // Same envelope, same credit, same caps — only the external call differs: accept([trade]) against
+                // the marketplace, or buy([item]) against the CollectionStore.
+                useCreditsCalldata = quote.Kind == CreditsListingKind.StoreMint
+                    ? CreditsTradeEncoder.BuildStoreMintUseCreditsCalldata(
+                        chainConfig.CollectionStoreAddress, mint.CollectionAddress, mint.ItemId, mint.PriceWei,
+                        buyer, authorization.credit, authorization.maxCreditedValue,
+                        externalCallExpiresAt, RandomSalt())
+                    : CreditsTradeEncoder.BuildUseCreditsCalldata(
+                        quote.Trade!, buyer, authorization.credit, authorization.maxCreditedValue,
+                        externalCallExpiresAt, RandomSalt());
             }
             catch (Exception e)
             {
@@ -236,10 +345,10 @@ namespace DCL.MarketplaceCredits.Purchase
             if (authorizedCap < requiredManaWei)
             {
                 ReportHub.LogWarning(ReportCategory.CREDITS_PURCHASE,
-                    $"Authorized cap {authorizedCap} wei cannot cover the {requiredManaWei} wei trade {quote.Trade.id} draws");
+                    $"Authorized cap {authorizedCap} wei cannot cover the {requiredManaWei} wei {QuoteLabel(quote)} draws");
 
                 await ReleaseIntentAsync(authorization.credit.id);
-                return Fail(CreditsPurchaseError.PriceChanged, message: "The authorized credit cannot cover this trade");
+                return Fail(CreditsPurchaseError.PriceChanged, message: "The authorized credit cannot cover this purchase");
             }
 
             SetState(CreditsPurchaseState.Signing);
@@ -269,7 +378,7 @@ namespace DCL.MarketplaceCredits.Purchase
                     SetState(CreditsPurchaseState.Failed);
                     return new CreditsPurchaseResult(CreditsPurchaseError.SettlementPending, message: relay.Message);
                 case RelayOutcome.RelayerRejected:
-                    ReportHub.LogWarning(ReportCategory.CREDITS_PURCHASE, $"Relayer refused trade {quote.Trade.id}: {relay.Message}");
+                    ReportHub.LogWarning(ReportCategory.CREDITS_PURCHASE, $"Relayer refused {QuoteLabel(quote)}: {relay.Message}");
                     await ReleaseIntentAsync(authorization.credit.id);
                     return Fail(CreditsPurchaseError.RelayerUnavailable, message: relay.Message);
             }
@@ -297,6 +406,12 @@ namespace DCL.MarketplaceCredits.Purchase
                     return new CreditsPurchaseResult(CreditsPurchaseError.SettlementPending, txHash);
             }
         }
+
+        /// <summary>What the logs should call this purchase — a mint has no trade id to name.</summary>
+        private static string QuoteLabel(in CreditsPurchaseQuote quote) =>
+            quote.Kind == CreditsListingKind.StoreMint
+                ? $"mint {quote.Mint.CollectionAddress}-{quote.Mint.ItemId}"
+                : $"trade {quote.Trade!.id}";
 
         private async UniTask ReleaseIntentAsync(string creditId)
         {

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/CreditsPurchaseTypes.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/CreditsPurchaseTypes.cs
@@ -32,22 +32,95 @@ namespace DCL.MarketplaceCredits.Purchase
         UnknownError,
     }
 
+    /// <summary>
+    ///     How a listing is bought. NOT a display detail — it picks the external call the CreditsManager makes,
+    ///     and the two are mutually exclusive: an offchain trade has a signed order to accept, a CollectionStore
+    ///     mint has nothing signed at all and is minted straight from the store contract.
+    /// </summary>
+    public enum CreditsListingKind
+    {
+        Trade,
+        StoreMint,
+    }
+
+    /// <summary>
+    ///     A CollectionStore mint: the primary-sale path for items that were never listed as a trade, so there is
+    ///     no tradeId, no orderId, and nothing to fetch from /v1/trades.
+    /// </summary>
+    public readonly struct StoreMintTarget
+    {
+        public readonly string CollectionAddress;
+        public readonly string ItemId;
+
+        /// <summary>
+        ///     MANA wei, as the contract will verify it. Re-read as late as possible: CollectionStore.buy takes
+        ///     the price as an argument and re-validates it against the item's live price, so a stale value is a
+        ///     revert rather than a wrong number.
+        /// </summary>
+        public readonly string PriceWei;
+
+        public StoreMintTarget(string collectionAddress, string itemId, string priceWei)
+        {
+            CollectionAddress = collectionAddress;
+            ItemId = itemId;
+            PriceWei = priceWei;
+        }
+    }
+
     public readonly struct CreditsPurchaseQuote
     {
-        public readonly TradeDto Trade;
+        public readonly CreditsListingKind Kind;
+
+        /// <summary>Null for a mint — see <see cref="CreditsListingKind" />.</summary>
+        public readonly TradeDto? Trade;
+
+        /// <summary>Meaningful only when <see cref="Kind" /> is <see cref="CreditsListingKind.StoreMint" />.</summary>
+        public readonly StoreMintTarget Mint;
+
         public readonly int UsdCents;
         public readonly int Credits;
         public readonly BigInteger RequiredManaWei;
         public readonly bool IsLiveRatePrice;
 
-        public CreditsPurchaseQuote(TradeDto trade, int usdCents, int credits, BigInteger requiredManaWei, bool isLiveRatePrice)
+        /// <summary>
+        ///     What the credit intent records, so the purchase history can name the item. A mint has no trade, so
+        ///     it is identified by the pair instead — the server takes either, and signs neither.
+        /// </summary>
+        // Null-tolerant: a default(CreditsPurchaseQuote) reads as a Trade with no trade, and this must not throw
+        // on the way to reporting the failure.
+        public string TradeId => Kind == CreditsListingKind.Trade ? Trade?.id ?? string.Empty : string.Empty;
+
+        public string ContractAddress => Kind == CreditsListingKind.StoreMint ? Mint.CollectionAddress : string.Empty;
+
+        public string ItemId => Kind == CreditsListingKind.StoreMint ? Mint.ItemId : string.Empty;
+
+        private CreditsPurchaseQuote(
+            CreditsListingKind kind,
+            TradeDto? trade,
+            StoreMintTarget mint,
+            int usdCents,
+            int credits,
+            BigInteger requiredManaWei,
+            bool isLiveRatePrice)
         {
+            Kind = kind;
             Trade = trade;
+            Mint = mint;
             UsdCents = usdCents;
             Credits = credits;
             RequiredManaWei = requiredManaWei;
             IsLiveRatePrice = isLiveRatePrice;
         }
+
+        public static CreditsPurchaseQuote ForTrade(TradeDto trade, int usdCents, int credits, BigInteger requiredManaWei, bool isLiveRatePrice) =>
+            new (CreditsListingKind.Trade, trade, default(StoreMintTarget), usdCents, credits, requiredManaWei, isLiveRatePrice);
+
+        /// <summary>
+        ///     A mint is always MANA-denominated, so its MANA is known up front (isLiveRatePrice: true) and its
+        ///     credit price exists only through the oracle — exactly like a legacy MANA trade.
+        /// </summary>
+        public static CreditsPurchaseQuote ForMint(StoreMintTarget mint, int usdCents, int credits, BigInteger requiredManaWei) =>
+            new (CreditsListingKind.StoreMint, null, mint, usdCents, credits, requiredManaWei, true);
     }
 
     public readonly struct CreditsQuoteResult

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Encoding/CreditsTradeEncoder.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Encoding/CreditsTradeEncoder.cs
@@ -11,8 +11,9 @@ namespace DCL.MarketplaceCredits.Purchase
 {
     /// <summary>
     ///     NOTE: AI generated based on the shop repo trade-encoding
-    ///     On-chain encoding for CreditsManager.useCredits(accept([trade])) and its gasless meta-transaction
-    ///     wrapper. Port of the shop web app's single source of truth for these bytes
+    ///     On-chain encoding for CreditsManager.useCredits(...) and its gasless meta-transaction wrapper,
+    ///     for BOTH rails: an offchain trade (accept([trade])) and a CollectionStore mint (buy([item])).
+    ///     Port of the shop web app's single source of truth for these bytes
     ///     (Server/shop/app/src/lib/trade-encoding.ts and buy-gasless.ts) — every normalization here fixed a
     ///     real on-chain failure there, so keep them byte-identical (guarded by golden-vector tests).
     /// </summary>
@@ -57,6 +58,15 @@ namespace DCL.MarketplaceCredits.Purchase
                 {""name"":""beneficiary"",""type"":""address""},
                 {""name"":""extra"",""type"":""bytes""}]}]}]}]";
 
+        // CollectionStore.buy's argument: ItemToBuy[] — one call mints many items across many collections, which
+        // is what lets a whole cart of mints settle in a single transaction. Mirrors the shop's
+        // ITEM_TO_BUY_TUPLE_ARRAY (Server/shop/app/src/lib/trade-encoding.ts).
+        private const string STORE_BUY_ABI = @"[{""name"":""buy"",""type"":""function"",""outputs"":[],""inputs"":[{""name"":""_itemsToBuy"",""type"":""tuple[]"",""components"":[
+            {""name"":""collection"",""type"":""address""},
+            {""name"":""ids"",""type"":""uint256[]""},
+            {""name"":""prices"",""type"":""uint256[]""},
+            {""name"":""beneficiaries"",""type"":""address[]""}]}]}]";
+
         private const string USE_CREDITS_ABI = @"[{""name"":""useCredits"",""type"":""function"",""outputs"":[],""inputs"":[{""name"":""_args"",""type"":""tuple"",""components"":[
             {""name"":""credits"",""type"":""tuple[]"",""components"":[
                 {""name"":""value"",""type"":""uint256""},
@@ -82,6 +92,7 @@ namespace DCL.MarketplaceCredits.Purchase
             {""name"":""_signer"",""type"":""address""}]}]";
 
         private static readonly FunctionABI ACCEPT_FUNCTION = DeserialiseFunction(ACCEPT_ABI);
+        private static readonly FunctionABI STORE_BUY_FUNCTION = DeserialiseFunction(STORE_BUY_ABI);
         private static readonly FunctionABI USE_CREDITS_FUNCTION = DeserialiseFunction(USE_CREDITS_ABI);
         private static readonly FunctionABI EXECUTE_META_TX_FUNCTION = DeserialiseFunction(EXECUTE_META_TX_ABI);
         private static readonly FunctionABI GET_NONCE_FUNCTION = DeserialiseFunction(GET_NONCE_ABI);
@@ -102,6 +113,36 @@ namespace DCL.MarketplaceCredits.Purchase
         }
 
         /// <summary>
+        ///     buy([item]) split into the (selector, data) pair consumed by the useCredits externalCall struct —
+        ///     the CollectionStore counterpart of <see cref="BuildAcceptCall" />.
+        ///     <para>
+        ///         The buyer is named EXPLICITLY as the beneficiary, which is what makes a mint relayable at all:
+        ///         the store never sees the buyer as msg.sender on either rail (the CreditsManager is the caller),
+        ///         so wrapping this in a meta-transaction changes only who transmits and who pays the gas.
+        ///     </para>
+        ///     <para>
+        ///         `priceWei` must be the LIVE on-chain price. CollectionStore.buy takes the prices as an argument
+        ///         and re-validates them against the item's current price, reverting if the creator moved it. A
+        ///         trade cannot fail this way — its price is signed into the order — so this is the one purchase
+        ///         path where a stale quote is a revert rather than a wrong number.
+        ///     </para>
+        /// </summary>
+        public static (byte[] selector, byte[] data) BuildStoreBuyCall(string collectionAddress, string itemId, string priceWei, string buyer)
+        {
+            var itemToBuy = new object[]
+            {
+                collectionAddress,
+                new[] { BigInteger.Parse(itemId) },
+                new[] { BigInteger.Parse(priceWei) },
+                new[] { buyer },
+            };
+
+            byte[] data = PARAMETERS_ENCODER.EncodeParameters(STORE_BUY_FUNCTION.InputParameters, new object[] { new object[] { itemToBuy } });
+            byte[] selector = STORE_BUY_FUNCTION.Sha3Signature.HexToByteArray();
+            return (selector, data);
+        }
+
+        /// <summary>
         ///     Full useCredits(UseCreditsArgs) calldata spending one authorized credit on one trade.
         ///     externalCallExpiresAt (unix seconds) and externalCallSalt (32 bytes) are injected by the caller
         ///     so the encoding stays deterministic for tests.
@@ -114,8 +155,45 @@ namespace DCL.MarketplaceCredits.Purchase
             long externalCallExpiresAt,
             byte[] externalCallSalt)
         {
-            (byte[] acceptSelector, byte[] acceptData) = BuildAcceptCall(trade, buyer);
+            (byte[] selector, byte[] data) = BuildAcceptCall(trade, buyer);
+            return BuildUseCreditsCalldata(trade.contract, selector, data, credit, maxCreditedValue, externalCallExpiresAt, externalCallSalt);
+        }
 
+        /// <summary>
+        ///     Full useCredits(UseCreditsArgs) calldata spending one authorized credit on one CollectionStore
+        ///     MINT — the primary-sale path for items that were never listed as a trade, and therefore have no
+        ///     tradeId and no order to fetch.
+        /// </summary>
+        public static string BuildStoreMintUseCreditsCalldata(
+            string collectionStoreAddress,
+            string collectionAddress,
+            string itemId,
+            string priceWei,
+            string buyer,
+            AuthorizedCredit credit,
+            string maxCreditedValue,
+            long externalCallExpiresAt,
+            byte[] externalCallSalt)
+        {
+            (byte[] selector, byte[] data) = BuildStoreBuyCall(collectionAddress, itemId, priceWei, buyer);
+            return BuildUseCreditsCalldata(collectionStoreAddress, selector, data, credit, maxCreditedValue, externalCallExpiresAt, externalCallSalt);
+        }
+
+        /// <summary>
+        ///     The shared useCredits envelope: the credit, its signature, the single external call and the value
+        ///     caps. Both rails go through here so they cannot drift on the part that moves the money — the trade
+        ///     and the mint differ ONLY in the (target, selector, data) triple. Mirrors the shop's
+        ///     `wrapInUseCredits`.
+        /// </summary>
+        private static string BuildUseCreditsCalldata(
+            string externalCallTarget,
+            byte[] externalCallSelector,
+            byte[] externalCallData,
+            AuthorizedCredit credit,
+            string maxCreditedValue,
+            long externalCallExpiresAt,
+            byte[] externalCallSalt)
+        {
             BigInteger maxCredited = BigInteger.Parse(maxCreditedValue);
             BigInteger uncredited = UncreditedValue(maxCreditedValue, credit.availableAmount);
 
@@ -128,7 +206,7 @@ namespace DCL.MarketplaceCredits.Purchase
             {
                 creditsTree,
                 new[] { credit.signature.HexToByteArray() },
-                new object[] { trade.contract, acceptSelector, acceptData, new BigInteger(externalCallExpiresAt), externalCallSalt },
+                new object[] { externalCallTarget, externalCallSelector, externalCallData, new BigInteger(externalCallExpiresAt), externalCallSalt },
                 Array.Empty<byte>(),
                 uncredited,
                 maxCredited,

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/ICreditsPurchaseService.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/ICreditsPurchaseService.cs
@@ -8,7 +8,7 @@ namespace DCL.MarketplaceCredits.Purchase
     {
         event Action<CreditsPurchaseState>? StateChanged;
 
-        UniTask<CreditsQuoteResult> QuoteAsync(string tradeId, CancellationToken ct);
+        UniTask<CreditsQuoteResult> QuoteAsync(ShopListingDto listing, CancellationToken ct);
 
         UniTask<CreditsPurchaseResult> PurchaseAsync(CreditsPurchaseQuote quote, CancellationToken ct);
     }

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsPurchaseServiceShould.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsPurchaseServiceShould.cs
@@ -1,5 +1,6 @@
 using Cysharp.Threading.Tasks;
 using DCL.FeatureFlags;
+using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Web3;
 using DCL.Web3.Identities;
 using NSubstitute;
@@ -21,6 +22,12 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
         private const string TRADE_ID = "trade-1";
         private const string CREDIT_ID = "intent-1";
         private const string TX_HASH = "0x1122";
+        private const string COLLECTION = "0x2222222222222222222222222222222222222222";
+        private const string MINT_ITEM_ID = "3";
+
+        // A mint priced at 5 MANA — $1.25 at the fixture rate, charged as 13 whole credits, same arithmetic as a
+        // legacy MANA trade because a mint is MANA-denominated too.
+        private const string MINT_MANA_WEI = "5000000000000000000";
 
         // $0.25 per MANA on a Chainlink-style 8-decimal feed.
         private const int ORACLE_DECIMALS = 8;
@@ -42,6 +49,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
         private CreditsManagerMetaTxRelayer metaTxRelayer = null!;
         private PolygonSettlementPoller settlementPoller = null!;
         private ManaUsdRateReader manaUsdRateReader = null!;
+        private CreditsChainConfig chainConfig = null!;
         private IWeb3IdentityCache identityCache = null!;
         private CreditsFeatureAccess creditsFeatureAccess = null!;
         private CancellationTokenSource warmUpCts = null!;
@@ -56,6 +64,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             metaTxRelayer = Substitute.For<CreditsManagerMetaTxRelayer>(null, null, null, null);
             settlementPoller = Substitute.For<PolygonSettlementPoller>(null, null);
             manaUsdRateReader = Substitute.For<ManaUsdRateReader>(null, null);
+            chainConfig = new CreditsChainConfig(DecentralandEnvironment.Zone);
             identityCache = Substitute.For<IWeb3IdentityCache>();
 
             IWeb3Identity identity = Substitute.For<IWeb3Identity>();
@@ -68,7 +77,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             manaUsdRateReader.ReadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
                              .Returns(UniTask.FromResult(new ManaUsdRate(MANA_USD_RATE, ORACLE_DECIMALS)));
 
-            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                             .Returns(UniTask.FromResult(CreateAuthorization()));
 
             metaTxRelayer.RelayUseCreditsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -100,7 +109,38 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
         }
 
         private CreditsPurchaseService CreateService(bool isFeatureEnabled, CreditsFeatureAccess? featureAccess = null) =>
-            new (shopAPIClient, creditsAPIClient, metaTxRelayer, settlementPoller, manaUsdRateReader, identityCache, featureAccess ?? creditsFeatureAccess, isFeatureEnabled);
+            new (shopAPIClient, creditsAPIClient, metaTxRelayer, settlementPoller, manaUsdRateReader, chainConfig, identityCache,
+                featureAccess ?? creditsFeatureAccess, isFeatureEnabled);
+
+        /// <summary>The listing row a trade is quoted from — the quote resolves the trade through its id.</summary>
+        private static ShopListingDto TradeListing() =>
+            new ()
+            {
+                tradeId = TRADE_ID,
+                acquisition = "trade",
+                listingType = "primary",
+                source = "native",
+                contractAddress = COLLECTION,
+                itemId = MINT_ITEM_ID,
+                available = 5,
+            };
+
+        /// <summary>
+        ///     A CollectionStore mint: no tradeId, no order, priced in MANA, with stock. Everything the quote
+        ///     needs is here, which is the point — there is nothing to fetch.
+        /// </summary>
+        private static ShopListingDto MintListing(int available = 8, string? manaWei = MINT_MANA_WEI) =>
+            new ()
+            {
+                tradeId = null!,
+                acquisition = "store",
+                listingType = "primary",
+                source = "legacy",
+                contractAddress = COLLECTION,
+                itemId = MINT_ITEM_ID,
+                manaWei = manaWei,
+                available = available,
+            };
 
         private static TradeDto CreateTrade() =>
             new ()
@@ -180,7 +220,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
 
         private async UniTask<CreditsPurchaseResult> QuoteAndPurchaseAsync()
         {
-            CreditsQuoteResult quote = await service.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult quote = await service.QuoteAsync(TradeListing(), CancellationToken.None);
             Assert.IsTrue(quote.Success, $"Quote failed with {quote.Error}: {quote.Message}");
             return await service.PurchaseAsync(quote.Quote, CancellationToken.None);
         }
@@ -209,7 +249,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
                              .Returns<UniTask<ManaUsdRate>>(_ => throw new InvalidOperationException("stale"));
 
             // Act
-            CreditsQuoteResult result = await service.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult result = await service.QuoteAsync(TradeListing(), CancellationToken.None);
 
             // Assert: the settlement wei is left for purchase time, and only the cache warm-up touches the reader.
             Assert.IsTrue(result.Success);
@@ -227,11 +267,11 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             // Arrange
             shopAPIClient.GetTradeAsync(TRADE_ID, Arg.Any<CancellationToken>()).Returns(UniTask.FromResult<TradeDto?>(CreateLegacyManaTrade()));
 
-            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                             .Returns(UniTask.FromResult(CreateAuthorization(LEGACY_PRICE_CENTS)));
 
             // Act
-            CreditsQuoteResult quote = await service.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult quote = await service.QuoteAsync(TradeListing(), CancellationToken.None);
             CreditsPurchaseResult result = await service.PurchaseAsync(quote.Quote, CancellationToken.None);
 
             // Assert: the MANA price is converted at the rate settlement uses, then rounded up to a whole credit.
@@ -241,7 +281,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             Assert.AreEqual(BigInteger.Parse(LEGACY_MANA_WEI), quote.Quote.RequiredManaWei);
             Assert.IsTrue(quote.Quote.IsLiveRatePrice);
             Assert.IsTrue(result.Success);
-            await creditsAPIClient.Received(1).AuthorizeUsdCreditAsync(LEGACY_PRICE_CENTS, TRADE_ID, Arg.Any<CancellationToken>());
+            await creditsAPIClient.Received(1).AuthorizeUsdCreditAsync(LEGACY_PRICE_CENTS, TRADE_ID, string.Empty, string.Empty, Arg.Any<CancellationToken>());
         }
 
         [Test]
@@ -254,18 +294,18 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
                              .Returns(UniTask.FromException<ManaUsdRate>(new InvalidOperationException("stale")));
 
             // Act
-            CreditsQuoteResult result = await service.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult result = await service.QuoteAsync(TradeListing(), CancellationToken.None);
 
             // Assert
             Assert.AreEqual(CreditsPurchaseError.PriceUnavailable, result.Error);
-            await creditsAPIClient.DidNotReceive().AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            await creditsAPIClient.DidNotReceive().AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
         }
 
         [Test]
         public async Task RejectPurchaseWithoutChargingWhenTheRateIsUnavailableAtConfirm()
         {
             // Arrange: the USD-pegged quote succeeds, then the oracle dies before the confirm click.
-            CreditsQuoteResult quote = await service.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult quote = await service.QuoteAsync(TradeListing(), CancellationToken.None);
             Assert.IsTrue(quote.Success);
 
             manaUsdRateReader.ReadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -276,7 +316,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
 
             // Assert: the rate failed before any credit intent existed, so there is nothing to release.
             Assert.AreEqual(CreditsPurchaseError.PriceUnavailable, result.Error);
-            await creditsAPIClient.DidNotReceive().AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            await creditsAPIClient.DidNotReceive().AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
             await creditsAPIClient.DidNotReceive().ReleaseUsdIntentsAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
         }
 
@@ -285,7 +325,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
         {
             // Arrange: MANA halves between authorization sizing and the purchase-time read, so the trade draws
             // 20 MANA against a cap sized for ~10.
-            CreditsQuoteResult quote = await service.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult quote = await service.QuoteAsync(TradeListing(), CancellationToken.None);
             Assert.IsTrue(quote.Success);
 
             manaUsdRateReader.ReadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -307,7 +347,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             CreditsPurchaseService disabledService = CreateService(isFeatureEnabled: false);
 
             // Act
-            CreditsQuoteResult result = await disabledService.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult result = await disabledService.QuoteAsync(TradeListing(), CancellationToken.None);
 
             // Assert
             Assert.AreEqual(CreditsPurchaseError.FeatureDisabled, result.Error);
@@ -334,7 +374,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             CreditsPurchaseService restrictedService = CreateService(isFeatureEnabled: true, new CreditsFeatureAccess(identityCache, warmUpCts.Token));
 
             // Act
-            CreditsQuoteResult result = await restrictedService.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult result = await restrictedService.QuoteAsync(TradeListing(), CancellationToken.None);
 
             // Assert
             Assert.AreEqual(CreditsPurchaseError.FeatureDisabled, result.Error);
@@ -350,11 +390,11 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             shopAPIClient.GetTradeAsync(TRADE_ID, Arg.Any<CancellationToken>()).Returns(UniTask.FromResult<TradeDto?>(trade));
 
             // Act
-            CreditsQuoteResult result = await service.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult result = await service.QuoteAsync(TradeListing(), CancellationToken.None);
 
             // Assert
             Assert.AreEqual(CreditsPurchaseError.OwnListing, result.Error);
-            await creditsAPIClient.DidNotReceive().AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            await creditsAPIClient.DidNotReceive().AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
         }
 
         [Test]
@@ -367,11 +407,11 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             shopAPIClient.GetTradeAsync(TRADE_ID, Arg.Any<CancellationToken>()).Returns(UniTask.FromResult<TradeDto?>(trade));
 
             // Act
-            CreditsQuoteResult result = await service.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult result = await service.QuoteAsync(TradeListing(), CancellationToken.None);
 
             // Assert
             Assert.AreEqual(CreditsPurchaseError.ListingNotAvailable, result.Error);
-            await creditsAPIClient.DidNotReceive().AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            await creditsAPIClient.DidNotReceive().AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
         }
 
         [Test]
@@ -380,11 +420,11 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             // Arrange
             LogAssert.Expect(LogType.Exception, "Exception: boom");
 
-            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                             .Returns(UniTask.FromException<AuthorizeCreditResponse>(new Exception("boom")));
 
             // Act
-            CreditsQuoteResult quote = await service.QuoteAsync(TRADE_ID, CancellationToken.None);
+            CreditsQuoteResult quote = await service.QuoteAsync(TradeListing(), CancellationToken.None);
             CreditsPurchaseResult result = await service.PurchaseAsync(quote.Quote, CancellationToken.None);
 
             // Assert
@@ -396,7 +436,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
         public async Task ReleaseReservationWhenAuthorizationPricesAboveTheConfirmedAmount()
         {
             // Arrange
-            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                             .Returns(UniTask.FromResult(CreateAuthorization(NATIVE_PRICE_CENTS + 50)));
 
             // Act
@@ -412,7 +452,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
         public async Task CompletePurchaseWhenAuthorizationPricesBelowTheConfirmedAmount()
         {
             // Arrange: a cheaper charge whose cap still covers the trade — the server read a rate kinder than ours.
-            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                             .Returns(UniTask.FromResult(CreateAuthorization(NATIVE_PRICE_CENTS - 50, manaCapWei: "10200000000000000000")));
 
             // Act
@@ -430,7 +470,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             // listing authorized off a stale catalogue price, which reverts on-chain if it is ever submitted.
             shopAPIClient.GetTradeAsync(TRADE_ID, Arg.Any<CancellationToken>()).Returns(UniTask.FromResult<TradeDto?>(CreateLegacyManaTrade()));
 
-            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            creditsAPIClient.AuthorizeUsdCreditAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                             .Returns(UniTask.FromResult(CreateAuthorization(10)));
 
             // Act
@@ -519,6 +559,169 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             Assert.AreEqual(CreditsPurchaseError.SettlementPending, result.Error);
             await creditsAPIClient.DidNotReceive().ReleaseUsdIntentsAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
             await settlementPoller.DidNotReceive().WaitForSettlementAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        }
+
+        /// <summary>
+        ///     BUYING A COLLECTIONSTORE MINT.
+        ///
+        ///     A mint has no trade and no order: nothing was ever signed or listed, and the item is minted straight
+        ///     from the store contract. Measured in production — the mint at 0xf90645e2…6213 could not be bought at
+        ///     all while the trade at 0x58628c49…a212 went through for the same buyer in the same session, because
+        ///     the whole quote was derived from a trade that does not exist for a mint.
+        /// </summary>
+        [Test]
+        public async Task QuoteAMintWithoutFetchingATrade()
+        {
+            // Act
+            CreditsQuoteResult quote = await service.QuoteAsync(MintListing(), CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(quote.Success, $"Quote failed with {quote.Error}: {quote.Message}");
+            Assert.AreEqual(CreditsListingKind.StoreMint, quote.Quote.Kind);
+            Assert.AreEqual(LEGACY_PRICE_CENTS, quote.Quote.UsdCents); // MANA-priced, so the oracle decides
+            Assert.AreEqual(LEGACY_PRICE_CREDITS, quote.Quote.Credits);
+            Assert.AreEqual(BigInteger.Parse(MINT_MANA_WEI), quote.Quote.RequiredManaWei);
+            Assert.AreEqual(COLLECTION, quote.Quote.Mint.CollectionAddress);
+            Assert.AreEqual(MINT_ITEM_ID, quote.Quote.Mint.ItemId);
+
+            // The point: /v1/trades was never called, because there is nothing there to call it with.
+            await shopAPIClient.DidNotReceive().GetTradeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+
+        [Test]
+        public async Task RefuseASoldOutMintOnStockRatherThanOnAMissingTrade()
+        {
+            // Act
+            CreditsQuoteResult quote = await service.QuoteAsync(MintListing(available: 0), CancellationToken.None);
+
+            // Assert — carried to an on-chain revert otherwise.
+            Assert.AreEqual(CreditsPurchaseError.ListingNotAvailable, quote.Error);
+        }
+
+        [Test]
+        public async Task RefuseAMintWithNoPrice()
+        {
+            // Act
+            CreditsQuoteResult quote = await service.QuoteAsync(MintListing(manaWei: null), CancellationToken.None);
+
+            // Assert
+            Assert.AreEqual(CreditsPurchaseError.ListingNotAvailable, quote.Error);
+        }
+
+        /// <summary>
+        ///     A missing `acquisition` is an OLDER SERVER, and back then every row was a trade. Reading the absence
+        ///     as "mint" would route a trade down the store rail and revert.
+        /// </summary>
+        [Test]
+        public async Task TreatAnAbsentAcquisitionAsATrade()
+        {
+            // Arrange
+            ShopListingDto listing = TradeListing();
+            listing.acquisition = null;
+
+            // Act
+            CreditsQuoteResult quote = await service.QuoteAsync(listing, CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(quote.Success, $"Quote failed with {quote.Error}: {quote.Message}");
+            Assert.AreEqual(CreditsListingKind.Trade, quote.Quote.Kind);
+            await shopAPIClient.Received(1).GetTradeAsync(TRADE_ID, Arg.Any<CancellationToken>());
+        }
+
+        /// <summary>
+        ///     The mint's price is an ARGUMENT to CollectionStore.buy and the contract re-validates it against the
+        ///     item's live price, so it is re-read immediately before encoding. A trade cannot fail this way — its
+        ///     price is signed into the order.
+        /// </summary>
+        [Test]
+        public async Task RereadTheMintPriceBeforeBuying()
+        {
+            // Arrange
+            shopAPIClient.GetShopListingForItemAsync(COLLECTION, MINT_ITEM_ID, Arg.Any<CancellationToken>())
+                         .Returns(UniTask.FromResult<ShopListingDto?>(MintListing()));
+
+            CreditsQuoteResult quote = await service.QuoteAsync(MintListing(), CancellationToken.None);
+
+            // Act
+            CreditsPurchaseResult result = await service.PurchaseAsync(quote.Quote, CancellationToken.None);
+
+            // Assert
+            Assert.AreEqual(CreditsPurchaseError.None, result.Error);
+            await shopAPIClient.Received(1).GetShopListingForItemAsync(COLLECTION, MINT_ITEM_ID, Arg.Any<CancellationToken>());
+        }
+
+        [Test]
+        public async Task RefuseAMintWhosePriceWentUpBeforeBuying()
+        {
+            // Arrange — the creator raised it between the quote and the click.
+            CreditsQuoteResult quote = await service.QuoteAsync(MintListing(), CancellationToken.None);
+
+            shopAPIClient.GetShopListingForItemAsync(COLLECTION, MINT_ITEM_ID, Arg.Any<CancellationToken>())
+                         .Returns(UniTask.FromResult<ShopListingDto?>(MintListing(manaWei: "9000000000000000000")));
+
+            // Act
+            CreditsPurchaseResult result = await service.PurchaseAsync(quote.Quote, CancellationToken.None);
+
+            // Assert — never charged silently at the new price.
+            Assert.AreEqual(CreditsPurchaseError.PriceChanged, result.Error);
+            await metaTxRelayer.DidNotReceive().RelayUseCreditsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+
+        [Test]
+        public async Task RefuseAMintThatSoldOutBetweenTheQuoteAndTheClick()
+        {
+            // Arrange
+            CreditsQuoteResult quote = await service.QuoteAsync(MintListing(), CancellationToken.None);
+
+            shopAPIClient.GetShopListingForItemAsync(COLLECTION, MINT_ITEM_ID, Arg.Any<CancellationToken>())
+                         .Returns(UniTask.FromResult<ShopListingDto?>(MintListing(available: 0)));
+
+            // Act
+            CreditsPurchaseResult result = await service.PurchaseAsync(quote.Quote, CancellationToken.None);
+
+            // Assert
+            Assert.AreEqual(CreditsPurchaseError.ListingNotAvailable, result.Error);
+            await metaTxRelayer.DidNotReceive().RelayUseCreditsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+
+        /// <summary>
+        ///     A mint is identified to the credits-server by WHAT it is, since it has no trade. Neither identifier
+        ///     is part of what the server signs — it signs a voucher for an amount — but without the pair the
+        ///     buyer's purchase history has no way to name the item.
+        /// </summary>
+        [Test]
+        public async Task AuthorizeAMintByItsItemRatherThanByATradeId()
+        {
+            // Arrange
+            shopAPIClient.GetShopListingForItemAsync(COLLECTION, MINT_ITEM_ID, Arg.Any<CancellationToken>())
+                         .Returns(UniTask.FromResult<ShopListingDto?>(MintListing()));
+
+            CreditsQuoteResult quote = await service.QuoteAsync(MintListing(), CancellationToken.None);
+
+            // Act
+            await service.PurchaseAsync(quote.Quote, CancellationToken.None);
+
+            // Assert
+            await creditsAPIClient.Received(1).AuthorizeUsdCreditAsync(
+                LEGACY_PRICE_CENTS, string.Empty, COLLECTION, MINT_ITEM_ID, Arg.Any<CancellationToken>());
+        }
+
+        [Test]
+        public async Task RelayTheMintSoABuyerWithNoPolCanStillBuyIt()
+        {
+            // Arrange
+            shopAPIClient.GetShopListingForItemAsync(COLLECTION, MINT_ITEM_ID, Arg.Any<CancellationToken>())
+                         .Returns(UniTask.FromResult<ShopListingDto?>(MintListing()));
+
+            CreditsQuoteResult quote = await service.QuoteAsync(MintListing(), CancellationToken.None);
+
+            // Act
+            CreditsPurchaseResult result = await service.PurchaseAsync(quote.Quote, CancellationToken.None);
+
+            // Assert — the same gasless rail a trade takes: the buyer signs, the relayer pays.
+            Assert.AreEqual(CreditsPurchaseError.None, result.Error);
+            Assert.AreEqual(TX_HASH, result.TxHash);
+            await metaTxRelayer.Received(1).RelayUseCreditsAsync(BUYER, Arg.Any<string>(), Arg.Any<CancellationToken>());
         }
     }
 }

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsTradeEncoderShould.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsTradeEncoderShould.cs
@@ -19,6 +19,48 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
 
         private const string EXPECTED_ACCEPT_SELECTOR = "0x961a547e";
 
+        // The CollectionStore rail. Generated from the same reference implementation, against the REAL
+        // CollectionStore ABI shipped in decentraland-transactions — never a hand-written signature, which is how
+        // a wrong selector gets shipped. Fixture: collection 0x2222…2222, item 3, 20 MANA, the buyer below.
+        private const string EXPECTED_STORE_BUY_SELECTOR = "0xa4fdc78a";
+        private const string EXPECTED_COLLECTION = "0x2222222222222222222222222222222222222222";
+        private const string EXPECTED_STORE_ADDRESS = "0x214ffc0f0103735728dc66b61a22e4f163e275ae";
+        private const string MINT_ITEM_ID = "3";
+        private const string MINT_PRICE_WEI = "20000000000000000000";
+
+        private const string EXPECTED_STORE_BUY_DATA =
+            "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000" +
+            "0000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000022222222222222222222" +
+            "2222222222222222222200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000" +
+            "0000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000100000000000000000000000000" +
+            "0000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000300000000000000" +
+            "00000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000001158e460913d000000000" +
+            "00000000000000000000000000000000000000000000000000000000000100000000000000000000000099995f38fc9d786eab5c3a1b1c4e6ae5f4" +
+            "e99999";
+
+        private const string EXPECTED_STORE_USE_CREDITS =
+            "0x1863572d00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000" +
+            "0000000000000000c00000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000" +
+            "0000000000000000000000000200000000000000000000000000000000000000000000000000000000000000046000000000000000000000000000" +
+            "00000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000006124fee993bc00000000000000000000" +
+            "00000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000053444835ec580000000000" +
+            "000000000000000000000000000000000000000000000000006955b900696e74656e742d6162632d31323300000000000000000000000000000000" +
+            "0000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000" +
+            "000000000000200000000000000000000000000000000000000000000000000000000000000041bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0000000000000000000000000000" +
+            "0000000000000000000000000000000000000000000000000000000000214ffc0f0103735728dc66b61a22e4f163e275aea4fdc78a000000000000" +
+            "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000" +
+            "00000000000000000000000000000000000000000000006b49d200cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd" +
+            "00000000000000000000000000000000000000000000000000000000000001a0000000000000000000000000000000000000000000000000000000" +
+            "0000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000" +
+            "0000000000000000002000000000000000000000000022222222222222222222222222222222222222220000000000000000000000000000000000" +
+            "00000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000" +
+            "0000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000100000000000000" +
+            "0000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000010000" +
+            "00000000000000000000000000000000000000000001158e460913d000000000000000000000000000000000000000000000000000000000000000" +
+            "00000100000000000000000000000099995f38fc9d786eab5c3a1b1c4e6ae5f4e99999000000000000000000000000000000000000000000000000" +
+            "0000000000000000";
+
         private const string EXPECTED_ACCEPT_DATA =
             "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000" +
             "0000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000024e5f44999c151f08609f8" +
@@ -221,6 +263,72 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
 
             // Assert
             Assert.AreEqual(EXPECTED_USE_CREDITS, calldata);
+        }
+
+        /// <summary>
+        ///     A CollectionStore MINT is bought with the same envelope as a trade — only the external call
+        ///     differs. There is no trade and no order to fetch: nothing was ever signed or listed, so the item is
+        ///     minted straight from the store contract.
+        /// </summary>
+        [Test]
+        public void EncodeStoreBuyCallMatchingReferenceImplementation()
+        {
+            // Act
+            (byte[] selector, byte[] data) = CreditsTradeEncoder.BuildStoreBuyCall(EXPECTED_COLLECTION, MINT_ITEM_ID, MINT_PRICE_WEI, BUYER);
+
+            // Assert
+            Assert.AreEqual(EXPECTED_STORE_BUY_SELECTOR, ToHex(selector));
+            Assert.AreEqual(EXPECTED_STORE_BUY_DATA, ToHex(data));
+        }
+
+        [Test]
+        public void EncodeStoreMintUseCreditsCalldataMatchingReferenceImplementation()
+        {
+            // Act
+            string calldata = CreditsTradeEncoder.BuildStoreMintUseCreditsCalldata(
+                EXPECTED_STORE_ADDRESS, EXPECTED_COLLECTION, MINT_ITEM_ID, MINT_PRICE_WEI,
+                BUYER, CreateCreditFixture(), MAX_CREDITED, EXTERNAL_CALL_EXPIRES_AT, CreateExternalCallSalt());
+
+            // Assert
+            Assert.AreEqual(EXPECTED_STORE_USE_CREDITS, calldata);
+        }
+
+        /// <summary>
+        ///     The buyer must be named as the beneficiary in the calldata itself. The store never sees them as
+        ///     msg.sender on either rail — the CreditsManager is the caller — so if the beneficiary came from the
+        ///     sender the relayed mint would send the item to the relayer.
+        /// </summary>
+        [Test]
+        public void NameTheBuyerAsTheMintBeneficiary()
+        {
+            // Act
+            (byte[] _, byte[] data) = CreditsTradeEncoder.BuildStoreBuyCall(EXPECTED_COLLECTION, MINT_ITEM_ID, MINT_PRICE_WEI, BUYER);
+
+            // Assert
+            StringAssert.Contains(BUYER.Substring(2).ToLowerInvariant(), ToHex(data));
+        }
+
+        /// <summary>
+        ///     The two rails share the envelope and differ only in the external call, so the mint's calldata must
+        ///     point at the STORE while the trade's points at the marketplace. Getting this backwards would send
+        ///     an accept() to the store (or a buy() to the marketplace) and revert.
+        /// </summary>
+        [Test]
+        public void TargetTheStoreForAMintAndTheMarketplaceForATrade()
+        {
+            // Act
+            string mint = CreditsTradeEncoder.BuildStoreMintUseCreditsCalldata(
+                EXPECTED_STORE_ADDRESS, EXPECTED_COLLECTION, MINT_ITEM_ID, MINT_PRICE_WEI,
+                BUYER, CreateCreditFixture(), MAX_CREDITED, EXTERNAL_CALL_EXPIRES_AT, CreateExternalCallSalt());
+
+            string trade = CreditsTradeEncoder.BuildUseCreditsCalldata(
+                CreateTradeFixture(), BUYER, CreateCreditFixture(), MAX_CREDITED, EXTERNAL_CALL_EXPIRES_AT, CreateExternalCallSalt());
+
+            // Assert
+            StringAssert.Contains(EXPECTED_STORE_ADDRESS.Substring(2), mint);
+            StringAssert.Contains(EXPECTED_STORE_BUY_SELECTOR.Substring(2), mint);
+            StringAssert.DoesNotContain(EXPECTED_STORE_BUY_SELECTOR.Substring(2), trade);
+            StringAssert.Contains(EXPECTED_ACCEPT_SELECTOR.Substring(2), trade);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/MarketplaceCreditsAPIClientCheckoutShould.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/MarketplaceCreditsAPIClientCheckoutShould.cs
@@ -59,5 +59,66 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
                 LogAssert.ignoreFailingMessages = false;
             }
         }
+
+        /// <summary>
+        ///     THE AUTHORIZE BODY CARRIES ONLY THE KEYS THAT APPLY.
+        ///
+        ///     The server validates `contractAddress`/`itemId` as a pair the moment either key is PRESENT, and an
+        ///     empty string counts as present. Sending both as `""` on a trade purchase therefore fails its address
+        ///     check with a 400 — which is exactly what happened: a mint went through (its pair was real) while
+        ///     buying a trade-backed item came back
+        ///     `"contractAddress" must be a valid address when an item is given`.
+        ///
+        ///     `JsonUtility` cannot omit a field, so the shape is chosen per rail. These tests pin that no request
+        ///     ever carries an empty identifier.
+        /// </summary>
+        [Test]
+        public void SendOnlyTheTradeIdForATradePurchase()
+        {
+            // Act
+            string body = MarketplaceCreditsAPIClient.BuildAuthorizeBody(110, "558f37e9-9844-45ae-b7ea-c19bd4aa4b58", string.Empty, string.Empty);
+
+            // Assert
+            StringAssert.Contains("\"tradeId\":\"558f37e9-9844-45ae-b7ea-c19bd4aa4b58\"", body);
+            StringAssert.DoesNotContain("contractAddress", body);
+            StringAssert.DoesNotContain("itemId", body);
+        }
+
+        [Test]
+        public void SendOnlyTheItemPairForAMint()
+        {
+            // Act
+            string body = MarketplaceCreditsAPIClient.BuildAuthorizeBody(130, string.Empty, "0x2222222222222222222222222222222222222222", "3");
+
+            // Assert
+            StringAssert.Contains("\"contractAddress\":\"0x2222222222222222222222222222222222222222\"", body);
+            StringAssert.Contains("\"itemId\":\"3\"", body);
+            // A mint has no trade, so the key is absent rather than empty.
+            StringAssert.DoesNotContain("tradeId", body);
+        }
+
+        [Test]
+        public void NeverSendAnEmptyIdentifier()
+        {
+            // Act
+            string trade = MarketplaceCreditsAPIClient.BuildAuthorizeBody(110, "trade-1", null, null);
+            string mint = MarketplaceCreditsAPIClient.BuildAuthorizeBody(130, null, "0x2222222222222222222222222222222222222222", "0");
+
+            // Assert
+            StringAssert.DoesNotContain("\"\"", trade);
+            StringAssert.DoesNotContain("\"\"", mint);
+        }
+
+        /// <summary>Half a pair is not a pair: it must not be sent, because it resolves to nothing.</summary>
+        [Test]
+        public void FallBackToTheTradeShapeWhenTheItemPairIsIncomplete()
+        {
+            // Act
+            string body = MarketplaceCreditsAPIClient.BuildAuthorizeBody(110, "trade-1", "0x2222222222222222222222222222222222222222", null);
+
+            // Assert
+            StringAssert.DoesNotContain("contractAddress", body);
+            StringAssert.Contains("\"tradeId\":\"trade-1\"", body);
+        }
     }
 }

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/ShopListingDtoShould.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/ShopListingDtoShould.cs
@@ -31,6 +31,24 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
                     ""chainId"": 80002
                 },
                 {
+                    ""tradeId"": null,
+                    ""acquisition"": ""store"",
+                    ""listingType"": ""primary"",
+                    ""source"": ""legacy"",
+                    ""contractAddress"": ""0x7777777777777777777777777777777777777777"",
+                    ""itemId"": ""0"",
+                    ""name"": ""Pixie Emote"",
+                    ""thumbnail"": ""https://peer.decentraland.zone/emote.png"",
+                    ""rarity"": ""legendary"",
+                    ""category"": ""emote"",
+                    ""creator"": ""0x8888888888888888888888888888888888888888"",
+                    ""priceCredits"": 14,
+                    ""manaWei"": ""20000000000000000000"",
+                    ""available"": 8,
+                    ""network"": ""MATIC"",
+                    ""chainId"": 137
+                },
+                {
                     ""tradeId"": ""trade-legacy"",
                     ""listingType"": ""primary"",
                     ""source"": ""legacy"",
@@ -60,7 +78,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             // Assert
             Assert.IsNotNull(response.data);
             ShopListingDto[] data = response.data!;
-            Assert.AreEqual(2, data.Length);
+            Assert.AreEqual(3, data.Length);
             Assert.AreEqual(58, response.total);
 
             ShopListingDto native = data[0];
@@ -69,13 +87,45 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             Assert.AreEqual("trade-native", native.tradeId);
             Assert.AreEqual(25, native.priceCredits);
 
-            ShopListingDto legacy = data[1];
+            ShopListingDto legacy = data[2];
             Assert.AreEqual("legacy", legacy.source);
             Assert.AreEqual("1000000000000000000", legacy.manaWei);
             Assert.AreEqual("trade-legacy", legacy.tradeId);
 
             // The server rounds a sub-credit legacy price up to 1; nothing here recomputes it.
             Assert.AreEqual(1, legacy.priceCredits);
+        }
+
+        /// <summary>
+        ///     The row for a CollectionStore MINT. `acquisition` is the server's own discriminator and the only
+        ///     thing that can tell this apart from a trade — a null tradeId cannot, and reading it as "not for
+        ///     sale" is what made the web shop show NOT FOR SALE on items it was itself selling.
+        /// </summary>
+        [Test]
+        public void ParseAStoreMintRowWithNoTrade()
+        {
+            // Act
+            ShopListingsResponse response = JsonConvert.DeserializeObject<ShopListingsResponse>(UNIFIED_PAYLOAD)!;
+
+            // Assert
+            ShopListingDto mint = response.data![1];
+            Assert.AreEqual("store", mint.acquisition);
+            Assert.IsNull(mint.tradeId);
+            Assert.AreEqual("20000000000000000000", mint.manaWei); // MANA-priced, so the oracle sets its credits
+            Assert.AreEqual(8, mint.available); // stock, not a trade, is what "on sale" means for a mint
+            Assert.AreEqual("0", mint.itemId);
+            Assert.AreEqual(137, mint.chainId);
+        }
+
+        /// <summary>An older server does not send `acquisition` at all — and back then every row was a trade.</summary>
+        [Test]
+        public void LeaveAcquisitionNullWhenTheServerDoesNotSendIt()
+        {
+            // Act
+            ShopListingsResponse response = JsonConvert.DeserializeObject<ShopListingsResponse>(UNIFIED_PAYLOAD)!;
+
+            // Assert
+            Assert.IsNull(response.data![0].acquisition);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/UI/CreditPurchaseModalController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/UI/CreditPurchaseModalController.cs
@@ -195,14 +195,16 @@ namespace DCL.MarketplaceCredits.Purchase.UI
                 return;
             }
 
-            CreditsQuoteResult quoteResult = await purchaseService.QuoteAsync(inputData.Listing.tradeId, ct);
+            // The whole row, not its tradeId: a mint has none, and everything the quote needs is already here.
+            CreditsQuoteResult quoteResult = await purchaseService.QuoteAsync(inputData.Listing, ct);
 
             if (ct.IsCancellationRequested)
                 return;
 
             if (!quoteResult.Success)
             {
-                ReportHub.LogWarning(ReportCategory.CREDITS_PURCHASE, $"Quote failed for trade {inputData.Listing.tradeId}: {quoteResult.Error} {quoteResult.Message}");
+                ReportHub.LogWarning(ReportCategory.CREDITS_PURCHASE,
+                    $"Quote failed for {inputData.Listing.contractAddress}-{inputData.Listing.itemId}: {quoteResult.Error} {quoteResult.Message}");
                 PurchaseFailed?.Invoke(inputData.Listing, ANALYTICS_STEP_QUOTE, MapAnalyticsErrorCode(quoteResult.Error), MapAnalyticsErrorDetail(quoteResult.Error));
                 ShowError(quoteResult.Error);
                 return;

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/CreditPurchaseAnalytics.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/EventBased/CreditPurchaseAnalytics.cs
@@ -134,6 +134,9 @@ namespace DCL.PerformanceAndDiagnostics.Analytics.EventBased
             return new JObject
             {
                 { "trade_id", listing.tradeId },
+                // Which rail settled it. A null trade_id is ambiguous on its own (a mint has none, but so does a
+                // row we failed to parse), and mints are now buyable, so the funnel needs to be able to split them.
+                { "acquisition", listing.acquisition },
                 { "contract_address", listing.contractAddress },
                 { "item_id", listing.itemId },
                 { "token_id", listing.tokenId },


### PR DESCRIPTION
## The problem

Two items, same buyer, same session. One could be bought with credits; the other could not be bought at all.

| item | `tradeId` | outcome |
|---|---|---|
| `0x58628c49…a212/0` — Curious Cat Beanie | `558f37e9-…` | bought fine |
| `0xf90645e2…6213/0` — Pixie Immelmann Turn | **null** | could not be bought |

Not the item — the **rail**. The whole quote was derived from `GET /v1/trades/{tradeId}`, so an item with no
trade had nothing to quote from. And a **CollectionStore mint has no trade and no order**: nothing was ever
signed and nothing was ever listed. The item is minted straight from the store contract, so there is no id
that would make that request succeed, and no id to substitute for it.

The web shop had the same defect, from the same inversion: it asked *"is there a tradeId?"* where the question
is *"how is this acquired?"*.

## The endpoint already answered it

`GET /v3/catalog/unified` — the endpoint the explorer **already** calls to resolve a listing — carries the
discriminator. Measured on production:

```
0xf90645e2… → acquisition: "store", tradeId: null, manaWei: "20000000000000000000", available: 8,  priceCredits: 14
0x58628c49… → acquisition: "trade", tradeId: "558f37e9-…",                          available: 9994, priceCredits: 11
```

`ShopListingDto` simply did not parse `acquisition`, and `CreditPurchaseModalController` passed only
`Listing.tradeId` into the quote — throwing away the row that already knew the answer. **No server change and
no new endpoint: this is entirely client-side.**

## What changed

**The quote takes the listing, not an id.** `QuoteAsync(ShopListingDto)` branches on `acquisition`, and the
mint branch never calls `/v1/trades`. What used to come from the trade now comes from the row:

| from the trade | for a mint |
|---|---|
| `trade == null` → not available | `available <= 0` → not available (**stock**, not a trade, is what "on sale" means) |
| `received[0].assetType` | always MANA-denominated, so always the oracle path a legacy MANA trade takes |
| `received[0].amount` | `manaWei` |
| `trade.contract` for the rate read | the chain's marketplace address — see below |
| `trade.signer == buyer` → own listing | no analogue: the "seller" is the creator, and minting your own item is not the same thing as buying your own resale. The web shop does not block it either. |

**The encoder gained the store call.** `BuildStoreBuyCall` is the counterpart of `BuildAcceptCall`, and both
now go through one shared `useCredits` envelope: the credit, its signature, the caps and the salt are
identical, and the rails differ **only** in the `(target, selector, data)` triple — the store instead of the
marketplace, `buy([item])` instead of `accept([trade])`. Same shape as the web shop's `wrapInUseCredits`, so
the two cannot drift on the bytes that move the money.

The buyer is named **explicitly** as the beneficiary in the calldata. That is what makes a mint relayable: the
store never sees the buyer as `msg.sender` on either rail (the CreditsManager is the caller), so wrapping it
in a meta-transaction changes only who transmits and who pays.

**The authorization identifies the mint by what it is.** `/credits/authorize` already accepts
`{usdPriceCents, contractAddress, itemId}` with no tradeId — that is how the web shop authorizes a mint.
Worth being explicit about why this works: the server does not sign "permission to buy order X", it signs a
**voucher for an amount** (value + expiry + salt + signature) plus the MANA cap the CreditsManager enforces
on-chain against whatever the external call actually moves. Neither the tradeId nor the item pair is part of
the signed payload; they are recorded on the intent so the buyer's purchase history can name what was bought
— and for a mint they are its only identity.

**Nothing in the relayer or the settlement poller changed.** `executeMetaTransaction(useCredits(...))` is
identical for both rails, so a mint is gasless from day one: a buyer with no POL can buy one.

## The one trap worth knowing about

**A mint's price is re-read immediately before encoding, not taken from the quote.**
`CollectionStore.buy` receives the prices as an *argument* and the contract re-validates them against the
item's live price, reverting if the creator moved it. A trade cannot fail this way — its price is signed into
the order — so this is the one purchase path where a stale quote is a revert rather than a wrong number. If
the price went **up** past what the buyer confirmed, the purchase fails with `PriceChanged` rather than
charging them the difference.

## Also

- `acquisition` is added to the purchase analytics. A null `trade_id` is ambiguous on its own (a mint has none,
  but so does a row we failed to parse), and mints are now buyable, so the funnel needs to split them.
- A missing `acquisition` reads as **trade**, never as mint: an older server did not send the field, and back
  then every row was a trade.

## Tests

- **Golden vectors** for `buy([item])` and for the full mint `useCredits` calldata, generated from the web
  shop's reference implementation against the **real** `CollectionStore` ABI shipped in
  `decentraland-transactions` — never a hand-written signature, which is exactly how a wrong selector gets
  shipped. Selector: `0xa4fdc78a`.
- The mint and the trade must target **different** contracts with **different** selectors — getting that
  backwards sends an `accept()` to the store and reverts.
- The buyer is named as the beneficiary in the encoded bytes.
- Quoting a mint **never** calls `/v1/trades`; a sold-out mint is refused on stock; an absent `acquisition`
  still routes to the trade rail.
- The price is re-read before buying; a price that moved up, or stock that ran out in between, fails before
  anything is relayed.
- The mint is authorized by `(contractAddress, itemId)` with an empty tradeId, and relayed on the same gasless
  path a trade takes.

## Not verified locally — please run before review

**I could not execute the C# suite** (no Unity/dotnet in the environment where this was written), so the
golden vectors are authoritative on the *expected* side (generated from the reference implementation that
settles real purchases today) but the assertions themselves have not been run. Draft for that reason. What
needs doing:

- [ ] `DCL.MarketplaceCredits.Purchase.Tests` in the Unity test runner
- [ ] A real mint bought with credits on `.zone` — the relayed mint path has never been exercised end to end
- [ ] Confirm the item lands with the buyer, not the relayer (the beneficiary assertion covers the bytes, but
      it deserves one real transaction)