### PR TITLE
chore: com.decentraland.pulse.transport to fix missing csproj .meta warning

### DIFF
--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -11,7 +11,7 @@
     "com.dcl.gpui-assets": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.dcl.gpui-assets",
     "com.decentraland.filebrowserpro": "git@github.com:decentraland/unity-explorer-packages.git?path=/FileBrowserPro",
     "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git#222d67ccc289337dadb5e8d96ee5b633dfb905b6",
-    "com.decentraland.pulse.transport": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport.Shared#6d882c73c8e1348e7918ea4377cc907776970995",
+    "com.decentraland.pulse.transport": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport.Shared#efe92879d9c6765421841fa67cf994500772fc6b",
     "com.decentraland.renum": "https://github.com/NickKhalow/REnum.git?path=REnum",
     "com.decentraland.renum.sourcegen": "https://github.com/NickKhalow/REnum.git#sourcegen/1.1.4",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src#f3dd251c7837cc2d844e1c07e741177a53676064",

--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -11,7 +11,7 @@
     "com.dcl.gpui-assets": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.dcl.gpui-assets",
     "com.decentraland.filebrowserpro": "git@github.com:decentraland/unity-explorer-packages.git?path=/FileBrowserPro",
     "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git#222d67ccc289337dadb5e8d96ee5b633dfb905b6",
-    "com.decentraland.pulse.transport": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport.Shared#536d308a96cd5dce1011b012e7d0b39c27b01993",
+    "com.decentraland.pulse.transport": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport.Shared#6d882c73c8e1348e7918ea4377cc907776970995",
     "com.decentraland.renum": "https://github.com/NickKhalow/REnum.git?path=REnum",
     "com.decentraland.renum.sourcegen": "https://github.com/NickKhalow/REnum.git#sourcegen/1.1.4",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src#f3dd251c7837cc2d844e1c07e741177a53676064",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -101,11 +101,11 @@
       "hash": "222d67ccc289337dadb5e8d96ee5b633dfb905b6"
     },
     "com.decentraland.pulse.transport": {
-      "version": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport.Shared#6d882c73c8e1348e7918ea4377cc907776970995",
+      "version": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport.Shared#efe92879d9c6765421841fa67cf994500772fc6b",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "6d882c73c8e1348e7918ea4377cc907776970995"
+      "hash": "efe92879d9c6765421841fa67cf994500772fc6b"
     },
     "com.decentraland.renum": {
       "version": "https://github.com/NickKhalow/REnum.git?path=REnum",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -101,11 +101,11 @@
       "hash": "222d67ccc289337dadb5e8d96ee5b633dfb905b6"
     },
     "com.decentraland.pulse.transport": {
-      "version": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport.Shared#536d308a96cd5dce1011b012e7d0b39c27b01993",
+      "version": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport.Shared#6d882c73c8e1348e7918ea4377cc907776970995",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "536d308a96cd5dce1011b012e7d0b39c27b01993"
+      "hash": "6d882c73c8e1348e7918ea4377cc907776970995"
     },
     "com.decentraland.renum": {
       "version": "https://github.com/NickKhalow/REnum.git?path=REnum",


### PR DESCRIPTION
## Problem

On every Unity import we get:

```
Asset Packages/com.decentraland.pulse.transport/DCLPulse.Transport.Shared.csproj has no meta file, but it's in an immutable folder. The asset will be ignored.
```

`com.decentraland.pulse.transport` is a Git UPM dependency pointing at `decentraland/Pulse` (`src/DCLPulse.Transport.Shared`). That folder ships a `.csproj` (so it can also build standalone with `dotnet build`) but the csproj had no `.meta`. Because packages resolve into an **immutable** cache, Unity can't generate one and warns + ignores the file. Nothing in this repo can fix it — the meta has to live in the Pulse package.

## Change

Bump the `com.decentraland.pulse.transport` pin (in `manifest.json` and `packages-lock.json`) to the Pulse commit that adds `DCLPulse.Transport.Shared.csproj.meta`.

## ⚠️ Blocked on decentraland/Pulse#36

Draft until that PR merges. It currently pins to the fix **branch** commit (`6d882c7`) so CI can resolve the package; **re-pin to the squash-merge commit on `main` before marking ready / merging**, so the pin references a commit that lives permanently on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)