### PR TITLE
fix: don't hand unresolved avatar elements to backpack equip flows

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/ElementProviderHelper.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/ElementProviderHelper.cs
@@ -77,7 +77,11 @@ namespace DCL.AvatarRendering.Wearables
                 await UniTask.SwitchToMainThread();
                 FailFetch();
             }
-            catch (OperationCanceledException) { onFetchFailed?.Invoke(); }
+            catch (OperationCanceledException)
+            {
+                await UniTask.SwitchToMainThread();
+                onFetchFailed?.Invoke();
+            }
             catch (Exception e)
             {
                 ReportHub.LogException(e, new ReportData(ReportCategory.EMOTE));

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/ElementProviderHelper.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/ElementProviderHelper.cs
@@ -84,7 +84,7 @@ namespace DCL.AvatarRendering.Wearables
             }
             catch (Exception e)
             {
-                ReportHub.LogException(e, new ReportData(ReportCategory.EMOTE));
+                ReportHub.LogException(e, reportData);
                 await UniTask.SwitchToMainThread();
                 onFetchFailed?.Invoke();
             }

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/ElementProviderHelper.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/ElementProviderHelper.cs
@@ -22,16 +22,34 @@ namespace DCL.AvatarRendering.Wearables
             IReadOnlyEquippedWearables equippedWearables,
             Action<TElement> onElementFetched,
             CancellationToken ct,
