### PR TITLE
feat: tag shop links opened from the client with utm_source

### DIFF
--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/ClientSourceUrlExtensions.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/ClientSourceUrlExtensions.cs
@@ -1,0 +1,39 @@
+// ReSharper disable once CheckNamespace
+namespace DCL.Browser.DecentralandUrls
+{
+    /// <summary>
+    ///     Tags an outgoing Decentraland web URL as coming from the client, so the web side can attribute the visit.
+    ///     <para>
+    ///         Without this the client is invisible as a traffic source. A native app opening the browser sends no
+    ///         Referer header, so every visit the client sends lands in the web analytics as "direct" — the same
+    ///         bucket as someone typing the address or using a bookmark. Measured on the Shop over its first days
+    ///         live, that bucket was three quarters of all visitors, which makes the question "how much traffic does
+    ///         the client actually drive" unanswerable rather than merely imprecise.
+    ///     </para>
+    ///     <para>
+    ///         Only <c>utm_source</c> is added. The other UTM fields carry nothing the destination cannot already
+    ///         infer (the campaign is the path, the medium is always organic), and the full set is not free: the
+    ///         confirmation dialog shown before leaving for the browser displays the URL in full, so every extra
+    ///         parameter is another line of query string in front of the user.
+    ///     </para>
+    /// </summary>
+    public static class ClientSourceUrlExtensions
+    {
+        private const string SOURCE_PARAM = "utm_source=client";
+
+        /// <summary>
+        ///     Returns <paramref name="url" /> with <c>utm_source=client</c> appended, picking <c>?</c> or <c>&amp;</c>
+        ///     according to whether the URL already carries a query string. A null or empty URL is returned unchanged:
+        ///     callers build these from user data that can legitimately resolve to nothing, and a bare
+        ///     <c>?utm_source=client</c> is worse than an empty string because it looks like a link.
+        /// </summary>
+        public static string WithClientSource(this string url)
+        {
+            if (string.IsNullOrEmpty(url))
+                return url;
+
+            char separator = url.Contains('?') ? '&' : '?';
+            return $"{url}{separator}{SOURCE_PARAM}";
+        }
+    }
+}

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/ClientSourceUrlExtensions.cs.meta
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/ClientSourceUrlExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 72fb4a66571d4e43852fcb53027eaf7d
+timeCreated: 1786365082

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -232,6 +232,10 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.TwitterNewPostLink => "https://twitter.com/intent/tweet?text={0}&hashtags={1}&url={2}",
                 DecentralandUrl.NewsletterSubscriptionLink => "https://decentraland.beehiiv.com/?utm_org=dcl&utm_source=client&utm_medium=organic&utm_campaign=marketplacecredits&utm_term=trialend",
                 DecentralandUrl.MarketplaceLink => $"https://decentraland.{ENV}/marketplace",
+                // Deliberately WITHOUT a query string: the passport builds an item URL by appending
+                // "/item/{contract}/{id}" to this value, and a `?` here would put the path after the
+                // query and produce a link that 404s. Callers that OPEN this url tag it themselves —
+                // see DecentralandUrlExtensions.WithClientSource.
                 DecentralandUrl.ShopLink => $"https://decentraland.{ENV}/shop",
                 DecentralandUrl.MarketplaceServer => $"https://marketplace-api.decentraland.{ENV}",
                 DecentralandUrl.PrivacyPolicy => $"https://decentraland.{ENV}/privacy",
@@ -297,7 +301,9 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.Servers => $"https://peer.decentraland.{ENV}/lambdas/contracts/servers",
                 DecentralandUrl.MediaConverter => $"https://metamorph-api.decentraland.{ENV}/convert?url={{0}}",
                 DecentralandUrl.MarketplaceCredits => $"https://credits.decentraland.{ENV}",
