### PR TITLE
feat: abgen-registry feature flag to switch AB registry + CDN

### DIFF
--- a/.github/actions/ci-status-comment/action.yml
+++ b/.github/actions/ci-status-comment/action.yml
@@ -1,17 +1,17 @@
 name: Upsert CI Status Comment
 description: >-
   Create or update the single unified CI status comment on a PR, replacing only
-  the given section (build | lint | tests | automation). Seeds a skeleton with
-  every section the first time it runs, appends a missing section fence to
-  older comments, and re-reads/retries so concurrent writers (build vs. Unity
-  Test) never clobber each other's section.
+  the given section (build | lint | tests | performance | automation). Seeds a
+  skeleton with every section the first time it runs, appends a missing section
+  fence to older comments, and re-reads/retries so concurrent writers (build
+  vs. Unity Test) never clobber each other's section.
 
 inputs:
   pr-number:
     description: Pull request number to comment on.
     required: true
   section:
-    description: Which section to replace — one of build, lint, tests, automation.
+    description: Which section to replace — one of build, lint, tests, performance, automation.
     required: true
   body:
     description: Markdown for this section (inline badge + message). Rendered as-is between the section markers.

--- a/.github/actions/ci-status-comment/action.yml
+++ b/.github/actions/ci-status-comment/action.yml
@@ -1,16 +1,17 @@
 name: Upsert CI Status Comment
 description: >-
   Create or update the single unified CI status comment on a PR, replacing only
-  the given section (build | lint | tests). Seeds a skeleton with all three
-  sections the first time it runs, and re-reads/retries so concurrent writers
-  (build vs. Unity Test) never clobber each other's section.
+  the given section (build | lint | tests | automation). Seeds a skeleton with
+  every section the first time it runs, appends a missing section fence to
+  older comments, and re-reads/retries so concurrent writers (build vs. Unity
+  Test) never clobber each other's section.
 
 inputs:
   pr-number:
     description: Pull request number to comment on.
     required: true
   section:
-    description: Which section to replace — one of build, lint, tests.
+    description: Which section to replace — one of build, lint, tests, automation.
     required: true
   body:
     description: Markdown for this section (inline badge + message). Rendered as-is between the section markers.

--- a/.github/actions/ci-status-comment/upsert-ci-status.sh
+++ b/.github/actions/ci-status-comment/upsert-ci-status.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 # Create or update the single unified CI status comment on a PR, replacing only
-# one section (build | lint | tests | automation). All CI comment workflows call
-# this through the ci-status-comment composite action, so the separate bot
-# comments collapse into one.
+# one section (build | lint | tests | performance | automation). All CI comment
+# workflows call this through the ci-status-comment composite action, so the
+# separate bot comments collapse into one.
 #
 # The comment is keyed by the hidden <!-- ci-status --> marker and holds one
 # fenced block per section:
 #
 #   <!-- ci-status -->
 #   ### 🚦 CI Status
-#   <!-- ci:build:start -->      …build…      <!-- ci:build:end -->
-#   <!-- ci:lint:start -->       …lint…       <!-- ci:lint:end -->
-#   <!-- ci:tests:start -->      …tests…      <!-- ci:tests:end -->
-#   <!-- ci:automation:start --> …automation… <!-- ci:automation:end -->
+#   <!-- ci:build:start -->       …build…       <!-- ci:build:end -->
+#   <!-- ci:lint:start -->        …lint…        <!-- ci:lint:end -->
+#   <!-- ci:tests:start -->       …tests…       <!-- ci:tests:end -->
+#   <!-- ci:performance:start --> …performance… <!-- ci:performance:end -->
+#   <!-- ci:automation:start -->  …automation…  <!-- ci:automation:end -->
 #
 # Build and Unity Test run as independent workflows whose comment writers can
 # fire at the same time, so a plain read-modify-write would drop a section or
@@ -35,6 +36,7 @@ section_default() {
     lint)  printf '![Lint](https://img.shields.io/badge/Lint-Waiting-lightgrey?logo=jetbrains&logoColor=white&style=for-the-badge)\n\n_Waiting for lint to start…_' ;;
     tests) printf '![Tests](https://img.shields.io/badge/Tests-Waiting-lightgrey?logo=codecov&logoColor=white&style=for-the-badge)\n\n_Waiting for tests to start…_' ;;
     automation) printf '![Automation](https://img.shields.io/badge/Automation-On%%20demand-lightgrey?logo=github&logoColor=white&style=for-the-badge)\n\n_On demand — comment `/visual-tests` on this PR to run the visual regression suite against its build._' ;;
+    performance) printf '![Performance](https://img.shields.io/badge/Performance-Waiting-lightgrey?logo=speedtest&logoColor=white&style=for-the-badge)\n\n_Bare-metal benchmarks run automatically after each successful build; results arrive as a separate comment. Add the `perf_test` label to run the in-repo Unity performance suite instead (skips normal CI and blocks merge while set)._' ;;
   esac
 }
 
@@ -43,11 +45,12 @@ wrap_section() { printf '<!-- ci:%s:start -->\n%s\n<!-- ci:%s:end -->' "$1" "$2"
 
 # A fresh comment with every section defaulted to "waiting".
 skeleton() {
-  printf '%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n' \
+  printf '%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n' \
     "$MARKER" "$HEADER" \
     "$(wrap_section build "$(section_default build)")" \
     "$(wrap_section lint  "$(section_default lint)")" \
     "$(wrap_section tests "$(section_default tests)")" \
+    "$(wrap_section performance "$(section_default performance)")" \
     "$(wrap_section automation "$(section_default automation)")"
 }
 

--- a/.github/actions/ci-status-comment/upsert-ci-status.sh
+++ b/.github/actions/ci-status-comment/upsert-ci-status.sh
@@ -33,14 +33,28 @@ set -euo pipefail
 #                       find it, spawning duplicates).
 if [ -n "${SECTION_BODY_FILE:-}" ]; then
   SECTION_BODY="$(cat "$SECTION_BODY_FILE")"
-  # GitHub caps an issue comment at 65536 chars across every section; keep one
-  # writer from consuming the whole budget and failing an unrelated section's
-  # PATCH with an opaque 422. Truncation is fine for a status section that
-  # already links out to the full report.
-  if [ "${#SECTION_BODY}" -gt 20000 ]; then
-    echo "::warning::Section body is ${#SECTION_BODY} chars; truncating to 20000."
-    SECTION_BODY="${SECTION_BODY:0:20000}"$'\n\n'"_…truncated; see the linked run for the full report._"
+fi
+
+# GitHub caps an issue comment at 65536 chars across every section; keep one
+# writer — whichever path its body arrived by — from consuming the whole budget
+# and failing an unrelated section's PATCH with an opaque 422. Truncation is
+# fine for a status section that already links out to the full report.
+if [ "${#SECTION_BODY}" -gt 20000 ]; then
+  echo "::warning::Section body is ${#SECTION_BODY} chars; truncating to 20000."
+  SECTION_BODY="${SECTION_BODY:0:20000}"
+  # Close constructs the cut may have severed — an unterminated code fence or
+  # <details> makes GitHub render everything after it in this comment inside
+  # the open block, visually eating the neighbouring sections.
+  if [ $(( $(grep -c '^```' <<< "$SECTION_BODY") % 2 )) -ne 0 ]; then
+    SECTION_BODY="$SECTION_BODY"$'\n''```'
   fi
+  opens=$(grep -oi '<details' <<< "$SECTION_BODY" | wc -l || true)
+  closes=$(grep -oi '</details' <<< "$SECTION_BODY" | wc -l || true)
+  while [ "${opens:-0}" -gt "${closes:-0}" ]; do
+    SECTION_BODY="$SECTION_BODY"$'\n</details>'
+    closes=$((closes + 1))
+  done
+  SECTION_BODY="$SECTION_BODY"$'\n\n'"_…truncated; see the linked run for the full report._"
 fi
 
 # Fail fast on a section name outside the fence set — an unknown name would

--- a/.github/actions/ci-status-comment/upsert-ci-status.sh
+++ b/.github/actions/ci-status-comment/upsert-ci-status.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 # Create or update the single unified CI status comment on a PR, replacing only
-# one section (build | lint | tests). All three CI comment workflows call this
-# through the ci-status-comment composite action, so the three separate bot
+# one section (build | lint | tests | automation). All CI comment workflows call
+# this through the ci-status-comment composite action, so the separate bot
 # comments collapse into one.
 #
-# The comment is keyed by the hidden <!-- ci-status --> marker and holds three
-# sections, each fenced by its own start/end markers:
+# The comment is keyed by the hidden <!-- ci-status --> marker and holds one
+# fenced block per section:
 #
 #   <!-- ci-status -->
 #   ### 🚦 CI Status
-#   <!-- ci:build:start -->  …build…  <!-- ci:build:end -->
-#   <!-- ci:lint:start -->   …lint…   <!-- ci:lint:end -->
-#   <!-- ci:tests:start -->  …tests…  <!-- ci:tests:end -->
+#   <!-- ci:build:start -->      …build…      <!-- ci:build:end -->
+#   <!-- ci:lint:start -->       …lint…       <!-- ci:lint:end -->
+#   <!-- ci:tests:start -->      …tests…      <!-- ci:tests:end -->
+#   <!-- ci:automation:start --> …automation… <!-- ci:automation:end -->
 #
 # Build and Unity Test run as independent workflows whose comment writers can
 # fire at the same time, so a plain read-modify-write would drop a section or
@@ -33,6 +34,7 @@ section_default() {
     build) printf '![Build](https://img.shields.io/badge/Build-Waiting-lightgrey?logo=unity&logoColor=white&style=for-the-badge)\n\n_Waiting for the build to start…_' ;;
     lint)  printf '![Lint](https://img.shields.io/badge/Lint-Waiting-lightgrey?logo=jetbrains&logoColor=white&style=for-the-badge)\n\n_Waiting for lint to start…_' ;;
     tests) printf '![Tests](https://img.shields.io/badge/Tests-Waiting-lightgrey?logo=codecov&logoColor=white&style=for-the-badge)\n\n_Waiting for tests to start…_' ;;
+    automation) printf '![Automation](https://img.shields.io/badge/Automation-On%%20demand-lightgrey?logo=github&logoColor=white&style=for-the-badge)\n\n_On demand — comment `/visual-tests` on this PR to run the visual regression suite against its build._' ;;
   esac
 }
 
