### PR TITLE
feat(abgen): local-ab follow-ups — reconversion mirroring, production fallback, orphan hardening

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/AbgenConversionMetrics.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/AbgenConversionMetrics.cs
@@ -49,6 +49,9 @@ namespace ECS.StreamableLoading.AssetBundles
 
         private bool panelOpenRequested;
 
+        private bool contentEditSignaled;
+        private string? contentEditSrc;
+
         private WarmUpStage warmUpStage;
         private string? warmUpSceneId;
         private float warmUpElapsedSeconds;
@@ -277,6 +280,36 @@ namespace ECS.StreamableLoading.AssetBundles
                 bool requested = panelOpenRequested;
                 panelOpenRequested = false;
                 return requested;
+            }
+        }
+
+        /// <summary>
+        ///     Signals that the LSD preview server reported a content edit, so the scene's bundles are about
+        ///     to be reconverted. <paramref name="changedSrc" /> names the edited model when the message
+        ///     carried one (UpdateModel); null for whole-scene updates. Rapid successive edits keep the
+        ///     latest name — one reconversion pass covers them all.
+        /// </summary>
+        public void OnContentEdit(string? changedSrc)
+        {
+            lock (gate)
+            {
+                contentEditSignaled = true;
+
+                // Protobuf strings default to "" — treat that as an unnamed (whole-scene) edit.
+                contentEditSrc = string.IsNullOrEmpty(changedSrc) ? null : changedSrc;
+            }
+        }
+
+        /// <summary>True once per <see cref="OnContentEdit" /> burst — consuming it resets the signal.</summary>
+        public bool TryConsumeContentEdit(out string? changedSrc)
+        {
+            lock (gate)
+            {
+                bool signaled = contentEditSignaled;
+                changedSrc = contentEditSrc;
+                contentEditSignaled = false;
+                contentEditSrc = null;
+                return signaled;
             }
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/AbgenManifestPrewarm.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/AbgenManifestPrewarm.cs
@@ -1,0 +1,55 @@
+#nullable enable
+
+namespace ECS.StreamableLoading.AssetBundles
+{
+    /// <summary>
+    ///     Hand-off of the abgen sidecar's already-fetched scene manifest to the scene loading lane.
+    ///     Boot holds on the warm-up's manifest request and the reconversion watcher re-fetches it after
+    ///     every content edit, so when the scene lane asks for the same URL the response is already in
+    ///     hand — reusing it removes the server's content revalidation (seconds on a large scene) from
+    ///     the scene-entry critical path. Single entry: local scene development serves exactly one scene.
+    /// </summary>
+    public static class AbgenManifestPrewarm
+    {
+        private static readonly object GATE = new ();
+
+        private static string? url;
+        private static string? json;
+
+        /// <summary>Stores the manifest response fetched from <paramref name="manifestUrl" />, replacing any previous entry.</summary>
+        public static void Set(string manifestUrl, string manifestJson)
+        {
+            lock (GATE)
+            {
+                url = manifestUrl;
+                json = manifestJson;
+            }
+        }
+
+        /// <summary>Drops the stored manifest. Called on a preview content edit, which may change the file census.</summary>
+        public static void Invalidate()
+        {
+            lock (GATE)
+            {
+                url = null;
+                json = null;
+            }
+        }
+
+        /// <summary>True when a manifest fetched from exactly <paramref name="manifestUrl" /> is held; the entry stays for scene reloads.</summary>
+        public static bool TryGet(string manifestUrl, out string manifestJson)
+        {
+            lock (GATE)
+            {
+                if (url == manifestUrl && json != null)
+                {
+                    manifestJson = json;
+                    return true;
+                }
+
+                manifestJson = string.Empty;
+                return false;
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/AbgenManifestPrewarm.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/AbgenManifestPrewarm.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8800242e7bf4d539657b44888dc6dfa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleManifestSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleManifestSystem.cs
@@ -59,8 +59,21 @@ namespace ECS.StreamableLoading.AssetBundles
                       .AppendPath(URLPath.FromString($"{hash}{PlatformUtils.GetCurrentPlatform()}.json"));
 
             URLAddress url = urlBuilder.Build();
-            SceneAbDto sceneAbDto = await webRequestController.GetAsync(new CommonArguments(url, RetryPolicy.WithRetries(1)), ct, reportCategory)
-                                                              .CreateFromJson<SceneAbDto>(WRJsonParser.Newtonsoft, WRThreadFlags.SwitchBackToMainThread);
+
+            // In local-ab the abgen sidecar already fetched this exact manifest — boot holds on the
+            // warm-up's request, and the reconversion watcher re-fetches after every content edit — so
+            // reuse the held response instead of paying the server's content revalidation a second time
+            // on the scene-entry critical path. Empty outside that flow.
+            SceneAbDto sceneAbDto;
+
+            if (AbgenManifestPrewarm.TryGet(url.Value, out string prewarmedJson))
+            {
+                sceneAbDto = JsonUtility.FromJson<SceneAbDto>(prewarmedJson);
+                ReportHub.Log(ReportCategory.ASSET_BUNDLES, $"manifest for {hash} served from the abgen warm-up hand-off (no re-fetch)");
+            }
+            else
+                sceneAbDto = await webRequestController.GetAsync(new CommonArguments(url, RetryPolicy.WithRetries(1)), ct, reportCategory)
+                                                       .CreateFromJson<SceneAbDto>(WRJsonParser.Newtonsoft, WRThreadFlags.SwitchBackToMainThread);
 
             CheckSceneAbDTO(sceneAbDto.Version, hash);
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/AbgenSidecar.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/AbgenSidecar.cs
@@ -307,7 +307,8 @@ namespace Global.Dynamic
             {
                 var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
-                using UnityWebRequest manifestRequest = UnityWebRequest.Get($"{BaseUrl}/manifest/{entityId}{PlatformUtils.GetCurrentPlatform()}.json");
+                string manifestUrl = $"{BaseUrl}/manifest/{entityId}{PlatformUtils.GetCurrentPlatform()}.json";
+                using UnityWebRequest manifestRequest = UnityWebRequest.Get(manifestUrl);
                 manifestRequest.timeout = 0; // a cold heavy scene converts for minutes; the server paces the build
                 UnityWebRequestAsyncOperation manifestOperation = manifestRequest.SendWebRequest();
 
@@ -362,6 +363,11 @@ namespace Global.Dynamic
                 // The progress poll only samples whichever file is converting at each tick, so fast files
                 // leave no row; backfill the panel with the scene's full convertible file list.
                 await ReconcileCensusAsync(entityId, ct);
+
+                // Hand the response to the scene lane, which requests this exact URL next (right after the
+                // boot-hold, or on the reload that follows an edit) — reusing it skips the server's content
+                // revalidation on the scene-entry critical path.
+                AbgenManifestPrewarm.Set(manifestUrl, manifestRequest.downloadHandler.text);
 
                 return ((float)stopwatch.Elapsed.TotalSeconds, sawBuildProgress, JsonUtility.FromJson<CorpusManifest>(manifestRequest.downloadHandler.text).exitCode);
             }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/AbgenSidecar.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/AbgenSidecar.cs
@@ -47,6 +47,7 @@ namespace Global.Dynamic
         private const int HEALTH_TIMEOUT_MS = 15000;
         private const int HEALTH_POLL_MS = 250;
         private const int PROGRESS_POLL_MS = 500;
+        private const int CONTENT_EDIT_SIGNAL_POLL_MS = 250;
 
         /// <summary>abgen's built-in default bind port (crate/src/abcdn/config.rs) — never exported as an env var.</summary>
         private const int ABGEN_DEFAULT_PORT = 5147;
@@ -74,6 +75,14 @@ namespace Global.Dynamic
 #endif
         private int restarts;
         private volatile bool disposed;
+        private string? warmedEntityId;
+
+#if UNITY_EDITOR || UNITY_STANDALONE_WIN
+        // Kill-on-close Job Object tying the child's lifetime to this process on Windows: when the
+        // explorer dies for ANY reason — crash included — the kernel closes the handle and reaps the
+        // child, so orderly Dispose is just the graceful path. Always IntPtr.Zero on the macOS editor.
+        private IntPtr jobHandle;
+#endif
 
         public string BaseUrl { get; }
 
@@ -142,6 +151,18 @@ namespace Global.Dynamic
         {
             if (Launch(executablePath) && await WaitHealthyAsync(ct))
             {
+                // The port answered, but only our own live child counts: with the fixed default
+                // endpoint, an orphaned abgen from a crashed session (or any foreign process on
+                // the port) could be the one listening — serving stale bundles from a stale
+                // version or another workspace's realm. Refuse to adopt it.
+                if (!ChildAlive())
+                {
+                    AbgenConversionMetrics.INSTANCE.OnMilestone($"another process owns {BaseUrl} (our server exited on startup) — kill it and relaunch; the scene loads as raw GLTFs");
+                    ReportHub.LogWarning(ReportCategory.ASSET_BUNDLES, $"abgen sidecar: {BaseUrl} answers but our child is dead — a foreign/orphaned server owns the port; refusing to adopt it");
+                    Dispose();
+                    return false;
+                }
+
                 SuperviseAsync(ct).Forget();
                 return true;
             }
@@ -160,8 +181,6 @@ namespace Global.Dynamic
         /// </summary>
         public async UniTask WarmUpLocalSceneAsync(CancellationToken ct)
         {
-            string? convertingFile = null;
-
             try
             {
                 using UnityWebRequest aboutRequest = UnityWebRequest.Get($"{realmRoot}/about");
@@ -178,10 +197,114 @@ namespace Global.Dynamic
                     return;
                 }
 
+                warmedEntityId = entityId;
                 AbgenConversionMetrics.INSTANCE.OnWarmUpStarted(entityId);
                 AbgenConversionMetrics.INSTANCE.OnMilestone($"warm-up started — converting scene {entityId} in the background");
                 ReportHub.Log(ReportCategory.ASSET_BUNDLES, $"abgen warm-up: converting scene {entityId} — asset bundles are being built in the background");
 
+                (float elapsedSeconds, bool sawBuildProgress, int exitCode) = await MirrorManifestBuildAsync(entityId, ct);
+
+                AbgenConversionMetrics.INSTANCE.OnWarmUpReady(elapsedSeconds, alreadyWarm: !sawBuildProgress);
+
+                AbgenConversionMetrics.INSTANCE.OnMilestone(sawBuildProgress
+                    ? $"manifest retrieved — asset bundles ready in {elapsedSeconds:F1}s"
+                    : "asset bundles already converted — manifest served from warm cache");
+
+                ReportHub.Log(ReportCategory.ASSET_BUNDLES, sawBuildProgress
+                    ? $"abgen warm-up: manifest retrieved — asset bundles READY for scene {entityId} in {elapsedSeconds:F1}s"
+                    : $"abgen warm-up: asset bundles already converted (warm cache) — manifest for scene {entityId} served in {elapsedSeconds:F1}s");
+
+                if (exitCode != 0)
+                {
+                    AbgenConversionMetrics.INSTANCE.OnMilestone($"some files failed server-side conversion (manifest exitCode {exitCode})");
+                    ReportHub.LogWarning(ReportCategory.ASSET_BUNDLES, $"abgen warm-up: manifest exitCode {exitCode} — some files failed server-side conversion; check the sidecar's cache logs");
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception e)
+            {
+                AbgenConversionMetrics.INSTANCE.OnWarmUpFailed();
+                AbgenConversionMetrics.INSTANCE.OnMilestone($"warm-up failed ({e.Message}) — bundles still convert lazily per request");
+                ReportHub.LogWarning(ReportCategory.ASSET_BUNDLES, "abgen warm-up failed — bundles still convert lazily per request");
+                ReportHub.LogException(e, ReportCategory.ASSET_BUNDLES);
+            }
+        }
+
+        /// <summary>
+        ///     Session-long reconversion mirror: waits for the content-edit signal the LSD reload path
+        ///     raises (see LocalSceneDevelopmentController) and re-runs the manifest lane for the warmed
+        ///     scene — the request coalesces with (or triggers) the server's rebuild of the edited files,
+        ///     so the AB panel flips back to converting, tracks the rebuild and settles to READY with the
+        ///     reconversion time even when the rebuild outpaces the progress poll. Runs detached until
+        ///     cancelled; never throws. No-op when the warm-up never resolved the scene entity.
+        /// </summary>
+        public async UniTask WatchReconversionsAsync(CancellationToken ct)
+        {
+            string? entityId = warmedEntityId;
+            if (entityId == null) return;
+
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    await UniTask.Delay(CONTENT_EDIT_SIGNAL_POLL_MS, DelayType.Realtime, cancellationToken: ct);
+
+                    if (!AbgenConversionMetrics.INSTANCE.TryConsumeContentEdit(out string? changedSrc))
+                        continue;
+
+                    AbgenConversionMetrics metrics = AbgenConversionMetrics.INSTANCE;
+
+                    try
+                    {
+                        metrics.OnWarmUpStarted(entityId);
+
+                        metrics.OnMilestone(changedSrc != null
+                            ? $"{changedSrc} changed — reconverting"
+                            : "scene content changed — revalidating bundles");
+
+                        (float elapsedSeconds, bool sawBuildProgress, int exitCode) = await MirrorManifestBuildAsync(entityId, ct);
+
+                        // A named model edit always rebuilt its bundle, even faster than the progress poll
+                        // samples; a whole-scene (code) update may genuinely have had nothing to rebuild.
+                        bool rebuilt = changedSrc != null || sawBuildProgress;
+
+                        metrics.OnWarmUpReady(elapsedSeconds, alreadyWarm: !rebuilt);
+
+                        metrics.OnMilestone(rebuilt
+                            ? $"reconverted in {elapsedSeconds:F1}s"
+                            : $"revalidated in {elapsedSeconds:F1}s — bundles already up to date");
+
+                        ReportHub.Log(ReportCategory.ASSET_BUNDLES, $"abgen: scene {entityId} {(rebuilt ? "reconverted" : "revalidated")} after a content edit in {elapsedSeconds:F1}s");
+
+                        if (exitCode != 0)
+                            metrics.OnMilestone($"some files failed server-side conversion (manifest exitCode {exitCode})");
+                    }
+                    catch (OperationCanceledException) { throw; }
+                    catch (Exception e)
+                    {
+                        metrics.OnWarmUpFailed();
+                        metrics.OnMilestone($"reconversion failed ({e.Message}) — bundles still convert lazily per request");
+                        ReportHub.LogException(e, ReportCategory.ASSET_BUNDLES);
+                    }
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception e) { ReportHub.LogException(e, ReportCategory.ASSET_BUNDLES); }
+        }
+
+        /// <summary>
+        ///     Requests the entity's manifest — making the server build every stale bundle of the scene,
+        ///     coalescing with any build already running — while mirroring <c>/progress/{entity}</c> into
+        ///     the AB panel rows, then backfills the census. Returns the request's wall time, whether any
+        ///     build progress was observed (false when everything was already warm or the build outpaced
+        ///     the poll), and the manifest's exitCode (non-zero when files failed server-side).
+        /// </summary>
+        private async UniTask<(float elapsedSeconds, bool sawBuildProgress, int exitCode)> MirrorManifestBuildAsync(string entityId, CancellationToken ct)
+        {
+            string? convertingFile = null;
+
+            try
+            {
                 var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
                 using UnityWebRequest manifestRequest = UnityWebRequest.Get($"{BaseUrl}/manifest/{entityId}{PlatformUtils.GetCurrentPlatform()}.json");
@@ -240,38 +363,14 @@ namespace Global.Dynamic
                 // leave no row; backfill the panel with the scene's full convertible file list.
                 await ReconcileCensusAsync(entityId, ct);
 
-                AbgenConversionMetrics.INSTANCE.OnWarmUpReady((float)stopwatch.Elapsed.TotalSeconds, alreadyWarm: !sawBuildProgress);
-
-                AbgenConversionMetrics.INSTANCE.OnMilestone(sawBuildProgress
-                    ? $"manifest retrieved — asset bundles ready in {stopwatch.Elapsed.TotalSeconds:F1}s"
-                    : "asset bundles already converted — manifest served from warm cache");
-
-                ReportHub.Log(ReportCategory.ASSET_BUNDLES, sawBuildProgress
-                    ? $"abgen warm-up: manifest retrieved — asset bundles READY for scene {entityId} in {stopwatch.Elapsed.TotalSeconds:F1}s"
-                    : $"abgen warm-up: asset bundles already converted (warm cache) — manifest for scene {entityId} served in {stopwatch.Elapsed.TotalSeconds:F1}s");
-
-                int exitCode = JsonUtility.FromJson<CorpusManifest>(manifestRequest.downloadHandler.text).exitCode;
-
-                if (exitCode != 0)
-                {
-                    AbgenConversionMetrics.INSTANCE.OnMilestone($"some files failed server-side conversion (manifest exitCode {exitCode})");
-                    ReportHub.LogWarning(ReportCategory.ASSET_BUNDLES, $"abgen warm-up: manifest exitCode {exitCode} — some files failed server-side conversion; check the sidecar's cache logs");
-                }
+                return ((float)stopwatch.Elapsed.TotalSeconds, sawBuildProgress, JsonUtility.FromJson<CorpusManifest>(manifestRequest.downloadHandler.text).exitCode);
             }
-            catch (OperationCanceledException)
-            {
-                if (convertingFile != null)
-                    AbgenConversionMetrics.INSTANCE.OnCancelled(convertingFile);
-            }
-            catch (Exception e)
+            catch
             {
                 if (convertingFile != null)
                     AbgenConversionMetrics.INSTANCE.OnCancelled(convertingFile);
 
-                AbgenConversionMetrics.INSTANCE.OnWarmUpFailed();
-                AbgenConversionMetrics.INSTANCE.OnMilestone($"warm-up failed ({e.Message}) — bundles still convert lazily per request");
-                ReportHub.LogWarning(ReportCategory.ASSET_BUNDLES, "abgen warm-up failed — bundles still convert lazily per request");
-                ReportHub.LogException(e, ReportCategory.ASSET_BUNDLES);
+                throw;
             }
         }
 
@@ -613,6 +712,10 @@ namespace Global.Dynamic
             process.ErrorDataReceived += static (_, _) => { };
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
+
+            if (IsWindows)
+                TieChildLifetimeToUs(process.Handle);
+
             return true;
 #elif UNITY_STANDALONE_WIN
             // CREATE_NO_WINDOW keeps the console-subsystem server from opening a console window;
@@ -630,6 +733,7 @@ namespace Global.Dynamic
 
             if (processHandle != IntPtr.Zero) CloseHandle(processHandle);
             processHandle = processInformation.hProcess;
+            TieChildLifetimeToUs(processHandle);
             return true;
 #else
             Result<int> result = DclProcesses.Start(executablePath, Array.Empty<string>());
@@ -679,6 +783,15 @@ namespace Global.Dynamic
 #else
             if (processId > 0) kill(processId, SIGKILL);
             processId = 0;
+#endif
+
+#if UNITY_EDITOR || UNITY_STANDALONE_WIN
+            if (jobHandle != IntPtr.Zero)
+            {
+                // Closing the kill-on-close job reaps anything still assigned to it.
+                CloseJobHandle(jobHandle);
+                jobHandle = IntPtr.Zero;
+            }
 #endif
         }
 
@@ -733,6 +846,88 @@ namespace Global.Dynamic
 
             return false;
         }
+
+#if UNITY_EDITOR || UNITY_STANDALONE_WIN
+        /// <summary>
+        ///     Assigns the child to a kill-on-close Job Object, tying its lifetime to this process at the
+        ///     kernel level. Best effort: on any failure the child just stays untethered, exactly as before.
+        ///     Restarted children join the same job. Windows only — call sites are IsWindows-guarded in the
+        ///     editor, so the kernel32 imports never bind on macOS.
+        /// </summary>
+        private void TieChildLifetimeToUs(IntPtr childProcessHandle)
+        {
+            if (jobHandle == IntPtr.Zero)
+            {
+                IntPtr job = CreateJobObjectW(IntPtr.Zero, null);
+                if (job == IntPtr.Zero) return;
+
+                var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+                info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+                if (!SetInformationJobObject(job, JOB_OBJECT_INFO_CLASS_EXTENDED_LIMIT, ref info, (uint)Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>()))
+                {
+                    CloseJobHandle(job);
+                    return;
+                }
+
+                jobHandle = job;
+            }
+
+            AssignProcessToJobObject(jobHandle, childProcessHandle);
+        }
+
+        private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+        private const int JOB_OBJECT_INFO_CLASS_EXTENDED_LIMIT = 9;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IO_COUNTERS
+        {
+            public ulong ReadOperationCount;
+            public ulong WriteOperationCount;
+            public ulong OtherOperationCount;
+            public ulong ReadTransferCount;
+            public ulong WriteTransferCount;
+            public ulong OtherTransferCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public long PerProcessUserTimeLimit;
+            public long PerJobUserTimeLimit;
+            public uint LimitFlags;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public uint ActiveProcessLimit;
+            public UIntPtr Affinity;
+            public uint PriorityClass;
+            public uint SchedulingClass;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public UIntPtr ProcessMemoryLimit;
+            public UIntPtr JobMemoryLimit;
+            public UIntPtr PeakProcessMemoryUsed;
+            public UIntPtr PeakJobMemoryUsed;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr CreateJobObjectW(IntPtr lpJobAttributes, string? lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool SetInformationJobObject(IntPtr hJob, int jobObjectInformationClass, ref JOBOBJECT_EXTENDED_LIMIT_INFORMATION lpJobObjectInformation, uint cbJobObjectInformationLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+        // Alias so the editor build (which lacks the player's CloseHandle import) can close the job.
+        [DllImport("kernel32.dll", EntryPoint = "CloseHandle", SetLastError = true)]
+        private static extern bool CloseJobHandle(IntPtr hObject);
+#endif
 
         private const uint UNIX_MODE_755 = 0x1ED; // rwxr-xr-x
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -112,11 +112,12 @@ namespace Global.Dynamic
         public ISystemClipboard SystemClipboard => uiShellContainer.Clipboard;
 
         /// <summary>
-        ///     Completed once the abgen sidecar reaches a terminal state — warm and serving, or given up
-        ///     (see <see cref="AbgenSidecarPlugin.ReadyAsync" />). Already completed when the sidecar is
-        ///     not mounted, so awaiting it costs nothing outside local scene development with local ABs.
+        ///     Completed once the abgen sidecar reaches a terminal state, with <c>true</c> when the server is up and
+        ///     serving or <c>false</c> when it never came up (see <see cref="AbgenSidecarPlugin.ReadyAsync" />).
+        ///     Resolves to <c>true</c> immediately when the sidecar is not mounted (nothing to fall back from), so
+        ///     awaiting it costs nothing outside local scene development with local ABs.
         /// </summary>
-        public UniTask AbgenSidecarReadyAsync => abgenSidecarPlugin?.ReadyAsync ?? UniTask.CompletedTask;
+        public UniTask<bool> AbgenSidecarReadyAsync => abgenSidecarPlugin?.ReadyAsync ?? UniTask.FromResult(true);
 
         private DynamicWorldContainer(
             UIShellContainer uiShellContainer,

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -418,7 +418,13 @@ namespace Global.Dynamic
                 // manifest request, whose bundles-vs-GLTFs verdict is final for the session. Hold it
                 // until the abgen sidecar is warm or has given up; completed immediately when the
                 // sidecar is not mounted.
-                await dynamicWorldContainer!.AbgenSidecarReadyAsync.AttachExternalCancellation(ct);
+                bool sidecarUsable = await dynamicWorldContainer!.AbgenSidecarReadyAsync.AttachExternalCancellation(ct);
+
+                // The sidecar the optimized-assets override points at never came up. Drop the override now,
+                // before any optimized-asset request resolves, so the whole session falls back to production
+                // cleanly instead of hitting the dead loopback port and recovering per request.
+                if (!sidecarUsable)
+                    decentralandUrlsSource.ClearOptimizedAssetsOverride();
 
                 await LoadStartingRealmAsync(ct);
                 await LoadUserFlowAsync(playerEntity, ct);

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
@@ -5,6 +5,7 @@ using DCL.Diagnostics;
 using DCL.SkyBox;
 using DCL.SkyBox.Components;
 using Decentraland.Sdk.Development;
+using ECS.StreamableLoading.AssetBundles;
 using Google.Protobuf;
 using System;
 using System.Threading;
@@ -90,6 +91,10 @@ namespace ECS.SceneLifeCycle.LocalSceneDevelopment
                         sceneId = wsSceneMessage.UpdateScene.SceneId;
                         changedModelSrc = null;
                     }
+
+                    // Arm the abgen sidecar's reconversion mirror before the reload's manifest request
+                    // lands; without --local-ab nothing consumes the signal and it stays inert.
+                    AbgenConversionMetrics.INSTANCE.OnContentEdit(changedModelSrc);
 
                     // Switch to the main thread because `TryReloadSceneAsync` requires that
                     await UniTask.SwitchToMainThread(cancellationToken: ct);

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/LocalSceneDevelopment/LocalSceneDevelopmentController.cs
@@ -93,8 +93,11 @@ namespace ECS.SceneLifeCycle.LocalSceneDevelopment
                     }
 
                     // Arm the abgen sidecar's reconversion mirror before the reload's manifest request
-                    // lands; without --local-ab nothing consumes the signal and it stays inert.
+                    // lands; without --local-ab nothing consumes the signal and it stays inert. The
+                    // prewarmed manifest may be stale from this moment (the edit can change the file
+                    // census), so drop it — the watcher's re-fetch repopulates it.
                     AbgenConversionMetrics.INSTANCE.OnContentEdit(changedModelSrc);
+                    AbgenManifestPrewarm.Invalidate();
 
                     // Switch to the main thread because `TryReloadSceneAsync` requires that
                     await UniTask.SwitchToMainThread(cancellationToken: ct);

--- a/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/IDecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/IDecentralandUrlsSource.cs
@@ -45,5 +45,11 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
         public string GetOriginalUrl(string url);
 
         string GetHostnameForFeatureFlag();
+
+        /// <summary>
+        ///     Drops the "--optimized-assets-url" override (local-ab) so optimized-asset endpoints fall back to their
+        ///     production hosts. No-op when no override is set.
+        /// </summary>
+        void ClearOptimizedAssetsOverride();
     }
 }

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -41,7 +41,7 @@ namespace DCL.Browser.DecentralandUrls
         private readonly ILaunchMode launchMode;
         private readonly string decentralandDomain;
         private readonly string? gatekeeperBaseOverride;
-        private readonly string? optimizedAssetsBaseOverride;
+        private string? optimizedAssetsBaseOverride;
         private readonly bool isTodayEnvironment;
 
         public DecentralandUrlsSource(
@@ -185,6 +185,31 @@ namespace DCL.Browser.DecentralandUrls
             realmDependentCachedUrls.AddRange(cache.Where(kvp => kvp.Value.Caching == CacheBehaviour.RealmDependent).Select(kvp => kvp.Key));
 
             foreach (DecentralandUrl url in realmDependentCachedUrls)
+                cache.Remove(url);
+        }
+
+        /// <summary>
+        ///     Drops the "--optimized-assets-url" override so every optimized-asset endpoint re-resolves to its
+        ///     production host. Called when the local-ab abgen sidecar the override pointed at never came up, so the
+        ///     session behaves as if local-ab were never requested instead of routing every scene, wearable, LOD and
+        ///     registry-composed profile/entities-active request at a dead loopback port and recovering per request.
+        /// </summary>
+        public void ClearOptimizedAssetsOverride()
+        {
+            if (optimizedAssetsBaseOverride == null)
+                return;
+
+            optimizedAssetsBaseOverride = null;
+
+            // With the override present these all resolved as FeatureFlagsDependent (the registry-composed
+            // profile/entities endpoints inherit the registry base's caching), so evicting that class forces
+            // production re-resolution. Anything already flag-dependent for other reasons simply re-resolves
+            // to the same value.
+            using PooledObject<List<DecentralandUrl>> _ = ListPool<DecentralandUrl>.Get(out List<DecentralandUrl>? flagDependentCachedUrls);
+
+            flagDependentCachedUrls.AddRange(cache.Where(kvp => kvp.Value.Caching == CacheBehaviour.FeatureFlagsDependent).Select(kvp => kvp.Key));
+
+            foreach (DecentralandUrl url in flagDependentCachedUrls)
                 cache.Remove(url);
         }
 

--- a/Explorer/Assets/DCL/PluginSystem/Global/AbgenSidecarPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/AbgenSidecarPlugin.cs
@@ -25,17 +25,19 @@ namespace DCL.PluginSystem.Global
         private readonly string baseUrl;
         private readonly RealmUrls realmUrls;
         private readonly DecentralandEnvironment environment;
-        private readonly UniTaskCompletionSource readyCompletionSource = new ();
+        private readonly UniTaskCompletionSource<bool> readyCompletionSource = new ();
 
         private AbgenSidecar? sidecar;
         private CancellationTokenSource? lifeCycleCancellationTokenSource;
 
         /// <summary>
-        ///     Completes when the sidecar reaches a terminal state: warm and serving (whole-scene warm-up
-        ///     finished), or given up (no binary and the download failed, launch failure, cancellation).
-        ///     Never faults. Single awaiter only.
+        ///     Completes when the sidecar reaches a terminal state, with <c>true</c> once the server is healthy and
+        ///     serving (whole-scene warm-up may still be running or have partially failed — the server answers those
+        ///     per request), or <c>false</c> when it never came up (no binary and the download failed, launch failure,
+        ///     cancellation). On <c>false</c> the caller drops the optimized-assets override so the session falls
+        ///     back to production instead of the dead loopback port. Never faults. Single awaiter only.
         /// </summary>
-        public UniTask ReadyAsync => readyCompletionSource.Task;
+        public UniTask<bool> ReadyAsync => readyCompletionSource.Task;
 
         public AbgenSidecarPlugin(string baseUrl, RealmUrls realmUrls, DecentralandEnvironment environment)
         {
@@ -50,7 +52,8 @@ namespace DCL.PluginSystem.Global
             sidecar?.Dispose();
 
             // Covers teardown before InjectToWorld ever ran; otherwise RunAsync's finally completes it.
-            readyCompletionSource.TrySetResult();
+            // Not usable: nothing is serving, so any override must fall back to production.
+            readyCompletionSource.TrySetResult(false);
         }
 
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in GlobalPluginArguments arguments)
@@ -61,6 +64,8 @@ namespace DCL.PluginSystem.Global
 
         private async UniTaskVoid RunAsync(CancellationToken ct)
         {
+            bool usable = false;
+
             try
             {
                 // The canonical LSD realm — the same resolution the rest of the app runs on.
@@ -88,11 +93,20 @@ namespace DCL.PluginSystem.Global
                 sidecar = created;
 
                 if (await sidecar.StartAsync(ct))
+                {
+                    // Server is healthy: the override is valid even if the warm-up below fails, since bundles
+                    // JIT on demand and non-scene lanes stream through the read-through.
+                    usable = true;
                     await sidecar.WarmUpLocalSceneAsync(ct);
+
+                    // Detached for the sidecar's lifetime (it swallows its own exceptions): mirrors content-edit
+                    // reconversions into the AB panel. RunAsync must return so the boot-hold releases.
+                    sidecar.WatchReconversionsAsync(ct).Forget();
+                }
             }
             catch (OperationCanceledException) { }
             catch (Exception e) { ReportHub.LogException(e, ReportCategory.ASSET_BUNDLES); }
-            finally { readyCompletionSource.TrySetResult(); }
+            finally { readyCompletionSource.TrySetResult(usable); }
         }
     }
 }

