### PR TITLE
chore: kill hung Unity test containers via stale editor-log watchdog

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -677,6 +677,25 @@ jobs:
           echo "image=$derived" >> $GITHUB_OUTPUT
           echo "Built derived image with ripgrep: $derived"
 
+      # game-ci pipes the editor output to artifacts/<mode>.log, so a deadlocked
+      # editor keeps the step console silent and burns the full 80-minute step
+      # timeout (run 29613116640 attempt 1: editmode console silent for 70 min
+      # after "Testing in editmode" until manually cancelled). The watchdog polls
+      # that log from the host and kills the Unity container when it stops
+      # growing, failing the step within ~15 min instead. It survives across
+      # steps as a background process and is stopped by the step after the
+      # runner; if the runner dies without cleanup it self-expires (MAX_LIFETIME).
+      - name: Start stale-log watchdog
+        env:
+          UNITY_IMAGE: ${{ matrix.testMode == 'editmode' && steps.rg-img.outputs.image || steps.img.outputs.ghcr }}
+          TEST_MODE: ${{ matrix.testMode }}
+        run: |
+          nohup bash scripts/ci/test-stale-log-watchdog.sh \
+            "artifacts/$TEST_MODE.log" "$UNITY_IMAGE" watchdog-status.json \
+            > watchdog-output.log 2>&1 &
+          echo $! > watchdog.pid
+          echo "Stale-log watchdog started (pid $(cat watchdog.pid)) for artifacts/$TEST_MODE.log"
+
       # Configure test runner
       - uses: game-ci/unity-test-runner@v4.3.1
         id: testRunner
@@ -691,6 +710,32 @@ jobs:
           customImage: ${{ matrix.testMode == 'editmode' && steps.rg-img.outputs.image || steps.img.outputs.ghcr }}
           customParameters: -buildTarget StandaloneLinux64 -testCategory "!Performance" -burst-disable-compilation -accept-apiupdate
           githubToken: ${{ env.GITHUB_TOKEN }}
+
+      # Fails the job with an explicit cause when the watchdog killed the
+      # container — without this the only signals are the confusing follow-on
+      # errors ("Input required and not supplied: path", "No test report files
+      # were found") seen in run 29613116640.
+      - name: Stop stale-log watchdog and fail on stall
+        if: always()
+        env:
+          TEST_MODE: ${{ matrix.testMode }}
+        run: |
+          if [ -f watchdog.pid ]; then
+            kill "$(cat watchdog.pid)" 2>/dev/null || true
+          fi
+          echo "::group::Watchdog output"
+          cat watchdog-output.log 2>/dev/null || echo "(no watchdog output)"
+          echo "::endgroup::"
+          # An unarmed watchdog gave this job no hang protection at all, usually
+          # because the editor log moved; don't let that pass unremarked.
+          if ! grep -q "stall detection armed" watchdog-output.log 2>/dev/null; then
+            echo "::warning::Stale-log watchdog never armed - artifacts/$TEST_MODE.log never grew, so a hang would still have run to the step timeout. Check that game-ci still writes the editor log there."
+          fi
+          if [ -f watchdog-status.json ]; then
+            stalled=$(jq -r '.stalledSeconds' watchdog-status.json)
+            echo "::error::Unity $TEST_MODE tests hung: artifacts/$TEST_MODE.log did not grow for ${stalled}s, so the stale-log watchdog killed the Unity container. See 'Dump Unity Editor log on failure' below for the log tail."
+            exit 1
+          fi
 
       - name: Dump Unity Editor log on failure
         if: always() && steps.testRunner.outcome != 'success'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -732,7 +732,8 @@ jobs:
           # that never reached a verdict (cancelled by cancel-in-progress, or
           # skipped) ended before the editor wrote anything, so there is no
           # drift to report there.
-          if [ "$RUNNER_OUTCOME" != cancelled ] && [ "$RUNNER_OUTCOME" != skipped ] \
+          if { [ "$RUNNER_OUTCOME" = success ] || [ "$RUNNER_OUTCOME" = failure ]; } \
+             && ! grep -q "stall detection armed" watchdog-output.log 2>/dev/null; then
              && ! grep -q "stall detection armed" watchdog-output.log 2>/dev/null; then
             echo "::warning::Stale-log watchdog never armed - artifacts/$TEST_MODE.log never grew, so a hang would still have run to the step timeout. Check that game-ci still writes the editor log there."
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -734,7 +734,6 @@ jobs:
           # drift to report there.
           if { [ "$RUNNER_OUTCOME" = success ] || [ "$RUNNER_OUTCOME" = failure ]; } \
              && ! grep -q "stall detection armed" watchdog-output.log 2>/dev/null; then
