### PR TITLE
chore: gate release and hotfix PRs on the InWorld suite

### DIFF
--- a/.github/actions/resolve-explorer-build/action.yml
+++ b/.github/actions/resolve-explorer-build/action.yml
@@ -148,16 +148,34 @@ runs:
         # gh has no built-in retry, and both callers below are decisive on a
         # single answer: the wait-minutes: 0 path has no second poll, and a
         # listing that fails every poll would otherwise read as "no build
-        # exists". stderr is dropped because a 90-minute wait polls ~90 times
-        # and every failure that survives the retry is reported, with an
-        # action, by the messages below.
+        # exists". Three attempts five seconds apart cover a transport failure
+        # — a 5xx, a connection reset — and only that. They do not rescue a
+        # spent rate limit, which refills on an hour boundary rather than in
+        # ten seconds: there every attempt fails by construction and the retry
+        # only spends more of a budget that is already gone. What separates
+        # that outage from a real "no build" is the LISTED/LISTED_NOW pair
+        # below, not this helper.
+        #
+        # stderr is dropped on the attempts that get another go, because a
+        # 90-minute wait polls ~90 times and a blip that the next attempt
+        # answers is not news. The last attempt keeps it, because a permanent
+        # failure — build-unitycloud.yml renamed, say — 404s on every attempt
+        # of every poll, and the messages below can only report that as an API
+        # that did not answer: without gh's own line the operator is sent to a
+        # status page that is green, with the one fact that explains it
+        # discarded.
         gh_api_retry() {
           local out attempt
           for attempt in 1 2 3; do
-            if out=$(gh api "$@" 2>/dev/null); then printf '%s' "$out"; return 0; fi
-            # Not after the last attempt: the callers below act on the answer
-            # immediately, so that sleep would only delay a red check.
-            if [ "$attempt" -lt 3 ]; then sleep 5; fi
+            if [ "$attempt" -lt 3 ]; then
+              if out=$(gh api "$@" 2>/dev/null); then printf '%s' "$out"; return 0; fi
+              # Only between attempts: the callers below act on the answer
+              # immediately, so a sleep after the last one would just delay a
+              # red check.
+              sleep 5
+            else
+              if out=$(gh api "$@"); then printf '%s' "$out"; return 0; fi
+            fi
           done
           return 1
         }
@@ -168,10 +186,13 @@ runs:
         # operator which of the two happened, and only one of them is fixed by
         # `force-build`. LISTED is "did any poll's listing ever answer";
         # LISTED_NOW, set per poll further down, is "did the last one". Both
-        # are needed: this loop spends ~360 requests/hour of a 1,000/hour
-        # budget it shares with build-unitycloud and the review bots, so the
-        # realistic outage — rate-limit exhaustion — begins partway through a
-        # 90-minute wait, and by then LISTED has long since flipped.
+        # are needed precisely for the outage the retry above cannot absorb:
+        # this loop spends ~360 requests/hour of the 1,000/hour per-repository
+        # GITHUB_TOKEN budget it shares with build-unitycloud and the review
+        # bots, so rate-limit exhaustion starts partway through a 90-minute
+        # wait and holds until the hour rolls over — every attempt of every
+        # remaining poll fails, and by then LISTED has long since flipped
+        # while LISTED_NOW has not. That difference is the whole diagnosis.
         LISTED=0
         DEADLINE=$(( SECONDS + WAIT_MINUTES * 60 ))
         while :; do

--- a/.github/actions/resolve-explorer-build/action.yml
+++ b/.github/actions/resolve-explorer-build/action.yml
@@ -1,0 +1,192 @@
+name: Resolve Explorer build
+description: >-
+  Resolves the macOS Unity Cloud Build artifact URL for a commit, plus the
+  explorer-automation ref its tests should come from. Shared by the dispatchers
+  for explorer-automation's reusable suites — visual-regression.yml and
+  in-world-tests.yml — which differ only in their trigger and in which suite
+  they call.
+
+inputs:
+  head-ref:
+    description: 'Branch under test. Looked up in explorer-automation to pick tests-ref.'
+    required: true
+  head-sha:
+    description: 'Commit to find a build for.'
+    required: true
+  wait-minutes:
+    description: >-
+      How long to wait for a build that has not finished yet. 0 (the default)
+      requires one to already exist — right for a caller a human triggers, since
+      they can look. A caller that fires the moment a PR opens has to wait for
+      the build the same event started.
+    required: false
+    default: '0'
+  build-url-override:
+    description: >-
+      Use this artifact URL as-is and skip resolution. For manual runs that
+      target a build this repo cannot derive — an older commit, another branch.
+    required: false
+    default: ''
+  public-url-prefix:
+    description: 'vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL — public prefix of the artifact bucket.'
+    required: true
+  github-token:
+    description: 'Token with actions:read on this repo.'
+    required: true
+  automation-token:
+    description: 'Token with contents:read on decentraland/explorer-automation (REPOS_READ_ONLY_TOKEN).'
+    required: true
+
+outputs:
+  build-url:
+    description: 'Direct URL to Decentraland_macos.zip, verified reachable.'
+    value: ${{ steps.build.outputs.build-url }}
+  short-sha:
+    description: 'First 7 characters of the commit the build was made from.'
+    value: ${{ steps.build.outputs.short-sha }}
+  tests-ref:
+    description: 'explorer-automation ref to take tests from. Empty means that repo default.'
+    value: ${{ steps.match.outputs.tests-ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve build URL
+      id: build
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+        WAIT_MINUTES: ${{ inputs.wait-minutes }}
+        BUILD_URL_OVERRIDE: ${{ inputs.build-url-override }}
+        PUBLIC_URL_PREFIX: ${{ inputs.public-url-prefix }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "$BUILD_URL_OVERRIDE" ]; then
+          # Everything below only ever produces bucket URLs; an override is the
+          # one path where a caller picks the host, so pin it here rather than
+          # leaving it to the suite's own check on the macOS runner.
+          case "$BUILD_URL_OVERRIDE" in
+            https://explorer-artifacts.decentraland.org/*) ;;
+            *)
+              echo "::error::build_url must be an https://explorer-artifacts.decentraland.org/ URL."
+              exit 1
+              ;;
+          esac
+          {
+            echo "build-url=${BUILD_URL_OVERRIDE}"
+            echo "short-sha=${HEAD_SHA:0:7}"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::Using caller-supplied build URL."
+          exit 0
+        fi
+
+        DEADLINE=$(( SECONDS + WAIT_MINUTES * 60 ))
+        while :; do
+          # Scoped to the build workflow file: a repo-wide head_sha listing gets
+          # crowded out by bot runs sharing the SHA (90+ on a typical release
+          # commit) and the build falls past the first page. Only
+          # pull_request/push builds qualify — dispatch builds can carry
+          # non-default options (e.g. profiling) that break the determinism the
+          # suites rely on.
+          RUNS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&per_page=20" \
+            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")]')
+          RUN_JSON=$(jq -c '[.[] | select(.conclusion == "success")] | .[0] // empty' <<< "$RUNS")
+          if [ -n "$RUN_JSON" ]; then break; fi
+
+          TOTAL=$(jq 'length' <<< "$RUNS")
+          RUNNING=$(jq '[.[] | select(.status != "completed")] | length' <<< "$RUNS")
+
+          if [ "$WAIT_MINUTES" -eq 0 ]; then
+            echo "::error::No successful Unity Cloud Build run for ${HEAD_SHA:0:7}. Is the build still in progress, or did it fail?"
+            exit 1
+          fi
+          # Every build for this commit finished and none produced an artifact.
+          # Waiting for a re-run that nobody has asked for only delays the red.
+          if [ "$TOTAL" -gt 0 ] && [ "$RUNNING" -eq 0 ]; then
+            echo "::error::Unity Cloud Build failed for ${HEAD_SHA:0:7} — there is nothing to test. Fix the build, or push again."
+            exit 1
+          fi
+          if [ "$SECONDS" -ge "$DEADLINE" ]; then
+            echo "::error::Gave up after ${WAIT_MINUTES}m waiting for a Unity Cloud Build of ${HEAD_SHA:0:7}."
+            if [ "$TOTAL" -eq 0 ]; then
+              # build-unitycloud.yml skips drafts and PRs that touch no
+              # Explorer/** file. A `force-build` label overrides both.
+              echo "::error::No build was ever queued for this commit. Label the PR \`force-build\`, or push a change under Explorer/, then re-run this job."
+            else
+              echo "::error::Re-run this job once the build is green."
+            fi
+            exit 1
+          fi
+          # TOTAL of 0 is normal right after a PR opens: the build is triggered
+          # by the same event as this job and takes a moment to register.
+          echo "Waiting for a build of ${HEAD_SHA:0:7} — ${RUNNING} of ${TOTAL} still running. $(( (DEADLINE - SECONDS) / 60 ))m left."
+          sleep 60
+        done
+
+        RUN_NUMBER=$(jq -r '.run_number'  <<< "$RUN_JSON")
+        RUN_EVENT=$(jq  -r '.event'       <<< "$RUN_JSON")
+        RUN_BRANCH=$(jq -r '.head_branch' <<< "$RUN_JSON")
+        BUILT_SHA=$(jq  -r '.head_sha'    <<< "$RUN_JSON")
+        SHORT_SHA="${BUILT_SHA:0:7}"
+
+        # The S3 prefix and branch segment come from the run that produced the
+        # build, not from what is under test: a commit's only build may have run
+        # on another trigger — e.g. bot-created release PRs, whose tip is built
+        # by the push to dev. Table mirrors build-unitycloud.yml's
+        # "Set SHA, branch, and build prefix".
+        case "$RUN_EVENT" in
+          pull_request)      BUILD_PREFIX="pr" ;;
+          push)              BUILD_PREFIX="pu" ;;
+          merge_group)       BUILD_PREFIX="mg" ;;
+          workflow_dispatch) BUILD_PREFIX="wd" ;;
+          workflow_call)     BUILD_PREFIX="wc" ;;
+          schedule)          BUILD_PREFIX="sc" ;;
+          *)                 BUILD_PREFIX="gn" ;;
+        esac
+
+        # Always the branch/ path, never releases/: release builds are compiled
+        # without the ALTTESTER scripting define (CloudBuild.cs strips it), so
+        # the client installs and renders but never accepts a connection, and
+        # the suite sits at "Wait for connection: 0%" until its job cap.
+        ARTIFACT_PATH="@dcl/${GITHUB_REPOSITORY##*/}/branch/${RUN_BRANCH}/${BUILD_PREFIX}-${RUN_NUMBER}-${SHORT_SHA}"
+        BUILD_URL="${PUBLIC_URL_PREFIX}/${ARTIFACT_PATH}/Decentraland_macos.zip"
+
+        # A successful run does not guarantee a macOS zip — build-unitycloud.yml
+        # takes a `platforms` input. Failing here costs seconds; the same failure
+        # inside the suite costs a whole macOS runner slot.
+        # curl still prints its -w output when it exits non-zero, so a
+        # `|| echo 000` fallback would concatenate codes ("200000") — normalize
+        # separately, and only when the output is empty.
+        HTTP=$(curl -sS -o /dev/null -w '%{http_code}' -I --retry 3 --retry-delay 5 "$BUILD_URL" || true)
+        HTTP=${HTTP:-000}
+        if [ "$HTTP" != "200" ]; then
+          echo "::error::Build artifact is not reachable (HTTP ${HTTP}): ${BUILD_URL}"
+          exit 1
+        fi
+
+        {
+          echo "build-url=${BUILD_URL}"
+          echo "short-sha=${SHORT_SHA}"
+        } >> "$GITHUB_OUTPUT"
+        echo "::notice::Using ${RUN_BRANCH} build ${BUILD_PREFIX}-${RUN_NUMBER}-${SHORT_SHA}."
+
+    - name: Look up matching explorer-automation branch
+      id: match
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.automation-token }}
+        HEAD_REF: ${{ inputs.head-ref }}
+      run: |
+        set -euo pipefail
+        # 200 = the branch exists there, so fixtures and visual baselines come
+        # from the matching feature branch. 404 = fall back to empty, which both
+        # reusable workflows resolve to their repo default.
+        if gh api "repos/decentraland/explorer-automation/branches/${HEAD_REF}" --silent >/dev/null 2>&1; then
+          echo "tests-ref=${HEAD_REF}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Using matching explorer-automation branch '${HEAD_REF}'."
+        else
+          echo "tests-ref=" >> "$GITHUB_OUTPUT"
+          echo "::notice::No matching explorer-automation branch '${HEAD_REF}' — using default."
+        fi

