### PR TITLE
fix: evict corrupt Unity AB cache entries and retry the download once

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/CorruptAbCacheEvictor.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/CorruptAbCacheEvictor.cs
@@ -1,0 +1,35 @@
+using CommunicationData.URLHelpers;
+using UnityEngine;
+
+namespace ECS.StreamableLoading.AssetBundles
+{
+    /// <summary>
+    ///     Maintains the invariant that an entry in Unity's built-in <see cref="Caching" /> is either mountable or absent:
+    ///     a corrupt cached archive completes its web request successfully (cache hit, no network) yet yields a null
+    ///     bundle from the native mount, and Unity never evicts such an entry on its own.
+    /// </summary>
+    internal static class CorruptAbCacheEvictor
+    {
+        /// <summary>
+        ///     Unity's <see cref="Caching" /> keys entries by the file name of the request URL (query string excluded).
+        /// </summary>
+        internal static string CacheNameFromUrl(URLAddress url)
+        {
+            string value = url.Value;
+            int end = value.IndexOf('?');
+
+            if (end < 0)
+                end = value.Length;
+
+            int lastSlash = value.LastIndexOf('/', end - 1);
+            return value.Substring(lastSlash + 1, end - lastSlash - 1);
+        }
+
+        /// <summary>
+        ///     Main thread only. Returns false when there was no entry for that url+hash pair or the entry is in use
+        ///     (a corrupt entry never mounts, so it can never be in use).
+        /// </summary>
+        internal static bool TryEvict(URLAddress url, Hash128 cacheHash) =>
+            Caching.ClearCachedVersion(CacheNameFromUrl(url), cacheHash);
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/CorruptAbCacheEvictor.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/CorruptAbCacheEvictor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 282016f172e045b081662efe7ba292c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs
@@ -3,7 +3,6 @@ using Arch.SystemGroups;
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
-using DCL.Optimization.PerformanceBudgeting;
 using DCL.Optimization.Pools;
 using DCL.Optimization.ThreadSafePool;
 using ECS.Prioritization.Components;
@@ -93,6 +92,27 @@ namespace ECS.StreamableLoading.AssetBundles
                     progressReporter: byteWeightedProgress ? state : null,
                     suppressErrors: true); // Suppress errors because here we have our own error handling
                 assetBundle = assetBundleResult.Value.AssetBundle;
+
+                if (assetBundle == null && intention.cacheHash.HasValue)
+                {
+                    // A corrupt entry in Unity's Caching completes the request without reaching the network yet fails
+                    // the native mount, and nothing else ever evicts it — the entry would poison this bundle across
+                    // sessions. Evicting turns the single re-request below into a real download that re-populates the
+                    // cache; for null bundles with non-cache causes it costs at most one extra attempt.
+                    await UniTask.SwitchToMainThread();
+                    CorruptAbCacheEvictor.TryEvict(intention.CommonArguments.URL, intention.cacheHash.Value);
+
+                    assetBundleResult = await webRequestController.GetAssetBundleAsync(
+                        intention.CommonArguments,
+                        new GetAssetBundleArguments(loadingMutex, intention.cacheHash),
+                        ct,
+                        GetReportCategory(),
+                        expectedContentLength: contentLength,
+                        progressReporter: byteWeightedProgress ? state : null,
+                        suppressErrors: true);
+
+                    assetBundle = assetBundleResult.Value.AssetBundle;
+                }
             }
 
             // Release budget now to not hold it until dependencies are resolved to prevent a deadlock
