### PR TITLE
fix: release CRDT sync buffer rent slot on failed batches

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/EngineAPIImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/EngineAPIImplementation.cs
@@ -105,37 +105,46 @@ namespace CrdtEcsBridge.JsModulesImplementation
             // as we no longer wait for a buffer to apply the thread should be frozen
             IWorldSyncCommandBuffer worldSyncBuffer = crdtWorldSynchronizer.GetSyncCommandBuffer();
 
-            // Reconcile CRDT state
-            for (var i = 0; i < messages.Count; i++)
+            try
             {
-                CRDTMessage message = messages[i];
-
-                // Skip Creator Hub components leaked from main.composite (inspector::*,
-                // specific asset-packs:: tooling metadata, composite::root) and phantom
-                // Creator Hub tags (custom components with empty data, e.g. cube-id).
-                if (message.Type is CRDTMessageType.PUT_COMPONENT
-                        or CRDTMessageType.DELETE_COMPONENT
-                        or CRDTMessageType.APPEND_COMPONENT
-                    && CreatorHubComponentFilter.ShouldFilter(in message))
+                // Reconcile CRDT state
+                for (var i = 0; i < messages.Count; i++)
                 {
-                    message.Data.Dispose();
-                    continue;
+                    CRDTMessage message = messages[i];
+
+                    // Skip Creator Hub components leaked from main.composite (inspector::*,
+                    // specific asset-packs:: tooling metadata, composite::root) and phantom
+                    // Creator Hub tags (custom components with empty data, e.g. cube-id).
+                    if (message.Type is CRDTMessageType.PUT_COMPONENT
+                            or CRDTMessageType.DELETE_COMPONENT
+                            or CRDTMessageType.APPEND_COMPONENT
+                        && CreatorHubComponentFilter.ShouldFilter(in message))
+                    {
+                        message.Data.Dispose();
+                        continue;
+                    }
+
+                    crdtProcessMessagesSampler.Begin();
+
+                    CRDTReconciliationResult reconciliationResult = crdtProtocol.ProcessMessage(in message);
+
+                    crdtProcessMessagesSampler.End();
+
+                    // TODO add metric to understand how many conflicts we have based on CRDTStateReconciliationResult
+
+                    // Prepare the message to be synced with the ECS World
+                    worldSyncBuffer.SyncCRDTMessage(in message, reconciliationResult.Effect);
                 }
 
-                crdtProcessMessagesSampler.Begin();
-
-                CRDTReconciliationResult reconciliationResult = crdtProtocol.ProcessMessage(in message);
-
-                crdtProcessMessagesSampler.End();
-
-                // TODO add metric to understand how many conflicts we have based on CRDTStateReconciliationResult
-
-                // Prepare the message to be synced with the ECS World
-                worldSyncBuffer.SyncCRDTMessage(in message, reconciliationResult.Effect);
+                // Deserialize messages
+                worldSyncBuffer.FinalizeAndDeserialize();
             }
-
-            // Deserialize messages
-            worldSyncBuffer.FinalizeAndDeserialize();
+            catch
+            {
+                // The buffer holds the single rent slot: release it on failure before the exception propagates
+                crdtWorldSynchronizer.AbortSyncCommandBuffer(worldSyncBuffer);
+                throw;
+            }
 
             worldSyncBufferSampler.End();
 
