### PR TITLE
opti(web-requests): pre-size PartialDownloadHandler and grow geometrically

### DIFF
--- a/Explorer/Assets/DCL/WebRequests/CustomDownloadHandlers/PartialDownloadHandler.cs
+++ b/Explorer/Assets/DCL/WebRequests/CustomDownloadHandlers/PartialDownloadHandler.cs
@@ -18,6 +18,17 @@ namespace DCL.WebRequests.CustomDownloadHandlers
             this.buffersPool = buffersPool;
         }
 
+        protected override void ReceiveContentLengthHeader(ulong contentLength)
+        {
+            if (PartialData == null && contentLength > 0)
+            {
+                var target = (int)Math.Min(contentLength, (ulong)PartialDownloadingRange.CHUNK_SIZE);
+
+                if (target > 0)
+                    PartialData = buffersPool.Rent(target);
+            }
+        }
+
         protected override bool ReceiveData(byte[] receivedData, int dataLength)
         {
             if (dataLength == 0)
@@ -30,8 +41,9 @@ namespace DCL.WebRequests.CustomDownloadHandlers
             }
             else if(PartialData.Length < bufferPointer + dataLength)
             {
-                var newBuffer = buffersPool.Rent(PartialData.Length + dataLength);
-                Array.Copy(PartialData, newBuffer, PartialData.Length);
+                var newSize = Math.Max(PartialData.Length * 2, bufferPointer + dataLength);
+                var newBuffer = buffersPool.Rent(newSize);
+                Array.Copy(PartialData, newBuffer, bufferPointer);
                 buffersPool.Return(PartialData, true);
                 PartialData = newBuffer;
             }

--- a/Explorer/Assets/DCL/WebRequests/CustomDownloadHandlers/PartialDownloadHandler.cs
+++ b/Explorer/Assets/DCL/WebRequests/CustomDownloadHandlers/PartialDownloadHandler.cs
@@ -20,6 +20,7 @@ namespace DCL.WebRequests.CustomDownloadHandlers
 
         protected override void ReceiveContentLengthHeader(ulong contentLength)
         {
+            // Try to apply new PartialData buffer if contentLength is available
             if (PartialData == null && contentLength > 0)
             {
                 var target = (int)Math.Min(contentLength, (ulong)PartialDownloadingRange.CHUNK_SIZE);
@@ -34,14 +35,17 @@ namespace DCL.WebRequests.CustomDownloadHandlers
             if (dataLength == 0)
                 return false; // No data received
 
+            var expectedLength = bufferPointer + dataLength;
 
             if (PartialData == null)
             {
                 PartialData = buffersPool.Rent(dataLength);
             }
-            else if(PartialData.Length < bufferPointer + dataLength)
+            else if (PartialData.Length < expectedLength)
             {
-                var newSize = Math.Max(PartialData.Length * 2, bufferPointer + dataLength);
+                // Max of (Twice the origin or expectedLength)
+                var newSize = Math.Max(PartialData.Length * 2, expectedLength);
+
                 var newBuffer = buffersPool.Rent(newSize);
                 Array.Copy(PartialData, newBuffer, bufferPointer);
                 buffersPool.Return(PartialData, true);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Removes the O(N²) rent+memcpy churn in `PartialDownloadHandler` when downloading chunked responses.

**Before:** `ReceiveData` rented a buffer of exactly `PartialData.Length + dataLength` on every overflow and copied the entire old buffer each time. Over a chunked download arriving in many small pieces, this meant a pool rent, a full-buffer copy, and a pool return per chunk — quadratic total copy cost in the number of chunks.

**After:**

- **Pre-size from `Content-Length`** — `ReceiveContentLengthHeader` rents the buffer up front at `min(contentLength, PartialDownloadingRange.CHUNK_SIZE)`, so in the common case (server reports length) the buffer is allocated once and never regrown.
- **Geometric growth as fallback** — when the header is absent or the data outgrows the buffer, the new size is `max(PartialData.Length * 2, bufferPointer + dataLength)`, turning the regrow count from O(N) into O(log N).
- **Copy only written bytes** — regrow now copies `bufferPointer` bytes (the data actually received) instead of the full old buffer length.

The `bufferPointer + dataLength` expression is also computed once into `expectedLength` instead of twice.

**Testing note:** exercising the growth path requires driving `DownloadHandlerScript`'s native callbacks, which has no stable unit-test seam in headless batch mode.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 9703
```

**Expected result**: Explorer behaves identically to `dev` — asset bundles, textures, and other partially downloaded content load normally. This is a pure allocation/copy optimization with no behavioral change.

### Additional Testing Notes
- The regrow path only triggers for responses without a `Content-Length` header or larger than `CHUNK_SIZE`; normal ranged downloads take the pre-sized path.
- Buffers are pool-rented, so sizes are upper bounds — consumers must keep relying on `bufferPointer`/received length, not `PartialData.Length` (unchanged contract).

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