--- a/.github/actions/resolve-explorer-build/action.yml
+++ b/.github/actions/resolve-explorer-build/action.yml
@@ -274,6 +274,35 @@ runs:
           done
           if [ -n "$RUN_JSON" ]; then break; fi
 
+          # These two verdicts are decided before the wait-minutes: 0 branch
+          # below, not after it. Both are conclusions the candidate loop has
+          # already reached, and the single-poll callers are precisely the ones
+          # that can do least with the generic message that branch ends in:
+          # visual-regression.yml takes this path on every /visual-tests, and
+          # in-world-tests.yml on the dispatch create-release-branch.yml gates
+          # a release cut with. Neither can wait the condition out, so telling
+          # them to guess at something already known is the one case where the
+          # specific message matters most.
+          #
+          # Hoisting them cannot mask that branch's listing-outage message: a
+          # listing that never answered leaves RUNS empty, so no candidate is
+          # ever examined and STATE stays `none` — which neither of these two
+          # matches. The waiting path is unaffected either way, since the
+          # branch between them never fires when WAIT_MINUTES is non-zero.
+          #
+          # Newest first, so `failed` means the most recent build we found is red
+          # on a leg we need. Waiting for a re-run nobody has asked for only
+          # delays that.
+          if [ "$STATE" = failed ]; then
+            echo "::error::A build leg failed for ${HEAD_SHA:0:7} — there is nothing to test. Fix the build, or push again."
+            exit 1
+          fi
+          # Equally decisive: the build is over and this leg was never in its
+          # matrix, so no amount of waiting will produce the zip.
+          if [ "$STATE" = nomatrix ]; then
+            echo "::error::The build of ${HEAD_SHA:0:7} finished without a job for every leg in [${BUILD_LEGS}]. Either the PR touches no Explorer/** file, so build-unitycloud.yml built nothing — label it \`force-build\`; or a \`windows-only\`/\`macos-only\` label narrowed its targets and left the leg out — remove it. Neither label re-triggers this workflow, so re-run this job once the build is green."
+            exit 1
+          fi
           if [ "$WAIT_MINUTES" -eq 0 ]; then
             # The consequential half of the same ambiguity: this path has no
             # second poll to correct itself, and it is the one
@@ -287,20 +316,12 @@ runs:
               echo "::error::Could not list build-unitycloud.yml runs for ${HEAD_SHA:0:7} — the GitHub Actions API did not answer. Nothing was learned about the build, so this says nothing about whether one exists: re-run this job."
               exit 1
             fi
-            echo "::error::No Unity Cloud Build of ${HEAD_SHA:0:7} with all of [${BUILD_LEGS}] green. Is the build still in progress, or did it fail?"
-            exit 1
-          fi
-          # Newest first, so `failed` means the most recent build we found is red
-          # on a leg we need. Waiting for a re-run nobody has asked for only
-          # delays that.
-          if [ "$STATE" = failed ]; then
-            echo "::error::A build leg failed for ${HEAD_SHA:0:7} — there is nothing to test. Fix the build, or push again."
-            exit 1
-          fi
-          # Equally decisive: the build is over and this leg was never in its
-          # matrix, so no amount of waiting will produce the zip.
-          if [ "$STATE" = nomatrix ]; then
-            echo "::error::The build of ${HEAD_SHA:0:7} finished without a job for every leg in [${BUILD_LEGS}]. Either the PR touches no Explorer/** file, so build-unitycloud.yml built nothing — label it \`force-build\`; or a \`windows-only\`/\`macos-only\` label narrowed its targets and left the leg out — remove it. Neither label re-triggers this workflow, so re-run this job once the build is green."
+            # With `failed` and `nomatrix` exiting above, what reaches here is
+            # `pending` — legs still building — or `none`: the listing answered
+            # and there is no build run for this commit at all. The old "or did
+            # it fail?" asked after a case that can no longer arrive, which is
+            # worse than vague now that the specific message exists.
+            echo "::error::No Unity Cloud Build of ${HEAD_SHA:0:7} with all of [${BUILD_LEGS}] green — no leg has failed, so the build is either still in progress or was never queued for this commit."
             exit 1
           fi
           if [ "$SECONDS" -ge "$DEADLINE" ]; then

--- a/.github/actions/resolve-explorer-build/action.yml
+++ b/.github/actions/resolve-explorer-build/action.yml
@@ -87,6 +87,24 @@ runs:
           if [ "$LEG" = "windows64" ]; then want_windows=1; fi
         done
 
+        # A green leg does not guarantee the zip is fetchable, and neither does a
+        # caller having typed a URL. Failing here costs seconds; the same failure
+        # inside a suite costs a whole runner slot, and the Windows one is a
+        # scarce self-hosted GPU box. Defined before the override branch because
+        # both paths end in a URL a suite will download.
+        # curl still prints its -w output when it exits non-zero, so a
+        # `|| echo 000` fallback would concatenate codes ("200000") — normalize
+        # separately, and only when the output is empty.
+        verify() {
+          local url="$1" http
+          http=$(curl -sS -o /dev/null -w '%{http_code}' -I --retry 3 --retry-delay 5 "$url" || true)
+          http=${http:-000}
+          if [ "$http" != "200" ]; then
+            echo "::error::Build artifact is not reachable (HTTP ${http}): ${url}"
+            return 1
+          fi
+        }
+
         if [ -n "$BUILD_URL_OVERRIDE" ]; then
           # Everything below only ever produces bucket URLs; an override is the
           # one path where a caller picks the host, so pin it here rather than
@@ -108,11 +126,18 @@ runs:
               exit 1
               ;;
           esac
+          # Same prefix, so the sibling needs no second input from the caller.
+          OVERRIDE_WINDOWS_URL="${BUILD_URL_OVERRIDE%/*}/Decentraland_windows64.zip"
+          # Checked like a resolved build rather than trusted because a human
+          # asserted it — and the sibling is not even asserted, it is derived, so
+          # an override naming a macOS-only build hands the Windows leg a 404 on
+          # the GPU box this check exists to protect.
+          verify "$BUILD_URL_OVERRIDE"
+          if [ "$want_windows" = "1" ]; then verify "$OVERRIDE_WINDOWS_URL"; fi
           {
             echo "build-url=${BUILD_URL_OVERRIDE}"
-            # Same prefix, so the sibling needs no second input from the caller.
             if [ "$want_windows" = "1" ]; then
-              echo "windows-build-url=${BUILD_URL_OVERRIDE%/*}/Decentraland_windows64.zip"
+              echo "windows-build-url=${OVERRIDE_WINDOWS_URL}"
             fi
             echo "short-sha=${HEAD_SHA:0:7}"
           } >> "$GITHUB_OUTPUT"
@@ -256,21 +281,6 @@ runs:
         BUILD_URL="${PUBLIC_URL_PREFIX}/${ARTIFACT_PATH}/Decentraland_macos.zip"
         WINDOWS_BUILD_URL="${PUBLIC_URL_PREFIX}/${ARTIFACT_PATH}/Decentraland_windows64.zip"
 
-        # A green leg does not guarantee the zip is fetchable. Failing here costs
-        # seconds; the same failure inside a suite costs a whole runner slot, and
-        # the Windows one is a scarce self-hosted GPU box.
-        # curl still prints its -w output when it exits non-zero, so a
-        # `|| echo 000` fallback would concatenate codes ("200000") — normalize
-        # separately, and only when the output is empty.
-        verify() {
-          local url="$1" http
-          http=$(curl -sS -o /dev/null -w '%{http_code}' -I --retry 3 --retry-delay 5 "$url" || true)
-          http=${http:-000}
-          if [ "$http" != "200" ]; then
-            echo "::error::Build artifact is not reachable (HTTP ${http}): ${url}"
-            return 1
-          fi
-        }
         verify "$BUILD_URL"
         if [ "$want_windows" = "1" ]; then verify "$WINDOWS_BUILD_URL"; fi
 

--- a/.github/actions/resolve-explorer-build/action.yml
+++ b/.github/actions/resolve-explorer-build/action.yml
@@ -89,39 +89,61 @@ runs:
           # commit) and the build falls past the first page. Only
           # pull_request/push builds qualify — dispatch builds can carry
           # non-default options (e.g. profiling) that break the determinism the
-          # suites rely on.
+          # suites rely on. Newest first.
           RUNS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&per_page=20" \
             --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")]')
