### PR TITLE
feat: send wearable links from the client to the shop

### DIFF
--- a/Explorer/Assets/DCL/Backpack/AvatarSection/AvatarController.cs
+++ b/Explorer/Assets/DCL/Backpack/AvatarSection/AvatarController.cs
@@ -25,7 +25,9 @@ namespace DCL.Backpack
         private readonly BackpackGridController backpackGridController;
         private readonly AvatarTabsManager tabsManager;
         private readonly URLBuilder urlBuilder = new ();
-        private readonly URLParameter marketplaceSourceParam = new ("utm_source", "backpack");
+        // Still "backpack" even though the destination is now the Shop: this names where the click came FROM,
+        // and keeping it is what lets the web side see this traffic move from the marketplace over to the Shop.
+        private readonly URLParameter shopSourceParam = new ("utm_source", "backpack");
 
         public AvatarController(AvatarView view,
             UnityAppWebBrowser webBrowser,
@@ -51,7 +53,7 @@ namespace DCL.Backpack
 
             rectTransform = view.GetComponent<RectTransform>();
 
-            view.marketplaceButton.onClick.AddListener(OnOpenMarketplace);
+            view.marketplaceButton.onClick.AddListener(OnOpenShop);
 
             slotsController = new BackpackSlotsController(slotViews,
                 backpackCommandBus,
@@ -72,11 +74,14 @@ namespace DCL.Backpack
             tabsManager.InitializeAndEnable();
         }
 
-        private void OnOpenMarketplace()
+        // The Shop and not the marketplace: this button lives in the avatar section, so what it is asked for is
+        // always wearables or emotes, and those are what the Shop sells. LAND keeps pointing at the marketplace
+        // elsewhere — the Shop carries no parcels or estates.
+        private void OnOpenShop()
         {
             urlBuilder.Clear();
-            urlBuilder.AppendDomain(URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.Market)));
-            urlBuilder.AppendParameter(marketplaceSourceParam);
+            urlBuilder.AppendDomain(URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.ShopLink)));
+            urlBuilder.AppendParameter(shopSourceParam);
             webBrowser.OpenUrlMainThreadOnly(urlBuilder.Build());
         }
 

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/EquippedWearableController.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/EquippedWearableController.cs
@@ -63,7 +63,7 @@ namespace DCL.InWorldCamera.PhotoDetail
             async UniTaskVoid AnimateAndAwaitAsync()
             {
                 await UniTask.Delay((int)(view.buyButtonAnimationDuration * 1000));
-                webBrowser.OpenUrlMainThreadOnly(currentWearable.GetMarketplaceLink(decentralandUrlsSource));
+                webBrowser.OpenUrlMainThreadOnly(currentWearable.GetShopLink(decentralandUrlsSource));
                 MarketClicked?.Invoke();
             }
 

--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailUtility.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailUtility.cs
@@ -8,12 +8,20 @@ namespace DCL.InWorldCamera.PhotoDetail
     public static class PhotoDetailUtility
     {
         /// <summary>
-        ///     Extracts the marketplace link from a wearable.
-        ///     Taken from the old renderer.
+        ///     Builds the Shop link for a wearable worn in a photo.
+        ///     <para>
+        ///         The Shop and not the marketplace: the subject here is always a wearable, which is what the Shop
+        ///         sells and prices in USD. LAND still belongs to the marketplace — the Shop carries no parcels.
+        ///     </para>
+        ///     <para>
+        ///         Note the route differs, so this is not a host swap: the marketplace addresses an item as
+        ///         <c>/contracts/{contract}/items/{id}</c> and the Shop as <c>/item/{contract}/{id}</c>. Keeping the
+        ///         old shape against the new host is a 404, not a redirect.
+        ///     </para>
         /// </summary>
-        public static string GetMarketplaceLink(this IWearable wearable, IDecentralandUrlsSource decentralandUrlsSource)
+        public static string GetShopLink(this IWearable wearable, IDecentralandUrlsSource decentralandUrlsSource)
         {
-            var marketplace = $"{decentralandUrlsSource.Url(DecentralandUrl.Market)}/contracts/{{0}}/items/{{1}}";
+            var shop = $"{decentralandUrlsSource.Url(DecentralandUrl.ShopLink)}/item/{{0}}/{{1}}";
             ReadOnlySpan<char> idSpan = wearable.GetUrn().ToString().AsSpan();
             int lastColonIndex = idSpan.LastIndexOf(':');
 
@@ -29,7 +37,7 @@ namespace DCL.InWorldCamera.PhotoDetail
             if (!contract.StartsWith("0x") || !int.TryParse(item, out int _))
                 return "";
 
-            return string.Format(marketplace, contract, item);
+            return string.Format(shop, contract, item);
         }
     }
 }


### PR DESCRIPTION
The client still sends people to the legacy marketplace when what they are after is a wearable. The Shop is
where wearables and emotes are sold and priced in USD, so those entry points should land there. LAND is
unchanged and stays on the marketplace — the Shop carries no parcels or estates.

The passport's equipped-item link already points at the Shop; this brings the remaining wearable entry
points in line with it.

## Changes

- **Backpack, avatar section** — the marketplace button now opens the Shop. This button sits in the avatar
  section, so what it is asked for is always a wearable or an emote.
- **Photo detail, buy a worn wearable** — now links to the Shop's item page. Note this is **not** a host
  swap: the marketplace addresses an item as `/contracts/{contract}/items/{id}` and the Shop as
  `/item/{contract}/{id}`, so keeping the old shape against the new host would 404. Verified against the
  Shop's routes.
- `GetMarketplaceLink` renamed to `GetShopLink` so the name matches where it goes.

`utm_source=backpack` is kept as-is. It names where the click came FROM, not where it lands, and keeping it
is what makes the shift in destination visible on the web side.

## Deliberately NOT changed

- **The sidebar's Marketplace button.** It is a generic marketplace entry, not a wearables one, and the Shop
  currently offers no way through to LAND. Repointing it would strand anyone who opened it looking for a
  parcel. That needs a product decision first, plus either a link from the Shop to the marketplace or a
  second entry in the sidebar.
- **`GoShoppingWithMarketplaceCredits`.** It looks like it should move, and it must not: marketplace credits
  only spend in the legacy marketplace, so sending that button to the Shop would drop the user somewhere
  their credits do not work.
- **Passport creations.** The URL there comes from the catalog API (`item.url`), so its shape is
  server-controlled and cannot be rewritten safely from here. It could be derived from the item's `urn`
  instead, which is worth doing separately.

## Test plan

- [ ] Backpack → avatar section → marketplace button opens `decentraland.org/shop?utm_source=backpack`
- [ ] Photo detail → a worn wearable → buy opens `decentraland.org/shop/item/<contract>/<id>` and the page
      resolves (not a 404)
- [ ] A wearable whose urn does not parse still yields no link rather than a broken one
- [ ] Sidebar → Marketplace still opens the legacy marketplace