### PR TITLE
docs: correct the feature flag probe's name in the automation docs

### DIFF
--- a/docs/automation-testing.md
+++ b/docs/automation-testing.md
@@ -44,18 +44,22 @@ tests call directly with `AltDriver.CallStaticMethod`, passing the type and its 
 
 ```csharp
 AltDriver.CallStaticMethod<bool>(
-    "DCL.FeatureFlags.AlttesterFeatureFlagsProbe", "IsFeatureEnabled",
+    "DCL.FeatureFlags.AltTesterFeatureFlagsProbe", "IsFeatureEnabled",
     "DCL.Network", new object[] { "MarketplaceCredits" });
 ```
 
 | Type | Assembly | Exposes |
 |---|---|---|
 | `SceneRunner.Scene.AlttesterSceneReadinessProbe` | `SceneRunner.Scene` | whether the current scene finished loading, plus its name and base parcel |
-| `DCL.FeatureFlags.AlttesterFeatureFlagsProbe` | `DCL.Network` | remote flag state, resolved `FeatureId` state, variant payloads |
+| `DCL.FeatureFlags.AltTesterFeatureFlagsProbe` | `DCL.Network` | remote flag state, resolved `FeatureId` state, variant payloads |
 | `DCL.PerformanceAndDiagnostics.AutoPilot.PerfSampler` | `DCL.Diagnostics.AutoPilot` | `Begin`/`End` around a test to write a perf CSV |
 
-The `Alttester*` probes are gated by the `ALTTESTER` define and are therefore absent from release
-builds; `PerfSampler` is not gated.
+Both probe types are gated by the `ALTTESTER` define and are therefore absent from release builds;
+`PerfSampler` is not gated. Note the inconsistent casing — `AltTesterFeatureFlagsProbe` against
+`AlttesterSceneReadinessProbe`. The driver resolves the type with `Assembly.GetType`, which is
+case-sensitive, so a probe renamed on this side silently becomes `componentNotFound` on the test
+side. That error means the assembly loaded but the type was not in it; a wrong *assembly* name
+reports `Assembly not found` instead.
 
 **Prefer a probe over re-deriving client state test-side.** Feature flags are the cautionary case:
 the remote document evaluates differently depending on request headers, and the client folds app

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -64,7 +64,7 @@ public void DoStuff()
 ```
 
 From an automation test, read the flags out of the running client via
-`AlttesterFeatureFlagsProbe` rather than fetching the remote document — see
+`AltTesterFeatureFlagsProbe` rather than fetching the remote document — see
 [Static Probes](automation-testing.md#static-probes).
 
 ## How to get content of a feature flag (variants)


### PR DESCRIPTION
## What does this PR change?

The probe merged in #9682 as `AltTesterFeatureFlagsProbe`, renamed from `Alttester…` during review,
but `docs/automation-testing.md` and `docs/feature-flags.md` still carry the old spelling — including
in a copy-pasteable `CallStaticMethod` snippet.

That is not a cosmetic typo. The driver resolves the type with `Assembly.GetType`, which is
case-sensitive, so the old name comes back as `componentNotFound` — the assembly loads, the type
isn't in it. It cost a CI cycle in
[explorer-automation#69](https://github.com/decentraland/explorer-automation/pull/69) before the
cause was clear, so the failure mode is now recorded next to the table, along with the fact that a
wrong *assembly* name reports `Assembly not found` instead. The casing between the two probes stays
inconsistent; the docs just point it out rather than churn a merged public name.

Docs only.

## Test Instructions

None — no code changes. The corrected snippet is exercised by explorer-automation#69, whose InWorld
run is green against dev build `9aa190d`.

## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included