### PR TITLE
fix: forward deeplink to the bridge when a second instance is blocked

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/ApplicationParametersParser.cs
@@ -25,6 +25,10 @@ namespace Global.AppArgs
         // or when the launch has no deep link.
         private string? pendingDeepLink;
 
+        // The raw decentraland:// argument of this launch, kept verbatim for the lifetime of the parser (unlike
+        // pendingDeepLink, which is nulled once processed). Null when the launch carries no deep link.
+        private string? rawDeepLink;
+
         // Guards InitializeDeepLinks so the merge and the argument log happen exactly once.
         private bool deepLinksInitialized;
 
@@ -105,6 +109,7 @@ namespace Global.AppArgs
                     // Stored, not processed here: the whitelisted-realm gate needs the world whitelist, which may not
                     // be available yet. InitializeDeepLinks() processes it once it is.
                     pendingDeepLink = arg;
+                    rawDeepLink = arg;
                 }
                 else if (!string.IsNullOrEmpty(lastKeyStored))
                     appParameters[lastKeyStored] = arg;
@@ -115,6 +120,13 @@ namespace Global.AppArgs
         ///     Whether a deep link was seen during parsing but not yet processed.
         /// </summary>
         public bool HasPendingDeepLink => pendingDeepLink != null;
+
+        /// <summary>
+        ///     The raw decentraland:// argument this launch was started with, or null when there is none. Unlike
+        ///     <see cref="HasPendingDeepLink" /> it survives <see cref="InitializeDeepLinks" />, so a launch that
+        ///     must hand its deep link to another instance (e.g. when the single-instance guard trips) still has it.
+        /// </summary>
+        public string? RawDeepLink => rawDeepLink;
 
         /// <summary>
         ///     Params the launch deep link carried that failed the <c>DeepLinkAllowlist</c>. They are NOT part

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -25,6 +25,7 @@ using DCL.PluginSystem.Global;
 using DCL.PluginSystem.World;
 using DCL.Prefs;
 using DCL.Quality.Runtime;
+using DCL.RuntimeDeepLink;
 using DCL.SceneLoadingScreens.SplashScreen;
 using DCL.UI.ErrorPopup;
 using DCL.Utilities;
@@ -312,6 +313,19 @@ namespace Global.Dynamic
 
                 if (ShouldForceSingleRunningInstance(applicationParametersParser))
                 {
+                    // Standard single-instance activation: a launch that carries a deeplink (e.g. the browser's
+                    // signin callback re-launching the app) forwards it through the bridge file the running
+                    // instance's DeepLinkSentinel polls, then exits silently. The popup remains for launches
+                    // without a deeplink, where a second window is a deliberate user action that deserves an
+                    // explanation.
+                    string? rawDeepLink = applicationParametersParser.RawDeepLink;
+
+                    if (!string.IsNullOrEmpty(rawDeepLink) && DeepLinkSentinel.TryPublishToBridge(rawDeepLink!))
+                    {
+                        ExitUtils.Exit();
+                        return;
+                    }
+
                     await ShowSingleRunningInstancePopupAsync(assetsProvisioner, ct);
                     return;
                 }

--- a/Explorer/Assets/DCL/RuntimeDeepLink/DeepLink.cs
+++ b/Explorer/Assets/DCL/RuntimeDeepLink/DeepLink.cs
@@ -35,6 +35,12 @@ namespace DCL.RuntimeDeepLink
             return FromRaw(raw);
         }
 
+        /// <summary>
+        ///     Serializes a raw deeplink into the exact bridge-file shape <see cref="FromJson" /> parses.
+        /// </summary>
+        public static string ToJson(string rawDeepLink) =>
+            JsonUtility.ToJson(new DeepLinkDTO { deeplink = rawDeepLink });
+
         public string? ValueOf(string key)
         {
             map.TryGetValue(key, out string? value);

--- a/Explorer/Assets/DCL/RuntimeDeepLink/DeepLinkSentinel.cs
+++ b/Explorer/Assets/DCL/RuntimeDeepLink/DeepLinkSentinel.cs
@@ -105,6 +105,34 @@ namespace DCL.RuntimeDeepLink
             }
         }
 