@@ -255,6 +264,11 @@ namespace CrdtEcsBridge.JsModulesImplementation
 
         private void ApplySyncCommandBuffer(IWorldSyncCommandBuffer worldSyncBuffer)
         {
+            // The rent slot is released by the synchronizer's ApplySyncCommandBuffer once it is entered;
+            // on any throw before that (e.g. mutex acquisition) the buffer must be aborted here instead —
+            // exactly one of the two must run, otherwise the slot either leaks or is double-released
+            var delegated = false;
+
             try
             {
                 using MultiThreadSync.Scope mutex = multiThreadSync.GetScope(syncOwner);
@@ -262,6 +276,7 @@ namespace CrdtEcsBridge.JsModulesImplementation
                 applyBufferSampler.Begin();
 
                 // Apply changes to the ECS World on the main thread
+                delegated = true;
                 crdtWorldSynchronizer.ApplySyncCommandBuffer(worldSyncBuffer);
                 applyBufferSampler.End();
 
@@ -269,7 +284,13 @@ namespace CrdtEcsBridge.JsModulesImplementation
                 // If the scene is updated more frequently than Unity Loop the gate will be effectively open all the time
                 systemGroupsUpdateGate.Open();
             }
-            catch (Exception e) { exceptionsHandler.OnEngineException(e, ReportCategory.CRDT_ECS_BRIDGE); }
+            catch (Exception e)
+            {
+                if (!delegated)
+                    crdtWorldSynchronizer.AbortSyncCommandBuffer(worldSyncBuffer);
+
+                exceptionsHandler.OnEngineException(e, ReportCategory.CRDT_ECS_BRIDGE);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/EngineAPISyncBufferRentShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/EngineAPISyncBufferRentShould.cs
@@ -1,0 +1,143 @@
+using Arch.Core;
+using CRDT;
+using CRDT.Deserializer;
+using CRDT.Memory;
+using CRDT.Protocol;
+using CRDT.Protocol.Factory;
+using CRDT.Serializer;
+using CrdtEcsBridge.Components;
+using CrdtEcsBridge.OutgoingMessages;
+using CrdtEcsBridge.PoolsProviders;
+using CrdtEcsBridge.UpdateGate;
+using CrdtEcsBridge.WorldSynchronizer;
+using DCL.Diagnostics;
+using DCL.Profiling;
+using NSubstitute;
+using NUnit.Framework;
+using SceneRunner.Scene.ExceptionsHandling;
+using System;
+using System.Collections.Generic;
+using UnityEngine.TestTools;
+using Utility.Multithreading;
+
+namespace CrdtEcsBridge.JsModulesImplementation.Tests
+{
+    /// <summary>
+    ///     The synchronizer holds a single rent slot: every buffer obtained by
+    ///     <see cref="EngineAPIImplementation.CrdtSendToRenderer" /> must free it on every path,
+    ///     including the failure ones, otherwise the scene is permanently wedged — each subsequent
+    ///     rent waits the full timeout and throws "Rent Wait Timeout".
+    /// </summary>
+    public class EngineAPISyncBufferRentShould
+    {
+        private static readonly byte[] INPUT = { 0, 3, 5, 7, 10, 19, 20, 40, 76 };
+
+        private World world = null!;
+        private MultiThreadSync multiThreadSync = null!;
+        private CRDTWorldSynchronizer crdtWorldSynchronizer = null!;
+        private ICRDTProtocol crdtProtocol = null!;
+        private ICRDTDeserializer crdtDeserializer = null!;
+
+        private EngineAPIImplementation engineApiImplementation = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = World.Create();
+            multiThreadSync = new MultiThreadSync(new SceneShortInfo());
+
+            crdtWorldSynchronizer = new CRDTWorldSynchronizer(
+                world,
+                Substitute.For<ISDKComponentsRegistry>(),
+                Substitute.For<ISceneEntityFactory>(),
+                new Dictionary<CRDTEntity, Entity>());
+
+            crdtProtocol = Substitute.For<ICRDTProtocol>();
+            crdtDeserializer = Substitute.For<ICRDTDeserializer>();
+
+            IInstancePoolsProvider instancePoolsProvider = Substitute.For<IInstancePoolsProvider>();
+            instancePoolsProvider.GetDeserializationMessagesPool().Returns(_ => new List<CRDTMessage>());
+
+            engineApiImplementation = new EngineAPIImplementation(
+                Substitute.For<ISharedPoolsProvider>(),
+                instancePoolsProvider,
+                crdtProtocol,
+                crdtDeserializer,
+                new NoOpCRDTSerializer(),
+                crdtWorldSynchronizer,
+                Substitute.For<IOutgoingCRDTMessagesProvider>(),
+                Substitute.For<ISystemGroupsUpdateGate>(),
+
+                // Swallows like the production pipeline (EngineApiWrapper reports and continues)
+                Substitute.For<ISceneExceptionsHandler>(),
+                multiThreadSync,
+                new MultiThreadSync.Owner("TEST"),
+                new SceneRuntimeMetrics());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // A run that failed with the slot leaked also leaks the pooled collections;
+            // the resulting error log must not mask the assertion failure
+            LogAssert.ignoreFailingMessages = true;
+
+            try
+            {
+                crdtWorldSynchronizer.Dispose();
+                multiThreadSync.Dispose();
+                world.Dispose();
+            }
+            finally { LogAssert.ignoreFailingMessages = false; }
+        }
+
+        [Test]
+        public void ReleaseRentSlotWhenMutexAcquisitionFails()
+        {
+            // Deterministic stand-in for the production acquisition failures (10 s MultiThreadSync
+            // timeout / disposal race): a disposed sync throws ObjectDisposedException at the same site
+            multiThreadSync.Dispose();
+
+            // The internal catch reports to the exceptions handler and returns normally
+            engineApiImplementation.CrdtSendToRenderer(INPUT, false);
+
+            AssertRentSlotIsFree();
+        }
+
+        [Test]
+        public void ReleaseRentSlotWhenMessageProcessingThrows()
+        {
+            crdtDeserializer.When(d => d.DeserializeBatch(ref Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<IList<CRDTMessage>>()))
+                            .Do(c => c.ArgAt<IList<CRDTMessage>>(1)
+                                      .Add(new CRDTMessage(CRDTMessageType.PUT_COMPONENT, 10, 100, 1, EmptyMemoryOwner<byte>.EMPTY)));
+
+            crdtProtocol.ProcessMessage(Arg.Any<CRDTMessage>())
+                        .Returns(_ => throw new InvalidOperationException("Corrupted CRDT message"));
+
+            // Propagates to the caller (the production wrapper swallows it there)
+            Assert.Throws<InvalidOperationException>(() => engineApiImplementation.CrdtSendToRenderer(INPUT, false));
+
+            AssertRentSlotIsFree();
+        }
+
+        private void AssertRentSlotIsFree()
+        {
+            IWorldSyncCommandBuffer? recovered = null;
+
+            // A leaked slot makes this rent wait the full RENT_WAIT_TIMEOUT (5 s)
+            // and throw TimeoutException("Rent Wait Timeout: Couldn't rent command buffer")
+            Assert.DoesNotThrow(
+                () => recovered = crdtWorldSynchronizer.GetSyncCommandBuffer(),
+                "The rent slot leaked: the failed CrdtSendToRenderer call did not release the sync command buffer");
+
+            // Balance the probe rent so the synchronizer disposes cleanly
+            recovered!.FinalizeAndDeserialize();
+            crdtWorldSynchronizer.ApplySyncCommandBuffer(recovered);
+        }
+
+        private class NoOpCRDTSerializer : ICRDTSerializer
+        {
+            public void Serialize(ref Span<byte> destination, in ProcessedCRDTMessage processedMessage) { }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/EngineAPISyncBufferRentShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/EngineAPISyncBufferRentShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 954dac4f31db4dfcbc8a7f8601063884
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/CrdtEcsSynchronizer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/CrdtEcsSynchronizer.cs
@@ -4,7 +4,6 @@ using CRDT;
 using CrdtEcsBridge.Components;
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using Utility.Multithreading;
 
 namespace CrdtEcsBridge.WorldSynchronizer
@@ -26,7 +25,7 @@ namespace CrdtEcsBridge.WorldSynchronizer
 
         // We can't use a mutex as it must be acquired and released by the same thread
         // and it is not guaranteed as we use thread pools (in the most cases different threads are used for getting and applying command buffers)
-        private readonly DCLSemaphoreSlim semaphore = new (1, 1);
+        private readonly DCLSemaphoreSlim semaphore = new ();
 
         private bool disposed;
 
@@ -87,6 +86,23 @@ namespace CrdtEcsBridge.WorldSynchronizer
                 // Pairs with semaphore.Wait in GetSyncCommandBuffer; must release on every path,
                 // including the disposed early-return and any exception thrown by Apply,
                 // otherwise the slot leaks and subsequent Rents time out forever.
+                semaphore.Release();
+#endif
+            }
+        }
+
+        public void AbortSyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer)
+        {
+            try
+            {
+                syncCommandBuffer.Dispose();
+            }
+            finally
+            {
+#if !UNITY_WEBGL
+                // Pairs with semaphore.Wait in GetSyncCommandBuffer for buffers that never reach
+                // ApplySyncCommandBuffer; must release even if Dispose throws, otherwise the slot
+                // leaks and subsequent Rents time out forever.
                 semaphore.Release();
 #endif
             }

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/ICRDTWorldSynchronizer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/ICRDTWorldSynchronizer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 
 namespace CrdtEcsBridge.WorldSynchronizer
 {
@@ -23,5 +22,15 @@ namespace CrdtEcsBridge.WorldSynchronizer
         /// </summary>
         /// <param name="syncCommandBuffer"></param>
         void ApplySyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer);
+
+        /// <summary>
+        ///     Disposes a rented command buffer that will never be applied and frees the rent slot.
+        ///     Every buffer obtained from <see cref="GetSyncCommandBuffer" /> must reach exactly one of
+        ///     <see cref="ApplySyncCommandBuffer" /> or this method, otherwise the single rent slot leaks
+        ///     and all subsequent rents time out.
+        ///     Can be called from the background thread
+        /// </summary>
+        /// <param name="syncCommandBuffer"></param>
+        void AbortSyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer);
     }
 }


