### PR TITLE
feat: add other options disclaimer for epic store

### DIFF
--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -92,6 +92,14 @@ on:
           - both
           - windows-only
           - macos-only
+      install_source:
+        description: 'Install source baked into the build'
+        required: true
+        default: 'launcher'
+        type: choice
+        options:
+          - launcher
+          - epic
   workflow_call:
     inputs:
       profile:

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/Prefabs/LoginSelection.Screen.prefab
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/Prefabs/LoginSelection.Screen.prefab
@@ -120,6 +120,221 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &286611025687677817
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3414079020129160184}
+  - component: {fileID: 8014165326776127162}
+  - component: {fileID: 5156572422652573198}
+  m_Layer: 0
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3414079020129160184
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 286611025687677817}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5269535992575051354}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 58.69, y: -23.02}
+  m_SizeDelta: {x: 200, y: 19}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &8014165326776127162
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 286611025687677817}
+  m_CullTransparentMesh: 1
+--- !u!114 &5156572422652573198
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 286611025687677817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: More ways to log in
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_sharedMaterial: {fileID: 735423033564544980, guid: 96ae0a2159a39234f858ea23bdcc74ad, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16.11
+  m_fontSizeBase: 16.11
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &308308401389710502
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5269535992575051354}
+  - component: {fileID: 2033597080855041459}
+  - component: {fileID: 1342149952037994826}
+  m_Layer: 0
+  m_Name: OtherLoginOptionsDisclaimer.Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5269535992575051354
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 308308401389710502}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 347619755398352162}
+  - {fileID: 3414079020129160184}
+  - {fileID: 8768531179240013751}
+  m_Father: {fileID: 4369993298298465176}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 229, y: -197.13}
+  m_SizeDelta: {x: 458, y: 162.26}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2033597080855041459
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 308308401389710502}
+  m_CullTransparentMesh: 1
+--- !u!114 &1342149952037994826
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 308308401389710502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.29803923}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 12dd1efc4e826764f9b02be515a9a033, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &455086688581633578
 GameObject:
   m_ObjectHideFlags: 0
@@ -1043,6 +1258,81 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3057037394322255694
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 347619755398352162}
+  - component: {fileID: 3023974292180830583}
+  - component: {fileID: 4929565454883755099}
+  m_Layer: 0
+  m_Name: InfoIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &347619755398352162
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3057037394322255694}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5269535992575051354}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 18.41, y: -19.56}
+  m_SizeDelta: {x: 27.619995, y: 27.620003}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &3023974292180830583
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3057037394322255694}
+  m_CullTransparentMesh: 1
+--- !u!114 &4929565454883755099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3057037394322255694}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: d63bc69a4cb0e4fd5b31fc3bd1f8e1fc, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3292026638963300296
 GameObject:
   m_ObjectHideFlags: 0
@@ -1589,12 +1879,12 @@ RectTransform:
   m_Children:
   - {fileID: 7358252246579509219}
   - {fileID: 1321724806577120997}
-  m_Father: {fileID: 2034299800128287215}
+  m_Father: {fileID: 5781027346591425177}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 229, y: -120}
-  m_SizeDelta: {x: 458, y: 29.18}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6861568952330199588
 CanvasRenderer:
@@ -1808,6 +2098,160 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4234757080699934069
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8768531179240013751}
+  - component: {fileID: 4708963003642885764}
+  - component: {fileID: 7888905309712706443}
+  - component: {fileID: 2214091251602670085}
+  m_Layer: 0
+  m_Name: Description
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8768531179240013751
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4234757080699934069}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 500093107284932764}
+  m_Father: {fileID: 5269535992575051354}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 58.690018, y: -59.84}
+  m_SizeDelta: {x: 371.6, y: 87.45999}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &4708963003642885764
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4234757080699934069}
+  m_CullTransparentMesh: 1
+--- !u!114 &7888905309712706443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4234757080699934069}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Google, Discord and other sign-in options
+
+    are available when you
+    download Decentraland directly from <link=https://decentraland.org><color=#32B0F4><b><u>decentraland.org</u></b></color></link>'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_sharedMaterial: {fileID: 1701868249614554837, guid: 35aa85d68d15435418848a03a2db81ec, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 16.11
+  m_fontSizeBase: 16.11
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 43
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &2214091251602670085
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4234757080699934069}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa79a46ad7d14748b3e248214931267e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UI::DCL.UI.TMP_Text_ClickeableLink
 --- !u!1 &4760450942047172602
 GameObject:
   m_ObjectHideFlags: 0