+        /// <summary>
+        ///     Publishes a raw deeplink to the bridge file the running instance polls — the client-side counterpart
+        ///     of the launcher's bridge write, for a second instance that holds a deeplink the first one is awaiting.
+        ///     Returns false when a bridge file is already pending (never clobber an unconsumed launcher write) or
+        ///     the write fails, so the caller can fall back to its default behaviour.
+        /// </summary>
+        public static bool TryPublishToBridge(string rawDeepLink)
+        {
+            try
+            {
+                if (File.Exists(DEEP_LINK_BRIDGE_PATH))
+                    return false;
+
+                Directory.CreateDirectory(Path.GetDirectoryName(DEEP_LINK_BRIDGE_PATH)!);
+
+                // Write-then-rename so the polling instance can never observe a half-written file.
+                string tempPath = DEEP_LINK_BRIDGE_PATH + ".tmp";
+                File.WriteAllText(tempPath, DeepLink.ToJson(rawDeepLink));
+                File.Move(tempPath, DEEP_LINK_BRIDGE_PATH);
+                return true;
+            }
+            catch (Exception e)
+            {
+                ReportHub.LogError(ReportCategory.RUNTIME_DEEPLINKS, $"Failed to publish deeplink to bridge file: {e.Message}");
+                return false;
+            }
+        }
+
         private static void TryDeleteBridgeFile()
         {
             try

--- a/Explorer/Assets/DCL/RuntimeDeepLink/Tests.meta
+++ b/Explorer/Assets/DCL/RuntimeDeepLink/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f236f3b6228141c2940e6b78f38442f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/RuntimeDeepLink/Tests/DeepLinkBridgePublishRoundTripShould.cs
+++ b/Explorer/Assets/DCL/RuntimeDeepLink/Tests/DeepLinkBridgePublishRoundTripShould.cs
@@ -1,0 +1,131 @@
+using DCL.Utility.Types;
+using Global.AppArgs;
+using NUnit.Framework;
+using System.IO;
+using System.Reflection;
+
+namespace DCL.RuntimeDeepLink.Tests
+{
+    /// <summary>
+    ///     Regression coverage for single-instance deeplink forwarding (unity-explorer#9520 — the Mac Intel
+    ///     MetaMask sign-in loop: a second launch carrying the browser's <c>decentraland://open?signin=...</c>
+    ///     callback trips the "Only a single instance of Decentraland is allowed to run" guard and the signin id
+    ///     is discarded, stranding the user on the sign-in screen).
+    ///     <para>
+    ///     The fix has the guarded second instance publish its raw deeplink to the same bridge file
+    ///     <see cref="DeepLinkSentinel" />'s poller already reads (<c>DeepLinkSentinel.TryPublishToBridge</c>),
+    ///     then exit silently instead of popping up. This is the write half of that round trip: publish via the
+    ///     new API, then feed the resulting file straight into the exact parse call the poller itself makes
+    ///     (<see cref="DeepLink.FromJson" />) and assert the DTO comes back with the same signin/authRequestId.
+    ///     </para>
+    ///     <para>
+    ///     <c>TryPublishToBridge</c> is new production API added by the fix, so it is looked up and invoked
+    ///     through reflection: on a pre-fix tree the lookup finds nothing and the test fails on an explicit
+    ///     "publish path missing" assertion instead of a compile error, keeping this file buildable against both
+    ///     trees (same reflection-shim idiom as <c>McpHttpServerShould</c> for production statics tests must not
+    ///     reference directly).
+    ///     </para>
+    /// </summary>
+    public class DeepLinkBridgePublishRoundTripShould
+    {
+        private const string PUBLISH_METHOD_NAME = "TryPublishToBridge";
+        private const string BRIDGE_PATH_FIELD_NAME = "DEEP_LINK_BRIDGE_PATH";
+
+        private const string SIGNIN_ID = "4df293cd-52d1-4e8a-9c3a-signinlooptest";
+        private const string AUTH_REQUEST_ID = "9c1d2e3f-authrequest-signinlooptest";
+        private const string RAW_SIGNIN_DEEPLINK = "decentraland://open?signin=" + SIGNIN_ID + "&authRequestId=" + AUTH_REQUEST_ID;
+
+        // Null on a pre-fix tree (method does not exist yet) — every [Test] below asserts on this first so the
+        // failure is an explicit, readable assertion rather than a NullReferenceException.
+        private static readonly MethodInfo? PUBLISH_METHOD =
+            typeof(DeepLinkSentinel).GetMethod(PUBLISH_METHOD_NAME, BindingFlags.Public | BindingFlags.Static);
+
+        private string bridgePath = null!;
+        private string tempPath = null!;
+        private bool hadPreExistingFile;
+        private string? preExistingContent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // DEEP_LINK_BRIDGE_PATH already exists pre-fix (it is what the poller reads today), so this lookup
+            // never fails on either tree — reflection is used purely to avoid hard-coding the platform-specific
+            // path a second time.
+            FieldInfo? pathField = typeof(DeepLinkSentinel).GetField(BRIDGE_PATH_FIELD_NAME, BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(pathField, Is.Not.Null, $"DeepLinkSentinel.{BRIDGE_PATH_FIELD_NAME} not found — the sentinel's own bridge-file path constant is missing");
+
+            bridgePath = (string) pathField!.GetValue(null)!;
+            tempPath = bridgePath + ".tmp";
+
+            // Never clobber a real pending bridge file this machine may already have (e.g. an unconsumed
+            // launcher-placed signin); back it up and restore it in TearDown no matter what the test does.
+            hadPreExistingFile = File.Exists(bridgePath);
+            if (hadPreExistingFile)
+                preExistingContent = File.ReadAllText(bridgePath);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(bridgePath)!);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+
+            if (hadPreExistingFile)
+                File.WriteAllText(bridgePath, preExistingContent!);
+            else if (File.Exists(bridgePath))
+                File.Delete(bridgePath);
+        }
+
+        [Test]
+        public void PublishASigninDeepLinkThatTheSentinelParsesBackIdentically()
+        {
+            Assert.That(PUBLISH_METHOD, Is.Not.Null,
+                $"publish path missing: DeepLinkSentinel.{PUBLISH_METHOD_NAME} does not exist on this tree — " +
+                "the single-instance deeplink-forwarding fix for the Mac Intel MetaMask sign-in loop " +
+                "(unity-explorer#9520) is absent, so a second-instance signin deeplink still has no way to " +
+                "reach the first instance's DeepLinkSentinel poller.");
+
+            if (hadPreExistingFile)
+                File.Delete(bridgePath); // the publish call itself must run against a clean slate
+
+            var published = (bool) PUBLISH_METHOD!.Invoke(null, new object[] { RAW_SIGNIN_DEEPLINK })!;
+
+            Assert.That(published, Is.True, "TryPublishToBridge must report success when no bridge file is already pending");
+            Assert.That(File.Exists(bridgePath), Is.True, "the bridge file must exist at the exact path DeepLinkSentinel's poller reads");
+            Assert.That(File.Exists(tempPath), Is.False, "the temp file used for the write-then-rename must not be left behind (atomicity)");
+
+            string writtenContent = File.ReadAllText(bridgePath);
+
+            // This is the SAME parse call DeepLinkSentinel.StartListenForDeepLinksAsync makes on every 200ms
+            // check-in: DeepLink.FromJson(fileContent). Reusing it here IS the round-trip assertion — if the
+            // writer's DTO shape ever drifts from the reader's (field name, casing, nesting), this fails.
+            Result<DeepLink> parsed = DeepLink.FromJson(writtenContent);
+
+            Assert.That(parsed.Success, Is.True, $"the sentinel's own parser must accept the published bridge file; error: {parsed.ErrorMessage}");
+            Assert.That(parsed.Value.ValueOf(AppArgsFlags.SIGNIN), Is.EqualTo(SIGNIN_ID), "the signin id must survive the write/read round trip unchanged");
+            Assert.That(parsed.Value.ValueOf(AppArgsFlags.AUTH_REQUEST_ID), Is.EqualTo(AUTH_REQUEST_ID), "authRequestId must survive the write/read round trip unchanged — it is what lets the awaiting login claim this exact signin");
+        }
+
+        [Test]
+        public void NotOverwriteAnAlreadyPendingBridgeFile()
+        {
+            Assert.That(PUBLISH_METHOD, Is.Not.Null,
+                $"publish path missing: DeepLinkSentinel.{PUBLISH_METHOD_NAME} does not exist on this tree.");
+
+            // Written by hand (not via the new DeepLink.ToJson) so this arrange step compiles unpatched too: an
+            // unconsumed bridge file already on disk (placed by the launcher, or a racing sibling instance) must
+            // never be clobbered by a second publisher.
+            File.WriteAllText(bridgePath, "{\"deeplink\":\"decentraland://open?signin=already-pending-signin\"}");
+
+            var published = (bool) PUBLISH_METHOD!.Invoke(null, new object[] { RAW_SIGNIN_DEEPLINK })!;
+
+            Assert.That(published, Is.False, "TryPublishToBridge must refuse to overwrite a bridge file that is already pending");
+
+            Result<DeepLink> stillPending = DeepLink.FromJson(File.ReadAllText(bridgePath));
+            Assert.That(stillPending.Success, Is.True);
+            Assert.That(stillPending.Value.ValueOf(AppArgsFlags.SIGNIN), Is.EqualTo("already-pending-signin"), "the pre-existing pending signin must be left untouched");
+        }
+    }
+}