-            ReportData reportData)
+            ReportData reportData,
+            Action? onFetchFailed = null)
             where TElement: IAvatarAttachment<TElementDTO>
             where TElementDTO: AvatarAttachmentDTO
         {
             if (elementStorage.TryGetElement(pointer, out var element))
             {
-                // Element could be in the storage but still loading their data. Wait until they finish loading.
-                await UniTask.WaitWhile(() => element.IsLoading, cancellationToken: ct);
+                try
+                {
+                    // Element could be in the storage but still loading their data. Wait until they finish loading.
+                    await UniTask.WaitWhile(() => element.IsLoading, cancellationToken: ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    onFetchFailed?.Invoke();
+                    return;
+                }
 
                 await UniTask.SwitchToMainThread();
+
+                // The callback contract is resolved elements only; an unresolved placeholder
+                // (IsLoading == false, DTO == null) is a failed fetch, never a callback argument.
+                if (element.DTO == null)
+                {
+                    FailFetch();
+                    return;
+                }
+
                 onElementFetched(element);
 
                 return;
@@ -49,21 +67,33 @@ namespace DCL.AvatarRendering.Wearables
                 await elementProvider.GetByPointersAsync(urnRequest, currenBodyShape, ct, results);
 
                 foreach (var result in results)
-                    if (result.GetUrn() == pointer)
+                    if (result.DTO != null && result.GetUrn() == pointer)
                     {
                         await UniTask.SwitchToMainThread();
                         onElementFetched(result);
                         return;
                     }
 
-                ReportHub.LogError(reportData, $"Couldn't fetch element of type {typeof(TElement)} for pointer: {pointer}");
+                await UniTask.SwitchToMainThread();
+                FailFetch();
             }
-            catch (OperationCanceledException) { }
-            catch (Exception e) { ReportHub.LogException(e, new ReportData(ReportCategory.EMOTE)); }
+            catch (OperationCanceledException) { onFetchFailed?.Invoke(); }
+            catch (Exception e)
+            {
+                ReportHub.LogException(e, new ReportData(ReportCategory.EMOTE));
+                await UniTask.SwitchToMainThread();
+                onFetchFailed?.Invoke();
+            }
             finally
             {
                 ListPool<URN>.Release(urnRequest);
                 ListPool<TElement>.Release(results);
+            }
+
+            void FailFetch()
+            {
+                ReportHub.LogError(reportData, $"Couldn't fetch element of type {typeof(TElement)} for pointer: {pointer}");
+                onFetchFailed?.Invoke();
             }
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ElementProviderHelperShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ElementProviderHelperShould.cs
@@ -1,0 +1,213 @@
+using CommunicationData.URLHelpers;
+using Cysharp.Threading.Tasks;
+using DCL.AvatarRendering.Emotes;
+using DCL.AvatarRendering.Loading.Components;
+using DCL.AvatarRendering.Wearables.Components;
+using DCL.AvatarRendering.Wearables.Equipped;
+using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Diagnostics;
+using ECS.StreamableLoading.Common.Components;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine.TestTools;
+
+namespace DCL.AvatarRendering.Wearables.Tests
+{
+    [TestFixture]
+    public class ElementProviderHelperShould
+    {
+        private const string EMOTE_POINTER = "urn:decentraland:matic:collections-v2:0x1234567890123456789012345678901234567890:0";
+        private const int PUMP_FRAMES = 60;
+
+        private MemoryEmotesStorage emoteStorage = null!;
+        private IEmoteProvider emoteProvider = null!;
+        private IReadOnlyEquippedWearables equippedWearables = null!;
+        private ReportData reportData;
+
+        [SetUp]
+        public void SetUp()
+        {
+            emoteStorage = new MemoryEmotesStorage();
+            emoteProvider = Substitute.For<IEmoteProvider>();
+            equippedWearables = Substitute.For<IReadOnlyEquippedWearables>();
+            reportData = new ReportData(ReportCategory.EMOTE);
+        }
+
+        [Test]
+        public async Task NotInvokeCallbackForStoredElementWithFailedDto()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            // The exact state ReportAndFinalizeWithError leaves in storage: failed Model, IsLoading == false, DTO == null.
+            IEmote emote = IEmote.NewEmpty();
+            emote.ResolvedFailedDTO(new StreamableLoadingResult<EmoteDTO>(reportData, new Exception("entities endpoint failed")));
+            emoteStorage.Set(EMOTE_POINTER, emote);
+
+            var invocations = 0;
+            var failures = 0;
+            Fetch(_ => invocations++, () => failures++);
+            await PumpAsync(() => failures > 0);
+
+            Assert.AreEqual(0, invocations, "The callback must not be invoked for a stored element whose DTO load failed");
+            Assert.AreEqual(1, failures, "The failure callback must be invoked exactly once for a stored element whose DTO load failed");
+        }
+
+        [Test]
+        public async Task NotInvokeCallbackForStoredElementWithCancelledLoad()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            // The exact state TryFinalizeIfCancelled leaves in storage: default Model, IsLoading == false, DTO == null.
+            IEmote emote = IEmote.NewEmpty();
+            emote.UpdateLoadingStatus(false);
+            emoteStorage.Set(EMOTE_POINTER, emote);
+
+            var invocations = 0;
+            var failures = 0;
+            Fetch(_ => invocations++, () => failures++);
+            await PumpAsync(() => failures > 0);
+
+            Assert.AreEqual(0, invocations, "The callback must not be invoked for a stored element whose DTO load was cancelled");
+            Assert.AreEqual(1, failures, "The failure callback must be invoked exactly once for a stored element whose DTO load was cancelled");
+        }
+
+        [Test]
+        public async Task InvokeCallbackOnceForResolvedStoredElement()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            var emote = new Emote(new StreamableLoadingResult<EmoteDTO>(NewDto(EMOTE_POINTER)), false);
+            emoteStorage.Set(EMOTE_POINTER, emote);
+
+            var invocations = 0;
+            var failures = 0;
+            IEmote? received = null;
+
+            Fetch(e =>
+            {
+                invocations++;
+                received = e;
+            }, () => failures++);
+
+            await PumpAsync(() => invocations > 0);
+
+            Assert.AreEqual(1, invocations, "The callback must be invoked exactly once for a resolved stored element");
+            Assert.AreSame(emote, received);
+            Assert.AreEqual(0, failures, "The failure callback must not be invoked for a resolved stored element");
+        }
+
+        [Test]
+        public async Task SkipUnresolvedProviderResultsAndInvokeCallbackWithResolvedMatch()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            EquipBodyShape();
+
+            IEmote unresolved = IEmote.NewEmpty();
+            unresolved.UpdateLoadingStatus(false);
+            var resolved = new Emote(new StreamableLoadingResult<EmoteDTO>(NewDto(EMOTE_POINTER)), false);
+
+            emoteProvider.GetByPointersAsync(Arg.Any<IReadOnlyCollection<URN>>(), Arg.Any<BodyShape>(), Arg.Any<CancellationToken>(), Arg.Any<List<IEmote>?>())
+                         .Returns(callInfo =>
+                          {
+                              List<IEmote> results = callInfo.Arg<List<IEmote>>();
+                              results.Add(unresolved);
+                              results.Add(resolved);
+                              return UniTask.FromResult<IReadOnlyCollection<IEmote>?>(results);
+                          });
+
+            var invocations = 0;
+            var failures = 0;
+            IEmote? received = null;
+
+            Fetch(e =>
+            {
+                invocations++;
+                received = e;
+            }, () => failures++);
+
+            await PumpAsync(() => invocations > 0);
+
+            Assert.AreEqual(1, invocations, "An unresolved provider result must be skipped, not abort the match loop");
+            Assert.AreSame(resolved, received);
+            Assert.AreEqual(0, failures, "The failure callback must not be invoked when a resolved match is found");
+        }
+
+        [Test]
+        public async Task InvokeFailureCallbackWhenProviderReturnsNoMatch()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            EquipBodyShape();
+
+            emoteProvider.GetByPointersAsync(Arg.Any<IReadOnlyCollection<URN>>(), Arg.Any<BodyShape>(), Arg.Any<CancellationToken>(), Arg.Any<List<IEmote>?>())
+                         .Returns(callInfo => UniTask.FromResult<IReadOnlyCollection<IEmote>?>(callInfo.Arg<List<IEmote>>()));
+
+            var invocations = 0;
+            var failures = 0;
+            Fetch(_ => invocations++, () => failures++);
+            await PumpAsync(() => failures > 0);
+
+            Assert.AreEqual(0, invocations, "The callback must not be invoked when the provider returns no match");
+            Assert.AreEqual(1, failures, "The failure callback must be invoked exactly once when the provider returns no match");
+        }
+
+        [Test]
+        public async Task InvokeFailureCallbackWhenProviderThrows()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            EquipBodyShape();
+
+            emoteProvider.GetByPointersAsync(Arg.Any<IReadOnlyCollection<URN>>(), Arg.Any<BodyShape>(), Arg.Any<CancellationToken>(), Arg.Any<List<IEmote>?>())
+                         .Returns(UniTask.FromException<IReadOnlyCollection<IEmote>?>(new Exception("entities endpoint failed")));
+
+            var invocations = 0;
+            var failures = 0;
+            Fetch(_ => invocations++, () => failures++);
+            await PumpAsync(() => failures > 0);
+
+            Assert.AreEqual(0, invocations, "The callback must not be invoked when the provider throws");
+            Assert.AreEqual(1, failures, "The failure callback must be invoked exactly once when the provider throws");
+        }
+
+        // Storage misses route through the provider; a body shape must be equipped on that path.
+        private void EquipBodyShape()
+        {
+            var bodyShapeWearable = new Wearable(new StreamableLoadingResult<WearableDTO>(new WearableDTO
+            {
+                metadata = new WearableDTO.WearableMetadataDto
+                {
+                    id = BodyShape.MALE,
+                    data = new WearableDTO.WearableMetadataDto.DataDto { category = "body_shape" },
+                },
+            }));
+
+            equippedWearables.Wearable(Arg.Any<string>()).Returns(bodyShapeWearable);
+        }
+
+        private void Fetch(Action<IEmote> onElementFetched, Action? onFetchFailed = null) =>
+            ElementProviderHelper.FetchElementByPointerAndExecuteAsync(
+                                      EMOTE_POINTER, emoteProvider, emoteStorage, equippedWearables, onElementFetched, CancellationToken.None, reportData, onFetchFailed)
+                                 .Forget();
+
+        private static async Task PumpAsync(Func<bool>? until = null)
+        {
+            for (var i = 0; i < PUMP_FRAMES && (until == null || !until()); i++)
+                await UniTask.Yield();
+        }
+
+        private static EmoteDTO NewDto(string urn) =>
+            new ()
+            {
+                metadata = new EmoteDTO.EmoteMetadataDto
+                {
+                    id = urn,
+                },
+            };
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ElementProviderHelperShould.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/ElementProviderHelperShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99ad2001bfd64109b79488edfdf12f04
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/Commands/CacheOutfitWearablesCommand.cs
+++ b/Explorer/Assets/DCL/Backpack/AvatarSection/Outfits/Commands/CacheOutfitWearablesCommand.cs
@@ -50,7 +50,7 @@ namespace DCL.Backpack.AvatarSection.Outfits.Commands
             try
             {
                 if (missingUrns.Count > 0)
-                    await wearablesProvider.GetByPointersAsync(missingUrns, bodyShape, ct, result);
+                    await FetchMissingDtosIntoResultAsync(missingUrns, bodyShape, result, ct);
 
                 foreach ((var baseUrn, var fullUrn, string tokenId) in tokenMappings)
                     // We don't strictly need transferredAt/price here; use safe defaults.
@@ -75,11 +75,64 @@ namespace DCL.Backpack.AvatarSection.Outfits.Commands
             catch (Exception e) { ReportHub.LogException(e, ReportCategory.OUTFITS); }
         }
 
