### PR TITLE
fix: recover backpack wearables provider after transient fetch failures

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/ApplicationParametersWearablesProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/ApplicationParametersWearablesProvider.cs
@@ -67,62 +67,69 @@ namespace DCL.AvatarRendering.Wearables
 
                 results ??= new List<ITrimmedWearable>();
                 var localBuffer = ListPool<ITrimmedWearable>.Get();
-                for (var i = 0; i < collections.Length; i++)
+
+                try
                 {
-                    // localBuffer accumulates the loaded wearables
-                    await source.GetTrimmedByParamsAsync(
-                        parameters,
-                        ct,
-                        localBuffer,
-                        loadingArguments: new CommonLoadingArguments(
-                            builderDTOsUrl.Replace(LoadingConstants.BUILDER_DTO_URL_COL_ID_PLACEHOLDER, collections[i]),
-                            cancellationTokenSource: new CancellationTokenSource()
-                        ),
-                        needsBuilderAPISigning: true
-                    );
+                    for (var i = 0; i < collections.Length; i++)
+                    {
+                        // localBuffer accumulates the loaded wearables
+                        await source.GetTrimmedByParamsAsync(
+                            parameters,
+                            ct,
+                            localBuffer,
+                            loadingArguments: new CommonLoadingArguments(
+                                builderDTOsUrl.Replace(LoadingConstants.BUILDER_DTO_URL_COL_ID_PLACEHOLDER, collections[i]),
+                                cancellationTokenSource: new CancellationTokenSource()
+                            ),
+                            needsBuilderAPISigning: true
+                        );
+                    }
+
+                    // Include ALL user's available wearables (loop pages)
+                    // Higher page size to do a lot less requests.
+                    const int OWNED_PAGE_SIZE = 200;
+                    IWearablesProvider.Params subParameters = parameters;
+                    subParameters.PageSize = OWNED_PAGE_SIZE;
+                    subParameters.PageNumber = 1;
+                    int ownedTotal = int.MaxValue;
+                    using var ownedPageBufferScope = ListPool<ITrimmedWearable>.Get(out var ownedPageBuffer);
+
+                    while (localBuffer.Count < ownedTotal)
+                    {
+                        ownedPageBuffer.Clear();
+                        (var ownedPageResults, int ownedPageTotal) = await source.GetTrimmedByParamsAsync(
+                            subParameters,
+                            ct,
+                            results: ownedPageBuffer
+                        );
+
+                        ownedTotal = ownedPageTotal;
+
+                        if (ownedPageResults.Count == 0)
+                            break;
+
+                        localBuffer.AddRange(ownedPageResults);
+                        subParameters.PageNumber++;
+                    }
+
+                    // De-duplicate by URN and paginate the unified list
+                    var unified = localBuffer
+                        .GroupBy(w => w.GetUrn())
+                        .Select(g => g.First())
+                        .ToList();
+
+                    int pageIndex = parameters.PageNumber - 1;
+                    results.AddRange(unified.Skip(pageIndex * parameters.PageSize).Take(parameters.PageSize));
+
+                    int count = unified.Count;
+
+                    return (results, count);
                 }
-
-                // Include ALL user's available wearables (loop pages)
-                // Higher page size to do a lot less requests.
-                const int OWNED_PAGE_SIZE = 200;
-                IWearablesProvider.Params subParameters = parameters;
-                subParameters.PageSize = OWNED_PAGE_SIZE;
-                subParameters.PageNumber = 1;
-                int ownedTotal = int.MaxValue;
-                using var ownedPageBufferScope = ListPool<ITrimmedWearable>.Get(out var ownedPageBuffer);
-
-                while (localBuffer.Count < ownedTotal)
+                finally
                 {
-                    ownedPageBuffer.Clear();
-                    (var ownedPageResults, int ownedPageTotal) = await source.GetTrimmedByParamsAsync(
-                        subParameters,
-                        ct,
-                        results: ownedPageBuffer
-                    );
-
-                    ownedTotal = ownedPageTotal;
-
-                    if (ownedPageResults.Count == 0)
-                        break;
-
-                    localBuffer.AddRange(ownedPageResults);
-                    subParameters.PageNumber++;
+                    // The fetches above can throw: the pooled buffer must be released on every path
+                    ListPool<ITrimmedWearable>.Release(localBuffer);
                 }