-          RUN_JSON=$(jq -c '[.[] | select(.conclusion == "success")] | .[0] // empty' <<< "$RUNS")
+          TOTAL=$(jq 'length' <<< "$RUNS")
+          LIMIT=$TOTAL
+          if [ "$LIMIT" -gt 5 ]; then LIMIT=5; fi
+
+          RUN_JSON=''
+          STATE=none
+          for (( i = 0; i < LIMIT; i++ )); do
+            CAND=$(jq -c ".[$i]" <<< "$RUNS")
+            # Wait on the macOS leg alone, not on the run. It uploads the zip we
+            # download and finishes ~9 minutes before Build (windows64); the run
+            # itself concludes later still. Nothing else the run does can make
+            # that artifact any more or less valid.
+            MAC=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/$(jq -r '.id' <<< "$CAND")/jobs?per_page=50" \
+              --jq '[.jobs[] | select(.name | test("^Build \\(macos"))] | .[0] // empty')
+            if [ -z "$MAC" ]; then
+              # Prebuild has not fanned the matrix out yet, or this run decided
+              # not to build at all (draft, no Explorer/** change).
+              if [ "$(jq -r '.status' <<< "$CAND")" != "completed" ]; then STATE=pending; fi
+              continue
+            fi
+            case "$(jq -r '"\(.status)/\(.conclusion // "-")"' <<< "$MAC")" in
+              completed/success) RUN_JSON="$CAND"; break ;;
+              completed/*)       if [ "$STATE" = none ]; then STATE=failed; fi ;;
+              *)                 STATE=pending ;;
+            esac
+          done
           if [ -n "$RUN_JSON" ]; then break; fi
 
-          TOTAL=$(jq 'length' <<< "$RUNS")
-          RUNNING=$(jq '[.[] | select(.status != "completed")] | length' <<< "$RUNS")
-
           if [ "$WAIT_MINUTES" -eq 0 ]; then
-            echo "::error::No successful Unity Cloud Build run for ${HEAD_SHA:0:7}. Is the build still in progress, or did it fail?"
+            echo "::error::No Unity Cloud Build with a green macOS leg for ${HEAD_SHA:0:7}. Is the build still in progress, or did it fail?"
             exit 1
           fi
-          # Every build for this commit finished and none produced an artifact.
-          # Waiting for a re-run that nobody has asked for only delays the red.
-          if [ "$TOTAL" -gt 0 ] && [ "$RUNNING" -eq 0 ]; then
-            echo "::error::Unity Cloud Build failed for ${HEAD_SHA:0:7} — there is nothing to test. Fix the build, or push again."
+          # Newest first, so `failed` means the most recent macOS build we found
+          # is red. Waiting for a re-run nobody has asked for only delays that.
+          if [ "$STATE" = failed ]; then
+            echo "::error::The macOS build failed for ${HEAD_SHA:0:7} — there is nothing to test. Fix the build, or push again."
             exit 1
           fi
           if [ "$SECONDS" -ge "$DEADLINE" ]; then
-            echo "::error::Gave up after ${WAIT_MINUTES}m waiting for a Unity Cloud Build of ${HEAD_SHA:0:7}."
-            if [ "$TOTAL" -eq 0 ]; then
-              # build-unitycloud.yml skips drafts and PRs that touch no
-              # Explorer/** file. A `force-build` label overrides both.
+            echo "::error::Gave up after ${WAIT_MINUTES}m waiting for a macOS build of ${HEAD_SHA:0:7}."
+            # build-unitycloud.yml skips drafts and PRs that touch no
+            # Explorer/** file. A `force-build` label overrides both. Note a
+            # skipped run still counts in TOTAL, hence the state rather than the
+            # count: it is what tells you nothing is coming.
+            if [ "$STATE" = none ]; then
               echo "::error::No build was ever queued for this commit. Label the PR \`force-build\`, or push a change under Explorer/, then re-run this job."
             else
               echo "::error::Re-run this job once the build is green."
             fi
             exit 1
           fi
-          # TOTAL of 0 is normal right after a PR opens: the build is triggered
-          # by the same event as this job and takes a moment to register.
-          echo "Waiting for a build of ${HEAD_SHA:0:7} — ${RUNNING} of ${TOTAL} still running. $(( (DEADLINE - SECONDS) / 60 ))m left."
+          echo "Waiting for the macOS build of ${HEAD_SHA:0:7} — ${TOTAL} build run(s), state: ${STATE}. $(( (DEADLINE - SECONDS) / 60 ))m left."
           sleep 60
         done
 

--- a/.github/actions/resolve-explorer-build/action.yml
+++ b/.github/actions/resolve-explorer-build/action.yml
@@ -1,10 +1,9 @@
 name: Resolve Explorer build
 description: >-
-  Resolves the macOS Unity Cloud Build artifact URL for a commit, plus the
+  Resolves Unity Cloud Build artifact URLs for a commit, plus the
   explorer-automation ref its tests should come from. Shared by the dispatchers
-  for explorer-automation's reusable suites — visual-regression.yml and
-  in-world-tests.yml — which differ only in their trigger and in which suite
-  they call.
+  for explorer-automation's reusable suites — visual-regression.yml, which needs
+  the macOS build, and in-world-tests.yml, which needs both.
 
 inputs:
   head-ref:
@@ -21,10 +20,20 @@ inputs:
       the build the same event started.
     required: false
     default: '0'
+  build-legs:
+    description: >-
+      Which build-unitycloud.yml matrix legs must be green before the artifacts
+      are usable, comma-separated. Each leg contributes its own URL, so asking
+      for `windows64` is also what makes windows-build-url non-empty. Waiting on
+      the legs rather than the run skips Build Gate and anything else downstream.
+    required: false
+    default: 'macos'
   build-url-override:
     description: >-
       Use this artifact URL as-is and skip resolution. For manual runs that
       target a build this repo cannot derive — an older commit, another branch.
+      Both platforms' zips share a prefix, so the sibling URL is derived from
+      this one rather than asked for separately.
     required: false
     default: ''
   public-url-prefix:
@@ -41,6 +50,11 @@ outputs:
   build-url:
     description: 'Direct URL to Decentraland_macos.zip, verified reachable.'
     value: ${{ steps.build.outputs.build-url }}
+  windows-build-url:
+    description: >-
+      Direct URL to Decentraland_windows64.zip, verified reachable. Empty unless
+      `windows64` is in build-legs.
+    value: ${{ steps.build.outputs.windows-build-url }}
   short-sha:
     description: 'First 7 characters of the commit the build was made from.'
     value: ${{ steps.build.outputs.short-sha }}
@@ -58,10 +72,20 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         HEAD_SHA: ${{ inputs.head-sha }}
         WAIT_MINUTES: ${{ inputs.wait-minutes }}
+        BUILD_LEGS: ${{ inputs.build-legs }}
         BUILD_URL_OVERRIDE: ${{ inputs.build-url-override }}
         PUBLIC_URL_PREFIX: ${{ inputs.public-url-prefix }}
       run: |
         set -euo pipefail
+
+        LEGS=${BUILD_LEGS//,/ }
+        # build-unitycloud.yml names both zips Decentraland_<matrix.target>.zip
+        # and uploads them to one prefix, so a leg name is all it takes to get
+        # from one to the other.
+        want_windows=0
+        for LEG in $LEGS; do
+          if [ "$LEG" = "windows64" ]; then want_windows=1; fi
+        done
 
         if [ -n "$BUILD_URL_OVERRIDE" ]; then
           # Everything below only ever produces bucket URLs; an override is the
@@ -76,6 +100,10 @@ runs:
           esac
           {
             echo "build-url=${BUILD_URL_OVERRIDE}"
+            # Same prefix, so the sibling needs no second input from the caller.
+            if [ "$want_windows" = "1" ]; then
+              echo "windows-build-url=${BUILD_URL_OVERRIDE%/*}/Decentraland_windows64.zip"
+            fi
             echo "short-sha=${HEAD_SHA:0:7}"
           } >> "$GITHUB_OUTPUT"
           echo "::notice::Using caller-supplied build URL."
@@ -100,38 +128,46 @@ runs:
           STATE=none
           for (( i = 0; i < LIMIT; i++ )); do
             CAND=$(jq -c ".[$i]" <<< "$RUNS")
-            # Wait on the macOS leg alone, not on the run. It uploads the zip we
-            # download and finishes ~9 minutes before Build (windows64); the run
-            # itself concludes later still. Nothing else the run does can make
-            # that artifact any more or less valid.
-            MAC=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/$(jq -r '.id' <<< "$CAND")/jobs?per_page=50" \
-              --jq '[.jobs[] | select(.name | test("^Build \\(macos"))] | .[0] // empty')
-            if [ -z "$MAC" ]; then
-              # Prebuild has not fanned the matrix out yet, or this run decided
-              # not to build at all (draft, no Explorer/** change).
-              if [ "$(jq -r '.status' <<< "$CAND")" != "completed" ]; then STATE=pending; fi
-              continue
-            fi
-            case "$(jq -r '"\(.status)/\(.conclusion // "-")"' <<< "$MAC")" in
-              completed/success) RUN_JSON="$CAND"; break ;;
-              completed/*)       if [ "$STATE" = none ]; then STATE=failed; fi ;;
-              *)                 STATE=pending ;;
-            esac
+            RUN_DONE=$(jq -r '.status' <<< "$CAND")
+            # Wait on the build legs, not on the run: they upload the zips, and
+            # Build Gate and everything else downstream only conclude later.
+            # One call per candidate, filtered per leg locally.
+            JOBS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/$(jq -r '.id' <<< "$CAND")/jobs?per_page=50" \
+              --jq '[.jobs[] | {name, status, conclusion}]')
+            legs_ok=1
+            for LEG in $LEGS; do
+              J=$(jq -c --arg leg "Build ($LEG" '[.[] | select(.name | startswith($leg))] | .[0] // empty' <<< "$JOBS")
+              if [ -z "$J" ]; then
+                # Prebuild has not fanned the matrix out yet, or this run decided
+                # not to build at all (draft, no Explorer/** change, or a
+                # platforms input that left this leg out).
+                legs_ok=0
+                if [ "$RUN_DONE" != "completed" ]; then STATE=pending; fi
+                continue
+              fi
+              case "$(jq -r '"\(.status)/\(.conclusion // "-")"' <<< "$J")" in
+                completed/success) ;;
+                completed/*)       legs_ok=0; if [ "$STATE" = none ]; then STATE=failed; fi ;;
+                *)                 legs_ok=0; STATE=pending ;;
+              esac
+            done
+            if [ "$legs_ok" = "1" ]; then RUN_JSON="$CAND"; break; fi
           done
           if [ -n "$RUN_JSON" ]; then break; fi
 
           if [ "$WAIT_MINUTES" -eq 0 ]; then
-            echo "::error::No Unity Cloud Build with a green macOS leg for ${HEAD_SHA:0:7}. Is the build still in progress, or did it fail?"
+            echo "::error::No Unity Cloud Build of ${HEAD_SHA:0:7} with all of [${BUILD_LEGS}] green. Is the build still in progress, or did it fail?"
             exit 1
           fi
-          # Newest first, so `failed` means the most recent macOS build we found
-          # is red. Waiting for a re-run nobody has asked for only delays that.
+          # Newest first, so `failed` means the most recent build we found is red
+          # on a leg we need. Waiting for a re-run nobody has asked for only
+          # delays that.
           if [ "$STATE" = failed ]; then
-            echo "::error::The macOS build failed for ${HEAD_SHA:0:7} — there is nothing to test. Fix the build, or push again."
+            echo "::error::A build leg failed for ${HEAD_SHA:0:7} — there is nothing to test. Fix the build, or push again."
             exit 1
           fi
           if [ "$SECONDS" -ge "$DEADLINE" ]; then
-            echo "::error::Gave up after ${WAIT_MINUTES}m waiting for a macOS build of ${HEAD_SHA:0:7}."
+            echo "::error::Gave up after ${WAIT_MINUTES}m waiting for a build of ${HEAD_SHA:0:7} with [${BUILD_LEGS}] green."
             # build-unitycloud.yml skips drafts and PRs that touch no
             # Explorer/** file. A `force-build` label overrides both. Note a
             # skipped run still counts in TOTAL, hence the state rather than the
@@ -143,7 +179,7 @@ runs:
             fi
             exit 1
           fi
-          echo "Waiting for the macOS build of ${HEAD_SHA:0:7} — ${TOTAL} build run(s), state: ${STATE}. $(( (DEADLINE - SECONDS) / 60 ))m left."
+          echo "Waiting for [${BUILD_LEGS}] on ${HEAD_SHA:0:7} — ${TOTAL} build run(s), state: ${STATE}. $(( (DEADLINE - SECONDS) / 60 ))m left."
           sleep 60
         done
 
@@ -174,25 +210,32 @@ runs:
         # the suite sits at "Wait for connection: 0%" until its job cap.
         ARTIFACT_PATH="@dcl/${GITHUB_REPOSITORY##*/}/branch/${RUN_BRANCH}/${BUILD_PREFIX}-${RUN_NUMBER}-${SHORT_SHA}"
         BUILD_URL="${PUBLIC_URL_PREFIX}/${ARTIFACT_PATH}/Decentraland_macos.zip"
+        WINDOWS_BUILD_URL="${PUBLIC_URL_PREFIX}/${ARTIFACT_PATH}/Decentraland_windows64.zip"
 
-        # A successful run does not guarantee a macOS zip — build-unitycloud.yml
-        # takes a `platforms` input. Failing here costs seconds; the same failure
-        # inside the suite costs a whole macOS runner slot.
+        # A green leg does not guarantee the zip is fetchable. Failing here costs
+        # seconds; the same failure inside a suite costs a whole runner slot, and
+        # the Windows one is a scarce self-hosted GPU box.
         # curl still prints its -w output when it exits non-zero, so a
         # `|| echo 000` fallback would concatenate codes ("200000") — normalize
         # separately, and only when the output is empty.
-        HTTP=$(curl -sS -o /dev/null -w '%{http_code}' -I --retry 3 --retry-delay 5 "$BUILD_URL" || true)
-        HTTP=${HTTP:-000}
-        if [ "$HTTP" != "200" ]; then
-          echo "::error::Build artifact is not reachable (HTTP ${HTTP}): ${BUILD_URL}"
-          exit 1
-        fi
+        verify() {
+          local url="$1" http
+          http=$(curl -sS -o /dev/null -w '%{http_code}' -I --retry 3 --retry-delay 5 "$url" || true)
+          http=${http:-000}
+          if [ "$http" != "200" ]; then
+            echo "::error::Build artifact is not reachable (HTTP ${http}): ${url}"
+            return 1
+          fi
+        }
+        verify "$BUILD_URL"
+        if [ "$want_windows" = "1" ]; then verify "$WINDOWS_BUILD_URL"; fi
 
         {
           echo "build-url=${BUILD_URL}"
+          if [ "$want_windows" = "1" ]; then echo "windows-build-url=${WINDOWS_BUILD_URL}"; fi
           echo "short-sha=${SHORT_SHA}"
         } >> "$GITHUB_OUTPUT"