-                DecentralandUrl.GoShoppingWithMarketplaceCredits => $"https://decentraland.{ENV}/marketplace/browse?sortBy=newest&status=on_sale&withCredits=true",
+                // Safe to tag on the constant, unlike ShopLink: nothing appends a path to this one, and it
+                // already carries a query string so the separator is '&'.
+                DecentralandUrl.GoShoppingWithMarketplaceCredits => $"https://decentraland.{ENV}/marketplace/browse?sortBy=newest&status=on_sale&withCredits=true&utm_source=client",
                 DecentralandUrl.Notifications => $"https://notifications.decentraland.{ENV}",
                 DecentralandUrl.Communities => $"https://social-api.decentraland.{ENV}/v1/communities",
                 DecentralandUrl.CommunitiesV2 => $"https://social-api.decentraland.{ENV}/v2/communities",

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/ClientSourceUrlExtensionsShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/ClientSourceUrlExtensionsShould.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+
+// ReSharper disable once CheckNamespace
+namespace DCL.Browser.DecentralandUrls.Tests
+{
+    public class ClientSourceUrlExtensionsShould
+    {
+        [Test]
+        public void OpenAQueryStringOnAPlainUrl()
+        {
+            Assert.AreEqual("https://decentraland.org/shop?utm_source=client",
+                "https://decentraland.org/shop".WithClientSource());
+        }
+
+        // The passport builds its item link by appending a path, so the value reaching here already carries
+        // one. Getting the separator wrong on this case is what would 404 the most valuable link we have.
+        [Test]
+        public void KeepThePathIntactWhenTaggingAnItemUrl()
+        {
+            Assert.AreEqual("https://decentraland.org/shop/item/0xabc/0?utm_source=client",
+                "https://decentraland.org/shop/item/0xabc/0".WithClientSource());
+        }
+
+        // A '?' already present means the parameter has to join with '&' — otherwise the url carries two
+        // query strings and every parameter after the second '?' is dropped by the browser.
+        [Test]
+        public void AppendWithAnAmpersandWhenAQueryAlreadyExists()
+        {
+            Assert.AreEqual("https://decentraland.org/marketplace/browse?status=on_sale&utm_source=client",
+                "https://decentraland.org/marketplace/browse?status=on_sale".WithClientSource());
+        }
+
+        // These urls are built from user data that can legitimately resolve to nothing — the passport returns
+        // "" for an unparseable urn. A bare "?utm_source=client" would look like a link and be opened as one.
+        [Test]
+        public void LeaveAnEmptyUrlAlone()
+        {
+            Assert.AreEqual("", "".WithClientSource());
+            Assert.IsNull(((string)null).WithClientSource());
+        }
+    }
+}

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/ClientSourceUrlExtensionsShould.cs.meta
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/ClientSourceUrlExtensionsShould.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f14f902baa3f43dd954792f79e3b59d4
+timeCreated: 1786365082

--- a/Explorer/Assets/DCL/Passport/Modules/EquippedItemsPassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/EquippedItemsPassportModuleController.cs
@@ -7,6 +7,7 @@ using DCL.AvatarRendering.Wearables.Components;
 using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Backpack;
 using DCL.Browser;
+using DCL.Browser.DecentralandUrls;
 using DCL.Diagnostics;
 using DCL.MarketplaceCredits.Purchase.UI;
 using DCL.Multiplayer.Connections.DecentralandUrls;
@@ -451,7 +452,9 @@ namespace DCL.Passport.Modules
             if (!contract.StartsWith("0x") || !int.TryParse(item, out int _))
                 return "";
 
-            return string.Format(marketplace, contract, item);
+            // Tagged here rather than on the ShopLink constant: the format string above appends a path to it,
+            // so a query string on the constant would land before the path and 404. See ClientSourceUrlExtensions.
+            return string.Format(marketplace, contract, item).WithClientSource();
         }
     }
 }


### PR DESCRIPTION
The client is invisible as a traffic source. A native app opening the browser sends no `Referer`, so every
visit we send lands in the web analytics as "direct" — the same bucket as someone typing the address or using
a bookmark. Measured on the Shop over its first days live, that bucket is **252 of 337 visitors (75%)**, which
makes "how much traffic does the client actually drive" unanswerable rather than merely imprecise.

The convention already exists here — `NewsletterSubscriptionLink` carries `utm_source=client` and shows up
correctly in the web-side analytics. The shop links simply never got it.

## Changes

- `ClientSourceUrlExtensions.WithClientSource()` appends `utm_source=client`, choosing `?` or `&` by whether
  the URL already has a query string, and leaving a null/empty URL untouched.
- Applied to the passport's item link (`EquippedItemsPassportModuleController`) — the link shown when you look
  at what another avatar is wearing, which is the social-discovery path into the Shop.
- `GoShoppingWithMarketplaceCredits` tagged on the constant, where it is safe to do so.

Only `utm_source`. The other UTM fields carry nothing the destination cannot infer (the campaign is the path,
the medium is always organic), and the confirmation dialog shown before leaving for the browser displays the
URL in full — every extra parameter is another line of query string in front of the user.

## Why ShopLink itself is NOT tagged

`ShopLink` stays a bare `https://decentraland.{ENV}/shop` because the passport builds its item URL by
appending `/item/{contract}/{id}` to it. A query string on the constant would put the path AFTER the query:

```
https://decentraland.org/shop?utm_source=client/item/0xabc/0   ← 404
```

So the tag goes on the finished URL, not the constant, and a comment on the constant says why. Nothing else
opens `ShopLink` directly today.

## Scope

This covers only the links the CLIENT builds. The confirmation dialog in the screenshots people share also
appears for shop links written into scene content by creators — those come through the generic hyperlink
handler and are not ours to rewrite. Attributing those would mean modifying a URL a creator authored, which
is a product decision rather than a fix, and is deliberately left out.

## Test plan

- [x] `ClientSourceUrlExtensionsShould` covers the four cases that matter: plain URL gets `?`, an item URL
      keeps its path intact (the 404 case above), an existing query joins with `&`, and empty/null is
      returned unchanged
- [ ] Open the passport of an avatar wearing a marketplace wearable and confirm the link carries the
      parameter and still resolves to the item page
- [ ] Confirm the parameter reaches `CONTEXT_CAMPAIGN_SOURCE` on the web side