### PR TITLE
chore: UCB write-probe throwaway (safe to delete)

### DIFF
--- a/Explorer/UCB_WRITE_PROBE_THROWAWAY.md
+++ b/Explorer/UCB_WRITE_PROBE_THROWAWAY.md
@@ -1,0 +1,1 @@
+Throwaway branch for an authorized UCB write-authorization security probe. Safe to delete.


### PR DESCRIPTION
Throwaway PR for an authorized Unity Cloud Build write-authorization security probe. Do not merge; safe to close/delete at any time.