### PR TITLE
opti: skip redundant avatar layer weight writes and cache animator layer indices

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
@@ -26,108 +26,109 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
 
         public int RandomID;
 
-                private List<KeyValuePair<AnimationClip, AnimationClip>> animationOverrides = null!;
-                private AnimationClip lastEmote = null!;
+        private List<KeyValuePair<AnimationClip, AnimationClip>> animationOverrides = null!;
+        private AnimationClip lastEmote = null!;
         private AnimationClip? lastMaskedEmote;
-                private AnimatorOverrideController overrideController = null!;
+        private AnimatorOverrideController overrideController = null!;
 
-                [field: SerializeField] public Animator AvatarAnimator { get; private set; } = null!;
-                [field: SerializeField] public AvatarAudioPlaybackController AudioPlaybackController { get; private set; } = null!;
+        [field: SerializeField] public Animator AvatarAnimator { get; private set; } = null!;
+        [field: SerializeField] public AvatarAudioPlaybackController AudioPlaybackController { get; private set; } = null!;
 
         public Animation? LegacyAnimation { get; private set; }
 
         private MaskedLegacyEmoteBlender? maskedLegacyBlender;
 
-                [field: SerializeField] public RigBuilder RigBuilder { get; private set; } = null!;
+        [field: SerializeField] public RigBuilder RigBuilder { get; private set; } = null!;
 
-                [field: SerializeField] public SkinnedMeshRenderer AvatarSkinnedMeshRenderer { get; private set; } = null!;
+        [field: SerializeField] public SkinnedMeshRenderer AvatarSkinnedMeshRenderer { get; private set; } = null!;
 
         [field: Header("FEET IK")]
 
         // This Rig controls the weight of ALL the feet IK constraints
-                [field: SerializeField] public Rig FeetIKRig { get; private set; } = null!;
+        [field: SerializeField] public Rig FeetIKRig { get; private set; } = null!;
 
         //This Transform position has the current position of the right leg feet, after the animation kicks in, before the IK. We raycast from this position
-                [field: SerializeField] public Transform RightLegConstraint { get; private set; } = null!;
+        [field: SerializeField] public Transform RightLegConstraint { get; private set; } = null!;
 
         // This transform position decides where we want to put the right leg
