### PR TITLE
fix: retry avatar thumbnail loads after a failed attempt instead of rethrowing forever

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/ECSThumbnailProviderShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/ECSThumbnailProviderShould.cs
@@ -1,0 +1,124 @@
+using Arch.Core;
+using Cysharp.Threading.Tasks;
+using DCL.AvatarRendering.Loading.Components;
+using DCL.AvatarRendering.Loading.DTO;
+using DCL.AvatarRendering.Loading.Exceptions;
+using DCL.AvatarRendering.Wearables;
+using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using ECS.StreamableLoading.Common.Components;
+using ECS.StreamableLoading.Textures;
+using NSubstitute;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using Promise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.Textures.TextureData, ECS.StreamableLoading.Textures.GetTextureIntention>;
+
+namespace DCL.AvatarRendering.AvatarShape.Tests
+{
+    [TestFixture]
+    public class ECSThumbnailProviderShould
+    {
+        private static readonly QueryDescription THUMBNAIL_PROMISES = new QueryDescription().WithAll<IThumbnailAttachment, Promise>();
+
+        private World world = null!;
+        private ECSThumbnailProvider provider = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = World.Create();
+
+            IDecentralandUrlsSource urlsSource = Substitute.For<IDecentralandUrlsSource>();
+            urlsSource.Url(Arg.Any<DecentralandUrl>()).Returns("https://peer.decentraland.test/content");
+
+            provider = new ECSThumbnailProvider(urlsSource, world);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            world.Dispose();
+        }
+
+        [Test]
+        public async Task RetryAfterFailedSlotInsteadOfRethrowing()
+        {
+            FakeWearable wearable = NewWearable();
+            wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.Failed();
+
+            UniTask<Sprite> getTask = provider.GetAsync(wearable, CancellationToken.None);
+            int promisesSpawned = world.CountEntities(in THUMBNAIL_PROMISES);
+
+            // Resolve the attachment the way ResolveAvatarAttachmentThumbnailSystem does on success.
+            SpriteData spriteData = NewSpriteData();
+            wearable.ThumbnailAssetResult = new StreamableLoadingResult<SpriteData>.WithFallback(spriteData);
+
+            Sprite? sprite;
+
+            try { sprite = await getTask; }
+            catch (ThumbnailLoadFailedException) { sprite = null; }
+
+            Assert.That(promisesSpawned, Is.EqualTo(1), "GetAsync must clear a Failed slot and spawn a fresh promise instead of rethrowing the cached failure");
+            Assert.That(sprite, Is.SameAs(spriteData.Sprite));
+        }
+
+        [Test]
+        public async Task ReturnCachedSuccessWithoutSpawningPromise()
+        {
+            FakeWearable wearable = NewWearable();
+            SpriteData spriteData = NewSpriteData();
+            wearable.ThumbnailAssetResult = new StreamableLoadingResult<SpriteData>.WithFallback(spriteData);
+
+            Sprite sprite = await provider.GetAsync(wearable, CancellationToken.None);
+
+            Assert.That(sprite, Is.SameAs(spriteData.Sprite));
+            Assert.That(world.CountEntities(in THUMBNAIL_PROMISES), Is.Zero);
+        }
+
+        [Test]
+        public async Task MarkFailedOnTimeoutAndRetryOnNextCall()
+        {
+            FakeWearable wearable = NewWearable();
+
+            try
+            {
+                await provider.GetAsync(wearable, CancellationToken.None, timeoutMs: 1);
+                Assert.Fail("Expected the first never-resolving load to throw after the timeout");
+            }
+            catch (ThumbnailLoadFailedException) { }
+
+            Assert.That(wearable.ThumbnailAssetResult, Is.Not.Null);
+            Assert.That(wearable.ThumbnailAssetResult!.Value.IsInitialized, Is.True);
+            Assert.That(wearable.ThumbnailAssetResult!.Value.Succeeded, Is.False);
+
+            int promisesAfterTimeout = world.CountEntities(in THUMBNAIL_PROMISES);
+
+            UniTask<Sprite> retryTask = provider.GetAsync(wearable, CancellationToken.None, timeoutMs: 1);
+            int promisesAfterRetry = world.CountEntities(in THUMBNAIL_PROMISES);
+
+            try { await retryTask; }
+            catch (ThumbnailLoadFailedException) { }
+
+            Assert.That(promisesAfterRetry, Is.EqualTo(promisesAfterTimeout + 1), "A call after a timed-out attempt must spawn a fresh promise instead of rethrowing the cached failure");
+        }
+
+        private static FakeWearable NewWearable() =>
+            new (new WearableDTO
+            {
+                metadata = new WearableDTO.WearableMetadataDto
+                {
+                    id = "urn:decentraland:off-chain:base-avatars:red_hoodie",
+                    thumbnail = "bafybeie7lzqakerm4n4x7557g3va4sv7aeoniexlomdgjskuoubo6s3mku",
+                    data =
+                    {
+                        representations = new AvatarAttachmentDTO.Representation[] { new () },
+                    },
+                },
+            });
+
+        private static SpriteData NewSpriteData() =>
+            new (new TextureData(Texture2D.whiteTexture), Sprite.Create(Texture2D.whiteTexture!, new Rect(0, 0, 1, 1), new Vector2()));
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/ECSThumbnailProviderShould.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/ECSThumbnailProviderShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5ac2b2c12d04e4daf8944308dc7d449
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/ECSThumbnailProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/ECSThumbnailProvider.cs
@@ -31,12 +31,10 @@ namespace DCL.AvatarRendering.Wearables
                 if (existing.Succeeded)
                     return existing.Asset;
 
-                // A previous attempt was cancelled (e.g. page change). Clear so a fresh promise
-                // can spawn below. Sticky failures keep the slot and fall through to throw.
-                if (existing.Cancelled)
-                    avatarAttachment.ThumbnailAssetResult = null;
-                else
-                    throw new ThumbnailLoadFailedException();
+                // A previous attempt ended without a sprite (timeout or cancellation). Terminal
+                // non-success states are per-attempt, never sticky across explicit requests:
+                // clear the slot so a fresh promise can spawn below.
+                avatarAttachment.ThumbnailAssetResult = null;
             }
 
             CancellationTokenSource promiseCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -59,10 +57,9 @@ namespace DCL.AvatarRendering.Wearables
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
-                // Timed out: cancel the underlying promise so the resolver cleans it up, and record
-                // a sticky Failed on the attachment so subsequent calls don't immediately re-attempt
-                // a load that we already gave up on. (The resolver will see IsCancellationRequested
-                // but skip overwriting because the slot is now Failed, not Cancelled.)
+                // Timed out: cancel the underlying promise so the resolver cleans it up. Failed
+                // releases concurrent waiters on this attachment and keeps the resolver from
+                // stamping Cancelled over the slot; the next explicit GetAsync clears it and retries.
                 promiseCts.Cancel();
                 avatarAttachment.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.Failed();
 

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
@@ -4,7 +4,6 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.AvatarRendering.Loading.Components;
 using DCL.AvatarRendering.Thumbnails.Utils;
