### PR TITLE
fix: stop waiting when a credits checkout is cancelled

### DIFF
--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/CreditsOrderStatusResponse.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/CreditsOrderStatusResponse.cs
@@ -10,6 +10,11 @@ namespace DCL.MarketplaceCredits
         public const string STATUS_CREDITED = "credited";
         public const string STATUS_FAILED = "failed";
 
+        // The checkout was retired without a payment — the buyer clicked back on Stripe's page, or the
+        // session expired. Terminal: no payment can be taken against it any more, so a poll that keeps
+        // waiting on it waits for something that can never arrive.
+        public const string STATUS_ABANDONED = "abandoned";
+
         public string status;
 
         // Whole credits granted by the order.

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsTopUpServiceShould.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsTopUpServiceShould.cs
@@ -127,6 +127,29 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             await creditsApiClient.Received(1).GetUserCreditsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         }
 
+        /// <summary>
+        /// The server has always reported `abandoned` for a checkout retired without payment, but the
+        /// client only recognised credited/failed — so a cancelled purchase looked exactly like one still
+        /// in flight and the modal span until the poll timed out (unity-explorer#9737).
+        /// </summary>
+        [Test]
+        public async Task TransitionToAbandonedWhenOrderIsRetired()
+        {
+            // Arrange
+            creditsApiClient.GetCheckoutOrderAsync(ORDER_ID, Arg.Any<CancellationToken>())
+                            .Returns(Order(CreditsOrderStatusResponse.STATUS_ABANDONED));
+
+            // Act
+            service.StartTopUp(PACK);
+            await WaitForStageAsync(CreditsTopUpStage.Abandoned);
+
+            // Assert
+            Assert.AreEqual(ORDER_ID, service.CurrentStatus.OrderId);
+            // Nobody was charged, so there is no balance to re-read and nothing to call an error.
+            Assert.IsNull(service.CurrentStatus.CheckoutError);
+            await creditsApiClient.DidNotReceive().GetUserCreditsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+
         [Test]
         public async Task TransitionToFailedWhenOrderFails()
         {

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/CreditsTopUpService.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/CreditsTopUpService.cs
@@ -15,6 +15,9 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
         {
             Credited,
             Failed,
+            // The ORDER was retired server-side. Distinct from Cancelled below, which means this local
+            // operation was aborted (the user closed the modal) and whoever aborted it owns the status.
+            Abandoned,
             TimedOut,
             Cancelled,
         }
@@ -153,6 +156,9 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
                     case PollOutcome.Failed:
                         SetStatus(CreditsTopUpStatus.GrantFailed(pack, orderId, order.error));
                         break;
+                    case PollOutcome.Abandoned:
+                        SetStatus(CreditsTopUpStatus.Abandoned(pack, orderId));
+                        break;
                 }
             }
             catch (OperationCanceledException) { }
@@ -182,6 +188,8 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
                             return (PollOutcome.Credited, result.Value);
                         case CreditsOrderStatusResponse.STATUS_FAILED:
                             return (PollOutcome.Failed, result.Value);
+                        case CreditsOrderStatusResponse.STATUS_ABANDONED:
+                            return (PollOutcome.Abandoned, result.Value);
                     }
                 }
                 else

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/CreditsTopUpTypes.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/CreditsTopUpTypes.cs
@@ -7,6 +7,7 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
         WaitingForPayment,
         PendingTimeout,
         Credited,
+        Abandoned,
         Failed,
     }
 
@@ -52,5 +53,12 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
 
         public static CreditsTopUpStatus GrantFailed(CreditPack pack, string orderId, string? errorMessage) =>
             new (CreditsTopUpStage.Failed, pack, orderId, errorMessage: errorMessage);
+
+        /// <summary>
+        /// The checkout was retired without a payment. Kept apart from Failed on purpose: nothing went
+        /// wrong and nobody was charged, so the UI should say "cancelled" rather than raise an error.
+        /// </summary>
+        public static CreditsTopUpStatus Abandoned(CreditPack pack, string orderId) =>
+            new (CreditsTopUpStage.Abandoned, pack, orderId);
     }
 }

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/UI/CreditsTopUpModalController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/UI/CreditsTopUpModalController.cs
@@ -294,6 +294,12 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp.UI
                     }
 
                     break;
+                case CreditsTopUpStage.Abandoned:
+                    // Nobody was charged and nothing broke, so this must not read as an error. Retry is
+                    // offered because starting again is exactly what the buyer is likely to want.
+                    viewInstance.FailedReasonText.text = "Purchase cancelled — you were not charged.";
+                    viewInstance.RetryButton.gameObject.SetActive(true);
+                    break;
                 case CreditsTopUpStage.Failed:
                     (string reason, bool allowRetry) = MapFailureCopy(status);
                     viewInstance.FailedReasonText.text = reason;
@@ -356,6 +362,10 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp.UI
                 CreditsTopUpStage.WaitingForPayment => ModalState.WaitingForBrowser,
                 CreditsTopUpStage.PendingTimeout => ModalState.Pending,
                 CreditsTopUpStage.Credited => ModalState.Success,
+                // Reuses the Failed panel rather than adding a state the prefab has no view for. The
+                // STAGE stays distinct so nothing downstream has to treat a cancellation as an error;
+                // only the presentation is shared, and the copy below says what actually happened.
+                CreditsTopUpStage.Abandoned => ModalState.Failed,
                 CreditsTopUpStage.Failed => ModalState.Failed,
                 _ => ModalState.PackSelection,
             };


### PR DESCRIPTION
Closes #9737 (the client half).

## What was wrong

`CreditsOrderStatusResponse` declared three statuses — `processing`, `credited`, `failed` — and the poll only breaks on the last two. The server has **always** been able to answer `abandoned` for a checkout retired without payment; its own comment says *"a poll that saw it as 'processing' would wait forever"*.

So a cancelled purchase was indistinguishable from one still in flight, and the modal span for the full 60s foreground + 10min background window before giving up.

## The change

- `STATUS_ABANDONED` added to the wire contract.
- A `PollOutcome.Abandoned`, kept **separate from the existing `Cancelled`** — that one means *this local operation* was aborted (the user closed the modal) and carries the rule that "whoever cancelled owns the status". Reusing it would have silently swallowed the new case.
- A `CreditsTopUpStage.Abandoned` with its own factory, kept apart from `Failed`: nobody was charged and nothing broke, so it must not be reported as an error.
- The modal renders it through the existing Failed panel — no new prefab state — with cancelled copy and Retry enabled: *"Purchase cancelled — you were not charged."*

## Needs the server change to be useful

This reads a status that, today, nothing sets in time: the order only becomes `abandoned` when the timed sweep retires it ~26h later. decentraland/credits-server#587 makes Stripe's `cancel_url` record it immediately, so clicking back flips the status within one poll (~1.5s).

Merging this alone is harmless but changes nothing observable.

## Deliberately not done

- **No auto-cancel on timeout.** Cancelling expires the Stripe session, so a client that gave up after 60s while the buyer was still typing their card would destroy a live purchase.
- **No analytics event.** `BuyCreditsFailed` would file a cancellation as a failure and skew the funnel; a cancelled step deserves its own event, which is a separate decision.
- **Closing the tab still is not detected** — no click, no redirect, no webhook. Nothing can observe that instantly.

## Test plan

- [x] New service test: an `abandoned` poll lands on the Abandoned stage, re-reads no balance and reports no error
- [ ] With #587 deployed: start a top-up, click back on Stripe, confirm the modal leaves the spinner and offers Retry
- [ ] Confirm closing the modal mid-checkout still behaves as before (local cancel path untouched)