@@ -2463,13 +2907,12 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8979018636815086978}
-  - {fileID: 7705340360496267998}
   m_Father: {fileID: 4369993298298465176}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 458, y: 116}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &5354155941627808391
 GameObject:
@@ -2774,6 +3217,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2034299800128287215}
+  - {fileID: 5269535992575051354}
+  - {fileID: 5781027346591425177}
   - {fileID: 1151621360254823839}
   m_Father: {fileID: 7873494142348841762}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2800,7 +3245,7 @@ MonoBehaviour:
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 0
-  m_Spacing: -90
+  m_Spacing: 0
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
@@ -2845,7 +3290,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 458, y: 236.0765}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &5934805659268293681
 GameObject:
@@ -3006,7 +3451,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 455.5, y: -149.5}
+  m_AnchoredPosition: {x: 455.5, y: -26.899994}
   m_SizeDelta: {x: 458, y: 25.4631}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!222 &6536901575588356123
@@ -3217,7 +3662,9 @@ MonoBehaviour:
   <EmailOTPContainer>k__BackingField: {fileID: 5285033395635913484}
   <EmailInputField>k__BackingField: {fileID: 2001940849056367380}
   <OtherLoginContainer>k__BackingField: {fileID: 5887702060069110797}
-  <ContinueWithTextContainer>k__BackingField: {fileID: 3844889584895123327}
+  <OtherLoginOptionsDisclaimer>k__BackingField: {fileID: 308308401389710502}
+  <OtherLoginOptionsDisclaimerLink>k__BackingField: {fileID: 2214091251602670085}
+  <ContinueWithTextContainer>k__BackingField: {fileID: 8938751799975341066}
   <LoginMetamaskButton>k__BackingField: {fileID: 4481630630708771614}
   <LoginGoogleButton>k__BackingField: {fileID: 9078712830092277137}
   <LoginDiscordButton>k__BackingField: {fileID: 8034867738283704265}
@@ -4205,7 +4652,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 227.63, y: -204.5}
+  m_AnchoredPosition: {x: 227.63, y: -81.899994}
   m_SizeDelta: {x: 458, y: 46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2410297199668446962
@@ -4694,6 +5141,117 @@ MonoBehaviour:
   m_Sprite: {fileID: 21300000, guid: 00cc69ba88b8143baa8ef5d80c99ab63, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8938751799975341066
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5781027346591425177}
+  m_Layer: 0
+  m_Name: Separator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5781027346591425177
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8938751799975341066}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7705340360496267998}
+  m_Father: {fileID: 4369993298298465176}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 458, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &9051290738927758090
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 500093107284932764}
+  - component: {fileID: 1654271087708001573}
+  - component: {fileID: 2484669764804337463}
+  m_Layer: 0
+  m_Name: LinkIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &500093107284932764
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9051290738927758090}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8768531179240013751}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 252.4, y: -54.8}
+  m_SizeDelta: {x: 20, y: 23}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &1654271087708001573
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9051290738927758090}
+  m_CullTransparentMesh: 1
+--- !u!114 &2484669764804337463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9051290738927758090}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.6901961, b: 0.95686275, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 3bffb1589fb814c70b23fbce43ba6736, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1
@@ -5841,7 +6399,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3152644595163223519, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -94
+      value: 28.600006
       objectReference: {fileID: 0}
     - target: {fileID: 3152644595163223519, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -8059,7 +8617,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3152644595163223519, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -37.6
+      value: 85
       objectReference: {fileID: 0}
     - target: {fileID: 3152644595163223519, guid: 83437f351686bca419378abea4d2ed07, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -165,7 +165,7 @@ namespace DCL.AuthenticationScreenFlow
             fsm.AddStates(
                 new InitAuthState(viewInstance, installSource),
                 new LoginSelectionAuthState(fsm, viewInstance, this, CurrentState, splashScreen, web3Authenticator, webBrowser,
-                    enableEmailOTP, otherLoginMethodsEnabled),
+                    enableEmailOTP, otherLoginMethodsEnabled, isEpicBuild),
                 new ProfileFetchingAuthState(fsm, viewInstance, this, CurrentState, selfProfile, storedIdentityProvider),
                 new IdentityVerificationDappDeepLinkAuthState(fsm, viewInstance, this, CurrentState, web3Authenticator),
                 new LobbyForExistingAccountAuthState(fsm, viewInstance, this, splashScreen, CurrentState, characterPreviewController),

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LoginSelectionAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LoginSelectionAuthState.cs
@@ -49,7 +49,6 @@ namespace DCL.AuthenticationScreenFlow
 
             // Cancel button persists in the Verification state (until code is shown)
             view.CancelLoginButton.onClick.AddListener(OnCancelBeforeVerification);
-            view.OtherLoginOptionsDisclaimerLink.OnLinkClicked += webBrowser.OpenUrlMainThreadOnly;
         }
 
         public new void Enter()
@@ -86,6 +85,9 @@ namespace DCL.AuthenticationScreenFlow
                 // ThirdWeb
                 view.EmailInputField.Submitted += OTPLogin;
             }
