### PR TITLE
fix: evict only the changed GLTF on LSD hot reload instead of draining every cache

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
@@ -151,6 +151,22 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
             ProfilingCounters.GltfInCacheAmount.Value -= unloadedAmount;
         }
 
+        public void Remove(in string key)
+        {
+            if (cache.TryGetValue(key, out List<GltfContainerAsset> assets))
+            {
+                foreach (GltfContainerAsset asset in assets)
+                    asset.Dispose();
+
+                ProfilingCounters.GltfInCacheAmount.Value -= assets.Count;
+                assets.Clear();
+                cache.Remove(key);
+                unloadQueue.TryRemove(key);
+            }
+
+            IrrecoverableFailures.Remove(key);
+        }
+
         bool IEqualityComparer<string>.Equals(string x, string y) =>
             string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/IGltfContainerAssetsCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/IGltfContainerAssetsCache.cs
@@ -14,6 +14,12 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
 
         void Unload(IPerformanceBudget frameTimeBudget, int maxUnloadAmount);
 
+        /// <summary>
+        ///     Evict a single cache key, disposing every pooled asset under it. Lets an edited GLTF be
+        ///     dropped in isolation while the rest of the cache stays warm across a scene reload.
+        /// </summary>
+        void Remove(in string key);
+
         void Dereference(in string key, GltfContainerAsset asset, bool putInBridge = false, bool handleAssetLoad = true);
 
         void SetAssetLoadCache(AssetPreLoadCache assetPreLoadCache);

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Cache/IStreamableCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Cache/IStreamableCache.cs
@@ -38,6 +38,13 @@ namespace ECS.StreamableLoading.Cache
         /// </summary>
         void Unload(IPerformanceBudget frameTimeBudget, int maxUnloadAmount);
 
+        /// <summary>
+        ///     Evict a single entry by key, disposing its asset when it is no longer referenced.
+        ///     Mirrors <see cref="Unload" /> scoped to one key, so an edited asset can be dropped
+        ///     without draining the whole cache. Default is a no-op for caches that hold nothing.
+        /// </summary>
+        void Remove(in TLoadingIntention key) { }
+
 #region Referencing
         /// <summary>
         ///     Base implementation is empty as not every asset requires reference counting

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Cache/RefCountStreamableCacheBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Cache/RefCountStreamableCacheBase.cs
@@ -79,5 +79,23 @@ namespace ECS.StreamableLoading.Cache
 
             inCacheCount.Value = cache.Count;
         }
+
+        public void Remove(in TLoadingIntention key)
+        {
+            if (!cache.TryGetValue(key, out TAssetData asset) || !asset.CanBeDisposed())
+                return;
+
+            asset.Dispose();
+            cache.Remove(key);
+
+            for (int i = listedCache.Count - 1; i >= 0; i--)
+                if (IntentionsComparer<TLoadingIntention>.INSTANCE.Equals(listedCache[i].intention, key))
+                {
+                    listedCache.RemoveAt(i);
+                    break;
+                }
+
+            inCacheCount.Value = cache.Count;
+        }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/GltfLoadCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/GltfLoadCache.cs
@@ -1,6 +1,7 @@
 using DCL.Profiling;
 using ECS.StreamableLoading.Cache;
 using GLTFast;
+using System;
 using Unity.Profiling;
 
 namespace ECS.StreamableLoading.GLTF
@@ -13,5 +14,23 @@ namespace ECS.StreamableLoading.GLTF
     public class GltfLoadCache : RefCountStreamableCacheBase<GLTFData, GltfImport, GetGLTFIntention>
     {
         protected override ref ProfilerCounterValue<int> inCacheCount => ref ProfilingCounters.GltfDataInCache;
+
+        /// <summary>
+        ///     Evict every entry whose content hash matches, regardless of the Name it was loaded
+        ///     under. <see cref="GetGLTFIntention" /> identity is (Name, Hash) and Name is the verbatim
+        ///     src string from scene code, which a caller evicting a changed file cannot reconstruct
+        ///     reliably — the hash alone identifies the content.
+        /// </summary>
+        public void RemoveByHash(string hash)
+        {
+            if (string.IsNullOrEmpty(hash))
+                return;
+
+            for (int i = listedCache.Count - 1; i >= 0; i--)
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(listedCache[i].intention.Hash, hash))
+                    Remove(listedCache[i].intention);
+            }
+        }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/ECSReloadScene.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/ECSReloadScene.cs
@@ -1,6 +1,7 @@
 ﻿using Arch.Core;
 using Cysharp.Threading.Tasks;
 using DCL.Character.Components;
+using DCL.Ipfs;
 using DCL.ResourcesUnloading;
 using ECS.LifeCycle.Components;
 using ECS.SceneLifeCycle.Components;
@@ -14,6 +15,22 @@ using Utility;
 
 namespace ECS.SceneLifeCycle
 {
+    /// <summary>
+    ///     The single GLTF model a local-development hot reload reported as changed, carried from the
+    ///     dev server's websocket message so the reload can evict just that asset instead of the whole cache.
+    /// </summary>
+    public readonly struct ChangedGltfModel
+    {
+        public readonly string Src;
+        public readonly string Hash;
+
+        public ChangedGltfModel(string src, string hash)
+        {
+            Src = src;
+            Hash = hash;
+        }
+    }
+
     public class ECSReloadScene
     {
         private readonly IScenesCache scenesCache;
@@ -44,19 +61,19 @@ namespace ECS.SceneLifeCycle
             var foundEntity = FindSceneEntity(sceneInCache);
             if (foundEntity == Entity.Null) return null;
 
-            await DisposeAndRestartAsync(foundEntity, sceneInCache, ct);
+            await DisposeAndRestartAsync(foundEntity, sceneInCache, null, ct);
 
             return sceneInCache;
         }
 
-        public async UniTask<ISceneFacade?> TryReloadSceneAsync(CancellationToken ct, string sceneId)
+        public async UniTask<ISceneFacade?> TryReloadSceneAsync(CancellationToken ct, string sceneId, ChangedGltfModel? changedModel = null)
         {
             if (!scenesCache.TryGetBySceneId(sceneId, out var sceneInCache)) return null;
 
             var foundEntity = FindSceneEntity(sceneInCache!);
             if (foundEntity == Entity.Null) return null;
 
-            await DisposeAndRestartAsync(foundEntity, sceneInCache!, ct);
+            await DisposeAndRestartAsync(foundEntity, sceneInCache!, changedModel, ct);
 
             return sceneInCache;
         }
@@ -74,9 +91,14 @@ namespace ECS.SceneLifeCycle
             return sceneEntity;
         }
 