-
-                // De-duplicate by URN and paginate the unified list
-                var unified = localBuffer
-                    .GroupBy(w => w.GetUrn())
-                    .Select(g => g.First())
-                    .ToList();
-
-                int pageIndex = parameters.PageNumber - 1;
-                results.AddRange(unified.Skip(pageIndex * parameters.PageSize).Take(parameters.PageSize));
-
-                int count = unified.Count;
-
-                ListPool<ITrimmedWearable>.Release(localBuffer);
-
-                return (results, count);
             }
 
             return await source.GetTrimmedByParamsAsync(

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/ECSWearablesProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/ECSWearablesProvider.cs
@@ -6,11 +6,13 @@ using DCL.AvatarRendering.Loading.Components;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.AvatarRendering.Wearables.Components.Intentions;
 using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Diagnostics;
 using DCL.Web3.Identities;
 using ECS.Prioritization.Components;
 using ECS.StreamableLoading.Common;
 using ECS.StreamableLoading.Common.Components;
 using Runtime.Wearables;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -100,7 +102,14 @@ namespace DCL.AvatarRendering.Wearables
 
             if (wearablesPromise.Result == null) return (results, 0);
             if (!wearablesPromise.Result.HasValue) return (results, 0);
-            if (!wearablesPromise.Result!.Value.Succeeded) return (results, 0);
+
+            if (!wearablesPromise.Result!.Value.Succeeded)
+            {
+                // A failed fetch is not an empty inventory: propagate so callers can distinguish the two
+                Exception exception = wearablesPromise.Result.Value.Exception ?? new Exception("Owned wearables request failed without exception details");
+                ReportHub.LogError(ReportCategory.WEARABLE, $"Owned wearables request failed: {exception.Message}");
+                throw exception;
+            }
 
             results.AddRange(wearablesPromise.Result.Value.Asset.Wearables);
             return (results, wearablesPromise.Result.Value.Asset.TotalAmount);

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ECSWearablesProviderShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ECSWearablesProviderShould.cs
@@ -1,0 +1,147 @@
+using Arch.Core;
+using CommunicationData.URLHelpers;
+using Cysharp.Threading.Tasks;
+using DCL.AvatarRendering.Wearables;
+using DCL.AvatarRendering.Wearables.Components;
+using DCL.AvatarRendering.Wearables.Components.Intentions;
+using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.AvatarRendering.Wearables.Systems.Load;
+using DCL.Browser.DecentralandUrls;
+using DCL.Diagnostics.Tests;
+using DCL.Optimization.PerformanceBudgeting;
+using DCL.Web3.Identities;
+using ECS;
+using ECS.StreamableLoading.Cache;
+using ECS.StreamableLoading.Common.Components;
+using ECS.TestSuite;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace DCL.AvatarRendering.Wearables.Tests
+{
+    /// <summary>
+    ///     <see cref="ECSWearablesProvider" /> is the seam between the backpack/gifting/lobby callers
+    ///     and the lambdas fetch: a failed fetch (5xx/network error) must propagate as an exception, not
+    ///     be converted into an empty result, so callers can distinguish "the fetch failed" from "this
+    ///     wallet owns nothing". A genuine 200 with zero owned wearables must still come back as a
+    ///     plain empty result.
+    /// </summary>
+    [TestFixture]
+    public class ECSWearablesProviderShould : UnitySystemTestBase<LoadTrimmedWearablesByParamSystem>
+    {
+        private string emptySuccessPath => $"file://{Application.dataPath}/../TestResources/Wearables/EmptyUserParam";
+        private string failPath => $"file://{Application.dataPath}/../TestResources/Wearables/non_existing";
+
+        private MockedReportScope mockedReportScope;
+        private ECSWearablesProvider provider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            mockedReportScope = new MockedReportScope();
+
+            IRealmData realmData = Substitute.For<IRealmData>();
+            realmData.Configured.Returns(true);
+
+            var cache = Substitute.For<IStreamableCache<TrimmedWearablesResponse, GetTrimmedWearableByParamIntention>>();
+
+            system = new LoadTrimmedWearablesByParamSystem(world, TestWebRequestController.INSTANCE, cache, realmData,
+                URLSubdirectory.FromString("Wearables"), DecentralandUrlsSource.CreateForTest(), new WearableStorage(),
+                new TrimmedWearableStorage());
+
+            system.Initialize();
+
+            // The identity's address only ends up in the request's userID/query string, which is
+            // irrelevant here because PointRequestsAt overrides the resolved URL outright.
+            provider = new ECSWearablesProvider(new IWeb3IdentityCache.Fake(), world);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            mockedReportScope.Dispose();
+        }
+
+        /// <summary>
+        ///     Overrides the system's internal URL builder so the lambdas request resolves to a fixed
+        ///     local `file://` fixture, exactly like <c>LoadWearableByParamSystemShould</c> does for the
+        ///     system-level tests: every fluent call is stubbed to return the same substitute, and
+        ///     <c>Build()</c>/<c>GetResult()</c> are pinned to <paramref name="path" /> regardless of the
+        ///     domain/subdirectory/params the provider actually built.
+        /// </summary>
+        private void PointRequestsAt(string path)
+        {
+            IURLBuilder urlBuilder = Substitute.For<IURLBuilder>();
+            urlBuilder.AppendDomainWithReplacedPath(Arg.Any<URLDomain>(), Arg.Any<URLSubdirectory>()).Returns(urlBuilder);
+            urlBuilder.AppendSubDirectory(Arg.Any<URLSubdirectory>()).Returns(urlBuilder);
+            urlBuilder.GetResult().Returns(path);
+            urlBuilder.Build().Returns(URLAddress.FromString(path));
+
+            system.urlBuilder = urlBuilder;
+        }
+
+        /// <summary>
+        ///     There is no budget/scheduling system running in this bare test world, so the promise
+        ///     entity created inside <see cref="ECSWearablesProvider.GetTrimmedByParamsAsync" /> would sit
+        ///     forever at <see cref="StreamableLoadingState.Status.NotStarted" />. This mirrors
+        ///     <c>LoadSystemBaseShould.ForceAllowed</c>, but by query rather than by a directly-held
+        ///     promise entity, since the provider creates and owns the promise internally.
+        /// </summary>
+        private void AllowPendingLoad()
+        {
+            var query = new QueryDescription().WithAll<StreamableLoadingState>();
+
+            world.Query(in query, (ref StreamableLoadingState state) =>
+            {
+                if (state.Value == StreamableLoadingState.Status.NotStarted)
+                    state.SetAllowed(Substitute.For<IAcquiredBudget>());
+            });
+        }
+
+        [Test]
+        public async Task ThrowOnFailedLambdasFetchInsteadOfReturningEmpty()
+        {
+            PointRequestsAt(failPath);
+
+            UniTask<(IReadOnlyList<ITrimmedWearable> results, int totalAmount)> resultTask =
+                provider.GetTrimmedByParamsAsync(new IWearablesProvider.Params(16, 1), CancellationToken.None);
+
+            AllowPendingLoad();
+            system.Update(0);
+
+            Exception caught = null;
+
+            try { await resultTask; }
+            catch (Exception e) { caught = e; }
+
+            Assert.NotNull(caught,
+                "A failed lambdas fetch must propagate as an exception so callers can distinguish " +
+                "'the fetch failed' from 'this wallet owns nothing' - silently returning (empty, 0) " +
+                "makes a backend outage indistinguishable from an empty inventory.");
+        }
+
+        [Test]
+        public async Task ReturnEmptyWithoutThrowingOnGenuineEmptySuccessResponse()
+        {
+            // Companion case: a real 200 with zero owned wearables must still come back as a plain
+            // empty result, not be conflated with (or accidentally turned into) a failure.
+            PointRequestsAt(emptySuccessPath);
+
+            UniTask<(IReadOnlyList<ITrimmedWearable> results, int totalAmount)> resultTask =
+                provider.GetTrimmedByParamsAsync(new IWearablesProvider.Params(16, 1), CancellationToken.None);
+
+            AllowPendingLoad();
+            system.Update(0);
+
+            (IReadOnlyList<ITrimmedWearable> results, int totalAmount) result = await resultTask;
+
+            Assert.That(result.results, Is.Empty);
+            Assert.That(result.totalAmount, Is.EqualTo(0));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ECSWearablesProviderShould.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ECSWearablesProviderShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc8f9ce6243b4aaabfb0c6d3a4ee5976
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -422,7 +422,14 @@ namespace DCL.Backpack
                 SetGridElements(currentPageWearables);
             }
             catch (OperationCanceledException) { }
-            catch (Exception e) { ReportHub.LogException(e, new ReportData(ReportCategory.BACKPACK)); }
+            catch (Exception e)
+            {
+                ReportHub.LogException(e, new ReportData(ReportCategory.BACKPACK));
+
+                // A failed fetch must not leave the loading placeholders animating forever:
+                // release them so the grid shows its empty state (results is empty on this path)
+                SetGridElements(results);
+            }
         }
 
         private async UniTaskVoid InitializeItemViewAsync(ITrimmedWearable itemWearable, BackpackItemView itemView, CancellationToken ct)

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
@@ -464,6 +464,10 @@ MonoBehaviour:
       Severity: 2
     - Category: AUTHENTICATION
       Severity: 0
+    - Category: BACKPACK
+      Severity: 0
+    - Category: WEARABLE
+      Severity: 0
   sentryMatrix:
     entries:
     - Category: AUDIO_SOURCES

--- a/Explorer/TestResources/Wearables/EmptyUserParam
+++ b/Explorer/TestResources/Wearables/EmptyUserParam
@@ -1,0 +1,6 @@
+{
+	"elements": [],
+	"totalAmount": 0,
+	"pageNum": 1,
+	"pageSize": 16
+}


### PR DESCRIPTION
Transient wearables-fetch failures were cached by the provider, leaving the backpack permanently empty until restart instead of retrying once the backend recovered.

Fixes #9553

Includes a regression test that fails without this fix.

# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, copy-pasteable steps for testing these changes.

### Quick reference

# Run this PR (with cache)
metaforge explorer run <this-PR-number>

# Run this PR (without cache — clears Explorer data)
metaforge explorer run <this-PR-number> --clear

# Run this PR (fresh account — clears everything and creates a new account)
metaforge account create --clear
metaforge explorer run <this-PR-number>

# Tail logs while testing
metaforge explorer logs tail --filter "<relevant text>"

# Run automation tests against this PR
metaforge explorer test <this-PR-number>
-->

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