--- a/Explorer/Assets/DCL/RuntimeDeepLink/Tests/DeepLinkBridgePublishRoundTripShould.cs.meta
+++ b/Explorer/Assets/DCL/RuntimeDeepLink/Tests/DeepLinkBridgePublishRoundTripShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39e47cf1d5684ea080fc297030dfe332
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/RuntimeDeepLink/Tests/RuntimeDeepLink.Tests.asmref
+++ b/Explorer/Assets/DCL/RuntimeDeepLink/Tests/RuntimeDeepLink.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/RuntimeDeepLink/Tests/RuntimeDeepLink.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/RuntimeDeepLink/Tests/RuntimeDeepLink.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 54b4a23a8d38410a8b1f004b4788192f
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
The affected machine is stranded on the old Electron launcher (the Rust launcher only gained Mac Intel support five days before this report, and the Electron launcher's auto-updater 404s, so it can't self-update). That launcher quits once its window closes, so the deeplink callback cold-starts a brand new launcher and a brand new Explorer instead of bridging the URL to the already-running one. The new Explorer trips unity-explorer's single-instance file-lock guard — and on every platform, not just this one, that guard branch discards whatever deeplink the second launch carried before exiting, so there is no client-side recovery even from a well-behaved launcher.

Fixes #9520

Includes a regression test that fails without this fix.

# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, copy-pasteable steps for testing these changes.

### Quick reference

# Run this PR (with cache)
metaforge explorer run <this-PR-number>

# Run this PR (without cache — clears Explorer data)
metaforge explorer run <this-PR-number> --clear

# Run this PR (fresh account — clears everything and creates a new account)
metaforge account create --clear
metaforge explorer run <this-PR-number>

# Tail logs while testing
metaforge explorer logs tail --filter "<relevant text>"

# Run automation tests against this PR
metaforge explorer test <this-PR-number>
-->

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
