### PR TITLE
perf: eliminate per-message topic string alloc in comms receive path

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
@@ -312,8 +312,8 @@ namespace SceneRuntime.Apis.Modules.CommsApi
             {
                 var entries = new List<TopicLookupEntry>(topicBuffers.Count);
 
-                foreach (KeyValuePair<string, DCLConcurrentQueue<BufferedDataMessage>> pair in topicBuffers)
-                    entries.Add(new TopicLookupEntry(Encoding.UTF8.GetBytes(pair.Key), pair.Value));
+                foreach ((string topic, DCLConcurrentQueue<BufferedDataMessage> queue) in topicBuffers)
+                    entries.Add(new TopicLookupEntry(Encoding.UTF8.GetBytes(topic), queue));
 
                 topicLookup = entries.ToArray();
             }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
@@ -70,7 +70,12 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         {
             sceneCommunicationPipe.RemoveSceneMessageHandler(sceneId, ISceneCommunicationPipe.MsgType.CommsData, onDataReceivedCached);
             topicBuffers.Clear();
-            topicLookup = Array.Empty<TopicLookupEntry>();
+
+            lock (topicLookupLock)
+            {
+                topicLookup = Array.Empty<TopicLookupEntry>();
+            }
+
             publishRateLimiters.Clear();
             commsWriter.Dispose();
         }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
@@ -8,6 +8,7 @@ using SceneRunner.Scene;
 using SceneRunner.Scene.ExceptionsHandling;
 using System;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -40,6 +41,15 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         private readonly DCLConcurrentDictionary<string, DCLConcurrentQueue<BufferedDataMessage>> topicBuffers = new ();
         private readonly DCLConcurrentDictionary<string, (int count, int windowStartMs)> publishRateLimiters = new ();
 
