### PR TITLE
fix: allow cleartext http to loopback only

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/SimpleFetchApiImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/SimpleFetchApiImplementation.cs
@@ -68,7 +68,7 @@ namespace CrdtEcsBridge.JsModulesImplementation
                 if (parsedRequestMethod == RequestMethod.INVALID)
                     throw new ArgumentException("Invalid request method.");
 
-                var commonArguments = new CommonArguments(URLAddress.FromString(url), RetryPolicy.HEADER_REQUIRED, timeout: timeout);
+                var commonArguments = new CommonArguments(URLAddress.FromString(url), RetryPolicy.HEADER_REQUIRED, timeout: timeout, allowInsecureCleartext: isLocalSceneDevelopment);
                 WebRequestHeadersInfo webRequestHeaders = HeadersFromJsObject(headers);
 
                 await UniTask.SwitchToMainThread();

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/AbgenSidecar.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/AbgenSidecar.cs
@@ -3,6 +3,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Utility;
+using DCL.WebRequests;
 using ECS.StreamableLoading.AssetBundles;
 using System;
 using System.Collections.Generic;
@@ -81,8 +82,12 @@ namespace Global.Dynamic
         {
             BaseUrl = baseUrl;
             this.executablePath = executablePath;
-            this.realmRoot = realmRoot;
-            catalystContentUrl = realmRoot + CONTENT_PATH;
+
+            // The realm/catalyst fetches in this class bypass IWebRequestController, so the
+            // transport-security policy binds the realm root here: cleartext http stays
+            // loopback-only (the LSD preview server); any other http realm goes over https
+            this.realmRoot = WebRequestUtils.EnforceSecureScheme(realmRoot);
+            catalystContentUrl = this.realmRoot + CONTENT_PATH;
             this.upstreamCdnUrl = upstreamCdnUrl;
             this.cacheRoot = cacheRoot;
             this.jitContentDigest = jitContentDigest;

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/Tests/UrlResolverServiceShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/Tests/UrlResolverServiceShould.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using DCL.WebRequests;
 using NSubstitute;
 using NUnit.Framework;
@@ -99,6 +100,31 @@ namespace DCL.SDKComponents.MediaStream.Tests
 
             Assert.That(result.DirectUrl, Is.EqualTo(url));
             Assert.That(result.IsReachable, Is.False);
+        }
+
+        // --- Transport-security policy (direct URLs) ---
+        // The substituted controller's SendAsync completes synchronously, so the HEAD probe
+        // reports reachable and the raw-UnityWebRequest GET fallback is never sent.
+
+        [Test]
+        public async Task ResolveAsync_WhenDirectHttpNonLoopbackUrl_UpgradesProbeAndPlaybackUrlToHttps()
+        {
+            const string URL = "http://media.example.org/video.mp4";
+            const string UPGRADED_URL = "https://media.example.org/video.mp4";
+
+            ResolvedMediaUrl result = await service.ResolveAsync(URL, ReportData.UNSPECIFIED, CancellationToken.None).AsTask();
+
+            Assert.That(result.DirectUrl, Is.EqualTo(UPGRADED_URL));
+            Assert.That(result.IsReachable, Is.True);
+        }
+
+        [TestCase("http://127.0.0.1:8000/video.mp4")]
+        [TestCase("http://localhost:8001/video.mp4")]
+        public async Task ResolveAsync_WhenDirectLoopbackHttpUrl_KeepsCleartextUrl(string url)
+        {
+            ResolvedMediaUrl result = await service.ResolveAsync(url, default, CancellationToken.None).AsTask();
+
+            Assert.That(result.DirectUrl, Is.EqualTo(url));
         }
 
         // --- Cancellation ---