@@ -41,11 +43,12 @@ wrap_section() { printf '<!-- ci:%s:start -->\n%s\n<!-- ci:%s:end -->' "$1" "$2"
 
 # A fresh comment with every section defaulted to "waiting".
 skeleton() {
-  printf '%s\n%s\n\n%s\n\n%s\n\n%s\n' \
+  printf '%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n' \
     "$MARKER" "$HEADER" \
     "$(wrap_section build "$(section_default build)")" \
     "$(wrap_section lint  "$(section_default lint)")" \
-    "$(wrap_section tests "$(section_default tests)")"
+    "$(wrap_section tests "$(section_default tests)")" \
+    "$(wrap_section automation "$(section_default automation)")"
 }
 
 # Emit the section body for this run to a file so awk can splice it verbatim,
@@ -108,10 +111,14 @@ for attempt in 1 2 3 4 5; do
     CURRENT_BODY=""
   fi
 
-  # No unified comment yet, or one missing our section markers: start clean so
-  # all three sections are always present.
-  if [ -z "$CURRENT_BODY" ] || ! grep -qF "$START" <<< "$CURRENT_BODY"; then
+  # No unified comment yet: start from the full skeleton. A comment that exists
+  # but lacks our markers predates this section (e.g. it was written before the
+  # automation section existed) — append an empty fence for just our section
+  # instead of resetting the whole comment and wiping the other sections' state.
+  if [ -z "$CURRENT_BODY" ]; then
     CURRENT_BODY="$(skeleton)"
+  elif ! grep -qF "$START" <<< "$CURRENT_BODY"; then
+    CURRENT_BODY="$CURRENT_BODY"$'\n\n'"$(wrap_section "$SECTION" "$(section_default "$SECTION")")"
   fi
 
   NEW_BODY="$(replace_section "$CURRENT_BODY")"

--- a/.github/actions/ci-status-comment/upsert-ci-status.sh
+++ b/.github/actions/ci-status-comment/upsert-ci-status.sh
@@ -33,7 +33,23 @@ set -euo pipefail
 #                       find it, spawning duplicates).
 if [ -n "${SECTION_BODY_FILE:-}" ]; then
   SECTION_BODY="$(cat "$SECTION_BODY_FILE")"
+  # GitHub caps an issue comment at 65536 chars across every section; keep one
+  # writer from consuming the whole budget and failing an unrelated section's
+  # PATCH with an opaque 422. Truncation is fine for a status section that
+  # already links out to the full report.
+  if [ "${#SECTION_BODY}" -gt 20000 ]; then
+    echo "::warning::Section body is ${#SECTION_BODY} chars; truncating to 20000."
+    SECTION_BODY="${SECTION_BODY:0:20000}"$'\n\n'"_…truncated; see the linked run for the full report._"
+  fi
 fi
+
+# Fail fast on a section name outside the fence set — an unknown name would
+# append a dead fence to the shared comment and then wedge the survive check
+# for 5 attempts, burning ~15 API calls per write from then on.
+case "${SECTION:-}" in
+  build|lint|tests|performance|automation) ;;
+  *) echo "::error::Unknown section '${SECTION:-}'."; exit 2 ;;
+esac
 
 MARKER="<!-- ci-status -->"
 HEADER="### 🚦 CI Status"
@@ -114,12 +130,23 @@ for attempt in 1 2 3 4 5; do
   COMMENT_ID="${IDS[0]:-}"
 
   if [ -z "$COMMENT_ID" ] && [ -n "${NO_CREATE:-}" ]; then
-    echo "No unified CI status comment exists and NO_CREATE is set; leaving creation to the repo's own workflows."
-    exit 3
+    # Lose one round before falling back: an external caller often lands here
+    # seconds before the build workflow seeds the comment, and the standalone
+    # fallback it would post instead is noise that never collapses.
+    if [ "$attempt" -ge 2 ]; then
+      echo "No unified CI status comment exists and NO_CREATE is set; leaving creation to the repo's own workflows."
+      exit 3
+    fi
+    echo "No unified CI status comment yet (attempt $attempt); waiting for the repo's own workflows to seed it."
+    sleep $((attempt * 2))
+    continue
   fi
 
-  # Collapse accidental duplicates from a create race: keep the oldest, drop the rest.
-  if [ "${#IDS[@]}" -gt 1 ]; then
+  # Collapse accidental duplicates from a create race: keep the oldest, drop the
+  # rest. Skipped for external callers — comment GC belongs to this repo's own
+  # workflows, which run often enough to clean up within minutes, and a misfire
+  # under a foreign token would delete evidence with nothing logged.
+  if [ "${#IDS[@]}" -gt 1 ] && [ -z "${NO_CREATE:-}" ]; then
     for extra in "${IDS[@]:1}"; do
       echo "Deleting duplicate CI status comment $extra."
       gh api -X DELETE "/repos/$REPO/issues/comments/$extra" >/dev/null || true
@@ -138,7 +165,11 @@ for attempt in 1 2 3 4 5; do
   # instead of resetting the whole comment and wiping the other sections' state.
   if [ -z "$CURRENT_BODY" ]; then
     CURRENT_BODY="$(skeleton)"
-  elif ! grep -qF "$START" <<< "$CURRENT_BODY"; then
+  # -x: whole-line, matching replace_section/extract_section's $0==s exactly. A
+  # substring hit on a marker embedded in a body line (which the strip filter
+  # deliberately lets through) would skip fence creation here while the awk
+  # matchers see nothing — leaving the section permanently unwritable.
+  elif ! grep -qxF "$START" <<< "$CURRENT_BODY"; then
     CURRENT_BODY="$CURRENT_BODY"$'\n\n'"$(wrap_section "$SECTION" "$(section_default "$SECTION")")"
   fi
 

--- a/.github/actions/ci-status-comment/upsert-ci-status.sh
+++ b/.github/actions/ci-status-comment/upsert-ci-status.sh
@@ -22,6 +22,19 @@
 # confirm the section landed and no duplicate slipped in — retrying otherwise.
 set -euo pipefail
 
+# Optional caller knobs (used by decentraland/performance-testing, which runs
+# this script directly against unity-explorer's unified comment):
+#   SECTION_BODY_FILE — read the body from a file instead of $SECTION_BODY,
+#                       for bodies too large to pass comfortably via env.
+#   NO_CREATE=1       — never create the unified comment; exit 3 when it does
+#                       not exist so the caller can fall back to a standalone
+#                       comment (a foreign-token creation would not be authored
+#                       by github-actions[bot] and later writers would not
+#                       find it, spawning duplicates).
+if [ -n "${SECTION_BODY_FILE:-}" ]; then
+  SECTION_BODY="$(cat "$SECTION_BODY_FILE")"
+fi
+
 MARKER="<!-- ci-status -->"
 HEADER="### 🚦 CI Status"
 BOT="github-actions[bot]"
@@ -99,6 +112,11 @@ for attempt in 1 2 3 4 5; do
   IDS=()
   while IFS= read -r line; do [ -n "$line" ] && IDS+=("$line"); done <<< "$(marker_ids "$COMMENTS")"
   COMMENT_ID="${IDS[0]:-}"
+
+  if [ -z "$COMMENT_ID" ] && [ -n "${NO_CREATE:-}" ]; then
+    echo "No unified CI status comment exists and NO_CREATE is set; leaving creation to the repo's own workflows."
+    exit 3
+  fi
 
   # Collapse accidental duplicates from a create race: keep the oldest, drop the rest.
   if [ "${#IDS[@]}" -gt 1 ]; then

--- a/.github/actions/ucb-build-links/action.yml
+++ b/.github/actions/ucb-build-links/action.yml
@@ -16,7 +16,8 @@ inputs:
 outputs:
   rows:
     description: >-
-      "| Name | Link |"-shaped rows for an existing two-column table; empty when
+      "| Name | Link |"-shaped rows for an existing two-column table, pairing
+      each target's Unity Cloud build page with its GitHub job log; empty when
       no valid build info was found.
     value: ${{ steps.fetch.outputs.rows }}
   section:
@@ -61,17 +62,31 @@ runs:
           fi
         }
 
+        # Per-target GitHub job pages, from the trusted Actions API (jobs of the
+        # matrix job "Build (<target>)"), so each row pairs the Unity Cloud build
+        # page with the GitHub-side job log.
+        JOBS_JSON=$(gh api "/repos/$REPO_FULL/actions/runs/$RUN_ID/jobs?per_page=100" 2>/dev/null || echo '{"jobs":[]}')
+
         ROWS=""
         for entry in "windows64:Windows" "macos:Mac"; do
           target="${entry%%:*}"
           label="${entry#*:}"
           parse_info "$target"
-          # A URL without a valid id only occurs on a tampered artifact — drop the row
+          job_url=$(jq -r --arg n "Build ($target)" '.jobs[]? | select(.name==$n) | .html_url // empty' <<< "$JOBS_JSON" | head -1)
+
+          cell=""
+          # A URL without a valid id only occurs on a tampered artifact — drop the link
           # rather than render an empty "[#](...)" label.
           if [ -n "$REPLY_ID" ] && [ -n "$REPLY_URL" ]; then
-            ROWS+="| Unity Cloud build (${label}) | [#${REPLY_ID}](${REPLY_URL}) |"$'\n'
+            cell="[Unity Cloud #${REPLY_ID}](${REPLY_URL})"
           elif [ -n "$REPLY_ID" ]; then
-            ROWS+="| Unity Cloud build (${label}) | #${REPLY_ID} |"$'\n'
+            cell="Unity Cloud #${REPLY_ID}"
+          fi
+          if [ -n "$cell" ] && [ -n "$job_url" ]; then
+            cell="${cell} · [GitHub job](${job_url})"
+          fi
+          if [ -n "$cell" ]; then
+            ROWS+="| ${label} build | ${cell} |"$'\n'
           fi
         done
 

--- a/.github/actions/ucb-build-links/action.yml
+++ b/.github/actions/ucb-build-links/action.yml
@@ -41,7 +41,10 @@ runs:
         # The info files come out of the PR-controlled build workflow, so treat them as
         # untrusted input: accept only a numeric build id and a Unity dashboard URL with
         # a conservative charset before letting them anywhere near a comment body.