### PR DESCRIPTION
## Problem

Once a scene hits one transient failure during CRDT sync, every subsequent
`CrdtSendToRenderer` from its JS thread blocks 5 s and throws
`TimeoutException: Rent Wait Timeout: Couldn't rent command buffer` - the scene is
permanently wedged at ~0.2 batches/s and Sentry receives one error per call until the
session ends. Sentry UNITY-EXPLORER-NPR: 195 week-events / 32 users, ongoing on the current
release. The newest event's breadcrumbs show the causal chain live: one MultiThreadSync
timeout (KM5) at 23:47:01, then Rent Wait Timeouts on an exact 5 s cadence forever after.

## Root cause

The single-slot semaphore is rented in `CrdtEcsSynchronizer.GetSyncCommandBuffer()` but the
sole release lives in the callee-side `finally` of `CRDTWorldSynchronizer.ApplySyncCommandBuffer`
 -  the pairing spans two classes. Any exception between a successful rent and entry into that
method (MultiThreadSync 10 s timeout, ObjectDisposedException on scene teardown, protobuf
parse failures in the message loop) leaks the slot permanently, and both surrounding catch
blocks swallow-and-continue.

## Fix (~60 LOC, 3 files)

- `ICRDTWorldSynchronizer`: new `AbortSyncCommandBuffer(IWorldSyncCommandBuffer)` - releases
  the rent slot of a buffer that will never be applied.
