### PR TITLE
fix: avoid failure in eth call for shop listings

### DIFF
--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3EthereumApi.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3EthereumApi.cs
@@ -298,7 +298,14 @@ namespace DCL.Web3.Authenticators
 
         private async UniTask<EthApiResponse> RequestEthMethodWithoutSignatureAsync(EthApiRequest request, CancellationToken ct)
         {
-            string reqJson = JsonConvert.SerializeObject(request);
+            // Part of the RPC gateway fleet rejects frames whose id is negative (-32600 "unknown
+            // command"), so the id is masked to a non-negative int for the wire — exactly
+            // representable even by a float64-based backend — and the caller's id restored on the
+            // response, keeping ids echoed back to SDK scenes untouched.
+            long callerId = request.id;
+            request.id &= int.MaxValue;
+
+            string reqJson = JsonConvert.SerializeObject(new { jsonrpc = "2.0", request.id, request.method, request.@params });
             byte[] bytes = Encoding.UTF8.GetBytes(reqJson);
             await rpcWebSocket!.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
 
@@ -317,7 +324,10 @@ namespace DCL.Web3.Authenticators
                         throw new Web3Exception($"RPC {request.method} failed: code {response.error.code} {response.error.message}");
 
                     if (response.id == request.id)
+                    {
+                        response.id = callerId;
                         return response;
+                    }
                 }
                 else if (result.MessageType == WebSocketMessageType.Close)
                 {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
When trying to buy new items from someone's passport and with a metamask account sometimes there was a failure in the retrieval of the price of the wearable like this:
<img width="1186" height="1008" alt="image (41)" src="https://github.com/user-attachments/assets/41f5cd78-a26f-4a18-9f99-f95929565ac4" />

The problem was random caused by a random request index sometimes being negative, when negative the request for the exchange rate of MANA/USD was failing.

(from editor: [CREDITS_PURCHASE]: MANA/USD rate unavailable for trade 558f37e9-9844-45ae-b7ea-c19bd4aa4b58: RPC eth_call failed: code -32600 unknown command:                                       
  {"jsonrpc":"2.0","id":-1409326930,"method":"eth_call","params":[{"to":"0xa40b1d129b8906888720686f3a01921ddf37716f","data":"0x05dec3e4"},"latest"]} )

To avoid changing drastically all dapp request the fix has been applied only at this scope with:
* The wire id is masked with & int.MaxValue, so a negative Guid.GetHashCode() id becomes a positive 31-bit one — exactly representable even if a backend parses ids as float64.
* The caller's original id is restored on the returned response, so SDK scenes that match responses by id see exactly what they sent.


## Test Instructions

### Test Steps
1. Open the client with a metamask account
2. Open someone's passport
3. Verify that if you click on buy on some items that are on sale the price loads correctly

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
