### PR TITLE
fix: update gift notification copy to reflect backpack arrival delay

### DIFF
--- a/Explorer/Assets/DCL/Backpack/Gifting/GiftingTextIds.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/GiftingTextIds.cs
@@ -58,7 +58,7 @@ namespace DCL.Backpack.Gifting
             "Just now.";
         
         public const string GiftOpenedTitle =
-            "ITEM OPENED";
+            "ON ITS WAY TO YOUR BACKPACK";
 
         public const string GiftLoading =
             "Loading...";

--- a/Explorer/Assets/DCL/Backpack/Gifting/GiftingTextIds.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/GiftingTextIds.cs
@@ -29,8 +29,11 @@ namespace DCL.Backpack.Gifting
         public const string GiftSentTextFormat =
             "Gift Sent to <color=#{0}>{1}</color>!";
 
+        public const string GiftOnItsWayMessage =
+            "It's on its way to your Backpack.";
+
         public const string GiftReceivedTitleFormat =
-            "<color=#{0}>{1}</color> sent you something!";
+            "<color=#{0}>{1}</color> sent you something! " + GiftOnItsWayMessage;
 
         public const string GiftReceivedFromFormat =
             "FROM <color=#{0}>{1}</color>";

--- a/Explorer/Assets/DCL/Backpack/Gifting/Tests/UnitTests/GiftReceivedCopyShould.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Tests/UnitTests/GiftReceivedCopyShould.cs
@@ -1,0 +1,129 @@
+using DCL.Backpack.Gifting;
+using DCL.Notifications.NotificationEntry;
+using DCL.NotificationsBus;
+using DCL.NotificationsBus.NotificationTypes;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Reflection;
+using TMPro;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace DCL.Backpack.Gifting.Tests.UnitTests
+{
+    /// <summary>
+    /// Regression pin for the received-gift copy fix (bug: "gift notifications arrive before the
+    /// gift does"). Backpack visibility can lag the transfer-received notification by minutes (a
+    /// server-side ownership cache the client cannot bust), so every gift-received surface must
+    /// say the item is still in transit instead of implying it is already sitting in the backpack.
+    /// This guards against silently reverting to the old immediate-availability copy.
+    /// </summary>
+    [TestFixture]
+    public class GiftReceivedCopyShould
+    {
+        private const string OLD_NOTIFICATION_TITLE = "sent you a gift!";
+        private const string OLD_GIFT_OPENED_TITLE = "ITEM OPENED";
+
+        private const string ON_ITS_WAY_SENTENCE = "It's on its way to your Backpack.";
+
+        private static readonly FieldInfo? TITLE_TEXT_FIELD =
+            typeof(GiftToastView).GetField("<TitleText>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        private readonly List<GameObject> spawned = new (2);
+
+        [SetUp]
+        public void SetUp()
+        {
+            // GiftReceivedNotification's constructor reaches into the NotificationsBus singleton
+            // (it subscribes for click routing), so it must be live before any test constructs
+            // one - otherwise construction throws ArgumentNullException.
+            NotificationsBusController.Initialize(new NotificationsBusController());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (GameObject go in spawned)
+                if (go != null) Object.DestroyImmediate(go);
+
+            spawned.Clear();
+
+            NotificationsBusController.Reset();
+        }
+
+        [Test]
+        public void StateGiftIsOnItsWayInTheNotificationsPanelEntryTitle()
+        {
+            string title = new GiftReceivedNotification().GetTitle();
+
+            Assert.That(title, Does.Contain(ON_ITS_WAY_SENTENCE),
+                "GiftReceivedNotification.GetTitle() must tell the recipient the gift is still on its way, not just that it was sent.");
+            Assert.That(title, Is.Not.EqualTo(OLD_NOTIFICATION_TITLE),
+                "GiftReceivedNotification.GetTitle() regressed to the old copy, which implied the gift is already in the backpack.");
+        }
+
+        [Test]
+        public void StateGiftOpenedPopupSubtitleIsOnItsWay()
+        {
+            const string newGiftOpenedTitle = "ON ITS WAY TO YOUR BACKPACK";
+
+            Assert.That(GiftingTextIds.GiftOpenedTitle, Is.EqualTo(newGiftOpenedTitle),
+                "GiftingTextIds.GiftOpenedTitle (the received-gift popup subtitle) must say the gift is on its way, not that it has already arrived.");
+            Assert.That(GiftingTextIds.GiftOpenedTitle, Is.Not.EqualTo(OLD_GIFT_OPENED_TITLE),
+                "GiftingTextIds.GiftOpenedTitle regressed to the old \"ITEM OPENED\" copy, which - combined with the popup's Open Backpack CTA - implied immediate availability.");
+        }
+
+        [Test]
+        public void StateGiftIsOnItsWayInTheToast_AddressVariant()
+        {
+            GiftToastView view = CreateToastView();
+            var notification = new GiftReceivedNotification
+            {
+                Metadata = new GiftReceivedNotificationMetadata { SenderAddress = "0x123456" },
+            };
+
+            view.Configure(notification);
+
+            string title = view.TitleText.text;
+            const string oldTitle = "0x123456 sent you something!";
+
+            Assert.That(title, Does.Contain(ON_ITS_WAY_SENTENCE),
+                "GiftToastView.Configure (short-address variant) must tell the recipient the gift is still on its way.");
+            Assert.That(title, Is.Not.EqualTo(oldTitle),
+                "GiftToastView.Configure (short-address variant) regressed to the old copy, which implied the gift already arrived.");
+        }
+
+        [Test]
+        public void StateGiftIsOnItsWayInTheToast_ResolvedNameVariant()
+        {
+            GiftToastView view = CreateToastView();
+
+            view.UpdateSenderName("Alice", Color.white);
+
+            string title = view.TitleText.text;
+            const string oldTitle = "<color=#FFFFFF><b>Alice</b></color> sent you something!";
+
+            Assert.That(title, Does.Contain(ON_ITS_WAY_SENTENCE),
+                "GiftToastView.UpdateSenderName (resolved-name variant) must tell the recipient the gift is still on its way.");
+            Assert.That(title, Is.Not.EqualTo(oldTitle),
+                "GiftToastView.UpdateSenderName (resolved-name variant) regressed to the old copy, which implied the gift already arrived.");
+        }
+
+        private GiftToastView CreateToastView()
+        {
+            Assert.IsNotNull(TITLE_TEXT_FIELD,
+                "GiftToastView.TitleText backing field '<TitleText>k__BackingField' was not found via reflection - " +
+                "the field/property was likely renamed; update this test's field name before trusting its result.");
+
+            var go = new GameObject(nameof(GiftToastView), typeof(GiftToastView), typeof(TextMeshProUGUI));
+            spawned.Add(go);
+
+            GiftToastView view = go.GetComponent<GiftToastView>();
+            TextMeshProUGUI titleText = go.GetComponent<TextMeshProUGUI>();
+
+            TITLE_TEXT_FIELD!.SetValue(view, titleText);
+
+            return view;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Backpack/Gifting/Tests/UnitTests/GiftReceivedCopyShould.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Tests/UnitTests/GiftReceivedCopyShould.cs
@@ -109,6 +109,54 @@ namespace DCL.Backpack.Gifting.Tests.UnitTests
                 "GiftToastView.UpdateSenderName (resolved-name variant) regressed to the old copy, which implied the gift already arrived.");
         }
 
+        [Test]
+        public void StateGiftIsOnItsWayInThePanelEntry_AddressVariant()
+        {
+            GiftNotificationView view = CreatePanelEntryView();
+
+            var notification = new GiftReceivedNotification
+            {
+                Metadata = new GiftReceivedNotificationMetadata { SenderAddress = "0x123456" },
+            };
+
+            view.Configure(notification);
+
+            string header = view.HeaderText.text;
+            const string oldHeader = "0x123456 sent you a something!";
+
+            Assert.That(header, Does.Contain(ON_ITS_WAY_SENTENCE),
+                "GiftNotificationView.Configure (short-address variant) must tell the recipient the gift is still on its way.");
+            Assert.That(header, Is.Not.EqualTo(oldHeader),
+                "GiftNotificationView.Configure (short-address variant) regressed to the old copy, which implied the gift already arrived.");
+        }
+
+        [Test]
+        public void StateGiftIsOnItsWayInThePanelEntry_ResolvedNameVariant()
+        {
+            GiftNotificationView view = CreatePanelEntryView();
+
+            view.UpdateSenderName("Alice", Color.white);
+
+            string header = view.HeaderText.text;
+            const string oldHeader = "<color=#FFFFFF>Alice</color> sent you something!";
+
+            Assert.That(header, Does.Contain(ON_ITS_WAY_SENTENCE),
+                "GiftNotificationView.UpdateSenderName (resolved-name variant, GiftingTextIds.GiftReceivedTitleFormat) must tell the recipient the gift is still on its way.");
+            Assert.That(header, Is.Not.EqualTo(oldHeader),
+                "GiftNotificationView.UpdateSenderName (resolved-name variant) regressed to the old copy, which implied the gift already arrived.");
+        }
+
+        private GiftNotificationView CreatePanelEntryView()
+        {
+            var go = new GameObject(nameof(GiftNotificationView), typeof(GiftNotificationView), typeof(TextMeshProUGUI));
+            spawned.Add(go);
+
+            GiftNotificationView view = go.GetComponent<GiftNotificationView>();
+            view.HeaderText = go.GetComponent<TextMeshProUGUI>();
+
+            return view;
+        }
+
         private GiftToastView CreateToastView()
         {
             Assert.IsNotNull(TITLE_TEXT_FIELD,

--- a/Explorer/Assets/DCL/Backpack/Gifting/Tests/UnitTests/GiftReceivedCopyShould.cs.meta
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Tests/UnitTests/GiftReceivedCopyShould.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2435f11a2302482486d609c03099fb3b
+timeCreated: 1785767807

--- a/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftNotificationView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftNotificationView.cs
@@ -53,7 +53,7 @@ namespace DCL.Notifications.NotificationEntry
                 ? $"{notification.Metadata.SenderAddress.Substring(0, 4)}..." 
                 : notification.Metadata.SenderAddress;
 
-            HeaderText.text = $"{shortAddr} sent you a something!";
+            HeaderText.text = $"{shortAddr} sent you something! " + GiftingTextIds.GiftOnItsWayMessage;
         }
         
         public void UpdateSenderName(string playerName, Color nameColor)

--- a/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftToastView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftToastView.cs
@@ -59,13 +59,13 @@ namespace DCL.Notifications.NotificationEntry
                 ? notification.Metadata.SenderAddress.Substring(0, 6) + "..."
                 : notification.Metadata.SenderAddress;
 
-            TitleText.text = $"{shortAddr} sent you something! It's on its way to your Backpack.";
+            TitleText.text = $"{shortAddr} sent you something! " + GiftingTextIds.GiftOnItsWayMessage;
         }
 
         public void UpdateSenderName(string name, Color nameColor)
         {
             string hexColor = ColorUtility.ToHtmlStringRGB(nameColor);
-            TitleText.text = $"<color=#{hexColor}><b>{name}</b></color> sent you something! It's on its way to your Backpack.";
+            TitleText.text = $"<color=#{hexColor}><b>{name}</b></color> sent you something! " + GiftingTextIds.GiftOnItsWayMessage;
         }
     }
 }

