### PR TITLE
chore: share a single sphere mesh; dedup primitive UV logic

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/PrimitiveRenderer/MeshPrimitive/SpherePrimitive.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/PrimitiveRenderer/MeshPrimitive/SpherePrimitive.cs
@@ -5,13 +5,22 @@ namespace ECS.Unity.PrimitiveRenderer.MeshPrimitive
 {
     public class SpherePrimitive : IPrimitiveMesh
     {
+        // Sphere geometry is constant (fixed radius and tessellation) and is never mutated per instance
+        // (MeshSetupSphere.Execute is a no-op), so every sphere shares this single immutable mesh.
+        private static Mesh? sharedMesh;
+
         public Mesh Mesh { get; }
 
         public SpherePrimitive()
         {
+            Mesh = sharedMesh ??= CreateSharedMesh();
+        }
+
+        private static Mesh CreateSharedMesh()
+        {
             var newMesh = new Mesh();
             SphereFactory.Create(ref newMesh);
-            Mesh = newMesh;
+            return newMesh;
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/PrimitiveRenderer/Tests/InstantiatePrimitiveRenderingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/PrimitiveRenderer/Tests/InstantiatePrimitiveRenderingSystemShould.cs
@@ -91,6 +91,12 @@ namespace ECS.Unity.PrimitiveRenderer.Tests
             system.Update(0);
 
             //Act
+            // Sphere primitives share a single immutable mesh, so the re-instantiated mesh is the same
+            // object as the initial one. Clear the recorded calls so the assertion below counts only the
+            // Execute triggered by re-instantiation and not the initial setup (which the mesh argument can
+            // no longer disambiguate).
+            setupMeshes[input.MeshCase].ClearReceivedCalls();
+
             input.IsDirty = true;
             world.Get<PrimitiveMeshRendererComponent>(entity).PrimitiveMesh = null;
             system.Update(0);

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Primitives/BoxFactory.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Primitives/BoxFactory.cs
@@ -232,10 +232,7 @@ namespace Utility.Primitives
 
         public static void UpdateMesh(ref Mesh mesh, RepeatedField<float> boxUVs = null)
         {
-            if (boxUVs is { Count: > 0 })
-                mesh.SetUVs(0, PrimitivesUtility.FloatArrayToV2List(boxUVs, mesh.uv), 0, VERTICES_NUM);
-            else
-                mesh.SetUVs(0, defaultUVs, 0, VERTICES_NUM);
+            PrimitivesUtility.ApplyUVs(mesh, boxUVs, defaultUVs, VERTICES_NUM);
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Primitives/PlaneFactory.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Primitives/PlaneFactory.cs
@@ -28,7 +28,6 @@ namespace Utility.Primitives
             vertices[6] = new Vector3(-halfSize.x, halfSize.y, 0);
             vertices[7] = new Vector3(-halfSize.x, -halfSize.y, 0);
 
-            Vector2[] uvs = PrimitivesBuffersPool.UVS.Rent(VERTICES_NUM);
             defaultUVs = new Vector2[VERTICES_NUM];
 
             defaultUVs[0] = new Vector2(0f, 0f);
@@ -85,10 +84,7 @@ namespace Utility.Primitives
 
         public static void UpdateMesh(ref Mesh mesh, RepeatedField<float> planeUvs)
         {
-            if (planeUvs is { Count: > 0 })
-                mesh.SetUVs(0, PrimitivesUtility.FloatArrayToV2List(planeUvs, mesh.uv), 0, VERTICES_NUM);
-            else
-                mesh.SetUVs(0, defaultUVs, 0, VERTICES_NUM);
+            PrimitivesUtility.ApplyUVs(mesh, planeUvs, defaultUVs, VERTICES_NUM);
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Primitives/PrimitivesUtility.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Primitives/PrimitivesUtility.cs
@@ -16,7 +16,7 @@ namespace Utility.Primitives
         }
 
         // Writes UV channel 0: the scene-provided UVs when present, otherwise the primitive's default set
-        public static void ApplyUVs(Mesh mesh, IList<float> customUVs, Vector2[] defaultUVs, int verticesNum)
+        public static void ApplyUVs(Mesh mesh, IList<float>? customUVs, Vector2[] defaultUVs, int verticesNum)
         {
             if (customUVs is { Count: > 0 })
                 mesh.SetUVs(0, FloatArrayToV2List(customUVs, mesh.uv), 0, verticesNum);

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Primitives/PrimitivesUtility.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Primitives/PrimitivesUtility.cs
@@ -14,5 +14,14 @@ namespace Utility.Primitives
 
             return uvsResult;
         }
+
+        // Writes UV channel 0: the scene-provided UVs when present, otherwise the primitive's default set
+        public static void ApplyUVs(Mesh mesh, IList<float> customUVs, Vector2[] defaultUVs, int verticesNum)
+        {
+            if (customUVs is { Count: > 0 })
+                mesh.SetUVs(0, FloatArrayToV2List(customUVs, mesh.uv), 0, verticesNum);
+            else
+                mesh.SetUVs(0, defaultUVs, 0, verticesNum);
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Two small, low-risk changes in the primitive mesh code:

**1. Sphere meshes are now shared (memory optimization).**
`SpherePrimitive` referenced its own newly-allocated `Mesh` per entity. Every sphere is geometrically identical (fixed radius/tessellation) and `MeshSetupSphere.Execute` is a no-op, so the mesh is never mutated per instance. It now references a single shared immutable `Mesh`.

- **Before:** N sphere entities → N `Mesh` instances.
- **After:** N sphere entities → 1 shared `Mesh`.

Safe teardown-wise: the primitive pools register no `actionOnDestroy` (meshes are never `Destroy`ed), and the pool registry is a global singleton, so the shared mesh lives for the app lifetime. Box/Plane/Cylinder are unchanged (they legitimately vary per instance).

**2. Reusability + a correctness fix (no behavior change).**
- Collapsed the byte-identical `UpdateMesh` UV logic in `BoxFactory`/`PlaneFactory` into `PrimitivesUtility.ApplyUVs`.
- Fixed a pool leak in `PlaneFactory.Create`: it rented a `Vector2[]` from `PrimitivesBuffersPool.UVS` that was never used and never returned, draining the pool on every plane creation. Removed the dead rent.

## Test Instructions

A companion benchmark scene is already **deployed to the world** for validation (decentraland/sdk7-test-scenes#84). The scene starts **empty** and exposes an on-screen panel to pile on spheres in real time:
- **`+1000 spheres`** — spawns a batch of sphere entities (`MeshRenderer.setSphere`). Spheres fill a 48×24 footprint and stack **upward** layer by layer as more are added.
- The batch size is a single knob (`ADD_BATCH = 1000`) at the top of the scene's `src/spawner.ts`.

There is deliberately **no in-scene control group**: the control is `prd` itself. On `prd`, every sphere allocates its own `Mesh`, so memory climbs fast with the sphere count. On this build all spheres reference **one** shared immutable `Mesh`, so the memory increase per batch is **much slower** (total memory still grows — transforms, materials, renderers are per-entity — just far more slowly).

- **World:** `sdk7testscenes.dcl.eth`
- **Parcels:** `40,40` / `41,40`

**Steps (standard run)**:
```bash
metaforge explorer run 9614
```

### Test Steps

Validation is done **entirely in the build via the in-app Memory debug panel — no Unity Editor / Memory Profiler involved.** The goal is a **side-by-side comparison of `prd` vs. this build** on the identical scene:

1. Load this scene on **`zone`**. Open the in-app debug panel and select the **Memory** widget. Optionally hit **`GC.Collect`** + **`Resources.UnloadUnusedAssets`** to settle a baseline, then note **`System Used Memory [MB]`** (and **`Profiler Used | Reserved [MB]`**).
2. Click **`+1000 spheres`** a few times. On `prd`, `System Used Memory` climbs **fast** — each sphere allocates its own `Mesh`.
3. Load the exact same scene on **this build** (with the optimization) and repeat.
4. This time the per-batch increase in `System Used Memory` is **dramatically smaller** than on `prd`, since all spheres share one `Mesh`.

That divergence — memory climbing fast on `prd` vs. climbing much slower here — is the proof the optimization is working.

### Additional Testing Notes
- Sanity-check other scenes using SDK `MeshRenderer` primitives (boxes, planes, cylinders) for visual regressions, including boxes/planes with custom UVs (unchanged path via `ApplyUVs`). This can be checked in Genesis Plaza, many emote triggers are white bright spheres

## Quality Checklist
- [x] Performance impact has been considered
- [x] For SDK features: Test scene is included and deployed (sdk7-test-scenes#84, world `sdk7testscenes.dcl.eth` @ 40,40)
- [ ] Changes have been tested locally (relying on CI EditMode tests + deployed benchmark scene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)