### PR TITLE
fix: make debug console log ingestion thread-safe via pending queue

### DIFF
--- a/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
@@ -22,20 +22,18 @@ namespace DCL.UI.DebugMenu
 
         private readonly DebugMenuConsoleLogHistory logsHistory = new ();
 
-        // Views and sidebar buttons are created in OnEnable, which Unity runs before Update,
-        // OnDisable and any UI callback: they are only null before the first enable.
-        private ConsolePanelView? consolePanelView;
-        private AbConversionPanelView? abConversionPanelView;
-        private MetricsPanelView? metricsPanelView;
+        private ConsolePanelView consolePanelView;
+        private AbConversionPanelView abConversionPanelView;
+        private MetricsPanelView metricsPanelView;
 
         private DebugPanelView? visiblePanel;
 
         private IInputBlock? inputBlock;
 
-        private Button? consoleButton;
-        private Button? abConversionButton;
-        private Button? metricsButton;
-        private Button? debugPanelButton;
+        private Button consoleButton;
+        private Button abConversionButton;
+        private Button metricsButton;
+        private Button debugPanelButton;
 
         private bool shouldRefreshConsole;
         private bool shouldHideDebugPanelOwnToggle;
@@ -67,16 +65,6 @@ namespace DCL.UI.DebugMenu
             consoleButton.clicked += OnConsoleButtonClicked;
             abConversionButton.clicked += OnAbConversionButtonClicked;
             metricsButton.clicked += OnMetricsButtonClicked;
-
-            // debugPanelButton is wired and shown only while a builder exists: SetDebugContainerBuilder
-            // covers the builder arriving after enable, this covers re-enables once the builder is set.
-            if (debugContainerBuilder != null)
-            {
-                // Idempotent: SetDebugContainerBuilder may have already wired this button while disabled
-                debugPanelButton.clicked -= OnDebugPanelButtonClicked;
-                debugPanelButton.clicked += OnDebugPanelButtonClicked;
-                debugPanelButton.style.display = DisplayStyle.Flex;
-            }
 
             // Views
             consolePanelView = new ConsolePanelView(root.Q("ConsolePanel"), consoleButton, OnConsoleButtonClicked, logsHistory);