+        // The outfit equip event needs DTO metadata only, so the wait ends when every missing
+        // pointer's DTO settles (resolved or failed); the provider's full fetch keeps loading
+        // assets in the background. Result entries stay resolved-only (DTO != null): a pointer
+        // whose DTO failed has no metadata to equip and is left out.
+        private async UniTask FetchMissingDtosIntoResultAsync(List<URN> missingUrns, BodyShape bodyShape, List<IWearable> result, CancellationToken ct)
+        {
+            // The background fetch and the settle-predicate can both run after this scope returns,
+            // once ExecuteAsync has returned missingUrns to the pool (where it may be cleared or
+            // reused). They read an owned snapshot so they never touch the released pooled list.
+            URN[] snapshot = missingUrns.ToArray();
+
+            UniTask fullFetch = FullFetchAsync();
+
+            // fullFetch is the termination backstop: AllMissingDtosSettled can stay false forever for
+            // a pointer that never starts loading, but the full fetch always completes and ends the wait.
+            await UniTask.WhenAny(fullFetch, UniTask.WaitUntil(AllMissingDtosSettled, cancellationToken: ct));
+
+            foreach (URN urn in snapshot)
+                if (TryGetStored(urn, out IWearable w) && w.DTO != null)
+                    result.Add(w);
+
+            return;
+
+            async UniTask FullFetchAsync()
+            {
+                try { await wearablesProvider.GetByPointersAsync(snapshot, bodyShape, ct); }
+                catch (OperationCanceledException) { }
+                catch (Exception e) { ReportHub.LogException(e, ReportCategory.OUTFITS); }
+            }
+
+            bool AllMissingDtosSettled()
+            {
+                foreach (URN urn in snapshot)
+                {
+                    if (!TryGetStored(urn, out IWearable w))
+                        return false;
+
+                    if (w.DTO == null && w.Model.Exception == null)
+                        return false;
+                }
+
+                return true;
+            }
+        }
+
+        // The resolution pipeline keys the storage by shortened URN, so an unshortened pointer
+        // must fall back to its shortened form.
+        private bool TryGetStored(URN urn, out IWearable wearable) =>
+            wearableStorage.TryGetElement(urn, out wearable)
+            || wearableStorage.TryGetElement(urn.Shorten(), out wearable);
+
         private void TryAdd(URN urn, List<IWearable> result, List<URN> missingUrns)
         {
             if (string.IsNullOrEmpty(urn)) return;
 
-            if (wearableStorage.TryGetElement(urn, out IWearable w))
+            // Only resolved storage hits (DTO != null) go straight into the result; anything else is
+            // routed through the provider.
+            if (wearableStorage.TryGetElement(urn, out IWearable w) && w.DTO != null)
                 result.Add(w);
             else
                 missingUrns.Add(urn);

--- a/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackBusController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackBus/BackpackBusController.cs
@@ -122,7 +122,7 @@ namespace DCL.Backpack.BackpackBus
             backpackEventBus.SendFilter(command.Category, command.CategoryEnum, command.SearchText);
 
         private void HandleSelectWearableCommand(BackpackSelectWearableCommand command) =>
-            ElementProviderHelper.FetchElementByPointerAndExecuteAsync(command.Id, wearablesProvider, wearableStorage, equippedWearables, item => SelectWearable(item, command), fetchWearableCts.Token, wearableReportData).Forget();
+            ElementProviderHelper.FetchElementByPointerAndExecuteAsync(command.Id, wearablesProvider, wearableStorage, equippedWearables, item => SelectWearable(item, command), fetchWearableCts.Token, wearableReportData, () => command.EndAction?.Invoke()).Forget();
 
         private void SelectWearable(IWearable wearable, BackpackSelectWearableCommand command)
         {
@@ -131,7 +131,7 @@ namespace DCL.Backpack.BackpackBus
         }
 
         private void HandleEquipWearableCommand(BackpackEquipWearableCommand command) =>
-            ElementProviderHelper.FetchElementByPointerAndExecuteAsync(command.Id, wearablesProvider, wearableStorage, equippedWearables, item => EquipWearable(item, command), fetchWearableCts.Token, wearableReportData).Forget();
+            ElementProviderHelper.FetchElementByPointerAndExecuteAsync(command.Id, wearablesProvider, wearableStorage, equippedWearables, item => EquipWearable(item, command), fetchWearableCts.Token, wearableReportData, () => command.EndAction?.Invoke()).Forget();
 
         private void EquipWearable(IWearable wearable, BackpackEquipWearableCommand command)
         {
@@ -186,7 +186,7 @@ namespace DCL.Backpack.BackpackBus
         }
 
         private void HandleEmoteEquipCommand(BackpackEquipEmoteCommand command) =>
-            ElementProviderHelper.FetchElementByPointerAndExecuteAsync(command.Id, emotesProvider, emoteStorage, equippedWearables, emote => EquipEmote(emote, command), fetchEmoteCts.Token, emoteReportData).Forget();
+            ElementProviderHelper.FetchElementByPointerAndExecuteAsync(command.Id, emotesProvider, emoteStorage, equippedWearables, emote => EquipEmote(emote, command), fetchEmoteCts.Token, emoteReportData, () => command.EndAction?.Invoke()).Forget();
 
         private void EquipEmote(IEmote emote, BackpackEquipEmoteCommand command)
         {
@@ -233,7 +233,7 @@ namespace DCL.Backpack.BackpackBus
         }
 
         private void HandleSelectEmoteCommand(BackpackSelectEmoteCommand command) =>
-            ElementProviderHelper.FetchElementByPointerAndExecuteAsync(command.Id, emotesProvider, emoteStorage, equippedWearables, emote => SelectEmote(emote, command), fetchEmoteCts.Token, emoteReportData).Forget();
+            ElementProviderHelper.FetchElementByPointerAndExecuteAsync(command.Id, emotesProvider, emoteStorage, equippedWearables, emote => SelectEmote(emote, command), fetchEmoteCts.Token, emoteReportData, () => command.EndAction?.Invoke()).Forget();
 
         private void SelectEmote(IEmote emote, BackpackSelectEmoteCommand command)
         {

--- a/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
+++ b/Explorer/Assets/DCL/Backpack/BackpackGridController.cs
@@ -291,7 +291,7 @@ namespace DCL.Backpack
             SetLoadingSlot(slot, true);
             ElementProviderHelper.FetchElementByPointerAndExecuteAsync(itemId, wearablesProvider, wearableStorage, equippedWearables,
                                       wearable => TryEquippingItemAsync(wearable, itemId, slot, CancellationToken.None).Forget(),
-                                      CancellationToken.None, wearableReportData)
+                                      CancellationToken.None, wearableReportData, () => SetLoadingSlot(slot, false))
                                  .Forget();
         }
 