--- a/docs/abgen-sidecar.md
+++ b/docs/abgen-sidecar.md
@@ -58,6 +58,16 @@ uses `CreateProcessW` with `CREATE_NO_WINDOW`, macOS/Linux the `DclProcesses` na
 `kill(pid, 0)`), not the managed `Exited` event. Only the editor keeps the managed `Process`
 path (with drained stdout/stderr pipes).
 
+**Orphan protection**: teardown is cooperative (Dispose kills the child), so a hard crash of the
+explorer used to leave the server running — and with the fixed default port an orphan *owns* the
+endpoint the next session expects. Two defenses: on Windows (player and editor) every child is
+assigned to a kill-on-close Job Object, so the kernel reaps it when the explorer dies for any
+reason; and `StartAsync` refuses to adopt a foreign listener — after the health check passes it
+verifies our own child is still alive, and if the port is answered by anything else (orphan from a
+crashed macOS session, unrelated process) it fails fast with an explicit milestone instead of
+silently serving stale bundles. macOS has no job-object equivalent; a parent-pid watchdog in abgen
+is the tracked upstream complement.
+
 Measured (Linux x86_64, CPU encoder): cold whole-entity JIT 0.8s (2-GLB scene) / 5.3s (24-GLB,
 12MB); warm disk-cache hits <1ms; server RSS ~16MB idle, 130–435MB peak during converts. v0.16.0's
 per-file parallelization cut cold whole-scene conversion by ~30 s on an M-series Mac against a real