+        private readonly object topicLookupLock = new ();
+
+        // Byte-keyed copy-on-write snapshot of topicBuffers (queues shared, not copied) so OnDataReceived
+        // can match the wire topic without materializing a string per message — Unity's BCL has no
+        // span-keyed dictionary lookup (GetAlternateLookup is .NET 9+). Writers rebuild under
+        // topicLookupLock and publish a new immutable array; the LiveKit-thread reader sees either
+        // the previous or the new snapshot, never a partial one.
+        private volatile TopicLookupEntry[] topicLookup = Array.Empty<TopicLookupEntry>();
+
         public CommsApiWrap(
             IRoomHub roomHub,
             ISceneCommunicationPipe sceneCommunicationPipe,
@@ -60,6 +70,7 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         {
             sceneCommunicationPipe.RemoveSceneMessageHandler(sceneId, ISceneCommunicationPipe.MsgType.CommsData, onDataReceivedCached);
             topicBuffers.Clear();
+            topicLookup = Array.Empty<TopicLookupEntry>();
             publishRateLimiters.Clear();
             commsWriter.Dispose();
         }
@@ -128,7 +139,7 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         /// Called from JS via ClearScript. Rate-limited to <see cref="MAX_MESSAGES_PER_SECOND"/> per topic.
         /// </summary>
         [UsedImplicitly]
-        public void PublishData(string topic, string data)
+        public void PublishData(string topic, string? data)
         {
             try
             {
@@ -191,7 +202,8 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         public void SubscribeToTopic(string topic)
         {
             // method is called relatively rare, allocation new Queue is acceptable, pooling not required
-            topicBuffers.TryAdd(topic, new DCLConcurrentQueue<BufferedDataMessage>());
+            if (topicBuffers.TryAdd(topic, new DCLConcurrentQueue<BufferedDataMessage>()))
+                RebuildTopicLookup();
         }
 
         /// <summary>
@@ -201,8 +213,10 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         [UsedImplicitly]
         public void UnsubscribeFromTopic(string topic)
         {
-            topicBuffers.TryRemove(topic, out DCLConcurrentQueue<BufferedDataMessage> _output);
-            // 'output' object is droped and will be collected by GC (it's assumed nothing else holds the reference)
+            if (topicBuffers.TryRemove(topic, out _))
+                RebuildTopicLookup();
+
+            // the removed queue is dropped and will be collected by GC (it's assumed nothing else holds the reference)
         }
 
         /// <summary>
@@ -248,13 +262,13 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
         /// <summary>
         /// Runs on the LiveKit callback thread (ORIGIN_THREAD), not the main thread.
-        /// Only thread-safe types (DCLConcurrentQueue, Encoding) are used here.
+        /// Only thread-safe access is used here: a volatile read of the immutable topicLookup
+        /// snapshot, DCLConcurrentQueue and Encoding. Must not allocate for messages on
+        /// unsubscribed topics — all CommsData traffic for the scene reaches this handler.
         /// Decodes wire format: [topicLen 2 bytes LE][topic UTF-8][data UTF-8].
         /// </summary>
         private void OnDataReceived(ISceneCommunicationPipe.DecodedMessage message)
         {
-            // TODO: implement GetAlternateLookup on ReadOnlySpan<char/byte> to avoid allocation of temp string instances
-            // Reference: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.getalternatelookup
             ReadOnlySpan<byte> span = message.Data;
 
             if (span.Length < TOPIC_LENGTH_PREFIX_BYTES) return;
@@ -263,10 +277,19 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
             if (span.Length < TOPIC_LENGTH_PREFIX_BYTES + topicLength) return;
 
-            string topic = Encoding.UTF8.GetString(span.Slice(TOPIC_LENGTH_PREFIX_BYTES, topicLength));
+            ReadOnlySpan<byte> topicSpan = span.Slice(TOPIC_LENGTH_PREFIX_BYTES, topicLength);
 
-            if (topicBuffers.TryGetValue(topic, out DCLConcurrentQueue<BufferedDataMessage> queue))
+            // Scenes subscribe to a handful of topics, so a linear scan over the snapshot
+            // beats hashing (which would require materializing a string key).
+            TopicLookupEntry[] lookup = topicLookup;
+
+            for (var i = 0; i < lookup.Length; i++)
             {
+                if (!topicSpan.SequenceEqual(lookup[i].Utf8Topic))
+                    continue;
+
+                DCLConcurrentQueue<BufferedDataMessage> queue = lookup[i].Queue;
+
                 // DROP OLD POLICY. Dequeues oldest item to insert new one
                 if (queue.Count >= TOPIC_BUFFER_MAX_MESSAGE_COUNT)
                 {
@@ -275,6 +298,20 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
                 string data = Encoding.UTF8.GetString(span[(TOPIC_LENGTH_PREFIX_BYTES + topicLength)..]);
                 queue.Enqueue(new BufferedDataMessage(message.FromWalletId, data));
+                return;
+            }
+        }
+
+        private void RebuildTopicLookup()
+        {
+            lock (topicLookupLock)
+            {
+                var entries = new List<TopicLookupEntry>(topicBuffers.Count);
+
+                foreach (KeyValuePair<string, DCLConcurrentQueue<BufferedDataMessage>> pair in topicBuffers)
+                    entries.Add(new TopicLookupEntry(Encoding.UTF8.GetBytes(pair.Key), pair.Value));
+
+                topicLookup = entries.ToArray();
             }
         }
 
@@ -301,6 +338,18 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
             publishRateLimiters[topic] = (limiter.count + 1, limiter.windowStartMs);
             return true;
+        }
+
+        private readonly struct TopicLookupEntry
+        {
+            public readonly byte[] Utf8Topic;
+            public readonly DCLConcurrentQueue<BufferedDataMessage> Queue;
+
+            public TopicLookupEntry(byte[] utf8Topic, DCLConcurrentQueue<BufferedDataMessage> queue)
+            {
+                Utf8Topic = utf8Topic;
+                Queue = queue;
+            }
         }
 
         private readonly struct BufferedDataMessage

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
@@ -43,11 +43,10 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
         private readonly object topicLookupLock = new ();
 
-        // Byte-keyed copy-on-write snapshot of topicBuffers (queues shared, not copied) so OnDataReceived
-        // can match the wire topic without materializing a string per message — Unity's BCL has no
-        // span-keyed dictionary lookup (GetAlternateLookup is .NET 9+). Writers rebuild under
-        // topicLookupLock and publish a new immutable array; the LiveKit-thread reader sees either
-        // the previous or the new snapshot, never a partial one.
+        // Copy-on-write byte-keyed snapshot of topicBuffers (queues shared, not copied) so OnDataReceived
+        // can match the wire topic without allocating a string per message (Unity's BCL has no span-keyed
+        // dictionary lookup). Writers rebuild under topicLookupLock; the volatile publish guarantees the
+        // LiveKit-thread reader a complete snapshot, never a partial one.
         private volatile TopicLookupEntry[] topicLookup = Array.Empty<TopicLookupEntry>();
 
         public CommsApiWrap(
@@ -266,10 +265,8 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         }
 
         /// <summary>
-        /// Runs on the LiveKit callback thread (ORIGIN_THREAD), not the main thread.
-        /// Only thread-safe access is used here: a volatile read of the immutable topicLookup
-        /// snapshot, DCLConcurrentQueue and Encoding. Must not allocate for messages on
-        /// unsubscribed topics — all CommsData traffic for the scene reaches this handler.
+        /// Runs on the LiveKit callback thread (ORIGIN_THREAD) for all scene CommsData traffic;
+        /// must not allocate for messages on unsubscribed topics.
         /// Decodes wire format: [topicLen 2 bytes LE][topic UTF-8][data UTF-8].
         /// </summary>
         private void OnDataReceived(ISceneCommunicationPipe.DecodedMessage message)
@@ -284,8 +281,7 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
             ReadOnlySpan<byte> topicSpan = span.Slice(TOPIC_LENGTH_PREFIX_BYTES, topicLength);
 
-            // Scenes subscribe to a handful of topics, so a linear scan over the snapshot
-            // beats hashing (which would require materializing a string key).
+            // Scenes subscribe to a handful of topics; a linear scan avoids the string key a hash lookup would need.
             TopicLookupEntry[] lookup = topicLookup;
 
             for (var i = 0; i < lookup.Length; i++)

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
@@ -305,6 +305,9 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
         private void RebuildTopicLookup()
         {
+            // Allocates freely (list, byte[] per topic, final array): it only runs on subscribe/unsubscribe,
+            // which happens a handful of times per scene lifetime. COW trades allocation on this rare write
+            // path for allocation-free reads in OnDataReceived; published arrays are never mutated or reused.
             lock (topicLookupLock)
             {
                 var entries = new List<TopicLookupEntry>(topicBuffers.Count);

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/CommsApiWrapShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/CommsApiWrapShould.cs
@@ -5,12 +5,12 @@ using NSubstitute;
 using NUnit.Framework;
 using SceneRunner.Scene;
 using SceneRunner.Scene.ExceptionsHandling;
-using SceneRuntime;
 using SceneRuntime.Apis.Modules.CommsApi;
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using UnityEngine.Profiling;
 
 namespace SceneRuntime.Tests
 {
@@ -18,11 +18,11 @@ namespace SceneRuntime.Tests
     {
         private const string TEST_SCENE_ID = "test-scene-123";
 
-        private CommsApiWrap commsApi;
-        private TestSceneCommunicationPipe pipe;
-        private IRoomHub roomHub;
-        private ISceneExceptionsHandler exceptionsHandler;
-        private CancellationTokenSource cts;
+        private CommsApiWrap commsApi = null!;
+        private TestSceneCommunicationPipe pipe = null!;
+        private IRoomHub roomHub = null!;
+        private ISceneExceptionsHandler exceptionsHandler = null!;
+        private CancellationTokenSource cts = null!;
 
         [SetUp]
         public void SetUp()
@@ -52,7 +52,7 @@ namespace SceneRuntime.Tests
             //Assert
             Assert.AreEqual(TEST_SCENE_ID, pipe.registeredSceneId);
             Assert.AreEqual(ISceneCommunicationPipe.MsgType.CommsData, pipe.registeredMsgType);
-            Assert.IsNotNull(pipe.onSceneMessage);
+            Assert.IsNotNull(pipe.sceneMessageHandler);
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace SceneRuntime.Tests
 
             // Simulate receive: SceneCommunicationPipe.DecodeMessage strips byte[0] (MsgType).
             ReadOnlySpan<byte> afterMsgType = wireBytes.AsSpan(1);
-            pipe.onSceneMessage.Invoke(new ISceneCommunicationPipe.DecodedMessage(afterMsgType, senderIdentity, isTrustedSource: true));
+            pipe.sceneMessageHandler.Invoke(new ISceneCommunicationPipe.DecodedMessage(afterMsgType, senderIdentity, isTrustedSource: true));
 
             //Assert — ConsumeMessages returns JSON; inner data string is JSON-escaped by JsonTextWriter.
             string json = commsApi.ConsumeMessages(topic);
@@ -173,6 +173,78 @@ namespace SceneRuntime.Tests
 
             //Assert
             Assert.AreEqual("[]", result, "Messages before subscription should be dropped.");
+        }
+
+        [Test]
+        public void ReceiveForUnsubscribedTopicDoesNotAllocate()
+        {
+            // GC.GetAllocatedBytesForCurrentThread is inert on the editor Mono runtime, and the
+            // strict AllocatingGCMemory constraint trips on runtime noise outside OnDataReceived —
+            // so this uses the budgeted GC.Alloc Recorder idiom with a liveness canary: the bug
+            // allocates at least one sample per message, the budget stays far under one per message.
+            const int MEASURED_INVOKES = 1000;
+            const int CANARY_ALLOCS = 16;
+            const int ALLOC_SAMPLE_BUDGET = 100;
+
+            //Arrange — capture real wire bytes via PublishData (round-trip pattern); topic is never subscribed.
+            commsApi.PublishData("never-subscribed-topic", "{\"type\":\"noise\"}");
+            Assert.AreEqual(1, pipe.sendMessageCalls.Count);
+            byte[] wireBytes = pipe.sendMessageCalls[0];
+
+            // SceneCommunicationPipe.DecodeMessage strips byte[0] (MsgType) before the handler sees it.
+            // DecodedMessage is a ref struct, so the span is rebuilt per call instead of captured.
+            // Warm-up: JIT the receive path outside the measured region.
+            for (var i = 0; i < 64; i++)
+                pipe.sceneMessageHandler.Invoke(new ISceneCommunicationPipe.DecodedMessage(wireBytes.AsSpan(1), "0xSENDER", isTrustedSource: true));
+
+            Recorder gcAllocRecorder = Recorder.Get("GC.Alloc");
+            gcAllocRecorder.FilterToCurrentThread();
+            gcAllocRecorder.enabled = false;
+            gcAllocRecorder.enabled = true;
+
+            //Act
+            for (var i = 0; i < MEASURED_INVOKES; i++)
+                pipe.sceneMessageHandler.Invoke(new ISceneCommunicationPipe.DecodedMessage(wireBytes.AsSpan(1), "0xSENDER", isTrustedSource: true));
+
+            byte[]? canary = null;
+
+            for (var i = 0; i < CANARY_ALLOCS; i++)
+                canary = new byte[16];
+
+            gcAllocRecorder.enabled = false;
+            int measured = gcAllocRecorder.sampleBlockCount;
+            GC.KeepAlive(canary);
+
+            Assert.GreaterOrEqual(measured, CANARY_ALLOCS,
+                "GC.Alloc recorder did not observe the deliberate canary allocations — the probe is inert on this runtime.");
+
+            //Assert — OnDataReceived runs on the LiveKit callback thread for ALL scene CommsData
+            // traffic; the unsubscribed-topic path must not allocate (e.g. a temp topic string).
+            Assert.Less(measured, ALLOC_SAMPLE_BUDGET,
+                $"OnDataReceived allocated GC memory for messages on a topic that was never subscribed ({measured} GC.Alloc samples over {MEASURED_INVOKES} messages).");
+        }
+
+        [Test]
+        public void ResubscribeAfterUnsubscribeReceivesAgain()
+        {
+            //Arrange
+            const string TOPIC = "flip-flop";
+
+            commsApi.SubscribeToTopic(TOPIC);
+            SimulateIncomingMessage(TOPIC, "{\"v\":1}", "sender1");
+
+            //Act — unsubscribe drops both the buffer and delivery; resubscribe restores delivery.
+            commsApi.UnsubscribeFromTopic(TOPIC);
+            SimulateIncomingMessage(TOPIC, "{\"v\":2}", "sender2");
+            commsApi.SubscribeToTopic(TOPIC);
+            SimulateIncomingMessage(TOPIC, "{\"v\":3}", "sender3");
+
+            string json = commsApi.ConsumeMessages(TOPIC);
+
+            //Assert — only the post-resubscribe message survives.
+            Assert.That(json, Does.Not.Contain("sender1"));
+            Assert.That(json, Does.Not.Contain("sender2"));
+            Assert.That(json, Does.Contain("sender3"));
         }
 
         [Test]
@@ -248,7 +320,7 @@ namespace SceneRuntime.Tests
             System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(encoded, (ushort)topicBytes.Length);
             topicBytes.CopyTo(encoded, 2);
             dataBytes.CopyTo(encoded, 2 + topicBytes.Length);
-            pipe.onSceneMessage.Invoke(new ISceneCommunicationPipe.DecodedMessage(encoded, senderIdentity, isTrustedSource: true));
+            pipe.sceneMessageHandler.Invoke(new ISceneCommunicationPipe.DecodedMessage(encoded, senderIdentity, isTrustedSource: true));
         }
 
         /// <summary>
@@ -258,8 +330,8 @@ namespace SceneRuntime.Tests
         private class TestSceneCommunicationPipe : ISceneCommunicationPipe
         {
             internal readonly List<byte[]> sendMessageCalls = new ();
-            internal ISceneCommunicationPipe.SceneMessageHandler onSceneMessage;
-            internal string registeredSceneId;
+            internal ISceneCommunicationPipe.SceneMessageHandler sceneMessageHandler = null!;
+            internal string registeredSceneId = null!;
             internal ISceneCommunicationPipe.MsgType registeredMsgType;
             internal bool handlerRemoved;
 
@@ -267,7 +339,7 @@ namespace SceneRuntime.Tests
             {
                 registeredSceneId = sceneId;
                 registeredMsgType = msgType;
-                this.onSceneMessage = onSceneMessage;
+                sceneMessageHandler = onSceneMessage;
             }
 
             public void RemoveSceneMessageHandler(string sceneId, ISceneCommunicationPipe.MsgType msgType, ISceneCommunicationPipe.SceneMessageHandler onSceneMessage)
@@ -275,7 +347,7 @@ namespace SceneRuntime.Tests
                 handlerRemoved = true;
             }
 
-            public void SendMessage(ReadOnlySpan<byte> message, string sceneId, ISceneCommunicationPipe.ConnectivityAssertiveness assertiveness, CancellationToken ct, string specialRecipient = null)
+            public void SendMessage(ReadOnlySpan<byte> message, string sceneId, ISceneCommunicationPipe.ConnectivityAssertiveness assertiveness, CancellationToken ct, string? specialRecipient = null)
             {
                 sendMessageCalls.Add(message.ToArray());
             }


### PR DESCRIPTION
## Problem

Every incoming LiveKit `CommsData` message allocates a temporary managed topic string on the
LiveKit callback thread, purely to key a dictionary lookup - including messages for topics
the scene never subscribed to (all scene-bound CommsData traffic reaches every
`CommsApiWrap` handler). In busy scenes this is a steady off-main-thread GC-pressure
stream. This is the exact TODO tracked by #9206 ("implement GetAlternateLookup ... to avoid
allocation of temp string instances").

## Root cause

Topic identity arrives as UTF-8 bytes inside the wire span, but the subscription registry
is only addressable by `string`, and `GetAlternateLookup` (span-keyed dictionary lookup) is
a .NET 9 API that Unity 6000.4's BCL does not have - so the hot receive path materialized
the key per message. The registry mutates only via rare JS-driven subscribe/unsubscribe and
scenes use a handful of topics.

## Fix (~55 LOC, single file)

`CommsApiWrap`: a byte-keyed immutable snapshot (`TopicLookupEntry[]` - UTF-8 topic bytes +
shared queue ref) rebuilt under a lock on successful subscribe/unsubscribe and published
via a volatile field. `OnDataReceived` volatile-reads the snapshot and linear-scans with
`SequenceEqual` on the topic span - zero allocation on the miss path; the data-string alloc
on the subscribed branch is required (handed to JS) and unchanged. Copy-on-write
publication means readers never see a partial snapshot; the string-keyed JS-side
`ConsumeMessages` shares the same queues and is untouched.

## Test

In the existing `CommsApiWrapShould` harness:

- `ReceiveForUnsubscribedTopicDoesNotAllocate` - budgeted GC.Alloc profiler-recorder window
  (same idiom as EventBusShould) with a liveness canary: pin allocates ~1 topic string per
  message; fix allocates none.
- `ResubscribeAfterUnsubscribeReceivesAgain` - snapshot-rebuild correctness on both
  mutation paths.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL as intended (1016 GC.Alloc samples
over 1000 messages vs a <100 budget - exactly one topic-string alloc per message plus the
16-alloc canary; the functional companion passed at pin) / GREEN PASS 2/2. The alloc probe
was hardened during validation (thread-local byte counters are inert on the editor Mono
runtime; the shipped test uses the GC.Alloc recorder + canary idiom).

Fixes #9206

Includes inspection-warning cleanup in all touched files.

Fixes #9206