--- a/Explorer/Assets/DCL/Tests/Editor/CacheOutfitWearablesCommandShould.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/CacheOutfitWearablesCommandShould.cs
@@ -1,0 +1,200 @@
+using CommunicationData.URLHelpers;
+using Cysharp.Threading.Tasks;
+using DCL.AvatarRendering.Loading.Components;
+using DCL.AvatarRendering.Wearables;
+using DCL.AvatarRendering.Wearables.Components;
+using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Backpack.AvatarSection.Outfits.Commands;
+using ECS.StreamableLoading.Common.Components;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine.TestTools;
+
+namespace DCL.Tests.Editor
+{
+    [TestFixture]
+    public class CacheOutfitWearablesCommandShould
+    {
+        private const string RESOLVED_URN = "urn:decentraland:off-chain:base-avatars:aviatorstyle";
+        private const string UNRESOLVED_URN = "urn:decentraland:off-chain:base-avatars:baggy_pullover";
+
+        private IWearablesProvider wearablesProvider = null!;
+        private IWearableStorage wearableStorage = null!;
+        private CacheOutfitWearablesCommand command = null!;
+
+        private IWearable resolvedWearable = null!;
+        private IWearable unresolvedWearable = null!;
+        private IWearable bodyShapeWearable = null!;
+        private List<string> requestedPointers = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            wearablesProvider = Substitute.For<IWearablesProvider>();
+            wearableStorage = Substitute.For<IWearableStorage>();
+            command = new CacheOutfitWearablesCommand(wearablesProvider, wearableStorage);
+
+            resolvedWearable = new Wearable(new StreamableLoadingResult<WearableDTO>(new WearableDTO
+            {
+                metadata = new WearableDTO.WearableMetadataDto
+                {
+                    id = RESOLVED_URN,
+                    data = new WearableDTO.WearableMetadataDto.DataDto { category = "hat" },
+                },
+            }));
+
+            // The equipped body shape is always a resolved storage hit by the time an outfit equips.
+            bodyShapeWearable = new Wearable(new StreamableLoadingResult<WearableDTO>(new WearableDTO
+            {
+                metadata = new WearableDTO.WearableMetadataDto
+                {
+                    id = BodyShape.MALE,
+                    data = new WearableDTO.WearableMetadataDto.DataDto { category = "body_shape" },
+                },
+            }));
+
+            // A storage-cached placeholder whose DTO load failed or was cancelled: IsLoading == false, DTO == null.
+            unresolvedWearable = IWearable.NewEmpty();
+            unresolvedWearable.UpdateLoadingStatus(false);
+
+            wearableStorage.TryGetElement(Arg.Any<URN>(), out Arg.Any<IWearable>())
+                           .Returns(callInfo =>
+                            {
+                                string urn = callInfo.Arg<URN>().ToString();
+
+                                if (urn == RESOLVED_URN)
+                                {
+                                    callInfo[1] = resolvedWearable;
+                                    return true;
+                                }
+
+                                if (urn == BodyShape.MALE)
+                                {
+                                    callInfo[1] = bodyShapeWearable;
+                                    return true;
+                                }
+
+                                if (urn == UNRESOLVED_URN)
+                                {
+                                    callInfo[1] = unresolvedWearable;
+                                    return true;
+                                }
+
+                                callInfo[1] = null;
+                                return false;
+                            });
+
+            requestedPointers = new List<string>();
+
+            wearablesProvider.GetByPointersAsync(Arg.Any<IReadOnlyCollection<URN>>(), Arg.Any<BodyShape>(), Arg.Any<CancellationToken>(), Arg.Any<List<IWearable>?>())
+                             .Returns(callInfo =>
+                              {
+                                  foreach (URN pointer in callInfo.Arg<IReadOnlyCollection<URN>>())
+                                      requestedPointers.Add(pointer.ToString());
+
+                                  // The IWearablesProvider contract doesn't promise resolved-only results;
+                                  // simulate an unresolved placeholder coming back.
+                                  List<IWearable> results = callInfo.ArgAt<List<IWearable>?>(3) ?? new List<IWearable>();
+                                  results.Add(unresolvedWearable);
+                                  return UniTask.FromResult<IReadOnlyCollection<IWearable>?>(results);
+                              });
+        }
+
+        [Test]
+        public async Task KeepOutfitResultResolvedOnlyAndRefetchUnresolvedStorageHits()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            var result = new List<IWearable>();
+            var urns = new List<URN> { RESOLVED_URN, UNRESOLVED_URN };
+
+            await command.ExecuteAsync(urns, BodyShape.MALE, CancellationToken.None, result, useFullUrns: true);
+
+            Assert.Contains(resolvedWearable, result, "The resolved storage hit must stay in the outfit result");
+
+            for (var i = 0; i < result.Count; i++)
+                Assert.IsNotNull(result[i].DTO, $"Outfit result[{i}] holds an unresolved wearable (DTO == null)");
+
+            Assert.Contains(UNRESOLVED_URN, requestedPointers, "An unresolved storage hit must be re-requested through the provider");
+        }
+
+        [Test]
+        public async Task CompleteOnDtoSettleAndApplyRefetchedStorageHitWithoutAwaitingAssets()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            var assetFetchNeverCompletes = new UniTaskCompletionSource<IReadOnlyCollection<IWearable>?>();
+
+            wearablesProvider.GetByPointersAsync(Arg.Any<IReadOnlyCollection<URN>>(), Arg.Any<BodyShape>(), Arg.Any<CancellationToken>(), Arg.Any<List<IWearable>?>())
+                             .Returns(_ =>
+                              {
+                                  // The DTO batch lands (resolving the placeholder in storage) while the
+                                  // returned task keeps downloading assets and never completes.
+                                  unresolvedWearable.ApplyAndMarkAsLoaded(new WearableDTO
+                                  {
+                                      metadata = new WearableDTO.WearableMetadataDto
+                                      {
+                                          id = UNRESOLVED_URN,
+                                          data = new WearableDTO.WearableMetadataDto.DataDto { category = "upper_body" },
+                                      },
+                                  });
+
+                                  return assetFetchNeverCompletes.Task;
+                              });
+
+            var result = new List<IWearable>();
+            var urns = new List<URN> { RESOLVED_URN, UNRESOLVED_URN };
+
+            UniTask execute = command.ExecuteAsync(urns, BodyShape.MALE, CancellationToken.None, result, useFullUrns: true);
+            int winner = await UniTask.WhenAny(execute, PumpAsync());
+
+            Assert.AreEqual(0, winner, "Outfit DTO caching must complete once every missing DTO settles, without awaiting the provider's asset fetch");
+            Assert.Contains(resolvedWearable, result, "The resolved storage hit must stay in the outfit result");
+            Assert.Contains(unresolvedWearable, result, "A storage hit whose DTO resolves during the re-fetch must be applied to the outfit");
+
+            for (var i = 0; i < result.Count; i++)
+                Assert.IsNotNull(result[i].DTO, $"Outfit result[{i}] holds an unresolved wearable (DTO == null)");
+
+            assetFetchNeverCompletes.TrySetCanceled();
+        }
+
+        [Test]
+        public async Task DetachedFetchReceivesOwnedSnapshotNotThePooledList()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            IReadOnlyCollection<URN>? handedToFetch = null;
+
+            wearablesProvider.GetByPointersAsync(Arg.Any<IReadOnlyCollection<URN>>(), Arg.Any<BodyShape>(), Arg.Any<CancellationToken>(), Arg.Any<List<IWearable>?>())
+                             .Returns(callInfo =>
+                              {
+                                  handedToFetch = callInfo.Arg<IReadOnlyCollection<URN>>();
+                                  return UniTask.FromResult<IReadOnlyCollection<IWearable>?>(null);
+                              });
+
+            var result = new List<IWearable>();
+            var urns = new List<URN> { RESOLVED_URN, UNRESOLVED_URN };
+
+            await command.ExecuteAsync(urns, BodyShape.MALE, CancellationToken.None, result, useFullUrns: true);
+
+            // ExecuteAsync has returned, so its pooled missingUrns list is back in the pool and free to be
+            // cleared or reused by the next command. The detached fetch it launched must therefore read an
+            // owned snapshot (a URN[]), never the pooled List<URN>, so pool reuse cannot corrupt it.
+            Assert.IsNotNull(handedToFetch, "The provider fetch must have been launched for the missing pointer");
+            Assert.IsInstanceOf<URN[]>(handedToFetch, "The detached fetch must receive an owned snapshot, not the pooled List<URN>");
+
+            var handed = new List<URN>(handedToFetch);
+            Assert.AreEqual(1, handed.Count, "The snapshot must carry exactly the missing pointers");
+            Assert.AreEqual(UNRESOLVED_URN, handed[0].ToString(), "The snapshot must carry the unresolved pointer to the provider");
+        }
+
+        private static async UniTask PumpAsync()
+        {
+            for (var i = 0; i < 120; i++)
+                await UniTask.Yield();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Tests/Editor/CacheOutfitWearablesCommandShould.cs.meta
+++ b/Explorer/Assets/DCL/Tests/Editor/CacheOutfitWearablesCommandShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 364cb7d7dc024e8a8edf42cca7192088
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Problem

Equipping an emote from the backpack grid throws `NullReferenceException` inside
`IAvatarAttachment.GetUrn` (Sentry UNITY-EXPLORER-PP8, escalating; UNITY-EXPLORER-PEH is
the same class via the outfit-equip path). The equip half-applies (the event subscriber
chain aborts mid-invocation) and the grid slot's loading lock never releases.

## Root cause

`ElementProviderHelper.FetchElementByPointerAndExecuteAsync`'s storage-hit branch treats
"finished loading" as "resolved": when the DTO fetch failed or was cancelled, the
`WaitWhile` completes and the helper invokes the callback with a DTO-less placeholder
(`IEmote.NewEmpty()` left in storage by the loading pipeline), violating its own contract  - 
the fetch-miss branch logs and does NOT invoke. The grid tile renders fine from the
independent trimmed request, so users can always click equip on an emote whose full-DTO
fetch failed. PEH is the same class via `CacheOutfitWearablesCommand.TryAdd`, which adds
any stored wearable to the outfit result with no resolved-check. The class already bit
twice before (#6511's symptom patch itself would NRE on its error path).

## Fix (~20 LOC, 2 files)

- `ElementProviderHelper`: storage-hit branch invokes the callback only when
  `element.DTO != null` (honoring the declared nullability of `IAvatarAttachment.DTO`  - 
  not a defensive check), otherwise logs the existing fetch-miss error; the fetch-branch
  match loop skips null-DTO results (same latent NRE one line lower). The helper gains an
  optional `onFetchFailed` completion invoked on every non-success path (unresolved
  placeholder, no provider match, cancellation, exception), wired at all 5 call sites to
  `command.EndAction` / `SetLoadingSlot(slot, false)` so the grid's loading lock releases
  on failure instead of wedging the grid.
- `CacheOutfitWearablesCommand`: unresolved storage hits route into `missingUrns` (getting
  a re-fetch), and the equip event gates on **DTO settling only** - the full provider fetch
  (asset bundles included) is kicked off and left to finish in the background
  (`WhenAny(fullFetch, WaitUntil(all missing DTOs resolved-or-failed))`), then the
  now-resolved storage entries join the outfit result. Awaiting the full fetch instead
  stalled `SendEquipOutfit` behind asset downloads whenever a slot was a cancelled/failed
  placeholder (caught in-world by explorer-automation
  `BackpackOutfitsTests.TestEquipFirstSavedOutfit`: the outfit's revert of a manual hair
  change never landed within its 8s window), and pointers whose DTO fetch had failed were
  silently dropped (the resolve pipeline never re-fetches them). The outfit result stays
  resolved-only: a pointer whose DTO load genuinely failed has no metadata to equip and
  stays out. Equip therefore completes metadata-first (assets stream in on the detached
  fetch), and that background fetch reads an owned `URN[]` snapshot of the missing pointers
  rather than the pooled `missingUrns` list - so it can never read a released/reused pooled
  list once `ExecuteAsync` returns.

Visible change: broken emotes can no longer be equipped into the profile - previously a
failed-DTO emote could persist an unresolvable URN into the published profile before the
crash.

## Test

New EditMode `ElementProviderHelperShould` (6 tests: failed-DTO and cancelled-load
placeholders never reach the callback and signal failure exactly once, resolved elements
are delivered exactly once with no failure signal, unresolved provider results are skipped
for the resolved match, no-match and provider-throw paths signal failure) and
`CacheOutfitWearablesCommandShould` (outfit result resolved-only + unresolved URN
re-requested; `CompleteOnDtoSettleAndApplyRefetchedStorageHitWithoutAwaitingAssets` - the
provider resolves the placeholder's DTO but its returned task never completes, and
`ExecuteAsync` must still complete with the refetched wearable applied).

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 4/5 as intended (callback invoked
with placeholders / resolved match never delivered / outfit result carried null-DTO
entries; the resolved-element control passed at pin) / GREEN PASS 5/5. Outfit DTO-gating
rework: RED on the pre-rework branch head (run aug16-regfix-red2: the new discriminator
fails - ExecuteAsync stalls behind the never-completing asset fetch) / GREEN with the fix
(run aug16-regfix-green4). In-world: explorer-automation
`BackpackOutfitsTests.TestEquipFirstSavedOutfit` (saved-outfit equip must revert a manual
hair change within 8s) is the end-to-end validation on the Windows rig.

Fixes #9741
Related: #6511 (prior wearable variant of the class, closed by a symptom patch this fix
mostly starves - a resolved DTO with malformed metadata can still reach its catch, so the
patch stays)