### PR TITLE
chore: note LODs aren't natively scene-level per-model in content-breakdown MCP tool

### DIFF
--- a/Explorer/Assets/DCL/McpServer/Tools/GetSceneContentBreakdownTool.cs
+++ b/Explorer/Assets/DCL/McpServer/Tools/GetSceneContentBreakdownTool.cs
@@ -40,7 +40,7 @@ namespace DCL.McpServer.Tools
             + "Interpretation: URP's SRP Batcher bins draws by shader variant, so many materials sharing few shaderVariants render cheaply — "
             + "a high material count mainly costs memory, textures and lost instancing opportunities. Check shaderVariants before recommending "
             + "material dedup as a frame-time optimization. Do not recommend LODs (level-of-detail meshes) to cut a heavy source's triangles: "
-            + "per-model LODs are not supported at the scene level currently and must be handled manually in the source asset. "
+            + "per-model LODs are not supported at the scene level currently — to reduce a heavy source's triangle count, prefer recommending mesh decimation or retopology. "
             + "Triggers a fresh counting pass over the currently rendered content.";
 
         public override JObject OutputSchema =>

--- a/Explorer/Assets/DCL/McpServer/Tools/GetSceneContentBreakdownTool.cs
+++ b/Explorer/Assets/DCL/McpServer/Tools/GetSceneContentBreakdownTool.cs
@@ -39,7 +39,9 @@ namespace DCL.McpServer.Tools
             + "(move_to/set_camera_pose). Use it after get_scene_content_stats shows a metric near its cap to find which assets to optimize. "
             + "Interpretation: URP's SRP Batcher bins draws by shader variant, so many materials sharing few shaderVariants render cheaply — "
             + "a high material count mainly costs memory, textures and lost instancing opportunities. Check shaderVariants before recommending "
-            + "material dedup as a frame-time optimization. Triggers a fresh counting pass over the currently rendered content.";
+            + "material dedup as a frame-time optimization. Do not recommend LODs (level-of-detail meshes) to cut a heavy source's triangles: "
+            + "per-model LODs are not supported at the scene level currently and must be handled manually in the source asset. "
+            + "Triggers a fresh counting pass over the currently rendered content.";
 
         public override JObject OutputSchema =>
             McpJsonSchema.Object()


### PR DESCRIPTION
## What

Adds a caveat to the `get_scene_content_breakdown` MCP tool's `Description`: LODs (level-of-detail meshes) are **not natively supported per model at the scene level** currently, so to cut a heavy source's triangles the agent should prefer recommending **mesh decimation or retopology**.

## Why

`get_scene_content_breakdown` ranks a scene's rendered content by triangle count so an agent can tell a creator *what to optimize*. Because the heaviest offenders surface by triangle count, the natural next suggestion is "add LODs to that mesh" — but that isn't something the platform supports per model at the scene level today. Without a steer in the tool description, the agent will confidently suggest an optimization that can't be applied, instead of the ones that can (decimation, retopology).

This follows the existing convention in the same `Description` (e.g. *"Check shaderVariants before recommending material dedup as a frame-time optimization"*) of correcting likely-wrong optimization advice at the source — in the tool listing the model reads.

## Change

Single-line addition to the authored guidance string in `Explorer/Assets/DCL/McpServer/Tools/GetSceneContentBreakdownTool.cs`:

> …LODs (level-of-detail meshes) are not natively supported per model at the scene level currently, so to cut a heavy source's triangles prefer recommending mesh decimation or retopology.…

No behavior/runtime change — only the MCP tool's description text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)