-        echo "::notice::Using ${RUN_BRANCH} build ${BUILD_PREFIX}-${RUN_NUMBER}-${SHORT_SHA}."
+        echo "::notice::Using ${RUN_BRANCH} build ${BUILD_PREFIX}-${RUN_NUMBER}-${SHORT_SHA} for [${BUILD_LEGS}]."
 
     - name: Look up matching explorer-automation branch
       id: match

--- a/.github/actions/resolve-explorer-build/action.yml
+++ b/.github/actions/resolve-explorer-build/action.yml
@@ -91,7 +91,17 @@ runs:
           # Everything below only ever produces bucket URLs; an override is the
           # one path where a caller picks the host, so pin it here rather than
           # leaving it to the suite's own check on the macOS runner.
+          #
+          # The newline arm comes first and is not just tidiness: $GITHUB_OUTPUT
+          # is line-oriented, the REST API accepts embedded newlines in a
+          # workflow_dispatch string input, and a glob matches across them. A
+          # payload could otherwise pass the host check on its first line and
+          # define a second, caller-chosen output (short-sha, say) on the next.
           case "$BUILD_URL_OVERRIDE" in
+            *[$'\n\r']*)
+              echo "::error::build_url must be a single line."
+              exit 1
+              ;;
             https://explorer-artifacts.decentraland.org/*) ;;
             *)
               echo "::error::build_url must be an https://explorer-artifacts.decentraland.org/ URL."
@@ -118,8 +128,14 @@ runs:
           # pull_request/push builds qualify — dispatch builds can carry
           # non-default options (e.g. profiling) that break the determinism the
           # suites rely on. Newest first.
-          RUNS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&per_page=20" \
-            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")]')
+          #
+          # Absorbed rather than left to `set -e`: one 5xx or rate-limit blip
+          # would otherwise end a 90-minute wait with a red required check on a
+          # release PR that has nothing wrong with it. An empty list reads as
+          # "nothing found this poll" and the loop asks again a minute later.
+          RUNS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")]') || RUNS=''
+          if [ -z "$RUNS" ]; then RUNS='[]'; fi
           TOTAL=$(jq 'length' <<< "$RUNS")
           LIMIT=$TOTAL
           if [ "$LIMIT" -gt 5 ]; then LIMIT=5; fi
@@ -133,25 +149,46 @@ runs:
             # Build Gate and everything else downstream only conclude later.
             # One call per candidate, filtered per leg locally.
             JOBS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/$(jq -r '.id' <<< "$CAND")/jobs?per_page=50" \
-              --jq '[.jobs[] | {name, status, conclusion}]')
+              --jq '[.jobs[] | {name, status, conclusion}]') || JOBS=''
+            if [ -z "$JOBS" ]; then
+              # Same blip tolerance as the listing above, but an unreachable API
+              # must not read as a run whose matrix left the leg out: that is a
+              # fast-fail below, and this candidate is simply unknown until the
+              # next poll.
+              if [ "$STATE" = none ]; then STATE=pending; fi
+              continue
+            fi
+            # Per candidate, because the states rank against each other only
+            # within the run that produced them: `failed` and `nomatrix` are
+            # decisive and must outrank a later leg that is merely `pending`,
+            # or a red macOS leg beside a Windows leg still building would be
+            # overwritten and neither fast-exit below would ever fire.
+            CAND_STATE=none
             legs_ok=1
             for LEG in $LEGS; do
               J=$(jq -c --arg leg "Build ($LEG" '[.[] | select(.name | startswith($leg))] | .[0] // empty' <<< "$JOBS")
               if [ -z "$J" ]; then
-                # Prebuild has not fanned the matrix out yet, or this run decided
-                # not to build at all (draft, no Explorer/** change, or a
-                # platforms input that left this leg out).
                 legs_ok=0
-                if [ "$RUN_DONE" != "completed" ]; then STATE=pending; fi
+                if [ "$RUN_DONE" = "completed" ]; then
+                  # The run is over and this leg never existed: prebuild's
+                  # targets left it out, or the build job never expanded at all.
+                  if [ "$CAND_STATE" != failed ]; then CAND_STATE=nomatrix; fi
+                else
+                  # Prebuild has not fanned the matrix out yet.
+                  if [ "$CAND_STATE" = none ]; then CAND_STATE=pending; fi
+                fi
                 continue
               fi
               case "$(jq -r '"\(.status)/\(.conclusion // "-")"' <<< "$J")" in
                 completed/success) ;;