-using DCL.AvatarRendering.Wearables;
 using DCL.Diagnostics;
 using ECS.Abstract;
 using ECS.StreamableLoading.Common.Components;
@@ -34,9 +33,8 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
         {
             if (promise.IsCancellationRequested(World))
             {
-                // Mark as Cancelled so the next GetAsync call clears the slot and retries.
-                // Don't overwrite a sticky Failed (e.g. from a consumer timeout); only reset to
-                // Cancelled when the slot is clear.
+                // Release waiters with Cancelled only while the slot still signals in-flight; an
+                // initialized slot (e.g. Failed from a consumer timeout) already carries this attempt's terminal state.
                 if (wearable.ThumbnailAssetResult is not { IsInitialized: true })
                     wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);
@@ -55,8 +53,8 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
         {
             if (promise.IsCancellationRequested(World))
             {
-                // Mark as Cancelled so the next GetAsync call clears the slot and retries.
-                // Don't overwrite a sticky Failed (e.g. from a consumer timeout).
+                // Release waiters with Cancelled only while the slot still signals in-flight; an
+                // initialized slot already carries this attempt's terminal state.
                 if (wearable.ThumbnailAssetResult is not { IsInitialized: true })
                     wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);

--- a/Explorer/Assets/DCL/EmotesWheel/EmotesWheelController.cs
+++ b/Explorer/Assets/DCL/EmotesWheel/EmotesWheelController.cs
@@ -2,7 +2,7 @@ using Arch.Core;
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.AvatarRendering.Emotes;
-using DCL.AvatarRendering.Loading.Components;
+using DCL.AvatarRendering.Thumbnails.Utils;
 using DCL.AvatarRendering.Wearables;
 using DCL.Backpack;
 using DCL.Diagnostics;
@@ -13,6 +13,7 @@ using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.UI;
 using MVC;
+using System;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -181,9 +182,24 @@ namespace DCL.EmotesWheel
             view.Thumbnail.gameObject.SetActive(false);
             view.LoadingSpinner.SetActive(true);
 
-            Sprite sprite = await thumbnailProvider.GetAsync(emote, ct);
+            try
+            {
+                Sprite sprite = await thumbnailProvider.GetAsync(emote, ct);
 
-            view.Thumbnail.sprite = sprite;
+                view.Thumbnail.sprite = sprite;
+            }
+            catch (OperationCanceledException) { return; }
+            catch (Exception e)
+            {
+                ReportHub.LogException(e, new ReportData(ReportCategory.THUMBNAILS));
+
+                if (ct.IsCancellationRequested) return;
+
+                // The failure path must still surface a sprite and release the spinner, otherwise
+                // the slot stays stuck on a load that already gave up.
+                view.Thumbnail.sprite = LoadThumbnailsUtils.DEFAULT_THUMBNAIL.Sprite;
+            }
+
             view.Thumbnail.gameObject.SetActive(true);
             view.LoadingSpinner.SetActive(false);
         }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Common/Components/StreamableLoadingResult.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Common/Components/StreamableLoadingResult.cs
@@ -1,8 +1,6 @@
-﻿using AssetManagement;
-using DCL.Diagnostics;
+﻿using DCL.Diagnostics;
 using System;
 using UnityEngine;
-using System.Runtime.CompilerServices;
 
 namespace ECS.StreamableLoading.Common.Components
 {
@@ -25,14 +23,14 @@ namespace ECS.StreamableLoading.Common.Components
 
             /// <summary>
             ///     True when the request reached a terminal successful (or fallback-acceptable) state.
-            ///     False when the request failed or was cancelled; check <see cref="Cancelled"/>
-            ///     to distinguish a transient cancellation from a sticky failure.
+            ///     False when the request failed or was cancelled; the value describes that single
+            ///     attempt only.
             /// </summary>
             public readonly bool Succeeded;
 
             /// <summary>
-            ///     True when the request was cancelled mid-flight (transient state — consumers can
-            ///     clear the slot and retry). False for both genuine successes and sticky failures.
+            ///     True when the request was cancelled mid-flight. False for both genuine
+            ///     successes and failures (e.g. a consumer timeout).
             /// </summary>
             public readonly bool Cancelled;
 


### PR DESCRIPTION
## Problem

One transient thumbnail failure poisons that item's thumbnail for the whole session:
`ECSThumbnailProvider.GetAsync` rethrows `ThumbnailLoadFailedException` from cache on every
subsequent request. The emote wheel's spinner sticks forever (unobserved `UniTaskVoid`
chain), and backpack grids replay-log the exception per page render. Sentry family
PAD/P9R/PD5 ≈ 260 events/week of pure cached replays (~396 events / ~33 users with the
one-shot timeout signals PA1/P9Y included). Introduced by #8824.

## Root cause

An initialized non-Succeeded `ThumbnailAssetResult` slot was treated as a permanent terminal
state: the only producer of the sticky `Failed` state is the provider's own 30 s
consumer-timeout catch, and there was no recovery path until restart. Separately,
`EmotesWheelController.WaitForThumbnailAsync` had no catch, so the exception vanished into a
`.Forget()` chain with the loading spinner still active.

## Fix

1. `ECSThumbnailProvider`: any initialized non-Succeeded slot is now clear-and-retry  - 
   reset the slot and spawn a fresh promise. The timeout path still writes `Failed()`
   (it remains the release signal for concurrent waiters); it just stops being permanent.
2. `EmotesWheelController.WaitForThumbnailAsync`: backpack-style catch - OCE returns; other
   exceptions log via `ReportHub` (THUMBNAILS), fall back to the default thumbnail, and
   release the spinner (mirrors `BackpackEmoteGridController`).
3. With the retry in place `WithFallback.Cancelled` lost its only in-lane reader, but the
   cancelled-vs-failed distinction is retained: the API pre-exists on dev and an in-flight
   sibling PR's disposal tests consume `CancelledResult()`; the resolver keeps stamping
   `Cancelled` for in-flight cancellation and `Failed` for terminal failures (see the
   Cross-PR note below).
4. Comment/doc updates stating the new per-attempt invariant (no behavior change).

Contract change: `GetAsync` moves from "throws instantly forever after first failure" to
"retries per explicit call". All 11 call sites are bounded per explicit call and concurrent
waiters are deduped per attachment while an attempt is in flight (the signal is
per-attachment, not per-attempt - a same-frame stale-entity overlap window exists and is
tracked as a follow-up); worst case a persistently-failing item costs one 30 s promise per
grid/wheel open.

## Test

New EditMode `ECSThumbnailProviderShould`: `RetryAfterFailedSlotInsteadOfRethrowing` (pin:
instant rethrow, 0 promises spawned), `MarkFailedOnTimeoutAndRetryOnNextCall` (pin: cached
rethrow without spawning), `ReturnCachedSuccessWithoutSpawningPromise` (guards against an
always-retry regression).

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 2/3 as intended (retry test expected
1 promise got 0; timeout test expected 2 got 1; success guard passed) / GREEN PASS 3/3.

Fixes #8902
Fixes #8891

## Cross-PR note

`WithFallback.Cancelled` / `CancelledResult()` are **retained** - an earlier revision of
this branch deleted them (Fix item 3 above describes that revision and is superseded;
`2b1374f8d3` reverted the deletion). The pair pre-exists this PR (present at the base
commit, `StreamableLoadingResult.cs:58`), and while this branch no longer reads the
`Cancelled` discriminator - `GetAsync` now treats every initialized non-Succeeded slot,
cancelled or failed, as clear-and-retry - it is not dead API: the in-flight sibling PR
`bugsweep/unload-thumbnail-nre-blocks-memory-release` consumes
`WithFallback.CancelledResult()` in its thumbnail-disposal test
(`StorageThumbnailDisposalShould.cs`), and the resolver's cancellation stamps remain the
waiter-release signal via `IsInitialized`. Removing a pre-existing shared-struct member
out from under a sibling in-flight PR is out of scope for this bugfix; if the
discriminator is still unread once both PRs land, collapsing `Cancelled` into `Failed`
can ship as its own cleanup.

Includes inspection-warning cleanup in all touched files.

Fixes #8891
Fixes #8902