### PR TITLE
opti(avatar-rendering): hoist frustum-plane extraction out of the outline query

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -22,6 +22,8 @@ namespace DCL.AvatarRendering.AvatarShape
     public partial class AvatarShapeVisibilitySystem : BaseUnityLoopSystem
     {
         private readonly RendererFeature_AvatarOutline? outlineFeature;
+        // Reused frustum-plane scratch buffer: rewritten once per tick in Update (CalculateFrustumPlanes) before the
+        // outline query reads it. Owned by the single-threaded ECS Update — NOT safe for concurrent callers.
         private readonly Plane[] planes;
         private readonly float startFadeDithering;
         private readonly float endFadeDithering;
@@ -30,6 +32,9 @@ namespace DCL.AvatarRendering.AvatarShape
 
         private SingleInstanceEntity camera;
         private GameObject? playerCamera;
+        // Camera the cached frustum planes were built for. IsVisibleInCamera validates against this so a
+        // caller cannot read planes computed for a different camera (or before any were computed).
+        private Camera? planesCamera;
 
         public AvatarShapeVisibilitySystem(World world, IUserBlockingCache userBlockingCache, IRendererFeaturesCache outlineFeature, float startFadeDithering, float endFadeDithering, bool includeBannedUsersFromScene) : base(world)
         {
@@ -60,12 +65,28 @@ namespace DCL.AvatarRendering.AvatarShape
             BanAvatarsQuery(World);
             UpdateAvatarsVisibilityStateQuery(World);
             UpdateMainPlayerAvatarVisibilityStateQuery(World, camera.GetCameraComponent(World));
-            GetAvatarsVisibleWithOutlineQuery(World);
+
+            if (outlineFeature != null && outlineFeature.isActive)
+            {
+                Camera cam = camera.GetCameraComponent(World).Camera;
+                CalculateFrustumPlanes(cam);
+                GetAvatarsVisibleWithOutlineQuery(World, cam);
+            }
         }
 
-        public bool IsVisibleInCamera(Camera camera, Bounds bounds)
+        public void CalculateFrustumPlanes(Camera camera)
         {
             GeometryUtility.CalculateFrustumPlanes(camera, planes);
+            planesCamera = camera;
+        }
+
+        // Tests the AABB against the frustum planes cached by the most recent CalculateFrustumPlanes call.
+        // Extraction runs once per tick in Update (not per avatar), so this does not recompute the planes;
+        // the camera argument is validated to match the camera those cached planes were built for.
+        public bool IsVisibleInCamera(Camera camera, Bounds bounds)
+        {
+            UnityEngine.Assertions.Assert.IsTrue(ReferenceEquals(planesCamera, camera),
+                "IsVisibleInCamera reads planes cached by CalculateFrustumPlanes; call it for this camera in the current tick first.");
             return GeometryUtility.TestPlanesAABB(planes, bounds);
         }
 
@@ -77,9 +98,9 @@ namespace DCL.AvatarRendering.AvatarShape
         }
 
         [Query]
-        private void GetAvatarsVisibleWithOutline(in AvatarBase avatarBase, ref AvatarShapeComponent avatarShape)
+        private void GetAvatarsVisibleWithOutline([Data] Camera cam, in AvatarBase avatarBase, ref AvatarShapeComponent avatarShape)
         {
-            if (outlineFeature != null && outlineFeature.isActive && (avatarShape.IsPreview || IsWithinCameraDistance(camera.GetCameraComponent(World).Camera, avatarBase.HeadAnchorPoint, 64.0f) && IsVisibleInCamera(camera.GetCameraComponent(World).Camera, avatarBase.AvatarSkinnedMeshRenderer.bounds)))
+            if (avatarShape.IsPreview || (IsWithinCameraDistance(cam, avatarBase.HeadAnchorPoint, 64.0f) && IsVisibleInCamera(cam, avatarBase.AvatarSkinnedMeshRenderer.bounds)))
             {
                 RendererFeature_AvatarOutline.m_AvatarOutlineRenderers.AddRange(avatarShape.OutlineCompatibleRenderers);
             }
@@ -159,18 +180,21 @@ namespace DCL.AvatarRendering.AvatarShape
             SetHiddenComponent(entity, isBanned, HiddenPlayerComponent.HiddenReason.Banned);
         }
 
