### PR TITLE
fix: cancel stalled login profile fetch instead of abandoning it

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs
@@ -19,7 +19,6 @@ namespace DCL.AuthenticationScreenFlow
 {
     public class ProfileFetchingAuthState : AuthStateBase, IPayloadedState<ProfileFetchingPayload>
     {
-        private const int PROFILE_FETCH_ATTEMPTS = 3;
         private static readonly TimeSpan PROFILE_FETCH_TIMEOUT = TimeSpan.FromSeconds(15);
 
         private readonly MVCStateMachine<AuthStateBase> machine;
@@ -111,7 +110,7 @@ namespace DCL.AuthenticationScreenFlow
                     });
 
                     // Timeout surfaces catalyst stalls as CONNECTION_ERROR instead of a frozen spinner.
-                    if (await FetchProfileWithTimeoutRetriesAsync(selfProfile, PROFILE_FETCH_TIMEOUT, PROFILE_FETCH_ATTEMPTS, ct) is { } profile)
+                    if (await FetchProfileWithTimeoutAsync(selfProfile, PROFILE_FETCH_TIMEOUT, ct) is { } profile)
                     {
                         // When the profile was already in cache, for example your previous account after logout, we need to ensure that all systems related to the profile will update
                         profile.IsDirty = true;
@@ -156,31 +155,27 @@ namespace DCL.AuthenticationScreenFlow
         }
 
         /// <summary>
-        ///     Each attempt owns a linked token, so a timed-out attempt cancels its underlying request instead of
-        ///     abandoning it. Only exhausting all attempts surfaces as <see cref="TimeoutException" /> (CONNECTION_ERROR);
+        ///     The fetch runs under a linked token, so a timed-out fetch cancels its underlying request instead of
+        ///     abandoning it. Timeout surfaces as <see cref="TimeoutException" /> (CONNECTION_ERROR);
         ///     cancellation of <paramref name="ct" /> surfaces as <see cref="OperationCanceledException" />.
         /// </summary>
-        internal static async UniTask<Profile?> FetchProfileWithTimeoutRetriesAsync(ISelfProfile selfProfile, TimeSpan attemptTimeout, int maxAttempts, CancellationToken ct)
+        internal static async UniTask<Profile?> FetchProfileWithTimeoutAsync(ISelfProfile selfProfile, TimeSpan timeout, CancellationToken ct)
         {
-            for (var attempt = 1;; attempt++)
-            {
-                using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                using IDisposable timeoutTimer = timeoutCts.CancelAfterSlim(attemptTimeout);
+            using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            using IDisposable timeoutTimer = timeoutCts.CancelAfterSlim(timeout);
 
-                if (await selfProfile.ProfileAsync(timeoutCts.Token) is { } profile)
-                    return profile;
+            if (await selfProfile.ProfileAsync(timeoutCts.Token) is { } profile)
+                return profile;
 
-                // The repository suppresses cancellation into a null profile, including cancellation of the flow token.
-                // Surface external cancellation as OCE so it is classified as a user cancel, not as "no deployed profile"
-                // (which on the cached flow would clear a still-valid stored identity)
-                ct.ThrowIfCancellationRequested();
+            // The repository suppresses cancellation into a null profile, including cancellation of the flow token.
+            // Surface external cancellation as OCE so it is classified as a user cancel, not as "no deployed profile"
+            // (which on the cached flow would clear a still-valid stored identity)
+            ct.ThrowIfCancellationRequested();
 
-                if (!timeoutCts.IsCancellationRequested)
-                    return null; // genuine "no deployed profile"
+            if (timeoutCts.IsCancellationRequested)
+                throw new TimeoutException($"Profile fetch timed out after {timeout.TotalSeconds:F0}s");
 
-                if (attempt >= maxAttempts)
-                    throw new TimeoutException($"Profile fetch timed out after {maxAttempts} attempts of {attemptTimeout.TotalSeconds:F0}s each");
-            }
+            return null; // genuine "no deployed profile"
         }
 
         private Profile CreateRandomProfile(string identityAddress)

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs
@@ -19,6 +19,7 @@ namespace DCL.AuthenticationScreenFlow
 {
     public class ProfileFetchingAuthState : AuthStateBase, IPayloadedState<ProfileFetchingPayload>
     {
+        private const int PROFILE_FETCH_ATTEMPTS = 3;
         private static readonly TimeSpan PROFILE_FETCH_TIMEOUT = TimeSpan.FromSeconds(15);
 
         private readonly MVCStateMachine<AuthStateBase> machine;
@@ -70,7 +71,7 @@ namespace DCL.AuthenticationScreenFlow
                                     ProfileNotFoundException ex => new SpanErrorInfo($"Profile not found during {nameof(ProfileFetchingAuthState)}", ex),
                                     NotAllowedUserException ex => new SpanErrorInfo(ex.Message, ex),
                                     TimeoutException ex => new SpanErrorInfo($"Profile fetch timed out during {nameof(ProfileFetchingAuthState)}", ex),
-                                    Exception ex => new SpanErrorInfo($"Unexpected error during {nameof(ProfileFetchingAuthState)}", ex),
+                                    { } ex => new SpanErrorInfo($"Unexpected error during {nameof(ProfileFetchingAuthState)}", ex),
                                 };
 
                 if (profileFetchException is not OperationCanceledException and not ProfileNotFoundException and not NotAllowedUserException)
@@ -110,9 +111,7 @@ namespace DCL.AuthenticationScreenFlow
                     });
 
                     // Timeout surfaces catalyst stalls as CONNECTION_ERROR instead of a frozen spinner.
