### PR TITLE
feat: notify the user when a scene writes to the clipboard

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/RestrictedActionsAPIImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/RestrictedActionsAPIImplementation.cs
@@ -10,6 +10,8 @@ using DCL.UI;
 using Utility.Arch;
 using DCL.ExternalUrlPrompt;
 using DCL.NftPrompt;
+using DCL.NotificationsBus;
+using DCL.NotificationsBus.NotificationTypes;
 using DCL.SceneRuntime.Apis.RestrictedActionsApi;
 using DCL.TeleportPrompt;
 using DCL.Utilities;
@@ -296,6 +298,11 @@ namespace CrdtEcsBridge.RestrictedActions
         {
             await UniTask.SwitchToMainThread();
             systemClipboard.Set(text);
+
+            // Raised on every write so a clipboard change driven by the scene, instead of by the user, is never
+            // silent: whatever the user had copied is gone and pasting now yields scene-controlled text. A scene
+            // can write on every tick, so the type is collapsible — the toast never queues more than one deep.
+            NotificationsBusController.Instance.AddNotification(new SceneClipboardWriteNotification());
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/Tests/RestrictedActionsAPIImplementationShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/Tests/RestrictedActionsAPIImplementationShould.cs
@@ -7,6 +7,8 @@ using DCL.CrdtEcsBridge.JsModulesImplementation;
 using DCL.ECSComponents;
 using DCL.ExternalUrlPrompt;
 using DCL.NftPrompt;
+using DCL.NotificationsBus;
+using DCL.NotificationsBus.NotificationTypes;
 using DCL.TeleportPrompt;
 using DCL.UI;
 using Decentraland.Kernel.Apis;
@@ -33,11 +35,16 @@ namespace CrdtEcsBridge.RestrictedActions.Tests
         private ISystemClipboard systemClipboard;
         private IExplorerUiActions explorerUiActions;
         private World sceneWorld;
+        private int clipboardNotificationsReceived;
 
         [SetUp]
         public void SetUp()
         {
             EcsTestsUtils.SetUpFeaturesRegistry();
+
+            NotificationsBusController.Initialize(new NotificationsBusController());
+            clipboardNotificationsReceived = 0;
+            NotificationsBusController.Instance.SubscribeToNotificationTypeReceived(NotificationType.INTERNAL_SCENE_CLIPBOARD_WRITE, _ => clipboardNotificationsReceived++);
 
             mvcManager = Substitute.For<IMVCManager>();
             sceneStateProvider = Substitute.For<ISceneStateProvider>();
@@ -78,6 +85,7 @@ namespace CrdtEcsBridge.RestrictedActions.Tests
         {
             World.Destroy(sceneWorld);
             EcsTestsUtils.TearDownFeaturesRegistry();
+            NotificationsBusController.Reset();
         }
 
         [Test]
@@ -270,6 +278,42 @@ namespace CrdtEcsBridge.RestrictedActions.Tests
 
             // Assert
             systemClipboard.Received(1).Set(TEST_TEXT);
+        }
+
+        [Test]
+        public void CopyToClipboard_NotifiesTheUser()
+        {
+            // Act
+            restrictedActionsAPIImplementation.TryCopyToClipboard("Ia Ia! Cthulhu Ftaghn!");
+
+            // Assert
+            Assert.AreEqual(1, clipboardNotificationsReceived);
+        }
+
+        [Test]
+        public void CopyToClipboard_NotifiesOnEveryWrite()
+        {
+            // Act: a scene calling from onUpdate writes on every tick
+            for (var i = 0; i < 10; i++)
+                restrictedActionsAPIImplementation.TryCopyToClipboard($"0xATTACKER{i}");
+
+            // Assert: the API reports every write; collapsing repeats into a single toast is the
+            // notification controller's job, so that it can uncollapse as soon as the toast is gone.
+            systemClipboard.Received(10).Set(Arg.Any<string>());
+            Assert.AreEqual(10, clipboardNotificationsReceived);
+        }
+
+        [Test]
+        public void CopyToClipboard_DoesNotNotify_WhenSceneIsNotCurrent()
+        {
+            // Arrange
+            sceneStateProvider.IsCurrent.Returns(false);
+
+            // Act
+            restrictedActionsAPIImplementation.TryCopyToClipboard("This should not be copied");
+
+            // Assert
+            Assert.AreEqual(0, clipboardNotificationsReceived);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Notifications/Assets/NotificationIcons.asset
+++ b/Explorer/Assets/DCL/Notifications/Assets/NotificationIcons.asset
@@ -65,6 +65,8 @@ MonoBehaviour:
     value: {fileID: 21300000, guid: be351c6750a9f4b3c92f55ba96046a81, type: 3}
   - key: 57
     value: {fileID: 21300000, guid: 68f219c76f1104541b1be7ee15787e14, type: 3}
+  - key: 58
+    value: {fileID: 21300000, guid: 11e50157680834b92b7f75220b425747, type: 3}
   defaultIcon: {fileID: 21300000, guid: 93b9e2f69bc2e4cada2159afb0632935, type: 3}
   notificationIconBackgrounds:
   - key: 28

--- a/Explorer/Assets/DCL/Notifications/NewNotification/NewNotificationController.cs
+++ b/Explorer/Assets/DCL/Notifications/NewNotification/NewNotificationController.cs
@@ -26,6 +26,16 @@ namespace DCL.Notifications.NewNotification
         private static readonly int HIDE_TRIGGER = Animator.StringToHash("Hide");
         private static readonly TimeSpan TIME_BEFORE_HIDE_NOTIFICATION_TIME_SPAN = TimeSpan.FromSeconds(5f);
 
+        /// <summary>
+        ///     Types that carry a standing condition rather than a one-off event, so a second one while the first is
+        ///     still on screen would say nothing new. Only one instance of these is ever queued or displayed at a
+        ///     time; further ones are dropped instead of piling up behind it.
+        /// </summary>
+        private static readonly List<NotificationType> COLLAPSIBLE_NOTIFICATION_TYPES = new ()
+        {
+            NotificationType.INTERNAL_SCENE_CLIPBOARD_WRITE,
+        };
+
         private readonly NotificationIconTypes notificationIconTypes;
         private readonly NotificationDefaultThumbnails notificationDefaultThumbnails;
         private readonly NftTypeIconSO rarityBackgroundMapping;
@@ -33,6 +43,7 @@ namespace DCL.Notifications.NewNotification
         private readonly ImageControllerProvider imageControllerProvider;
         private readonly Queue<INotification> notificationQueue = new ();
         private bool isDisplaying;
+        private NotificationType? displayingNotificationType;
         private ImageController? thumbnailImageController;
         private ImageController badgeThumbnailImageController;
         private ImageController friendsThumbnailImageController;
@@ -93,6 +104,10 @@ namespace DCL.Notifications.NewNotification
             cts.SafeCancelAndDispose();
             cts = new CancellationTokenSource();
             cts.Token.ThrowIfCancellationRequested();
+
+            // Dismissing hands the screen slot back immediately — the fade-out that follows is cosmetic, so a
+            // collapsible type must not stay suppressed for its duration.
+            displayingNotificationType = null;
         }
 
         private void ClickedNotification(NotificationType notificationType, INotification notification)
@@ -104,9 +119,30 @@ namespace DCL.Notifications.NewNotification
         private void QueueNewNotification(INotification newNotification)
         {
             ReportHub.Log(ReportCategory.GIFTING, $"{newNotification.Type}");
+
+            if (COLLAPSIBLE_NOTIFICATION_TYPES.Contains(newNotification.Type) && IsPending(newNotification.Type))
+                return;
+
             notificationQueue.Enqueue(newNotification);
 
             if (!isDisplaying) { DisplayNewNotificationAsync().Forget(); }
+        }
+
+        /// <summary>
+        ///     Whether a notification of this type is on screen right now or waiting behind the one that is.
+        /// </summary>
+        private bool IsPending(NotificationType type)
+        {
+            if (displayingNotificationType == type)
+                return true;
+
+            foreach (INotification queued in notificationQueue)
+            {
+                if (queued.Type == type)
+                    return true;
+            }
+
+            return false;
         }
 
         private async UniTaskVoid DisplayNewNotificationAsync()
@@ -118,11 +154,13 @@ namespace DCL.Notifications.NewNotification
             {
                 isDisplaying = true;
                 INotification notification = notificationQueue.Dequeue();
+                displayingNotificationType = notification.Type;
 
                 switch (notification.Type)
                 {
                     case NotificationType.INTERNAL_ARRIVED_TO_DESTINATION:
                     case NotificationType.INTERNAL_SERVER_ERROR:
+                    case NotificationType.INTERNAL_SCENE_CLIPBOARD_WRITE:
                         await ProcessArrivedNotificationAsync(notification);
                         break;
                     case NotificationType.COMMUNITY_VOICE_CHAT_STARTED:
@@ -158,6 +196,9 @@ namespace DCL.Notifications.NewNotification
                         await ProcessDefaultNotificationAsync(notification);
                         break;
                 }
+
+                // The natural-expiry counterpart to the reset in StopAnimation, which covers early dismissal.
+                displayingNotificationType = null;
             }
 
             isDisplaying = false;

--- a/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsPanelController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsMenu/NotificationsPanelController.cs
@@ -41,6 +41,7 @@ namespace DCL.Notifications.NotificationsMenu
             NotificationType.COMMUNITY_DEEP_LINK,
             NotificationType.INTERNAL_DEFAULT_SUCCESS,
             NotificationType.INTERNAL_SERVER_ERROR,
+            NotificationType.INTERNAL_SCENE_CLIPBOARD_WRITE,
         };
 
         private readonly NotificationsRequestController notificationsRequestController;

