### PR TITLE
fix: report scene UI panel's real pixels-per-point as DevicePixelRatio

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/SceneUIPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/SceneUIPlugin.cs
@@ -98,7 +98,7 @@ namespace DCL.PluginSystem.World
             UIDropdownInstantiationSystem.InjectToWorld(ref builder, componentPoolsRegistry, sharedDependencies.EcsToCRDTWriter, styleFontDefinitions);
             UIDropdownReleaseSystem.InjectToWorld(ref builder, componentPoolsRegistry);
             UIPointerEventsSystem.InjectToWorld(ref builder, sharedDependencies.SceneStateProvider, sharedDependencies.EcsToCRDTWriter);
-            UICanvasInformationSystem.InjectToWorld(ref builder, sharedDependencies.EcsToCRDTWriter);
+            UICanvasInformationSystem.InjectToWorld(ref builder, sharedDependencies.EcsToCRDTWriter, uiDocument);
             UIFixPbPointerEventsSystem.InjectToWorld(ref builder);
 
             ResetDirtyFlagSystem<PBUiTransform>.InjectToWorld(ref builder);

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UICanvasInformation/UICanvasInformationSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UICanvasInformation/UICanvasInformationSystem.cs
@@ -10,6 +10,7 @@ using Decentraland.Common;
 using ECS.Abstract;
 using ECS.Groups;
 using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
 {
@@ -18,9 +19,11 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
     public partial class UICanvasInformationSystem : BaseUnityLoopSystem
     {
         private readonly IECSToCRDTWriter ecsToCRDTWriter;
+        private readonly UIDocument canvas;
         private BorderRect interactableArea;
         private int lastViewportResolutionWidth = -1;
-        private int lastScreenRealResolutionWidth = -1;
+        private int lastViewportResolutionHeight = -1;
+        private float lastDevicePixelRatio = -1;
 
         public override void Initialize()
         {
@@ -31,9 +34,10 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
             WriteToCRDT();
         }
 
-        private UICanvasInformationSystem(World world, IECSToCRDTWriter ecsToCRDTWriter) : base(world)
+        private UICanvasInformationSystem(World world, IECSToCRDTWriter ecsToCRDTWriter, UIDocument canvas) : base(world)
         {
             this.ecsToCRDTWriter = ecsToCRDTWriter;
+            this.canvas = canvas;
         }
 
         protected override void Update(float t)
@@ -50,15 +54,24 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
 
         private void UpdateUICanvasInformationComponent()
         {
-            if (lastViewportResolutionWidth == Screen.width && lastScreenRealResolutionWidth == Screen.mainWindowDisplayInfo.width)
+            float devicePixelRatio = GetDevicePixelRatio();
+
+            if (lastViewportResolutionWidth == Screen.width && lastViewportResolutionHeight == Screen.height && Mathf.Approximately(lastDevicePixelRatio, devicePixelRatio))
                 return;
 
-            lastScreenRealResolutionWidth = Screen.mainWindowDisplayInfo.width;
             lastViewportResolutionWidth = Screen.width;
+            lastViewportResolutionHeight = Screen.height;
+            lastDevicePixelRatio = devicePixelRatio;
 
             interactableArea.Left = Screen.width * 0.25f;
 
             WriteToCRDT();
+        }
+
+        private float GetDevicePixelRatio()
+        {
+            VisualElement root = canvas.rootVisualElement;
+            return root?.panel != null ? root.scaledPixelsPerPoint : 1f;
         }
 
         private void WriteToCRDT()
@@ -68,7 +81,7 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
                 component.InteractableArea = system.interactableArea;
                 component.Width = Screen.width;
                 component.Height = Screen.height;
-                component.DevicePixelRatio = Screen.mainWindowDisplayInfo.width / (float)Screen.width;
+                component.DevicePixelRatio = system.GetDevicePixelRatio();
             }, SpecialEntitiesID.SCENE_ROOT_ENTITY, this);
         }
     }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UICanvasInformation/UICanvasInformationSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UICanvasInformation/UICanvasInformationSystem.cs
@@ -30,6 +30,7 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
             base.Initialize();
 
             interactableArea = new BorderRect { Bottom = 0, Left = Screen.width * 0.25f, Right = 0, Top = 0 };
+            lastDevicePixelRatio = GetDevicePixelRatio();
 
             WriteToCRDT();
         }