-        private async UniTask DisposeAndRestartAsync(Entity entity, ISceneFacade currentScene, CancellationToken ct)
+        private async UniTask DisposeAndRestartAsync(Entity entity, ISceneFacade currentScene, ChangedGltfModel? changedModel, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
+
+            // Captured before the teardown below strips the scene entity's components.
+            SceneEntityDefinition? definition = localSceneDevelopment
+                ? world.Get<SceneDefinitionComponent>(entity).Definition
+                : null;
 
             //There is a lingering promise we need to remove, and add the DeleteEntityIntention to make the standard unload flow.
             world.Add<DeleteEntityIntention>(entity);
@@ -96,11 +118,21 @@ namespace ECS.SceneLifeCycle
                 world.Query(in new QueryDescription().WithAll<RealmComponent>(),
                     (ref StaticScenePointers staticScenePointers) => { staticScenePointers.Promise = null; });
 
-                // Force-drain dereferenced caches on LSD reload. The local dev server derives hashes
-                // from the file path, not content, so an updated model keeps the same hash and cache
-                // hits would return stale assets. Draining guarantees fresh loads.
-                cacheCleaner.UnloadCache(budgeted: false);
-                Resources.UnloadUnusedAssets();
+                if (changedModel is { } model && IsRawGltfModel(definition, model.Hash))
+                {
+                    // The dev server named the exact model that changed. In raw-GLTF development its
+                    // cache key is the bare content hash, so evict just that asset and let every other
+                    // cache stay warm across the reload.
+                    cacheCleaner.EvictGltfModel(model.Hash, model.Src);
+                }
+                else
+                {
+                    // Force-drain dereferenced caches on LSD reload. The local dev server derives hashes
+                    // from the file path, not content, so an updated model keeps the same hash and cache
+                    // hits would return stale assets. Draining guarantees fresh loads.
+                    cacheCleaner.UnloadCache(budgeted: false);
+                    Resources.UnloadUnusedAssets();
+                }
 
                 await WaitUntilNewSceneIsFullyLoadedAsync();
             }
@@ -133,6 +165,20 @@ namespace ECS.SceneLifeCycle
                     return isLoadCompleted;
                 }, cancellationToken: ct);
             }
+        }
+
+        /// <summary>
+        ///     True when the hash addresses a raw GLTF, i.e. no asset-bundle manifest maps it. The GLTF
+        ///     container cache is keyed by <see cref="AssetBundleManifestVersion.ComposeCacheKey" />,
+        ///     which returns the bare hash only in that case; under <c>--local-ab</c> the key differs and
+        ///     the model lives in the asset-bundle caches instead, so scoped eviction must not be used.
+        /// </summary>
+        internal static bool IsRawGltfModel(SceneEntityDefinition? definition, string hash)
+        {
+            if (definition == null || string.IsNullOrEmpty(hash))
+                return false;
+
+            return definition.AssetBundleManifestVersionOrFailed.ComposeCacheKey(hash) == hash;
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/ECSReloadScene.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/ECSReloadScene.cs
@@ -9,28 +9,13 @@ using ECS.SceneLifeCycle.IncreasingRadius;
 using ECS.SceneLifeCycle.SceneDefinition;
 using ECS.StreamableLoading.Common;
 using SceneRunner.Scene;
+using System;
 using System.Threading;
 using UnityEngine;
 using Utility;
 
 namespace ECS.SceneLifeCycle
 {
-    /// <summary>
-    ///     The single GLTF model a local-development hot reload reported as changed, carried from the
-    ///     dev server's websocket message so the reload can evict just that asset instead of the whole cache.
-    /// </summary>
-    public readonly struct ChangedGltfModel
-    {
-        public readonly string Src;
-        public readonly string Hash;
-
-        public ChangedGltfModel(string src, string hash)
-        {
-            Src = src;
-            Hash = hash;
-        }
-    }
-
     public class ECSReloadScene
     {
         private readonly IScenesCache scenesCache;
@@ -66,14 +51,14 @@ namespace ECS.SceneLifeCycle
             return sceneInCache;
         }
 
-        public async UniTask<ISceneFacade?> TryReloadSceneAsync(CancellationToken ct, string sceneId, ChangedGltfModel? changedModel = null)
+        public async UniTask<ISceneFacade?> TryReloadSceneAsync(CancellationToken ct, string sceneId, string? changedModelSrc = null)
         {
             if (!scenesCache.TryGetBySceneId(sceneId, out var sceneInCache)) return null;
 
             var foundEntity = FindSceneEntity(sceneInCache!);
             if (foundEntity == Entity.Null) return null;
 
-            await DisposeAndRestartAsync(foundEntity, sceneInCache!, changedModel, ct);
+            await DisposeAndRestartAsync(foundEntity, sceneInCache!, changedModelSrc, ct);
 
             return sceneInCache;
         }
@@ -91,7 +76,7 @@ namespace ECS.SceneLifeCycle
             return sceneEntity;
         }
 
-        private async UniTask DisposeAndRestartAsync(Entity entity, ISceneFacade currentScene, ChangedGltfModel? changedModel, CancellationToken ct)
+        private async UniTask DisposeAndRestartAsync(Entity entity, ISceneFacade currentScene, string? changedModelSrc, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
 
@@ -118,12 +103,14 @@ namespace ECS.SceneLifeCycle
                 world.Query(in new QueryDescription().WithAll<RealmComponent>(),
                     (ref StaticScenePointers staticScenePointers) => { staticScenePointers.Promise = null; });
 
-                if (changedModel is { } model && IsRawGltfModel(definition, model.Hash))
+                if (changedModelSrc != null
+                    && TryResolveContentHash(definition, changedModelSrc, out string contentHash)
+                    && IsRawGltfModel(definition, contentHash))
                 {
                     // The dev server named the exact model that changed. In raw-GLTF development its
                     // cache key is the bare content hash, so evict just that asset and let every other
                     // cache stay warm across the reload.
-                    cacheCleaner.EvictGltfModel(model.Hash, model.Src);
+                    cacheCleaner.EvictGltfModel(contentHash);
                 }
                 else
                 {
@@ -165,6 +152,33 @@ namespace ECS.SceneLifeCycle
                     return isLoadCompleted;
                 }, cancellationToken: ct);
             }