-                [field: SerializeField] public Transform RightLegIKTarget { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftLegConstraint { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftLegIKTarget { get; private set; } = null!;
+        [field: SerializeField] public Transform RightLegIKTarget { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftLegConstraint { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftLegIKTarget { get; private set; } = null!;
 
         // Constraint that controls the weight of the leg IK
-                [field: SerializeField] public TwoBoneIKConstraint RightLegIK { get; private set; } = null!;
-                [field: SerializeField] public TwoBoneIKConstraint LeftLegIK { get; private set; } = null!;
+        [field: SerializeField] public TwoBoneIKConstraint RightLegIK { get; private set; } = null!;
+        [field: SerializeField] public TwoBoneIKConstraint LeftLegIK { get; private set; } = null!;
 
         //This constraint Applies an offset to the hips, lowering the avatar position based on the desired feet position
-                [field: SerializeField] public MultiPositionConstraint HipsConstraint { get; private set; } = null!;
+        [field: SerializeField] public MultiPositionConstraint HipsConstraint { get; private set; } = null!;
 
         [field: Header("HANDS IK")]
-                [field: SerializeField] public Rig HandsIKRig { get; private set; } = null!;
-                [field: SerializeField] public TwoBoneIKConstraint LeftHandIK { get; private set; } = null!;
+        [field: SerializeField] public Rig HandsIKRig { get; private set; } = null!;
+        [field: SerializeField] public TwoBoneIKConstraint LeftHandIK { get; private set; } = null!;
 
         // IK target position and rotation, its called subTarget because the real target has a parent constraint based on this transform to fix some offsets
-                [field: SerializeField] public Transform LeftHandSubTarget { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftHandSubTarget { get; private set; } = null!;
 
         // Position where we raycast from
-                [field: SerializeField] public Transform LeftHandRaycast { get; private set; } = null!;
-                [field: SerializeField] public TwoBoneIKConstraint RightHandIK { get; private set; } = null!;
-                [field: SerializeField] public Transform RightHandSubTarget { get; private set; } = null!;
-                [field: SerializeField] public Transform RightHandTarget { get; private set; } = null!;
-                [field: SerializeField] public Transform RightHandRaycast { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftHandRaycast { get; private set; } = null!;
+        [field: SerializeField] public TwoBoneIKConstraint RightHandIK { get; private set; } = null!;
+        [field: SerializeField] public Transform RightHandSubTarget { get; private set; } = null!;
+        [field: SerializeField] public Transform RightHandTarget { get; private set; } = null!;
+        [field: SerializeField] public Transform RightHandRaycast { get; private set; } = null!;
 
         [field: Header("LOOK-AT IK")]
-                [field: SerializeField] public Rig HeadIKRig { get; private set; } = null!;
+        [field: SerializeField] public Rig HeadIKRig { get; private set; } = null!;
 
         // The LookAt IK is based on 2 constraints, one for horizontal rotation and other for vertical rotation in order to control different bone chains for both of them, Horizontal is applied first
-                [field: SerializeField] public TwistChainConstraint HeadLookAtTargetVerticalConstraint { get; private set; } = null!;
-                [field: SerializeField] public Transform HeadLookAtTargetHorizontal { get; private set; } = null!;
-                [field: SerializeField] public Transform HeadLookAtTargetVertical { get; private set; } = null!;
+        [field: SerializeField] public TwistChainConstraint HeadLookAtTargetVerticalConstraint { get; private set; } = null!;
+        [field: SerializeField] public Transform HeadLookAtTargetHorizontal { get; private set; } = null!;
+        [field: SerializeField] public Transform HeadLookAtTargetVertical { get; private set; } = null!;
 
         // Position of the head after the animations
-                [field: SerializeField] public Transform HeadPositionConstraint { get; private set; } = null!;
+        [field: SerializeField] public Transform HeadPositionConstraint { get; private set; } = null!;
 
         [field: Header("TORSO IK")]
-                [field: SerializeField] public Rig TorsoIKRig { get; private set; } = null!;
-                [field: SerializeField] public Transform TorsoTarget { get; private set; } = null!;
+        [field: SerializeField] public Rig TorsoIKRig { get; private set; } = null!;
+        [field: SerializeField] public Transform TorsoTarget { get; private set; } = null!;
 
         [field: Header("ADDITIVE BREATH")]
-                [field: SerializeField] public Rig CachePoseRig { get; private set; } = null!;
-                [field: SerializeField] public Rig AdditiveBreathRig { get; private set; } = null!;
-                [field: SerializeField] public AdditiveBreathDataBridge AdditiveBreathBridge { get; private set; } = null!;
+        [field: SerializeField] public Rig CachePoseRig { get; private set; } = null!;
+        [field: SerializeField] public Rig AdditiveBreathRig { get; private set; } = null!;
+        [field: SerializeField] public AdditiveBreathDataBridge AdditiveBreathBridge { get; private set; } = null!;
 
         [field: Header("OTHER")]
+
         // Anchor points to attach entities to, through the SDK
-                [field: SerializeField] public Transform NameTagAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform HeadAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform NeckAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform SpineAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform Spine1AnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform Spine2AnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform HipAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftShoulderAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftArmAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftForearmAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftHandAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftHandIndexAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform RightShoulderAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform RightArmAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform RightForearmAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform RightHandAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform RightHandIndexAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftUpLegAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftLegAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftFootAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform LeftToeBaseAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform RightUpLegAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform RightLegAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform RightFootAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform RightToeBaseAnchorPoint { get; private set; } = null!;
-                [field: SerializeField] public Transform Armature { get; private set; } = null!;
+        [field: SerializeField] public Transform NameTagAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform HeadAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform NeckAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform SpineAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform Spine1AnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform Spine2AnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform HipAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftShoulderAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftArmAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftForearmAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftHandAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftHandIndexAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform RightShoulderAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform RightArmAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform RightForearmAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform RightHandAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform RightHandIndexAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftUpLegAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftLegAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftFootAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform LeftToeBaseAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform RightUpLegAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform RightLegAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform RightFootAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform RightToeBaseAnchorPoint { get; private set; } = null!;
+        [field: SerializeField] public Transform Armature { get; private set; } = null!;
 
-                [field: SerializeField] public GameObject GhostGameObject { get; private set; } = null!;
+        [field: SerializeField] public GameObject GhostGameObject { get; private set; } = null!;
 
-                public Renderer GhostRenderer { get; private set; } = null!;
+        public Renderer GhostRenderer { get; private set; } = null!;
 
         [Header("NAMETAG RELATED")]
         [SerializeField] [Tooltip("How high could nametag be, [m]")]
@@ -139,8 +140,8 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         [SerializeField] [Tooltip("Extra height added to the nametag while the glider is deployed, to avoid clipping the glider model, [m]")]
         private float nametagGlideOffset = 0.8f;
 
-                [SerializeField] private Transform headAramatureBone = null!;
-                [SerializeField] private Transform[] potentialHighestBones = null!;
+        [SerializeField] private Transform headAramatureBone = null!;
+        [SerializeField] private Transform[] potentialHighestBones = null!;
         private float cachedHeadWearableOffset; // Cached offset from head bone to the highest point of head wearables (like tall hats). Updated when wearables change.
         private Vector3 headArmatureBoneStartPosition;
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
@@ -2,10 +2,13 @@ using CommunicationData.URLHelpers;
 using DCL.Audio.Avatar;
 using DCL.AvatarRendering.Wearables.Components.Intentions;
 using DCL.Diagnostics;
+using AvatarEmoteMask = DCL.ECSComponents.AvatarEmoteMask;
+using DclAvatarMask = DCL.ECSComponents.AvatarMask;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Animations.Rigging;
+using Utility.Animations;
 using Random = UnityEngine.Random;
 
 namespace DCL.AvatarRendering.AvatarShape.UnityInterface
@@ -16,111 +19,115 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
 
         private int rightPointAtLayerIndex;
         private int rotationLayerIndex;
+        private int upperBodyLayerIndex;
+
+        private float lastPointAtLayerWeight = float.NaN;
+        private float lastRotationLayerWeight = float.NaN;
 
         public int RandomID;
 
-        private List<KeyValuePair<AnimationClip, AnimationClip>> animationOverrides;
-        private AnimationClip lastEmote;
+                private List<KeyValuePair<AnimationClip, AnimationClip>> animationOverrides = null!;
+                private AnimationClip lastEmote = null!;
         private AnimationClip? lastMaskedEmote;
-        private AnimatorOverrideController overrideController;
+                private AnimatorOverrideController overrideController = null!;
 
-        [field: SerializeField] public Animator AvatarAnimator { get; private set; }
-        [field: SerializeField] public AvatarAudioPlaybackController AudioPlaybackController { get; private set; }
+                [field: SerializeField] public Animator AvatarAnimator { get; private set; } = null!;
+                [field: SerializeField] public AvatarAudioPlaybackController AudioPlaybackController { get; private set; } = null!;
 
         public Animation? LegacyAnimation { get; private set; }
 
         private MaskedLegacyEmoteBlender? maskedLegacyBlender;
 
-        [field: SerializeField] public RigBuilder RigBuilder { get; private set; }
+                [field: SerializeField] public RigBuilder RigBuilder { get; private set; } = null!;
 
-        [field: SerializeField] public SkinnedMeshRenderer AvatarSkinnedMeshRenderer { get; private set; }
+                [field: SerializeField] public SkinnedMeshRenderer AvatarSkinnedMeshRenderer { get; private set; } = null!;
 
         [field: Header("FEET IK")]
 
         // This Rig controls the weight of ALL the feet IK constraints
-        [field: SerializeField] public Rig FeetIKRig { get; private set; }
+                [field: SerializeField] public Rig FeetIKRig { get; private set; } = null!;
 
         //This Transform position has the current position of the right leg feet, after the animation kicks in, before the IK. We raycast from this position
-        [field: SerializeField] public Transform RightLegConstraint { get; private set; }
+                [field: SerializeField] public Transform RightLegConstraint { get; private set; } = null!;
 
         // This transform position decides where we want to put the right leg
-        [field: SerializeField] public Transform RightLegIKTarget { get; private set; }
-        [field: SerializeField] public Transform LeftLegConstraint { get; private set; }
-        [field: SerializeField] public Transform LeftLegIKTarget { get; private set; }
+                [field: SerializeField] public Transform RightLegIKTarget { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftLegConstraint { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftLegIKTarget { get; private set; } = null!;
 
         // Constraint that controls the weight of the leg IK
-        [field: SerializeField] public TwoBoneIKConstraint RightLegIK { get; private set; }
-        [field: SerializeField] public TwoBoneIKConstraint LeftLegIK { get; private set; }
+                [field: SerializeField] public TwoBoneIKConstraint RightLegIK { get; private set; } = null!;
+                [field: SerializeField] public TwoBoneIKConstraint LeftLegIK { get; private set; } = null!;
 
         //This constraint Applies an offset to the hips, lowering the avatar position based on the desired feet position
-        [field: SerializeField] public MultiPositionConstraint HipsConstraint { get; private set; }
+                [field: SerializeField] public MultiPositionConstraint HipsConstraint { get; private set; } = null!;
 
         [field: Header("HANDS IK")]
-        [field: SerializeField] public Rig HandsIKRig { get; private set; }
-        [field: SerializeField] public TwoBoneIKConstraint LeftHandIK { get; private set; }
+                [field: SerializeField] public Rig HandsIKRig { get; private set; } = null!;
+                [field: SerializeField] public TwoBoneIKConstraint LeftHandIK { get; private set; } = null!;
 
         // IK target position and rotation, its called subTarget because the real target has a parent constraint based on this transform to fix some offsets
-        [field: SerializeField] public Transform LeftHandSubTarget { get; private set; }
+                [field: SerializeField] public Transform LeftHandSubTarget { get; private set; } = null!;
 
         // Position where we raycast from
-        [field: SerializeField] public Transform LeftHandRaycast { get; private set; }
-        [field: SerializeField] public TwoBoneIKConstraint RightHandIK { get; private set; }
-        [field: SerializeField] public Transform RightHandSubTarget { get; private set; }
-        [field: SerializeField] public Transform RightHandTarget { get; private set; }
-        [field: SerializeField] public Transform RightHandRaycast { get; private set; }
+                [field: SerializeField] public Transform LeftHandRaycast { get; private set; } = null!;
+                [field: SerializeField] public TwoBoneIKConstraint RightHandIK { get; private set; } = null!;
+                [field: SerializeField] public Transform RightHandSubTarget { get; private set; } = null!;
+                [field: SerializeField] public Transform RightHandTarget { get; private set; } = null!;
+                [field: SerializeField] public Transform RightHandRaycast { get; private set; } = null!;
 
         [field: Header("LOOK-AT IK")]
-        [field: SerializeField] public Rig HeadIKRig { get; private set; }
+                [field: SerializeField] public Rig HeadIKRig { get; private set; } = null!;
 
         // The LookAt IK is based on 2 constraints, one for horizontal rotation and other for vertical rotation in order to control different bone chains for both of them, Horizontal is applied first
-        [field: SerializeField] public TwistChainConstraint HeadLookAtTargetVerticalConstraint { get; private set; }
-        [field: SerializeField] public Transform HeadLookAtTargetHorizontal { get; private set; }
-        [field: SerializeField] public Transform HeadLookAtTargetVertical { get; private set; }
+                [field: SerializeField] public TwistChainConstraint HeadLookAtTargetVerticalConstraint { get; private set; } = null!;
+                [field: SerializeField] public Transform HeadLookAtTargetHorizontal { get; private set; } = null!;
+                [field: SerializeField] public Transform HeadLookAtTargetVertical { get; private set; } = null!;
 
         // Position of the head after the animations
-        [field: SerializeField] public Transform HeadPositionConstraint { get; private set; }
+                [field: SerializeField] public Transform HeadPositionConstraint { get; private set; } = null!;
 
         [field: Header("TORSO IK")]
-        [field: SerializeField] public Rig TorsoIKRig { get; private set; }
-        [field: SerializeField] public Transform TorsoTarget { get; private set; }
+                [field: SerializeField] public Rig TorsoIKRig { get; private set; } = null!;
+                [field: SerializeField] public Transform TorsoTarget { get; private set; } = null!;
 
         [field: Header("ADDITIVE BREATH")]
-        [field: SerializeField] public Rig CachePoseRig { get; private set; }
-        [field: SerializeField] public Rig AdditiveBreathRig { get; private set; }
-        [field: SerializeField] public AdditiveBreathDataBridge AdditiveBreathBridge { get; private set; }
+                [field: SerializeField] public Rig CachePoseRig { get; private set; } = null!;
+                [field: SerializeField] public Rig AdditiveBreathRig { get; private set; } = null!;
+                [field: SerializeField] public AdditiveBreathDataBridge AdditiveBreathBridge { get; private set; } = null!;
 
         [field: Header("OTHER")]
         // Anchor points to attach entities to, through the SDK
-        [field: SerializeField] public Transform NameTagAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform HeadAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform NeckAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform SpineAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform Spine1AnchorPoint { get; private set; }
-        [field: SerializeField] public Transform Spine2AnchorPoint { get; private set; }
-        [field: SerializeField] public Transform HipAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform LeftShoulderAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform LeftArmAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform LeftForearmAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform LeftHandAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform LeftHandIndexAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform RightShoulderAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform RightArmAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform RightForearmAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform RightHandAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform RightHandIndexAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform LeftUpLegAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform LeftLegAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform LeftFootAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform LeftToeBaseAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform RightUpLegAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform RightLegAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform RightFootAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform RightToeBaseAnchorPoint { get; private set; }
-        [field: SerializeField] public Transform Armature { get; private set; }
+                [field: SerializeField] public Transform NameTagAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform HeadAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform NeckAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform SpineAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform Spine1AnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform Spine2AnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform HipAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftShoulderAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftArmAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftForearmAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftHandAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftHandIndexAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform RightShoulderAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform RightArmAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform RightForearmAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform RightHandAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform RightHandIndexAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftUpLegAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftLegAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftFootAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform LeftToeBaseAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform RightUpLegAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform RightLegAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform RightFootAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform RightToeBaseAnchorPoint { get; private set; } = null!;
+                [field: SerializeField] public Transform Armature { get; private set; } = null!;
 
-        [field: SerializeField] public GameObject GhostGameObject { get; private set; }
+                [field: SerializeField] public GameObject GhostGameObject { get; private set; } = null!;
 
-        public Renderer GhostRenderer { get; private set; }
+                public Renderer GhostRenderer { get; private set; } = null!;
 
         [Header("NAMETAG RELATED")]
         [SerializeField] [Tooltip("How high could nametag be, [m]")]
@@ -132,8 +139,8 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         [SerializeField] [Tooltip("Extra height added to the nametag while the glider is deployed, to avoid clipping the glider model, [m]")]
         private float nametagGlideOffset = 0.8f;
 
-        [SerializeField] private Transform headAramatureBone;
-        [SerializeField] private Transform[] potentialHighestBones;
+                [SerializeField] private Transform headAramatureBone = null!;
+                [SerializeField] private Transform[] potentialHighestBones = null!;
         private float cachedHeadWearableOffset; // Cached offset from head bone to the highest point of head wearables (like tall hats). Updated when wearables change.
         private Vector3 headArmatureBoneStartPosition;
 
@@ -152,6 +159,7 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
 
             rightPointAtLayerIndex = AvatarAnimator.GetLayerIndex("RightPointAtHand");
             rotationLayerIndex = AvatarAnimator.GetLayerIndex("Rotation");
+            upperBodyLayerIndex = AvatarAnimator.GetLayerIndex(AnimatorEmoteLayers.UPPER_BODY_LAYER);
             overrideController = new AnimatorOverrideController(AvatarAnimator.runtimeAnimatorController);
             animationOverrides = new List<KeyValuePair<AnimationClip, AnimationClip>>();
             overrideController.GetOverrides(animationOverrides);
@@ -200,11 +208,19 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         public void StopMaskedLegacyEmote() =>
             maskedLegacyBlender?.Stop();
 
-        public void SetPointAtLayerWeight(float weight) =>
+        public void SetPointAtLayerWeight(float weight)
+        {
+            if (weight == lastPointAtLayerWeight) return;
+            lastPointAtLayerWeight = weight;
             AvatarAnimator.SetLayerWeight(rightPointAtLayerIndex, weight);
+        }
 
-        public void SetRotationLayerWeight(float weight) =>
+        public void SetRotationLayerWeight(float weight)
+        {
+            if (weight == lastRotationLayerWeight) return;
+            lastRotationLayerWeight = weight;
             AvatarAnimator.SetLayerWeight(rotationLayerIndex, weight);
+        }
 
         public void SetAnimatorFloat(int hash, float value)
         {
@@ -241,6 +257,17 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
             return AvatarAnimator.GetCurrentAnimatorStateInfo(layerIndex).tagHash;
         }
 
+        public int UpperBodyLayerIndex => upperBodyLayerIndex;
+
+        public int GetAnimatorCurrentStateTag(int layerIndex) =>
+            AvatarAnimator.GetCurrentAnimatorStateInfo(layerIndex).tagHash;
+
+        public void SetLayerWeight(int layerIndex, float weight) =>
+            AvatarAnimator.SetLayerWeight(layerIndex, weight);
+
+        public int GetEmoteLayerIndex(AvatarEmoteMask mask) =>
+            mask == AvatarEmoteMask.AemUpperBody ? upperBodyLayerIndex : AnimatorEmoteLayers.BASE_LAYER_INDEX;
+
         public void ResetAnimatorTrigger(int hash) =>
             AvatarAnimator.ResetTrigger(hash);
 
@@ -261,6 +288,10 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
             LegacyAnimation?.Stop();
             maskedLegacyBlender?.Stop();
             AvatarAnimator.Rebind();
+
+            lastPointAtLayerWeight = float.NaN;
+            lastRotationLayerWeight = float.NaN;
+
             HipsConstraint.data.offset = Vector3.zero;
             HipsConstraint.weight = 0;
             FeetIKRig.enabled = false;
@@ -409,10 +440,18 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
 
         int GetAnimatorCurrentStateTag(string layerName);
 
+        int UpperBodyLayerIndex { get; }
+
+        int GetAnimatorCurrentStateTag(int layerIndex);
+
+        int GetEmoteLayerIndex(AvatarEmoteMask mask);
+
         void ResetAnimatorTrigger(int hash);
 
         void ResetArmatureInclination();
 
         void SetLayerWeight(string layerName, float weight);
+
+        void SetLayerWeight(int layerIndex, float weight);
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/UnityInterface/AvatarBase.cs
@@ -2,13 +2,12 @@ using CommunicationData.URLHelpers;
 using DCL.Audio.Avatar;
 using DCL.AvatarRendering.Wearables.Components.Intentions;
 using DCL.Diagnostics;
-using AvatarEmoteMask = DCL.ECSComponents.AvatarEmoteMask;
-using DclAvatarMask = DCL.ECSComponents.AvatarMask;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Animations.Rigging;
 using Utility.Animations;
+using AvatarEmoteMask = DCL.ECSComponents.AvatarEmoteMask;
 using Random = UnityEngine.Random;
 
 namespace DCL.AvatarRendering.AvatarShape.UnityInterface
@@ -151,6 +150,8 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         public bool IsMaskedLegacyEmotePlaying => maskedLegacyBlender != null && maskedLegacyBlender.IsPlaying;
         public bool HasMaskedLegacyEmoteFinished => maskedLegacyBlender != null && maskedLegacyBlender.HasFinished;
 
+        public int UpperBodyLayerIndex => upperBodyLayerIndex;
+
         private void Awake()
         {
             if (!AvatarAnimator)
@@ -252,19 +253,8 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
         public bool IsAnimatorInTag(int hashTag) =>
             AvatarAnimator.GetCurrentAnimatorStateInfo(0).tagHash == hashTag;
 
-        public int GetAnimatorCurrentStateTag(string layerName)
-        {
-            int layerIndex = AvatarAnimator.GetLayerIndex(layerName);
-            return AvatarAnimator.GetCurrentAnimatorStateInfo(layerIndex).tagHash;
-        }
-
-        public int UpperBodyLayerIndex => upperBodyLayerIndex;
-
         public int GetAnimatorCurrentStateTag(int layerIndex) =>
             AvatarAnimator.GetCurrentAnimatorStateInfo(layerIndex).tagHash;
-
-        public void SetLayerWeight(int layerIndex, float weight) =>
-            AvatarAnimator.SetLayerWeight(layerIndex, weight);
 
         public int GetEmoteLayerIndex(AvatarEmoteMask mask) =>
             mask == AvatarEmoteMask.AemUpperBody ? upperBodyLayerIndex : AnimatorEmoteLayers.BASE_LAYER_INDEX;
@@ -298,11 +288,8 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
             FeetIKRig.enabled = false;
         }
 
-        public void SetLayerWeight(string layerName, float weight)
-        {
-            int index = AvatarAnimator.GetLayerIndex(layerName);
-            AvatarAnimator.SetLayerWeight(index, weight);
-        }
+        public void SetLayerWeight(int layerIndex, float weight) =>
+            AvatarAnimator.SetLayerWeight(layerIndex, weight);
 
         public bool GetAnimatorBool(int hash) =>
             AvatarAnimator.GetBool(hash);
@@ -439,19 +426,15 @@ namespace DCL.AvatarRendering.AvatarShape.UnityInterface
 
         bool IsAnimatorInTag(int hashTag);
 
-        int GetAnimatorCurrentStateTag(string layerName);
+        int GetAnimatorCurrentStateTag(int layerIndex);
 
         int UpperBodyLayerIndex { get; }
-
-        int GetAnimatorCurrentStateTag(int layerIndex);
 
         int GetEmoteLayerIndex(AvatarEmoteMask mask);
 
         void ResetAnimatorTrigger(int hash);
 
         void ResetArmatureInclination();
-
-        void SetLayerWeight(string layerName, float weight);
 
         void SetLayerWeight(int layerIndex, float weight);
     }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -152,7 +152,7 @@ namespace DCL.AvatarRendering.Emotes.Play
         [Query]
         private void UpdateEmoteTags(ref CharacterEmoteComponent emoteComponent, in IAvatarView avatarView)
         {
-            int currentStateTag = avatarView.GetAnimatorCurrentStateTag(AnimatorEmoteLayers.BASE_LAYER);
+            int currentStateTag = avatarView.GetAnimatorCurrentStateTag(AnimatorEmoteLayers.BASE_LAYER_INDEX);
             emoteComponent.SetAnimationTag(currentStateTag);
         }
 
@@ -188,7 +188,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                 return;
             }
 
-            int animatorCurrentStateTag = avatarView.GetAnimatorCurrentStateTag(AnimatorEmoteLayers.BASE_LAYER);
+            int animatorCurrentStateTag = avatarView.GetAnimatorCurrentStateTag(AnimatorEmoteLayers.BASE_LAYER_INDEX);
             bool isOnAnotherTag = animatorCurrentStateTag != AnimationHashes.EMOTE && animatorCurrentStateTag != AnimationHashes.EMOTE_LOOP;
 
             // The animator left the emote tags on its own: the clip reached its natural end.
@@ -523,7 +523,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             int prevTag = animationComponent.CurrentAnimationTag;
             if (prevTag == 0) return;
 
-            int currentTag = avatarView.GetAnimatorCurrentStateTag(AnimatorEmoteLayers.BASE_LAYER);
+            int currentTag = avatarView.GetAnimatorCurrentStateTag(AnimatorEmoteLayers.BASE_LAYER_INDEX);
 
             if ((prevTag != AnimationHashes.EMOTE || currentTag != AnimationHashes.EMOTE_LOOP)
                 && (prevTag != AnimationHashes.EMOTE_LOOP || currentTag != AnimationHashes.EMOTE)) return;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
@@ -143,7 +143,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             avatarView.ResetAnimatorTrigger(AnimationHashes.MASKED_EMOTE_REFRESH);
             avatarView.SetAnimatorTrigger(AnimationHashes.MASKED_EMOTE_STOP);
 
-            string layer = AnimatorEmoteLayers.GetFromEmoteMask(mask);
+            int layer = avatarView.GetEmoteLayerIndex(mask);
             avatarView.SetLayerWeight(layer, 0);
 
             avatarView.ClearMaskedEmoteAnimationCache();
@@ -168,7 +168,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                     shouldCancel = avatarView.HasMaskedLegacyEmoteFinished;
                 else if (masked.IsPlaying)
                 {
-                    string layer = AnimatorEmoteLayers.GetFromEmoteMask(masked.Mask);
+                    int layer = avatarView.GetEmoteLayerIndex(masked.Mask);
                     int currentTag = avatarView.GetAnimatorCurrentStateTag(layer);
                     shouldCancel = currentTag != AnimationHashes.MASKED_EMOTE && currentTag != AnimationHashes.MASKED_EMOTE_LOOP;
                 }
@@ -190,7 +190,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             // by HasMaskedLegacyEmoteFinished on the avatar view, not by tag transitions.
             if (avatarView.IsMaskedLegacyEmotePlaying || avatarView.HasMaskedLegacyEmoteFinished) return;
 
-            string layer = AnimatorEmoteLayers.GetFromEmoteMask(masked.Mask);
+            int layer = avatarView.GetEmoteLayerIndex(masked.Mask);
             int currentStateTag = avatarView.GetAnimatorCurrentStateTag(layer);
             masked.SetAnimationTag(currentStateTag);
         }
@@ -393,7 +393,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             view.ResetAnimatorTrigger(AnimationHashes.MASKED_EMOTE);
             view.ResetAnimatorTrigger(AnimationHashes.MASKED_EMOTE_REFRESH);
 
-            string emoteLayer = AnimatorEmoteLayers.GetFromEmoteMask(maskedEmote.Mask);
+            int emoteLayer = view.GetEmoteLayerIndex(maskedEmote.Mask);
             view.SetLayerWeight(emoteLayer, 1);
 
             int targetLayerTag = view.GetAnimatorCurrentStateTag(emoteLayer);

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/SceneMaskedEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/SceneMaskedEmoteSystem.cs
@@ -104,7 +104,7 @@ namespace DCL.AvatarRendering.Emotes.Play
 
             if (!masked.IsPlaying) return;
 
-            string layer = AnimatorEmoteLayers.GetFromEmoteMask(masked.Mask);
+            int layer = view.GetEmoteLayerIndex(masked.Mask);
             int currentTag = view.GetAnimatorCurrentStateTag(layer);
             bool isOnAnotherTag = currentTag != AnimationHashes.MASKED_EMOTE && currentTag != AnimationHashes.MASKED_EMOTE_LOOP;
 
@@ -270,7 +270,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             int prevTag = masked.CurrentAnimationTag;
             if (prevTag == 0) return;
 
-            string layer = AnimatorEmoteLayers.GetFromEmoteMask(masked.Mask);
+            int layer = mainPlayerAvatarBaseProxy.Object!.GetEmoteLayerIndex(masked.Mask);
             int currentTag = mainPlayerAvatarBaseProxy.Object!.GetAnimatorCurrentStateTag(layer);
 
             if ((prevTag != AnimationHashes.MASKED_EMOTE || currentTag != AnimationHashes.MASKED_EMOTE_LOOP)

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/HandsIKSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/HandsIKSystem.cs
@@ -73,7 +73,7 @@ namespace DCL.CharacterMotion.Systems
         {
             handsIKComponent.IsDisabled = !handsIkSystemIsEnabled;
 
-            int maskedLayerTag = avatarBase.GetAnimatorCurrentStateTag(AnimatorEmoteLayers.UPPER_BODY_LAYER);
+            int maskedLayerTag = avatarBase.GetAnimatorCurrentStateTag(avatarBase.UpperBodyLayerIndex);
             bool isPlayingMaskedEmote = maskedLayerTag == AnimationHashes.MASKED_EMOTE || maskedLayerTag == AnimationHashes.MASKED_EMOTE_LOOP;
 
             // To avoid using the Hands IK during any special state we update this

--- a/Explorer/Assets/DCL/Character/CharacterMotion/Systems/HeadIKSystem.cs
+++ b/Explorer/Assets/DCL/Character/CharacterMotion/Systems/HeadIKSystem.cs
@@ -170,7 +170,7 @@ namespace DCL.CharacterMotion.Systems
         {
             // Check the upper body layer animator state to detect masked emotes.
             // The component lives in scene worlds (not global), so we check the animator directly.
-            int maskedLayerTag = avatarBase.GetAnimatorCurrentStateTag(AnimatorEmoteLayers.UPPER_BODY_LAYER);
+            int maskedLayerTag = avatarBase.GetAnimatorCurrentStateTag(avatarBase.UpperBodyLayerIndex);
             bool isPlayingMaskedEmote = maskedLayerTag == AnimationHashes.MASKED_EMOTE || maskedLayerTag == AnimationHashes.MASKED_EMOTE_LOOP;
 
             bool pitchEnabled = debugHeadIKIsEnabled &&

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Animations/AnimatorEmoteLayers.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Animations/AnimatorEmoteLayers.cs
@@ -1,29 +1,10 @@
-using DCL.ECSComponents;
-
 namespace Utility.Animations
 {
     public static class AnimatorEmoteLayers
     {
-        public const string BASE_LAYER = "Base Layer";
+        // Unity's Animator always places the base layer at index 0.
+        public const int BASE_LAYER_INDEX = 0;
+
         public const string UPPER_BODY_LAYER = "Upper Body Layer";
-
-        public static readonly string[] ALL_LAYERS =
-        {
-            BASE_LAYER,
-            UPPER_BODY_LAYER,
-        };
-
-        public static readonly string[] NON_BASE_LAYERS =
-        {
-            UPPER_BODY_LAYER,
-        };
-
-        public static string GetFromEmoteMask(AvatarEmoteMask mask) =>
-                    mask switch
-                    {
-                        AvatarEmoteMask.AemFullBody => BASE_LAYER,
-                        AvatarEmoteMask.AemUpperBody => UPPER_BODY_LAYER,
-                        _ => BASE_LAYER,
-                    };
     }
 }

--- a/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/AvatarLayerWeightGuardPerformanceTest.cs
+++ b/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/AvatarLayerWeightGuardPerformanceTest.cs
@@ -1,0 +1,132 @@
+using DCL.AvatarRendering.AvatarShape.UnityInterface;
+using NUnit.Framework;
+using System.Diagnostics;
+using System.Reflection;
+using Unity.PerformanceTesting;
+using Unity.Profiling;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace DCL.Tests.PlayMode.PerformanceTests
+{
+    /// <summary>
+    /// Verifies SetPointAtLayerWeight / SetRotationLayerWeight skip the native Animator.SetLayerWeight write when the
+    /// value is unchanged from the last call, and that ResetState clears the shadowed value so the next write after
+    /// a rebind (e.g. pool reuse) is not skipped.
+    /// </summary>
+    [Category("Performance")]
+    public class AvatarLayerWeightGuardPerformanceTest
+    {
+#if UNITY_EDITOR
+        private const string AVATAR_BASE_TEST_ASSET_PATH = "Assets/DCL/AvatarRendering/AvatarShape/Tests/Instantiate/TestAssets/AvatarBase_TestAsset.prefab";
+        private const string ANIMATOR_CONTROLLER_PATH = "Assets/DCL/AvatarRendering/AvatarShape/Assets/Animator/CharacterAnimator.controller";
+
+        private GameObject avatarGameObject = null!;
+        private AvatarBase avatarBase = null!;
+        private Animator animator = null!;
+        private int pointAtIndex;
+        private int rotationIndex;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(AVATAR_BASE_TEST_ASSET_PATH);
+            Assert.IsNotNull(prefab, $"Could not load AvatarBase test prefab from {AVATAR_BASE_TEST_ASSET_PATH}");
+
+            avatarGameObject = Object.Instantiate(prefab);
+            avatarBase = avatarGameObject.GetComponentInChildren<AvatarBase>();
+            animator = avatarBase.AvatarAnimator;
+
+            var controller = AssetDatabase.LoadAssetAtPath<RuntimeAnimatorController>(ANIMATOR_CONTROLLER_PATH);
+            Assert.IsNotNull(controller, $"Could not load animator controller from {ANIMATOR_CONTROLLER_PATH}");
+            animator.runtimeAnimatorController = controller;
+
+            typeof(AvatarBase).GetMethod("Awake", BindingFlags.NonPublic | BindingFlags.Instance)!
+                              .Invoke(avatarBase, null);
+
+            // The test prefab leaves several serialized IK references unassigned (fileID: 0). ResetState() touches
+            // Armature (via ResetArmatureInclination), HipsConstraint and FeetIKRig, so each would throw
+            // UnassignedReferenceException. Wire throwaway objects into the private serialized backing fields via
+            // reflection (the same technique sibling AvatarBase tests use). The rigging component types are resolved
+            // from the property types, so the test needs no Animation-Rigging asmref.
+            var rigHolder = new GameObject("test-rig-holder");
+            rigHolder.transform.SetParent(avatarGameObject.transform, false);
+
+            WireBackingField("Armature", rigHolder.transform);
+            WireBackingField("FeetIKRig", rigHolder.AddComponent(typeof(AvatarBase).GetProperty("FeetIKRig")!.PropertyType));
+            WireBackingField("HipsConstraint", rigHolder.AddComponent(typeof(AvatarBase).GetProperty("HipsConstraint")!.PropertyType));
+
+            pointAtIndex = animator.GetLayerIndex("RightPointAtHand");
+            rotationIndex = animator.GetLayerIndex("Rotation");
+            Assert.GreaterOrEqual(pointAtIndex, 0, "RightPointAtHand layer missing from controller");
+            Assert.GreaterOrEqual(rotationIndex, 0, "Rotation layer missing from controller");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (avatarGameObject != null) Object.DestroyImmediate(avatarGameObject);
+        }
+
+        private void WireBackingField(string propertyName, Object value) =>
+            typeof(AvatarBase).GetField($"<{propertyName}>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)!
+                              .SetValue(avatarBase, value);
+
+        [Test]
+        [Performance]
+        public void RedundantLayerWeightWrites_AreElided_AndResetStateRearms()
+        {
+            avatarBase.SetPointAtLayerWeight(0.5f);
+            Assert.AreEqual(0.5f, animator.GetLayerWeight(pointAtIndex), 1e-4f);
+            avatarBase.SetPointAtLayerWeight(1f);
+            Assert.AreEqual(1f, animator.GetLayerWeight(pointAtIndex), 1e-4f);
+
+            avatarBase.SetRotationLayerWeight(0.25f);
+            Assert.AreEqual(0.25f, animator.GetLayerWeight(rotationIndex), 1e-4f);
+
+            avatarBase.SetPointAtLayerWeight(0.7f);
+            avatarBase.SetRotationLayerWeight(0.7f);
+            avatarBase.ResetState();
+            Assert.AreNotEqual(0.7f, animator.GetLayerWeight(pointAtIndex), "Rebind should have reset the native weight");
+
+            avatarBase.SetPointAtLayerWeight(0.7f);
+            Assert.AreEqual(0.7f, animator.GetLayerWeight(pointAtIndex), 1e-4f, "shadow was not re-armed by ResetState (point-at)");
+            avatarBase.SetRotationLayerWeight(0.7f);
+            Assert.AreEqual(0.7f, animator.GetLayerWeight(rotationIndex), 1e-4f, "shadow was not re-armed by ResetState (rotation)");
+
+            avatarBase.SetPointAtLayerWeight(0f);
+
+            const int ITER = 200_000;
+            long bestRedundant = long.MaxValue, bestAlternating = long.MaxValue;
+
+            for (int run = 0; run < 3; run++)
+            {
+                var sw = Stopwatch.StartNew();
+                for (int k = 0; k < ITER; k++) avatarBase.SetPointAtLayerWeight(0f);
+                sw.Stop();
+                bestRedundant = System.Math.Min(bestRedundant, sw.ElapsedTicks);
+
+                sw.Restart();
+                for (int k = 0; k < ITER; k++) avatarBase.SetPointAtLayerWeight(k % 2);
+                sw.Stop();
+                bestAlternating = System.Math.Min(bestAlternating, sw.ElapsedTicks);
+            }
+
+            Measure.Custom(new SampleGroup("RedundantWeightWrites", SampleUnit.Nanosecond), bestRedundant);
+            Measure.Custom(new SampleGroup("AlternatingWeightWrites", SampleUnit.Nanosecond), bestAlternating);
+
+            Assert.Less(bestRedundant, bestAlternating * 0.5, $"redundant writes ({bestRedundant}) should be far cheaper than alternating ({bestAlternating})");
+
+            avatarBase.SetPointAtLayerWeight(0f);
+            ProfilerRecorder gcAlloc = ProfilerRecorder.StartNew(ProfilerCategory.Memory, "GC.Alloc");
+            Measure.Method(() => { for (int k = 0; k < 1000; k++) avatarBase.SetPointAtLayerWeight(0f); })
+                   .WarmupCount(5).MeasurementCount(10).GC().Run();
+            long gcBytes = gcAlloc.LastValue;
+            gcAlloc.Dispose();
+            Assert.AreEqual(0, gcBytes, $"redundant weight writes must be allocation-free, allocated {gcBytes} bytes");
+        }
+#endif
+    }
+}

--- a/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/AvatarLayerWeightGuardPerformanceTest.cs.meta
+++ b/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/AvatarLayerWeightGuardPerformanceTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 771f2800e0283019d9adb2871a34a175
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Two related micro-optimizations in the avatar animation hot path, plus the API cleanup that falls out of them:

**1. Layer-weight write guard (`AvatarBase`)**
`SetPointAtLayerWeight` and `SetRotationLayerWeight` are called every frame per avatar and previously forwarded straight to the native `Animator.SetLayerWeight` call even when the weight hadn't changed — which is the common case (the weights sit at 0 or 1 most of the time). Both setters now shadow the last value written and skip the native call when it is unchanged. `ResetState()` clears the shadows: avatars are pooled and `Animator.Rebind()` resets the real layer weights, so a reused avatar must not skip its first genuine write.

**2. Cached animator layer indices (all layer-API callers)**
`GetAnimatorCurrentStateTag(string)` and `SetLayerWeight(string)` resolved the layer via a native `Animator.GetLayerIndex(name)` call (with string marshaling) on every invocation — per frame in `HeadIKSystem` and `HandsIKSystem`. `AvatarBase` now caches the upper-body layer index once in `Awake` and exposes an index-based API (`UpperBodyLayerIndex`, `GetEmoteLayerIndex(mask)`, `int` overloads). All callers (`EmotePlayer`, `SceneMaskedEmoteSystem`, `CharacterEmoteSystem`, `HeadIKSystem`, `HandsIKSystem`) are migrated and the string overloads are deleted, along with `AnimatorEmoteLayers.GetFromEmoteMask` and its unused layer arrays.

**Performance**: no behavior change intended. The included PlayMode performance test (`AvatarLayerWeightGuardPerformanceTest`) asserts that redundant weight writes are at least 2× cheaper than alternating writes, that the writes are allocation-free, and that `ResetState` re-arms the guard so pool reuse is not skipped.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 9701
```

**Expected result**:
Avatar animation behaves exactly as on `dev` — this PR must cause no visible change. Verify the animator-layer-driven features below.

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run 9701
```

**Expected result**:
Same as above — no visible difference in avatar animation on a clean profile.

**Automation** (if applicable):
```bash
metaforge explorer test 9701
```

### Prerequisites
- [ ] Any world with other players or NPCs visible (to exercise pooled avatars)
- [ ] An upper-body (masked) emote equipped or available in the emote wheel

### Test Steps
1. Point the cursor at another player and use the point-at interaction — the right-hand point-at layer should blend in and out normally.
2. Rotate the character while standing still — the body-rotation blend should look unchanged.
3. Play a full-body emote, then an upper-body (masked) emote while walking — the upper body plays the emote while legs keep the locomotion animation; both cancel correctly on movement/jump.
4. While the masked emote plays, look around — head look-at and hands IK should disable during the masked emote and re-enable after it ends.
5. Teleport somewhere crowded and back so avatars get pooled and reused — reused avatars must animate correctly (point-at and rotation layers must not stay stuck after reuse).
6. Play the same masked emote twice in a row and let a looping emote replay — loop replication and cancel-by-tag must behave as on `dev`.

### Additional Testing Notes
- The riskiest surface is emote layer selection: a wrong layer index would make masked emotes play on the base layer (full body) or break emote cancellation. Step 3 and 6 cover this.
- Avatar pool reuse (step 5) covers the `ResetState` re-arm path.
- Remote players' masked emotes (`SceneMaskedEmoteSystem` / replication paths) are worth a quick two-client check if available.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
