### PR TITLE
feat: add support for abbandoned status in credits topup

### DIFF
--- a/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/CreditsOrderStatusResponse.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/MarketplaceCreditsAPIService/CreditsOrderStatusResponse.cs
@@ -9,6 +9,7 @@ namespace DCL.MarketplaceCredits
         public const string STATUS_PROCESSING = "processing";
         public const string STATUS_CREDITED = "credited";
         public const string STATUS_FAILED = "failed";
+        public const string STATUS_ABANDONED = "abandoned";
 
         public string status;
 

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/CreditsTopUpService.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/CreditsTopUpService.cs
@@ -17,6 +17,7 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
             Failed,
             TimedOut,
             Cancelled,
+            Abandoned
         }
 
         private static readonly TimeSpan FOREGROUND_POLL_INTERVAL = TimeSpan.FromSeconds(1.5);
@@ -92,7 +93,7 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
 
         public void AcknowledgeTerminalState()
         {
-            if (CurrentStatus.Stage is CreditsTopUpStage.Credited or CreditsTopUpStage.Failed)
+            if (CurrentStatus.Stage is CreditsTopUpStage.Credited or CreditsTopUpStage.Failed or CreditsTopUpStage.Abandoned)
                 SetStatus(CreditsTopUpStatus.Idle());
         }
 
@@ -153,6 +154,9 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
                     case PollOutcome.Failed:
                         SetStatus(CreditsTopUpStatus.GrantFailed(pack, orderId, order.error));
                         break;
+                    case PollOutcome.Abandoned:
+                        SetStatus(CreditsTopUpStatus.Abandoned(pack, orderId));
+                        break;
                 }
             }
             catch (OperationCanceledException) { }
@@ -182,6 +186,8 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
                             return (PollOutcome.Credited, result.Value);
                         case CreditsOrderStatusResponse.STATUS_FAILED:
                             return (PollOutcome.Failed, result.Value);
+                        case CreditsOrderStatusResponse.STATUS_ABANDONED:
+                            return (PollOutcome.Abandoned, result.Value);
                     }
                 }
                 else

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/CreditsTopUpService.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/CreditsTopUpService.cs
@@ -17,7 +17,7 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
             Failed,
             TimedOut,
             Cancelled,
-            Abandoned
+            Abandoned,
         }
 
         private static readonly TimeSpan FOREGROUND_POLL_INTERVAL = TimeSpan.FromSeconds(1.5);

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/CreditsTopUpTypes.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/CreditsTopUpTypes.cs
@@ -8,6 +8,7 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
         PendingTimeout,
         Credited,
         Failed,
+        Abandoned,
     }
 
     public readonly struct CreditsTopUpStatus
@@ -52,5 +53,8 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp
 
         public static CreditsTopUpStatus GrantFailed(CreditPack pack, string orderId, string? errorMessage) =>
             new (CreditsTopUpStage.Failed, pack, orderId, errorMessage: errorMessage);
+
+        public static CreditsTopUpStatus Abandoned(CreditPack pack, string orderId) =>
+            new (CreditsTopUpStage.Abandoned, pack, orderId);
     }
 }

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/UI/CreditsTopUpModalController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/UI/CreditsTopUpModalController.cs
@@ -26,6 +26,7 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp.UI
         private const string ANALYTICS_STEP_CHECKOUT = "checkout";
         private const string ANALYTICS_STEP_GRANT = "grant";
         private const string ANALYTICS_ERROR_GRANT_FAILED = "grant_failed";
+        private const string ANALYTICS_ABANDONED = "abandoned";
         private const string PACKS_LOAD_FAILED_REQUEST = "request_failed";
         private const string PACKS_LOAD_FAILED_EMPTY = "empty_response";
 
@@ -262,7 +263,12 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp.UI
                             status.CheckoutError != null ? ANALYTICS_STEP_CHECKOUT : ANALYTICS_STEP_GRANT,
                             MapAnalyticsErrorCode(status),
                             status.Pack);
-
+                        break;
+                    case CreditsTopUpStage.Abandoned:
+                        BuyCreditsFailed?.Invoke(
+                            ANALYTICS_STEP_GRANT,
+                            ANALYTICS_ABANDONED,
+                            status.Pack);
                         break;
                 }
 

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/UI/CreditsTopUpModalController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/UI/CreditsTopUpModalController.cs
@@ -299,6 +299,10 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp.UI
                     viewInstance.FailedReasonText.text = reason;
                     viewInstance.RetryButton.gameObject.SetActive(allowRetry);
                     break;
+                case CreditsTopUpStage.Abandoned:
+                    viewInstance.FailedReasonText.text = "Purchase cancelled — you were not charged.";
+                    viewInstance.RetryButton.gameObject.SetActive(true);
+                    break;
             }
         }
 
@@ -357,6 +361,7 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp.UI
                 CreditsTopUpStage.PendingTimeout => ModalState.Pending,
                 CreditsTopUpStage.Credited => ModalState.Success,
                 CreditsTopUpStage.Failed => ModalState.Failed,
+                CreditsTopUpStage.Abandoned => ModalState.Failed,
                 _ => ModalState.PackSelection,
             };
 

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/UI/CreditsTopUpModalController.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/TopUp/UI/CreditsTopUpModalController.cs
@@ -29,6 +29,7 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp.UI
         private const string ANALYTICS_ABANDONED = "abandoned";
         private const string PACKS_LOAD_FAILED_REQUEST = "request_failed";
         private const string PACKS_LOAD_FAILED_EMPTY = "empty_response";
+        private const string PURCHASE_CANCELLED_TEXT = "Purchase cancelled — you were not charged.";
 
         private readonly ICreditsTopUpService topUpService;
         private readonly MarketplaceCreditsAPIClient creditsApiClient;
@@ -306,7 +307,7 @@ namespace DCL.MarketplaceCredits.Purchase.TopUp.UI
                     viewInstance.RetryButton.gameObject.SetActive(allowRetry);
                     break;
                 case CreditsTopUpStage.Abandoned:
-                    viewInstance.FailedReasonText.text = "Purchase cancelled — you were not charged.";
+                    viewInstance.FailedReasonText.text = PURCHASE_CANCELLED_TEXT;
                     viewInstance.RetryButton.gameObject.SetActive(true);
                     break;
             }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix https://github.com/decentraland/unity-explorer/issues/9737
This PR adds support for the abbandoned status of a credits topup transaction. The abbandoned status happens when a user cancels the transaction in the browser.
This DOES NOT cover the case when a user closes the browser tab of the transaction, in that case we cannot do anything to detect it.

## Test Instructions


### Test Steps
1. Launch the client
2. Open the credits topup UI
3. select any pack
4. In the browser press on "Back" in the top right of the stripe transaction
5. Verify that in the client the UI shows that the transaction was cancelled
This DOES NOT work when closing the browser page and it's normal, we cannot avoid that

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