-                    Profile? profile = await selfProfile.ProfileAsync(ct).Timeout(PROFILE_FETCH_TIMEOUT);
-
-                    if (profile != null)
+                    if (await FetchProfileWithTimeoutRetriesAsync(selfProfile, PROFILE_FETCH_TIMEOUT, PROFILE_FETCH_ATTEMPTS, ct) is { } profile)
                     {
                         // When the profile was already in cache, for example your previous account after logout, we need to ensure that all systems related to the profile will update
                         profile.IsDirty = true;
@@ -153,6 +152,34 @@ namespace DCL.AuthenticationScreenFlow
                     profileFetchException = e;
                     machine.Enter<LoginSelectionAuthState, ErrorType>(ErrorType.ConnectionError);
                 }
+            }
+        }
+
+        /// <summary>
+        ///     Each attempt owns a linked token, so a timed-out attempt cancels its underlying request instead of
+        ///     abandoning it. Only exhausting all attempts surfaces as <see cref="TimeoutException" /> (CONNECTION_ERROR);
+        ///     cancellation of <paramref name="ct" /> surfaces as <see cref="OperationCanceledException" />.
+        /// </summary>
+        internal static async UniTask<Profile?> FetchProfileWithTimeoutRetriesAsync(ISelfProfile selfProfile, TimeSpan attemptTimeout, int maxAttempts, CancellationToken ct)
+        {
+            for (var attempt = 1;; attempt++)
+            {
+                using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                using IDisposable timeoutTimer = timeoutCts.CancelAfterSlim(attemptTimeout);
+
+                if (await selfProfile.ProfileAsync(timeoutCts.Token) is { } profile)
+                    return profile;
+
+                // The repository suppresses cancellation into a null profile, including cancellation of the flow token.
+                // Surface external cancellation as OCE so it is classified as a user cancel, not as "no deployed profile"
+                // (which on the cached flow would clear a still-valid stored identity)
+                ct.ThrowIfCancellationRequested();
+
+                if (!timeoutCts.IsCancellationRequested)
+                    return null; // genuine "no deployed profile"
+
+                if (attempt >= maxAttempts)
+                    throw new TimeoutException($"Profile fetch timed out after {maxAttempts} attempts of {attemptTimeout.TotalSeconds:F0}s each");
             }
         }
 

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs
@@ -23,13 +23,13 @@ namespace DCL.AuthenticationScreenFlow.Tests
     public class ProfileFetchingAuthStateShould
     {
         // Mirrors ProfileFetchingAuthState.PROFILE_FETCH_TIMEOUT (private)
-        private const float ATTEMPT_TIMEOUT_SECONDS = 15f;
+        private const float FETCH_TIMEOUT_SECONDS = 15f;
 
-        // Long enough for the first attempt to time out and a retry to start, short enough to stay before a second timeout
+        // Long enough for the fetch timeout to fire and be observed
         private const float OBSERVATION_SECONDS = 16.5f;
 
         [UnityTest]
-        public IEnumerator CancelStalledFetchAndRetryOnTimeout() =>
+        public IEnumerator CancelStalledFetchOnTimeout() =>
             UniTask.ToCoroutine(async () =>
             {
                 // The state machine has no states registered: transitions attempted by the flow throw and are logged
@@ -75,14 +75,11 @@ namespace DCL.AuthenticationScreenFlow.Tests
                     while (UnityEngine.Time.realtimeSinceStartup < deadline)
                         await UniTask.Yield();
 
-                    Assert.That(selfProfile.CapturedTokens.Count, Is.GreaterThanOrEqualTo(1), "the profile fetch was never started");
+                    Assert.That(selfProfile.CapturedTokens.Count, Is.EqualTo(1), "the profile fetch must run exactly once (no retries)");
 
                     Assert.That(selfProfile.CapturedTokens[0].IsCancellationRequested, Is.True,
-                        $"the first fetch attempt's token must be cancelled once the {ATTEMPT_TIMEOUT_SECONDS}s attempt timeout elapses; " +
+                        $"the fetch's token must be cancelled once the {FETCH_TIMEOUT_SECONDS}s timeout elapses; " +
                         "an uncancelled token means the request was abandoned and keeps poisoning the repository's ongoing batch");
-
-                    Assert.That(selfProfile.CapturedTokens.Count, Is.GreaterThanOrEqualTo(2),
-                        "a timed-out attempt must be retried before the login flow gives up");
                 }
                 finally
                 {
@@ -104,8 +101,8 @@ namespace DCL.AuthenticationScreenFlow.Tests
                 var selfProfile = new StalledSelfProfile();
                 using var cts = new CancellationTokenSource();
 
-                UniTask<Profile?> fetch = ProfileFetchingAuthState.FetchProfileWithTimeoutRetriesAsync(
-                    selfProfile, TimeSpan.FromSeconds(ATTEMPT_TIMEOUT_SECONDS), maxAttempts: 3, cts.Token);
+                UniTask<Profile?> fetch = ProfileFetchingAuthState.FetchProfileWithTimeoutAsync(
+                    selfProfile, TimeSpan.FromSeconds(FETCH_TIMEOUT_SECONDS), cts.Token);
 
                 float deadline = UnityEngine.Time.realtimeSinceStartup + 5f;
 
@@ -128,37 +125,37 @@ namespace DCL.AuthenticationScreenFlow.Tests
             });
 
         [UnityTest]
-        public IEnumerator ThrowTimeoutOnlyAfterExhaustingAllAttempts() =>
+        public IEnumerator ThrowTimeoutWhenFetchStalls() =>
             UniTask.ToCoroutine(async () =>
             {
                 var selfProfile = new StalledSelfProfile();
 
                 try
                 {
-                    await ProfileFetchingAuthState.FetchProfileWithTimeoutRetriesAsync(
-                        selfProfile, TimeSpan.FromSeconds(0.25), maxAttempts: 2, CancellationToken.None);
+                    await ProfileFetchingAuthState.FetchProfileWithTimeoutAsync(
+                        selfProfile, TimeSpan.FromSeconds(0.25), CancellationToken.None);
 
-                    Assert.Fail("exhausting all attempts must surface as TimeoutException");
+                    Assert.Fail("a stalled fetch must surface as TimeoutException");
                 }
                 catch (TimeoutException) { }
 
-                Assert.That(selfProfile.CapturedTokens.Count, Is.EqualTo(2), "every attempt up to the limit must run");
+                Assert.That(selfProfile.CapturedTokens.Count, Is.EqualTo(1), "the fetch must run exactly once");
 
-                Assert.That(selfProfile.CapturedTokens.TrueForAll(t => t.IsCancellationRequested), Is.True,
-                    "each timed-out attempt must cancel its own request instead of abandoning it");
+                Assert.That(selfProfile.CapturedTokens[0].IsCancellationRequested, Is.True,
+                    "a timed-out fetch must cancel its own request instead of abandoning it");
             });
 
         [UnityTest]
-        public IEnumerator ReturnNullWithoutRetryWhenProfileIsNotDeployed() =>
+        public IEnumerator ReturnNullWhenProfileIsNotDeployed() =>
             UniTask.ToCoroutine(async () =>
             {
                 var selfProfile = new MissingProfileSelfProfile();
 
-                Profile? result = await ProfileFetchingAuthState.FetchProfileWithTimeoutRetriesAsync(
-                    selfProfile, TimeSpan.FromSeconds(ATTEMPT_TIMEOUT_SECONDS), maxAttempts: 3, CancellationToken.None);
+                Profile? result = await ProfileFetchingAuthState.FetchProfileWithTimeoutAsync(
+                    selfProfile, TimeSpan.FromSeconds(FETCH_TIMEOUT_SECONDS), CancellationToken.None);
 
                 Assert.That(result, Is.Null);
-                Assert.That(selfProfile.Calls, Is.EqualTo(1), "a genuine \"no deployed profile\" must not be retried");
+                Assert.That(selfProfile.Calls, Is.EqualTo(1), "a genuine \"no deployed profile\" must resolve on the single fetch");
             });
 
         private static void SetBackingField(object target, Type declaringType, string propertyName, object value)

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs
@@ -1,0 +1,233 @@
+using Cysharp.Threading.Tasks;
+using DCL.Profiles;
+using DCL.Profiles.Self;
+using DCL.Utilities;
+using DCL.Web3.Identities;
+using MVC;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+using static DCL.AuthenticationScreenFlow.AuthenticationScreenController;
+
+namespace DCL.AuthenticationScreenFlow.Tests
+{
+    [TestFixture]
+    public class ProfileFetchingAuthStateShould
+    {
+        // Mirrors ProfileFetchingAuthState.PROFILE_FETCH_TIMEOUT (private)
+        private const float ATTEMPT_TIMEOUT_SECONDS = 15f;
+
+        // Long enough for the first attempt to time out and a retry to start, short enough to stay before a second timeout
+        private const float OBSERVATION_SECONDS = 16.5f;
+
+        [UnityTest]
+        public IEnumerator CancelStalledFetchAndRetryOnTimeout() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                // The state machine has no states registered: transitions attempted by the flow throw and are logged
+                // through the fire-and-forget UniTaskVoid; those logs are irrelevant to the invariant under test
+                LogAssert.ignoreFailingMessages = true;
+
+                using var cts = new CancellationTokenSource();
+                var root = new GameObject(nameof(ProfileFetchingAuthStateShould));
+
+                try
+                {
+                    AuthenticationScreenView screenView = root.AddComponent<AuthenticationScreenView>();
+
+                    var viewGo = new GameObject(nameof(ProfileFetchingAuthView));
+                    viewGo.transform.SetParent(root.transform);
+                    StubProfileFetchingAuthView fetchingView = viewGo.AddComponent<StubProfileFetchingAuthView>();
+
+                    var buttonGo = new GameObject("CancelButton");
+                    buttonGo.transform.SetParent(viewGo.transform);
+                    Button cancelButton = buttonGo.AddComponent<Button>();
+
+                    SetBackingField(fetchingView, typeof(ProfileFetchingAuthView), nameof(ProfileFetchingAuthView.CancelButton), cancelButton);
+                    SetBackingField(screenView, typeof(AuthenticationScreenView), nameof(AuthenticationScreenView.ProfileFetchingAuthView), fetchingView);
+
+                    var machine = new MVCStateMachine<AuthStateBase>();
+                    var selfProfile = new StalledSelfProfile();
+
+                    // The controller is only captured for the Cancel button listener, which is never invoked here
+                    var controller = (AuthenticationScreenController)FormatterServices.GetUninitializedObject(typeof(AuthenticationScreenController));
+
+                    var state = new ProfileFetchingAuthState(
+                        machine,
+                        screenView,
+                        controller,
+                        new ReactiveProperty<AuthStatus>(AuthStatus.None),
+                        selfProfile,
+                        Substitute.For<IWeb3IdentityCache>());
+
+                    state.Enter(new ProfileFetchingPayload(Substitute.For<IWeb3Identity>(), true, cts.Token));
+
+                    float deadline = UnityEngine.Time.realtimeSinceStartup + OBSERVATION_SECONDS;
+
+                    while (UnityEngine.Time.realtimeSinceStartup < deadline)
+                        await UniTask.Yield();
+
+                    Assert.That(selfProfile.CapturedTokens.Count, Is.GreaterThanOrEqualTo(1), "the profile fetch was never started");
+
+                    Assert.That(selfProfile.CapturedTokens[0].IsCancellationRequested, Is.True,
+                        $"the first fetch attempt's token must be cancelled once the {ATTEMPT_TIMEOUT_SECONDS}s attempt timeout elapses; " +
+                        "an uncancelled token means the request was abandoned and keeps poisoning the repository's ongoing batch");
+
+                    Assert.That(selfProfile.CapturedTokens.Count, Is.GreaterThanOrEqualTo(2),
+                        "a timed-out attempt must be retried before the login flow gives up");
+                }
+                finally
+                {
+                    // Unblock the pending attempt (even on assertion failure) so the detached flow finishes
+                    // inside this test's ignore-failing-messages window instead of erroring into a later test
+                    cts.Cancel();
+
+                    for (var i = 0; i < 32; i++)
+                        await UniTask.Yield();
+
+                    UnityEngine.Object.DestroyImmediate(root);
+                }
+            });
+
+        [UnityTest]
+        public IEnumerator SurfaceExternalCancellationInsteadOfMissingProfile() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                var selfProfile = new StalledSelfProfile();
+                using var cts = new CancellationTokenSource();
+
+                UniTask<Profile?> fetch = ProfileFetchingAuthState.FetchProfileWithTimeoutRetriesAsync(
+                    selfProfile, TimeSpan.FromSeconds(ATTEMPT_TIMEOUT_SECONDS), maxAttempts: 3, cts.Token);
+
+                float deadline = UnityEngine.Time.realtimeSinceStartup + 5f;
+
+                while (selfProfile.CapturedTokens.Count == 0 && UnityEngine.Time.realtimeSinceStartup < deadline)
+                    await UniTask.Yield();
+
+                Assert.That(selfProfile.CapturedTokens.Count, Is.EqualTo(1), "the fetch must be in flight before the external cancel");
+
+                cts.Cancel();
+
+                try
+                {
+                    Profile? result = await fetch;
+
+                    Assert.Fail("cancelling the flow token must surface as OperationCanceledException, not be read as " +
+                                $"\"no deployed profile\" (got {(result == null ? "null" : "a profile")}); a null here wipes " +
+                                "a still-valid cached identity on the cached flow");
+                }
+                catch (OperationCanceledException) { }
+            });
+
+        [UnityTest]
+        public IEnumerator ThrowTimeoutOnlyAfterExhaustingAllAttempts() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                var selfProfile = new StalledSelfProfile();
+
+                try
+                {
+                    await ProfileFetchingAuthState.FetchProfileWithTimeoutRetriesAsync(
+                        selfProfile, TimeSpan.FromSeconds(0.25), maxAttempts: 2, CancellationToken.None);
+
+                    Assert.Fail("exhausting all attempts must surface as TimeoutException");
+                }
+                catch (TimeoutException) { }
+
+                Assert.That(selfProfile.CapturedTokens.Count, Is.EqualTo(2), "every attempt up to the limit must run");
+
+                Assert.That(selfProfile.CapturedTokens.TrueForAll(t => t.IsCancellationRequested), Is.True,
+                    "each timed-out attempt must cancel its own request instead of abandoning it");
+            });
+
+        [UnityTest]
+        public IEnumerator ReturnNullWithoutRetryWhenProfileIsNotDeployed() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                var selfProfile = new MissingProfileSelfProfile();
+
+                Profile? result = await ProfileFetchingAuthState.FetchProfileWithTimeoutRetriesAsync(
+                    selfProfile, TimeSpan.FromSeconds(ATTEMPT_TIMEOUT_SECONDS), maxAttempts: 3, CancellationToken.None);
+
+                Assert.That(result, Is.Null);
+                Assert.That(selfProfile.Calls, Is.EqualTo(1), "a genuine \"no deployed profile\" must not be retried");
+            });
+
+        private static void SetBackingField(object target, Type declaringType, string propertyName, object value)
+        {
+            FieldInfo? field = declaringType.GetField($"<{propertyName}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null, $"auto-property backing field for {declaringType.Name}.{propertyName} not found");
+            field!.SetValue(target, value);
+        }
+
+        /// <summary>
+        ///     Simulates a stalled catalyst request. Mirrors the production contract of
+        ///     <see cref="SelfProfile.ProfileAsync" />: cancellation is suppressed into a null profile
+        ///     (RealmProfileRepository's suppressing GetAsync extension), never surfaced as an exception.
+        /// </summary>
+        private class StalledSelfProfile : ISelfProfile
+        {
+            public readonly List<CancellationToken> CapturedTokens = new ();
+
+            public event Action<Profile>? ProfilePropagated;
+
+            public async UniTask<Profile?> ProfileAsync(CancellationToken ct)
+            {
+                CapturedTokens.Add(ct);
+
+                try { return await UniTask.Never<Profile?>(ct); }
+                catch (OperationCanceledException) { return null; }
+            }
+
+            public UniTask<Profile?> UpdateProfileAsync(CancellationToken ct, bool updateAvatarInWorld = true) =>
+                UniTask.FromResult<Profile?>(null);
+
+            public UniTask<Profile?> UpdateProfileAsync(Profile profile, CancellationToken ct, bool updateAvatarInWorld = true) =>
+                UniTask.FromResult<Profile?>(null);
+
+            public void Dispose() { }
+        }
+
+        /// <summary>
+        ///     Simulates a responsive catalyst that has no deployed profile for the address:
+        ///     resolves to null immediately, without any cancellation involved.
+        /// </summary>
+        private class MissingProfileSelfProfile : ISelfProfile
+        {
+            public int Calls { get; private set; }
+
+            public event Action<Profile>? ProfilePropagated;
+
+            public UniTask<Profile?> ProfileAsync(CancellationToken ct)
+            {
+                Calls++;
+                return UniTask.FromResult<Profile?>(null);
+            }
+
+            public UniTask<Profile?> UpdateProfileAsync(CancellationToken ct, bool updateAvatarInWorld = true) =>
+                UniTask.FromResult<Profile?>(null);
+
+            public UniTask<Profile?> UpdateProfileAsync(Profile profile, CancellationToken ct, bool updateAvatarInWorld = true) =>
+                UniTask.FromResult<Profile?>(null);
+
+            public void Dispose() { }
+        }
+    }
+
+    public class StubProfileFetchingAuthView : ProfileFetchingAuthView
+    {
+        public override UniTask ShowAsync(CancellationToken ct) =>
+            UniTask.CompletedTask;
+
+        public override UniTask HideAsync(CancellationToken ct, bool isInstant = false) =>
+            UniTask.CompletedTask;
+    }
+}

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs.meta
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52b0bfdf4a194c62b8121caa81ed45b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Problem