+
+            if (isEpicBuild)
+                view.OtherLoginOptionsDisclaimerLink.OnLinkClicked += webBrowser.OpenUrlMainThreadOnly;
         }
 
         public override void Exit()

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LoginSelectionAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LoginSelectionAuthState.cs
@@ -84,10 +84,10 @@ namespace DCL.AuthenticationScreenFlow
 
                 // ThirdWeb
                 view.EmailInputField.Submitted += OTPLogin;
-            }
 
-            if (isEpicBuild)
-                view.OtherLoginOptionsDisclaimerLink.OnLinkClicked += webBrowser.OpenUrlMainThreadOnly;
+                if (isEpicBuild)
+                    view.OtherLoginOptionsDisclaimerLink.OnLinkClicked += webBrowser.OpenUrlMainThreadOnly;
+            }
         }
 
         public override void Exit()

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LoginSelectionAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/LoginSelectionAuthState.cs
@@ -25,13 +25,15 @@ namespace DCL.AuthenticationScreenFlow
         private readonly UnityAppWebBrowser webBrowser;
         private readonly bool enableEmailOTP;
         private readonly bool otherLoginMethodsEnabled;
+        private readonly bool isEpicBuild;
 
         public LoginSelectionAuthState(MVCStateMachine<AuthStateBase> machine,
             AuthenticationScreenView viewInstance, AuthenticationScreenController controller,
             ReactiveProperty<AuthStatus> currentState, SplashScreen splashScreen,
             ICompositeWeb3Provider compositeWeb3Provider, UnityAppWebBrowser webBrowser,
             bool enableEmailOTP,
-            bool otherLoginMethodsEnabled) : base(viewInstance)
+            bool otherLoginMethodsEnabled,
+            bool isEpicBuild) : base(viewInstance)
         {
             view = viewInstance.LoginSelectionAuthView;
 
@@ -43,9 +45,11 @@ namespace DCL.AuthenticationScreenFlow
             this.webBrowser = webBrowser;
             this.enableEmailOTP = enableEmailOTP;
             this.otherLoginMethodsEnabled = otherLoginMethodsEnabled;
+            this.isEpicBuild = isEpicBuild;
 
             // Cancel button persists in the Verification state (until code is shown)
             view.CancelLoginButton.onClick.AddListener(OnCancelBeforeVerification);
+            view.OtherLoginOptionsDisclaimerLink.OnLinkClicked += webBrowser.OpenUrlMainThreadOnly;
         }
 
         public new void Enter()
@@ -87,7 +91,7 @@ namespace DCL.AuthenticationScreenFlow
         public override void Exit()
         {
             view.RestrictedUserContainer.SetActive(false);
-            view!.ErrorPopupRoot.SetActive(false);
+            view.ErrorPopupRoot.SetActive(false);
 
             view.LoginMetamaskButton.onClick.RemoveAllListeners();
             view.LoginGoogleButton.onClick.RemoveAllListeners();
@@ -111,6 +115,8 @@ namespace DCL.AuthenticationScreenFlow
 
             // ThirdWeb
             view.EmailInputField.Submitted -= OTPLogin;
+
+            view.OtherLoginOptionsDisclaimerLink.OnLinkClicked -= webBrowser.OpenUrlMainThreadOnly;
             base.Exit();
         }
 
