### PR TITLE
opti(avatar-rendering): bound bone-matrix job by each avatar's actual bone count

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarTransformMatrixJobWrapper.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarTransformMatrixJobWrapper.cs
@@ -87,6 +87,23 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             remoteAvatars.Register(avatarBase, ref transformMatrixComponent);
         }
 
+        /// <summary>
+        ///     Pushes the avatar's authoritative bone count (AvatarCustomSkinningComponent.BoneCount — the
+        ///     exact number of matrices ComputeSkinning uploads) into the matching pipeline so the
+        ///     calculation job produces precisely that range. Must be called every frame before
+        ///     ScheduleBoneMatrixCalculation; unregistered avatars (invalid index) are ignored.
+        /// </summary>
+        public void SetBoneCount(ref AvatarTransformMatrixComponent transformMatrixComponent, int boneCount)
+        {
+            if (transformMatrixComponent.IndexInGlobalJobArray.TryGetValue(out int validIndex) == false)
+                return;
+
+            if (transformMatrixComponent.IsMainPlayer)
+                mainPlayerAvatar.SetBoneCount(boneCount);
+            else
+                remoteAvatars.SetBoneCount(validIndex, boneCount);
+        }
+
         public void Dispose()
         {
             // Leak the resouces. Managed dispose of TransformAccessArray takes very much time.

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/MainPlayerPipeline.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/MainPlayerPipeline.cs
@@ -24,6 +24,8 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         private NativeArray<float4x4> avatarMatrix;
         private NativeArray<bool> updateFlag;
 
+        private NativeArray<int> perAvatarBoneCount;
+
         public BoneMatrixCalculationJob Job;
 
         internal MainPlayerPipeline(int bonesArrayLength)
@@ -34,7 +36,17 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             bonesCombined = new NativeArray<float4x4>(bonesArrayLength, Allocator.Persistent);
             avatarMatrix = new NativeArray<float4x4>(1, Allocator.Persistent);
             updateFlag = new NativeArray<bool>(1, Allocator.Persistent);
+            perAvatarBoneCount = new NativeArray<int>(1, Allocator.Persistent) { [0] = bonesArrayLength };
             Job = new BoneMatrixCalculationJob(bonesArrayLength, bonesArrayLength, bonesCombined);
+        }
+
+        /// <summary>
+        ///     Refreshes the matrix count for the main player from the authoritative
+        ///     AvatarCustomSkinningComponent.BoneCount. Called every frame before ScheduleAndComplete.
+        /// </summary>
+        public void SetBoneCount(int boneCount)
+        {
+            perAvatarBoneCount[0] = boneCount;
         }
 
         public void Register(Transform rootTransform, BoneArray bones, Transform dummyTransform)
@@ -76,6 +88,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
             Job.AvatarTransform = avatarMatrix;
             Job.UpdateAvatar = updateFlag;
+            Job.PerAvatarBoneCount = perAvatarBoneCount;
             var calcHandle = Job.Schedule(1, 1, gatherHandle);
             calcHandle.Complete(); // Fast — 1 avatar, 62 bones. Unlocks main player transforms.
         }
@@ -85,6 +98,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             bonesCombined.Dispose();
             avatarMatrix.Dispose();
             updateFlag.Dispose();
+            perAvatarBoneCount.Dispose();
             Job.Dispose();
 
             if (bonesTA.isCreated) bonesTA.Dispose();

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/RemoteAvatarPipeline.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/RemoteAvatarPipeline.cs
@@ -30,6 +30,8 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         private QuickArray<bool> updateAvatar;
         private QuickArray<float4x4> bonesCombined;
 
+        private QuickArray<int> perAvatarBoneCount;
+
         private Transform[] flatBones;
         private Transform[] flatRoots;
 
@@ -60,6 +62,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
             matrixFromAllAvatars = new QuickArray<float4x4>(initialCapacity);
             updateAvatar = new QuickArray<bool>(initialCapacity);