-                completed/*)       legs_ok=0; if [ "$STATE" = none ]; then STATE=failed; fi ;;
-                *)                 legs_ok=0; STATE=pending ;;
+                completed/*)       legs_ok=0; CAND_STATE=failed ;;
+                *)                 legs_ok=0; if [ "$CAND_STATE" = none ]; then CAND_STATE=pending; fi ;;
               esac
             done
             if [ "$legs_ok" = "1" ]; then RUN_JSON="$CAND"; break; fi
+            # Candidates are newest first and the fast-exits act on the newest
+            # verdict there is, so an older run's must not stomp it.
+            if [ "$STATE" = none ]; then STATE=$CAND_STATE; fi
           done
           if [ -n "$RUN_JSON" ]; then break; fi
 
@@ -166,12 +203,19 @@ runs:
             echo "::error::A build leg failed for ${HEAD_SHA:0:7} — there is nothing to test. Fix the build, or push again."
             exit 1
           fi
+          # Equally decisive: the build is over and this leg was never in its
+          # matrix, so no amount of waiting will produce the zip.
+          if [ "$STATE" = nomatrix ]; then
+            echo "::error::The build of ${HEAD_SHA:0:7} finished without a job for every leg in [${BUILD_LEGS}]. Either the PR touches no Explorer/** file, so build-unitycloud.yml built nothing — label it \`force-build\`; or a \`windows-only\`/\`macos-only\` label narrowed its targets and left the leg out — remove it. Neither label re-triggers this workflow, so re-run this job once the build is green."
+            exit 1
+          fi
           if [ "$SECONDS" -ge "$DEADLINE" ]; then
             echo "::error::Gave up after ${WAIT_MINUTES}m waiting for a build of ${HEAD_SHA:0:7} with [${BUILD_LEGS}] green."
-            # build-unitycloud.yml skips drafts and PRs that touch no
-            # Explorer/** file. A `force-build` label overrides both. Note a
-            # skipped run still counts in TOTAL, hence the state rather than the
-            # count: it is what tells you nothing is coming.
+            # With the case above carved out, `none` is only reachable when no
+            # pull_request or push run of build-unitycloud.yml exists for the
+            # SHA at all — a run that started and built nothing is `nomatrix`.
+            # Labelling and pushing are both trigger types of that workflow, so
+            # either queues the run this commit never got.
             if [ "$STATE" = none ]; then
               echo "::error::No build was ever queued for this commit. Label the PR \`force-build\`, or push a change under Explorer/, then re-run this job."
             else
@@ -179,7 +223,7 @@ runs:
             fi
             exit 1
           fi
-          echo "Waiting for [${BUILD_LEGS}] on ${HEAD_SHA:0:7} — ${TOTAL} build run(s), state: ${STATE}. $(( (DEADLINE - SECONDS) / 60 ))m left."
+          echo "Waiting for [${BUILD_LEGS}] on ${HEAD_SHA:0:7} — ${TOTAL} build run(s) found, newest ${LIMIT} examined, state: ${STATE}. $(( (DEADLINE - SECONDS) / 60 ))m left."
           sleep 60
         done
 

--- a/.github/actions/resolve-explorer-build/action.yml
+++ b/.github/actions/resolve-explorer-build/action.yml
@@ -145,6 +145,34 @@ runs:
           exit 0
         fi
 
+        # gh has no built-in retry, and both callers below are decisive on a
+        # single answer: the wait-minutes: 0 path has no second poll, and a
+        # listing that fails every poll would otherwise read as "no build
+        # exists". stderr is dropped because a 90-minute wait polls ~90 times
+        # and every failure that survives the retry is reported, with an
+        # action, by the messages below.
+        gh_api_retry() {
+          local out attempt
+          for attempt in 1 2 3; do
+            if out=$(gh api "$@" 2>/dev/null); then printf '%s' "$out"; return 0; fi
+            # Not after the last attempt: the callers below act on the answer
+            # immediately, so that sleep would only delay a red check.
+            if [ "$attempt" -lt 3 ]; then sleep 5; fi
+          done
+          return 1
+        }
+
+        # A listing that fails leaves the same candidate set as a commit with
+        # no build — TOTAL=0, nothing examined, STATE=none — so without a
+        # record of the listing itself the messages below cannot tell an
+        # operator which of the two happened, and only one of them is fixed by
+        # `force-build`. LISTED is "did any poll's listing ever answer";
+        # LISTED_NOW, set per poll further down, is "did the last one". Both
+        # are needed: this loop spends ~360 requests/hour of a 1,000/hour
+        # budget it shares with build-unitycloud and the review bots, so the
+        # realistic outage — rate-limit exhaustion — begins partway through a
+        # 90-minute wait, and by then LISTED has long since flipped.
+        LISTED=0
         DEADLINE=$(( SECONDS + WAIT_MINUTES * 60 ))
         while :; do
           # Scoped to the build workflow file: a repo-wide head_sha listing gets
@@ -156,10 +184,18 @@ runs:
           #
           # Absorbed rather than left to `set -e`: one 5xx or rate-limit blip
           # would otherwise end a 90-minute wait with a red required check on a
-          # release PR that has nothing wrong with it. An empty list reads as
-          # "nothing found this poll" and the loop asks again a minute later.
-          RUNS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&per_page=50" \
-            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")]') || RUNS=''
+          # release PR that has nothing wrong with it. Only an outage that
+          # survives all three attempts lands in the else arm; an empty list
+          # reads as "nothing found this poll" and the loop asks again a
+          # minute later.
+          LISTED_NOW=0
+          if RUNS=$(gh_api_retry "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")]'); then
+            LISTED=1
+            LISTED_NOW=1
+          else
+            RUNS=''
+          fi
           if [ -z "$RUNS" ]; then RUNS='[]'; fi
           TOTAL=$(jq 'length' <<< "$RUNS")
           LIMIT=$TOTAL
@@ -173,7 +209,7 @@ runs:
             # Wait on the build legs, not on the run: they upload the zips, and
             # Build Gate and everything else downstream only conclude later.
             # One call per candidate, filtered per leg locally.
-            JOBS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/$(jq -r '.id' <<< "$CAND")/jobs?per_page=50" \
+            JOBS=$(gh_api_retry "repos/${GITHUB_REPOSITORY}/actions/runs/$(jq -r '.id' <<< "$CAND")/jobs?per_page=50" \
               --jq '[.jobs[] | {name, status, conclusion}]') || JOBS=''
             if [ -z "$JOBS" ]; then
               # Same blip tolerance as the listing above, but an unreachable API
@@ -218,6 +254,18 @@ runs:
           if [ -n "$RUN_JSON" ]; then break; fi
 
           if [ "$WAIT_MINUTES" -eq 0 ]; then
+            # The consequential half of the same ambiguity: this path has no
+            # second poll to correct itself, and it is the one
+            # visual-regression.yml takes on every /visual-tests, and
+            # in-world-tests.yml on every dispatch — which is how
+            # create-release-branch.yml gates a release cut. Reporting an
+            # unanswered API as a missing build sends the operator after a
+            # build that is very likely fine. One poll, so LISTED and
+            # LISTED_NOW are the same bit here.
+            if [ "$LISTED" = "0" ]; then
+              echo "::error::Could not list build-unitycloud.yml runs for ${HEAD_SHA:0:7} — the GitHub Actions API did not answer. Nothing was learned about the build, so this says nothing about whether one exists: re-run this job."
+              exit 1
+            fi
             echo "::error::No Unity Cloud Build of ${HEAD_SHA:0:7} with all of [${BUILD_LEGS}] green. Is the build still in progress, or did it fail?"
             exit 1
           fi
@@ -236,19 +284,43 @@ runs:
           fi
           if [ "$SECONDS" -ge "$DEADLINE" ]; then
             echo "::error::Gave up after ${WAIT_MINUTES}m waiting for a build of ${HEAD_SHA:0:7} with [${BUILD_LEGS}] green."
-            # With the case above carved out, `none` is only reachable when no
+            # With the cases above carved out, `none` means the candidate loop
+            # never reached a verdict, which happens two ways: no
             # pull_request or push run of build-unitycloud.yml exists for the
-            # SHA at all — a run that started and built nothing is `nomatrix`.
-            # Labelling and pushing are both trigger types of that workflow, so
-            # either queues the run this commit never got.
+            # SHA at all — a run that started and built nothing is `nomatrix`
+            # — or the last poll's listing went unanswered, leaving the same
+            # empty set with nothing learned. Only the first is a build
+            # problem: labelling and pushing are both trigger types of that
+            # workflow, so either queues the run this commit never got,
+            # whereas a `force-build` label does nothing whatsoever for an API
+            # that is not replying.
             if [ "$STATE" = none ]; then
-              echo "::error::No build was ever queued for this commit. Label the PR \`force-build\`, or push a change under Explorer/, then re-run this job."
+              if [ "$LISTED_NOW" = "0" ]; then
+                # The wait ended blind, so nothing here establishes that no
+                # build exists. LISTED then separates an outage that lasted
+                # the whole wait from one that began during it, because the
+                # remedies differ: a spent rate-limit budget refills on its
+                # own hour boundary and needs no page checked.
+                if [ "$LISTED" = "0" ]; then
+                  echo "::error::The GitHub Actions API never answered a single run listing in ${WAIT_MINUTES}m, so no build was ever looked at. Check https://www.githubstatus.com, then re-run this job."
+                else
+                  echo "::error::The GitHub Actions API stopped answering run listings partway through the wait, so whether a build exists is unknown — most likely this token's hourly request budget is spent. Re-run this job after the hour rolls over."
+                fi
+              else
+                echo "::error::No build was ever queued for this commit. Label the PR \`force-build\`, or push a change under Explorer/, then re-run this job."
+              fi
             else
               echo "::error::Re-run this job once the build is green."
             fi
             exit 1
           fi
-          echo "Waiting for [${BUILD_LEGS}] on ${HEAD_SHA:0:7} — ${TOTAL} build run(s) found, newest ${LIMIT} examined, state: ${STATE}. $(( (DEADLINE - SECONDS) / 60 ))m left."
+          # Without the note this line claims "0 build run(s) found" once a
+          # minute for an hour and a half, which is the same thing the flags
+          # above exist to stop asserting — and this trail is what makes an
+          # outage diagnosable after the fact.
+          LISTING_NOTE=''
+          if [ "$LISTED_NOW" = "0" ]; then LISTING_NOTE=' (run listing unavailable this poll)'; fi
+          echo "Waiting for [${BUILD_LEGS}] on ${HEAD_SHA:0:7} — ${TOTAL} build run(s) found, newest ${LIMIT} examined, state: ${STATE}${LISTING_NOTE}. $(( (DEADLINE - SECONDS) / 60 ))m left."
           sleep 60
         done
 

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -164,12 +164,48 @@ jobs:
           # Runs come back newest first, and only the newest few are worth
           # asking about — the same candidate cap resolve-explorer-build uses.
           HEAD_SHA=$(git rev-parse HEAD)
+
+          # The helper resolve-explorer-build defines, duplicated because a
+          # composite action cannot export a shell function to its caller. Same
+          # justification, more sharply: this step decides on one answer and
+          # then the workflow ends, so a single 5xx must not settle a release
+          # cut. Three attempts five seconds apart cover a transport failure —
+          # a 5xx, a connection reset — and only that; a spent rate limit
+          # refills on an hour boundary, which is why the flags below record
+          # whether the API answered rather than trusting the retry to make it.
+          # stderr is kept on the last attempt so a permanent failure (this
+          # workflow file renamed, say) says what it was instead of vanishing
+          # into "the API did not answer".
+          gh_api_retry() {
+            local out attempt
+            for attempt in 1 2 3; do
+              if [ "$attempt" -lt 3 ]; then
+                if out=$(gh api "$@" 2>/dev/null); then printf '%s' "$out"; return 0; fi
+                sleep 5
+              else
+                if out=$(gh api "$@"); then printf '%s' "$out"; return 0; fi
+              fi
+            done
+            return 1
+          }
+
           # Absorbed rather than left to set -e, here and on the jobs call
-          # below: an API blip must not red a cut whose branch, PR and comment
-          # all landed. Nothing found reads as "no build", which is the notice
-          # path, and re-running this workflow is the remedy either way.
-          RUN_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&per_page=50" \
-            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push") | .id]') || RUN_IDS=''
+          # below: an API blip must not red a cut whose branch, PR, labels and
+          # build-links comment have all landed. But it must not be reported as
+          # "no build" either — that is the conflation LISTED/LISTED_NOW exist
+          # to stop in resolve-explorer-build, and it costs more here, because
+          # this message is the operator's only instruction and the workflow
+          # ends after it. LISTED is "the run listing answered at all";
+          # UNEXAMINED is "a candidate's jobs call did not", which leaves that
+          # run neither green nor known to be anything else.
+          LISTED=0
+          UNEXAMINED=0
+          if RUN_IDS=$(gh_api_retry "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push") | .id]'); then
+            LISTED=1
+          else
+            RUN_IDS=''
+          fi
           if [ -z "$RUN_IDS" ]; then RUN_IDS='[]'; fi
           LIMIT=$(jq 'length' <<< "$RUN_IDS")
           if [ "$LIMIT" -gt 5 ]; then LIMIT=5; fi
@@ -177,13 +213,37 @@ jobs:
           LEGS_GREEN=false
           for (( i = 0; i < LIMIT; i++ )); do
             RUN_ID=$(jq -r ".[$i]" <<< "$RUN_IDS")
-            LEGS_GREEN=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=50" \
-              --jq '[.jobs[] | select(.conclusion == "success") | .name] | any(startswith("Build (macos")) and any(startswith("Build (windows64"))') || LEGS_GREEN=false
-            if [ "$LEGS_GREEN" = "true" ]; then break; fi
+            if LEGS_GREEN=$(gh_api_retry "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=50" \
+              --jq '[.jobs[] | select(.conclusion == "success") | .name] | any(startswith("Build (macos")) and any(startswith("Build (windows64"))'); then
+              if [ "$LEGS_GREEN" = "true" ]; then break; fi
+            else
+              LEGS_GREEN=false
+              UNEXAMINED=1
+            fi
           done
 
+          # Three ways to end up not dispatching, and only the last is a build
+          # problem — so they get three messages. All three are `::error::`:
+          # each one ends with the gate unreported and the release unmergeable,
+          # which is not a line in a green log, and the dispatch failure below
+          # already annotates for exactly that outcome.
+          #
+          # None of them says "re-run this workflow". Re-running re-enters the
+          # `Create or update branch` step above, which force-pushes
+          # ${BRANCH_NAME} from dev's current tip — quietly re-cutting the
+          # release from newer commits than the one that was reviewed. Starting
+          # `In-World Tests` by hand is the remedy in every case, and it is the
+          # same instruction the dispatch failure below gives.
+          if [ "$LISTED" = "0" ]; then
+            echo "::error::Could not list build-unitycloud.yml runs for ${HEAD_SHA:0:7} — the GitHub Actions API did not answer, so no build was ever looked at and the InWorld gate was not started. This says nothing about whether a build exists. The release branch and its PR are fine: start \`In-World Tests\` by hand from the Actions tab against ${BRANCH_NAME}. Do not re-run this workflow — it force-pushes ${BRANCH_NAME} and would re-cut the release from a newer dev tip."
+            exit 0
+          fi
+          if [ "$LEGS_GREEN" != "true" ] && [ "$UNEXAMINED" = "1" ]; then
+            echo "::error::The GitHub Actions API did not answer for at least one build run of ${HEAD_SHA:0:7}, so whether its legs are green is unknown and the InWorld gate was not started. This is not evidence that no build exists. The release branch and its PR are fine: start \`In-World Tests\` by hand from the Actions tab against ${BRANCH_NAME}. Do not re-run this workflow — it force-pushes ${BRANCH_NAME} and would re-cut the release from a newer dev tip."
+            exit 0
+          fi
           if [ "$LEGS_GREEN" != "true" ]; then
-            echo "::notice::No build of ${HEAD_SHA:0:7} has both Build (macos) and Build (windows64) green, so the InWorld gate was not started — it would fail on its first poll. Build the commit, then re-run this workflow."
+            echo "::error::No build of ${HEAD_SHA:0:7} has both Build (macos) and Build (windows64) green, so the InWorld gate was not started — it would fail on its first poll. Build the commit: label the release PR \`force-build\` if build-unitycloud.yml built nothing, or remove a \`windows-only\`/\`macos-only\` label that narrowed its targets. Then start \`In-World Tests\` by hand against ${BRANCH_NAME}. Do not re-run this workflow — it force-pushes ${BRANCH_NAME} and would re-cut the release from a newer dev tip."
             exit 0
           fi
 

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -151,16 +151,53 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A dispatched gate resolves this commit's build and fails fast when
-          # there is none, so only start it once one exists. Same condition as
-          # the comment above, and the same fix: re-run this workflow.
+          # On the dispatch path the gate resolves this commit's build with
+          # wait-minutes 0, so it fails within seconds unless both zips are
+          # already up. Ask it the same question — did both build legs conclude
+          # success — rather than whether a run went green: build-unitycloud.yml
+          # also concludes green having built nothing, when the commit touches
+          # no Explorer/** file and the matrix never expands, and green having
+          # built one platform, when a windows-only/macos-only label narrows it.
+          # Either would dispatch a gate that immediately reds a brand-new
+          # release PR with nothing wrong in it.
+          #
+          # Runs come back newest first, and only the newest few are worth
+          # asking about — the same candidate cap resolve-explorer-build uses.
           HEAD_SHA=$(git rev-parse HEAD)
-          RUN_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&status=success&per_page=20" \
-            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")] | .[0]')
-          if [ -z "$RUN_JSON" ] || [ "$RUN_JSON" = "null" ]; then
-            echo "::notice::No build for ${HEAD_SHA:0:7} yet, so the InWorld gate was not started. Re-run this workflow once one finishes."
+          # Absorbed rather than left to set -e, here and on the jobs call
+          # below: an API blip must not red a cut whose branch, PR and comment
+          # all landed. Nothing found reads as "no build", which is the notice
+          # path, and re-running this workflow is the remedy either way.
+          RUN_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push") | .id]') || RUN_IDS=''
+          if [ -z "$RUN_IDS" ]; then RUN_IDS='[]'; fi
+          LIMIT=$(jq 'length' <<< "$RUN_IDS")
+          if [ "$LIMIT" -gt 5 ]; then LIMIT=5; fi
+
+          LEGS_GREEN=false
+          for (( i = 0; i < LIMIT; i++ )); do
+            RUN_ID=$(jq -r ".[$i]" <<< "$RUN_IDS")
+            LEGS_GREEN=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=50" \
+              --jq '[.jobs[] | select(.conclusion == "success") | .name] | any(startswith("Build (macos")) and any(startswith("Build (windows64"))') || LEGS_GREEN=false
+            if [ "$LEGS_GREEN" = "true" ]; then break; fi
+          done
+
+          if [ "$LEGS_GREEN" != "true" ]; then
+            echo "::notice::No build of ${HEAD_SHA:0:7} has both Build (macos) and Build (windows64) green, so the InWorld gate was not started — it would fail on its first poll. Build the commit, then re-run this workflow."
             exit 0
           fi
 
-          gh workflow run in-world-tests.yml --ref "$BRANCH_NAME"
+          # Loud but deliberately not fatal. `gh workflow run` needs
+          # `actions: write`, which ORG_ACCESS_TOKEN's other uses in this repo
+          # (org membership, PR reviews) do not require, so it may not have it —
+          # and a secret's scopes cannot be inspected from here. Failing the job
+          # would invite a re-run, and re-running this workflow force-pushes the
+          # release branch, quietly re-cutting the release from a newer dev tip.
+          # The branch, PR, labels and build-links comment have all landed by
+          # now; the annotation is what makes the missing gate visible, and the
+          # required check staying unreported is what keeps the release blocked.
+          if ! gh workflow run in-world-tests.yml --ref "$BRANCH_NAME"; then
+            echo "::error::Could not dispatch the InWorld gate against ${BRANCH_NAME}. The likeliest cause is that ORG_ACCESS_TOKEN lacks \`actions: write\` on this repository, which \`gh workflow run\` requires. The release branch and its PR are fine — start \`In-World Tests\` by hand from the Actions tab against ${BRANCH_NAME}, or its required check will sit unreported and the release will not be mergeable."
+            exit 0
+          fi
           echo "::notice::InWorld gate dispatched against ${BRANCH_NAME}."

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -136,3 +136,31 @@ jobs:
             echo "[badge]: https://img.shields.io/badge/Build-Success!-3fb950?logo=github&style=for-the-badge"
           } > comment.md
           post_comment
+
+      # The PR above was opened with GITHUB_TOKEN, whose events start no workflow
+      # runs — the same suppression the build-links step exists to work around.
+      # So the InWorld gate has to be started explicitly, by a token that can.
+      #
+      # Dispatching against the release branch is what puts the gate on the PR:
+      # a workflow_dispatch run attaches its checks to the dispatched ref's tip,
+      # and that tip is the PR head. Without this the required check on main
+      # never reports and the release cannot merge.
+      - name: Start the InWorld gate on the release branch
+        env:
+          GH_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # A dispatched gate resolves this commit's build and fails fast when
+          # there is none, so only start it once one exists. Same condition as
+          # the comment above, and the same fix: re-run this workflow.
+          HEAD_SHA=$(git rev-parse HEAD)
+          RUN_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&status=success&per_page=20" \
+            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")] | .[0]')
+          if [ -z "$RUN_JSON" ] || [ "$RUN_JSON" = "null" ]; then
+            echo "::notice::No build for ${HEAD_SHA:0:7} yet, so the InWorld gate was not started. Re-run this workflow once one finishes."
+            exit 0
+          fi
+
+          gh workflow run in-world-tests.yml --ref "$BRANCH_NAME"
+          echo "::notice::InWorld gate dispatched against ${BRANCH_NAME}."

--- a/.github/workflows/in-world-tests.yml
+++ b/.github/workflows/in-world-tests.yml
@@ -44,7 +44,7 @@ on:
   workflow_dispatch:
     inputs:
       filter:
-        description: 'NUnit filter. Empty runs the whole Category=InWorld suite.'
+        description: 'NUnit filter. Empty runs the whole Category=InWorld suite, split across Windows runners; anything narrower runs on one.'
         required: false
         default: ''
         type: string
@@ -160,6 +160,16 @@ jobs:
       # `build_url` is the macOS zip; the Windows leg needs its own or it
       # resolves the newest dev build and reports on the wrong commit.
       windows_build_url: ${{ needs.resolve.outputs.windows_build_url }}
+      # What the Windows leg splits across runners. The gate runs everything, so
+      # say ALL — the same thing inworld-main.yml says for the same reason.
+      #
+      # The planner would infer it: an empty scope plus the whole-category filter
+      # reads as ALL. But that inference exists to stop callers who resolved
+      # nothing from running unsplit, and a gate should not lean on a fallback
+      # for its runtime. Empty here is reserved for the other case — a manual run
+      # with a narrow `filter`, which has no scope to split and belongs on one
+      # runner as `1/1`.
+      scope: ${{ (inputs.filter || '') == '' && 'ALL' || '' }}
     secrets: inherit
 
   result:

--- a/.github/workflows/in-world-tests.yml
+++ b/.github/workflows/in-world-tests.yml
@@ -1,0 +1,181 @@
+name: In-World Tests
+
+# Dispatcher for the InWorld NUnit suite. The mechanics — Explorer install,
+# AltTester, `mf explorer test`, Allure upload, PR comment — live in
+# decentraland/explorer-automation's `run-inworld-suite.yml`. This file only
+# decides when to run and against which build, and shares its build resolution
+# with visual-regression.yml via .github/actions/resolve-explorer-build.
+#
+# Triggers:
+#   - Every PR into main from a `release/**` or `hotfix/**` branch. `pull_request`
+#     and not `workflow_run` on the build, because a workflow_run reports against
+#     the default branch's SHA: it never joins the PR's checks and so can never
+#     gate a merge. Here the check is on the PR from the moment it opens, and the
+#     first job waits out the ~40-minute Unity Cloud Build the same event started.
+#   - Manually, from the Actions tab, against any ref.
+#
+# To make a red suite block the merge, add `InWorld suite result` to main's
+# required status checks. That job is the gate: it is the only name worth
+# requiring, it stays stable when the reusable workflow's own job names change,
+# and it passes for PRs into main that are not release or hotfix.
+#
+# One gap to know about: create-release-branch.yml opens the release PR with
+# GITHUB_TOKEN, and that raises no events, so nothing runs until the first human
+# push. A required check on a PR nobody has pushed to reads as "waiting to be
+# reported" — push a commit, or run this workflow by hand.
+#
+# Required vars:
+#   - vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL  Artifact bucket, and where the
+#     Allure report is published
+#
+# Inherited by the reusable workflow via `secrets: inherit`:
+#   - secrets.ALTTESTER_LICENSE
+#   - secrets.REPOS_READ_ONLY_TOKEN
+#   - secrets.EXPLORER_TEAM_S3_BUCKET
+#   - secrets.EXPLORER_TEAM_AWS_DEFAULT_REGION
+#   - secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID
+#   - secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'NUnit filter. Empty runs the whole Category=InWorld suite.'
+        required: false
+        default: ''
+        type: string
+      build_url:
+        description: 'Artifact URL to test. Empty resolves the selected ref''s own Unity Cloud Build.'
+        required: false
+        default: ''
+        type: string
+      tests_ref:
+        description: 'explorer-automation ref for the tests. Empty matches this ref''s name there, else main.'
+        required: false
+        default: ''
+        type: string
+      record_perf:
+        description: 'Record fixture-level perf samples. Off by default — paravirt numbers are unreliable.'
+        required: false
+        default: false
+        type: boolean
+
+# A newer commit supersedes the run in flight: the question is whether the branch
+# is good now, and the newer commit contains the older one.
+concurrency:
+  group: in-world-tests-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  # `actions: read` for the build lookup; the other two must be a superset of
+  # run-inworld-suite.yml's, or the call dies at startup.
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  resolve:
+    name: Wait for the build
+    # Skipped rather than filtered at the trigger, so the gate job below still
+    # reports on every PR into main and a required check never hangs unreported.
+    #
+    # Drafts are excluded to match build-unitycloud.yml, which does not build
+    # them without a `force-build` label — waiting for a build that will never
+    # start just turns into a timeout. `ready_for_review` above picks the PR up
+    # the moment it leaves draft.
+    #
+    # Fork PRs are excluded because they get no secrets, and the suite needs the
+    # AltTester licence. Release and hotfix branches never come from a fork.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      ((startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/')) &&
+       github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    # Covers the wait below plus the artifact check. Builds measure ~40m.
+    timeout-minutes: 100
+
+    env:
+      HEAD_REF: ${{ github.head_ref || github.ref_name }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    outputs:
+      build_url: ${{ steps.resolve.outputs.build-url }}
+      commit_sha: ${{ steps.resolve.outputs.short-sha }}
+      tests_ref: ${{ inputs.tests_ref || steps.resolve.outputs.tests-ref }}
+      branch_label: ${{ github.head_ref || github.ref_name }}
+
+    steps:
+      # `uses: ./…` resolves against $GITHUB_WORKSPACE, so the action has to be
+      # on disk. Sparse, because the full tree is ~21k files and none of the
+      # rest is read here.
+      - name: Fetch the resolver action
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/resolve-explorer-build
+
+      - name: Resolve build URL and tests ref
+        id: resolve
+        uses: ./.github/actions/resolve-explorer-build
+        with:
+          head-ref: ${{ env.HEAD_REF }}
+          head-sha: ${{ env.HEAD_SHA }}
+          # A PR opens before its build exists, so wait one out. Manual runs
+          # pick a ref whose build is already there — or say which to use.
+          wait-minutes: ${{ github.event_name == 'pull_request' && 90 || 0 }}
+          build-url-override: ${{ inputs.build_url }}
+          public-url-prefix: ${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          automation-token: ${{ secrets.REPOS_READ_ONLY_TOKEN }}
+
+  run-suite:
+    name: InWorld suite
+    needs: resolve
+    # @main pins the merged version of the reusable, so PRs to
+    # explorer-automation that touch it cannot change release validation here.
+    uses: decentraland/explorer-automation/.github/workflows/run-inworld-suite.yml@main
+    with:
+      build_url: ${{ needs.resolve.outputs.build_url }}
+      filter: ${{ inputs.filter || '' }}
+      # Empty on a manual run, so the reusable keeps it to the job summary.
+      pr_number: ${{ github.event.pull_request.number || '' }}
+      tests_ref: ${{ needs.resolve.outputs.tests_ref }}
+      commit_sha: ${{ needs.resolve.outputs.commit_sha }}
+      branch_label: ${{ needs.resolve.outputs.branch_label }}
+      # `== true` rather than the raw input: a pull_request event supplies no
+      # inputs at all, and the reusable's parameter is typed boolean.
+      record_perf: ${{ inputs.record_perf == true }}
+    secrets: inherit
+
+  result:
+    name: InWorld suite result
+    needs: [resolve, run-suite]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # The one check worth requiring on main. Everything above is either
+      # plumbing or a job name owned by another repository.
+      - name: Gate on the suite
+        env:
+          RESOLVE: ${{ needs.resolve.result }}
+          SUITE: ${{ needs.run-suite.result }}
+        run: |
+          set -euo pipefail
+          if [ "$RESOLVE" = "skipped" ]; then
+            echo "::notice::Not a release or hotfix PR — the InWorld suite does not gate this one."
+            exit 0
+          fi
+          if [ "$RESOLVE" = "success" ] && [ "$SUITE" = "success" ]; then
+            echo "::notice::InWorld suite passed."
+            exit 0
+          fi
+          # Cancelled counts as failure on purpose: a merge gate must not go
+          # green because the run was interrupted. The superseding run reports
+          # its own result.
+          echo "::error::InWorld gate failed — build: ${RESOLVE}, suite: ${SUITE}. See the Allure report linked in the suite's job summary."
+          exit 1

--- a/.github/workflows/in-world-tests.yml
+++ b/.github/workflows/in-world-tests.yml
@@ -105,6 +105,7 @@ jobs:
 
     outputs:
       build_url: ${{ steps.resolve.outputs.build-url }}
+      windows_build_url: ${{ steps.resolve.outputs.windows-build-url }}
       commit_sha: ${{ steps.resolve.outputs.short-sha }}
       tests_ref: ${{ inputs.tests_ref || steps.resolve.outputs.tests-ref }}
       branch_label: ${{ github.head_ref || github.ref_name }}
@@ -127,6 +128,8 @@ jobs:
           # A PR opens before its build exists, so wait one out. Manual runs
           # pick a ref whose build is already there — or say which to use.
           wait-minutes: ${{ github.event_name == 'pull_request' && 90 || 0 }}
+          # Both suites run, so both zips have to exist before either starts.
+          build-legs: macos,windows64
           build-url-override: ${{ inputs.build_url }}
           public-url-prefix: ${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -149,23 +152,14 @@ jobs:
       # `== true` rather than the raw input: a pull_request event supplies no
       # inputs at all, and the reusable's parameter is typed boolean.
       record_perf: ${{ inputs.record_perf == true }}
-      # macOS only, for now. explorer-automation#55 added a Windows leg and
-      # defaulted it on, but it is not callable from this repo yet:
-      #
-      #   - its checkout is bare, so in a workflow_call run it fetches the
-      #     CALLER — this repo — and then cannot find explorer/ci/*.ps1.
-      #     run-inworld-suite.yml's macOS leg names the repository explicitly;
-      #     the Windows one still has to.
-      #   - run-inworld-suite.yml passes it no build_url, so it resolves the
-      #     newest dev build. A release gate has to test the commit on the PR,
-      #     and the Windows artifact is a different file anyway
-      #     (Decentraland_windows64.zip beside the macOS zip, same prefix — the
-      #     resolver here can hand it over once there is an input for it).
-      #   - it runs on `win-gpu-t4-explorer`, and a called workflow's jobs use
-      #     runners the *caller* can reach. This repo registers none.
-      #
-      # Flip to true once those land; the suite splits across both legs then.
-      windows: false
+      # Both platforms gate a release. `windows` defaults to true upstream, but
+      # say it here anyway: a default that changes underneath a caller pinned to
+      # @main is how this repo silently acquired a Windows leg it could not run
+      # (explorer-automation#55, fixed by #73).
+      windows: true
+      # `build_url` is the macOS zip; the Windows leg needs its own or it
+      # resolves the newest dev build and reports on the wrong commit.
+      windows_build_url: ${{ needs.resolve.outputs.windows_build_url }}
     secrets: inherit
 
   result:

--- a/.github/workflows/in-world-tests.yml
+++ b/.github/workflows/in-world-tests.yml
@@ -75,8 +75,22 @@ on:
 # required check. `github.head_ref` is the source branch on `pull_request` (where
 # `ref_name` is the merge ref) and empty everywhere else, so the fallback is what
 # a dispatch and a manual run against any ref key on.
+#
+# Keyed on the head repo as well, because a branch name is not ours to reserve:
+# a fork PR into main may name its branch `release/2026-08-10` too, and
+# `cancel-in-progress` is applied when the run is created — before any job's
+# `if:` is evaluated, so the fork exclusion in `resolve`'s own `if:` (:113)
+# only skips the jobs of a run that has already cancelled the real gate.
+# Without this segment an outsider could red a release's required check at
+# will, by guessing a name that release cuts make predictable.
+# `head.repo.full_name` is the head repo on `pull_request` — ours on a same-repo
+# PR, `attacker/whatever` on a fork — and absent on `workflow_dispatch`, whose
+# payload carries only `inputs`, `ref` and `workflow`; the fallback therefore
+# resolves to the same string a same-repo PR produces, which is what keeps the
+# two triggers in one group. A fork cannot collide with us: everything before
+# the first `/` is the head repo's owner, and only we can be `decentraland`.
 concurrency:
-  group: in-world-tests-${{ github.head_ref || github.ref_name }}
+  group: in-world-tests-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/in-world-tests.yml
+++ b/.github/workflows/in-world-tests.yml
@@ -149,6 +149,23 @@ jobs:
       # `== true` rather than the raw input: a pull_request event supplies no
       # inputs at all, and the reusable's parameter is typed boolean.
       record_perf: ${{ inputs.record_perf == true }}
+      # macOS only, for now. explorer-automation#55 added a Windows leg and
+      # defaulted it on, but it is not callable from this repo yet:
+      #
+      #   - its checkout is bare, so in a workflow_call run it fetches the
+      #     CALLER — this repo — and then cannot find explorer/ci/*.ps1.
+      #     run-inworld-suite.yml's macOS leg names the repository explicitly;
+      #     the Windows one still has to.
+      #   - run-inworld-suite.yml passes it no build_url, so it resolves the
+      #     newest dev build. A release gate has to test the commit on the PR,
+      #     and the Windows artifact is a different file anyway
+      #     (Decentraland_windows64.zip beside the macOS zip, same prefix — the
+      #     resolver here can hand it over once there is an input for it).
+      #   - it runs on `win-gpu-t4-explorer`, and a called workflow's jobs use
+      #     runners the *caller* can reach. This repo registers none.
+      #
+      # Flip to true once those land; the suite splits across both legs then.
+      windows: false
     secrets: inherit
 
   result:

--- a/.github/workflows/in-world-tests.yml
+++ b/.github/workflows/in-world-tests.yml
@@ -66,8 +66,17 @@ on:
 
 # A newer commit supersedes the run in flight: the question is whether the branch
 # is good now, and the newer commit contains the older one.
+#
+# Keyed on the branch, not the PR number, because both triggers have to land in
+# one group: create-release-branch.yml dispatches this workflow against the same
+# release branch a `pull_request` run also covers, and a PR-number key would put
+# the two in groups that can never cancel each other — two gates on one commit,
+# four shards on the self-hosted GPU pool, and whichever finishes last owning the
+# required check. `github.head_ref` is the source branch on `pull_request` (where
+# `ref_name` is the merge ref) and empty everywhere else, so the fallback is what
+# a dispatch and a manual run against any ref key on.
 concurrency:
-  group: in-world-tests-${{ github.event.pull_request.number || github.ref_name }}
+  group: in-world-tests-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -196,8 +205,9 @@ jobs:
       # reads as ALL. But that inference exists to stop callers who resolved
       # nothing from running unsplit, and a gate should not lean on a fallback
       # for its runtime. Empty here is reserved for the other case — a manual run
-      # with a narrow `filter`, which has no scope to split and belongs on one
-      # runner as `1/1`.
+      # that passed a `filter` at all. This repo cannot map an arbitrary NUnit
+      # filter to a scope, so the planner infers the split from the filter
+      # instead; a narrow one lands on one runner as `1/1`.
       scope: ${{ (inputs.filter || '') == '' && 'ALL' || '' }}
     secrets: inherit
 

--- a/.github/workflows/in-world-tests.yml
+++ b/.github/workflows/in-world-tests.yml
@@ -19,10 +19,10 @@ name: In-World Tests
 # requiring, it stays stable when the reusable workflow's own job names change,
 # and it passes for PRs into main that are not release or hotfix.
 #
-# One gap to know about: create-release-branch.yml opens the release PR with
-# GITHUB_TOKEN, and that raises no events, so nothing runs until the first human
-# push. A required check on a PR nobody has pushed to reads as "waiting to be
-# reported" — push a commit, or run this workflow by hand.
+# Release PRs are opened by create-release-branch.yml with GITHUB_TOKEN, and
+# events that token raises start no workflow runs — so that workflow dispatches
+# this one itself. A dispatch attaches its checks to the dispatched ref's tip,
+# which is the PR head, so the gate still lands on the PR.
 #
 # Required vars:
 #   - vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL  Artifact bucket, and where the
@@ -109,6 +109,7 @@ jobs:
       commit_sha: ${{ steps.resolve.outputs.short-sha }}
       tests_ref: ${{ inputs.tests_ref || steps.resolve.outputs.tests-ref }}
       branch_label: ${{ github.head_ref || github.ref_name }}
+      pr_number: ${{ github.event.pull_request.number || steps.pr.outputs.number }}
 
     steps:
       # `uses: ./…` resolves against $GITHUB_WORKSPACE, so the action has to be
@@ -135,6 +136,26 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           automation-token: ${{ secrets.REPOS_READ_ONLY_TOKEN }}
 
+      # A dispatched run carries no PR, and the release gate is started that way
+      # — create-release-branch.yml dispatches it, because the PR it opens with
+      # GITHUB_TOKEN raises no events. Without this the result reaches only the
+      # job summary, on the one path where the PR is the whole point.
+      # `--head` matches on branch name alone, hence the fork exclusion.
+      - name: Find the branch's open PR
+        id: pr
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$HEAD_REF" --state open \
+            --json number,isCrossRepository \
+            --jq '[.[] | select(.isCrossRepository == false)] | .[0].number // ""')
+          if [ -n "$NUMBER" ]; then
+            echo "::notice::Results will be commented on PR #${NUMBER}."
+          fi
+          echo "number=${NUMBER}" >> "$GITHUB_OUTPUT"
+
   run-suite:
     name: InWorld suite
     needs: resolve
@@ -144,8 +165,8 @@ jobs:
     with:
       build_url: ${{ needs.resolve.outputs.build_url }}
       filter: ${{ inputs.filter || '' }}
-      # Empty on a manual run, so the reusable keeps it to the job summary.
-      pr_number: ${{ github.event.pull_request.number || '' }}
+      # From the event on a PR run, looked up on a dispatched one.
+      pr_number: ${{ needs.resolve.outputs.pr_number }}
       tests_ref: ${{ needs.resolve.outputs.tests_ref }}
       commit_sha: ${{ needs.resolve.outputs.commit_sha }}
       branch_label: ${{ needs.resolve.outputs.branch_label }}

--- a/.github/workflows/in-world-tests.yml
+++ b/.github/workflows/in-world-tests.yml
@@ -70,13 +70,6 @@ concurrency:
   group: in-world-tests-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
-permissions:
-  # `actions: read` for the build lookup; the other two must be a superset of
-  # run-inworld-suite.yml's, or the call dies at startup.
-  actions: read
-  contents: read
-  pull-requests: write
-
 jobs:
   resolve:
     name: Wait for the build
@@ -98,6 +91,15 @@ jobs:
     runs-on: ubuntu-latest
     # Covers the wait below plus the artifact check. Builds measure ~40m.
     timeout-minutes: 100
+
+    # `actions: read` for the build-unitycloud lookup, `contents: read` for the
+    # sparse checkout, `pull-requests: read` for the `gh pr list` below. Read
+    # access to public data survives whatever this block says while the repo is
+    # public, but the grant should not hinge on that. Nothing here writes.
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
 
     env:
       HEAD_REF: ${{ github.head_ref || github.ref_name }}
@@ -162,6 +164,12 @@ jobs:
     # @main pins the merged version of the reusable, so PRs to
     # explorer-automation that touch it cannot change release validation here.
     uses: decentraland/explorer-automation/.github/workflows/run-inworld-suite.yml@main
+    # Must be a superset of run-inworld-suite.yml's own `permissions:`, or the
+    # call dies at startup. The write is the PR comment it posts; this is the
+    # only job that needs one, hence per job rather than at the top of the file.
+    permissions:
+      contents: read
+      pull-requests: write
     with:
       build_url: ${{ needs.resolve.outputs.build_url }}
       filter: ${{ inputs.filter || '' }}
@@ -199,6 +207,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Reads its `needs` results and nothing else — no API call, no checkout.
+    permissions: {}
     steps:
       # The one check worth requiring on main. Everything above is either
       # plumbing or a job name owned by another repository.

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -3,7 +3,8 @@ name: Visual Regression
 # Slash-command-driven visual regression runner. The actual mechanics live in
 # decentraland/explorer-automation's `run-visual-suite.yml` reusable workflow;
 # this file only handles trigger validation, branch matching, and dispatching
-# to that workflow.
+# to that workflow. Build resolution and branch matching are shared with
+# in-world-tests.yml via .github/actions/resolve-explorer-build.
 #
 # Trigger:
 #   Comment "/visual-tests" on a PR. Restricted to OWNER / MEMBER /
@@ -26,16 +27,20 @@ name: Visual Regression
 # on this repo even though the dispatcher itself doesn't reference them:
 #   - secrets.ALTTESTER_LICENSE
 #   - secrets.REPOS_READ_ONLY_TOKEN
-#   - secrets.DEV_EXPLORER_TEAM_S3_BUCKET
-#   - secrets.DEV_EXPLORER_TEAM_AWS_DEFAULT_REGION
-#   - secrets.DEV_EXPLORER_TEAM_AWS_ACCESS_KEY_ID
-#   - secrets.DEV_EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY
+#   - secrets.EXPLORER_TEAM_S3_BUCKET
+#   - secrets.EXPLORER_TEAM_AWS_DEFAULT_REGION
+#   - secrets.EXPLORER_TEAM_AWS_ACCESS_KEY_ID
+#   - secrets.EXPLORER_TEAM_AWS_SECRET_ACCESS_KEY
 
 on:
   issue_comment:
     types: [created]
 
 permissions:
+  # `actions: read` for the build lookup. It resolves anyway while this repo is
+  # public — GITHUB_TOKEN keeps read access to public data whatever the block
+  # says — but the grant should not hinge on that.
+  actions: read
   contents: write
   pull-requests: write
 
@@ -53,8 +58,8 @@ jobs:
     outputs:
       authorized: ${{ steps.gate.outputs.authorized }}
       pr_number: ${{ steps.pr.outputs.number }}
-      build_url: ${{ steps.pr.outputs.build_url }}
-      tests_ref: ${{ steps.match.outputs.tests_ref }}
+      build_url: ${{ steps.resolve.outputs.build-url }}
+      tests_ref: ${{ steps.resolve.outputs.tests-ref }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
       head_short_sha: ${{ steps.pr.outputs.head_short_sha }}
       head_ref: ${{ steps.pr.outputs.head_ref }}
@@ -85,83 +90,44 @@ jobs:
             "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content=eyes >/dev/null
 
-      - name: Resolve PR head + build URL
+      - name: Resolve PR head
         id: pr
         if: steps.gate.outputs.authorized == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
-          PUBLIC_URL_PREFIX: ${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}
         run: |
           set -euo pipefail
-
-          # 1. Fetch PR head — issue_comment events don't carry it in the payload.
+          # issue_comment events don't carry the PR head in the payload.
           PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
           HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
           HEAD_REF=$(echo "$PR_JSON" | jq -r '.head.ref')
-          SHORT_SHA="${HEAD_SHA:0:7}"
-
-          # 2. Find the most recent successful Unity Cloud Build run for this
-          #    SHA, scoped to the build workflow file — a repo-wide head_sha
-          #    listing gets crowded out by bot runs sharing the SHA (90+ on a
-          #    typical release commit) and the build falls past the first page.
-          #    Only pull_request/push builds qualify — dispatch builds can
-          #    carry non-default options (e.g. profiling) that break the
-          #    determinism visual tests rely on.
-          RUN_JSON=$(gh api "repos/${{ github.repository }}/actions/workflows/build-unitycloud.yml/runs?head_sha=${HEAD_SHA}&status=success&per_page=20" \
-            --jq '[.workflow_runs[] | select(.event == "pull_request" or .event == "push")] | .[0]')
-          if [ -z "$RUN_JSON" ] || [ "$RUN_JSON" = "null" ]; then
-            echo "::error::No successful Unity Cloud Build run found for SHA ${SHORT_SHA}. Is the build still in progress, or did it fail?"
-            exit 1
-          fi
-          RUN_NUMBER=$(echo "$RUN_JSON" | jq -r '.run_number')
-          ORIGINAL_EVENT=$(echo "$RUN_JSON" | jq -r '.event')
-          RUN_BRANCH=$(echo "$RUN_JSON" | jq -r '.head_branch')
-
-          # The S3 prefix and branch segment depend on the event and branch of
-          # the run that produced the build (see build-unitycloud.yml), not on
-          # this PR. Derive both from the run so /visual-tests also works on
-          # PRs whose only build for the SHA ran on another trigger — e.g.
-          # bot-created release PRs, whose tip is built by the push to dev.
-          case "$ORIGINAL_EVENT" in
-            pull_request) BUILD_PREFIX="pr" ;;
-            push) BUILD_PREFIX="pu" ;;
-            merge_group) BUILD_PREFIX="mg" ;;
-            workflow_dispatch) BUILD_PREFIX="wd" ;;
-            workflow_call) BUILD_PREFIX="wc" ;;
-            schedule) BUILD_PREFIX="sc" ;;
-            *) BUILD_PREFIX="gn" ;;
-          esac
-
-          ARTIFACT_PATH="@dcl/${{ github.event.repository.name }}/branch/${RUN_BRANCH}/${BUILD_PREFIX}-${RUN_NUMBER}-${SHORT_SHA}"
-          BUILD_URL="${PUBLIC_URL_PREFIX}/${ARTIFACT_PATH}/Decentraland_macos.zip"
-
           {
             echo "number=${PR_NUMBER}"
             echo "head_sha=${HEAD_SHA}"
-            echo "head_short_sha=${SHORT_SHA}"
+            echo "head_short_sha=${HEAD_SHA:0:7}"
             echo "head_ref=${HEAD_REF}"
-            echo "build_url=${BUILD_URL}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Look up matching explorer-automation branch
-        id: match
+      # `uses: ./…` resolves against $GITHUB_WORKSPACE, so the action has to be
+      # on disk. Sparse, because the full tree is ~21k files and nothing else
+      # here is read.
+      - name: Fetch the resolver action
         if: steps.gate.outputs.authorized == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.REPOS_READ_ONLY_TOKEN }}
-          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
-        run: |
-          set -euo pipefail
-          # 200 = branch exists on explorer-automation, use it as tests_ref.
-          # 404 = no matching branch, fall back to default (empty string =>
-          # metaforge resolves to main).
-          if gh api "repos/decentraland/explorer-automation/branches/${HEAD_REF}" --silent >/dev/null 2>&1; then
-            echo "tests_ref=${HEAD_REF}" >> "$GITHUB_OUTPUT"
-            echo "::notice::Using matching explorer-automation branch '${HEAD_REF}'."
-          else
-            echo "tests_ref=" >> "$GITHUB_OUTPUT"
-            echo "::notice::No matching explorer-automation branch '${HEAD_REF}' — using default."
-          fi
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/resolve-explorer-build
+
+      - name: Resolve build URL and tests ref
+        id: resolve
+        if: steps.gate.outputs.authorized == 'true'
+        uses: ./.github/actions/resolve-explorer-build
+        with:
+          head-ref: ${{ steps.pr.outputs.head_ref }}
+          head-sha: ${{ steps.pr.outputs.head_sha }}
+          public-url-prefix: ${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          automation-token: ${{ secrets.REPOS_READ_ONLY_TOKEN }}
 
   run-suite:
     name: Run visual suite


### PR DESCRIPTION
Runs explorer-automation's **InWorld suite** as a merge gate on every `release/**` and `hotfix/**` PR into `main`, on macOS and Windows, and manually from the Actions tab against any ref.

The suite mechanics live in `decentraland/explorer-automation` (`run-inworld-suite.yml`), the same way `visual-regression.yml` calls `run-visual-suite.yml`. This PR is the dispatcher — plus the deduplication that a second dispatcher makes worth doing.

| file | |
|---|---|
| `.github/actions/resolve-explorer-build/` | **new** — find this commit's builds, and the matching explorer-automation branch. Lifted out of `visual-regression.yml`, which held the only copy |
| `.github/workflows/in-world-tests.yml` | **new** — trigger, call, gate |
| `.github/workflows/create-release-branch.yml` | +28 — start the gate on bot-created release PRs |
| `.github/workflows/visual-regression.yml` | −55 lines, moved onto the shared action |

## The flow

1. A `release/**` or `hotfix/**` PR opens against `main` → **`InWorld suite result`** appears as a pending check.
2. `Wait for the build` polls for that commit's `Build (macos)` **and** `Build (windows64)` jobs, and verifies both zips are reachable. It fails early if either leg goes red, and gives up after 90 minutes with a message naming the likely cause.
3. Both suites run — macOS on `macos-14`, Windows split across self-hosted GPU runners — and the result is commented on the PR.
4. `InWorld suite result` goes red if anything above failed, or was cancelled.

Drafts are skipped, matching `build-unitycloud.yml`, which doesn't build them either. `ready_for_review` picks the PR up the moment it leaves draft.

## To actually block the merge

Add **`InWorld suite result`** to `main`'s required status checks — it currently requires `Test (editmode)` and `Test (playmode)`, which work the same way: they run on the PR, not on `main`, and gate the merge into it.

That job is the one worth requiring. It stays stable when job names change inside the reusable workflow, it fails rather than going green on a cancelled run, and it **passes for PRs into `main` that aren't release or hotfix** — which is why the branch filtering is a job-level `if:` rather than a trigger filter. A required check that never reports blocks a merge forever, so the gate reports on every PR into `main` while only running the suite for the ones that need it.

I haven't touched branch protection — that's a repo setting and yours to make.

## Design notes

**Why `pull_request` and not `workflow_run` on the build.** A `workflow_run` workflow reports its check against the *default branch's* SHA. It never joins the PR's check list, so branch protection can't require it and it can't block a merge. The check has to be on the PR from the moment it opens. The cost is an idle `ubuntu-latest` job waiting out the build — free on a public repo, and visible as an honest pending check meanwhile.

**Why not a job inside `build-unitycloud.yml` with `needs:`,** which would need no polling at all. It wouldn't be faster: `needs: [build]` waits for the whole matrix anyway. And it would couple release testing to build discovery — a red InWorld job makes the *build run's* conclusion `failure`, and both `create-release-branch.yml` and the resolver `/visual-tests` uses look builds up by `status=success`. One flaky test would make a release PR lose its build links and break `/visual-tests` for that commit.

**Bot-created release PRs.** `create-release-branch.yml` opens the PR with `GITHUB_TOKEN`, whose events start no workflow runs — the same suppression its build-link reuse already works around. So it now dispatches the gate explicitly with `ORG_ACCESS_TOKEN`. A `workflow_dispatch` run attaches its checks to the dispatched ref's tip, which is the PR head, so the gate lands on the PR. The alternative — a PAT on the checkout and `gh pr create` — would trigger a full rebuild of a commit `dev` already built, which is the 40 minutes that workflow exists to avoid.

## Validation

**[31717537499](https://github.com/decentraland/unity-explorer/actions/runs/31717537499)** — the full `pull_request` path on this PR, both platforms, sharded. Green:

| job | |
|---|---|
| `Wait for the build` | 15:53:31 → 16:25:15 |
| `InWorld suite (macOS)` | 19m45s, success |
| `Windows / Plan shards` | 42s → 2 shards |
| `Windows InWorld tests 1/2` | 12m57s, success |
| `Windows InWorld tests 2/2` | 14m44s, success |
| **`InWorld suite result`** | **success** at 16:45:18 |

`Build (macos)` finished 16:15:36 and `Build (windows64)` 16:24:37; the wait released 38s after the later one, so both-leg waiting works. Both Windows shards finished *before* the macOS leg, so Windows costs nothing in the suite phase — its cost is the ~9 minutes of extra build wait. Whole gate: ~55 minutes from push.

**[31589604419](https://github.com/decentraland/unity-explorer/actions/runs/31589604419)** — the first cross-repo call into `run-inworld-suite.yml` from this repo, pinned to `release/2026-08-10`'s build to exercise a real release target. 65 passed, 1 failed; the failure was `NavbarTests.TestSidebarShowsAllNavigationButtons` on a feature flag, fixed since by explorer-automation#69. It also confirmed the `EXPLORER_TEAM_*` secret family reaches this repo, correcting a stale header this PR fixes.

**A superseded run** confirmed the gate reports **failure** on cancellation, rather than going green.

The resolver's shell is unit-tested against a stubbed `gh` for: both legs green, one leg still building, a leg failed, newest run skipped with an older green one, never queued, timeout, bad override host, and override sibling derivation. `actionlint` clean throughout.

**Not yet exercised:** the dispatched path — `create-release-branch.yml`'s step and the PR lookup it feeds — can't run until `in-world-tests.yml` is on `dev`, since `gh workflow run` resolves workflows from the default branch. The check-attachment mechanism it relies on was verified separately against a real dispatch run.

## Upstream

Depends on explorer-automation#73 (cross-repo Windows leg) and #72 (sharding from one planner), both merged.