-        private void SetHiddenComponent(Entity entity, bool hiddenValue, HiddenPlayerComponent.HiddenReason hiddenReason)
+        // Bitwise test in place of Enum.HasFlag, which boxes receiver and argument on Mono/IL2CPP (no
+        // intrinsic elision) — two heap allocations per test on this per-frame tick. Relies on callers
+        // passing a single flag: "& != 0" means ANY bit set, whereas HasFlag means ALL bits set.
+        internal void SetHiddenComponent(Entity entity, bool hiddenValue, HiddenPlayerComponent.HiddenReason hiddenReason)
         {
             ref HiddenPlayerComponent attachedHiddenComponent = ref World.TryGetRef<HiddenPlayerComponent>(entity, out bool isHiddenComponentAttached);
 
-            if (hiddenValue && (!isHiddenComponentAttached || (isHiddenComponentAttached && !attachedHiddenComponent.Reason.HasFlag(hiddenReason))))
+            if (hiddenValue && (!isHiddenComponentAttached || (isHiddenComponentAttached && (attachedHiddenComponent.Reason & hiddenReason) == 0)))
             {
                 if (!isHiddenComponentAttached)
                     World.Add(entity, new HiddenPlayerComponent { Reason = hiddenReason } );
                 else
                     attachedHiddenComponent.Reason |= hiddenReason;
             }
-            else if (!hiddenValue && isHiddenComponentAttached && attachedHiddenComponent.Reason.HasFlag(hiddenReason))
+            else if (!hiddenValue && isHiddenComponentAttached && (attachedHiddenComponent.Reason & hiddenReason) != 0)
             {
                 attachedHiddenComponent.Reason &= ~hiddenReason;
                 if (attachedHiddenComponent.Reason == 0)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -32,9 +32,6 @@ namespace DCL.AvatarRendering.AvatarShape
 
         private SingleInstanceEntity camera;
         private GameObject? playerCamera;
-        // Camera the cached frustum planes were built for. IsVisibleInCamera validates against this so a
-        // caller cannot read planes computed for a different camera (or before any were computed).
-        private Camera? planesCamera;
 
         public AvatarShapeVisibilitySystem(World world, IUserBlockingCache userBlockingCache, IRendererFeaturesCache outlineFeature, float startFadeDithering, float endFadeDithering, bool includeBannedUsersFromScene) : base(world)
         {
@@ -68,27 +65,21 @@ namespace DCL.AvatarRendering.AvatarShape
 
             if (outlineFeature != null && outlineFeature.isActive)
             {
-                Camera cam = camera.GetCameraComponent(World).Camera;
-                CalculateFrustumPlanes(cam);
-                GetAvatarsVisibleWithOutlineQuery(World, cam);
+                CameraComponent cameraComponent = camera.GetCameraComponent(World);
+                CalculateFrustumPlanes(cameraComponent.Camera);
+                GetAvatarsVisibleWithOutlineQuery(World, cameraComponent);
             }
         }
 
-        public void CalculateFrustumPlanes(Camera camera)
+        internal void CalculateFrustumPlanes(Camera camera)
         {
             GeometryUtility.CalculateFrustumPlanes(camera, planes);
-            planesCamera = camera;
         }
 
         // Tests the AABB against the frustum planes cached by the most recent CalculateFrustumPlanes call.
-        // Extraction runs once per tick in Update (not per avatar), so this does not recompute the planes;
-        // the camera argument is validated to match the camera those cached planes were built for.
-        public bool IsVisibleInCamera(Camera camera, Bounds bounds)
-        {
-            UnityEngine.Assertions.Assert.IsTrue(ReferenceEquals(planesCamera, camera),
-                "IsVisibleInCamera reads planes cached by CalculateFrustumPlanes; call it for this camera in the current tick first.");
-            return GeometryUtility.TestPlanesAABB(planes, bounds);
-        }
+        // Extraction runs once per tick in Update (not per avatar), so this does not recompute the planes.
+        internal bool IsVisibleInCamera(Bounds bounds) =>
+            GeometryUtility.TestPlanesAABB(planes, bounds);
 
         public bool IsWithinCameraDistance(Camera camera, Transform objectTransform, float maxDistancesquared)
         {
@@ -98,9 +89,9 @@ namespace DCL.AvatarRendering.AvatarShape
         }
 
         [Query]
-        private void GetAvatarsVisibleWithOutline([Data] Camera cam, in AvatarBase avatarBase, ref AvatarShapeComponent avatarShape)
+        private void GetAvatarsVisibleWithOutline([Data] in CameraComponent cameraComponent, in AvatarBase avatarBase, ref AvatarShapeComponent avatarShape)
         {
-            if (avatarShape.IsPreview || (IsWithinCameraDistance(cam, avatarBase.HeadAnchorPoint, 64.0f) && IsVisibleInCamera(cam, avatarBase.AvatarSkinnedMeshRenderer.bounds)))
+            if (avatarShape.IsPreview || (IsWithinCameraDistance(cameraComponent.Camera, avatarBase.HeadAnchorPoint, 64.0f) && IsVisibleInCamera(avatarBase.AvatarSkinnedMeshRenderer.bounds)))
             {
                 RendererFeature_AvatarOutline.m_AvatarOutlineRenderers.AddRange(avatarShape.OutlineCompatibleRenderers);
             }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarShapeVisibilitySystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarShapeVisibilitySystemShould.cs
@@ -131,38 +131,10 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
 
             // Act
             system!.CalculateFrustumPlanes(testCamera);
-            bool isVisible = system.IsVisibleInCamera(testCamera, bounds);
+            bool isVisible = system.IsVisibleInCamera(bounds);
 
             // Assert
             Assert.IsTrue(isVisible);
-        }
-
-        [Test]
-        public void IsVisibleInCameraRejectsPlanesFromDifferentCamera()
-        {
-            // The frustum-plane extraction is hoisted out of the per-avatar loop into CalculateFrustumPlanes,
-            // so IsVisibleInCamera reads cached planes. Querying it with a camera whose planes were not the
-            // ones just computed must be caught, not silently answered against another camera's planes.
-            var bounds = new Bounds(new Vector3(0, 1, 5), Vector3.one);
-
-            var otherCameraGo = new GameObject("OtherCamera");
-            createdGameObjects.Add(otherCameraGo);
-            Camera otherCamera = otherCameraGo.AddComponent<Camera>();
-
-            system.CalculateFrustumPlanes(testCamera);
-
-            bool previousRaiseExceptions = UnityEngine.Assertions.Assert.raiseExceptions;
-            UnityEngine.Assertions.Assert.raiseExceptions = true;
-
-            try
-            {
-                Assert.Throws<UnityEngine.Assertions.AssertionException>(
-                    () => system.IsVisibleInCamera(otherCamera, bounds));
-            }
-            finally
-            {
-                UnityEngine.Assertions.Assert.raiseExceptions = previousRaiseExceptions;
-            }
         }
 
         [Test]
@@ -174,7 +146,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
 
             // Act
             system!.CalculateFrustumPlanes(testCamera);
-            bool isVisible = system.IsVisibleInCamera(testCamera, bounds);
+            bool isVisible = system.IsVisibleInCamera(bounds);
 
             // Assert
             Assert.IsFalse(isVisible);

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarShapeVisibilitySystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarShapeVisibilitySystemShould.cs
@@ -24,15 +24,15 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
         private const float START_FADE_DITHERING = 2.0f;
         private const float END_FADE_DITHERING = 0.5f;
 
-        private IUserBlockingCache userBlockingCache;
-        private IRendererFeaturesCache rendererFeaturesCache;
+                private IUserBlockingCache userBlockingCache = null!;
+                private IRendererFeaturesCache rendererFeaturesCache = null!;
 
-        private GameObject cameraGameObject;
-        private Camera testCamera;
+                private GameObject cameraGameObject = null!;
+                private Camera testCamera = null!;
         private Entity cameraEntity;
 
-        private GameObject avatarGameObject;
-        private AvatarBase avatarBase;
+                private GameObject avatarGameObject = null!;
+                private AvatarBase avatarBase = null!;
 
         private readonly List<GameObject> createdGameObjects = new ();
 
@@ -115,7 +115,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             var renderer = wearableGO.AddComponent<MeshRenderer>();
 
             // CachedAttachment requires proper initialization - we use reflection to create one with Renderers list
-            var attachment = new Loading.Assets.CachedAttachment(null, wearableGO, false, Array.Empty<SpringBoneData>());
+            var attachment = new Loading.Assets.CachedAttachment(null!, wearableGO, false, Array.Empty<SpringBoneData>());
             // The Renderers list is created but empty, we need to add a renderer to it
             attachment.Renderers.Add(renderer);
 
@@ -130,10 +130,39 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             cameraGameObject.transform.LookAt(bounds.center);
 
             // Act
+            system!.CalculateFrustumPlanes(testCamera);
             bool isVisible = system.IsVisibleInCamera(testCamera, bounds);
 
             // Assert
             Assert.IsTrue(isVisible);
+        }
+
+        [Test]
+        public void IsVisibleInCameraRejectsPlanesFromDifferentCamera()
+        {
+            // The frustum-plane extraction is hoisted out of the per-avatar loop into CalculateFrustumPlanes,
+            // so IsVisibleInCamera reads cached planes. Querying it with a camera whose planes were not the
+            // ones just computed must be caught, not silently answered against another camera's planes.
+            var bounds = new Bounds(new Vector3(0, 1, 5), Vector3.one);
+
+            var otherCameraGo = new GameObject("OtherCamera");
+            createdGameObjects.Add(otherCameraGo);
+            Camera otherCamera = otherCameraGo.AddComponent<Camera>();
+
+            system.CalculateFrustumPlanes(testCamera);
+
+            bool previousRaiseExceptions = UnityEngine.Assertions.Assert.raiseExceptions;
+            UnityEngine.Assertions.Assert.raiseExceptions = true;
+
+            try
+            {
+                Assert.Throws<UnityEngine.Assertions.AssertionException>(
+                    () => system.IsVisibleInCamera(otherCamera, bounds));
+            }
+            finally
+            {
+                UnityEngine.Assertions.Assert.raiseExceptions = previousRaiseExceptions;
+            }
         }
 
         [Test]
@@ -144,6 +173,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             cameraGameObject.transform.rotation = Quaternion.identity; // Looking forward (+Z)
 
             // Act
+            system!.CalculateFrustumPlanes(testCamera);
             bool isVisible = system.IsVisibleInCamera(testCamera, bounds);
 
             // Assert
@@ -158,7 +188,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             avatarGameObject.transform.position = new Vector3(0, 0, 5); // 5 units away
 
             // Act
-            bool isWithin = system.IsWithinCameraDistance(testCamera, avatarGameObject.transform, maxDistanceSquared);
+            bool isWithin = system!.IsWithinCameraDistance(testCamera, avatarGameObject.transform, maxDistanceSquared);
 
             // Assert
             Assert.IsTrue(isWithin);
@@ -172,7 +202,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             avatarGameObject.transform.position = new Vector3(0, 0, 10); // 10 units away
 
             // Act
-            bool isWithin = system.IsWithinCameraDistance(testCamera, avatarGameObject.transform, maxDistanceSquared);
+            bool isWithin = system!.IsWithinCameraDistance(testCamera, avatarGameObject.transform, maxDistanceSquared);
 
             // Assert
             Assert.IsFalse(isWithin);
@@ -189,7 +219,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Entity playerEntity = world.Create(avatarShape, playerComponent, avatarBase, new CharacterEmoteComponent());
 
             // Act
-            system.Update(0);
+            system!.Update(0);
 
             // Assert
             Assert.IsTrue(world.Has<AvatarCachedVisibilityComponent>(playerEntity));
@@ -203,7 +233,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Entity otherEntity = world.Create(avatarShape, avatarBase, new CharacterEmoteComponent());
 
             // Act
-            system.Update(0);
+            system!.Update(0);
 
             // Assert
             Assert.IsTrue(world.Has<AvatarCachedVisibilityComponent>(otherEntity));
@@ -225,7 +255,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             cameraComponent.Mode = CameraMode.FirstPerson;
 
             // Act - first update adds component, second updates state
-            system.Update(0);
+            system!.Update(0);
             system.Update(0);
 
             // Assert
@@ -247,7 +277,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             ref var cameraComponent = ref world.Get<CameraComponent>(cameraEntity);
             cameraComponent.Mode = CameraMode.FirstPerson;
 
-            system.Update(0);
+            system!.Update(0);
 
             // Verify avatar is hidden in first person
             ref var avatarShapeAfterFirstPerson = ref world.Get<AvatarShapeComponent>(playerEntity);
@@ -277,7 +307,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Entity avatarEntity = world.Create(avatarShape, avatarBase, new CharacterEmoteComponent());
 
             // Act
-            system.Update(0);
+            system!.Update(0);
 
             // Assert
             Assert.IsTrue(world.Has<HiddenPlayerComponent>(avatarEntity));
@@ -298,7 +328,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Entity avatarEntity = world.Create(avatarShape, avatarBase, new CharacterEmoteComponent());
 
             // First update - user is blocked
-            system.Update(0);
+            system!.Update(0);
             Assert.IsTrue(world.Has<HiddenPlayerComponent>(avatarEntity));
 
             // Change blocking status
@@ -353,7 +383,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Entity avatarEntity = world.Create(avatarShape, avatarBase, new CharacterEmoteComponent());
 
             // Act
-            system.Update(0);
+            system!.Update(0);
 
             // Assert
             Assert.IsFalse(world.Has<HiddenPlayerComponent>(avatarEntity));
@@ -370,7 +400,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Entity avatarEntity = world.Create(avatarShape, avatarBase, new CharacterEmoteComponent());
 
             // Act
-            system.Update(0);
+            system!.Update(0);
             system.Update(0);
 
             // Assert
@@ -388,7 +418,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Entity avatarEntity = world.Create(avatarShape, avatarBase, new CharacterEmoteComponent());
 
             // First update - avatar should be hidden due to modifier area
-            system.Update(0);
+            system!.Update(0);
 
             ref var avatarShapeAfterHide = ref world.Get<AvatarShapeComponent>(avatarEntity);
             Assert.IsFalse(avatarShapeAfterHide.IsVisible, "Avatar should be hidden by modifier area");
@@ -415,7 +445,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Entity playerEntity = world.Create(avatarShape, playerComponent, avatarBase, new CharacterEmoteComponent());
 
             // Act - first update adds component
-            system.Update(0);
+            system!.Update(0);
 
             // Set dirty again
             ref var shapeRef = ref world.Get<AvatarShapeComponent>(playerEntity);
@@ -423,7 +453,6 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
 
             // Add skinning component for dither test
             var skinningMaterials = new List<AvatarCustomSkinningComponent.MaterialSetup>();
-            var skinningComponent = new AvatarCustomSkinningComponent();
 
             // Act - This update should trigger ResetDitherState due to IsDirty
             system.Update(0);
@@ -445,7 +474,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Entity avatarEntity = world.Create(avatarShape, avatarBase, new CharacterEmoteComponent());
 
             // First, add blocked reason
-            system.Update(0);
+            system!.Update(0);
 
             // Manually add banned reason to test combination
             ref var hiddenComponent = ref world.Get<HiddenPlayerComponent>(avatarEntity);
@@ -475,7 +504,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Entity avatarEntity = world.Create(avatarShape, avatarBase, new CharacterEmoteComponent());
 
             // Prime the cached state — marks the avatar as hidden so the next update's visible-transition is NOT early-returned.
-            system.Update(0);
+            system!.Update(0);
 
             // Start a legacy Animation on the avatar — LSD/Builder-preview FullBody emotes run through this component.
             Animation legacyAnimation = avatarBase.AddOrGetLegacyAnimation();
@@ -519,7 +548,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             cameraComponent.IsTransitioningToFirstPerson = true;
 
             // Act
-            system.Update(0);
+            system!.Update(0);
             system.Update(0);
 
             // Assert
@@ -545,7 +574,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             cameraComponent.IsTransitioningToFirstPerson = true;
 
             // Act
-            system.Update(0);
+            system!.Update(0);
             system.Update(0);
 
             // Assert

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/PerformanceTests/AvatarOutlineFrustumHoistPerformanceTest.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/PerformanceTests/AvatarOutlineFrustumHoistPerformanceTest.cs
@@ -1,0 +1,194 @@
+using Arch.Core;
+using DCL.AvatarRendering.AvatarShape.Components;
+using DCL.AvatarRendering.AvatarShape.UnityInterface;
+using DCL.CharacterCamera;
+using DCL.Friends.UserBlocking;
+using ECS.TestSuite;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Unity.PerformanceTesting;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace DCL.AvatarRendering.AvatarShape.Tests.PerformanceTests
+{
+    /// <summary>
+    /// Benchmarks <see cref="AvatarShapeVisibilitySystem.Update"/> on its per-avatar outline pass
+    /// (<c>GetAvatarsVisibleWithOutline</c>) with the AvatarOutline render feature ACTIVE.
+    ///
+    /// <para>
+    /// Frustum planes and the active camera are identical for every avatar in a frame — only each
+    /// avatar's AABB differs — so <see cref="GeometryUtility.CalculateFrustumPlanes(Camera, Plane[])"/>
+    /// (a managed→native rebuild of all 6 planes) and the camera-component fetch run ONCE per frame in
+    /// <c>Update</c>, before the query runs, rather than once per avatar; the query receives the camera
+    /// via <c>[Data] Camera</c> instead of re-fetching it.
+    /// </para>
+    ///
+    /// <para>
+    /// Because the outline query is private (source-generated) and the feature gate lives in
+    /// <c>Update</c>, the test drives the real production <c>system.Update(0)</c> with a concrete
+    /// <c>RendererFeature_AvatarOutline</c> injected via reflection (its assembly is not referenced
+    /// by the test assembly) and made active, so the whole pass is exercised end to end.
+    /// </para>
+    ///
+    /// <para>
+    /// Half the avatars are placed IN FRONT of the camera, half BEHIND it. With the frustum planes
+    /// extracted once per frame and reused, exactly the front avatars are classified visible and
+    /// contribute their outline renderer to the static bucket — stale or zeroed planes would make
+    /// <c>TestPlanesAABB</c> mis-classify the behind avatars and the bucket count would diverge from
+    /// <c>frontCount</c>. <c>Measure.Method</c> also records median <c>Update</c> time at 10/50/100
+    /// avatars.
+    /// </para>
+    /// </summary>
+    [Category("Performance")]
+    public class AvatarOutlineFrustumHoistPerformanceTest : UnitySystemTestBase<AvatarShapeVisibilitySystem>
+    {
+        private const float START_FADE_DITHERING = 2.0f;
+        private const float END_FADE_DITHERING = 0.5f;
+
+        private static readonly FieldInfo HEAD_ANCHOR_FIELD =
+            typeof(AvatarBase).GetField("<HeadAnchorPoint>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo SKINNED_RENDERER_FIELD =
+            typeof(AvatarBase).GetField("<AvatarSkinnedMeshRenderer>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private readonly List<GameObject> gameObjects = new (256);
+
+                private GameObject cameraGameObject = null!;
+                private ScriptableObject outlineFeature = null!;
+                private Type outlineType = null!;
+                private FieldInfo outlineBucketField = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            cameraGameObject = CreateTrackedGameObject("PerfCamera");
+            var testCamera = cameraGameObject.AddComponent<Camera>();
+            testCamera.nearClipPlane = 0.1f;
+            testCamera.farClipPlane = 1000f;
+            testCamera.fieldOfView = 60f;
+            cameraGameObject.transform.SetPositionAndRotation(Vector3.zero, Quaternion.identity);
+
+            world.Create(new CameraComponent(testCamera) { Mode = CameraMode.ThirdPerson });
+
+            var userBlockingCache = Substitute.For<IUserBlockingCache>();
+
+            Type featuresCacheType = FindLoadedType("DCL.Quality.IRendererFeaturesCache");
+            Assert.IsNotNull(featuresCacheType, "IRendererFeaturesCache type not found in any loaded assembly");
+            object featuresCache = Substitute.For(new[] { featuresCacheType }, null);
+
+            system = (AvatarShapeVisibilitySystem)Activator.CreateInstance(
+                typeof(AvatarShapeVisibilitySystem),
+                world, userBlockingCache, featuresCache, START_FADE_DITHERING, END_FADE_DITHERING, false);
+
+            system.Initialize();
+
+            outlineType = FindLoadedType("DCL.Rendering.RenderGraphs.RenderFeatures.AvatarOutline.RendererFeature_AvatarOutline");
+            Assert.IsNotNull(outlineType, "RendererFeature_AvatarOutline type not found in any loaded assembly");
+
+            outlineFeature = ScriptableObject.CreateInstance(outlineType);
+            outlineType.GetMethod("SetActive", new[] { typeof(bool) })!.Invoke(outlineFeature, new object[] { true });
+
+            typeof(AvatarShapeVisibilitySystem)
+               .GetField("outlineFeature", BindingFlags.NonPublic | BindingFlags.Instance)!
+               .SetValue(system, outlineFeature);
+
+            outlineBucketField = outlineType.GetField("m_AvatarOutlineRenderers", BindingFlags.Public | BindingFlags.Static)!;
+        }
+
+        protected override void OnTearDown()
+        {
+            ClearBucket();
+
+            foreach (GameObject go in gameObjects)
+                if (go != null) Object.DestroyImmediate(go);
+            gameObjects.Clear();
+
+            if (outlineFeature != null) Object.DestroyImmediate(outlineFeature);
+        }
+
+        [Test]
+        [Performance]
+        [TestCase(10)]
+        [TestCase(50)]
+        [TestCase(100)]
+        public void UpdateOutlineActiveWithNAvatars(int avatarCount)
+        {
+            int frontCount = 0;
+
+            for (int i = 0; i < avatarCount; i++)
+            {
+                bool inFront = (i % 2) == 0;
+                if (inFront) frontCount++;
+                CreateAvatarEntity(i, inFront ? new Vector3(0, 0, 5) : new Vector3(0, 0, -5));
+            }
+
+            ClearBucket();
+            system!.Update(0);
+            Assert.AreEqual(frontCount, BucketCount(),
+                "Outline bucket must contain exactly the front-facing avatars. A wrong count means the "
+                + "once-per-frame frustum planes were stale/zeroed and TestPlanesAABB mis-classified avatars.");
+
+            Measure
+               .Method(() =>
+                {
+                    ClearBucket();
+                    system.Update(0);
+                })
+               .WarmupCount(5)
+               .MeasurementCount(50)
+               .GC()
+               .Run();
+        }
+
+        private void CreateAvatarEntity(int index, Vector3 worldPosition)
+        {
+            var avatarGo = CreateTrackedGameObject($"Avatar_{index}");
+            AvatarBase avatarBase = avatarGo.AddComponent<AvatarBase>();
+
+            var headAnchorGo = CreateTrackedGameObject($"HeadAnchor_{index}");
+            headAnchorGo.transform.SetParent(avatarGo.transform, worldPositionStays: false);
+            headAnchorGo.transform.position = worldPosition;
+            HEAD_ANCHOR_FIELD.SetValue(avatarBase, headAnchorGo.transform);
+
+            var skinnedGo = CreateTrackedGameObject($"Skinned_{index}");
+            skinnedGo.transform.SetParent(avatarGo.transform, worldPositionStays: false);
+            skinnedGo.transform.position = worldPosition;
+            var skinned = skinnedGo.AddComponent<SkinnedMeshRenderer>();
+            skinned.localBounds = new Bounds(Vector3.zero, Vector3.one);
+            SKINNED_RENDERER_FIELD.SetValue(avatarBase, skinned);
+
+            var shape = new AvatarShapeComponent($"perf-{index}", $"perf-{index}");
+            shape.OutlineCompatibleRenderers.Add(skinned);
+
+            world.Create(avatarBase, shape, new AvatarCachedVisibilityComponent());
+        }
+
+        private void ClearBucket() => Bucket().Clear();
+
+        private int BucketCount() => Bucket().Count;
+
+        private IList Bucket() => (IList)outlineBucketField.GetValue(null);
+
+        private GameObject CreateTrackedGameObject(string name)
+        {
+            var go = new GameObject(name);
+            gameObjects.Add(go);
+            return go;
+        }
+
+        private static Type FindLoadedType(string fullName) =>
+            AppDomain.CurrentDomain.GetAssemblies()
+                     .Select(a =>
+                      {
+                          try { return a.GetType(fullName, throwOnError: false); }
+                          catch { return null; }
+                      })
+                     .FirstOrDefault(t => t != null)!;
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/PerformanceTests/DCL.AvatarRendering.AvatarShape.PerformanceTests.asmref
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/PerformanceTests/DCL.AvatarRendering.AvatarShape.PerformanceTests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:7213a1d35667f9b40be6aca8cbfcee23"
+}

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/PerformanceTests/DCL.AvatarRendering.AvatarShape.PerformanceTests.asmref.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/PerformanceTests/DCL.AvatarRendering.AvatarShape.PerformanceTests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0f650cfbe10c4dbfaeed6e2dae34dc25
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Hoists frustum-plane extraction out of the per-avatar outline query in `AvatarShapeVisibilitySystem`.

**Before:** `GetAvatarsVisibleWithOutline` did all of this **per avatar, per frame**:

- `GeometryUtility.CalculateFrustumPlanes` — re-extracted the six frustum planes (a native interop call) for every avatar, even though they only change once per frame.
- Two `camera.GetCameraComponent(World)` singleton lookups per avatar.
- The `outlineFeature != null && isActive` check per avatar.

**After:**

- The feature check, camera fetch, and plane extraction run **once per tick** in `Update`; when the outline feature is inactive the query is skipped entirely.
- The camera reaches the query as `[Data] in CameraComponent`, consistent with the system's other queries.
- `IsVisibleInCamera(Bounds)` tests against the planes cached by `CalculateFrustumPlanes`; both are `internal`, exposed to tests via the existing `InternalsVisibleTo("DCL.EditMode.Tests")`.
- `SetHiddenComponent` replaces two `Enum.HasFlag` calls with bitwise tests — `HasFlag` boxes both operands on this per-frame path, so this removes two heap allocations per call (allocation-free `Update` rule).

Within a single tick the camera is unchanged, so per-tick vs. per-avatar plane extraction is behaviorally identical.

Includes `AvatarOutlineFrustumHoistPerformanceTest` and updated EditMode tests.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 9706
```

**Expected result**: Avatar outlines behave identically to `dev` — outlined when within 64 units and inside the camera frustum (and in preview), not outlined otherwise. Pure work-reduction, no visual change.

### Test Steps
1. Enter a crowded scene and verify avatar outlines appear/disappear as avatars enter and leave the view, exactly as on `dev`.
2. Toggle the avatar outline renderer feature off and verify no outline-related cost appears in the profiler.
3. Profile `AvatarShapeVisibilitySystem.Update` in a crowd before/after to confirm the reduced cost.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