+        }
+
+        /// <summary>
+        ///     Resolve the changed file to the hash the caches are actually keyed on. The reload
+        ///     message's own hash is minted from the watcher-relative path, while every cache key
+        ///     derives from the content-mapping hash (minted from the absolute path) — the two never
+        ///     match, so the file must be joined to the definition's content list by its src instead.
+        /// </summary>
+        internal static bool TryResolveContentHash(SceneEntityDefinition? definition, string src, out string hash)
+        {
+            hash = string.Empty;
+
+            ContentDefinition[]? content = definition?.content;
+
+            if (content == null || string.IsNullOrEmpty(src))
+                return false;
+
+            foreach (ContentDefinition entry in content)
+            {
+                if (string.Equals(entry.file, src, StringComparison.OrdinalIgnoreCase))
+                {
+                    hash = entry.hash;
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/ECSReloadScene.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/ECSReloadScene.cs
@@ -9,7 +9,6 @@ using ECS.SceneLifeCycle.IncreasingRadius;
 using ECS.SceneLifeCycle.SceneDefinition;
 using ECS.StreamableLoading.Common;
 using SceneRunner.Scene;
-using System;
 using System.Threading;
 using UnityEngine;
 using Utility;
@@ -171,7 +170,7 @@ namespace ECS.SceneLifeCycle
 
             foreach (ContentDefinition entry in content)
             {
-                if (string.Equals(entry.file, src, StringComparison.OrdinalIgnoreCase))
+                if (ContentPathEquals(entry.file, src))
                 {
                     hash = entry.hash;
                     return true;
@@ -179,6 +178,32 @@ namespace ECS.SceneLifeCycle
             }
 
             return false;
+        }
+
+        /// <summary>
+        ///     Case- and separator-insensitive content path comparison. Content mappings always spell
+        ///     paths with '/', while the local dev server's file watcher reports the platform separator —
+        ///     on Windows that is '\', so an ordinal comparison never matches there even though the two
+        ///     name the same file. Compared in place to keep the reload path allocation-free.
+        /// </summary>
+        private static bool ContentPathEquals(string? contentFile, string src)
+        {
+            if (contentFile == null || contentFile.Length != src.Length)
+                return false;
+
+            for (var i = 0; i < contentFile.Length; i++)
+            {
+                char a = contentFile[i];
+                char b = src[i];
+
+                if (a == '\\') a = '/';
+                if (b == '\\') b = '/';
+
+                if (a != b && char.ToLowerInvariant(a) != char.ToLowerInvariant(b))
+                    return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
@@ -73,7 +73,21 @@ namespace ECS.SceneLifeCycle.LocalSceneDevelopment
                     wsSceneMessage.MergeFrom(receiveBuffer.AsSpan(0, receiveResult.Count));
                     ReportHub.Log(ReportCategory.SDK_LOCAL_SCENE_DEVELOPMENT, $"Websocket scene message received: {wsSceneMessage.MessageCase}");
 
-                    // TODO: Discriminate 'wsSceneMessage.MessageCase == WsSceneMessage.MessageOneofCase.UpdateModel' to only update GLTF models...
+                    // An UpdateModel message names the single GLTF that changed; carry it through so the
+                    // reload can evict just that asset instead of draining every cache.
+                    string sceneId;
+                    ChangedGltfModel? changedModel;
+
+                    if (wsSceneMessage.MessageCase == WsSceneMessage.MessageOneofCase.UpdateModel)
+                    {
+                        sceneId = wsSceneMessage.UpdateModel.SceneId;
+                        changedModel = new ChangedGltfModel(wsSceneMessage.UpdateModel.Src, wsSceneMessage.UpdateModel.Hash);
+                    }
+                    else
+                    {
+                        sceneId = wsSceneMessage.UpdateScene.SceneId;
+                        changedModel = null;
+                    }
 
                     // Switch to the main thread because `TryReloadSceneAsync` requires that
                     await UniTask.SwitchToMainThread(cancellationToken: ct);
@@ -86,8 +100,7 @@ namespace ECS.SceneLifeCycle.LocalSceneDevelopment
                         // And pause the skybox update while loading to avoid transitions
                         globalWorld.AddOrGet(skyboxEntity, new PauseSkyboxTimeUpdate());
 
-                        await reloadScene.TryReloadSceneAsync(ct,
-                                              wsSceneMessage.MessageCase == WsSceneMessage.MessageOneofCase.UpdateScene ? wsSceneMessage.UpdateScene.SceneId : wsSceneMessage.UpdateModel.SceneId)
+                        await reloadScene.TryReloadSceneAsync(ct, sceneId, changedModel)
                                          .Timeout(TimeSpan.FromSeconds(RELOAD_SCENE_TIMEOUT_SECS));
                     }
                     catch (TimeoutException) { }

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
@@ -73,20 +73,22 @@ namespace ECS.SceneLifeCycle.LocalSceneDevelopment
                     wsSceneMessage.MergeFrom(receiveBuffer.AsSpan(0, receiveResult.Count));
                     ReportHub.Log(ReportCategory.SDK_LOCAL_SCENE_DEVELOPMENT, $"Websocket scene message received: {wsSceneMessage.MessageCase}");
 
-                    // An UpdateModel message names the single GLTF that changed; carry it through so the
-                    // reload can evict just that asset instead of draining every cache.
+                    // An UpdateModel message names the single GLTF that changed; carry its src through so
+                    // the reload can evict just that asset instead of draining every cache. The message's
+                    // own hash is unusable — it is minted from the watcher-relative path while cache keys
+                    // derive from the content-mapping hash, so the reload resolves the hash by src itself.
                     string sceneId;
-                    ChangedGltfModel? changedModel;
+                    string? changedModelSrc;
 
                     if (wsSceneMessage.MessageCase == WsSceneMessage.MessageOneofCase.UpdateModel)
                     {
                         sceneId = wsSceneMessage.UpdateModel.SceneId;
-                        changedModel = new ChangedGltfModel(wsSceneMessage.UpdateModel.Src, wsSceneMessage.UpdateModel.Hash);
+                        changedModelSrc = wsSceneMessage.UpdateModel.Src;
                     }
                     else
                     {
                         sceneId = wsSceneMessage.UpdateScene.SceneId;
-                        changedModel = null;
+                        changedModelSrc = null;
                     }
 
                     // Switch to the main thread because `TryReloadSceneAsync` requires that
@@ -100,7 +102,7 @@ namespace ECS.SceneLifeCycle.LocalSceneDevelopment
                         // And pause the skybox update while loading to avoid transitions
                         globalWorld.AddOrGet(skyboxEntity, new PauseSkyboxTimeUpdate());
 
-                        await reloadScene.TryReloadSceneAsync(ct, sceneId, changedModel)
+                        await reloadScene.TryReloadSceneAsync(ct, sceneId, changedModelSrc)
                                          .Timeout(TimeSpan.FromSeconds(RELOAD_SCENE_TIMEOUT_SECS));
                     }
                     catch (TimeoutException) { }

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ECSReloadSceneShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ECSReloadSceneShould.cs
@@ -1,0 +1,37 @@
+using DCL.Ipfs;
+using ECS.SceneLifeCycle;
+using NUnit.Framework;
+using System;
+
+namespace DCL.SceneLifeCycle.Tests
+{
+    public class ECSReloadSceneShould
+    {
+        [Test]
+        public void TreatDefinitionWithoutManifestAsRawGltf()
+        {
+            //Arrange: no asset-bundle manifest -> the container cache is keyed by the bare hash
+            SceneEntityDefinition definition = CreateDefinition();
+
+            //Act & Assert
+            Assert.That(ECSReloadScene.IsRawGltfModel(definition, "b64-somehash"), Is.True);
+        }
+
+        [Test]
+        public void NotTreatMissingDefinitionOrEmptyHashAsRawGltf()
+        {
+            SceneEntityDefinition definition = CreateDefinition();
+
+            Assert.That(ECSReloadScene.IsRawGltfModel(null, "b64-somehash"), Is.False);
+            Assert.That(ECSReloadScene.IsRawGltfModel(definition, string.Empty), Is.False);
+            Assert.That(ECSReloadScene.IsRawGltfModel(definition, null!), Is.False);
+        }
+
+        private static SceneEntityDefinition CreateDefinition() =>
+            new ("test-scene", new SceneMetadata())
+            {
+                pointers = new[] { "0,0" },
+                content = Array.Empty<ContentDefinition>(),
+            };
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ECSReloadSceneShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ECSReloadSceneShould.cs
@@ -42,6 +42,22 @@ namespace DCL.SceneLifeCycle.Tests
         }
 
         [Test]
+        public void ResolveContentHashWhenSrcUsesWindowsSeparators()
+        {
+            //Arrange: content mappings always spell paths with '/', but the local dev server's file
+            //watcher reports the platform separator — on Windows that is '\'.
+            SceneEntityDefinition definition = CreateDefinition(
+                new ContentDefinition { file = "assets/models/out/models/BenchStreet.glb", hash = "b64-content-hash" });
+
+            //Act
+            bool resolved = ECSReloadScene.TryResolveContentHash(definition, @"assets\models\out\models\BenchStreet.glb", out string hash);
+
+            //Assert
+            Assert.That(resolved, Is.True);
+            Assert.That(hash, Is.EqualTo("b64-content-hash"));
+        }
+
+        [Test]
         public void NotResolveContentHashWhenSrcIsUnknownOrMissing()
         {
             //Arrange

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ECSReloadSceneShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ECSReloadSceneShould.cs
@@ -1,7 +1,6 @@
 using DCL.Ipfs;
 using ECS.SceneLifeCycle;
 using NUnit.Framework;
-using System;
 
 namespace DCL.SceneLifeCycle.Tests
 {
@@ -27,11 +26,39 @@ namespace DCL.SceneLifeCycle.Tests
             Assert.That(ECSReloadScene.IsRawGltfModel(definition, null!), Is.False);
         }
 
-        private static SceneEntityDefinition CreateDefinition() =>
+        [Test]
+        public void ResolveContentHashBySrcIgnoringCase()
+        {
+            //Arrange
+            SceneEntityDefinition definition = CreateDefinition(
+                new ContentDefinition { file = "models/shark.glb", hash = "b64-content-hash" });
+
+            //Act
+            bool resolved = ECSReloadScene.TryResolveContentHash(definition, "Models/Shark.GLB", out string hash);
+
+            //Assert
+            Assert.That(resolved, Is.True);
+            Assert.That(hash, Is.EqualTo("b64-content-hash"));
+        }
+
+        [Test]
+        public void NotResolveContentHashWhenSrcIsUnknownOrMissing()
+        {
+            //Arrange
+            SceneEntityDefinition definition = CreateDefinition(
+                new ContentDefinition { file = "models/shark.glb", hash = "b64-content-hash" });
+
+            //Act & Assert
+            Assert.That(ECSReloadScene.TryResolveContentHash(definition, "models/monster.glb", out _), Is.False);
+            Assert.That(ECSReloadScene.TryResolveContentHash(definition, string.Empty, out _), Is.False);
+            Assert.That(ECSReloadScene.TryResolveContentHash(null, "models/shark.glb", out _), Is.False);
+        }
+
+        private static SceneEntityDefinition CreateDefinition(params ContentDefinition[] content) =>
             new ("test-scene", new SceneMetadata())
             {
                 pointers = new[] { "0,0" },
-                content = Array.Empty<ContentDefinition>(),
+                content = content,
             };
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ECSReloadSceneShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ECSReloadSceneShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16967943194449009d1abd6f0dfaf872
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/LOD/Tests/EditMode/ResolveISSLODSystemShould.cs
+++ b/Explorer/Assets/DCL/LOD/Tests/EditMode/ResolveISSLODSystemShould.cs
@@ -38,10 +38,10 @@ namespace DCL.LOD.Tests
     {
         private const string SCENE_ID = "FAKE_ISS_SCENE";
 
-        private static GltfContainerTestResources sharedResources;
+        private static GltfContainerTestResources? sharedResources;
         private static StreamableLoadingResult<AssetBundleData> sharedAB;
 
-        private TrackingGltfCache cache;
+        private TrackingGltfCache cache = null!;
         private SceneDefinitionComponent sceneDefinition;
 
         [SetUp]
@@ -106,7 +106,7 @@ namespace DCL.LOD.Tests
 
             InitialSceneStateLOD lod = CreateLODEntity(descriptor);
 
-            system.Update(0);
+            system!.Update(0);
 
             Assert.That(lod.AllAssetsInstantiated(), Is.True);
             Assert.That(cache.Outstanding(HASH_A), Is.EqualTo(1));
@@ -124,7 +124,7 @@ namespace DCL.LOD.Tests
             StreamableLoadingResult<AssetBundleData> abResult = await EnsureSharedAB();
 
             // Mimic the loader: each delivered result holds one reference.
-            abResult.Asset.AddReference();
+            abResult.Asset!.AddReference();
             int refsBefore = abResult.Asset.referenceCount;
 
             var descriptor = ISSDescriptor.CreateUninitialized();
@@ -132,7 +132,7 @@ namespace DCL.LOD.Tests
 
             InitialSceneStateLOD lod = CreateLODEntity(descriptor);
 
-            system.Update(0);
+            system!.Update(0);
 
             Entity helper = FindHelperEntity();
             Assert.That(helper, Is.Not.EqualTo(Entity.Null), "Update must spawn one helper entity per descriptor asset");
@@ -152,7 +152,7 @@ namespace DCL.LOD.Tests
         {
             StreamableLoadingResult<AssetBundleData> abResult = await EnsureSharedAB();
 
-            abResult.Asset.AddReference();
+            abResult.Asset!.AddReference();
             int refsBefore = abResult.Asset.referenceCount;
 
             var descriptor = ISSDescriptor.CreateUninitialized();
@@ -160,7 +160,7 @@ namespace DCL.LOD.Tests
 
             InitialSceneStateLOD lod = CreateLODEntity(descriptor);
 
-            system.Update(0);
+            system!.Update(0);
             DeliverResult(FindHelperEntity(), abResult);
             system.Update(0);
 
@@ -186,7 +186,7 @@ namespace DCL.LOD.Tests
             descriptor.MarkResolved(new[] { NewDescriptorEntry("MISSING_HASH") });
 
             InitialSceneStateLOD lod = CreateLODEntity(descriptor);
-            system.Update(0);
+            system!.Update(0);
 
             var failure = new StreamableLoadingResult<AssetBundleData>(
                 ReportData.UNSPECIFIED,
@@ -226,7 +226,7 @@ namespace DCL.LOD.Tests
 
             InitialSceneStateLOD lod = CreateLODEntity(descriptor);
 
-            system.Update(0);
+            system!.Update(0);
 
             Assert.That(lod.AllAssetsInstantiated(), Is.True);
 
@@ -258,7 +258,7 @@ namespace DCL.LOD.Tests
 
             InitialSceneStateLOD lod = CreateLODEntity(descriptor);
 
-            system.Update(0);
+            system!.Update(0);
             Assert.That(renderer.forceRenderingOff, Is.True);
 
             lod.Dispose(world);
@@ -282,7 +282,7 @@ namespace DCL.LOD.Tests
             Assert.That(descriptor.TryReserveBridgeSlot(HASH), Is.False, "Capacity is 1 — second reserve must fail");
 
             CreateLODEntity(descriptor);
-            system.Update(0);
+            system!.Update(0);
 
             Assert.That(descriptor.TryReserveBridgeSlot(HASH), Is.True,
                 "Cache hit must call TryReleaseBridgeSlot so the slot is reusable");

--- a/Explorer/Assets/DCL/LOD/Tests/EditMode/ResolveISSLODSystemShould.cs
+++ b/Explorer/Assets/DCL/LOD/Tests/EditMode/ResolveISSLODSystemShould.cs
@@ -396,6 +396,8 @@ namespace DCL.LOD.Tests
 
             public void Unload(IPerformanceBudget frameTimeBudget, int maxUnloadAmount) { }
 
+            public void Remove(in string key) { }
+
             public void SetAssetLoadCache(AssetPreLoadCache assetPreLoadCache) { }
         }
     }

--- a/Explorer/Assets/DCL/ResourcesUnloading/CacheCleaner.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/CacheCleaner.cs
@@ -97,13 +97,14 @@ namespace DCL.ResourcesUnloading
             ClearExtendedObjectPools(budgetToUse, budgeted ? POOLS_UNLOAD_CHUNK : int.MaxValue);
         }
 
-        public void EvictGltfModel(string hash, string src)
+        public void EvictGltfModel(string hash)
         {
-            // In raw-GLTF development the container cache is keyed by the bare content hash, while the
-            // parsed-import cache is keyed by (src, hash). Evict both: dropping only the container asset
-            // would let it be rebuilt from the still-cached stale import.
+            // In raw-GLTF development the container cache is keyed by the bare content hash. Evict both
+            // layers: dropping only the container asset would let it be rebuilt from the still-cached
+            // stale import. The import cache is keyed by (Name, Hash) where Name is the verbatim src
+            // from scene code, which this caller cannot reconstruct — evict by hash instead.
             gltfContainerAssetsCache?.Remove(hash);
-            gltfLoadCache?.Remove(GetGLTFIntention.Create(src, hash));
+            (gltfLoadCache as GltfLoadCache)?.RemoveByHash(hash);
         }
 
         private void ClearExtendedObjectPools(IPerformanceBudget budgetToUse, int maxUnload)

--- a/Explorer/Assets/DCL/ResourcesUnloading/CacheCleaner.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/CacheCleaner.cs
@@ -97,6 +97,15 @@ namespace DCL.ResourcesUnloading
             ClearExtendedObjectPools(budgetToUse, budgeted ? POOLS_UNLOAD_CHUNK : int.MaxValue);
         }
 
+        public void EvictGltfModel(string hash, string src)
+        {
+            // In raw-GLTF development the container cache is keyed by the bare content hash, while the
+            // parsed-import cache is keyed by (src, hash). Evict both: dropping only the container asset
+            // would let it be rebuilt from the still-cached stale import.
+            gltfContainerAssetsCache?.Remove(hash);
+            gltfLoadCache?.Remove(GetGLTFIntention.Create(src, hash));
+        }
+
         private void ClearExtendedObjectPools(IPerformanceBudget budgetToUse, int maxUnload)
         {
             foreach (IThrottledClearable pool in extendedObjectPools)

--- a/Explorer/Assets/DCL/ResourcesUnloading/CacheCleaner.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/CacheCleaner.cs
@@ -104,7 +104,8 @@ namespace DCL.ResourcesUnloading
             // stale import. The import cache is keyed by (Name, Hash) where Name is the verbatim src
             // from scene code, which this caller cannot reconstruct — evict by hash instead.
             gltfContainerAssetsCache?.Remove(hash);
-            (gltfLoadCache as GltfLoadCache)?.RemoveByHash(hash);
+            if (gltfLoadCache is GltfLoadCache typedCache)
+                typedCache.RemoveByHash(hash);
         }
 
         private void ClearExtendedObjectPools(IPerformanceBudget budgetToUse, int maxUnload)

--- a/Explorer/Assets/DCL/ResourcesUnloading/ICacheCleaner.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/ICacheCleaner.cs
@@ -6,10 +6,10 @@
 
         /// <summary>
         ///     Evict a single raw-GLTF model (parsed import and instantiated container asset) by its
-        ///     content hash, leaving every other cache warm. Used on a scene reload when the dev server
-        ///     told us exactly which model changed, so we can avoid draining the whole cache.
+        ///     content-mapping hash, leaving every other cache warm. Used on a scene reload when the dev
+        ///     server told us exactly which model changed, so we can avoid draining the whole cache.
         /// </summary>
-        void EvictGltfModel(string hash, string src);
+        void EvictGltfModel(string hash);
 
         void UpdateProfilingCounters();
     }

--- a/Explorer/Assets/DCL/ResourcesUnloading/ICacheCleaner.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/ICacheCleaner.cs
@@ -3,6 +3,14 @@
     public interface ICacheCleaner
     {
         void UnloadCache(bool budgeted = true);
+
+        /// <summary>
+        ///     Evict a single raw-GLTF model (parsed import and instantiated container asset) by its
+        ///     content hash, leaving every other cache warm. Used on a scene reload when the dev server
+        ///     told us exactly which model changed, so we can avoid draining the whole cache.
+        /// </summary>
+        void EvictGltfModel(string hash, string src);
+
         void UpdateProfilingCounters();
     }
 }

--- a/Explorer/Assets/DCL/ResourcesUnloading/Tests/CacheCleanerIntegrationTests.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/Tests/CacheCleanerIntegrationTests.cs
@@ -206,6 +206,46 @@ namespace DCL.ResourcesUnloading.Tests
             Assert.That(innerOfCache.Count, Is.EqualTo(0));
         }
 
+        [Category(INTEGRATION)]
+        [Test]
+        public void EvictGltfModelDropsTargetedModelAndKeepsOtherCachesWarm()
+        {
+            // Arrange
+            FillCachesWithElements(hashID: "test");
+
+            Assert.That(gltfContainerAssetsCache.cache.Count, Is.EqualTo(1));
+            Assert.That(texturesCache.cache.Count, Is.EqualTo(1));
+            Assert.That(audioClipsCache.cache.Count, Is.EqualTo(1));
+
+            // Act
+            cacheCleaner.EvictGltfModel("test", "model.glb");
+
+            // Assert: only the GLTF container entry for that hash is gone; unrelated caches stay warm
+            Assert.That(gltfContainerAssetsCache.cache.Count, Is.EqualTo(0));
+            Assert.That(texturesCache.cache.Count, Is.EqualTo(1));
+            Assert.That(audioClipsCache.cache.Count, Is.EqualTo(1));
+            Assert.That(assetBundleCache.cache.Count, Is.EqualTo(1));
+        }
+
+        [Category(INTEGRATION)]
+        [Test]
+        public void RemoveEvictsSingleStreamableEntryLeavingOthers()
+        {
+            // Arrange
+            var keyA = new GetTextureIntention { CommonArguments = new CommonLoadingArguments { URL = URLAddress.FromString("textureA") } };
+            var keyB = new GetTextureIntention { CommonArguments = new CommonLoadingArguments { URL = URLAddress.FromString("textureB") } };
+            texturesCache.Add(keyA, new TextureData(new Texture2D(1, 1)));
+            texturesCache.Add(keyB, new TextureData(new Texture2D(1, 1)));
+
+            // Act
+            texturesCache.Remove(keyA);
+
+            // Assert
+            Assert.That(texturesCache.cache.Count, Is.EqualTo(1));
+            Assert.That(texturesCache.TryGet(keyB, out _), Is.True);
+            Assert.That(texturesCache.TryGet(keyA, out _), Is.False);
+        }
+
         private void FillCachesWithElements(string hashID)
         {
             var textureIntention = new GetTextureIntention { CommonArguments = new CommonLoadingArguments { URL = URLAddress.FromString(hashID) } };

--- a/Explorer/Assets/DCL/ResourcesUnloading/Tests/CacheCleanerIntegrationTests.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/Tests/CacheCleanerIntegrationTests.cs
@@ -30,31 +30,29 @@ namespace DCL.ResourcesUnloading.Tests
 {
     public class CacheCleanerIntegrationTests
     {
-        private CacheCleaner cacheCleaner;
+        private CacheCleaner cacheCleaner = null!;
 
-        private IReleasablePerformanceBudget releasablePerformanceBudget;
+        private IReleasablePerformanceBudget releasablePerformanceBudget = null!;
 
         // Caches
-        private WearableStorage wearableStorage;
-        private TrimmedWearableStorage trimmedWearableStorage;
-        private TrimmedEmoteStorage trimmedEmoteStorage;
-        private AttachmentsAssetsCache attachmentsAssetsCache;
-        private TexturesCache<GetTextureIntention> texturesCache;
-        private AudioClipsCache audioClipsCache;
-        private GltfContainerAssetsCache gltfContainerAssetsCache;
-        private GltfLoadCache gltfLoadCache;
-        private LODCache lodAssets;
-        private RoadAssetsPool roadAssets;
-        private IEmoteStorage emoteStorage;
-        private IProfileCache profileCache;
-        private IComponentPoolsRegistry poolsRegistry;
+        private WearableStorage wearableStorage = null!;
+        private TrimmedWearableStorage trimmedWearableStorage = null!;
+        private TrimmedEmoteStorage trimmedEmoteStorage = null!;
+        private AttachmentsAssetsCache attachmentsAssetsCache = null!;
+        private TexturesCache<GetTextureIntention> texturesCache = null!;
+        private AudioClipsCache audioClipsCache = null!;
+        private GltfContainerAssetsCache gltfContainerAssetsCache = null!;
+        private GltfLoadCache gltfLoadCache = null!;
+        private LODCache lodAssets = null!;
+        private RoadAssetsPool roadAssets = null!;
+        private IEmoteStorage emoteStorage = null!;
+        private IProfileCache profileCache = null!;
+        private IComponentPoolsRegistry poolsRegistry = null!;
 
-        private IReadOnlyDictionary<string, string> innerOfCache;
-        private IMemoryCache<string, string> jsSourcesCache;
+        private IReadOnlyDictionary<string, string> innerOfCache = null!;
+        private IMemoryCache<string, string> jsSourcesCache = null!;
 
-        private AssetBundleCache assetBundleCache;
-
-        private IExtendedObjectPool<Material> materialPool;
+        private AssetBundleCache assetBundleCache = null!;
 
         [SetUp]
         public void SetUp()
@@ -123,7 +121,7 @@ namespace DCL.ResourcesUnloading.Tests
             releasablePerformanceBudget.TrySpendBudget().Returns(true);
 
             for (var i = 0; i < cachedElementsAmount; i++)
-                FillCachesWithElements(hashID: $"test{i}");
+                FillCachesWithElements(hashId: $"test{i}");
 
             // Measure
             Measure.Method(() =>
@@ -147,7 +145,7 @@ namespace DCL.ResourcesUnloading.Tests
             releasablePerformanceBudget.TrySpendBudget().Returns(true);
 
             for (var i = 0; i < cachedElementsAmount; i++)
-                FillCachesWithElements(hashID: $"test{i}");
+                FillCachesWithElements(hashId: $"test{i}");
 
             SampleGroup totalAllocatedMemory = new SampleGroup("TotalAllocatedMemory", SampleUnit.Kilobyte, increaseIsBetter: false);
 
@@ -164,7 +162,7 @@ namespace DCL.ResourcesUnloading.Tests
         public void DisposingShouldProperlyDereferenceDependencyChain()
         {
             // Arrange
-            var assetBundleData = new AssetBundleData(null, Array.Empty<Object>(), typeof(GameObject), null);
+            var assetBundleData = new AssetBundleData(null!, Array.Empty<Object>(), typeof(GameObject), null!);
 
             var gltfAsset = GltfContainerAsset.Create(new GameObject(), assetBundleData);
             assetBundleData.AddReference();
@@ -191,7 +189,7 @@ namespace DCL.ResourcesUnloading.Tests
         {
             // Arrange
             releasablePerformanceBudget.TrySpendBudget().Returns(true);
-            FillCachesWithElements(hashID: "test");
+            FillCachesWithElements(hashId: "test");
 
             // Act
             cacheCleaner.UnloadCache();
@@ -211,7 +209,7 @@ namespace DCL.ResourcesUnloading.Tests
         public void EvictGltfModelDropsTargetedModelAndKeepsOtherCachesWarm()
         {
             // Arrange
-            FillCachesWithElements(hashID: "test");
+            FillCachesWithElements(hashId: "test");
 
             Assert.That(gltfContainerAssetsCache.cache.Count, Is.EqualTo(1));
             Assert.That(texturesCache.cache.Count, Is.EqualTo(1));
@@ -246,28 +244,28 @@ namespace DCL.ResourcesUnloading.Tests
             Assert.That(texturesCache.TryGet(keyA, out _), Is.False);
         }
 
-        private void FillCachesWithElements(string hashID)
+        private void FillCachesWithElements(string hashId)
         {
-            var textureIntention = new GetTextureIntention { CommonArguments = new CommonLoadingArguments { URL = URLAddress.FromString(hashID) } };
+            var textureIntention = new GetTextureIntention { CommonArguments = new CommonLoadingArguments { URL = URLAddress.FromString(hashId) } };
             texturesCache.Add(textureIntention, new TextureData(new Texture2D(1, 1)));
 
-            var audioClipIntention = new GetAudioClipIntention { CommonArguments = new CommonLoadingArguments { URL = URLAddress.FromString(hashID) } };
-            var audioClip = new AudioClipData(AudioClip.Create(hashID, 1, 1, 2000, false));
+            var audioClipIntention = new GetAudioClipIntention { CommonArguments = new CommonLoadingArguments { URL = URLAddress.FromString(hashId) } };
+            var audioClip = new AudioClipData(AudioClip.Create(hashId, 1, 1, 2000, false));
             audioClipsCache.Add(audioClipIntention, audioClip);
             audioClipsCache.AddReference(in audioClipIntention, audioClip);
             audioClip.Dereference();
 
-            var assetBundleData = new AssetBundleData(null, new []{new GameObject()}, typeof(GameObject), Array.Empty<AssetBundleData>());
-            assetBundleCache.Add(new GetAssetBundleIntention { Hash = hashID }, assetBundleData);
+            var assetBundleData = new AssetBundleData(null!, new Object[] { new GameObject() }, typeof(GameObject), Array.Empty<AssetBundleData>());
+            assetBundleCache.Add(new GetAssetBundleIntention { Hash = hashId }, assetBundleData);
 
             var gltfContainerAsset = GltfContainerAsset.Create(new GameObject(), assetBundleData);
             assetBundleData.AddReference();
-            gltfContainerAssetsCache.Dereference(hashID, gltfContainerAsset); // add to cache
+            gltfContainerAssetsCache.Dereference(hashId, gltfContainerAsset); // add to cache
 
             var wearableAsset = new AttachmentRegularAsset(new GameObject(), new List<AttachmentRegularAsset.RendererInfo>(10), assetBundleData);
             assetBundleData.AddReference();
             var wearable = new Wearable { WearableAssetResults = { [0] = new StreamableLoadingResult<AttachmentAssetBase>(wearableAsset) } };
-            wearableStorage.AddWearable(hashID, wearable, true); // add to cache
+            wearableStorage.AddWearable(hashId, wearable, true); // add to cache
 
             var cachedWearable = new CachedAttachment(wearableAsset, new GameObject(), true, Array.Empty<SpringBoneData>());
             wearableAsset.AddReference();

--- a/Explorer/Assets/DCL/ResourcesUnloading/Tests/CacheCleanerIntegrationTests.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/Tests/CacheCleanerIntegrationTests.cs
@@ -208,18 +208,22 @@ namespace DCL.ResourcesUnloading.Tests
         [Test]
         public void EvictGltfModelDropsTargetedModelAndKeepsOtherCachesWarm()
         {
-            // Arrange
+            // Arrange: the parsed import sits under a Name whose casing the evictor cannot know —
+            // eviction must match by content hash alone.
             FillCachesWithElements(hashId: "test");
+            gltfLoadCache.Add(GetGLTFIntention.Create("Models/Test.GLB", "test"), new GLTFData(null!, new GameObject()));
 
             Assert.That(gltfContainerAssetsCache.cache.Count, Is.EqualTo(1));
+            Assert.That(gltfLoadCache.cache.Count, Is.EqualTo(1));
             Assert.That(texturesCache.cache.Count, Is.EqualTo(1));
             Assert.That(audioClipsCache.cache.Count, Is.EqualTo(1));
 
             // Act
-            cacheCleaner.EvictGltfModel("test", "model.glb");
+            cacheCleaner.EvictGltfModel("test");
 
-            // Assert: only the GLTF container entry for that hash is gone; unrelated caches stay warm
+            // Assert: only the GLTF entries for that hash are gone; unrelated caches stay warm
             Assert.That(gltfContainerAssetsCache.cache.Count, Is.EqualTo(0));
+            Assert.That(gltfLoadCache.cache.Count, Is.EqualTo(0));
             Assert.That(texturesCache.cache.Count, Is.EqualTo(1));
             Assert.That(audioClipsCache.cache.Count, Is.EqualTo(1));
             Assert.That(assetBundleCache.cache.Count, Is.EqualTo(1));


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Resolves the long-standing TODO in `LocalSceneDevelopmentController`: the sdk-commands dev server's `UpdateModel` websocket message already names the exact GLTF that changed (`src` + path-derived `hash`), but the client discarded it and **force-drained every cache** on each hot reload.

This PR consumes that message. When a `.glb`/`.gltf` is saved during local scene development (raw-GLTF mode):

- **Evict only the changed model** — its parsed import (`GltfLoadCache`) and its pooled container instances (`GltfContainerAssetsCache`) — via a new `ICacheCleaner.EvictGltfModel(hash, src)`.
- **Every other cache stays warm** across the reload: unchanged models are served from the pool without re-downloading, re-parsing or re-instantiating (meshes, colliders, materials).

Everything else keeps today's conservative behavior:
- **Non-model changes** (textures, code, `scene.json`) arrive as a coarse `updateScene` carrying only the scene id — we can't know what went stale (e.g. a `.gltf`'s external texture), so the full drain remains.
- **`--local-ab` mode**: the model lives in the asset-bundle caches, so scoped eviction is skipped. Guarded by `IsRawGltfModel`, which mirrors the exact key composition the container cache uses (`AssetBundleManifestVersionOrFailed.ComposeCacheKey(hash) == hash`), so the guard can't drift from the real cache keying.

New primitives: `IStreamableCache.Remove(key)` (default no-op; real implementation in `RefCountStreamableCacheBase` mirrors `Unload` scoped to one key, honoring refcounts) and `IGltfContainerAssetsCache.Remove(key)`.

### Performance (measured in editor, LSD, dev vs this branch)

**Genesis Plaza `central-plaza` (70 parcels, 390 GLBs, 1.13M triangles):**

Two timings are reported, because they diverge badly on a scene this size:
- **"Reload reported done"** — when the client considers the reload finished (`SceneLoadingConcluded`). This only tracks GLTFs declared in the scene's first ticks, so it fires while most content is still streaming in.
- **"All content back"** — when scene content stats (triangles/bodies) return to the pre-reload baseline, cross-checked visually. This is what the creator actually experiences.

(Memory budget was disabled during measurement so budget-driven eviction/throttling wouldn't pollute the numbers.)

| | Reload reported done | All content back | World during reload |
|---|---|---|---|
| dev — `.glb` save | ~5s | **~15–26s** | fully torn down: a 1KB model save empties the plaza (no ground, no buildings) and re-streams everything |
| this branch — `.glb` save (1KB / 3.5MB / 4.2MB model) | **3.0s / 3.2s / 3.5s** | ≈ when reported done (baseline stats at the first poll, ≤12–15s incl. polling granularity) | stays standing; only the edited model re-streams |
| plain reload (both) | ~5s | ~20–35s | torn down (unchanged behavior) |

Numbers re-measured after the content-hash resolution fix, i.e. with the edited model genuinely evicted and re-downloaded — model size adds ~0.5s at most against the local dev server. Eviction correctness was verified with a real content swap (replacing one model's bytes with a different model): the new content shows after the reload.

On heavy scenes the win is qualitative: a model save no longer wipes the world for ~20s of visible popping — the scene is whole ~5s after hitting save, regardless of how big the scene or the edited model is.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 9667
```

Run against a local scene (`npm run start` in any SDK7 scene, connect with the local-scene-development launch args, **without** `--local-ab`).

**Expected result**:
1. Save/`touch` a `.glb` in the scene's assets → the scene reloads noticeably faster than on `dev`, and the edited model shows the new content.
IE:
- For Genesis Plaza, make yourself a copy of `BenchStreet.glb` and `BushPot.glb` on a separate folder than the one you are running the build from (so you dont accidentlaly trigger reloading)
- Then just rename and copy. IE: Rename bench street to bush, and step over the bench street. Doing it like that, you will get bushes instead of benches. 
- Remember, the important part is that scene reload is fast now, given that you just changed a glb
2. Edit a texture or `scene.json` → reload behaves exactly as on `dev` (full drain), changes show up.


### Additional Testing Notes
- **Edge to verify**: with `--local-ab`, a `.glb` save must still do the full drain (scoped eviction is guarded off).
- A `.gltf` that references an *external* texture: editing the **texture** triggers full drain (correct); editing the `.gltf` itself takes the scoped path.
- Genesis City / worlds are untouched — the new branch only runs under `localSceneDevelopment`.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