@@ -81,7 +82,7 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
                 component.InteractableArea = system.interactableArea;
                 component.Width = Screen.width;
                 component.Height = Screen.height;
-                component.DevicePixelRatio = system.GetDevicePixelRatio();
+                component.DevicePixelRatio = system.lastDevicePixelRatio;
             }, SpecialEntitiesID.SCENE_ROOT_ENTITY, this);
         }
     }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
@@ -1,0 +1,123 @@
+using Arch.Core;
+using Arch.SystemGroups;
+using CRDT;
+using CrdtEcsBridge.ECSToCRDTWriter;
+using DCL.ECSComponents;
+using DCL.SDKComponents.SceneUI.Systems.UICanvasInformation;
+using ECS.Groups;
+using ECS.TestSuite;
+using NSubstitute;
+using NUnit.Framework;
+using SceneRunner.Scene;
+using System;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace DCL.SDKComponents.SceneUI.Tests
+{
+    // Regression coverage for the dpr-vh-vw-positionunit bug: UICanvasInformationSystem used to
+    // publish DevicePixelRatio = Screen.mainWindowDisplayInfo.width / Screen.width (the
+    // monitor-native-width / window-client-width ratio). That quantity is not a device pixel
+    // ratio for unity-explorer's scene UI - the scene panel (DCLScenePanelSettings) is
+    // ConstantPixelSize @ scale 1, so 1 UI-Toolkit point == 1 framebuffer pixel regardless of
+    // which monitor hosts the window or its native resolution. Scenes derive vh/vw (and, since
+    // js-sdk-toolchain #1433, every virtual-screen-scaled px value and scaleFontSize) from this
+    // field via `points = (dim / 100) * (scale / devicePixelRatio)`, so the bogus ratio silently
+    // mis-sizes `vw`/`vh` elements and live-resizes them when the window crosses monitors.
+    //
+    // The fix plumbs the scene UIDocument into the system and reports the panel's own
+    // `scaledPixelsPerPoint` (1.0f fallback while unattached) instead of the monitor/window
+    // ratio - see report.md "## Patch" and potential-fix.patch in
+    // bugreports-late-jul/dpr-vh-vw-positionunit/.
+    public class UICanvasInformationSystemShould : UnitySystemTestBase<UICanvasInformationSystem>
+    {
+        // Deliberately NOT 1.0 (the system's own unattached-panel fallback) and NOT a common OS
+        // DPI preset (100/125/150/175/200/225/250/300/350%): this isolates the injected-UIDocument
+        // seam from the OLD formula's monitorWidth/windowWidth ratio. Screen and
+        // Screen.mainWindowDisplayInfo are static Unity APIs with no injectable abstraction - the
+        // ROBUST patch variant is testable only because it additionally plumbs a UIDocument, which
+        // IS injectable. The OLD formula is a ratio of two real screen-pixel widths in the test
+        // runner's own window/monitor; landing on exactly 2.75 by coincidence is not realistic.
+        private const float SCENE_PANEL_SCALE = 2.75f;
+
+        private IECSToCRDTWriter ecsToCRDTWriter;
+        private GameObject canvasGameObject;
+        private PanelSettings panelSettings;
+        private UIDocument canvas;
+        private PBUiCanvasInformation? capturedComponent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            ecsToCRDTWriter = Substitute.For<IECSToCRDTWriter>();
+            capturedComponent = null;
+
+            // UICanvasInformationSystem.WriteToCRDT() rents the message from the writer and
+            // populates it via a static delegate - capture that delegate and invoke it against a
+            // fresh instance to observe what would have been written, exactly as the real
+            // IECSToCRDTWriter implementation would.
+            ecsToCRDTWriter
+               .When(x => x.PutMessage(
+                    Arg.Any<Action<PBUiCanvasInformation, UICanvasInformationSystem>>(),
+                    Arg.Any<CRDTEntity>(),
+                    Arg.Any<UICanvasInformationSystem>()))
+               .Do(callInfo =>
+                {
+                    var prepareMessage = callInfo.Arg<Action<PBUiCanvasInformation, UICanvasInformationSystem>>();
+                    var data = callInfo.Arg<UICanvasInformationSystem>();
+                    var component = new PBUiCanvasInformation();
+                    prepareMessage(component, data);
+                    capturedComponent = component;
+                });
+
+            // ConstantPixelSize mirrors the shipped DCLScenePanelSettings.asset (m_ScaleMode: 0)
+            // but with a scale the OLD Screen-ratio formula cannot plausibly reproduce.
+            panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
+            panelSettings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            panelSettings.scale = SCENE_PANEL_SCALE;
+
+            canvasGameObject = new GameObject(nameof(UICanvasInformationSystemShould) + "_Canvas");
+            canvas = canvasGameObject.AddComponent<UIDocument>();
+            canvas.panelSettings = panelSettings;
+
+            var builder = new ArchSystemsWorldBuilder<World>(world);
+
+            // UICanvasInformationSystem is [UpdateInGroup(typeof(SyncedInitializationSystemGroup))] -
+            // a CUSTOM group, so it must be injected into the builder before the system is, exactly as
+            // production does in ECSWorldFactory.cs (InjectCustomGroup(new SyncedInitializationSystemGroup(...))).
+            // Otherwise InjectToWorld throws Arch.SystemGroups.GroupNotFoundException in SetUp.
+            builder.InjectCustomGroup(new SyncedInitializationSystemGroup(Substitute.For<ISceneStateProvider>()));
+            system = UICanvasInformationSystem.InjectToWorld(ref builder, ecsToCRDTWriter, canvas);
+        }
+
+        protected override void OnTearDown()
+        {
+            if (canvasGameObject != null)
+                UnityEngine.Object.DestroyImmediate(canvasGameObject);
+
+            if (panelSettings != null)
+                UnityEngine.Object.DestroyImmediate(panelSettings);
+        }
+
+        [Test]
+        public void ReportScenePanelPixelsPerPointAsDevicePixelRatio()
+        {
+            // Arrange-time invariant: the seam only exercises the fixed code path once the
+            // UIDocument is actually attached to a live panel.
+            Assert.That(canvas.rootVisualElement, Is.Not.Null);
+            Assert.That(canvas.rootVisualElement.panel, Is.Not.Null);
+
+            // Act - Initialize() publishes unconditionally (bypasses the dirty-check).
+            system.Initialize();
+
+            // Assert
+            Assert.That(capturedComponent, Is.Not.Null, "UICanvasInformationSystem.Initialize() must publish a PBUiCanvasInformation via PutMessage.");
+
+            // Pre-fix: DevicePixelRatio = Screen.mainWindowDisplayInfo.width / Screen.width (the
+            // monitor/window ratio) - unrelated to SCENE_PANEL_SCALE, so this fails.
+            // Post-fix: DevicePixelRatio = canvas.rootVisualElement.scaledPixelsPerPoint, i.e.
+            // exactly the configured panel scale, so this passes.
+            Assert.That(capturedComponent!.DevicePixelRatio, Is.EqualTo(SCENE_PANEL_SCALE).Within(0.001f));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
@@ -1,6 +1,7 @@
 using Arch.Core;
 using Arch.SystemGroups;
 using CRDT;
+using CrdtEcsBridge.Components.Special;
 using CrdtEcsBridge.ECSToCRDTWriter;
 using DCL.ECSComponents;
 using DCL.SDKComponents.SceneUI.Systems.UICanvasInformation;
@@ -10,52 +11,42 @@ using NSubstitute;
 using NUnit.Framework;
 using SceneRunner.Scene;
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace DCL.SDKComponents.SceneUI.Tests
 {
-    // Regression coverage for the dpr-vh-vw-positionunit bug: UICanvasInformationSystem used to
-    // publish DevicePixelRatio = Screen.mainWindowDisplayInfo.width / Screen.width (the
-    // monitor-native-width / window-client-width ratio). That quantity is not a device pixel
-    // ratio for unity-explorer's scene UI - the scene panel (DCLScenePanelSettings) is
-    // ConstantPixelSize @ scale 1, so 1 UI-Toolkit point == 1 framebuffer pixel regardless of
-    // which monitor hosts the window or its native resolution. Scenes derive vh/vw (and, since
-    // js-sdk-toolchain #1433, every virtual-screen-scaled px value and scaleFontSize) from this
-    // field via `points = (dim / 100) * (scale / devicePixelRatio)`, so the bogus ratio silently
-    // mis-sizes `vw`/`vh` elements and live-resizes them when the window crosses monitors.
-    //
-    // The fix plumbs the scene UIDocument into the system and reports the panel's own
-    // `scaledPixelsPerPoint` (1.0f fallback while unattached) instead of the monitor/window
-    // ratio - see report.md "## Patch" and potential-fix.patch in
-    // bugreports-late-jul/dpr-vh-vw-positionunit/.
+    /// <summary>
+    ///     Pins the contract of PBUiCanvasInformation.DevicePixelRatio: it reports the scene panel's own
+    ///     physical-pixels-per-UI-point density, republished whenever that density or the viewport moves.
+    /// </summary>
     public class UICanvasInformationSystemShould : UnitySystemTestBase<UICanvasInformationSystem>
     {
-        // Deliberately NOT 1.0 (the system's own unattached-panel fallback) and NOT a common OS
-        // DPI preset (100/125/150/175/200/225/250/300/350%): this isolates the injected-UIDocument
-        // seam from the OLD formula's monitorWidth/windowWidth ratio. Screen and
-        // Screen.mainWindowDisplayInfo are static Unity APIs with no injectable abstraction - the
-        // ROBUST patch variant is testable only because it additionally plumbs a UIDocument, which
-        // IS injectable. The OLD formula is a ratio of two real screen-pixel widths in the test
-        // runner's own window/monitor; landing on exactly 2.75 by coincidence is not realistic.
+        /// <summary>Panel scale the system is expected to report verbatim; deliberately not the unattached-panel fallback of 1.</summary>
         private const float SCENE_PANEL_SCALE = 2.75f;
+
+        /// <summary>Panel scale applied mid-test to move the ratio and trip the dirty check.</summary>
+        private const float RESCALED_SCENE_PANEL_SCALE = 1.5f;
+
+        /// <summary>Tolerance for comparing a reported ratio against the panel scale that produced it.</summary>
+        private const float RATIO_TOLERANCE = 0.001f;
+
+        private readonly List<PBUiCanvasInformation> publishedComponents = new ();
 
         private IECSToCRDTWriter ecsToCRDTWriter;
         private GameObject canvasGameObject;
         private PanelSettings panelSettings;
         private UIDocument canvas;
-        private PBUiCanvasInformation? capturedComponent;
 
         [SetUp]
         public void SetUp()
         {
+            publishedComponents.Clear();
             ecsToCRDTWriter = Substitute.For<IECSToCRDTWriter>();
-            capturedComponent = null;
 
-            // UICanvasInformationSystem.WriteToCRDT() rents the message from the writer and
-            // populates it via a static delegate - capture that delegate and invoke it against a
-            // fresh instance to observe what would have been written, exactly as the real
-            // IECSToCRDTWriter implementation would.
+            // The system never touches the message itself: it hands the writer a static delegate that
+            // fills a rented instance, so the delegate has to be run to observe what would be written.
             ecsToCRDTWriter
                .When(x => x.PutMessage(
                     Arg.Any<Action<PBUiCanvasInformation, UICanvasInformationSystem>>(),
@@ -67,11 +58,10 @@ namespace DCL.SDKComponents.SceneUI.Tests
                     var data = callInfo.Arg<UICanvasInformationSystem>();
                     var component = new PBUiCanvasInformation();
                     prepareMessage(component, data);
-                    capturedComponent = component;
+                    publishedComponents.Add(component);
                 });
 
-            // ConstantPixelSize mirrors the shipped DCLScenePanelSettings.asset (m_ScaleMode: 0)
-            // but with a scale the OLD Screen-ratio formula cannot plausibly reproduce.
+            // ConstantPixelSize mirrors the shipped DCLScenePanelSettings.asset (m_ScaleMode: 0).
             panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
             panelSettings.scaleMode = PanelScaleMode.ConstantPixelSize;
             panelSettings.scale = SCENE_PANEL_SCALE;
@@ -80,14 +70,17 @@ namespace DCL.SDKComponents.SceneUI.Tests
             canvas = canvasGameObject.AddComponent<UIDocument>();
             canvas.panelSettings = panelSettings;
 
+            Assert.That(canvas.rootVisualElement?.panel, Is.Not.Null,
+                "The scene UIDocument must be attached to a live panel, otherwise the system reports its unattached fallback instead of the panel ratio.");
+
             var builder = new ArchSystemsWorldBuilder<World>(world);
 
-            // UICanvasInformationSystem is [UpdateInGroup(typeof(SyncedInitializationSystemGroup))] -
-            // a CUSTOM group, so it must be injected into the builder before the system is, exactly as
-            // production does in ECSWorldFactory.cs (InjectCustomGroup(new SyncedInitializationSystemGroup(...))).
-            // Otherwise InjectToWorld throws Arch.SystemGroups.GroupNotFoundException in SetUp.
+            // SyncedInitializationSystemGroup is a custom group: InjectToWorld throws GroupNotFoundException
+            // unless it is injected first, as production does in ECSWorldFactory.
             builder.InjectCustomGroup(new SyncedInitializationSystemGroup(Substitute.For<ISceneStateProvider>()));
             system = UICanvasInformationSystem.InjectToWorld(ref builder, ecsToCRDTWriter, canvas);
+
+            world.Create(new SceneRootComponent());
         }
 
         protected override void OnTearDown()
@@ -102,22 +95,36 @@ namespace DCL.SDKComponents.SceneUI.Tests
         [Test]
         public void ReportScenePanelPixelsPerPointAsDevicePixelRatio()
         {
-            // Arrange-time invariant: the seam only exercises the fixed code path once the
-            // UIDocument is actually attached to a live panel.
-            Assert.That(canvas.rootVisualElement, Is.Not.Null);
-            Assert.That(canvas.rootVisualElement.panel, Is.Not.Null);
-
-            // Act - Initialize() publishes unconditionally (bypasses the dirty-check).
             system.Initialize();
 
-            // Assert
-            Assert.That(capturedComponent, Is.Not.Null, "UICanvasInformationSystem.Initialize() must publish a PBUiCanvasInformation via PutMessage.");
+            Assert.That(publishedComponents, Is.Not.Empty, "Initialize() must publish a PBUiCanvasInformation via PutMessage.");
+            Assert.That(publishedComponents[0].DevicePixelRatio, Is.EqualTo(SCENE_PANEL_SCALE).Within(RATIO_TOLERANCE));
+        }
 
-            // Pre-fix: DevicePixelRatio = Screen.mainWindowDisplayInfo.width / Screen.width (the
-            // monitor/window ratio) - unrelated to SCENE_PANEL_SCALE, so this fails.
-            // Post-fix: DevicePixelRatio = canvas.rootVisualElement.scaledPixelsPerPoint, i.e.
-            // exactly the configured panel scale, so this passes.
-            Assert.That(capturedComponent!.DevicePixelRatio, Is.EqualTo(SCENE_PANEL_SCALE).Within(0.001f));
+        [Test]
+        public void NotRepublishWhenViewportAndPixelsPerPointAreUnchanged()
+        {
+            system.Initialize();
+            system.Update(0);
+
+            int publishedAfterFirstUpdate = publishedComponents.Count;
+            system.Update(0);
+
+            Assert.That(publishedComponents.Count, Is.EqualTo(publishedAfterFirstUpdate), "A tick that changes neither the viewport nor the panel ratio must not republish.");
+        }
+
+        [Test]
+        public void RepublishWhenScenePanelPixelsPerPointChanges()
+        {
+            system.Initialize();
+            system.Update(0);
+
+            int publishedAfterFirstUpdate = publishedComponents.Count;
+            panelSettings.scale = RESCALED_SCENE_PANEL_SCALE;
+            system.Update(0);
+
+            Assert.That(publishedComponents.Count, Is.EqualTo(publishedAfterFirstUpdate + 1));
+            Assert.That(publishedComponents[^1].DevicePixelRatio, Is.EqualTo(RESCALED_SCENE_PANEL_SCALE).Within(RATIO_TOLERANCE));
         }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs.meta
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 562b128f9cab4ef49d6c7b23fd7a7abf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
UICanvasInformationSystem published Screen.mainWindowDisplayInfo.width / Screen.width as "DevicePixelRatio" — that's monitor-native-width divided by window-client-width, not a device pixel ratio. Since the scene UI panel renders 1:1 in physical pixels (ConstantPixelSize, scale 1), the only contract-correct value is the panel's own scaledPixelsPerPoint. The bogus value made every SDK7 vh/vw (and, since js-sdk-toolchain #1433, every virtual-screen-scaled px value) render at the wrong size and live-resize when the window crossed monitors of different native resolution.

Fixes #9482
