### PR TITLE
fix: expire stale point-at state from replayed remote snapshots

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Movement/Systems/RemotePlayersMovementSystem.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Systems/RemotePlayersMovementSystem.cs
@@ -46,8 +46,19 @@ namespace DCL.Multiplayer.Movement
 
             remotePlayerMovement.AddPassed(firstRemote, characterControllerSettings, wasTeleported: true);
             remotePlayerMovement.UpdateHeadIK(firstRemote);
-            remotePlayerMovement.UpdatePointAtIK(firstRemote);
+            UpdatePointAtIK(ref remotePlayerMovement, ref handPointAt, firstRemote);
             remotePlayerMovement.Initialized = true;
+        }
+
+        private void UpdatePointAtIK(ref RemotePlayerMovementComponent remotePlayerMovement, ref HandPointAtComponent handPointAt, in NetworkMovementMessage message)
+        {
+            remotePlayerMovement.UpdatePointAtIK(message);
+
+            // A point-at assertion aims at an absolute world point and is only as fresh as the
+            // message that carried it: rearm the same expiry the local gesture uses, so a
+            // snapshot-replayed point-at cannot outlive the gesture it mirrors.
+            if (message.isPointingAt)
+                handPointAt.RefreshDuration(characterControllerSettings.PointAtDuration);
         }
 
         [Query]
@@ -87,6 +98,13 @@ namespace DCL.Multiplayer.Movement
             if (remotePlayerMovement.IsPointingAt) pointAtWorldHitPoint = Interpolation.InterpolatePointAtIK(handPointAt, remotePlayerMovement.PointAtWorldHitPoint, settings.InterpolationSettings.PointAtIKInterpolationFactor);
             ApplyPointAtIK(ref handPointAt, remotePlayerMovement.IsPointingAt, pointAtWorldHitPoint);
 
+            // Mirrors the local PointAtDuration timer (HandPointAtSystem): unless a newer message
+            // rearms it, remote pointing self-expires instead of pinning the arm at a stale
+            // absolute world point forever when no contradicting message ever arrives.
+            handPointAt.TickDuration(deltaTime);
+            if (remotePlayerMovement.IsPointingAt && !handPointAt.IsPointing)
+                remotePlayerMovement.IsPointingAt = false;
+
             if (intComp.Enabled)
             {
                 deltaTime = Interpolate(deltaTime, ref transComp, ref remotePlayerMovement, ref intComp);
@@ -114,15 +132,15 @@ namespace DCL.Multiplayer.Movement
             }
 
             if (playerInbox.Count > 0)