Login dies with a raw `System.TimeoutException: Exceed Timeout:00:00:15` from
`ProfileFetchingAuthState.FetchProfileFlowAsync` after a 15 s stall, and the stalled request
poisons every subsequent profile fetch for the same address. Sentry UNITY-EXPLORER-NRB: 78
events / 40 users past week, ongoing.

## Root cause

The profile fetch was guarded by `UniTask.Timeout()`, whose overload abandons the underlying
request rather than cancelling it. The zombie request keeps holding its entry in
`RealmProfileRepository.ongoingBatches`, so every subsequent fetch for the same address
latches onto the stalled request: one stall poisons the whole login flow.

## Fix

Behavior is unchanged: still a single 15 s attempt, still `TimeoutException` →
CONNECTION_ERROR on stall. The only change is that the fetch now runs under a CTS linked to
the flow token with `CancelAfterSlim(15s)`, so a timed-out fetch actually cancels the
request (the repository's cancellation path removes the ongoing-batch entry before
rethrowing) instead of abandoning it. Because the repository suppresses cancellation into a
null profile, the helper discriminates the timeout from a genuine "no deployed profile"
null; otherwise a stall would mint a random new-account profile (non-cached flow) or wipe
the cached identity (cached flow). Timer and CTS are `using`-scoped with timer-before-CTS
disposal order.

