### PR TITLE
fix: L1 Wearables (#9612)

### DIFF
--- a/Explorer/Assets/DCL/NetworkDefinitions/AssetBundleManifestVersion.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/AssetBundleManifestVersion.cs
@@ -215,8 +215,8 @@ public class AssetBundleManifestVersion
             var assetBundleManifestVersion = new AssetBundleManifestVersion();
             var assets = new AssetBundleManifestVersionPerPlatform
             {
-                mac = new PlatformInfo(AB_MIN_SUPPORTED_VERSION_WINDOWS.ToString(), "1"),
-                windows = new PlatformInfo(AB_MIN_SUPPORTED_VERSION_MAC.ToString(), "1"),
+                windows = new PlatformInfo(AB_MIN_SUPPORTED_VERSION_WINDOWS.ToString(), "1"),
+                mac = new PlatformInfo(AB_MIN_SUPPORTED_VERSION_MAC.ToString(), "1"),
             };
             assetBundleManifestVersion.assets = assets;
             assetBundleManifestVersion.HasHashInPath();


### PR DESCRIPTION
This sat harmless for months because the AB request URL used to be hash+platform (version-free). Then #9442 (merged 2026-07-31) made the manifest version load-bearing in the CDN path: PrepareAssetBundleLoadingParametersSystemBase.cs:66 now builds the URL from GetCdnRequestPath → "v{version}/{hash}". So on Windows, GetAssetBundleManifestVersion() reads the crossed windows.version = 16 instead of 15, the client requests a nonexistent AB version → 404 → the wearable never loads → invisible. Windows-only because only the Windows branch reads the crossed value; the Mac branch reads mac=15 which the CDN still serves. This manifest is used for the default MALE/FEMALE base bodies (LoadDefaultWearablesSystem) and the useManualManifest fallback — i.e. exactly the base L1 wearables, matching "L1 wearables… not visible when equipped, except upper-body."