@@ -140,7 +146,8 @@ namespace DCL.AuthenticationScreenFlow
             if (splashScreen != null) // it can be destroyed after first login
                 splashScreen.FadeOutAndHide();
 
-            view.Show(animHash, moreOptionsExpanded: !enableEmailOTP, otherLoginMethodsEnabled);
+            view.Show(animHash, moreOptionsExpanded: !enableEmailOTP, otherLoginMethodsEnabled,
+                otherLoginOptionsDisclaimer: isEpicBuild);
             Enter();
         }
 

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/LoginSelectionAuthView.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Views/LoginSelectionAuthView.cs
@@ -27,6 +27,12 @@ namespace DCL.AuthenticationScreenFlow
         public GameObject OtherLoginContainer { get; private set; } = null!;
 
         [field: SerializeField]
+        public GameObject OtherLoginOptionsDisclaimer { get; private set; } = null!;
+
+        [field: SerializeField]
+        public TMP_Text_ClickeableLink OtherLoginOptionsDisclaimerLink { get; private set; } = null!;
+
+        [field: SerializeField]
         public GameObject ContinueWithTextContainer { get; private set; } = null!;
 
         [field: SerializeField]
@@ -85,14 +91,14 @@ namespace DCL.AuthenticationScreenFlow
         public Button[] UseAnotherAccountButton { get; private set; } = null!;
 
         [Space]
-        [SerializeField] private GameObject moreOptionsPanel;
+        [SerializeField] private GameObject moreOptionsPanel = null!;
 
         [Space]
-        [SerializeField] private Animator animator;
-        [SerializeField] private CanvasGroup canvasGroup;
+        [SerializeField] private Animator animator = null!;
+        [SerializeField] private CanvasGroup canvasGroup = null!;
 
-        [SerializeField] private GameObject loadingSpinner;
-        [SerializeField] private GameObject mainElementsPanel;
+        [SerializeField] private GameObject loadingSpinner = null!;
+        [SerializeField] private GameObject mainElementsPanel = null!;
 
         private int showAnimHash = UIAnimationHashes.OUT;
         private bool areOptionsExpanded;
@@ -109,7 +115,7 @@ namespace DCL.AuthenticationScreenFlow
             moreOptionsPanel.SetActive(isExpanded);
         }
 
-        public void Show(int animHash, bool moreOptionsExpanded, bool otherLoginMethodsEnabled)
+        public void Show(int animHash, bool moreOptionsExpanded, bool otherLoginMethodsEnabled, bool otherLoginOptionsDisclaimer)
         {
             showAnimHash = animHash;
             ShowAsync(CancellationToken.None).Forget();
@@ -117,6 +123,7 @@ namespace DCL.AuthenticationScreenFlow
             areOptionsExpanded = moreOptionsExpanded;
             OtherLoginContainer.SetActive(otherLoginMethodsEnabled);
             ContinueWithTextContainer.SetActive(otherLoginMethodsEnabled && !moreOptionsExpanded);
+            OtherLoginOptionsDisclaimer.SetActive(otherLoginOptionsDisclaimer);
             SetOptionsPanelVisibility(areOptionsExpanded && otherLoginMethodsEnabled);
 
             SetLoadingSpinnerVisibility(false);


### PR DESCRIPTION
## What does this PR change?

On Epic Store builds, email OTP is the only available login method — Google, Discord, Metamask and the rest of the social/wallet options are hidden. Until now nothing explained why, so users had no way of knowing those options still exist.

This PR adds a short disclaimer under the login form telling users that the other sign-in options are available if they download Decentraland directly from `decentraland.org`, with the domain as a clickable link that opens the site in their browser.

The disclaimer is only shown on Epic Store builds; every other build is unchanged.

## Test Instructions

**Expected result**: the login screen looks exactly as it does today — no disclaimer, all login options present.

### Test Steps (Epic build behaviour)

1. Reach the login screen.
2. Only the email login is offered, and the disclaimer appears below it.
3. Click the `decentraland.org` link → the site opens in the default browser.
4. Start an email login, go back to the login screen, and click the link again → it still opens the site.

## Quality Checklist
- [ ] Changes have been tested locally
- [x] Documentation has been updated (if required) — n/a
- [x] Performance impact has been considered — UI-only, no runtime cost
- [x] For SDK features: Test scene is included — n/a