--- a/Explorer/Assets/DCL/NotificationsBus/NotificationTypes/NotificationType.cs
+++ b/Explorer/Assets/DCL/NotificationsBus/NotificationTypes/NotificationType.cs
@@ -73,5 +73,7 @@ namespace DCL.NotificationsBus.NotificationTypes
         BAN_WARNING,
         BANNED,
         BAN_LIFTED,
+
+        INTERNAL_SCENE_CLIPBOARD_WRITE,
     }
 }

--- a/Explorer/Assets/DCL/NotificationsBus/NotificationTypes/SceneClipboardWriteNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBus/NotificationTypes/SceneClipboardWriteNotification.cs
@@ -1,0 +1,21 @@
+
+namespace DCL.NotificationsBus.NotificationTypes
+{
+    /// <summary>
+    /// An internal notification used to let the user know that the scene they are in wrote to the system clipboard,
+    /// discarding whatever they had copied before.
+    /// It will appear at the top of the screen, and not in the notifications feed.
+    /// </summary>
+    public class SceneClipboardWriteNotification : NotificationBase
+    {
+        private const string HEADER_TEXT = "A scene has replaced your clipboard content";
+
+        public override string GetHeader() =>
+            HEADER_TEXT;
+
+        public SceneClipboardWriteNotification()
+        {
+            Type = NotificationType.INTERNAL_SCENE_CLIPBOARD_WRITE;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/NotificationsBus/NotificationTypes/SceneClipboardWriteNotification.cs.meta
+++ b/Explorer/Assets/DCL/NotificationsBus/NotificationTypes/SceneClipboardWriteNotification.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f1c0a4d5e8b4c1ea3d92f6b8c4a1d70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes **SEC-001 (clipboard hijacking via `copyToClipboard`)**.

A scene could silently overwrite your operating-system clipboard: there was no permission, no prompt, and no feedback of any kind. A malicious scene could wait for you to copy something sensitive (for example a wallet address you are about to send funds to) and replace it with its own, so the next time you paste you get the scene's text instead of yours.

This PR makes such a write visible. Whenever the scene you are standing in writes to the clipboard, a message appears at the top of the screen:

> **A scene has replaced your clipboard content**

If the scene writes over and over (some do this many times a second), the message does not stack up or spam you: only one is ever shown at a time, and a new one can appear as soon as the previous one is gone or you close it.

The write itself still happens. This PR is about making it no longer silent, so you always know your clipboard was changed by the scene rather than by you.

## Test Instructions

A test scene is already published on the **.zone** (test) environment. You do not need to build or deploy anything.

**Steps**

1. Launch the Explorer build for this PR.
2. Once you are in, travel to the test World: **`progdude.dcl.eth`** on **.zone**.
3. You will see a row of coloured boxes with labels. Click any of them; each one asks the scene to write something to your clipboard.
4. Watch the top of the screen.

**What you should see**

- A message appears at the top of the screen: *"A scene has replaced your clipboard content"*, with a close (X) button.
- To prove the clipboard really changed, click outside the Explorer (a browser address bar, a notes app, a chat box) and paste (Ctrl+V / Cmd+V). You will see the scene's text, not whatever you had copied before.

**Things worth checking**

- Click a box, wait for the message to fade, then click again: you should get a fresh message each time.
- Close the message with its X, then click a box: a new message should appear right away. Closing it does not mute future ones.
- The box labelled **"Hijack Every Frame"** makes the scene write constantly. You should get a steady stream of messages, not one giant pile that keeps draining after you turn it off.
- The message appears only as a pop-up at the top of the screen. It should **not** show up in the notifications feed (the bell panel).

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does. This is especially useful for first-time contributors.