@@ -111,11 +131,11 @@ namespace ECS.StreamableLoading.AssetBundles
             {
                 // get metrics
 
-                string? metadataJSON;
+                string metadataJson;
 
                 using (AssetBundleLoadingMutex.LoadingRegion _ = await loadingMutex.AcquireAsync(ct))
                 {
-                    metadataJSON = assetBundle.LoadAsset<TextAsset>(METADATA_FILENAME)?.text;
+                    metadataJson = assetBundle.LoadAsset<TextAsset>(METADATA_FILENAME)?.text ?? string.Empty;
                 }
 
                 // Switch to thread pool to parse JSONs
@@ -126,12 +146,12 @@ namespace ECS.StreamableLoading.AssetBundles
                 AssetBundleData[] dependencies;
                 var mainAsset = "";
 
-                if (!string.IsNullOrEmpty(metadataJSON))
+                if (!string.IsNullOrEmpty(metadataJson))
                 {
                     using PoolExtensions.Scope<AssetBundleMetadata> reusableMetadata = METADATA_POOL.AutoScope();
 
                     // Parse metadata
-                    JsonUtility.FromJsonOverwrite(metadataJSON, reusableMetadata.Value);
+                    JsonUtility.FromJsonOverwrite(metadataJson, reusableMetadata.Value);
                     mainAsset = reusableMetadata.Value.mainAsset;
                     dependencies = await LoadDependenciesAsync(intention, partition, reusableMetadata.Value, ct);
                 }
@@ -185,14 +205,14 @@ namespace ECS.StreamableLoading.AssetBundles
                     throw new StreamableLoadingException(LogType.Warning, nameof(LoadAssetBundleSystem), new AssetBundleContainsShaderException(assetBundle.name));
             }
 
-            Object[]? asset = await LoadAllAssetsAsync(assetBundle, expectedObjType, mainAsset, loadingMutex, reportCategory, ct);
+            Object[]? asset = await LoadAllAssetsAsync(assetBundle, expectedObjType, mainAsset, loadingMutex, ct);
 
             return new StreamableLoadingResult<AssetBundleData>(new AssetBundleData(assetBundle, asset, expectedObjType, dependencies,
                 version: version,
                 source: source));
         }
 
