### PR TITLE
chore: sanitize "com.decentraland.pulse.transport" from unity-unrelated stuff

### DIFF
--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -11,7 +11,7 @@
     "com.dcl.gpui-assets": "git@github.com:decentraland/unity-explorer-packages.git?path=/GPUInstancerPro/com.dcl.gpui-assets",
     "com.decentraland.filebrowserpro": "git@github.com:decentraland/unity-explorer-packages.git?path=/FileBrowserPro",
     "com.decentraland.livekit-sdk": "https://github.com/decentraland/client-sdk-unity.git#222d67ccc289337dadb5e8d96ee5b633dfb905b6",
-    "com.decentraland.pulse.transport": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport.Shared#efe92879d9c6765421841fa67cf994500772fc6b",
+    "com.decentraland.pulse.transport": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport/Package",
     "com.decentraland.renum": "https://github.com/NickKhalow/REnum.git?path=REnum",
     "com.decentraland.renum.sourcegen": "https://github.com/NickKhalow/REnum.git#sourcegen/1.1.4",
     "com.decentraland.rpc-csharp": "https://github.com/decentraland/rpc-csharp.git?path=rpc-csharp/src#f3dd251c7837cc2d844e1c07e741177a53676064",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -101,11 +101,11 @@
       "hash": "222d67ccc289337dadb5e8d96ee5b633dfb905b6"
     },
     "com.decentraland.pulse.transport": {
-      "version": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport.Shared#efe92879d9c6765421841fa67cf994500772fc6b",
+      "version": "https://github.com/decentraland/Pulse.git?path=src/DCLPulse.Transport/Package",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "efe92879d9c6765421841fa67cf994500772fc6b"
+      "hash": "994b07ee161c63bf3d2508902ec77c4fad3d4009"
     },
     "com.decentraland.renum": {
       "version": "https://github.com/NickKhalow/REnum.git?path=REnum",


### PR DESCRIPTION
Move unity-unrelated files from the package folder