-                HandleNewMessage(deltaTime, ref transComp, ref remotePlayerMovement, ref intComp, ref extComp, playerInbox);
+                HandleNewMessage(deltaTime, ref transComp, ref remotePlayerMovement, ref intComp, ref extComp, ref handPointAt, playerInbox);
         }
 
         private void HandleNewMessage(float deltaTime, ref CharacterTransform transComp, ref RemotePlayerMovementComponent remotePlayerMovement, ref InterpolationComponent intComp, ref ExtrapolationComponent extComp,
-            SimplePriorityQueue<NetworkMovementMessage, double> playerInbox)
+            ref HandPointAtComponent handPointAt, SimplePriorityQueue<NetworkMovementMessage, double> playerInbox)
         {
             NetworkMovementMessage remote = playerInbox.Dequeue();
             remotePlayerMovement.UpdateHeadIK(remote);
-            remotePlayerMovement.UpdatePointAtIK(remote);
+            UpdatePointAtIK(ref remotePlayerMovement, ref handPointAt, remote);
 
             var isBlend = false;
 
@@ -143,7 +161,7 @@ namespace DCL.Multiplayer.Movement
 
                 remote = playerInbox.Dequeue();
                 remotePlayerMovement.UpdateHeadIK(remote);
-                remotePlayerMovement.UpdatePointAtIK(remote);
+                UpdatePointAtIK(ref remotePlayerMovement, ref handPointAt, remote);
             }
 
             StartInterpolation(deltaTime, ref transComp, ref remotePlayerMovement, ref intComp, remote, isBlend);

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Tests/RemotePlayerPointAtExpiryShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Tests/RemotePlayerPointAtExpiryShould.cs
@@ -1,0 +1,140 @@
+using Arch.Core;
+using DCL.Character.CharacterMotion.Components;
+using DCL.Character.Components;
+using DCL.CharacterMotion.Components;
+using DCL.CharacterMotion.Settings;
+using DCL.Multiplayer.Movement.Settings;
+using ECS.TestSuite;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Pool;
+using Utility.PriorityQueue;
+
+namespace DCL.Multiplayer.Movement.Tests
+{
+    /// <summary>
+    ///     Regression coverage for the "arm points in the wrong direction" bug: a remote point-at
+    ///     assertion aims the avatar's arm at an absolute <see cref="HandPointAtComponent.WorldHitPoint" />,
+    ///     and unlike the local gesture (<c>HandPointAtSystem</c>, bounded by
+    ///     <see cref="ICharacterControllerSettings.PointAtDuration" />), the remote replay path had no expiry:
+    ///     a single stale snapshot (e.g. a respawn/reconnect/teleport-return replay) pinned the arm at an
+    ///     outdated world point forever, because nothing ever contradicted an idle pointer.
+    /// </summary>
+    public class RemotePlayerPointAtExpiryShould : UnitySystemTestBase<RemotePlayersMovementSystem>
+    {
+        private const float POINT_AT_DURATION = 1f;
+        private const float MOVE_SEND_RATE = 0.1f;
+        private const float STEP = 0.1f;
+
+        private GameObject remoteGameObject;
+        private Entity remoteEntity;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var movementSettings = Substitute.For<IMultiplayerMovementSettings>();
+            movementSettings.MoveSendRate.Returns(MOVE_SEND_RATE);
+            movementSettings.MinTeleportDistance.Returns(100f);
+            movementSettings.MinPositionDelta.Returns(0.01f);
+            movementSettings.MinRotationDelta.Returns(0.01f);
+
+            // ReSharper disable once Unity.IncorrectScriptableObjectInstantiation
+            movementSettings.InterpolationSettings.Returns(new RemotePlayerInterpolationSettings
+            {
+                UseSpeedUp = false,
+                UseBlend = false,
+            });
+
+            var characterControllerSettings = Substitute.For<ICharacterControllerSettings>();
+            characterControllerSettings.RotationSpeed.Returns(10f);
+            characterControllerSettings.PointAtDuration.Returns(POINT_AT_DURATION);
+
+            system = new RemotePlayersMovementSystem(world, movementSettings, characterControllerSettings);
+
+            remoteGameObject = new GameObject(nameof(RemotePlayerPointAtExpiryShould));
+            var characterTransform = new CharacterTransform(remoteGameObject.transform);
+
+            var queuePool = new ObjectPool<SimplePriorityQueue<NetworkMovementMessage, double>>(
+                () => new SimplePriorityQueue<NetworkMovementMessage, double>(),
+                actionOnRelease: queue => queue.Clear());
+
+            remoteEntity = world.Create(
+                characterTransform,
+                new HeadIKComponent(),
+                new HandPointAtComponent(),
+                new RemotePlayerMovementComponent(queuePool),
+                new InterpolationComponent(),
+                new ExtrapolationComponent());
+
+            // Pre-clear the "wait for 2 messages" interpolation-stability gate so the per-frame
+            // point-at branch (where the expiry tick lives) runs starting the very next Update
+            // after the first message is applied, instead of needing a throwaway priming call.
+            ref RemotePlayerMovementComponent movementComponent = ref world.Get<RemotePlayerMovementComponent>(remoteEntity);
+            movementComponent.InitialCooldownTime = 2 * MOVE_SEND_RATE;
+            world.Set(remoteEntity, movementComponent);
+        }
+
+        protected override void OnTearDown()
+        {
+            world.Dispose();
+            Object.DestroyImmediate(remoteGameObject);
+        }
+
+        [Test]
+        public void ExpirePointingAfterPointAtDurationWithNoReassertion()
+        {
+            // Arrange - a single point-at snapshot arrives for a (re)spawned remote avatar, exactly
+            // like the server-cached snapshot replayed via HandlePlayerJoined / HandleTeleport /
+            // EmoteStarted after the reported scene-reload / teleport-return.
+            var pointingMessage = new NetworkMovementMessage
+            {
+                timestamp = 0,
+                position = Vector3.zero,
+                rotationY = 0f,
+                velocity = Vector3.zero,
+                velocitySqrMagnitude = 0f,
+                movementKind = MovementKind.Idle,
+                isInstant = true,
+                isPointingAt = true,
+                pointAtWorldHitPoint = new Vector3(5f, 1f, 5f),
+            };
+
+            ref RemotePlayerMovementComponent movementComponent = ref world.Get<RemotePlayerMovementComponent>(remoteEntity);
+            movementComponent.Enqueue(pointingMessage);
+            world.Set(remoteEntity, movementComponent);
+
+            // Act - process the first (and only) message.
+            system.Update(0.1f);
+
+            // Assert - the pointing state and IK input are applied immediately, as observed by others.
+            ref RemotePlayerMovementComponent afterFirstMessage = ref world.Get<RemotePlayerMovementComponent>(remoteEntity);
+            ref HandPointAtComponent handPointAtAfterFirstMessage = ref world.Get<HandPointAtComponent>(remoteEntity);
+            Assert.IsTrue(afterFirstMessage.IsPointingAt, "The first message should apply the replicated pointing state");
+            Assert.IsTrue(handPointAtAfterFirstMessage.IsPointing, "The first message should drive the point-at IK input");
+
+            // Act - advance time well past PointAtDuration via repeated per-frame updates, with NO
+            // further messages ever arriving -- this is the idle-pointer scenario from the bug report:
+            // nothing re-asserts or contradicts the stale point-at, yet nothing should keep driving the arm.
+            float elapsed = 0f;
+
+            while (elapsed < POINT_AT_DURATION + STEP)
+            {
+                system.Update(STEP);
+                elapsed += STEP;
+            }
+
+            // Assert - the stale point-at must have self-expired by now.
+            // Unpatched: HandPointAtComponent.IsPointing/RemotePlayerMovementComponent.IsPointingAt are
+            // never ticked or cleared on the remote path, so both remain stuck true indefinitely and
+            // these assertions fail.
+            ref HandPointAtComponent handPointAtAfterExpiry = ref world.Get<HandPointAtComponent>(remoteEntity);
+            ref RemotePlayerMovementComponent movementAfterExpiry = ref world.Get<RemotePlayerMovementComponent>(remoteEntity);
+
+            Assert.IsFalse(handPointAtAfterExpiry.IsPointing,
+                "Remote pointing must stop driving the arm IK after PointAtDuration elapses with no re-assertion");
+            Assert.IsFalse(movementAfterExpiry.IsPointingAt,
+                "The replicated pointing flag must clear too, otherwise it re-asserts handPointAt.IsPointing every subsequent frame");
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Tests/RemotePlayerPointAtExpiryShould.cs.meta
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Tests/RemotePlayerPointAtExpiryShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7acfc4e8b4ba4760ab02fb2ee982d5a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Server-cached movement snapshots delivered on join/teleport are applied by HandleFirstMessage with no freshness bound, and the remote path never expires IsPointing — one replayed pointing=true snapshot pins a remote avatar's arm at a stale absolute WorldHitPoint indefinitely. Bound the remote point-at lifetime the same way HandPointAtSystem bounds the local gesture.

Includes a regression test that fails without this fix.

# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, copy-pasteable steps for testing these changes.

### Quick reference

# Run this PR (with cache)
metaforge explorer run <this-PR-number>

# Run this PR (without cache — clears Explorer data)
metaforge explorer run <this-PR-number> --clear

# Run this PR (fresh account — clears everything and creates a new account)
metaforge account create --clear
metaforge explorer run <this-PR-number>

# Tail logs while testing
metaforge explorer logs tail --filter "<relevant text>"

# Run automation tests against this PR
metaforge explorer test <this-PR-number>
-->

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
