### PR TITLE
fix: added tracking of source for topup and IAP

### DIFF
--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/AuthorizeCreditResponse.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/AuthorizeCreditResponse.cs
@@ -31,6 +31,7 @@ namespace DCL.MarketplaceCredits
     {
         public int usdPriceCents;
         public string tradeId;
+        public string source;
     }
 
     [Serializable]
@@ -39,6 +40,7 @@ namespace DCL.MarketplaceCredits
         public int usdPriceCents;
         public string contractAddress;
         public string itemId;
+        public string source;
     }
 
     [Serializable]

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/CheckoutResponse.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/CheckoutResponse.cs
@@ -14,5 +14,6 @@ namespace DCL.MarketplaceCredits
     public struct CheckoutRequestBody
     {
         public string packId;
+        public string source;
     }
 }

--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/MarketplaceCreditsAPIClient.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/MarketplaceCreditsAPIClient.cs
@@ -16,6 +16,8 @@ namespace DCL.MarketplaceCredits
     {
         private const string NO_DATA_STATE = "NO_DATA";
         private const string SEASON_NOT_STARTED_STATE = "NOT_STARTED";
+        private const string PURCHASE_SOURCE = "client";
+
         public event Action<CreditsProgramProgressResponse> OnProgramProgressUpdated;
         public event Action<UserCreditsResponse> OnUserCreditsFetched;
 
@@ -109,11 +111,13 @@ namespace DCL.MarketplaceCredits
                     usdPriceCents = usdPriceCents,
                     contractAddress = contractAddress,
                     itemId = itemId,
+                    source = PURCHASE_SOURCE,
                 })
                 : JsonUtility.ToJson(new AuthorizeUsdCreditBody
                 {
                     usdPriceCents = usdPriceCents,
                     tradeId = tradeId ?? string.Empty,
+                    source = PURCHASE_SOURCE,
                 });
         }
 
@@ -227,7 +231,7 @@ namespace DCL.MarketplaceCredits
         public virtual async UniTask<EnumResult<CheckoutResponse, CreditsCheckoutError>> CreateCheckoutAsync(string packId, CancellationToken ct)
         {
             var url = $"{marketplaceCreditsBaseUrl}/credits/checkout";
-            string jsonBody = JsonUtility.ToJson(new CheckoutRequestBody { packId = packId });
+            string jsonBody = JsonUtility.ToJson(new CheckoutRequestBody { packId = packId, source = PURCHASE_SOURCE });
 
             try
             {


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #9719 
This PR adds the tracking of the source for credits topup and in app purchases, by just adding a field expected by BE

## Test Instructions

### Test Steps
1. Launch the client in .zone
2. Perform a credits topup by buying any credits pack (remember to use card with number 4242 4242 4242 4242)
3. Verify it works as always

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