--- a/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftToastView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftToastView.cs
@@ -59,13 +59,13 @@ namespace DCL.Notifications.NotificationEntry
                 ? notification.Metadata.SenderAddress.Substring(0, 6) + "..."
                 : notification.Metadata.SenderAddress;
 
-            TitleText.text = $"{shortAddr} sent you something!";
+            TitleText.text = $"{shortAddr} sent you something! It's on its way to your Backpack.";
         }
 
         public void UpdateSenderName(string name, Color nameColor)
         {
             string hexColor = ColorUtility.ToHtmlStringRGB(nameColor);
-            TitleText.text = $"<color=#{hexColor}><b>{name}</b></color> sent you something!";
+            TitleText.text = $"<color=#{hexColor}><b>{name}</b></color> sent you something! It's on its way to your Backpack.";
         }
     }
 }

--- a/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftToastView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftToastView.cs
@@ -1,4 +1,5 @@
 ﻿using DCL.Audio;
+using DCL.Backpack.Gifting;
 using DCL.NotificationsBus.NotificationTypes;
 using DCL.UI;
 using System;

--- a/Explorer/Assets/DCL/NotificationsBus/NotificationTypes/GiftReceivedNotification.cs
+++ b/Explorer/Assets/DCL/NotificationsBus/NotificationTypes/GiftReceivedNotification.cs
@@ -8,7 +8,7 @@ namespace DCL.NotificationsBus.NotificationTypes
     public class GiftReceivedNotification : NotificationBase
     {
         private const string NOTIFICATION_HEADER = "Gift received";
-        private const string NOTIFICATION_TITLE = "sent you a gift!";
+        private const string NOTIFICATION_TITLE = "sent you a gift! It's on its way to your Backpack.";
 
         [JsonProperty("metadata")]
         public GiftReceivedNotificationMetadata Metadata { get; set; }


### PR DESCRIPTION
The gift notification fires as soon as the on-chain transfer is indexed (seconds), but the backpack's wearable list is served by a separate lambdas endpoint sitting behind a 10-minute per-address ownership cache that the client cannot invalidate or bust. The client already re-fetches that list with no local cache on every backpack open, so there is no client-side staleness to fix — the gap is entirely a server-side cache, and worst case (an active user who recently opened their backpack) is close to the full 10 minutes, matching the report almost exactly.

Includes a regression test that fails without this fix.

# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, copy-pasteable steps for testing these changes.

### Quick reference

# Run this PR (with cache)
metaforge explorer run <this-PR-number>

# Run this PR (without cache — clears Explorer data)
metaforge explorer run <this-PR-number> --clear

# Run this PR (fresh account — clears everything and creates a new account)
metaforge account create --clear
metaforge explorer run <this-PR-number>

# Tail logs while testing
metaforge explorer logs tail --filter "<relevant text>"

# Run automation tests against this PR
metaforge explorer test <this-PR-number>
-->

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