+
+            perAvatarBoneCount = new QuickArray<int>(initialCapacity);
+            FillWithStride(perAvatarBoneCount, 0, initialCapacity, bonesArrayLength);
 
             flatBones = new Transform[initialCapacity * bonesArrayLength];
             flatRoots = new Transform[initialCapacity];
@@ -152,6 +157,19 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             avatarTransformMatrixComponent.IndexInGlobalJobArray = GlobalJobArrayIndex.Unassign();
         }
 
+        /// <summary>
+        ///     Refreshes the per-avatar matrix count for a live slot from the authoritative
+        ///     AvatarCustomSkinningComponent.BoneCount. Called every frame (before Schedule) so a
+        ///     wearable re-equip that changes the bone count is reflected without needing a re-register.
+        /// </summary>
+        public void SetBoneCount(int validIndex, int boneCount)
+        {
+            if (validIndex < 0 || validIndex >= perAvatarBoneCount.Length)
+                return;
+
+            perAvatarBoneCount[validIndex] = boneCount;
+        }
+
         public void Schedule(int batchCount)
         {
             if (avatarIndex == 0)
@@ -173,6 +191,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
             Job.AvatarTransform = matrixFromAllAvatars.InnerNativeArray();
             Job.UpdateAvatar = updateAvatar.InnerNativeArray();
+            Job.PerAvatarBoneCount = perAvatarBoneCount.InnerNativeArray();
             handle = Job.Schedule(avatarIndex, batchCount, combinedGatherHandle);
         }
 
@@ -203,6 +222,10 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             matrixFromAllAvatars.ReAlloc(newCapacity);
             updateAvatar.ReAlloc(newCapacity);
 
+            int oldCapacity = currentAvatarAmountSupported;
+            perAvatarBoneCount.ReAlloc(newCapacity);
+            FillWithStride(perAvatarBoneCount, oldCapacity, newCapacity - oldCapacity, bonesArrayLength);
+
             int oldBonesLength = flatBones.Length;
             int oldRootsLength = flatRoots.Length;
 
@@ -225,6 +248,12 @@ namespace DCL.AvatarRendering.AvatarShape.Components
                 array[i] = dummy;
         }
 