-             && ! grep -q "stall detection armed" watchdog-output.log 2>/dev/null; then
             echo "::warning::Stale-log watchdog never armed - artifacts/$TEST_MODE.log never grew, so a hang would still have run to the step timeout. Check that game-ci still writes the editor log there."
           fi
           if [ -f watchdog-status.json ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -719,6 +719,7 @@ jobs:
         if: always()
         env:
           TEST_MODE: ${{ matrix.testMode }}
+          RUNNER_OUTCOME: ${{ steps.testRunner.outcome }}
         run: |
           if [ -f watchdog.pid ]; then
             kill "$(cat watchdog.pid)" 2>/dev/null || true
@@ -727,12 +728,16 @@ jobs:
           cat watchdog-output.log 2>/dev/null || echo "(no watchdog output)"
           echo "::endgroup::"
           # An unarmed watchdog gave this job no hang protection at all, usually
-          # because the editor log moved; don't let that pass unremarked.
-          if ! grep -q "stall detection armed" watchdog-output.log 2>/dev/null; then
+          # because the editor log moved; don't let that pass unremarked. Runs
+          # that never reached a verdict (cancelled by cancel-in-progress, or
+          # skipped) ended before the editor wrote anything, so there is no
+          # drift to report there.
+          if [ "$RUNNER_OUTCOME" != cancelled ] && [ "$RUNNER_OUTCOME" != skipped ] \
+             && ! grep -q "stall detection armed" watchdog-output.log 2>/dev/null; then
             echo "::warning::Stale-log watchdog never armed - artifacts/$TEST_MODE.log never grew, so a hang would still have run to the step timeout. Check that game-ci still writes the editor log there."
           fi
           if [ -f watchdog-status.json ]; then
-            stalled=$(jq -r '.stalledSeconds' watchdog-status.json)
+            stalled=$(jq -r '.stalledSeconds' watchdog-status.json 2>/dev/null || echo unknown)
             echo "::error::Unity $TEST_MODE tests hung: artifacts/$TEST_MODE.log did not grow for ${stalled}s, so the stale-log watchdog killed the Unity container. See 'Dump Unity Editor log on failure' below for the log tail."
             exit 1
           fi

--- a/scripts/ci/test-stale-log-watchdog.sh
+++ b/scripts/ci/test-stale-log-watchdog.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Stale-log watchdog for game-ci Unity test containers.
+#
+# game-ci/unity-test-runner starts the Unity editor with
+# `-logFile <workspace>/artifacts/<mode>.log`, so while the step runs the
+# editor log grows on the host but the step's own console stays silent. When
+# the editor deadlocks mid-run the job burns the whole `timeout-minutes`
+# budget with no output (run 29613116640 attempt 1: console silent from
+# 21:04:21 right after the "Testing in editmode" banner until manually
+# cancelled at 22:14:52 — 70 minutes).
+#
+# This script polls the editor log's byte size from the host and kills the
+# Unity container when the log stops growing, failing the test step within
+# ~STALL_THRESHOLD seconds instead. Arming rules mirror the build-phase
+# watchdog in scripts/cloudbuild/build.py (LOG_STALL_THRESHOLD):
+#   - the stall clock arms only after one observed size *increase* — a log
+#     that never grows reads as "watchdog inactive", never as "stalled";
+#   - a size *decrease* (log replaced or truncated) resets the clock.
+# If the log stalls but no container matches the image, the step is already
+# tearing down — the watchdog exits without reporting a stall.
+#
+# Usage: test-stale-log-watchdog.sh <editor-log> <container-image> <status-file>
+#   <editor-log>      host path of the Unity editor log to watch
+#   <container-image> image the Unity container runs (docker ancestor filter)
+#   <status-file>     written (JSON) only when a stall kill actually happened
+# Env overrides:
+#   STALL_THRESHOLD   seconds without log growth before the kill (default 900)
+#   POLL_INTERVAL     seconds between size probes (default 30)
+#   MAX_LIFETIME      hard cap on the watchdog's own runtime (default 7200)
+#
+# Deliberately no `set -e`: the poll loop must survive transient stat/docker
+# failures; every external call is individually guarded instead.
+set -u
+
+LOG_FILE=$1
+IMAGE=$2
+STATUS_FILE=$3
+STALL_THRESHOLD=${STALL_THRESHOLD:-900}
+POLL_INTERVAL=${POLL_INTERVAL:-30}
+MAX_LIFETIME=${MAX_LIFETIME:-7200}
+
+start=$(date +%s)
+last_size=-1
+last_growth=$start
+growth_observed=false
+
+echo "Watching $LOG_FILE for container image $IMAGE (stall threshold ${STALL_THRESHOLD}s, poll ${POLL_INTERVAL}s)"
+
+while :; do
+    sleep "$POLL_INTERVAL"
+    now=$(date +%s)
+
+    if (( now - start > MAX_LIFETIME )); then
+        echo "Max lifetime (${MAX_LIFETIME}s) reached - exiting without a verdict."
+        exit 0
+    fi
+
+    size=$(stat -c%s "$LOG_FILE" 2>/dev/null) || continue
+
+    if (( last_size < 0 || size < last_size )); then
+        # First observation, or the log was replaced/truncated.
+        last_size=$size
+        last_growth=$now
+        continue
+    fi
+
+    if (( size > last_size )); then
+        if [ "$growth_observed" = false ]; then
+            echo "Log is growing ($size bytes) - stall detection armed."
+        fi
+        last_size=$size
+        last_growth=$now
+        growth_observed=true
+        continue
+    fi
+
+    if [ "$growth_observed" = true ] && (( now - last_growth > STALL_THRESHOLD )); then
+        stalled_for=$(( now - last_growth ))
+        # Results on disk mean the editor already exited: the log went quiet
+        # during game-ci's post-run work, which is not a hang.
+        if compgen -G "$(dirname "$LOG_FILE")/*.xml" > /dev/null; then
+            echo "Log stalled for ${stalled_for}s but test results are already written - exiting without a verdict."
+            exit 0
+        fi
+        containers=$(docker ps -q --filter "ancestor=$IMAGE" 2>/dev/null || true)
+        if [ -z "$containers" ]; then
+            echo "Log stalled for ${stalled_for}s but no container is running $IMAGE - step is tearing down, exiting."
+            exit 0
+        fi
+        echo "Log has not grown for ${stalled_for}s (size $size bytes). Killing Unity container(s): $containers"
+        jq -n --argjson stalled "$stalled_for" --argjson size "$size" --arg log "$LOG_FILE" \
+            '{stalledSeconds: $stalled, logSizeBytes: $size, log: $log}' > "$STATUS_FILE"
+        # container ids are newline/space separated words
+        # shellcheck disable=SC2086
+        docker kill $containers || true
+        exit 0
+    fi
+done


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Edit-mode tests occasionally deadlock in CI and burn the full 80-minute step timeout with a completely silent console. [Run 29613116640 (attempt 1)](https://github.com/decentraland/unity-explorer/actions/runs/29613116640/attempts/1) is a concrete example: the job printed the `Testing in editmode` banner at 21:04:21 and produced **zero further output for 70.5 minutes** until it was manually cancelled at 22:14:52. The console is silent by design — game-ci runs the editor with `-logFile artifacts/<mode>.log`, so all output lands in that file (which lives on the host via the volume-mounted workspace), not in the step console. The manual cancel then produced only misleading follow-on errors ("Input required and not supplied: path", "No test report files were found").

This PR extends the stale-log watchdog idea from #9616 (`scripts/cloudbuild/build.py` `LOG_STALL_THRESHOLD`) to the test jobs:

- **`scripts/ci/test-stale-log-watchdog.sh`** — a host-side background process that polls the editor log's byte size every 30 s. If the log hasn't grown for 15 min, it kills the Unity container (matched via docker `ancestor` image filter), failing the step immediately. Arming rules mirror `build.py`: the stall clock arms only after one observed size *increase* (a never-growing file reads as "watchdog inactive", never "stalled"), a size *decrease* resets the clock, and if no container matches at stall time the step is already tearing down, so it exits without a verdict. It self-expires after 2 h if never stopped.
- **`.github/workflows/test.yml`** — starts the watchdog just before the `game-ci/unity-test-runner` step (background process survives across steps) and stops it right after. If a stall kill happened, the stop step fails the job with an explicit `::error::` naming the real cause and pointing at the existing "Dump Unity Editor log on failure" step, which already tails the editor log for diagnosis.

Applies to both `editmode` and `playmode` (same hang risk). Net effect: a hang like the linked run fails in ~15–20 min with a clear annotation and the editor log tail, instead of 80 min of silence ending in confusing errors.

**Known gap (documented in the script):** if the container hangs before Unity ever writes the log (e.g. license activation), the watchdog never arms and the 80-minute step timeout remains the backstop. Deliberate — "no growth yet" is indistinguishable from "probe not live", and a false kill is worse than a slow timeout.

## Test Instructions

CI-only change — there is no Explorer runtime surface, so `metaforge explorer run` does not apply.

**Steps (standard run)**: N/A (CI workflow change)

**Expected result**: N/A

**Steps (fresh account)**: N/A

**Expected result**: N/A

**Automation** (if applicable): N/A

### Prerequisites
- [ ] None — the Unity Test workflow runs on this PR automatically

### Test Steps
1. Open this PR's `Unity Test` workflow run and check both `Test (editmode)` and `Test (playmode)` jobs.
2. Verify the "Start stale-log watchdog" step logs the watched path and PID.
3. Verify the "Stop stale-log watchdog and fail on stall" step shows the watchdog output group containing "Log is growing (N bytes) - stall detection armed." and no stall verdict, and that the job result is unchanged (tests pass/fail on their own merits).
4. (Optional, to see the kill path) Re-run a job with `STALL_THRESHOLD=60` set on the watchdog step: the container is killed ~1 min into any quiet phase and the job fails with the explicit "tests hung" annotation instead of the generic timeout.

### Additional Testing Notes
- The watchdog script's four paths (arm-on-growth, stall→kill→status file, no-container teardown, never-growing log stays inactive) were exercised locally with stat/docker shims; shellcheck passes.
- The 15-min threshold matches `LOG_STALL_THRESHOLD` in `build.py`; edit-mode editor logs are chatty (per-asset import, per-test output), so genuine 15-min silences are far outside normal behavior.
- Stacked on #9616 (branched from `chore/build-time-quick-wins`); GitHub will retarget to `dev` when that merges.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)