-        URL_RE='^https://(cloud\.unity\.com|developer\.cloud\.unity3d\.com|dashboard\.unity3d\.com)/[A-Za-z0-9./_%~?=&#-]*$'
+        # Mirrors the producer's '/builds/<id>' requirement (build.py) so the two
+        # validators agree, and pins the id to digits — a query-string-only path
+        # under a Unity host (open-redirect bait) no longer passes.
+        URL_RE='^https://(cloud\.unity\.com|developer\.cloud\.unity3d\.com|dashboard\.unity3d\.com)/[A-Za-z0-9./_%~?=&#-]*/builds/[0-9]+[A-Za-z0-9./_%~?=&#-]*$'
         parse_info() {
           local target="$1"
           local dir="ucb_info_${target}"

--- a/.github/actions/ucb-build-links/action.yml
+++ b/.github/actions/ucb-build-links/action.yml
@@ -1,0 +1,93 @@
+name: Fetch Unity Cloud Build Links
+description: >-
+  Download the unity_build_info_* artifacts of a Unity Cloud Build run and emit
+  sanitized markdown linking each build id to its Unity Cloud dashboard page:
+  bare table rows for appending to an existing two-column table, and a standalone
+  table section for comment bodies that have no table of their own.
+
+inputs:
+  run-id:
+    description: Workflow run id of the Unity Cloud Build run whose artifacts to read.
+    required: true
+  github-token:
+    description: Token used to download the run's artifacts.
+    required: true
+
+outputs:
+  rows:
+    description: >-
+      "| Name | Link |"-shaped rows for an existing two-column table; empty when
+      no valid build info was found.
+    value: ${{ steps.fetch.outputs.rows }}
+  section:
+    description: >-
+      Standalone table (header + rows); empty when no valid build info was found.
+    value: ${{ steps.fetch.outputs.section }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download and sanitize Unity Cloud build info
+      id: fetch
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        RUN_ID: ${{ inputs.run-id }}
+        REPO_FULL: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        # The info files come out of the PR-controlled build workflow, so treat them as
+        # untrusted input: accept only a numeric build id and a Unity dashboard URL with
+        # a conservative charset before letting them anywhere near a comment body.
+        URL_RE='^https://(cloud\.unity\.com|developer\.cloud\.unity3d\.com|dashboard\.unity3d\.com)/[A-Za-z0-9./_%~?=&#-]*$'
+        parse_info() {
+          local target="$1"
+          local dir="ucb_info_${target}"
+          REPLY_ID=""
+          REPLY_URL=""
+          if gh run download "$RUN_ID" \
+               --repo "$REPO_FULL" \
+               --name "unity_build_info_${target}_launcher" \
+               --dir "$dir" 2>"${dir}.err"; then
+            REPLY_ID=$(grep -m1 '^BUILD_ID=' "$dir/unity_cloud_build_info.env" | cut -d= -f2- || true)
+            REPLY_URL=$(grep -m1 '^DASHBOARD_URL=' "$dir/unity_cloud_build_info.env" | cut -d= -f2- || true)
+            [[ "$REPLY_ID" =~ ^[0-9]+$ ]] || REPLY_ID=""
+            [[ "$REPLY_URL" =~ $URL_RE ]] || REPLY_URL=""
+          else
+            # Absence is normal for runs predating the info artifact; still surface the
+            # gh error so an auth/permission regression doesn't silently eat the rows.
+            echo "note: could not fetch unity_build_info_${target}_launcher: $(tr '\n' ' ' < "${dir}.err")"
+          fi
+        }
+
+        ROWS=""
+        for entry in "windows64:Windows" "macos:Mac"; do
+          target="${entry%%:*}"
+          label="${entry#*:}"
+          parse_info "$target"
+          # A URL without a valid id only occurs on a tampered artifact — drop the row
+          # rather than render an empty "[#](...)" label.
+          if [ -n "$REPLY_ID" ] && [ -n "$REPLY_URL" ]; then
+            ROWS+="| Unity Cloud build (${label}) | [#${REPLY_ID}](${REPLY_URL}) |"$'\n'
+          elif [ -n "$REPLY_ID" ]; then
+            ROWS+="| Unity Cloud build (${label}) | #${REPLY_ID} |"$'\n'
+          fi
+        done
+
+        SECTION=""
+        if [ -n "$ROWS" ]; then
+          SECTION="| Name | Link |"$'\n'"| -------- | ----------------------- |"$'\n'"$ROWS"
+        fi
+
+        # The payload derives from artifact bytes, so the heredoc delimiter must not be
+        # guessable content even though the validation above already forbids newlines.
+        DELIM="UCB_EOF_${RANDOM}${RANDOM}_$$"
+        {
+          echo "rows<<${DELIM}"
+          printf '%s' "$ROWS"
+          echo "${DELIM}"
+          echo "section<<${DELIM}"
+          printf '%s' "$SECTION"
+          echo "${DELIM}"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -986,6 +986,8 @@ jobs:
           name: unity_build_info_${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}
           path: unity_cloud_build_info.env
           if-no-files-found: error
+          # Only consumed by the immediately-following PR status comment run.
+          retention-days: 7
 
       - name: Print cloud logs
         if: ${{ always() && hashFiles('unity_cloud_log.log') != '' }}

--- a/.github/workflows/build-unitycloud.yml
+++ b/.github/workflows/build-unitycloud.yml
@@ -976,6 +976,17 @@ jobs:
           path: unity_cloud_log.log
           if-no-files-found: error
 
+      # Written by build.py as soon as the Unity-side build id is known, so it exists for
+      # failed builds too. The PR status comment uses it to deep-link the Unity Cloud
+      # build page instead of asking humans to search cloud.unity.com by hand.
+      - name: Upload Unity Cloud build info
+        if: ${{ always() && hashFiles('unity_cloud_build_info.env') != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: unity_build_info_${{ matrix.target }}_${{ needs.prebuild.outputs.install_source }}
+          path: unity_cloud_build_info.env
+          if-no-files-found: error
+
       - name: Print cloud logs
         if: ${{ always() && hashFiles('unity_cloud_log.log') != '' }}
         run: cat unity_cloud_log.log

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       build-ran: ${{ steps.check.outputs.build-ran }}
+      player-artifacts: ${{ steps.check.outputs.player-artifacts }}
     steps:
       - name: Check if build jobs actually ran
         id: check
@@ -80,14 +81,24 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
-          # Check if any build artifacts exist (they only exist when Build jobs ran).
-          # unity_build_info_* is uploaded as soon as the Unity-side build starts, so a
-          # build that failed before producing player artifacts still counts as "ran"
-          # and gets a failure comment with a Unity Cloud link instead of staying pending.
-          ARTIFACT_COUNT=$(gh api "/repos/$OWNER/$REPO/actions/runs/$RUN_ID/artifacts" \
-            --jq '[.artifacts[] | select((.name | startswith("Decentraland_")) or (.name | startswith("unity_build_info_")))] | length')
-          echo "Build artifact count: $ARTIFACT_COUNT"
-          if [ "$ARTIFACT_COUNT" -gt 0 ]; then
+          # player-artifacts: Decentraland_* zips exist. comment-success interpolates
+          # their artifact ids into download URLs, so the success/skipped split must
+          # keep gating on this and only this.
+          # build-ran: any evidence a Unity-side build started. unity_build_info_* is
+          # uploaded as soon as the build id is known, so a build that failed before
+          # producing player artifacts still posts a failure comment (with the Unity
+          # Cloud link) instead of leaving the comment stuck on "Pending".
+          NAMES=$(gh api "/repos/$OWNER/$REPO/actions/runs/$RUN_ID/artifacts" \
+            --jq '[.artifacts[].name]')
+          PLAYER_COUNT=$(jq 'map(select(startswith("Decentraland_"))) | length' <<< "$NAMES")
+          INFO_COUNT=$(jq 'map(select(startswith("unity_build_info_"))) | length' <<< "$NAMES")
+          echo "Player artifact count: $PLAYER_COUNT; build info artifact count: $INFO_COUNT"
+          if [ "$PLAYER_COUNT" -gt 0 ]; then
+            echo "player-artifacts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "player-artifacts=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "$PLAYER_COUNT" -gt 0 ] || [ "$INFO_COUNT" -gt 0 ]; then
             echo "build-ran=true" >> "$GITHUB_OUTPUT"
           else
             echo "build-ran=false" >> "$GITHUB_OUTPUT"
@@ -95,7 +106,7 @@ jobs:
 
   comment-skipped:
     needs: [pre-validation, check-build-ran]
-    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.build-ran == 'false'
+    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.player-artifacts == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CI status action
@@ -118,13 +129,15 @@ jobs:
 
   comment-success:
     needs: [pre-validation, check-build-ran]
-    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.build-ran == 'true'
+    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.player-artifacts == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CI status action
         uses: actions/checkout@v6
         with:
-          sparse-checkout: .github/actions/ci-status-comment
+          sparse-checkout: |
+            .github/actions/ci-status-comment
+            .github/actions/ucb-build-links
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -234,52 +247,11 @@ jobs:
           fi
 
       - name: Fetch Unity Cloud build links
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
-        run: |
-          set -euo pipefail
-
-          # The info files come out of the PR-controlled build workflow, so treat them as
-          # untrusted input: accept only a numeric build id and a Unity dashboard URL with
-          # a conservative charset before letting them anywhere near the comment body.
-          URL_RE='^https://(cloud\.unity\.com|developer\.cloud\.unity3d\.com|dashboard\.unity3d\.com)/[A-Za-z0-9./_%~?=&-]*$'
-          parse_info() {
-            local target="$1"
-            local dir="ucb_info_${target}"
-            REPLY_ID=""
-            REPLY_URL=""
-            if gh run download "$PREVIOUS_JOB_ID" \
-                 --repo "$OWNER/$REPO" \
-                 --name "unity_build_info_${target}_launcher" \
-                 --dir "$dir" 2>/dev/null; then
-              REPLY_ID=$(grep -m1 '^BUILD_ID=' "$dir/unity_cloud_build_info.env" | cut -d= -f2- || true)
-              REPLY_URL=$(grep -m1 '^DASHBOARD_URL=' "$dir/unity_cloud_build_info.env" | cut -d= -f2- || true)
-              [[ "$REPLY_ID" =~ ^[0-9]+$ ]] || REPLY_ID=""
-              [[ "$REPLY_URL" =~ $URL_RE ]] || REPLY_URL=""
-            fi
-          }
-
-          ROWS=""
-          parse_info windows64
-          if [ -n "$REPLY_URL" ]; then
-            ROWS+="| Unity Cloud build (Windows) | [#${REPLY_ID}](${REPLY_URL}) |"$'\n'
-          elif [ -n "$REPLY_ID" ]; then
-            ROWS+="| Unity Cloud build (Windows) | #${REPLY_ID} |"$'\n'
-          fi
-          parse_info macos
-          if [ -n "$REPLY_URL" ]; then
-            ROWS+="| Unity Cloud build (Mac) | [#${REPLY_ID}](${REPLY_URL}) |"$'\n'
-          elif [ -n "$REPLY_ID" ]; then
-            ROWS+="| Unity Cloud build (Mac) | #${REPLY_ID} |"$'\n'
-          fi
-
-          {
-            echo "UCB_ROWS<<UCB_ROWS_EOF"
-            printf '%s' "$ROWS"
-            echo "UCB_ROWS_EOF"
-          } >> "$GITHUB_ENV"
+        id: ucb
+        uses: ./.github/actions/ucb-build-links
+        with:
+          run-id: ${{ env.PREVIOUS_JOB_ID }}
+          github-token: ${{ github.token }}
 
       - name: Update build section
         uses: ./.github/actions/ci-status-comment
@@ -301,7 +273,7 @@ jobs:
             | Download Mac        | ${{ github.server_url }}/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.MAC_ARTIFACT_ID }} |
             | Download Mac S3     | ${{ format('{0}/{1}/Decentraland_macos.zip', vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL, env.ARTIFACT_S3_DESTINATION_PATH) }} |
             | Built on            | ${{ env.BUILD_DATE }} |
-            ${{ env.UCB_ROWS }}
+            ${{ steps.ucb.outputs.rows }}
 
             ${{ env.SIZE_REPORT }}
 
@@ -338,63 +310,18 @@ jobs:
       - name: Checkout CI status action
         uses: actions/checkout@v6
         with:
-          sparse-checkout: .github/actions/ci-status-comment
+          sparse-checkout: |
+            .github/actions/ci-status-comment
+            .github/actions/ucb-build-links
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
       - name: Fetch Unity Cloud build links
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-        run: |
-          set -euo pipefail
-
-          # The info files come out of the PR-controlled build workflow, so treat them as
-          # untrusted input: accept only a numeric build id and a Unity dashboard URL with
-          # a conservative charset before letting them anywhere near the comment body.
-          URL_RE='^https://(cloud\.unity\.com|developer\.cloud\.unity3d\.com|dashboard\.unity3d\.com)/[A-Za-z0-9./_%~?=&-]*$'
-          parse_info() {
-            local target="$1"
-            local dir="ucb_info_${target}"
-            REPLY_ID=""
-            REPLY_URL=""
-            if gh run download "$RUN_ID" \
-                 --repo "$OWNER/$REPO" \
-                 --name "unity_build_info_${target}_launcher" \
-                 --dir "$dir" 2>/dev/null; then
-              REPLY_ID=$(grep -m1 '^BUILD_ID=' "$dir/unity_cloud_build_info.env" | cut -d= -f2- || true)
-              REPLY_URL=$(grep -m1 '^DASHBOARD_URL=' "$dir/unity_cloud_build_info.env" | cut -d= -f2- || true)
-              [[ "$REPLY_ID" =~ ^[0-9]+$ ]] || REPLY_ID=""
-              [[ "$REPLY_URL" =~ $URL_RE ]] || REPLY_URL=""
-            fi
-          }
-
-          ROWS=""
-          parse_info windows64
-          if [ -n "$REPLY_URL" ]; then
-            ROWS+="| Unity Cloud build (Windows) | [#${REPLY_ID}](${REPLY_URL}) |"$'\n'
-          elif [ -n "$REPLY_ID" ]; then
-            ROWS+="| Unity Cloud build (Windows) | #${REPLY_ID} |"$'\n'
-          fi
-          parse_info macos
-          if [ -n "$REPLY_URL" ]; then
-            ROWS+="| Unity Cloud build (Mac) | [#${REPLY_ID}](${REPLY_URL}) |"$'\n'
-          elif [ -n "$REPLY_ID" ]; then
-            ROWS+="| Unity Cloud build (Mac) | #${REPLY_ID} |"$'\n'
-          fi
-
-          SECTION=""
-          if [ -n "$ROWS" ]; then
-            SECTION="| Name | Link |"$'\n'"| -------- | ----------------------- |"$'\n'"$ROWS"
-          fi
-
-          {
-            echo "UCB_SECTION<<UCB_SECTION_EOF"
-            printf '%s' "$SECTION"
-            echo "UCB_SECTION_EOF"
-          } >> "$GITHUB_ENV"
+        id: ucb
+        uses: ./.github/actions/ucb-build-links
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
 
       - name: Update build section
         uses: ./.github/actions/ci-status-comment
@@ -408,4 +335,4 @@ jobs:
             Build failed! Check the [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}) to see what went wrong.
             If the error repeats please consider the `clean-build` tag.
 
-            ${{ env.UCB_SECTION }}
+            ${{ steps.ucb.outputs.section }}

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -88,7 +88,11 @@ jobs:
           # uploaded as soon as the build id is known, so a build that failed before
           # producing player artifacts still posts a failure comment (with the Unity
           # Cloud link) instead of leaving the comment stuck on "Pending".
-          NAMES=$(gh api "/repos/$OWNER/$REPO/actions/runs/$RUN_ID/artifacts" \
+          # per_page=100: the default page holds 30 and a two-target run already
+          # uploads ~a dozen artifacts — unity_build_info_* falling off page 1
+          # would read as build-ran=false, the exact stuck-on-Pending bug the
+          # flag exists to prevent.
+          NAMES=$(gh api "/repos/$OWNER/$REPO/actions/runs/$RUN_ID/artifacts?per_page=100" \
             --jq '[.artifacts[].name]')
           PLAYER_COUNT=$(jq 'map(select(startswith("Decentraland_"))) | length' <<< "$NAMES")
           INFO_COUNT=$(jq 'map(select(startswith("unity_build_info_"))) | length' <<< "$NAMES")
@@ -308,13 +312,20 @@ jobs:
       # expiry canary — the 2026-06..08 outage was exactly this token expiring
       # with no warning anywhere a human looks.
       - name: Probe performance PAT expiry
+        # Purely decorative — its whole output is one optional sentence, so it
+        # must never gate the dispatched/dispatch-failed section writes below.
         if: steps.perf_dispatch.outcome == 'success'
+        continue-on-error: true
         env:
           PAT: ${{ secrets.PERFORMANCE_TESTING_PAT }}
         run: |
           set -euo pipefail
-          exp=$(curl -sI -H "Authorization: Bearer $PAT" https://api.github.com/repos/decentraland/performance-testing \
-            | tr -d '\r' | grep -i '^github-authentication-token-expiration:' | cut -d' ' -f2- || true)
+          # The expiry header rides every authenticated call; /rate_limit spends
+          # no quota and names no repo that could drift. gh reads the token from
+          # the environment, keeping it out of any process's argv. head -1 keeps
+          # $GITHUB_ENV single-line even if the response ever repeats the header.
+          exp=$(GH_TOKEN="$PAT" timeout 15 gh api --include --method HEAD /rate_limit 2>/dev/null \
+            | tr -d '\r' | grep -i '^github-authentication-token-expiration:' | head -1 | cut -d' ' -f2- || true)
           msg=""
           if [ -n "$exp" ]; then
             exp_s=$(date -d "$exp" +%s 2>/dev/null || echo 0)
@@ -325,6 +336,8 @@ jobs:
                 msg="⚠️ \`PERFORMANCE_TESTING_PAT\` expires in **$days days** ($exp) — rotate it before benchmark dispatches start failing."
               fi
             fi
+          else
+            echo "::warning::No github-authentication-token-expiration header returned — PAT expiry cannot be monitored."
           fi
           echo "PAT_EXPIRY_WARNING=$msg" >> "$GITHUB_ENV"
 
@@ -349,8 +362,12 @@ jobs:
       # cause — it broke silently from 2026-06-15 to 2026-08-13) turns this job
       # red but leaves no trace on the PR; surface it in the performance section
       # so it cannot go unnoticed for weeks again.
+      # outcome != 'success' rather than == 'failure': anything failing between
+      # the checkout and the dispatch (Find latest release, the build-section
+      # upsert) skips perf_dispatch, and a skipped dispatch is the same silence
+      # on the PR as a failed one.
       - name: Mark performance section as dispatch-failed
-        if: failure() && steps.perf_dispatch.outcome == 'failure'
+        if: failure() && steps.perf_dispatch.outcome != 'success'
         uses: ./.github/actions/ci-status-comment
         with:
           pr-number: ${{ needs.pre-validation.outputs.pr-number }}
@@ -359,7 +376,7 @@ jobs:
           body: |-
             [![Performance](https://img.shields.io/badge/Performance-Dispatch%20failed-ff0000?logo=speedtest&logoColor=white&style=for-the-badge)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-            ❌ Could not dispatch the bare-metal benchmark — see the [step log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). If it says "Repository not found, OR token has insufficient permissions", the `PERFORMANCE_TESTING_PAT` secret has expired and needs to be rotated.
+            ❌ Could not dispatch the bare-metal benchmark (the job failed before or during the dispatch) — see the [step log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). If it says "Repository not found, OR token has insufficient permissions", the `PERFORMANCE_TESTING_PAT` secret has expired and needs to be rotated.
 
   comment-failed:
     needs: [pre-validation, check-build-ran]

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -61,7 +61,7 @@ jobs:
           section: build
           github-token: ${{ github.token }}
           body: |-
-            ![Build](https://img.shields.io/badge/Build-Pending!-ffff00?logo=github&style=for-the-badge)  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">
+            [![Build](https://img.shields.io/badge/Build-Pending!-ffff00?logo=github&style=for-the-badge)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">
 
             New build in progress, come back later!
 
@@ -80,9 +80,12 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
-          # Check if any build artifacts exist (they only exist when Build jobs ran)
+          # Check if any build artifacts exist (they only exist when Build jobs ran).
+          # unity_build_info_* is uploaded as soon as the Unity-side build starts, so a
+          # build that failed before producing player artifacts still counts as "ran"
+          # and gets a failure comment with a Unity Cloud link instead of staying pending.
           ARTIFACT_COUNT=$(gh api "/repos/$OWNER/$REPO/actions/runs/$RUN_ID/artifacts" \
-            --jq '[.artifacts[] | select(.name | startswith("Decentraland_"))] | length')
+            --jq '[.artifacts[] | select((.name | startswith("Decentraland_")) or (.name | startswith("unity_build_info_")))] | length')
           echo "Build artifact count: $ARTIFACT_COUNT"
           if [ "$ARTIFACT_COUNT" -gt 0 ]; then
             echo "build-ran=true" >> "$GITHUB_OUTPUT"
@@ -109,7 +112,7 @@ jobs:
           section: build
           github-token: ${{ github.token }}
           body: |-
-            ![Build](https://img.shields.io/badge/Build-Skipped-yellow?logo=unity&logoColor=white&style=for-the-badge)  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">
+            [![Build](https://img.shields.io/badge/Build-Skipped-yellow?logo=unity&logoColor=white&style=for-the-badge)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">
 
             Build skipped — no changes detected under `Explorer/`.
 
@@ -230,6 +233,54 @@ jobs:
             echo "SIZE_REPORT=" >> "$GITHUB_ENV"
           fi
 
+      - name: Fetch Unity Cloud build links
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+
+          # The info files come out of the PR-controlled build workflow, so treat them as
+          # untrusted input: accept only a numeric build id and a Unity dashboard URL with
+          # a conservative charset before letting them anywhere near the comment body.
+          URL_RE='^https://(cloud\.unity\.com|developer\.cloud\.unity3d\.com|dashboard\.unity3d\.com)/[A-Za-z0-9./_%~?=&-]*$'
+          parse_info() {
+            local target="$1"
+            local dir="ucb_info_${target}"
+            REPLY_ID=""
+            REPLY_URL=""
+            if gh run download "$PREVIOUS_JOB_ID" \
+                 --repo "$OWNER/$REPO" \
+                 --name "unity_build_info_${target}_launcher" \
+                 --dir "$dir" 2>/dev/null; then
+              REPLY_ID=$(grep -m1 '^BUILD_ID=' "$dir/unity_cloud_build_info.env" | cut -d= -f2- || true)
+              REPLY_URL=$(grep -m1 '^DASHBOARD_URL=' "$dir/unity_cloud_build_info.env" | cut -d= -f2- || true)
+              [[ "$REPLY_ID" =~ ^[0-9]+$ ]] || REPLY_ID=""
+              [[ "$REPLY_URL" =~ $URL_RE ]] || REPLY_URL=""
+            fi
+          }
+
+          ROWS=""
+          parse_info windows64
+          if [ -n "$REPLY_URL" ]; then
+            ROWS+="| Unity Cloud build (Windows) | [#${REPLY_ID}](${REPLY_URL}) |"$'\n'
+          elif [ -n "$REPLY_ID" ]; then
+            ROWS+="| Unity Cloud build (Windows) | #${REPLY_ID} |"$'\n'
+          fi
+          parse_info macos
+          if [ -n "$REPLY_URL" ]; then
+            ROWS+="| Unity Cloud build (Mac) | [#${REPLY_ID}](${REPLY_URL}) |"$'\n'
+          elif [ -n "$REPLY_ID" ]; then
+            ROWS+="| Unity Cloud build (Mac) | #${REPLY_ID} |"$'\n'
+          fi
+
+          {
+            echo "UCB_ROWS<<UCB_ROWS_EOF"
+            printf '%s' "$ROWS"
+            echo "UCB_ROWS_EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Update build section
         uses: ./.github/actions/ci-status-comment
         with:
@@ -237,7 +288,7 @@ jobs:
           section: build
           github-token: ${{ github.token }}
           body: |-
-            ![Build](https://img.shields.io/badge/Build-Success!-3fb950?logo=unity&logoColor=white&style=for-the-badge)  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">
+            [![Build](https://img.shields.io/badge/Build-Success!-3fb950?logo=unity&logoColor=white&style=for-the-badge)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ env.PREVIOUS_JOB_ID }})  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">
 
             Windows and Mac build successful in Unity Cloud! You can find a link to the downloadable artifact below.
 
@@ -250,6 +301,7 @@ jobs:
             | Download Mac        | ${{ github.server_url }}/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.MAC_ARTIFACT_ID }} |
             | Download Mac S3     | ${{ format('{0}/{1}/Decentraland_macos.zip', vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL, env.ARTIFACT_S3_DESTINATION_PATH) }} |
             | Built on            | ${{ env.BUILD_DATE }} |
+            ${{ env.UCB_ROWS }}
 
             ${{ env.SIZE_REPORT }}
 
@@ -290,6 +342,60 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
+      - name: Fetch Unity Cloud build links
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          # The info files come out of the PR-controlled build workflow, so treat them as
+          # untrusted input: accept only a numeric build id and a Unity dashboard URL with
+          # a conservative charset before letting them anywhere near the comment body.
+          URL_RE='^https://(cloud\.unity\.com|developer\.cloud\.unity3d\.com|dashboard\.unity3d\.com)/[A-Za-z0-9./_%~?=&-]*$'
+          parse_info() {
+            local target="$1"
+            local dir="ucb_info_${target}"
+            REPLY_ID=""
+            REPLY_URL=""
+            if gh run download "$RUN_ID" \
+                 --repo "$OWNER/$REPO" \
+                 --name "unity_build_info_${target}_launcher" \
+                 --dir "$dir" 2>/dev/null; then
+              REPLY_ID=$(grep -m1 '^BUILD_ID=' "$dir/unity_cloud_build_info.env" | cut -d= -f2- || true)
+              REPLY_URL=$(grep -m1 '^DASHBOARD_URL=' "$dir/unity_cloud_build_info.env" | cut -d= -f2- || true)
+              [[ "$REPLY_ID" =~ ^[0-9]+$ ]] || REPLY_ID=""
+              [[ "$REPLY_URL" =~ $URL_RE ]] || REPLY_URL=""
+            fi
+          }
+
+          ROWS=""
+          parse_info windows64
+          if [ -n "$REPLY_URL" ]; then
+            ROWS+="| Unity Cloud build (Windows) | [#${REPLY_ID}](${REPLY_URL}) |"$'\n'
+          elif [ -n "$REPLY_ID" ]; then
+            ROWS+="| Unity Cloud build (Windows) | #${REPLY_ID} |"$'\n'
+          fi
+          parse_info macos
+          if [ -n "$REPLY_URL" ]; then
+            ROWS+="| Unity Cloud build (Mac) | [#${REPLY_ID}](${REPLY_URL}) |"$'\n'
+          elif [ -n "$REPLY_ID" ]; then
+            ROWS+="| Unity Cloud build (Mac) | #${REPLY_ID} |"$'\n'
+          fi
+
+          SECTION=""
+          if [ -n "$ROWS" ]; then
+            SECTION="| Name | Link |"$'\n'"| -------- | ----------------------- |"$'\n'"$ROWS"
+          fi
+
+          {
+            echo "UCB_SECTION<<UCB_SECTION_EOF"
+            printf '%s' "$SECTION"
+            echo "UCB_SECTION_EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Update build section
         uses: ./.github/actions/ci-status-comment
         with:
@@ -297,7 +403,9 @@ jobs:
           section: build
           github-token: ${{ github.token }}
           body: |-
-            ![Build](https://img.shields.io/badge/Build-Failed!-ff0000?logo=unity&logoColor=white&style=for-the-badge)  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">
+            [![Build](https://img.shields.io/badge/Build-Failed!-ff0000?logo=unity&logoColor=white&style=for-the-badge)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})  <img src="https://ui.decentraland.org/decentraland_256x256.png" width="30">
 
-            Build failed! Check the logs to see what went wrong.
+            Build failed! Check the [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}) to see what went wrong.
             If the error repeats please consider the `clean-build` tag.
+
+            ${{ env.UCB_SECTION }}

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -318,6 +318,22 @@ jobs:
 
             🏁 Bare-metal benchmark dispatched for this build ([run queue](https://github.com/decentraland/performance-testing/actions/workflows/unity-explorer.yaml)) — results across the runner fleet will be posted as a separate `perf-test-summary` comment.
 
+      # A failing dispatch (an expired PERFORMANCE_TESTING_PAT is the historical
+      # cause — it broke silently from 2026-06-15 to 2026-08-13) turns this job
+      # red but leaves no trace on the PR; surface it in the performance section
+      # so it cannot go unnoticed for weeks again.
+      - name: Mark performance section as dispatch-failed
+        if: failure() && steps.perf_dispatch.outcome == 'failure'
+        uses: ./.github/actions/ci-status-comment
+        with:
+          pr-number: ${{ needs.pre-validation.outputs.pr-number }}
+          section: performance
+          github-token: ${{ github.token }}
+          body: |-
+            [![Performance](https://img.shields.io/badge/Performance-Dispatch%20failed-ff0000?logo=speedtest&logoColor=white&style=for-the-badge)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            ❌ Could not dispatch the bare-metal benchmark — see the [step log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). If it says "Repository not found, OR token has insufficient permissions", the `PERFORMANCE_TESTING_PAT` secret has expired and needs to be rotated.
+
   comment-failed:
     needs: [pre-validation, check-build-ran]
     if: github.event.workflow_run.conclusion == 'failure' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.build-ran == 'true'

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -303,6 +303,31 @@ jobs:
               "mac_base_build_url": "${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}/@dcl/unity-explorer/releases/${{ env.RELEASE_TAG }}/Decentraland_macos.zip"
             }
 
+      # The PAT's remaining lifetime comes back as a response header on any API
+      # call it makes; surfacing it in the status comment replaces a separate
+      # expiry canary — the 2026-06..08 outage was exactly this token expiring
+      # with no warning anywhere a human looks.
+      - name: Probe performance PAT expiry
+        if: steps.perf_dispatch.outcome == 'success'
+        env:
+          PAT: ${{ secrets.PERFORMANCE_TESTING_PAT }}
+        run: |
+          set -euo pipefail
+          exp=$(curl -sI -H "Authorization: Bearer $PAT" https://api.github.com/repos/decentraland/performance-testing \
+            | tr -d '\r' | grep -i '^github-authentication-token-expiration:' | cut -d' ' -f2- || true)
+          msg=""
+          if [ -n "$exp" ]; then
+            exp_s=$(date -d "$exp" +%s 2>/dev/null || echo 0)
+            if [ "$exp_s" -gt 0 ]; then
+              days=$(( (exp_s - $(date +%s)) / 86400 ))
+              echo "PERFORMANCE_TESTING_PAT expires in $days days ($exp)"
+              if [ "$days" -lt 30 ]; then
+                msg="⚠️ \`PERFORMANCE_TESTING_PAT\` expires in **$days days** ($exp) — rotate it before benchmark dispatches start failing."
+              fi
+            fi
+          fi
+          echo "PAT_EXPIRY_WARNING=$msg" >> "$GITHUB_ENV"
+
       # repository_dispatch is fire-and-forget (no run id comes back), so this
       # links the target workflow's run list; the benchmark itself posts a
       # separate perf-test-summary comment with its run link when it finishes.
@@ -317,6 +342,8 @@ jobs:
             [![Performance](https://img.shields.io/badge/Performance-Dispatched!-ffff00?logo=speedtest&logoColor=white&style=for-the-badge)](https://github.com/decentraland/performance-testing/actions/workflows/unity-explorer.yaml)
 
             🏁 Bare-metal benchmark dispatched for this build ([run queue](https://github.com/decentraland/performance-testing/actions/workflows/unity-explorer.yaml)) — results across the runner fleet will be posted as a separate `perf-test-summary` comment.
+
+            ${{ env.PAT_EXPIRY_WARNING }}
 
       # A failing dispatch (an expired PERFORMANCE_TESTING_PAT is the historical
       # cause — it broke silently from 2026-06-15 to 2026-08-13) turns this job

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -283,6 +283,7 @@ jobs:
         run: gh release view -R $GITHUB_REPOSITORY --json tagName --template "RELEASE_TAG={{.tagName}}" >> $GITHUB_ENV
 
       - name: Trigger performance test
+        id: perf_dispatch
         uses: peter-evans/repository-dispatch@v4
         with:
           repository: decentraland/performance-testing
@@ -301,6 +302,21 @@ jobs:
               "mac_change_build_url": ${{ toJSON(format('{0}/{1}/Decentraland_macos.zip', vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL, env.ARTIFACT_S3_DESTINATION_PATH)) }},
               "mac_base_build_url": "${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}/@dcl/unity-explorer/releases/${{ env.RELEASE_TAG }}/Decentraland_macos.zip"
             }
+
+      # repository_dispatch is fire-and-forget (no run id comes back), so this
+      # links the target workflow's run list; the benchmark itself posts a
+      # separate perf-test-summary comment with its run link when it finishes.
+      - name: Mark performance section as dispatched
+        if: steps.perf_dispatch.outcome == 'success'
+        uses: ./.github/actions/ci-status-comment
+        with:
+          pr-number: ${{ needs.pre-validation.outputs.pr-number }}
+          section: performance
+          github-token: ${{ github.token }}
+          body: |-
+            [![Performance](https://img.shields.io/badge/Performance-Dispatched!-ffff00?logo=speedtest&logoColor=white&style=for-the-badge)](https://github.com/decentraland/performance-testing/actions/workflows/unity-explorer.yaml)
+
+            🏁 Bare-metal benchmark dispatched for this build ([run queue](https://github.com/decentraland/performance-testing/actions/workflows/unity-explorer.yaml)) — results across the runner fleet will be posted as a separate `perf-test-summary` comment.
 
   comment-failed:
     needs: [pre-validation, check-build-ran]

--- a/.github/workflows/pr-comment-perf.yml
+++ b/.github/workflows/pr-comment-perf.yml
@@ -1,0 +1,120 @@
+# pr-comment-perf.yml
+---
+name: Comment Performance Results on PR
+
+# Runs in the trusted base-repo context after the (possibly fork) "Unity
+# Performance Test" run completes, and writes the "performance" section of the
+# unified CI status comment. Mirrors pr-comment-test-failures.yml.
+#
+# "Unity Performance Test" fires on every PR event but its job gates on the
+# 'perf_test' label, so most runs conclude 'success' with the job skipped —
+# those must not touch the section (it belongs to the bare-metal benchmark
+# status written by pr-comment-artifact-url.yml on label-less PRs).
+on:
+  workflow_run:
+    types:
+      - "completed"
+    workflows:
+      - "Unity Performance Test"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number
+        id: pr
+        env:
+          WORKFLOW_RUN_EVENT_OBJ: ${{ toJSON(github.event.workflow_run) }}
+        run: |
+          PR_NUMBER=$(jq -r '.pull_requests[0].number' <<< "$WORKFLOW_RUN_EVENT_OBJ")
+          echo "PR number: $PR_NUMBER"
+          if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
+            echo "No PR associated with this run, skipping."
+            echo "pr-number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check the performance job actually ran
+        id: ran
+        if: steps.pr.outputs.pr-number != ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          CONCLUSION=$(gh api "/repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" \
+            --jq '[.jobs[] | select(.name | startswith("Performance Test"))][0].conclusion // "absent"')
+          echo "Performance job conclusion: $CONCLUSION"
+          if [ "$CONCLUSION" = "skipped" ] || [ "$CONCLUSION" = "absent" ]; then
+            echo "ran=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ran=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compose comment body
+        id: body
+        if: steps.pr.outputs.pr-number != '' && steps.ran.outputs.ran == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+          BADGE_STYLE="?logo=speedtest&logoColor=white&style=for-the-badge"
+          case "$CONCLUSION" in
+            success) BADGE="https://img.shields.io/badge/Performance-Passed!-3fb950${BADGE_STYLE}"; MSG="✅ Unity performance suite finished." ;;
+            failure) BADGE="https://img.shields.io/badge/Performance-Failed!-ff0000${BADGE_STYLE}"; MSG="❌ Unity performance suite failed." ;;
+            *)       BADGE="https://img.shields.io/badge/Performance-Cancelled-lightgrey${BADGE_STYLE}"; MSG="Unity performance suite did not finish (\`$CONCLUSION\`)." ;;
+          esac
+
+          # Artifact download links come from the trusted Actions API.
+          ARTS_JSON=$(gh api "/repos/$REPO/actions/runs/$RUN_ID/artifacts?per_page=100" 2>/dev/null || echo '{"artifacts":[]}')
+          links=""
+          for entry in "results (JSON):Performance test results (JSON)" "benchmark report (PDF):Performance benchmark report (PDF)"; do
+            label="${entry%%:*}"
+            art_name="${entry#*:}"
+            art_id=$(jq -r --arg n "$art_name" '.artifacts[]? | select(.name==$n) | .id // empty' <<< "$ARTS_JSON" | head -1)
+            [ -n "$art_id" ] && links="$links · [$label](https://github.com/$REPO/actions/runs/$RUN_ID/artifacts/$art_id)"
+          done
+
+          DELIM="EOF_${RANDOM}${RANDOM}_$$"
+          {
+            echo "body<<$DELIM"
+            echo "[![Performance]($BADGE)]($RUN_URL)"
+            echo ""
+            echo "$MSG The benchmark report is rendered on the [run summary]($RUN_URL)."
+            echo ""
+            if [ -n "$links" ]; then
+              echo "<sub>Download:${links#" ·"}</sub>"
+            else
+              echo "<sub>No result artifacts were produced — check the [run]($RUN_URL).</sub>"
+            fi
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout CI status action
+        if: steps.body.outcome == 'success' && steps.ran.outputs.ran == 'true'
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/ci-status-comment
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Update performance section
+        if: steps.body.outcome == 'success' && steps.ran.outputs.ran == 'true'
+        uses: ./.github/actions/ci-status-comment
+        with:
+          pr-number: ${{ steps.pr.outputs.pr-number }}
+          section: performance
+          github-token: ${{ github.token }}
+          body: ${{ steps.body.outputs.body }}

--- a/.github/workflows/pr-comment-test-failures.yml
+++ b/.github/workflows/pr-comment-test-failures.yml
@@ -72,9 +72,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Job list of the originating "Unity Test" run, used to deep-link a
-          # crashed/timed-out suite straight to its job page in the warning line.
-          JOBS_JSON=$(gh api "/repos/$REPO/actions/runs/$WORKFLOW_RUN_ID/jobs" 2>/dev/null || echo '{"jobs":[]}')
+          # Job and artifact lists of the originating "Unity Test" run, used to
+          # deep-link each suite to its job page and the result artifacts
+          # (NUnit XML + editor logs) to their download links.
+          JOBS_JSON=$(gh api "/repos/$REPO/actions/runs/$WORKFLOW_RUN_ID/jobs?per_page=100" 2>/dev/null || echo '{"jobs":[]}')
+          ARTS_JSON=$(gh api "/repos/$REPO/actions/runs/$WORKFLOW_RUN_ID/artifacts?per_page=100" 2>/dev/null || echo '{"artifacts":[]}')
+
+          fmt_secs() {
+            awk -v s="$1" 'BEGIN { s=int(s+0.5); m=int(s/60); r=s%60; if (m>0) printf("%dm %02ds", m, r); else printf("%ds", r) }'
+          }
 
           declare -A DISPLAY=( [editmode]=EditMode [playmode]=PlayMode )
 
@@ -82,6 +88,7 @@ jobs:
           rows=""
           warnings=""
           failed_list=""
+          slowest_list=""
           total_failed=0
 
           for mode in editmode playmode; do
@@ -89,13 +96,15 @@ jobs:
             [ -f "$file" ] || continue
             disp=${DISPLAY[$mode]}
 
+            job_url=$(jq -r --arg n "Test ($mode)" '.jobs[]? | select(.name==$n) | .html_url // empty' <<< "$JOBS_JSON" | head -1)
+            if [ -n "$job_url" ]; then disp_cell="[$disp]($job_url)"; else disp_cell="$disp"; fi
+
             # A suite that produced no result XML crashed or timed out before finishing.
             # Surface it as its own state instead of silently contributing 0 to a green total.
             if [ "$(jq -r '.hasResults' "$file")" != "true" ]; then
               status=incomplete
-              job_url=$(jq -r --arg n "Test ($mode)" '.jobs[]? | select(.name==$n) | .html_url' <<< "$JOBS_JSON" | head -1)
               [ -n "$job_url" ] || job_url="$WORKFLOW_RUN_URL"
-              rows="$rows| $disp | ⚠️ No results | — | — | — |"$'\n'
+              rows="$rows| $disp_cell | ⚠️ No results | — | — | — | — |"$'\n'
               warnings="$warnings⚠️ **$disp** produced no results — the run likely crashed or timed out before finishing. Check the [\`Unity Test / Test ($mode)\`]($job_url) job."$'\n\n'
               continue
             fi
@@ -107,14 +116,24 @@ jobs:
             f=$(jq -r '.failed | length' "$file")
             s=$((t - p - f)); if [ "$s" -lt 0 ]; then s=0; fi
 
+            # Suite duration + slowest tests come from the same untrusted artifact:
+            # duration must be numeric before it reaches awk, and slowest entries are
+            # type-checked in jq with names flattened to a single line.
+            d=$(jq -r '.duration // empty' "$file")
+            if [[ "$d" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then dur=$(fmt_secs "$d"); else dur="—"; fi
+            slow=$(jq -r --arg mode "$mode" \
+              '.slowest[]? | select((.seconds|type=="number") and (.name|type=="string")) | "- [\($mode)] \(.seconds)s  \(.name | gsub("[\r\n]"; " "))"' \
+              "$file" 2>/dev/null || true)
+            [ -n "$slow" ] && slowest_list="$slowest_list$slow"$'\n'
+
             if [ "$f" -gt 0 ]; then
               if [ "$status" = "passed" ]; then status=failed; fi
               total_failed=$((total_failed + f))
-              rows="$rows| $disp | ❌ $f failed | $p | $f | $s |"$'\n'
+              rows="$rows| $disp_cell | ❌ $f failed | $p | $f | $s | $dur |"$'\n'
               names=$(jq -r --arg mode "$mode" '.failed[] | "- [\($mode)] \(. | gsub("[\r\n]"; " "))"' "$file")
               failed_list="$failed_list$names"$'\n'
             else
-              rows="$rows| $disp | ✅ Passed | $p | 0 | $s |"$'\n'
+              rows="$rows| $disp_cell | ✅ Passed | $p | 0 | $s | $dur |"$'\n'
             fi
           done
 
@@ -124,15 +143,24 @@ jobs:
             *)          badge="https://img.shields.io/badge/Tests-Passed!-3fb950?logo=codecov&logoColor=white&style=for-the-badge";     headline="All Unity tests passed ✅" ;;
           esac
 
+          # Artifact download links (ids come from the trusted Actions API).
+          art_footer=""
+          for entry in "editmode:Test results (editmode)" "playmode:Test results (playmode)"; do
+            mode="${entry%%:*}"
+            art_name="${entry#*:}"
+            art_id=$(jq -r --arg n "$art_name" '.artifacts[]? | select(.name==$n) | .id // empty' <<< "$ARTS_JSON" | head -1)
+            [ -n "$art_id" ] && art_footer="$art_footer · [$mode](https://github.com/$REPO/actions/runs/$WORKFLOW_RUN_ID/artifacts/$art_id)"
+          done
+
           DELIM="EOF_$(uuidgen)"
           {
             echo "body<<$DELIM"
-            echo "![Tests]($badge)"
+            echo "[![Tests]($badge)]($WORKFLOW_RUN_URL)"
             echo ""
             printf '%s\n' "$headline"
             echo ""
-            echo "| TESTS SUITE | Result | Passed | Failed | Skipped |"
-            echo "| ----------- | ------ | -----: | -----: | ------: |"
+            echo "| TESTS SUITE | Result | Passed | Failed | Skipped | Time |"
+            echo "| ----------- | ------ | -----: | -----: | ------: | ---: |"
             printf '%s' "$rows"
             if [ "$total_failed" -gt 0 ]; then
               echo ""
@@ -141,6 +169,20 @@ jobs:
               printf '%s' "$failed_list"
               echo ""
               echo "</details>"
+            fi
+            if [ -n "$slowest_list" ]; then
+              echo ""
+              echo "<details><summary>Slowest tests</summary>"
+              echo ""
+              printf '%s' "$slowest_list"
+              echo ""
+              echo "</details>"
+            fi
+            echo ""
+            if [ -n "$art_footer" ]; then
+              echo "<sub>Full report: [run summary]($WORKFLOW_RUN_URL) · results + editor logs:${art_footer#" ·"}</sub>"
+            else
+              echo "<sub>Full report: [run summary]($WORKFLOW_RUN_URL)</sub>"
             fi
             echo "$DELIM"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-comment-test-failures.yml
+++ b/.github/workflows/pr-comment-test-failures.yml
@@ -118,11 +118,14 @@ jobs:
 
             # Suite duration + slowest tests come from the same untrusted artifact:
             # duration must be numeric before it reaches awk, and slowest entries are
-            # type-checked in jq with names flattened to a single line.
+            # type-checked in jq with names flattened to a single line. Names render
+            # inside inline code (backticks/pipes stripped) so a name shaped like
+            # markdown — a link, an <img>, a </details> — reads as text instead of
+            # rendering as first-party comment furniture.
             d=$(jq -r '.duration // empty' "$file")
             if [[ "$d" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then dur=$(fmt_secs "$d"); else dur="—"; fi
             slow=$(jq -r --arg mode "$mode" \
-              '.slowest[]? | select((.seconds|type=="number") and (.name|type=="string")) | "- [\($mode)] \(.seconds)s  \(.name | gsub("[\r\n]"; " "))"' \
+              '.slowest[]? | select((.seconds|type=="number") and (.name|type=="string")) | "- [\($mode)] \(.seconds)s  `\(.name | gsub("[\r\n`|]"; " "))`"' \
               "$file" 2>/dev/null || true)
             [ -n "$slow" ] && slowest_list="$slowest_list$slow"$'\n'
 
@@ -130,7 +133,7 @@ jobs:
               if [ "$status" = "passed" ]; then status=failed; fi
               total_failed=$((total_failed + f))
               rows="$rows| $disp_cell | ❌ $f failed | $p | $f | $s | $dur |"$'\n'
-              names=$(jq -r --arg mode "$mode" '.failed[] | "- [\($mode)] \(. | gsub("[\r\n]"; " "))"' "$file")
+              names=$(jq -r --arg mode "$mode" '.failed[] | "- [\($mode)] `\(. | gsub("[\r\n`|]"; " "))`"' "$file")
               failed_list="$failed_list$names"$'\n'
             else
               rows="$rows| $disp_cell | ✅ Passed | $p | 0 | $s | $dur |"$'\n'

--- a/.github/workflows/pr-comment-warnings.yml
+++ b/.github/workflows/pr-comment-warnings.yml
@@ -62,7 +62,7 @@ jobs:
           section: lint
           github-token: ${{ github.token }}
           body: |-
-            ![Lint](https://img.shields.io/badge/Lint-Pending!-ffff00?logo=jetbrains&logoColor=white&style=for-the-badge)
+            [![Lint](https://img.shields.io/badge/Lint-Pending!-ffff00?logo=jetbrains&logoColor=white&style=for-the-badge)](${{ github.event.workflow_run.html_url }})
 
             Lint in progress, come back later!
 
@@ -123,6 +123,9 @@ jobs:
           ALLOW_EQUAL: ${{ steps.result.outputs.allow-equal }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           DELIM="EOF_$(uuidgen)"
           BADGE_STYLE="?logo=jetbrains&logoColor=white&style=for-the-badge"
@@ -205,12 +208,28 @@ jobs:
             fi
           fi
 
+          # Footer: the lint job run plus the full InspectCode report artifact (the
+          # findings list above is capped; the artifact has everything). The id comes
+          # from the trusted Actions API.
+          FOOTER=""
+          if [ "$FOUND" = "true" ]; then
+            ART_ID=$(gh api "/repos/$REPO/actions/runs/$RUN_ID/artifacts?per_page=100" \
+              --jq '.artifacts[] | select(.name=="csharp-lint-reports") | .id' 2>/dev/null | head -1)
+            FOOTER="<sub>[Lint run]($RUN_URL)"
+            [ -n "$ART_ID" ] && FOOTER="$FOOTER · [full InspectCode report](https://github.com/$REPO/actions/runs/$RUN_ID/artifacts/$ART_ID)"
+            FOOTER="$FOOTER</sub>"
+          fi
+
           {
             echo "body<<$DELIM"
-            echo "![Lint]($BADGE)"
+            echo "[![Lint]($BADGE)]($RUN_URL)"
             echo ""
             echo "$MSG"
             [ -n "$DETAILS" ] && cat "$DETAILS"
+            if [ -n "$FOOTER" ]; then
+              echo ""
+              echo "$FOOTER"
+            fi
             echo "$DELIM"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -841,14 +841,19 @@ jobs:
                   if case_result == "Passed":
                       passed += 1
                   elif case_result == "Failed":
-                      failed.append(test_case.get("fullname") or test_case.get("name"))
+                      # "(unnamed)" keeps the set homogeneous — one None among
+                      # strings makes sorted() raise and kills the whole file.
+                      failed.append(test_case.get("fullname") or test_case.get("name") or "(unnamed)")
 
           result = {
               "hasResults": len(xml_files) > 0,
               "total": total,
               "passed": passed,
               "failed": sorted(set(failed)),
-              "duration": round(duration, 1),
+              # The per-case clamp keeps each addend (and the slowest list)
+              # finite, but a sum of finite doubles can still overflow to inf —
+              # clamp again at the one point the accumulator is serialised.
+              "duration": round(duration, 1) if math.isfinite(duration) else 0.0,
               "slowest": [
                   {"name": name, "seconds": round(seconds, 1)}
                   for seconds, name in sorted(timings, key=lambda t: -t[0])[:10]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -814,6 +814,8 @@ jobs:
           total = 0
           passed = 0
           failed = []
+          duration = 0.0
+          timings = []
 
           for path in xml_files:
               try:
@@ -825,6 +827,12 @@ jobs:
                   if case_result is None:
                       continue
                   total += 1
+                  try:
+                      seconds = float(test_case.get("duration") or 0)
+                  except ValueError:
+                      seconds = 0.0
+                  duration += seconds
+                  timings.append((seconds, test_case.get("fullname") or test_case.get("name")))
                   if case_result == "Passed":
                       passed += 1
                   elif case_result == "Failed":
@@ -835,6 +843,11 @@ jobs:
               "total": total,
               "passed": passed,
               "failed": sorted(set(failed)),
+              "duration": round(duration, 1),
+              "slowest": [
+                  {"name": name, "seconds": round(seconds, 1)}
+                  for seconds, name in sorted(timings, key=lambda t: -t[0])[:10]
+              ],
           }
 
           with open(f"failed-tests-{test_mode}.json", "w") as f:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -805,7 +805,7 @@ jobs:
           TEST_MODE: ${{ matrix.testMode }}
         run: |
           python3 - <<'PY'
-          import glob, json, os, xml.etree.ElementTree as ET
+          import glob, json, math, os, xml.etree.ElementTree as ET
 
           artifacts_path = os.environ["ARTIFACTS_PATH"]
           test_mode = os.environ["TEST_MODE"]
@@ -830,6 +830,11 @@ jobs:
                   try:
                       seconds = float(test_case.get("duration") or 0)
                   except ValueError:
+                      seconds = 0.0
+                  # float() admits nan/inf/1e999 without raising, and json.dump
+                  # would then emit bare NaN/Infinity — invalid JSON that aborts
+                  # the consumer's very first jq read of this file.
+                  if not math.isfinite(seconds):
                       seconds = 0.0
                   duration += seconds
                   timings.append((seconds, test_case.get("fullname") or test_case.get("name")))

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -163,6 +163,33 @@ jobs:
             echo "::notice::No matching explorer-automation branch '${HEAD_REF}' — using default."
           fi
 
+  # Flip the unified CI status comment's automation section to "running" the
+  # moment the suite is dispatched, so the on-demand placeholder never lingers
+  # while a run is in flight.
+  automation-pending:
+    name: Mark automation running
+    needs: resolve
+    if: needs.resolve.outputs.authorized == 'true' && needs.resolve.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout CI status action
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/ci-status-comment
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Set automation section to running
+        uses: ./.github/actions/ci-status-comment
+        with:
+          pr-number: ${{ needs.resolve.outputs.pr_number }}
+          section: automation
+          github-token: ${{ github.token }}
+          body: |-
+            [![Automation](https://img.shields.io/badge/Automation-Running!-ffff00?logo=github&logoColor=white&style=for-the-badge)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            Visual regression suite running for commit `${{ needs.resolve.outputs.head_short_sha }}` — [watch the run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
   run-suite:
     name: Run visual suite
     needs: resolve
@@ -179,3 +206,67 @@ jobs:
       commit_sha: ${{ needs.resolve.outputs.head_short_sha }}
       branch_label: ${{ needs.resolve.outputs.head_ref }}
     secrets: inherit
+
+  # Final state of the automation section: badge + Allure report + run links.
+  # The reusable workflow still posts its own detailed per-platform comment;
+  # this section is the at-a-glance summary inside the unified CI status comment.
+  report:
+    name: Update CI status comment
+    needs: [resolve, run-suite]
+    if: always() && needs.resolve.outputs.authorized == 'true' && needs.resolve.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout CI status action
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/ci-status-comment
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Compose automation section
+        id: compose
+        env:
+          RESULT: ${{ needs.run-suite.result }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          COMMIT_SHA: ${{ needs.resolve.outputs.head_short_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PUBLIC_URL_PREFIX: ${{ vars.EXPLORER_TEAM_S3_BUCKET_PUBLIC_URL }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          BADGE_STYLE="?logo=github&logoColor=white&style=for-the-badge"
+          case "$RESULT" in
+            success) BADGE="https://img.shields.io/badge/Automation-Passed!-3fb950${BADGE_STYLE}"; MSG="✅ Visual regression suite passed." ;;
+            failure) BADGE="https://img.shields.io/badge/Automation-Failed!-ff0000${BADGE_STYLE}"; MSG="❌ Visual regression suite failed." ;;
+            *)       BADGE="https://img.shields.io/badge/Automation-Cancelled-lightgrey${BADGE_STYLE}"; MSG="Visual regression suite did not finish (\`$RESULT\`)." ;;
+          esac
+
+          # Mirrors run-visual-suite.yml's "Compute identifiers" S3 path. mode=test
+          # and platform=macos are the reusable workflow's defaults — this dispatcher
+          # passes neither, so keep the three in lockstep if that ever changes.
+          REPORT_URL="${PUBLIC_URL_PREFIX}/@dcl/${REPO//\//-}/visual-regression/test/macos/${PR_NUMBER}/${COMMIT_SHA}/index.html"
+
+          DELIM="EOF_${RANDOM}${RANDOM}_$$"
+          {
+            echo "body<<$DELIM"
+            echo "[![Automation]($BADGE)]($RUN_URL)"
+            echo ""
+            echo "$MSG"
+            echo ""
+            echo "| Name | Link |"
+            echo "| -------- | ----------------------- |"
+            echo "| Commit | \`$COMMIT_SHA\` |"
+            echo "| Allure report | $REPORT_URL |"
+            echo "| Workflow run | $RUN_URL |"
+            echo ""
+            echo "<sub>Triggered via \`/visual-tests\` · the detailed per-platform comment is posted separately.</sub>"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update automation section
+        uses: ./.github/actions/ci-status-comment
+        with:
+          pr-number: ${{ needs.resolve.outputs.pr_number }}
+          section: automation
+          github-token: ${{ github.token }}
+          body: ${{ steps.compose.outputs.body }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -171,6 +171,11 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.authorized == 'true' && needs.resolve.outputs.pr_number != ''
     runs-on: ubuntu-latest
+    # This job only writes the status comment; the workflow-level contents:write
+    # ceiling exists for the reusable suite call, not for it.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout CI status action
         uses: actions/checkout@v6
@@ -215,6 +220,11 @@ jobs:
     needs: [resolve, run-suite]
     if: always() && needs.resolve.outputs.authorized == 'true' && needs.resolve.outputs.pr_number != ''
     runs-on: ubuntu-latest
+    # This job only writes the status comment; the workflow-level contents:write
+    # ceiling exists for the reusable suite call, not for it.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout CI status action
         uses: actions/checkout@v6

--- a/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
+++ b/Explorer/Assets/DCL/FeatureFlags/FeatureFlagsStrings.cs
@@ -90,6 +90,12 @@ namespace DCL.FeatureFlags
         public const string HARDWARE_FINGERPRINT = "alfa-hardware-fingerprint";
         public const string OPTIMIZED_ASSETS = "optimized-assets";
         public const string OPTIMIZED_ASSETS_BASE_URL_VARIANT = "assets-base-url";
+
+        // Routes the asset-bundle registry + CDN to their `-abgen` parallel-pipeline
+        // siblings (own registry, ab-cdn-abgen CDN). Takes precedence over
+        // OPTIMIZED_ASSETS so the whole AB surface moves together. See
+        // DecentralandUrlsSource.ResolveAssetBundleUrl.
+        public const string ABGEN_REGISTRY = "abgen-registry";
         public const string USE_CUSTOM_MEDIA_PLAYER_WINDOWS = "use-custom-media-player-windows";
         public const string USE_CUSTOM_MEDIA_PLAYER_MAC_SILICON = "use-custom-media-player-mac-silicon";
         public const string USE_CUSTOM_MEDIA_PLAYER_MAC_INTEL = "use-custom-media-player-mac-intel";

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -216,6 +216,36 @@ namespace DCL.Browser.DecentralandUrls
             return new UrlData(CacheBehaviour.FeatureFlagsDependent, $"https://abcdn.decentraland.{ENV}");
         }
 
+        /// <summary>
+        ///     Asset-bundle registry / CDN base resolution. When the abgen parallel-pipeline flag is on,
+        ///     routes to the `-abgen` sibling host (own registry + ab-cdn-abgen CDN), taking precedence over
+        ///     OPTIMIZED_ASSETS so the whole AB surface (registry + CDN) moves together. The CLI
+        ///     "--optimized-assets-url" override still wins. LODs are intentionally NOT routed here (abgen's
+        ///     LOD lane is unimplemented) — LodGeneratorCDN keeps calling ResolveOptimizedAssetsUrl directly.
+        /// </summary>
+        private UrlData ResolveAssetBundleUrl(string dedicatedHostUrl)
+        {
+            if (optimizedAssetsBaseOverride is { Length: > 0 })
+                return new UrlData(CacheBehaviour.FeatureFlagsDependent, optimizedAssetsBaseOverride);
+
+            FeatureFlagsConfiguration featureFlags = FeatureFlagsConfiguration.Instance;
+
+            // FeatureFlagsDependent so the abgen host is re-resolved (not cached) until flags load — the
+            // {ENV} token is substituted in Url() once the environment domain is applied.
+            if (!featureFlags.IsEmpty && featureFlags.IsEnabled(FeatureFlagsStrings.ABGEN_REGISTRY))
+                return new UrlData(CacheBehaviour.FeatureFlagsDependent, InsertAbgenSubdomain(dedicatedHostUrl));
+
+            return ResolveOptimizedAssetsUrl(dedicatedHostUrl);
+        }
+
+        /// <summary>
+        ///     Inserts the `-abgen` label into the leading subdomain of an AB host, leaving the {ENV} token
+        ///     intact: `https://ab-cdn.decentraland.{ENV}` → `https://ab-cdn-abgen.decentraland.{ENV}`,
+        ///     `https://asset-bundle-registry.decentraland.{ENV}` → `https://asset-bundle-registry-abgen.decentraland.{ENV}`.
+        /// </summary>
+        private static string InsertAbgenSubdomain(string hostUrl) =>
+            hostUrl.Replace(".decentraland.", "-abgen.decentraland.");
+
         /// <summary>Registry-composed endpoints inherit the registry base's caching so a flag-driven base is not cached early.</summary>
         private UrlData ComposeRegistryUrl(string path) =>
             new (RawUrl(DecentralandUrl.AssetBundleRegistry).Caching, $"{Url(DecentralandUrl.AssetBundleRegistry)}{path}");
@@ -273,7 +303,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.Account => $"https://decentraland.{ENV}/account/",
                 DecentralandUrl.MinimumSpecs => $"https://docs.decentraland.{ENV}/player/FAQs/decentraland-101/#what-hardware-do-i-need-to-run-decentraland",
                 DecentralandUrl.Market => $"https://market.decentraland.{ENV}",
-                DecentralandUrl.AssetBundlesCDN => ResolveOptimizedAssetsUrl($"https://ab-cdn.decentraland.{ENV}"),
+                DecentralandUrl.AssetBundlesCDN => ResolveAssetBundleUrl($"https://ab-cdn.decentraland.{ENV}"),
                 DecentralandUrl.LodGeneratorCDN => ResolveOptimizedAssetsUrl($"https://lod-generator-unity-cdn.decentraland.{ENV}"),
                 DecentralandUrl.ArchipelagoStatus => $"https://archipelago-ea-stats.decentraland.{ENV}/status",
                 DecentralandUrl.ArchipelagoHotScenes => $"https://archipelago-ea-stats.decentraland.{ENV}/hot-scenes",
@@ -286,7 +316,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.CameraReelLink => $"https://reels.decentraland.{ENV}",
                 DecentralandUrl.Blocklist => $"https://config.decentraland.{ENV}/denylist.json",
                 DecentralandUrl.ApiFriends => $"wss://rpc-social-service-ea.decentraland.{ENV}",
-                DecentralandUrl.AssetBundleRegistry => ResolveOptimizedAssetsUrl($"https://asset-bundle-registry.decentraland.{ENV}"),
+                DecentralandUrl.AssetBundleRegistry => ResolveAssetBundleUrl($"https://asset-bundle-registry.decentraland.{ENV}"),
 
                 DecentralandUrl.AssetBundleRegistryVersion => ComposeRegistryUrl("/entities/versions"),
                 DecentralandUrl.MarketplaceClaimName => $"https://decentraland.{ENV}/marketplace/names/claim",

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -61,6 +61,13 @@ TERMINAL_STATUSES = {'success', 'failure', 'canceled', 'unknown'}
 
 build_healthy = True
 
+# Deep link to this build in the Unity Cloud dashboard, captured from the first build
+# response that carries one. Persisted to BUILD_LINK_INFO_PATH so the workflow can
+# upload it and the PR status comment can link the build directly.
+BUILD_LINK_INFO_PATH = 'unity_cloud_build_info.env'
+dashboard_url = None
+_build_link_info_written = False
+
 parser = argparse.ArgumentParser()
 parser.add_argument('--resume', help='Resume tracking a running build stored in build_info.json', action='store_true')
 parser.add_argument('--cancel', help='Cancel a running build stored in build_info.json', action='store_true')
@@ -616,6 +623,44 @@ def try_resume_build():
     return None
 
 
+def record_build_link_info(id, response_json):
+    """Persist the Unity Cloud dashboard deep link for this build (best-effort).
+
+    Build API responses carry dashboard links; the workflow uploads the written file
+    as an artifact so the PR status comment can link the build id directly instead
+    of telling humans to search cloud.unity.com by hand.
+    """
+    global dashboard_url, _build_link_info_written
+
+    links = response_json.get('links') or {}
+    href = None
+    # dashboard_summary is the build's page and dashboard_log its log tab;
+    # dashboard_url can be just the dashboard root, so a candidate only
+    # qualifies when it points at this specific build.
+    for key in ('dashboard_summary', 'dashboard_log', 'dashboard_url'):
+        candidate = (links.get(key) or {}).get('href')
+        if candidate and '/builds/' in candidate:
+            href = candidate
+            break
+
+    if _build_link_info_written and not href:
+        return
+
+    try:
+        with open(BUILD_LINK_INFO_PATH, 'w') as f:
+            f.write(f'BUILD_TARGET={os.getenv("TARGET")}\n')
+            f.write(f'BUILD_ID={id}\n')
+            if href:
+                f.write(f'DASHBOARD_URL={href}\n')
+    except OSError as e:
+        print(f'Warning: could not write {BUILD_LINK_INFO_PATH}: {e}')
+
+    if href:
+        dashboard_url = href
+        print(f'::notice::Unity Cloud build #{id} ({os.getenv("TARGET")}): {href}')
+    _build_link_info_written = True
+
+
 def write_step_summary(target, build_id, final_status, phase_durations, queue_reasons, queue_elapsed, build_elapsed):
     """Append a phase breakdown to $GITHUB_STEP_SUMMARY (best-effort)."""
     summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
@@ -635,6 +680,8 @@ def write_step_summary(target, build_id, final_status, phase_durations, queue_re
     lines.append('')
     lines.append(f'- Target: `{target}`')
     lines.append(f'- Build ID: `{build_id}`')
+    if dashboard_url:
+        lines.append(f'- Unity Cloud build page: {dashboard_url}')
     lines.append(f'- Final outcome: `{final_status}`')
     if queue_reasons:
         lines.append(f"- Queue reasons seen: {', '.join(f'`{r}`' for r in sorted(queue_reasons))}")
@@ -710,6 +757,9 @@ def run_poll_loop(id, build_already_active=False, resumed_build_elapsed=0):
                 return 'build_timeout', phase_durations, queue_reasons, queue_elapsed, build_elapsed
 
         keep_polling, status, response_json = poll_build(id)
+
+        if dashboard_url is None:
+            record_build_link_info(id, response_json)
 
         queued_reason = response_json.get('queuedReason')
         if queued_reason and status in QUEUE_STATUSES:
@@ -920,7 +970,8 @@ download_artifact(id)
 download_log(id)
 
 if not build_healthy:
-    print(f'Build unhealthy - check the downloaded logs or go to https://cloud.unity.com/ and search for target "{os.getenv('TARGET')}" and build ID "{id}"')
+    where = dashboard_url or f'https://cloud.unity.com/ (search for target "{os.getenv("TARGET")}" and build ID "{id}")'
+    print(f'Build unhealthy - check the downloaded logs or the Unity Cloud build page: {where}')
     sys.exit(1)
 
 # Cleanup (only if build is healthy and not release)

--- a/scripts/cloudbuild/build.py
+++ b/scripts/cloudbuild/build.py
@@ -636,10 +636,11 @@ def record_build_link_info(id, response_json):
     href = None
     # dashboard_summary is the build's page and dashboard_log its log tab;
     # dashboard_url can be just the dashboard root, so a candidate only
-    # qualifies when it points at this specific build.
+    # qualifies when it is an absolute link to this specific build (the
+    # comment workflow rejects anything else, so don't persist it either).
     for key in ('dashboard_summary', 'dashboard_log', 'dashboard_url'):
         candidate = (links.get(key) or {}).get('href')
-        if candidate and '/builds/' in candidate:
+        if candidate and candidate.startswith('https://') and '/builds/' in candidate:
             href = candidate
             break
 
@@ -902,6 +903,10 @@ else:
         utils.persist_build_info(os.getenv('TARGET'), None)
         id = run_build(os.getenv('BRANCH_NAME'), get_clean_build_bool())
         utils.persist_build_info(os.getenv('TARGET'), id)
+        # Write the link info file (target + id, no URL yet) immediately so it exists
+        # even if the runner dies before the first poll; the poll loop upgrades it
+        # with the dashboard URL once a response carries one.
+        record_build_link_info(id, {})
         print(f'For more info and live logs, go to https://cloud.unity.com/ and search for target "{os.getenv('TARGET')}" and build ID "{id}"')
 
 final_outcome, phase_durations, queue_reasons, queue_elapsed, build_elapsed = run_poll_loop(


### PR DESCRIPTION
## What

Adds a feature flag that switches the asset-bundle **registry and CDN** to their parallel `-abgen` siblings — the client half of the effort to run an abgen-backed asset-bundle pipeline side-by-side with the production Unity one.

## Changes

- **`FeatureFlagsStrings.cs`** — new `ABGEN_REGISTRY = "abgen-registry"` flag constant.
- **`DecentralandUrlsSource.cs`** — new `ResolveAssetBundleUrl` seam used by `AssetBundleRegistry` and `AssetBundlesCDN`. When the flag is on, it rewrites the host `\*.decentraland.\*` → `\*-abgen.decentraland.\*` (e.g. `asset-bundle-registry-abgen.decentraland.org`, `ab-cdn-abgen.decentraland.org`) via `InsertAbgenSubdomain`.

## Behavior

- Switching the single `AssetBundleRegistry` base auto-repoints every registry-derived endpoint (`/entities/versions`, `/entities/active`, `/profiles`, world manifest) through `ComposeRegistryUrl`; the CDN host moves with it.
- Takes precedence over `OPTIMIZED_ASSETS` so the whole AB surface moves together.
- Returns `CacheBehaviour.FeatureFlagsDependent` so the host is re-resolved (not cached) until flags load.
- The `--optimized-assets-url` CLI override still wins.
- **LODs are intentionally not routed** — abgen's LOD lane is unimplemented, so `LodGeneratorCDN` keeps calling `ResolveOptimizedAssetsUrl` directly.

## Rollout

Ship off-by-default, then enable per-wallet → percentage → default. Note the registry base is boot-time (ctor-injected into world factories) — the client must be restarted between flag changes, not just re-deeplinked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)