@@ -83,13 +93,30 @@ failure). First run therefore enters the world with bundles already served; outs
 LSD + `--local-ab` the task is pre-completed and boot is unaffected. The wait is absorbed under
 the splash screen, before the authentication screen.
 
+**Clean fallback when the sidecar can't be had**: the readiness task resolves to a bool — false
+when the server never came up — and `MainSceneLoader` then drops the optimized-assets override
+(`DecentralandUrlsSource.ClearOptimizedAssetsOverride`, which also evicts the flag-dependent URL
+cache) before any optimized-asset request has resolved. The whole session — scene bundles,
+wearables, emotes, LODs, and the registry-composed profile/entities endpoints — falls back to the
+production hosts exactly as if `--local-ab` had not been passed, instead of hitting the dead
+loopback port and recovering per request. A server that turns healthy and dies later keeps the
+override (bundles JIT per request; supervision restarts it up to 3×).
+
 ## Visibility
 
 The scene dev console's AB tab mirrors `/progress/{entity}` live: the summary shows the server's
 authoritative `converted/total` counter, per-file rows show whatever the 500 ms poll catches
 (backfilled to the full census when the manifest lands), and milestone rows mark every lifecycle
 moment — download progress, installed, warm-up started, READY in Ns, already-warm, server-side
-failures (manifest exitCode), sidecar failed. The sidebar AB button pulses while conversion runs
+failures (manifest exitCode), sidecar failed. Content-edit reconversions are mirrored too: the LSD
+reload path (`LocalSceneDevelopmentController`, which already receives the preview server's edit
+message — including the changed model's path) raises a consumable signal on
+`AbgenConversionMetrics`; the sidecar's session-long watcher (`WatchReconversionsAsync`) consumes it
+and re-runs the manifest lane, which coalesces with (or triggers) the server's rebuild — the panel
+flips back to converting, names the edited file, tracks the rebuild and settles to READY with a
+"reconverted in Ns" milestone, accurate even when the rebuild outpaces the progress poll (texture
+edits arrive as unnamed whole-scene updates — sdk-commands only names `.glb/.gltf` changes).
+The sidebar AB button pulses while conversion runs
 and stays lit after unseen failures. The panel **opens itself** when long-running work starts
 (consumable open-request on `AbgenConversionMetrics`, consumed by `DebugMenuController`) and
 **closes itself** a few seconds after a clean READY — any failure keeps it open, and a manual

--- a/docs/abgen-sidecar.md
+++ b/docs/abgen-sidecar.md
@@ -36,7 +36,12 @@ loses content. The loading flow is untouched: bundles stream over loopback via
 standard v25+ hash-in-path lane (`{version}/{sceneID}/{hash}`). Deps digests are skipped in LSD
 (`SceneAssetBundleDigestsLoader` takes `isLocalSceneDevelopment`): LSD hashes are path-derived and
 unique per file, so the collisions digests disambiguate cannot occur, and skipping the second
-manifest download removes ~3 s of scene-entry latency against a JIT-revalidating server.
+manifest download removes ~3 s of scene-entry latency against a JIT-revalidating server. The scene
+lane's own manifest request is also served from a hand-off (`AbgenManifestPrewarm`): the warm-up
+(and, after edits, the reconversion watcher) stores the response it already awaited, keyed by the
+exact URL, and `LoadAssetBundleManifestSystem` reuses it instead of paying the server's content
+revalidation again — several more seconds on a large scene. A content edit invalidates the entry
+(the census may have changed), so a racing reload falls back to a fresh fetch.
 
 At boot the warm-up (`WarmUpLocalSceneAsync`) resolves the scene entity from the realm (`/about`
 `scenesUrn`, falling back to `localSceneParcels` + `POST /entities/active`) and requests its


### PR DESCRIPTION
Follow-ups to #9704 (explorer-owned abgen sidecar). Closes #9749, plus orphan-process hardening. Based on `main` (where #9704 landed); to be rebased/retargeted as the trunks sync.

## 1. AB panel mirrors content-edit reconversions (#9749)

QA-confirmed on Windows + macOS: replacing a GLB reconverted correctly, but the panel kept saying "SCENE ALREADY CONVERTED" — the `/progress` mirroring only existed inside the boot warm-up.

Now event-driven end to end: `LocalSceneDevelopmentController` (the websocket handler that already receives the preview server's edit messages) raises a consumable signal on `AbgenConversionMetrics` — carrying the changed model's path for `UpdateModel`, null for whole-scene updates — and the sidecar's session-long watcher consumes it and **re-runs the manifest lane itself**. That request coalesces with (or front-runs) the server's rebuild and returns when the build finishes, so the panel flips to converting, names the edited file, and settles to READY with an accurate "reconverted in Ns" even when the rebuild outpaces the 500 ms progress poll. Named edits always report "reconverted"; unnamed (code-only) updates with no observed build report "revalidated — bundles already up to date". The manifest+progress+census loop is extracted into `MirrorManifestBuildAsync`, shared verbatim with the boot warm-up. No new assembly wiring (SceneLifeCycle already references ECS.Unity); outside `--local-ab` the signal is never consumed and stays inert.

Known limit: texture edits arrive as unnamed whole-scene updates (sdk-commands names only `.glb/.gltf` in `file-watch-notifier.ts`) — mirrored anonymously; widening that gate is a candidate js-sdk-toolchain follow-up.

## 2. Clean production fallback when the sidecar can't be had (#9749)

`ReserveBaseUrl` seeds the optimized-assets override before the sidecar ever starts, and a download/launch failure used to leave the dead loopback port as the base for the whole session: the scene degraded per request, wearables/emotes lost their production-CDN bundles entirely (per-request GLTF fallback), and the registry-composed `Profiles`/`ProfilesMetadata`/`EntitiesActiveElements` endpoints ate a dead-port round trip each.

`AbgenSidecarPlugin.ReadyAsync` is now `UniTask<bool>` — true once the server is **healthy** (warm-up outcome doesn't gate it: bundles JIT per request), false when it never came up (download failure, launch failure, port owned by someone else, teardown before start). On false, `MainSceneLoader` calls `DecentralandUrlsSource.ClearOptimizedAssetsOverride()` at the boot-hold — before any optimized-asset URL has resolved — which nulls the override and evicts the `FeatureFlagsDependent` URL cache class (the one every affected endpoint, registry-composed included, resolves under). The session then behaves byte-for-byte as if `--local-ab` had not been passed. A server that turns healthy and dies later keeps the override: supervision restarts it up to 3×, and per-request recovery remains the safety net.

## 3. Orphan-process hardening

Teardown was purely cooperative (Dispose kills the child), so a hard crash of the explorer orphaned the server — and with #9704's fixed default port (`127.0.0.1:5147`), the orphan *owns the endpoint the next session expects*. The health check accepted any listener, so the new session's child died on bind while a stale server (old version after a pin bump, or another workspace's realm) was silently adopted. Reproduced in the wild during Windows testing.

- **Refuse adoption**: after the health check passes, `StartAsync` verifies our own child is still alive. If the port is answered by anything else, it fails fast with an explicit milestone ("another process owns … — kill it and relaunch") instead of serving stale bundles — and with §2, the session then falls back to production cleanly.
- **Windows kill-on-close Job Object** (player + editor): every child (including supervision restarts) is assigned to a job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, so the kernel reaps it when the explorer dies for any reason, crash included. Pure kernel32 P/Invoke, IL2CPP-safe, best-effort (failure leaves behavior exactly as before). macOS has no equivalent primitive; a parent-pid watchdog in abgen is the tracked upstream complement.

## 4. Scene-entry manifest reuse (~6 s on a large scene)

Boot already holds until the warm-up's manifest request returns — then the scene lane re-fetched the exact same URL seconds later, paying abgen's content revalidation (`ABGEN_JIT_CONTENT_DIGEST`) twice: ~6 s on a Genesis-Plaza-sized scene.

The sidecar now hands the awaited response over (`AbgenManifestPrewarm`, a single-entry holder keyed by the exact URL) and `LoadAssetBundleManifestSystem` consumes it instead of re-fetching, logging the reuse. A content edit invalidates the entry immediately (the file census may have changed) and the reconversion watcher's re-fetch repopulates it, so post-edit reloads benefit too; a reload that races the watcher just misses and fetches fresh. Any URL mismatch degrades silently to the normal network path, and outside `--local-ab` the holder is never populated.

## Related upstream work (not in this PR)

- [abgen#47](https://github.com/decentraland/abgen/pull/47) (open): namespaces the bind env vars as `ABGEN_HTTP_HOST`/`ABGEN_HTTP_PORT` with the legacy generic names kept as fallbacks. Once released and the pin is bumped, the explorer can return to a per-session free port — dissolving the single-instance limitation and shrinking the orphan-collision surface further.
- **Disk usage** (analyzed, fix pending upstream): the sidecar's LSD store measured ~981 MB for one Genesis-Plaza-sized scene — ~340 MB of built bundles stored **twice** (JIT bundle cache + the corpus layout the HTTP routes serve from; `build_entity_into_corpus` rewrites the bytes `bundle()` just cached) plus ~300 MB of mirrored source content. The corpus write becoming a hard link (the idiom that function already uses for the digest alias) halves the bundle storage; abgen PR to follow. The CLEAR CACHE button in the AB panel remains the manual relief valve.
- **macOS crash-orphan reaping**: no job-object equivalent exists there, so the complement to §3 is a parent-pid watchdog in abgen (exit when reparented); to be filed upstream.

## Test plan

- Cold boot into a large scene: log shows "manifest for {hash} served from the abgen warm-up hand-off" and scene entry skips the second ~6 s manifest wait.
- Edit a GLB with the scene warm: panel flips to converting, names the file, settles to "reconverted in Ns"; repeat with a sub-second edit — same, with accurate elapsed.
- Code-only edit: "scene content changed — revalidating bundles" → "revalidated — bundles already up to date"; no false "reconverted".
- Break the download (offline) on a machine without the binary: boot proceeds, wearables/emotes load their production-CDN bundles (not GLTFs), profiles resolve against production directly.
- Windows: kill the explorer from Task Manager mid-session → abgen.exe disappears with it; start a bare abgen manually, then launch the explorer → "another process owns http://127.0.0.1:5147" milestone, session on production/GLTFs.
- Outside `--local-ab`: no behavior change (signal unconsumed, readiness pre-completed true, no job object, no clear call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