-        private static async UniTask<Object[]> LoadAllAssetsAsync(AssetBundle assetBundle, Type? objectType, string? mainAsset, AssetBundleLoadingMutex loadingMutex, ReportData reportCategory, CancellationToken ct)
+        private static async UniTask<Object[]> LoadAllAssetsAsync(AssetBundle assetBundle, Type? objectType, string? mainAsset, AssetBundleLoadingMutex loadingMutex, CancellationToken ct)
         {
             using AssetBundleLoadingMutex.LoadingRegion _ = await loadingMutex.AcquireAsync(ct);
 
@@ -215,12 +235,12 @@ namespace ECS.StreamableLoading.AssetBundles
         private async UniTask<AssetBundleData> WaitForDependencyAsync(
             string hash,
             AssetBundleManifestVersion assetBundleManifestVersion,
-            string parentEntityID,
+            string parentEntityId,
             URLSubdirectory customEmbeddedSubdirectory,
             IPartitionComponent partition, CancellationToken ct)
         {
             // Inherit partition from the parent promise
-            var assetBundlePromise = AssetPromise<AssetBundleData, GetAssetBundleIntention>.Create(World, GetAssetBundleIntention.FromHash(hash, assetBundleManifestVersion: assetBundleManifestVersion, parentEntityID: parentEntityID, customEmbeddedSubDirectory: customEmbeddedSubdirectory, isDependency : true), partition);
+            var assetBundlePromise = AssetPromise<AssetBundleData, GetAssetBundleIntention>.Create(World, GetAssetBundleIntention.FromHash(hash, assetBundleManifestVersion: assetBundleManifestVersion, parentEntityID: parentEntityId, customEmbeddedSubDirectory: customEmbeddedSubdirectory, isDependency : true), partition);
 
             try
             {
@@ -229,10 +249,10 @@ namespace ECS.StreamableLoading.AssetBundles
                 if (!assetBundlePromise.TryGetResult(World, out StreamableLoadingResult<AssetBundleData> depResult))
                     throw new Exception($"Dependency {hash} is not resolved");
 
-                if (!depResult.Succeeded)
+                if (depResult is not { Succeeded: true, Asset: { } depAsset })
                     throw new Exception($"Dependency {hash} resolution failed", depResult.Exception);
 
-                return depResult.Asset;
+                return depAsset;
             }
             catch (OperationCanceledException)
             {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs
@@ -100,7 +100,9 @@ namespace ECS.StreamableLoading.AssetBundles
                     // sessions. Evicting turns the single re-request below into a real download that re-populates the
                     // cache; for null bundles with non-cache causes it costs at most one extra attempt.
                     await UniTask.SwitchToMainThread();
-                    CorruptAbCacheEvictor.TryEvict(intention.CommonArguments.URL, intention.cacheHash.Value);
+
+                    if (CorruptAbCacheEvictor.TryEvict(intention.CommonArguments.URL, intention.cacheHash.Value))
+                        ReportHub.Log(GetReportData(), $"Evicted corrupt cached AssetBundle for {intention.Hash}, retrying download");
 
                     assetBundleResult = await webRequestController.GetAssetBundleAsync(
                         intention.CommonArguments,

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/EditModeTests/CorruptAbCacheRecoveryShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/EditModeTests/CorruptAbCacheRecoveryShould.cs
@@ -1,0 +1,193 @@
+using Arch.Core;
+using Cysharp.Threading.Tasks;
+using DCL.WebRequests;
+using ECS.Prioritization.Components;
+using ECS.StreamableLoading.Cache;
+using ECS.StreamableLoading.Cache.Disk;
+using ECS.StreamableLoading.Common.Components;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.TestTools;
+
+namespace ECS.StreamableLoading.AssetBundles.Tests
+{
+    /// <summary>
+    ///     Covers the recovery invariant for corrupt entries in Unity's built-in <see cref="Caching" />:
+    ///     a corrupt cached archive completes its web request successfully (cache hit, no network) yet
+    ///     yields a null bundle from the native mount ("Unable to open archive file"), and since nothing
+    ///     evicts the entry, the bundle stays broken for the user across sessions. The load flow must
+    ///     evict the entry and re-request once so the cache is re-populated with a whole archive.
+    /// </summary>
+    [TestFixture]
+    public class CorruptAbCacheRecoveryShould
+    {
+        private const string BUNDLE_CACHE_NAME = "bafkreid3xecd44iujaz5qekbdrt5orqdqj3wivg5zc5mya3zkorjhyrkda";
+
+        private static string bundlePath => $"{Application.dataPath}/../TestResources/AssetBundles/{BUNDLE_CACHE_NAME}";
+        private static string bundleUrl => $"file://{bundlePath}";
+
+        private World world = null!;
+        private IStreamableCache<AssetBundleData, GetAssetBundleIntention> cache = null!;
+        private ExposedLoadAssetBundleSystem? system;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = World.Create();
+            cache = Substitute.For<IStreamableCache<AssetBundleData, GetAssetBundleIntention>>();
+            Caching.ClearAllCachedVersions(BUNDLE_CACHE_NAME);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            LogAssert.ignoreFailingMessages = false;
+            AssetBundle.UnloadAllAssetBundles(true);
+            Caching.ClearAllCachedVersions(BUNDLE_CACHE_NAME);
+            system?.Dispose();
+            world.Dispose();
+        }
+
+        [Test]
+        public async Task RecoverFromCorruptCachedArchive()
+        {
+            // The native "Unable to open archive file" error raised by the corrupt mount is the expected symptom
+            LogAssert.ignoreFailingMessages = true;
+
+            Hash128 cacheHash = Hash128.Compute("corrupt-ab-cache-recovery");
+
+            await SeedCacheAsync(cacheHash);
+
+            string dataFile = FindCachedDataFile();
+            byte[] original = File.ReadAllBytes(dataFile);
+            var garbage = new byte[original.Length];
+
+            for (var i = 0; i < garbage.Length; i++)
+                garbage[i] = 0xAB;
+
+            // Same-length corruption models the real defect: presence checks still hit, only the mount fails
+            File.WriteAllBytes(dataFile, garbage);
+
+            system = new ExposedLoadAssetBundleSystem(world, cache, IWebRequestController.TEST);
+
+            // Without the eviction retry this await faults with NullReferenceException: the corrupt entry is
+            // served from the cache, DownloadHandlerAssetBundle.GetContent returns null and no recovery exists,
+            // while the corrupt entry stays cached for every future attempt.
+            StreamableLoadingResult<AssetBundleData> result = await system.FlowAsync(
+                NewWebIntention(bundleUrl, cacheHash), StreamableLoadingState.Create(), PartitionComponent.TOP_PRIORITY, CancellationToken.None);
+
+            Assert.That(result.Succeeded, Is.True, result.Exception?.ToString());
+            Assert.That(result.Asset, Is.Not.Null);
+
+            // The corrupt entry was evicted and re-downloaded: the cached archive is whole again
+            Assert.That(Caching.IsVersionCached(bundleUrl, cacheHash), Is.True);
+
+            byte[] repaired = File.ReadAllBytes(FindCachedDataFile());
+            Assert.That(repaired[..8], Is.EqualTo(original[..8]), "the cached archive must be re-populated with real content");
+
+            await PumpAsync();
+        }
+
+        [Test]
+        public async Task RetryExactlyOnceAfterEvictingWhenCachedRequestYieldsNullBundle()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            IWebRequestController controller = Substitute.For<IWebRequestController>();
+            var requests = 0;
+            AssetBundle? retryBundle = null;
+
+            controller.SendAsync<GetAssetBundleWebRequest, GetAssetBundleArguments, GetAssetBundleWebRequest.CreateAssetBundleOp, AssetBundleLoadingResult>(
+                           Arg.Any<RequestEnvelope<GetAssetBundleWebRequest, GetAssetBundleArguments>>(),
+                           Arg.Any<GetAssetBundleWebRequest.CreateAssetBundleOp>(),
+                           Arg.Any<long>(),
+                           Arg.Any<IProgress<float>?>())
+                      .Returns(_ =>
+                       {
+                           requests++;
+
+                           // The first response models a corrupt cache-served archive: the request "succeeds", the bundle is null
+                           if (requests == 1)
+                               return UniTask.FromResult(new AssetBundleLoadingResult(null, "Unable to open archive file"));
+
+                           retryBundle ??= AssetBundle.LoadFromFile(bundlePath);
+                           return UniTask.FromResult(new AssetBundleLoadingResult(retryBundle, null));
+                       });
+
+            system = new ExposedLoadAssetBundleSystem(world, cache, controller);
+
+            // Without the eviction retry this await faults with NullReferenceException after a single request
+            StreamableLoadingResult<AssetBundleData> result = await system.FlowAsync(
+                NewWebIntention("https://ab-cdn.decentraland.test/v49/assets/corrupt_stub_windows", Hash128.Compute("corrupt-stub")),
+                StreamableLoadingState.Create(), PartitionComponent.TOP_PRIORITY, CancellationToken.None);
+
+            Assert.That(requests, Is.EqualTo(2), "a cache-eligible null bundle must be followed by exactly one evict-and-retry re-request");
+            Assert.That(result.Succeeded, Is.True, result.Exception?.ToString());
+            Assert.That(result.Asset, Is.Not.Null);
+
+            await PumpAsync();
+        }
+
+        private static GetAssetBundleIntention NewWebIntention(string url, Hash128 cacheHash) =>
+            new (new CommonLoadingArguments(url, attempts: 1)) { cacheHash = cacheHash };
+
+        private static async Task SeedCacheAsync(Hash128 cacheHash)
+        {
+            using UnityWebRequest webRequest = UnityWebRequestAssetBundle.GetAssetBundle(bundleUrl, cacheHash);
+            UnityWebRequestAsyncOperation operation = webRequest.SendWebRequest();
+
+            while (!operation.isDone)
+                await UniTask.Yield();
+
+            Assume.That(webRequest.result, Is.EqualTo(UnityWebRequest.Result.Success), "seeding Unity's AssetBundle cache failed");
+
+            AssetBundle? seeded = DownloadHandlerAssetBundle.GetContent(webRequest);
+            Assume.That(seeded, Is.Not.Null, "seeding Unity's AssetBundle cache produced no bundle");
+            seeded!.Unload(true);
+
+            Assume.That(Caching.IsVersionCached(bundleUrl, cacheHash), Is.True, "Editor Caching did not store the seeded bundle");
+        }
+
+        private static string FindCachedDataFile()
+        {
+            string bundleRoot = Path.Combine(Caching.currentCacheForWriting.path, BUNDLE_CACHE_NAME);
+            Assume.That(Directory.Exists(bundleRoot), Is.True, $"no cache folder at {bundleRoot}");
+
+            string[] entries = Directory.GetDirectories(bundleRoot);
+
+            for (var i = 0; i < entries.Length; i++)
+            {
+                string candidate = Path.Combine(entries[i], "__data");
+
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            Assume.That(false, $"no cached __data found under {bundleRoot}");
+            return null!;
+        }
+
+        private static async Task PumpAsync()
+        {
+            // Land detached continuations inside the test window instead of after it (EditMode harness requirement)
+            for (var i = 0; i < 10; i++)
+                await UniTask.Yield();
+        }
+
+        private class ExposedLoadAssetBundleSystem : LoadAssetBundleSystem
+        {
+            public ExposedLoadAssetBundleSystem(World world, IStreamableCache<AssetBundleData, GetAssetBundleIntention> cache, IWebRequestController webRequestController)
+                : base(world, cache, webRequestController, ArrayPool<byte>.Shared, new AssetBundleLoadingMutex(), Substitute.For<IDiskCache<PartialLoadingState>>(), byteWeightedProgress: false) { }
+
+            public UniTask<StreamableLoadingResult<AssetBundleData>> FlowAsync(GetAssetBundleIntention intention, StreamableLoadingState state, IPartitionComponent partition, CancellationToken ct) =>
+                FlowInternalAsync(intention, state, partition, ct);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/EditModeTests/CorruptAbCacheRecoveryShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/EditModeTests/CorruptAbCacheRecoveryShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68a774edbf304f41bdc2a346e87cd9dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Problem

Unity native error `Unable to open archive file: <LocalLow cache>/<name>/<hash>/__data`
whenever a corrupted entry in Unity's built-in AssetBundle cache is mounted. The affected
bundle (scene, wearable, LOD) then fails permanently: the corrupt entry is never evicted,
so every retry and every future session hits the same broken file; the only recovery today
is the user manually deleting the cache folder. Sentry UNITY-EXPLORER-KFX (ongoing,
8 ev/wk, 353 total); same class on macOS (#8704, #8643).

## Root cause

The load pipeline has no recovery path for a cache-served corrupt archive. A cache hit
completes the web request successfully; the null bundle from the failed native mount lands
in a branch that throws without retrying - and even a retry would re-read the same corrupt
file, since a cache hit never reaches the network. Nothing in the runtime ever calls
`Caching.ClearCachedVersion` (the only `Caching` call at the pin is an Editor-only menu).
The invariant "a cache entry is either loadable or absent" is maintained nowhere.

## Fix (~50 LOC, single locus)

- New internal `CorruptAbCacheEvictor`: `CacheNameFromUrl` (Unity keys cache entries by the
  URL's file name) + `TryEvict(url, cacheHash)` via `Caching.ClearCachedVersion`.
- `LoadAssetBundleSystem.FlowInternalAsync`: in the null-bundle branch, when the intention
  carries a `cacheHash` - switch to main thread, evict, and re-issue the identical request
  exactly once (now a cache miss → real download that re-populates the entry). If still
  null, the existing exception fires. `LoadGlobalAssetBundleSystem` inherits the flow;
  embedded/StreamingAssets loads never set `cacheHash` and are untouched.

Worst case for a non-cache null bundle (CDN serves a garbage 200): one extra download
attempt, then the exact pre-fix failure. Out of scope: `StreamingAssets/aa` install
corruption (#8312/#8131/#7789) - no cache to evict.

## Test

New EditMode `CorruptAbCacheRecoveryShould`:

- `RecoverFromCorruptCachedArchive` - seeds the real Editor cache with the repo's test
  bundle, corrupts `__data` in place, drives the real flow (environment preconditions
  guarded by `Assume.That`).
- `RetryExactlyOnceAfterEvictingWhenCachedRequestYieldsNullBundle` - deterministic stub
  repro: first request returns a null bundle, second a real one; pin throws after exactly
  one request, fix makes exactly two and succeeds.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL as intended on the stub test (the
exact "Asset Bundle is null: Unable to open archive file" signature; the Editor-Caching
test proved non-discriminating under batchmode on this lane - the stub test is the
load-bearing repro) / GREEN PASS 2/2.

Fixes #8023
Related: #8704, #8643 (same defect class on macOS), #9610 (custom IDiskCache hardening  - 
different cache layer)

Includes inspection-warning cleanup in all touched files.

Fixes #8023