--- a/Explorer/Assets/DCL/SDKComponents/MediaStream/UrlResolverService.cs
+++ b/Explorer/Assets/DCL/SDKComponents/MediaStream/UrlResolverService.cs
@@ -23,6 +23,17 @@ namespace DCL.SDKComponents.MediaStream
 
         public async UniTask<ResolvedMediaUrl> ResolveAsync(string url, ReportData reportData, CancellationToken ct)
         {
+            // The transport-security policy binds the resolved URL itself, not just the probes:
+            // reachability checks and playback must agree on one wire URL, and cleartext http
+            // stays loopback-only for both
+            string secureUrl = WebRequestUtils.EnforceSecureScheme(url);
+
+            if (!ReferenceEquals(url, secureUrl))
+            {
+                ReportHub.LogWarning(reportData, $"Cleartext http media URL to a non-loopback host upgraded to https: {url}");
+                url = secureUrl;
+            }
+
             // YouTube resolution
             if (url.IsYouTubeUrl())
                 return await ResolveYouTubeAsync(url, ct);
@@ -90,7 +101,9 @@ namespace DCL.SDKComponents.MediaStream
 
         private static async UniTask<bool> IsGetReachableAsync(string url, CancellationToken ct)
         {
-            UnityWebRequest request = UnityWebRequest.Get(url);
+            // This request bypasses IWebRequestController, so the media transport-security policy
+            // (no cleartext to non-loopback hosts) binds directly at this send site
+            UnityWebRequest request = UnityWebRequest.Get(WebRequestUtils.EnforceSecureScheme(url));
 
             try
             {

--- a/Explorer/Assets/DCL/WebRequests/CommonArguments.cs
+++ b/Explorer/Assets/DCL/WebRequests/CommonArguments.cs
@@ -19,12 +19,21 @@ namespace DCL.WebRequests
         public readonly int Timeout;
         public readonly RetryPolicy RetryPolicy;
 
+        /// <summary>
+        ///     Cleartext http to any host is permitted for this request only when set. Used solely
+        ///     by the local-scene-development scene fetch, whose own module gate already vets the
+        ///     dev-mode case; every other request keeps the default and gets the secure-scheme
+        ///     enforcement.
+        /// </summary>
+        public readonly bool AllowInsecureCleartext;
+
         [JsonConstructor]
-        public CommonArguments(URLAddress url, RetryPolicy? retryPolicy = null, int timeout = DEFAULT_TIMEOUT)
+        public CommonArguments(URLAddress url, RetryPolicy? retryPolicy = null, int timeout = DEFAULT_TIMEOUT, bool allowInsecureCleartext = false)
         {
             URL = url;
             Timeout = timeout;
             RetryPolicy = retryPolicy ?? RetryPolicy.DEFAULT;
+            AllowInsecureCleartext = allowInsecureCleartext;
         }
 
         public static implicit operator CommonArguments(URLAddress url) =>

--- a/Explorer/Assets/DCL/WebRequests/RequestEnvelope.cs
+++ b/Explorer/Assets/DCL/WebRequests/RequestEnvelope.cs
@@ -1,17 +1,14 @@
 using DCL.Diagnostics;
-using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Optimization.Pools;
 using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using DCL.WebRequests.RequestsHub;
-using Sentry;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using UnityEngine.Networking;
-using UnityEngine.Pool;
 
 namespace DCL.WebRequests
 {
@@ -100,6 +97,24 @@ namespace DCL.WebRequests
         {
             TWebRequest request = initializeRequest(CommonArguments.URL, ref args);
             UnityWebRequest unityWebRequest = request.UnityWebRequest;
+
+            if (!CommonArguments.AllowInsecureCleartext)
+            {
+                // Secure-scheme enforcement runs on the wire URL of every request — signed and
+                // unsigned alike — except those that explicitly opted into cleartext
+                // (local-scene-development scene fetch). Default-deny at the app level is the
+                // property that lets the player insecureHttpOption stay AlwaysAllowed. It runs
+                // before AssignHeaders so a signed request's signature covers the upgraded URL,
+                // and the identity auth chain never travels over forbidden cleartext.
+                string wireUrl = unityWebRequest.url;
+                string secureUrl = WebRequestUtils.EnforceSecureScheme(wireUrl);
+
+                if (!ReferenceEquals(wireUrl, secureUrl))
+                {
+                    ReportHub.LogWarning(ReportData, $"Cleartext http to a non-loopback host upgraded to https: {wireUrl}");
+                    unityWebRequest.url = secureUrl;
+                }
+            }
 
             AssignTimeout(unityWebRequest);
             AssignHeaders(unityWebRequest, web3IdentityCache);

--- a/Explorer/Assets/DCL/WebRequests/Tests/InsecureSchemePolicyShould.cs
+++ b/Explorer/Assets/DCL/WebRequests/Tests/InsecureSchemePolicyShould.cs
@@ -1,0 +1,231 @@
+using CommunicationData.URLHelpers;
+using DCL.Diagnostics;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Web3.Chains;
+using DCL.Web3.Identities;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using UnityEditor;
+using UnityEngine.Networking;
+
+namespace DCL.WebRequests.Tests
+{
+    // Transport-security policy invariants: cleartext http is loopback-only, enforced on the
+    // wire URL of every envelope — signed and unsigned alike — and at infra URL-resolution
+    // sites (media resolution, sidecar realm root). The single exemption is an explicit
+    // per-request opt-in (CommonArguments.AllowInsecureCleartext), used only by the
+    // local-scene-development scene fetch, whose own module gate vets the dev-mode case.
+    // The redirect guard blocks only mid-flight downgrades, and the player-level
+    // insecureHttpOption stays AlwaysAllowed so the client-side policy is the single
+    // enforcement point — a default-deny policy is what justifies that setting.
+    public class InsecureSchemePolicyShould
+    {
+        private const string MEDIA_CONVERTER_TEMPLATE = "https://metamorph-api.decentraland.org/convert?url={0}";
+
+        [TestCase("http://192.168.1.50:8000/api", "https://192.168.1.50:8000/api")]
+        [TestCase("http://peer.decentraland.org/x", "https://peer.decentraland.org/x")]
+        public void UpgradeNonLoopbackHttpToHttpsWhenUnsigned(string url, string expected)
+        {
+            // Unsigned envelope traffic (textures, asset bundles, catalyst content, thumbnails)
+            // gets the same default-deny enforcement as signed traffic
+            Assert.That(UrlAfterEnvelopeInitialization(url), Is.EqualTo(UnityCanonicalUrl(expected)));
+        }
+
+        [TestCase("http://192.168.1.50:8000/api")]
+        [TestCase("http://peer.decentraland.org/x")]
+        public void PassNonLoopbackHttpThroughUnchangedWhenCleartextAllowed(string url)
+        {
+            // The local-scene-development scene fetch opts into cleartext explicitly; the
+            // envelope must not rewrite a request that carries the opt-in
+            Assert.That(
+                UrlAfterEnvelopeInitialization(url, allowInsecureCleartext: true),
+                Is.EqualTo(UnityCanonicalUrl(url)));
+        }
+
+        [Test]
+        public void UpgradeNonLoopbackHttpToHttpsWhenSigned()
+        {
+            // Enforcement precedes signing, so the signature covers the upgraded URL and the
+            // auth chain never travels over forbidden cleartext
+            Assert.That(
+                UrlAfterEnvelopeInitialization("http://peer.decentraland.org/x", signInfo: new WebRequestSignInfo(string.Empty)),
+                Is.EqualTo(UnityCanonicalUrl("https://peer.decentraland.org/x")));
+        }
+
+        [TestCase("http://127.0.0.1:8000/content/contents/bafkreib")]
+        [TestCase("http://localhost:8001/x")]
+        public void PassLoopbackHttpThroughUnchangedWhenSigned(string url)
+        {
+            Assert.That(
+                UrlAfterEnvelopeInitialization(url, signInfo: new WebRequestSignInfo(string.Empty)),
+                Is.EqualTo(UnityCanonicalUrl(url)));
+        }
+
+        [Test]
+        public void PassLoopbackHttpThroughUnchanged(
+            [Values(
+                "http://127.0.0.1:8000/content/contents/bafkreib",
+                "http://127.0.0.5:8000/x",
+                "http://localhost:8001/x",
+                "http://[::1]:8000/x")]
+            string url,
+            [Values(false, true)] bool allowInsecureCleartext)
+        {
+            Assert.That(
+                UrlAfterEnvelopeInitialization(url, allowInsecureCleartext: allowInsecureCleartext),
+                Is.EqualTo(UnityCanonicalUrl(url)));
+        }
+
+        [TestCase("https://peer.decentraland.org/lambdas/profiles")]
+        [TestCase("file:///tmp/streaming-asset.bin")]
+        public void PassNonHttpSchemesThroughUnchanged(string url)
+        {
+            Assert.That(UrlAfterEnvelopeInitialization(url), Is.EqualTo(UnityCanonicalUrl(url)));
+        }
+
+        [Test]
+        public void UpgradeNonConvertedTextureUrlAtTheWire()
+        {
+            const string HTTP_URL = "http://textures.example.com/a.png";
+
+            Assert.That(
+                TextureUrlAfterEnvelopeInitialization(HTTP_URL, ktxEnabled: false),
+                Is.EqualTo(UnityCanonicalUrl("https://textures.example.com/a.png")));
+        }
+
+        [Test]
+        public void KeepLoopbackTextureDirectWhenKtxEnabled()
+        {
+            // The loopback classification the converter reroute keys on must match the wire
+            // policy: a loopback origin the policy lets through as cleartext must never be
+            // rerouted to the public media converter, which cannot reach it
+            const string LOOPBACK_URL = "http://127.0.0.5:8000/a.png";
+
+            Assert.That(
+                TextureUrlAfterEnvelopeInitialization(LOOPBACK_URL, ktxEnabled: true),
+                Is.EqualTo(UnityCanonicalUrl(LOOPBACK_URL)));
+        }
+
+        [TestCase("http://127.0.0.5:8000/x", true)]
+        [TestCase("http://localhost:8001/x", true)]
+        [TestCase("https://localhost:3000/x", true)]
+        [TestCase("http://[::1]:8000/x", true)]
+        [TestCase("http://localhost.evil.com/x", false)]
+        [TestCase("http://peer.decentraland.org/x", false)]
+        [TestCase("file:///tmp/streaming-asset.bin", false)]
+        public void ClassifyLocalhostBySchemeAndLoopbackHost(string url, bool isLocalhost)
+        {
+            Assert.That(WebRequestUtils.IsLocalhost(url), Is.EqualTo(isLocalhost));
+        }
+
+        [Test]
+        public void PreserveHttpOriginEmbeddedInConverterUrl()
+        {
+            const string HTTP_ORIGIN = "http://textures.example.com/a.png";
+
+            Assert.That(
+                TextureUrlAfterEnvelopeInitialization(HTTP_ORIGIN, ktxEnabled: true),
+                Is.EqualTo(UnityCanonicalUrl(string.Format(MEDIA_CONVERTER_TEMPLATE, Uri.EscapeDataString(HTTP_ORIGIN)))));
+        }
+
+        [TestCase("http://peer.decentraland.org/x", true)]
+        [TestCase("http://127.0.0.1:8000/x", false)]
+        [TestCase("http://localhost:8001/x", false)]
+        [TestCase("http://[::1]:8000/x", false)]
+        [TestCase("https://peer.decentraland.org/x", false)]
+        [TestCase("file:///tmp/streaming-asset.bin", false)]
+        public void ClassifyForbiddenCleartext(string url, bool forbidden)
+        {
+            Assert.That(WebRequestUtils.IsForbiddenCleartext(url), Is.EqualTo(forbidden));
+        }
+
+        [TestCase("https://peer.decentraland.org/x", "http://peer.decentraland.org/x", true)]
+        [TestCase("http://127.0.0.1:8000/x", "http://192.168.1.50:8000/x", true)]
+        [TestCase("http://192.168.1.50:8000/api", "http://192.168.1.50:8000/api", false)]
+        [TestCase("http://192.168.1.50:8000/x", "http://10.0.0.7:9000/y", false)]
+        [TestCase("https://peer.decentraland.org/x", "https://cdn.decentraland.org/x", false)]
+        [TestCase("https://peer.decentraland.org/x", "http://127.0.0.1:8000/x", false)]
+        public void ClassifyCleartextDowngradeForTheRedirectGuard(string sentUrl, string finalUrl, bool downgrade)
+        {
+            Assert.That(WebRequestUtils.IsCleartextDowngrade(sentUrl, finalUrl), Is.EqualTo(downgrade));
+        }
+
+        [Test]
+        public void KeepPlayerSettingAlwaysAllowed()
+        {
+            // Unity's own block is inexpressible for this product (all-http or no-http, loopback
+            // included); the setting must stay AlwaysAllowed with the client-side policy as the guard.
+            Assert.That(PlayerSettings.insecureHttpOption, Is.EqualTo(InsecureHttpOption.AlwaysAllowed));
+        }
+
+        /// <summary>
+        ///     Builds the request through the same envelope path production uses
+        ///     (WebRequestController.SendAsync -> InitializedWebRequest) and returns the URL the
+        ///     UnityWebRequest would actually be sent with. The request is never sent.
+        /// </summary>
+        private static string UrlAfterEnvelopeInitialization(string url, WebRequestSignInfo? signInfo = null, bool allowInsecureCleartext = false)
+        {
+            using var envelope = new RequestEnvelope<GenericGetRequest, GenericGetArguments>(
+                GenericGetRequest.Initialize,
+                new CommonArguments(URLAddress.FromString(url), allowInsecureCleartext: allowInsecureCleartext),
+                new GenericGetArguments(),
+                CancellationToken.None,
+                ReportData.UNSPECIFIED,
+                WebRequestHeadersInfo.NewEmpty(),
+                signInfo);
+
+            GenericGetRequest request = envelope.InitializedWebRequest(SigningIdentityCache());
+            using UnityWebRequest unityWebRequest = request.UnityWebRequest;
+            return unityWebRequest.url;
+        }
+
+        /// <summary>
+        ///     Same envelope path, through the texture request's own URL composition (the media
+        ///     converter wraps the origin as an escaped query parameter when ktx is enabled).
+        /// </summary>
+        private static string TextureUrlAfterEnvelopeInitialization(string url, bool ktxEnabled)
+        {
+            IDecentralandUrlsSource urlsSource = Substitute.For<IDecentralandUrlsSource>();
+            urlsSource.Url(DecentralandUrl.MediaConverter).Returns(MEDIA_CONVERTER_TEMPLATE);
+
+            using var envelope = new RequestEnvelope<GetTextureWebRequest, GetTextureArguments>(
+                (string effectiveUrl, ref GetTextureArguments textureArguments) => GetTextureWebRequest.Initialize(effectiveUrl, textureArguments, urlsSource, ktxEnabled),
+                new CommonArguments(URLAddress.FromString(url)),
+                new GetTextureArguments(TextureType.Albedo),
+                CancellationToken.None,
+                ReportData.UNSPECIFIED,
+                WebRequestHeadersInfo.NewEmpty(),
+                signInfo: null);
+
+            GetTextureWebRequest request = envelope.InitializedWebRequest(SigningIdentityCache());
+            using UnityWebRequest unityWebRequest = request.UnityWebRequest;
+            return unityWebRequest.url;
+        }
+
+        /// <summary>
+        ///     An identity cache whose identity signs any payload with an empty auth chain, so
+        ///     signed envelopes can be initialized without a real wallet.
+        /// </summary>
+        private static IWeb3IdentityCache SigningIdentityCache()
+        {
+            IWeb3Identity identity = Substitute.For<IWeb3Identity>();
+            identity.Sign(Arg.Any<string>()).Returns(_ => AuthChain.Create());
+
+            IWeb3IdentityCache cache = Substitute.For<IWeb3IdentityCache>();
+            cache.Identity.Returns(identity);
+            return cache;
+        }
+
+        /// <summary>
+        ///     UnityWebRequest applies its own URL canonicalization; comparing against the same
+        ///     canonicalization keeps the assertions about the scheme policy only.
+        /// </summary>
+        private static string UnityCanonicalUrl(string url)
+        {
+            using UnityWebRequest unityWebRequest = UnityWebRequest.Get(url);
+            return unityWebRequest.url;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/WebRequests/Tests/InsecureSchemePolicyShould.cs.meta
+++ b/Explorer/Assets/DCL/WebRequests/Tests/InsecureSchemePolicyShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a146a8fe02304043bce56181b0f75506

--- a/Explorer/Assets/DCL/WebRequests/WebRequestController.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestController.cs
@@ -72,6 +72,10 @@ namespace DCL.WebRequests
                 // No matter what we must release UnityWebRequest, otherwise it crashes in the destructor
                 using UnityWebRequest wr = request.UnityWebRequest;
 
+                // wr.url mutates to the final hop as redirects are followed; the as-sent form
+                // anchors the downgrade checks below
+                string sentUrl = wr.url;
+
                 try
                 {
                     analyticsContainer.OnBeforeBudgeting(in envelope, request);
@@ -89,6 +93,12 @@ namespace DCL.WebRequests
                         analyticsContainer.OnRequestFinished(request);
                     }
 
+                    // A redirect can hop from an allowed sent URL to forbidden cleartext; a response
+                    // from such a downgraded exchange is never consumed. An exchange sent as
+                    // cleartext on purpose (local-scene-development fetch) is not a downgrade
+                    if (WebRequestUtils.IsCleartextDowngrade(sentUrl, wr.url))
+                        throw new InvalidOperationException($"Insecure redirect blocked: request to {sentUrl} was redirected to {wr.url}");
+
                     if (!realmClock.HasSample)
                         realmClock.TryRecordHttpDate(wr.GetResponseHeader(DATE_HEADER));
 
@@ -104,6 +114,12 @@ namespace DCL.WebRequests
                 catch (UnityWebRequestException exception)
                 {
                     analyticsContainer.OnException(request, exception);
+
+                    // An exchange that downgraded from an allowed sent URL to forbidden cleartext
+                    // fails permanently: never ignored, never retried (a retry would re-send
+                    // headers over cleartext)
+                    if (WebRequestUtils.IsCleartextDowngrade(sentUrl, wr.url))
+                        throw;
 
                     // No result can be concluded in this case
                     if (envelope.ShouldIgnoreResponseError(exception.UnityWebRequest!))

--- a/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
@@ -3,6 +3,7 @@ using DCL.Diagnostics;
 using DCL.Utilities.Extensions;
 using System;
 using System.Globalization;
+using System.Net;
 using System.Threading;
 using UnityEngine.Networking;
 
@@ -11,6 +12,9 @@ namespace DCL.WebRequests
     public static class WebRequestUtils
     {
         public const string CANNOT_CONNECT_ERROR = "Cannot connect to destination host";
+
+        private const string HTTP_SCHEME_PREFIX = "http://";
+        private const string HTTPS_SCHEME_PREFIX = "https://";
 
         public const int BAD_REQUEST = 400;
         public const int UNAUTHORIZED_ACCESS = 401;
@@ -108,17 +112,17 @@ namespace DCL.WebRequests
             }
         }
 
-        private static bool IsDNSLookupError(this UnityWebRequestException exception) =>
+        private static bool IsDnsLookupError(this UnityWebRequestException exception) =>
             exception.ResponseCode == 0 && exception.Message.Contains(CANNOT_CONNECT_ERROR);
 
         public static bool IsIrrecoverableError(this UnityWebRequestException exception)
         {
-            if (exception.IsDNSLookupError())
+            if (exception.IsDnsLookupError())
                 return false;
 
             return (exception.IsAborted() || IsIrrecoverableResponseCode(exception.ResponseCode))
-                   && !exception.IsUnableToCompleteSSLConnection()
-                   && !exception.IsSSLCACertificateError();
+                   && !exception.IsUnableToCompleteSslConnection()
+                   && !exception.IsSslCaCertificateError();
         }
 
         private static bool IsIrrecoverableResponseCode(long responseCode)
@@ -150,10 +154,10 @@ namespace DCL.WebRequests
             }
         }
 
-        private static bool IsUnableToCompleteSSLConnection(this UnityWebRequestException exception) =>
+        private static bool IsUnableToCompleteSslConnection(this UnityWebRequestException exception) =>
             exception.Message.Contains("Unable to complete SSL connection");
 
-        private static bool IsSSLCACertificateError(this UnityWebRequestException exception) =>
+        private static bool IsSslCaCertificateError(this UnityWebRequestException exception) =>
             exception.Message.Contains("SSL CA certificate error");
 
         public static bool IsTimedOut(this UnityWebRequestException exception) =>
@@ -168,13 +172,56 @@ namespace DCL.WebRequests
         public static string GetResponseContentEncoding(this UnityWebRequest unityWebRequest) =>
             unityWebRequest.GetResponseHeader("Content-Encoding");
 
+        /// <summary>
+        ///     Client-side transport-security policy, standing in for the player-level insecure-http
+        ///     block (which is global and cannot exempt loopback): cleartext http is permitted to
+        ///     loopback hosts only (local preview servers, sidecars); http to any other host is
+        ///     upgraded to https. Binds on the wire URL of every envelope whose request did not opt
+        ///     into cleartext (<see cref="CommonArguments.AllowInsecureCleartext" />) and where a
+        ///     policed infra URL is resolved (media resolution, sidecar realm root) — never to URLs
+        ///     embedded in a request as data. Non-http URLs pass through unchanged (same reference).
+        /// </summary>
+        public static string EnforceSecureScheme(string url) =>
+            IsForbiddenCleartext(url)
+                ? string.Concat(HTTPS_SCHEME_PREFIX, url.Substring(HTTP_SCHEME_PREFIX.Length))
+                : url;
+
+        /// <summary>
+        ///     True only for the scheme/host combination the transport policy forbids: cleartext
+        ///     http to a non-loopback host. Unparsable http URLs are forbidden too — the policy
+        ///     fails closed on cleartext. Holds for final (post-redirect) URLs as much as for
+        ///     outgoing ones.
+        /// </summary>
+        public static bool IsForbiddenCleartext(string url) =>
+            !string.IsNullOrEmpty(url)
+            && url.StartsWith(HTTP_SCHEME_PREFIX, StringComparison.OrdinalIgnoreCase)
+            && !(Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) && IsLoopbackHost(uri.Host));
+
+        /// <summary>
+        ///     True when an exchange left on an allowed scheme/host but its final (post-redirect)
+        ///     URL is forbidden cleartext. A request sent to forbidden cleartext in the first place
+        ///     is not a downgrade: that scheme is the sender's own policy decision.
+        /// </summary>
+        public static bool IsCleartextDowngrade(string sentUrl, string finalUrl) =>
+            !IsForbiddenCleartext(sentUrl) && IsForbiddenCleartext(finalUrl);
+
+        /// <summary>
+        ///     Loopback means "localhost", 127.0.0.0/8 or [::1] — the hosts a local preview
+        ///     server or sidecar can be reached on.
+        /// </summary>
+        private static bool IsLoopbackHost(string host) =>
+            string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase)
+            || (IPAddress.TryParse(host, out IPAddress? ip) && IPAddress.IsLoopback(ip));
+
+        /// <summary>
+        ///     Scheme-inclusive URL form of the single loopback definition (<see cref="IsLoopbackHost" />):
+        ///     true only for http/https URLs whose parsed host is loopback. Non-http(s) schemes and
+        ///     unparsable URLs are not localhost.
+        /// </summary>
         public static bool IsLocalhost(string url) =>
-            url.StartsWith("http://localhost", StringComparison.OrdinalIgnoreCase)
-            || url.StartsWith("https://localhost", StringComparison.OrdinalIgnoreCase)
-            || url.StartsWith("http://127.0.0.1", StringComparison.OrdinalIgnoreCase)
-            || url.StartsWith("https://127.0.0.1", StringComparison.OrdinalIgnoreCase)
-            || url.StartsWith("http://[::1]", StringComparison.OrdinalIgnoreCase)
-            || url.StartsWith("https://[::1]", StringComparison.OrdinalIgnoreCase);
+            Uri.TryCreate(url, UriKind.Absolute, out Uri? uri)
+            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+            && IsLoopbackHost(uri.Host);
 
         /// <summary>
         ///     Does nothing with the web request

--- a/Explorer/ProjectSettings/ProjectSettings.asset
+++ b/Explorer/ProjectSettings/ProjectSettings.asset
@@ -1060,7 +1060,7 @@ PlayerSettings:
   hmiLoadingImage: {fileID: 0}
   platformRequiresReadableAssets: 0
   virtualTexturingSupportEnabled: 0
-  insecureHttpOption: 0
+  insecureHttpOption: 2
   androidVulkanDenyFilterList: []
   androidVulkanAllowFilterList: []
   androidVulkanDeviceFilterListAsset: {fileID: 0}


### PR DESCRIPTION
upgrading other http to ttps unless the request explicitly opts in (local-scene development)

## Problem

`InvalidOperationException: Insecure connection not allowed` on every wearable main-file / profile / content fetch whenever the request URL scheme is `http`. Sentry UNITY-EXPLORER-P42 (105 ev/wk) + P4G (76 ev/wk), ongoing since May. Every sampled event is the Creator Hub / sdk-commands local preview flow (`http://127.0.0.1:8000`): release builds systematically break the officially supported local-preview path for every creator.

## Root cause

The client's transport-security policy lives solely in Unity's baked, global `insecureHttpOption: NotAllowed`, which cannot express the policy the product needs — cleartext is fine to loopback (local preview, sidecars), never to real hosts. Not a wearables bug: the wearable frame is just the highest-volume victim of the missing scheme policy at the web-request choke point.

## Fix

1. `ProjectSettings.asset`: `insecureHttpOption` → AlwaysAllowed; enforcement moves into the client layer.
2. `WebRequestUtils`: pure static policy — `EnforceSecureScheme(url)` + `IsForbiddenCleartext(url)`. Non-http schemes untouched (zero-alloc https fast path); http+loopback (`localhost`, 127.0.0.0/8, `[::1]` via `IPAddress.IsLoopback`) allowed; http+any other host rewritten to https (those threw before sending at the pin, so the upgrade can only equal or improve the outcome). Unparsable http URLs fail closed.
3. `RequestEnvelope.InitializedWebRequest`: secure-scheme enforcement applies to the wire URL of **every request, signed and unsigned alike** — default-deny is the property that justifies flipping the player setting to AlwaysAllowed. The single exemption is an explicit per-request opt-in: `CommonArguments.AllowInsecureCleartext` (new readonly field, trailing optional ctor param, default false), set only by the scene `fetch()` API (`SimpleFetchApiImplementation.FetchAsync`) in local-scene-development mode. That module already enforces its own dev-mode-aware gate — https required unless `isLocalSceneDevelopment` — and in dev mode a scene may fetch cleartext http to any host (LAN dev server, remote test endpoint), so the envelope must not rewrite those. Enforcement runs before signing, so a signed request's signature covers the upgraded URL and the identity auth chain never travels over forbidden cleartext; loopback http always passes through, so signed requests against a local preview realm keep working. Per-request composition (the media-converter's embedded http origin query param) is untouched. One warning log per upgrade for support triage.
4. `WebRequestController.SendAsync`: redirect-downgrade guard — `IsCleartextDowngrade(sentUrl, finalUrl)` fires only when the exchange left on an allowed scheme/host (https, or loopback http) and its final (post-redirect) URL is forbidden cleartext; checked on both success and exception paths, so a downgraded exchange is never consumed and never retried. Because every non-opted-in wire URL is upgraded to https before send, the guard covers all of that traffic; an exchange deliberately sent as cleartext (an opted-in local-scene-development fetch) is not a downgrade and is not blocked. This is weaker than the old player setting's pre-send block — Unity's internal redirect handling has already sent the downgraded hop by the time the guard sees it; a true per-hop block would need `redirectLimit = 0` + manual redirect handling for signed requests (follow-up). The guard throws a distinct "Insecure redirect blocked" message so these events don't land in the P42/P4G buckets.
5. `WebRequestUtils.IsLocalhost`: reimplemented on top of the policy's single loopback definition (`Uri`-parsed; http/https + `localhost`/127.0.0.0/8/`[::1]`) — the old prefix check missed 127.0.0.0/8 beyond 127.0.0.1 (rerouting loopback textures through the public media converter, which cannot reach the creator's machine) and false-positived on `localhost.evil.com`.
6. Bypass sites the settings flip would otherwise leave un-gated now apply the same policy: `UrlResolverService` (scene-controlled media URLs — the resolved URL itself is upgraded, so reachability probes and playback agree on one wire URL, and the raw GET probe enforces the scheme at the emit site) and `AbgenSidecar` (the realm root behind its /about + catalyst fetches; loopback LSD preview roots pass through unchanged).

Known behavior change: http realms/worlds (#7827 class) now fail as a retried TLS connect error instead of a synchronous "Insecure connection not allowed" — same terminal outcome, different message, slower on probe-style paths.

## Test

New EditMode `InsecureSchemePolicyShould` (40 cases): default-deny locks (`UpgradeNonLoopbackHttpToHttpsWhenUnsigned` ×2 and `UpgradeNonConvertedTextureUrlAtTheWire` — unsigned envelope/texture wire URLs are upgraded to https), the dev opt-in lock (`PassNonLoopbackHttpThroughUnchangedWhenCleartextAllowed` ×2 — with `CommonArguments.AllowInsecureCleartext` the URL comes out byte-identical), signed-request upgrade (enforce-before-sign) + signed-loopback pass-through, the `KeepPlayerSettingAlwaysAllowed` lock pairing the settings flip with the client policy, loopback pass-through combinatorial over the opt-in flag (never upgraded either way), https/file pass-through guards, the converter-embedded-origin preservation guard, `IsForbiddenCleartext` + `IsCleartextDowngrade` classification cases (downgrade, deliberate-cleartext, redirect-to-loopback), the loopback-texture-stays-direct guard (ktx enabled), and `IsLocalhost` classification cases (127.0.0.0/8, `localhost.evil.com`). Plus 3 `UrlResolverServiceShould` cases: direct non-loopback http upgraded for probe + playback, loopback http kept cleartext.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 3 as intended (non-loopback http stayed http; setting was NotAllowed) + 7 guards passed / GREEN PASS 16/16 for the original round. Rescope round (security review): GREEN (full fix) passes all 40; RED (same tests with the envelope guard reverted to signed-only) fails exactly the 3 default-deny locks — the coverage the review flagged as dropped.

Fixes #3661
Related: #8761, #8762 (same-day auto-closed dupes of P42/P4G), #8080 (MediaStream direct probe — its bypass site now applies the same policy, see Fix 6), #7827 (realm-connect variant; failure message changes as described above)

Includes inspection-warning cleanup in all touched files.

# Pull Request Description

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

## Test Instructions
<!--
Provide clear, copy-pasteable steps for testing these changes.

### Quick reference

# Run this PR (with cache)
metaforge explorer run <this-PR-number>

# Run this PR (without cache — clears Explorer data)
metaforge explorer run <this-PR-number> --clear

# Run this PR (fresh account — clears everything and creates a new account)
metaforge account create --clear
metaforge explorer run <this-PR-number>

# Tail logs while testing
metaforge explorer logs tail --filter "<relevant text>"

# Run automation tests against this PR
metaforge explorer test <this-PR-number>
-->

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
<!-- What should the reviewer see/verify? -->

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Prerequisites
- [ ] List any required setup steps
- [ ] Include environment/configuration requirements

### Test Steps
1. First step
2. Second step
3. Expected result after step 2
4. ...

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