- `CrdtEcsSynchronizer`: implement it (`try { Dispose } finally { semaphore.Release() }`,
  mirroring the existing disposed-scene branch; WebGL guards preserved).
- `EngineAPIImplementation`: leak window 2 (message loop + `FinalizeAndDeserialize`) wrapped
  in `catch { Abort; throw; }`; leak window 1 uses a `delegated` flag set immediately before
  the delegated call so release is exactly-once (Apply's finally or Abort, never both).

The KM5 stall symptom itself is out of scope (prior campaign judged it not
targeted-fixable); its consequence collapses from permanent scene wedge to one dropped
CRDT batch.

## Test

New EditMode fixture `EngineAPISyncBufferRentShould` with a real `CRDTWorldSynchronizer` and
real `MultiThreadSync`:

- `ReleaseRentSlotWhenMutexAcquisitionFails` - deterministic stand-in for the KM5 window
  (disposed MultiThreadSync throws at the exact production throw-site).
- `ReleaseRentSlotWhenMessageProcessingThrows` - `crdtProtocol.ProcessMessage` throws.

Both then assert `GetSyncCommandBuffer()` succeeds. RED at pin: the recovery rent blocks the
full 5 s and throws the exact NPR signature.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 2/2 as intended (both tests:
`TimeoutException: Rent Wait Timeout`, 5 s cadence as predicted) / GREEN PASS 2/2.

Fixes #7792
Related: #7695, #7631 (older Sentry groupings of the same title), #8089 (sibling
rent/release-pairing defect class, different semaphore - not touched here)

Includes inspection-warning cleanup in all touched files.