@@ -122,13 +110,10 @@ namespace DCL.UI.DebugMenu
         {
             debugContainerBuilder = builder;
 
-            if (debugPanelButton != null)
-            {
-                // Panel handled at DebugContainerBuilder
-                debugPanelButton.clicked -= OnDebugPanelButtonClicked;
-                debugPanelButton.clicked += OnDebugPanelButtonClicked;
-                debugPanelButton.style.display = DisplayStyle.Flex;
-            }
+            // Panel handled at DebugContainerBuilder
+            debugPanelButton.clicked -= OnDebugPanelButtonClicked;
+            debugPanelButton.clicked += OnDebugPanelButtonClicked;
+            debugPanelButton.style.display = DisplayStyle.Flex;
 
             // DebugPanel has its own separate toggle button (that must still be used when the
             // DebugMenu is not enabled), so we must hide that one.
@@ -138,25 +123,14 @@ namespace DCL.UI.DebugMenu
         private void SetInputBlock(IInputBlock block)
         {
             this.inputBlock = block;
-            consolePanelView?.SetInputBlock(block);
+            consolePanelView.SetInputBlock(block);
         }
 
         private void OnDisable()
         {
             logsHistory.LogsUpdated -= OnLogsUpdated;
-
-            if (consoleButton != null)
-                consoleButton.clicked -= OnConsoleButtonClicked;
-
-            if (abConversionButton != null)
-                abConversionButton.clicked -= OnAbConversionButtonClicked;
-
-            if (metricsButton != null)
-                metricsButton.clicked -= OnMetricsButtonClicked;
-
-            if (debugPanelButton != null)
-                debugPanelButton.clicked -= OnDebugPanelButtonClicked;
-
+            abConversionButton.clicked -= OnAbConversionButtonClicked;
+            metricsButton.clicked -= OnMetricsButtonClicked;
             DCLInput.Instance.Shortcuts.ToggleSceneDebugConsole.performed -= OnToggleConsoleShortcutPerformed;
 
             if (metricsScene != null)
@@ -183,11 +157,11 @@ namespace DCL.UI.DebugMenu
             if (shouldRefreshConsole)
             {
                 shouldRefreshConsole = false;
-                consolePanelView?.Refresh();
+                consolePanelView.Refresh();
             }
 
             // Long-running abgen work (binary download, cold conversion) asks to be brought on screen.
-            if (AbgenConversionMetrics.INSTANCE.TryConsumePanelOpenRequest() && abConversionPanelView is { Visible: false })
+            if (AbgenConversionMetrics.INSTANCE.TryConsumePanelOpenRequest() && !abConversionPanelView.Visible)
             {
                 TogglePanel(abConversionPanelView);
                 abPanelAutoOpened = true;
@@ -211,7 +185,7 @@ namespace DCL.UI.DebugMenu
         {
             if (!abPanelAutoOpened) return;
 
-            if (abConversionPanelView is not { Visible: true })
+            if (!abConversionPanelView.Visible)
             {
                 abPanelAutoOpened = false;
                 return;
@@ -239,9 +213,6 @@ namespace DCL.UI.DebugMenu
         /// </summary>
         private void UpdateAbConversionAttention()
         {
-            if (abConversionPanelView == null || abConversionButton == null)
-                return;
-
             AbgenConversionMetrics metrics = AbgenConversionMetrics.INSTANCE;
 
             AbgenConversionMetrics.WarmUpStage warmUpStage = metrics.WarmUp;
@@ -270,9 +241,6 @@ namespace DCL.UI.DebugMenu
 
         private void UpdateMetricsPanel()
         {
-            if (metricsPanelView == null)
-                return;
-
             ISceneFacade? currentScene = scenesCache?.CurrentScene.Value;
 
             if (currentScene != metricsScene)
@@ -355,13 +323,11 @@ namespace DCL.UI.DebugMenu
 
             debugContainerBuilder.Container.TogglePanelVisibility();
 
-            debugPanelButton?.EnableInClassList(USS_SIDEBAR_BUTTON_SELECTED, debugContainerBuilder.Container.IsPanelVisible());
+            debugPanelButton.EnableInClassList(USS_SIDEBAR_BUTTON_SELECTED, debugContainerBuilder.Container.IsPanelVisible());
         }
 
-        private void TogglePanel(DebugPanelView? panelView)
+        private void TogglePanel(DebugPanelView panelView)
         {
-            if (panelView == null) return;
-
             if (panelView.Visible)
             {
                 panelView.Toggle();
@@ -380,7 +346,7 @@ namespace DCL.UI.DebugMenu
 
         private void OnLogsUpdated()
         {
-            if (consolePanelView is not { Visible: true }) return;
+            if (!consolePanelView.Visible) return;
             shouldRefreshConsole = true;
         }
     }

--- a/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
@@ -72,6 +72,8 @@ namespace DCL.UI.DebugMenu
             // covers the builder arriving after enable, this covers re-enables once the builder is set.
             if (debugContainerBuilder != null)
             {
+                // Idempotent: SetDebugContainerBuilder may have already wired this button while disabled
+                debugPanelButton.clicked -= OnDebugPanelButtonClicked;
                 debugPanelButton.clicked += OnDebugPanelButtonClicked;
                 debugPanelButton.style.display = DisplayStyle.Flex;
             }

--- a/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
@@ -22,18 +22,20 @@ namespace DCL.UI.DebugMenu
 
         private readonly DebugMenuConsoleLogHistory logsHistory = new ();
 
-        private ConsolePanelView consolePanelView;
-        private AbConversionPanelView abConversionPanelView;
-        private MetricsPanelView metricsPanelView;
+        // Views and sidebar buttons are created in OnEnable, which Unity runs before Update,
+        // OnDisable and any UI callback: they are only null before the first enable.
+        private ConsolePanelView? consolePanelView;
+        private AbConversionPanelView? abConversionPanelView;
+        private MetricsPanelView? metricsPanelView;
 
         private DebugPanelView? visiblePanel;
 
         private IInputBlock? inputBlock;
 
-        private Button consoleButton;
-        private Button abConversionButton;
-        private Button metricsButton;
-        private Button debugPanelButton;
+        private Button? consoleButton;
+        private Button? abConversionButton;
+        private Button? metricsButton;
+        private Button? debugPanelButton;
 
         private bool shouldRefreshConsole;
         private bool shouldHideDebugPanelOwnToggle;
@@ -65,6 +67,14 @@ namespace DCL.UI.DebugMenu
             consoleButton.clicked += OnConsoleButtonClicked;
             abConversionButton.clicked += OnAbConversionButtonClicked;
             metricsButton.clicked += OnMetricsButtonClicked;
+
+            // debugPanelButton is wired and shown only while a builder exists: SetDebugContainerBuilder
+            // covers the builder arriving after enable, this covers re-enables once the builder is set.
+            if (debugContainerBuilder != null)
+            {
+                debugPanelButton.clicked += OnDebugPanelButtonClicked;
+                debugPanelButton.style.display = DisplayStyle.Flex;
+            }
 
             // Views
             consolePanelView = new ConsolePanelView(root.Q("ConsolePanel"), consoleButton, OnConsoleButtonClicked, logsHistory);
@@ -110,10 +120,13 @@ namespace DCL.UI.DebugMenu
         {
             debugContainerBuilder = builder;
 
-            // Panel handled at DebugContainerBuilder
-            debugPanelButton.clicked -= OnDebugPanelButtonClicked;
-            debugPanelButton.clicked += OnDebugPanelButtonClicked;
-            debugPanelButton.style.display = DisplayStyle.Flex;
+            if (debugPanelButton != null)
+            {
+                // Panel handled at DebugContainerBuilder
+                debugPanelButton.clicked -= OnDebugPanelButtonClicked;
+                debugPanelButton.clicked += OnDebugPanelButtonClicked;
+                debugPanelButton.style.display = DisplayStyle.Flex;
+            }
 
             // DebugPanel has its own separate toggle button (that must still be used when the
             // DebugMenu is not enabled), so we must hide that one.
@@ -123,14 +136,25 @@ namespace DCL.UI.DebugMenu
         private void SetInputBlock(IInputBlock block)
         {
             this.inputBlock = block;
-            consolePanelView.SetInputBlock(block);
+            consolePanelView?.SetInputBlock(block);
         }
 
         private void OnDisable()
         {
             logsHistory.LogsUpdated -= OnLogsUpdated;
-            abConversionButton.clicked -= OnAbConversionButtonClicked;
-            metricsButton.clicked -= OnMetricsButtonClicked;
+
+            if (consoleButton != null)
+                consoleButton.clicked -= OnConsoleButtonClicked;
+
+            if (abConversionButton != null)
+                abConversionButton.clicked -= OnAbConversionButtonClicked;
+
+            if (metricsButton != null)
+                metricsButton.clicked -= OnMetricsButtonClicked;
+
+            if (debugPanelButton != null)
+                debugPanelButton.clicked -= OnDebugPanelButtonClicked;
+
             DCLInput.Instance.Shortcuts.ToggleSceneDebugConsole.performed -= OnToggleConsoleShortcutPerformed;
 
             if (metricsScene != null)
@@ -150,14 +174,18 @@ namespace DCL.UI.DebugMenu
                 HideDebugPanelOwnToggle();
             }
 
+            // Logs pushed from other threads since last frame become visible here; a resulting
+            // LogsUpdated sets shouldRefreshConsole synchronously, so they render this same frame.
+            logsHistory.DrainPendingLogs();
+
             if (shouldRefreshConsole)
             {
                 shouldRefreshConsole = false;
-                consolePanelView.Refresh();
+                consolePanelView?.Refresh();
             }
 
             // Long-running abgen work (binary download, cold conversion) asks to be brought on screen.
-            if (AbgenConversionMetrics.INSTANCE.TryConsumePanelOpenRequest() && !abConversionPanelView.Visible)
+            if (AbgenConversionMetrics.INSTANCE.TryConsumePanelOpenRequest() && abConversionPanelView is { Visible: false })
             {
                 TogglePanel(abConversionPanelView);
                 abPanelAutoOpened = true;
@@ -181,7 +209,7 @@ namespace DCL.UI.DebugMenu
         {
             if (!abPanelAutoOpened) return;
 
-            if (!abConversionPanelView.Visible)
+            if (abConversionPanelView is not { Visible: true })
             {
                 abPanelAutoOpened = false;
                 return;
@@ -209,6 +237,9 @@ namespace DCL.UI.DebugMenu
         /// </summary>
         private void UpdateAbConversionAttention()
         {
+            if (abConversionPanelView == null || abConversionButton == null)
+                return;
+
             AbgenConversionMetrics metrics = AbgenConversionMetrics.INSTANCE;
 
             AbgenConversionMetrics.WarmUpStage warmUpStage = metrics.WarmUp;
@@ -237,6 +268,9 @@ namespace DCL.UI.DebugMenu
 
         private void UpdateMetricsPanel()
         {
+            if (metricsPanelView == null)
+                return;
+
             ISceneFacade? currentScene = scenesCache?.CurrentScene.Value;
 
             if (currentScene != metricsScene)
@@ -319,11 +353,13 @@ namespace DCL.UI.DebugMenu
 
             debugContainerBuilder.Container.TogglePanelVisibility();
 
-            debugPanelButton.EnableInClassList(USS_SIDEBAR_BUTTON_SELECTED, debugContainerBuilder.Container.IsPanelVisible());
+            debugPanelButton?.EnableInClassList(USS_SIDEBAR_BUTTON_SELECTED, debugContainerBuilder.Container.IsPanelVisible());
         }
 
-        private void TogglePanel(DebugPanelView panelView)
+        private void TogglePanel(DebugPanelView? panelView)
         {
+            if (panelView == null) return;
+
             if (panelView.Visible)
             {
                 panelView.Toggle();
@@ -342,7 +378,7 @@ namespace DCL.UI.DebugMenu
 
         private void OnLogsUpdated()
         {
-            if (!consolePanelView.Visible) return;
+            if (consolePanelView is not { Visible: true }) return;
             shouldRefreshConsole = true;
         }
     }

--- a/Explorer/Assets/DCL/UI/DebugMenu/LogHistory/DebugMenuConsoleLogHistory.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/LogHistory/DebugMenuConsoleLogHistory.cs
@@ -4,16 +4,29 @@ using System.Linq;
 
 namespace DCL.UI.DebugMenu.LogHistory
 {
+    /// <summary>
+    ///     <see cref="AddLogMessage" /> is fed from the global log callback and may be invoked from any
+    ///     thread; it only enqueues into a capped pending queue. <see cref="Paused" /> is written on the
+    ///     main thread and read on the logging threads: a stale read may admit or drop a borderline
+    ///     entry, which is acceptable for a pause toggle. Every other member — the lists, the counters
+    ///     and <see cref="LogsUpdated" /> — is main-thread-only: entries become visible when
+    ///     <see cref="DrainPendingLogs" /> runs on the main thread.
+    /// </summary>
     public class DebugMenuConsoleLogHistory
     {
-        public readonly List<DebugMenuConsoleLogEntry> FilteredLogMessages = new ();
-        public event Action LogsUpdated;
-        public bool Paused { get; set; }
-        public int LogEntryCount => allLogMessages.Count(logEntry => logEntry.Type == LogMessageType.Log);
-        public int ErrorEntryCount => allLogMessages.Count(logEntry => logEntry.Type == LogMessageType.Error);
+        private const int MAX_PENDING_LOGS = 10000;
 
+        public readonly List<DebugMenuConsoleLogEntry> FilteredLogMessages = new ();
+        public event Action? LogsUpdated;
+        public bool Paused { get; set; }
+        public int LogEntryCount { get; private set; }
+        public int ErrorEntryCount { get; private set; }
+
+        private readonly object pendingLock = new ();
+        private readonly Queue<DebugMenuConsoleLogEntry> pendingLogMessages = new ();
+        private readonly List<DebugMenuConsoleLogEntry> drainBuffer = new ();
         private readonly List<DebugMenuConsoleLogEntry> allLogMessages = new ();
-        private string textFilter;
+        private string? textFilter;
         private bool showErrorEntries = true;
         private bool showLogEntries = true;
 
@@ -21,18 +34,52 @@ namespace DCL.UI.DebugMenu.LogHistory
         {
             if (Paused) return;
 
-            allLogMessages.Add(logEntry);
+            lock (pendingLock)
+            {
+                if (pendingLogMessages.Count == MAX_PENDING_LOGS)
+                    pendingLogMessages.Dequeue();
 
-            if (!KeepAfterFilter(logEntry)) return;
+                pendingLogMessages.Enqueue(logEntry);
+            }
+        }
 
-            FilteredLogMessages.Add(logEntry);
+        public void DrainPendingLogs()
+        {
+            lock (pendingLock)
+            {
+                while (pendingLogMessages.Count > 0)
+                    drainBuffer.Add(pendingLogMessages.Dequeue());
+            }
+
+            if (drainBuffer.Count == 0) return;
+
+            for (var i = 0; i < drainBuffer.Count; i++)
+            {
+                DebugMenuConsoleLogEntry logEntry = drainBuffer[i];
+
+                allLogMessages.Add(logEntry);
+
+                if (logEntry.Type == LogMessageType.Log)
+                    LogEntryCount++;
+                else if (logEntry.Type == LogMessageType.Error)
+                    ErrorEntryCount++;
+
+                if (KeepAfterFilter(logEntry))
+                    FilteredLogMessages.Add(logEntry);
+            }
+
+            drainBuffer.Clear();
             LogsUpdated?.Invoke();
         }
 
         public void ClearLogMessages()
         {
+            lock (pendingLock) { pendingLogMessages.Clear(); }
+
             allLogMessages.Clear();
             FilteredLogMessages.Clear();
+            LogEntryCount = 0;
+            ErrorEntryCount = 0;
             LogsUpdated?.Invoke();
         }
 

--- a/Explorer/Assets/DCL/UI/DebugMenu/LogHistory/DebugMenuConsoleLogHistory.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/LogHistory/DebugMenuConsoleLogHistory.cs
@@ -7,8 +7,9 @@ namespace DCL.UI.DebugMenu.LogHistory
     /// <summary>
     ///     <see cref="AddLogMessage" /> is fed from the global log callback and may be invoked from any
     ///     thread; it only enqueues into a capped pending queue. <see cref="Paused" /> is written on the
-    ///     main thread and read on the logging threads: a stale read may admit or drop a borderline
-    ///     entry, which is acceptable for a pause toggle. Every other member — the lists, the counters
+    ///     main thread and read on the logging threads through a volatile field: a toggle racing an
+    ///     enqueue may admit or drop a borderline entry, which is acceptable for a pause toggle. Every
+    ///     other member — the lists, the counters
     ///     and <see cref="LogsUpdated" /> — is main-thread-only: entries become visible when
     ///     <see cref="DrainPendingLogs" /> runs on the main thread.
     /// </summary>
@@ -18,9 +19,12 @@ namespace DCL.UI.DebugMenu.LogHistory
 
         public readonly List<DebugMenuConsoleLogEntry> FilteredLogMessages = new ();
         public event Action? LogsUpdated;
-        public bool Paused { get; set; }
+        public bool Paused { get => paused; set => paused = value; }
         public int LogEntryCount { get; private set; }
         public int ErrorEntryCount { get; private set; }
+
+        // volatile so a main-thread toggle becomes visible promptly on the logging threads
+        private volatile bool paused;
 
         private readonly object pendingLock = new ();
         private readonly Queue<DebugMenuConsoleLogEntry> pendingLogMessages = new ();

--- a/Explorer/Assets/DCL/UI/DebugMenu/Tests/DebugMenuConsoleLogHistoryShould.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/Tests/DebugMenuConsoleLogHistoryShould.cs
@@ -2,13 +2,14 @@ using DCL.UI.DebugMenu.LogHistory;
 using NUnit.Framework;
 using System;
 using System.Linq;
+using System.Threading;
 
 namespace DCL.UI.DebugMenu.Tests
 {
     [TestFixture]
     public class DebugMenuConsoleLogHistoryShould
     {
-        private DebugMenuConsoleLogHistory logHistory;
+        private DebugMenuConsoleLogHistory logHistory = null!;
 
         [SetUp]
         public void SetUp()
@@ -19,7 +20,109 @@ namespace DCL.UI.DebugMenu.Tests
         [TearDown]
         public void TearDown()
         {
-            logHistory = null;
+            logHistory = null!;
+        }
+
+        [Test]
+        public void AddLogMessage_FromWorkerThread_DoesNotBreakMainThreadEnumeration()
+        {
+            // AddLogMessage is fed by the global Unity log callback, which fires on arbitrary
+            // threads while the main thread reads the counters and enumerates FilteredLogMessages
+            // (ConsolePanelView.Refresh / ListView binding / copy-all).
+            const int ENTRY_COUNT = 50000;
+
+            Exception? mainThreadException = null;
+            Exception? workerException = null;
+
+            var worker = new Thread(() =>
+            {
+                try
+                {
+                    for (var i = 0; i < ENTRY_COUNT; i++)
+                        logHistory.AddLogMessage(new DebugMenuConsoleLogEntry(i % 2 == 0 ? LogMessageType.Log : LogMessageType.Error, "worker entry"));
+                }
+                catch (Exception e) { workerException = e; }
+            });
+
+            worker.Start();
+
+            try
+            {
+                while (worker.IsAlive)
+                {
+                    _ = logHistory.LogEntryCount + logHistory.ErrorEntryCount;
+
+                    foreach (DebugMenuConsoleLogEntry entry in logHistory.FilteredLogMessages)
+                        _ = entry.Type == LogMessageType.Error;
+                }
+            }
+            catch (Exception e) { mainThreadException = e; }
+
+            worker.Join();
+
+            Assert.That(mainThreadException, Is.Null, $"Main-thread read raced a logging-thread AddLogMessage: {mainThreadException}");
+            Assert.That(workerException, Is.Null, $"Logging-thread AddLogMessage threw: {workerException}");
+        }
+
+        [Test]
+        public void AddLogMessage_FromWorkerThread_IsInvisibleUntilDrained()
+        {
+            // Arrange
+            int eventCallCount = 0;
+            logHistory.LogsUpdated += () => eventCallCount++;
+
+            // Act
+            var worker = new Thread(() => logHistory.AddLogMessage(new DebugMenuConsoleLogEntry(LogMessageType.Log, "Worker message")));
+            worker.Start();
+            worker.Join();
+
+            // Assert: nothing surfaces on the ingestion thread
+            Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(0));
+            Assert.That(logHistory.LogEntryCount, Is.EqualTo(0));
+            Assert.That(eventCallCount, Is.EqualTo(0));
+
+            // Act: main thread drains
+            logHistory.DrainPendingLogs();
+
+            // Assert
+            Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(1));
+            Assert.That(logHistory.FilteredLogMessages[0].Message, Does.Contain("Worker message"));
+            Assert.That(logHistory.LogEntryCount, Is.EqualTo(1));
+            Assert.That(eventCallCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void DrainPendingLogs_WithNothingPending_ShouldNotFireEvent()
+        {
+            // Arrange
+            bool eventFired = false;
+            logHistory.LogsUpdated += () => eventFired = true;
+
+            // Act
+            logHistory.DrainPendingLogs();
+
+            // Assert
+            Assert.That(eventFired, Is.False);
+        }
+
+        [Test]
+        public void AddLogMessage_BeyondPendingCap_ShouldDropOldestPendingEntries()
+        {
+            // Arrange: 5 entries beyond the pending cap (10000)
+            const int PENDING_CAP = 10000;
+            const int OVERFLOW = 5;
+
+            for (var i = 0; i < PENDING_CAP + OVERFLOW; i++)
+                logHistory.AddLogMessage(new DebugMenuConsoleLogEntry(LogMessageType.Log, $"entry #{i:D5}"));
+
+            // Act
+            logHistory.DrainPendingLogs();
+
+            // Assert: oldest OVERFLOW entries were dropped, newest survive in order
+            Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(PENDING_CAP));
+            Assert.That(logHistory.LogEntryCount, Is.EqualTo(PENDING_CAP));
+            Assert.That(logHistory.FilteredLogMessages[0].Message, Does.Contain($"entry #{OVERFLOW:D5}"));
+            Assert.That(logHistory.FilteredLogMessages[PENDING_CAP - 1].Message, Does.Contain($"entry #{PENDING_CAP + OVERFLOW - 1:D5}"));
         }
 
         [Test]
@@ -32,6 +135,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             // Act
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             // Assert
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(1));
@@ -50,6 +154,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             // Act
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             // Assert
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(0));
@@ -68,6 +173,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry1);
             logHistory.AddLogMessage(logEntry2);
             logHistory.AddLogMessage(errorEntry);
+            logHistory.DrainPendingLogs();
 
             // Assert
             Assert.That(logHistory.LogEntryCount, Is.EqualTo(2));
@@ -84,6 +190,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             logHistory.AddLogMessage(logEntry);
             logHistory.AddLogMessage(errorEntry);
+            logHistory.DrainPendingLogs();
             logHistory.LogsUpdated += () => eventFired = true;
 
             // Act
@@ -108,6 +215,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry1);
             logHistory.AddLogMessage(logEntry2);
             logHistory.AddLogMessage(logEntry3);
+            logHistory.DrainPendingLogs();
             logHistory.LogsUpdated += () => eventFired = true;
 
             // Act
@@ -128,6 +236,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             logHistory.AddLogMessage(logEntry1);
             logHistory.AddLogMessage(logEntry2);
+            logHistory.DrainPendingLogs();
 
             // Act
             logHistory.ApplyFilter("TEST", true, true);
@@ -148,6 +257,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry);
             logHistory.AddLogMessage(errorEntry);
             logHistory.AddLogMessage(warningEntry);
+            logHistory.DrainPendingLogs();
 
             // Act
             logHistory.ApplyFilter("", false, true);
@@ -170,6 +280,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry);
             logHistory.AddLogMessage(errorEntry);
             logHistory.AddLogMessage(warningEntry);
+            logHistory.DrainPendingLogs();
 
             // Act
             logHistory.ApplyFilter("", true, false);
@@ -192,6 +303,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry1);
             logHistory.AddLogMessage(logEntry2);
             logHistory.AddLogMessage(errorEntry);
+            logHistory.DrainPendingLogs();
 
             // Act
             logHistory.ApplyFilter("Important", false, true);
@@ -211,6 +323,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             logHistory.AddLogMessage(logEntry);
             logHistory.AddLogMessage(errorEntry);
+            logHistory.DrainPendingLogs();
 
             // Act
             logHistory.ApplyFilter("", true, true);
@@ -220,17 +333,20 @@ namespace DCL.UI.DebugMenu.Tests
         }
 
         [Test]
-        public void LogsUpdated_Event_ShouldFireOnAddLogMessage()
+        public void LogsUpdated_Event_ShouldFireOncePerDrainWithPendingLogs()
         {
             // Arrange
-            var logEntry = new DebugMenuConsoleLogEntry(LogMessageType.Log, "Test message");
+            var logEntry1 = new DebugMenuConsoleLogEntry(LogMessageType.Log, "Test message 1");
+            var logEntry2 = new DebugMenuConsoleLogEntry(LogMessageType.Log, "Test message 2");
             int eventCallCount = 0;
             logHistory.LogsUpdated += () => eventCallCount++;
 
             // Act
-            logHistory.AddLogMessage(logEntry);
+            logHistory.AddLogMessage(logEntry1);
+            logHistory.AddLogMessage(logEntry2);
+            logHistory.DrainPendingLogs();
 
-            // Assert
+            // Assert: a drained batch fires a single update
             Assert.That(eventCallCount, Is.EqualTo(1));
         }
 
@@ -240,6 +356,7 @@ namespace DCL.UI.DebugMenu.Tests
             // Arrange
             var logEntry = new DebugMenuConsoleLogEntry(LogMessageType.Log, "Test message");
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             int eventCallCount = 0;
             logHistory.LogsUpdated += () => eventCallCount++;
@@ -257,6 +374,7 @@ namespace DCL.UI.DebugMenu.Tests
             // Arrange
             var logEntry = new DebugMenuConsoleLogEntry(LogMessageType.Log, "Test message");
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             int eventCallCount = 0;
             logHistory.LogsUpdated += () => eventCallCount++;
@@ -277,6 +395,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             // Act
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             // Assert
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(0));
@@ -292,6 +411,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             // Act
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             // Assert
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(0));


### PR DESCRIPTION
## Problem

`InvalidOperationException: Collection was modified; enumeration operation may not execute`
from the debug console - four Sentry groups (~43 events / 6 users past week) across
`LogEntryCount`, `ErrorEntryCount`, and `ConsolePanelView.Refresh`.

## Root cause

`DebugMenuConsoleLogHistory` backs the console with plain `List<T>`s mutated synchronously
inside `AddLogMessage`, but ingestion is the global Unity log callback chain, which fires on
arbitrary threads (scene runtime, thread pool, LiveKit) while the main thread runs LINQ
`Count` over the same lists and enumerates `FilteredLogMessages` for the ListView. Any log
burst during a refresh throws; the `LogsUpdated` event also made subscribers read UI
Toolkit state off the main thread. The same bus's other consumer (`SceneLogBuffer`)
documents the cross-thread contract and locks - this consumer didn't.

## Fix (single-threaded-consumer model)

- `AddLogMessage` (any thread): lock-enqueue only, into a pending queue capped at 10 000
  (drop-oldest). No list mutation, no event.
- New `DrainPendingLogs()` (main thread, called from `DebugMenuController.Update` before the
  refresh check): drains the queue into the real lists, bumps O(1) running counters
  (replacing the per-refresh O(n) LINQ counts), fires `LogsUpdated` once per drained batch  - 
  making the event main-thread-only by construction.
- `ClearLogMessages` clears the pending queue and counters.

Behavior parity: visible-console updates were already deferred to the next `Update`, so no
added user-visible delay. Blast radius: debug-menu console only.

## Also in this PR

- Nullable sweep of `DebugMenuController` (separate `chore:` commit): view/button fields
  became `T?` with guards - they are genuinely null before the first `OnEnable`, and the
  style guide confines `= null!` to DTO fields. Roughly half the controller diff is this
  mechanical sweep.
- Sidebar-button teardown symmetry in the same `OnEnable`/`OnDisable` blocks:
  `consoleButton.clicked` (and `debugPanelButton.clicked`) now unsubscribe in `OnDisable`,
  so a disable/enable cycle over a persistent UI tree no longer stacks handlers (one click
  previously toggled the console twice); `debugPanelButton` re-wires on enable while a
  debug-container builder exists.

## Test

`DebugMenuConsoleLogHistoryShould` (EditMode, plain NUnit): a worker thread hammers
`AddLogMessage` while the test thread loops the counts and enumerates - RED at pin within
milliseconds with the exact Sentry stack shape; plus deferred-contract, one-event-per-drain,
empty-drain, and cap/drop-oldest tests; the 13 pre-existing tests keep passing with
mechanical drain insertions.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 1/1 as intended (the stress test hit
"Collection was modified" in the ErrorEntryCount LINQ Count; 16 parity tests green at pin) /
GREEN PASS 20/20 including the 3 new drain-semantics tests.

Fixes #7907
Fixes #9346
Related: #7908 (autoclosed twin of the same signature, still occurring)

Includes inspection-warning cleanup in all touched files.

Fixes #7908