+        private static void FillWithStride(QuickArray<int> array, int startIndex, int count, int value)
+        {
+            for (int i = startIndex; i < startIndex + count; i++)
+                array[i] = value;
+        }
+
         public void Dispose()
         {
             // Leak the resouces. Managed dispose of TransformAccessArray takes very much time.
@@ -243,6 +272,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
             updateAvatar.Dispose();
             stopwatch.LogStep("updateAvatar.Dispose");
+
+            perAvatarBoneCount.Dispose();
+            stopwatch.LogStep("perAvatarBoneCount.Dispose");
 
             Job.Dispose();
             stopwatch.LogStep("job.Dispose");

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/BoneMatrixCalculationJob.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/BoneMatrixCalculationJob.cs
@@ -9,7 +9,7 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
     [BurstCompile]
     public struct BoneMatrixCalculationJob : IJobParallelFor, IDisposable
     {
-        private readonly int boneCount;
+        private readonly int boneStride;
 
         [NativeDisableParallelForRestriction]
         private NativeArray<float4x4> bonesMatricesResult;
@@ -20,14 +20,17 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
         [NativeDisableParallelForRestriction] public NativeArray<bool> UpdateAvatar;
 
+        [ReadOnly] [NativeDisableParallelForRestriction] public NativeArray<int> PerAvatarBoneCount;
+
         public NativeArray<float4x4> BonesMatricesResult => bonesMatricesResult;
 
-        public BoneMatrixCalculationJob(int boneCount, int bonesPerAvatarLength, NativeArray<float4x4> boneWorldMatrixArray)
+        public BoneMatrixCalculationJob(int boneStride, int bonesPerAvatarLength, NativeArray<float4x4> boneWorldMatrixArray)
         {
-            this.boneCount = boneCount;
+            this.boneStride = boneStride;
             bonesMatricesResult = new NativeArray<float4x4>(bonesPerAvatarLength, Allocator.Persistent);
             AvatarTransform = default;
             UpdateAvatar = default;
+            PerAvatarBoneCount = default;
 
             this.boneWorldMatrixArray = boneWorldMatrixArray;
         }
@@ -45,9 +48,10 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
                 return;
 
             float4x4 avatarMatrix = AvatarTransform[avatarIdx];
-            int offset = avatarIdx * boneCount;
+            int offset = avatarIdx * boneStride;
+            int count = math.min(PerAvatarBoneCount[avatarIdx], boneStride);
 
-            for (int b = 0; b < boneCount; b++)
+            for (int b = 0; b < count; b++)
                 bonesMatricesResult[offset + b] = math.mul(avatarMatrix, boneWorldMatrixArray[offset + b]);
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/StartAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/StartAvatarMatricesCalculationSystem.cs
@@ -29,6 +29,9 @@ namespace DCL.AvatarRendering.AvatarShape
         {
             RegisterMainPlayerQuery(World);
             RegisterRemoteAvatarsQuery(World);
+
+            RefreshBoneCountsQuery(World);
+
             avatarTransformMatrixBatchJob.ScheduleBoneMatrixCalculation();
         }
 
@@ -53,6 +56,13 @@ namespace DCL.AvatarRendering.AvatarShape
                 return;
 
             avatarTransformMatrixBatchJob.RegisterAvatar(avatarBase, ref transformMatrixComponent);
+        }
+
+        [Query]
+        [None(typeof(DeleteEntityIntention))]
+        private void RefreshBoneCounts(ref AvatarTransformMatrixComponent transformMatrixComponent, ref AvatarCustomSkinningComponent skinningComponent)
+        {
+            avatarTransformMatrixBatchJob.SetBoneCount(ref transformMatrixComponent, skinningComponent.BoneCount);
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/PlayMode/BoneMatrixCalculationJobPerformanceTest.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/PlayMode/BoneMatrixCalculationJobPerformanceTest.cs
@@ -1,0 +1,152 @@
+using DCL.AvatarRendering.AvatarShape.ComputeShader;
+using NUnit.Framework;
+using Unity.Collections;
+using Unity.Mathematics;
+using Unity.PerformanceTesting;
+
+namespace DCL.AvatarRendering.AvatarShape.Tests.PlayMode
+{
+    /// <summary>
+    /// <see cref="BoneMatrixCalculationJob"/> must compute exactly the matrices
+    /// <c>AvatarCustomSkinningComponent.ComputeSkinning</c> uploads — the first
+    /// <c>PerAvatarBoneCount[avatarIdx]</c> slots of each avatar's <c>MAX_BONE_COUNT</c> (256) stride
+    /// (<c>bones.SetData(bonesResult, validIndex * MAX_BONE_COUNT, 0, BoneCount)</c>) — not a smaller,
+    /// independently re-derived count.
+    ///
+    /// <para>
+    /// A wearable's spring chain can trip the root-guard, making the gathered/filtered spring-bone
+    /// count (<c>actualCount</c>) strictly less than the uploaded <c>BoneCount</c>; bounding the loop
+    /// by that smaller count would leave slots <c>[actualCount, BoneCount)</c> uncomputed, and
+    /// <c>ComputeSkinning</c> would then upload stale/garbage matrices for spring-bone-weighted
+    /// vertices. This test feeds <c>PerAvatarBoneCount</c> (the upload count) strictly greater than a
+    /// filtered baseline (<c>BASE_BONE_COUNT</c>) and asserts the whole uploaded range — including the
+    /// extended spring-bone tail past the baseline — is computed with no stale slot.
+    /// </para>
+    ///
+    /// <para>
+    /// It also asserts the padding slots <c>[BoneCount, MAX_BONE_COUNT)</c> (never uploaded) stay
+    /// untouched, catching a regression to full-stride recompute.
+    /// </para>
+    ///
+    /// Execute() is invoked directly per index (single-threaded) so the per-avatar bounds logic is
+    /// exercised deterministically without the Burst/Jobs scheduler.
+    /// </summary>
+    [Category("Performance")]
+    public class BoneMatrixCalculationJobPerformanceTest
+    {
+        private const int STRIDE = ComputeShaderConstants.MAX_BONE_COUNT;
+        private const int FILTERED_BASELINE = ComputeShaderConstants.BASE_BONE_COUNT;
+
+        private static readonly float4x4 SENTINEL = new float4x4(
+            new float4(float.NaN), new float4(float.NaN), new float4(float.NaN), new float4(float.NaN));
+
+        [Test]
+        [Performance]
+        [TestCase(32)]
+        [TestCase(64)]
+        public void ProducesExactlyTheUploadedRange_NoStaleTail_AndSkipsPadding(int avatarCount)
+        {
+            var boneWorld = new NativeArray<float4x4>(avatarCount * STRIDE, Allocator.Persistent);
+            var avatarTransform = new NativeArray<float4x4>(avatarCount, Allocator.Persistent);
+            var updateAvatar = new NativeArray<bool>(avatarCount, Allocator.Persistent);
+            var perAvatarBoneCount = new NativeArray<int>(avatarCount, Allocator.Persistent);
+
+            for (int a = 0; a < avatarCount; a++)
+            {
+                avatarTransform[a] = float4x4.Translate(new float3(a + 1, 0f, 0f));
+
+                updateAvatar[a] = (a % 2) == 0;
+
+                perAvatarBoneCount[a] = FILTERED_BASELINE + 1 + (a % 16);
+
+                for (int b = 0; b < STRIDE; b++)
+                    boneWorld[(a * STRIDE) + b] = float4x4.Translate(new float3(0f, (a * STRIDE) + b + 1, 0f));
+            }
+
+            var job = new BoneMatrixCalculationJob(STRIDE, avatarCount * STRIDE, boneWorld)
+            {
+                AvatarTransform = avatarTransform,
+                UpdateAvatar = updateAvatar,
+                PerAvatarBoneCount = perAvatarBoneCount,
+            };
+
+            NativeArray<float4x4> result = job.BonesMatricesResult;
+
+            void RunOnce()
+            {
+                for (int i = 0; i < result.Length; i++)
+                    result[i] = SENTINEL;
+
+                for (int a = 0; a < avatarCount; a++)
+                    job.Execute(a);
+            }
+
+            RunOnce();
+
+            int computedSlots = 0;
+
+            for (int a = 0; a < avatarCount; a++)
+            {
+                int offset = a * STRIDE;
+                int uploaded = perAvatarBoneCount[a];
+
+                if (!updateAvatar[a])
+                {
+                    for (int b = 0; b < STRIDE; b++)
+                        Assert.IsTrue(IsSentinel(result[offset + b]),
+                            $"Released avatar {a} slot {b} was written but should have been skipped.");
+
+                    continue;
+                }
+
+                for (int b = 0; b < uploaded; b++)
+                {
+                    float4x4 expected = math.mul(avatarTransform[a], boneWorld[offset + b]);
+                    Assert.IsFalse(IsSentinel(result[offset + b]),
+                        $"Avatar {a} slot {b} in the uploaded range [0,{uploaded}) was left stale — " +
+                        $"ComputeSkinning would upload uninitialised matrices here.");
+                    Assert.IsTrue(Equalish(result[offset + b], expected),
+                        $"Avatar {a} slot {b} computed the wrong matrix.");
+                }
+
+                for (int b = uploaded; b < STRIDE; b++)
+                    Assert.IsTrue(IsSentinel(result[offset + b]),
+                        $"Avatar {a} padding slot {b} (>= BoneCount {uploaded}) was recomputed — the " +
+                        "per-avatar bound was not applied.");
+
+                computedSlots += uploaded;
+            }
+
+            int activeAvatars = 0;
+            for (int a = 0; a < avatarCount; a++)
+                if (updateAvatar[a]) activeAvatars++;
+
+            Assert.Less(computedSlots, activeAvatars * STRIDE,
+                "Expected fewer matrix multiplies than the full-stride baseline.");
+
+            Measure.Method(RunOnce)
+                   .WarmupCount(5)
+                   .MeasurementCount(20)
+                   .Run();
+
+            job.Dispose();
+            boneWorld.Dispose();
+            avatarTransform.Dispose();
+            updateAvatar.Dispose();
+            perAvatarBoneCount.Dispose();
+        }
+
+        private static bool IsSentinel(float4x4 m) =>
+            math.all(math.isnan(m.c0)) && math.all(math.isnan(m.c1)) &&
+            math.all(math.isnan(m.c2)) && math.all(math.isnan(m.c3));
+
+        private static bool Equalish(float4x4 a, float4x4 b)
+        {
+            const float EPS = 1e-4f;
+            return math.all(math.abs(a.c0 - b.c0) <= EPS) &&
+                   math.all(math.abs(a.c1 - b.c1) <= EPS) &&
+                   math.all(math.abs(a.c2 - b.c2) <= EPS) &&
+                   math.all(math.abs(a.c3 - b.c3) <= EPS);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Bounds `BoneMatrixCalculationJob` by each avatar's actual bone count instead of the full slot stride.

**Before:** the job looped over the full per-avatar slot stride — `MAX_BONE_COUNT = 256` — for every avatar, every frame. An actual avatar has `BASE_BONE_COUNT = 62` plus its spring bones (typically ~62–80 total); the 256 stride is only capacity headroom for spring-bone support. Roughly 4× the necessary `math.mul` work per avatar.

**After:**

- A new `PerAvatarBoneCount` native array feeds each avatar's authoritative `AvatarCustomSkinningComponent.BoneCount` into the job, which clamps its loop with `math.min(count, boneStride)`.
- `StartAvatarMatricesCalculationSystem.RefreshBoneCounts` pushes the count every frame (after registration, before scheduling), so a wearable re-equip that changes the spring-bone count is reflected without re-registration.
- Unset slots are pre-filled with the full stride (`FillWithStride`), so any avatar whose count was never pushed falls back to exactly the old behavior — the job can over-compute but never under-compute.

**Impact:** ~4× fewer matrix multiplies in the job (256 → ~65 per avatar). With 100 remote avatars that is ~25,600 → ~6,500 multiplies per frame on worker threads; the main-player pipeline completes its job synchronously (`calcHandle.Complete()`), so its share comes straight off the main thread.

Result entries past each avatar's bound are no longer written and hold stale data; this is safe because skinning weights never index ≥ `BoneCount` and the compute-skinning upload is bounded by `BoneCount`.

Includes `BoneMatrixCalculationJobPerformanceTest` covering the bounded loop.

**Known follow-up:** the transform *gather* still runs over `flatBones` at full stride — 256 `Transform` slots per avatar, mostly dummies that `IJobParallelForTransform` still visits. Compacting or bounding the gather is the larger remaining win in this chain.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 9705
```

**Expected result**: Avatars (own and remote) animate identically to `dev` — no exploded vertices or frozen bones. This is a pure work-reduction change with no visual difference.

### Test Steps
1. Enter a crowded scene with many remote avatars and verify they all animate normally.
2. Equip/unequip wearables with spring bones (e.g. hair/tails) and verify the avatar skins correctly on the frame of the swap.
3. Profile `BoneMatrixCalculationJob` before/after in a crowd to confirm the reduced job time.

### Additional Testing Notes
- The one scenario worth watching is a wearable swap that changes the spring-bone count: `BoneCount` and the bone-weight buffers refresh on the same component, but a one-frame transient would show up as a brief skinning glitch during the swap.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
