### PR TITLE
fix: send mention wallet strings, not UserId objects, in chat analytics

### DIFF
--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests/ChatMessagesBusAnalyticsDecoratorShould.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests/ChatMessagesBusAnalyticsDecoratorShould.cs
@@ -1,0 +1,109 @@
+using DCL.Chat.History;
+using DCL.PerformanceAndDiagnostics.Analytics;
+using DCL.Profiles;
+using ECS.TestSuite;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace DCL.Chat.MessageBus.Tests
+{
+    /// <summary>
+    ///     Regression coverage for the "mentions" field of the <see cref="AnalyticsEvents.Ui.MESSAGE_SENT" /> event:
+    ///     it must carry wallet-address strings (JArray.Add takes object, so <see cref="UserId" />'s implicit
+    ///     string conversion never applies), and each tracked payload must own its mentions array so
+    ///     later sends cannot mutate events already queued for flush.
+    /// </summary>
+    [TestFixture]
+    public class ChatMessagesBusAnalyticsDecoratorShould
+    {
+        private const string FIRST_WALLET = "0x1111111111111111111111111111111111111111";
+        private const string SECOND_WALLET = "0x2222222222222222222222222222222222222222";
+
+        private IChatMessagesBus core = null!;
+        private IAnalyticsController analytics = null!;
+        private IProfileCache profileCache = null!;
+        private ChatMessagesBusAnalyticsDecorator decorator = null!;
+        private List<JObject> trackedPayloads = null!;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            // Profile.CompactInfo touches FeaturesRegistry.Instance on construction; the editor
+            // domain may still hold an initialized registry from a play-mode session
+            EcsTestsUtils.TearDownFeaturesRegistry();
+            EcsTestsUtils.SetUpFeaturesRegistry();
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown() =>
+            EcsTestsUtils.TearDownFeaturesRegistry();
+
+        [SetUp]
+        public void SetUp()
+        {
+            core = Substitute.For<IChatMessagesBus>();
+            analytics = Substitute.For<IAnalyticsController>();
+            profileCache = Substitute.For<IProfileCache>();
+            trackedPayloads = new List<JObject>();
+
+            analytics.When(a => a.Track(AnalyticsEvents.Ui.MESSAGE_SENT, Arg.Any<JObject?>(), Arg.Any<bool>()))
+                     .Do(call => trackedPayloads.Add((JObject)call[1]!));
+
+            // selfProfile is only dereferenced when timestamp > 0; every Send here passes 0
+            decorator = new ChatMessagesBusAnalyticsDecorator(core, analytics, profileCache, null!);
+        }
+
+        [TearDown]
+        public void TearDown() =>
+            decorator.Dispose();
+
+        private static ProfileTier? CachedProfile(string wallet, string name) =>
+            new Profile.CompactInfo(UserId.New(wallet).Unwrap(), name);
+
+        [Test]
+        public void TrackMentionOfCachedProfileAsWalletAddressString()
+        {
+            profileCache.GetByUserName("TestName").Returns(CachedProfile(FIRST_WALLET, "TestName"));
+
+            Assert.DoesNotThrow(() => decorator.Send(ChatChannel.NEARBY_CHANNEL, "hello @TestName", ChatMessageOrigin.Chat, 0));
+
+            core.Received(1).Send(ChatChannel.NEARBY_CHANNEL, "hello @TestName", ChatMessageOrigin.Chat, 0);
+            Assert.That(trackedPayloads, Has.Count.EqualTo(1));
+
+            JObject payload = trackedPayloads[0];
+            Assert.That(payload["is_mention"]!.Value<bool>(), Is.True);
+
+            var mentions = (JArray)payload["mentions"]!;
+            Assert.That(mentions, Has.Count.EqualTo(1));
+            Assert.That(mentions[0].Type, Is.EqualTo(JTokenType.String));
+            Assert.That(mentions[0].Value<string>(), Is.EqualTo(FIRST_WALLET));
+        }
+
+        [Test]
+        public void KeepMentionsOfQueuedEventsIntactAcrossSends()
+        {
+            profileCache.GetByUserName("FirstUser").Returns(CachedProfile(FIRST_WALLET, "FirstUser"));
+            profileCache.GetByUserName("SecondUser").Returns(CachedProfile(SECOND_WALLET, "SecondUser"));
+
+            Assert.DoesNotThrow(() =>
+            {
+                decorator.Send(ChatChannel.NEARBY_CHANNEL, "hi @FirstUser", ChatMessageOrigin.Chat, 0);
+                decorator.Send(ChatChannel.NEARBY_CHANNEL, "hi @SecondUser", ChatMessageOrigin.Chat, 0);
+            });
+
+            Assert.That(trackedPayloads, Has.Count.EqualTo(2));
+
+            // The analytics queue holds payload references until flush: the first event's mentions
+            // must survive the second send unchanged
+            var firstMentions = (JArray)trackedPayloads[0]["mentions"]!;
+            Assert.That(firstMentions, Has.Count.EqualTo(1));
+            Assert.That(firstMentions[0].Value<string>(), Is.EqualTo(FIRST_WALLET));
+
+            var secondMentions = (JArray)trackedPayloads[1]["mentions"]!;
+            Assert.That(secondMentions, Has.Count.EqualTo(1));
+            Assert.That(secondMentions[0].Value<string>(), Is.EqualTo(SECOND_WALLET));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests/ChatMessagesBusAnalyticsDecoratorShould.cs.meta
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests/ChatMessagesBusAnalyticsDecoratorShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70e4e9e01f6c42b995033fa817c2d60d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
@@ -10,7 +10,6 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 {
     public class ChatMessagesBusAnalyticsDecorator : IChatMessagesBus
     {
-        private static readonly JArray MENTION_WALLET_IDS = new ();
         private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{1,15}(?:#[A-Za-z0-9]{4})?)(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
 
         private readonly IChatMessagesBus core;
@@ -42,7 +41,10 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
         {
             core.Send(channel, message, origin, timestamp);
 
-            bool isMentionMessage = CheckIfIsMention(message);
+            // Local per-send array: the tracked JObject takes ownership of it, and queued events
+            // must keep their mentions untouched by later sends
+            JArray mentionWalletIds = new ();
+            bool isMentionMessage = CheckIfIsMention(message, mentionWalletIds);
 
             JObject jsonObject = new JObject
                 {
@@ -50,13 +52,13 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
                     { "length", message.Length },
                     { "origin", origin.ToStringValue() },
                     { "is_mention", isMentionMessage},
-                    { "mentions", MENTION_WALLET_IDS },
+                    { "mentions", mentionWalletIds },
                     { "is_private", channel.ChannelType == ChatChannel.ChatChannelType.USER},
                     // { "emoji_count", emoji_count },
                 };
 
             if (timestamp > 0 && selfProfile is { OwnProfile: not null })
-                jsonObject.Add("message_id", ChatUtils.GetId(selfProfile.OwnProfile.UserId, timestamp));
+                jsonObject.Add("message_id", ChatUtils.GetId(selfProfile.OwnProfile.UserId.Value, timestamp));
 
             if (channel.ChannelType == ChatChannel.ChatChannelType.USER)
                 jsonObject.Add("receiver_id", channel.Id.Id);
@@ -67,9 +69,8 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
             analytics.Track(AnalyticsEvents.Ui.MESSAGE_SENT, jsonObject);
         }
 
-        private bool CheckIfIsMention(string message)
+        private bool CheckIfIsMention(string message, JArray mentionWalletIds)
         {
-            MENTION_WALLET_IDS.Clear();
             var isValidMention = false;
             var matches = USERNAME_REGEX.Matches(message);
 
@@ -83,7 +84,9 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
                 if (profile != null)
                 {
-                    MENTION_WALLET_IDS.Add(profile.Value.UserId);
+                    // JArray.Add takes object, so UserId's implicit string conversion does not apply:
+                    // the wire shape carries the wallet-address string, never the domain object
+                    mentionWalletIds.Add(profile.Value.UserId.Value);
                     //returning a valid mention only if at least one of the mentions are a real user
                     isValidMention = true;
                 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
@@ -41,8 +41,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
         {
             core.Send(channel, message, origin, timestamp);
 
-            // Local per-send array: the tracked JObject takes ownership of it, and queued events
-            // must keep their mentions untouched by later sends
+            // Each tracked JObject takes ownership of its own mentions array
             JArray mentionWalletIds = new ();
             bool isMentionMessage = CheckIfIsMention(message, mentionWalletIds);
 
@@ -84,8 +83,7 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
                 if (profile != null)
                 {
-                    // JArray.Add takes object, so UserId's implicit string conversion does not apply:
-                    // the wire shape carries the wallet-address string, never the domain object
+                    // Extract the wallet-address string; JArray.Add(object) boxes without implicit conversion
                     mentionWalletIds.Add(profile.Value.UserId.Value);
                     //returning a valid mention only if at least one of the mentions are a real user
                     isValidMention = true;


### PR DESCRIPTION
## Problem

Sending a chat message that @mentions a user whose profile is cached throws
`ArgumentException: Could not determine JSON object type for type DCL.Profiles.UserId`,
aborts the `chat_message_sent` analytics event for every mention message, and escapes into
the UI update loop. Sentry UNITY-EXPLORER-PP7: 604 events / 83 users in its first week,
escalating, first seen 2026-08-13 - the first release after PR #9681 merged.

## Root cause

PR #9681 retyped `ProfileTier.UserId` from `string` to the `UserId` domain object.
`JArray.Add(object)` takes `object`, so the implicit `UserId -> string?` conversion does not
apply; the raw `UserId` is boxed into Newtonsoft, whose `JValue` constructor has no mapping
for arbitrary reference types and throws. Secondary defect at the same locus: the static
mutable `MENTION_WALLET_IDS` JArray is shared across sends and parented into each tracked
JObject, so each send's `Clear()` rewrites the mentions of already-queued events.

## Fix

`ChatMessagesBusAnalyticsDecorator.cs` (~10 LOC): delete the static `MENTION_WALLET_IDS`;
build a local `JArray` per `Send` (user-initiated path, not hot); add
`profile.Value.UserId.Value` - the wallet-address string - restoring the pre-#9681 wire
shape the data pipeline expects.

## Test

New EditMode `ChatMessagesBusAnalyticsDecoratorShould` (folds into DCL.EditMode.Tests via the
existing asmref):

- `TrackMentionOfCachedProfileAsWalletAddressString` - RED at pin (the exact
  ArgumentException), GREEN with fix: one tracked payload, `is_mention == true`,
  `mentions == ["0x…"]` with string token type asserted.
- `KeepMentionsOfQueuedEventsIntactAcrossSends` - guards the static-array removal: the first
  queued payload's mentions must survive a second send.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 2/2 as intended (both tests hit the
exact root-cause exception out of `JValue..ctor`) / GREEN PASS 2/2 with the fix.

Note for data: since 08-12 every mention message's `chat_message_sent` event was lost, so
expect a step up in that metric after this ships.

Fixes #9738
Related: #9681 (regression source), #4241 (historical `is_mention` data bug, context)

Includes inspection-warning cleanup in all touched files.