## Test

New EditMode tests in `ProfileFetchingAuthStateShould` (AuthenticationScreenFlow tests
lane):

- `CancelStalledFetchOnTimeout`: drives the real flow with a stalling profile stub, asserts
  the fetch runs exactly once and its token is actually cancelled at the 15 s timeout.
- `ThrowTimeoutWhenFetchStalls`: a stalled fetch surfaces as `TimeoutException` with its
  request cancelled.
- `SurfaceExternalCancellationInsteadOfMissingProfile`: cancelling the flow token surfaces
  as `OperationCanceledException`, not as "no deployed profile" (which would wipe a
  still-valid cached identity).
- `ReturnNullWhenProfileIsNotDeployed`: a genuine missing profile still resolves to null.

## Validation

The cancellation invariant was RED/GREEN validated on the Windows Unity 6000.4 EditMode
lane in the initial submission ("the fetch's token must be cancelled once the 15s timeout
elapses - Expected: True But was: False" against `.Timeout()`, PASS with the linked CTS).
The retry removal is a strict simplification of that validated helper; the updated 4-test
suite runs on the CI EditMode lane.

Related: #7884 (Sentry UNITY-EXPLORER-NRB, heterogeneous grouping of all UniTask
`.Timeout()` throws; this fixes only the profile-fetch culprit), #9474 (same
abandon-not-cancel defect class on remote profile fetches)

Includes inspection-warning cleanup in all touched files.
