### PR TITLE
perf: pool the off-main-thread EventBus publish continuation

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Utility/EventBus/EventBus.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/EventBus/EventBus.cs
@@ -1,6 +1,8 @@
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using System;
 using System.Collections.Generic;
+using Utility.Multithreading;
 
 namespace Utility
 {
@@ -28,9 +30,7 @@ namespace Utility
                 var typedDelegate = (Action<T>)del;
 
                 if (invokeSubscribersOnMainThread && !PlayerLoopHelper.IsMainThread)
-
-                    // TODO find a way to prevent an allocation from capture
-                    PlayerLoopHelper.AddContinuation(PlayerLoopTiming.Update, () => typedDelegate?.Invoke(evt));
+                    PooledContinuation<T>.Schedule(typedDelegate, evt);
                 else
                     typedDelegate?.Invoke(evt);
             }
@@ -44,6 +44,56 @@ namespace Utility
                 handler
             );
             return new Unsubscriber<T>(this, handler);
+        }
+
+        /// <summary>
+        ///     Carries the delegate snapshot and event payload across the main-thread hop without a
+        ///     compiler-synthesized closure; entries are pooled so steady-state publishes allocate nothing.
+        ///     State is copied to locals and the entry recycled before the handlers run, so reentrant
+        ///     publishes are safe and class-typed payloads are not retained by the pool.
+        ///     The pool is a <see cref="DCLConcurrentQueue{T}" /> because Schedule takes entries
+        ///     from it on background threads while Run recycles them on the main thread.
+        /// </summary>
+        private sealed class PooledContinuation<T>
+        {
+            private static readonly DCLConcurrentQueue<PooledContinuation<T>> POOL = new ();
+
+            private readonly Action run;
+            private Action<T>? typedDelegate;
+            private T evt = default!;
+
+            private PooledContinuation()
+            {
+                run = Run;
+            }
+
+            public static void Schedule(Action<T> typedDelegate, T evt)
+            {
+                if (!POOL.TryDequeue(out PooledContinuation<T>? continuation))
+                    continuation = new PooledContinuation<T>();
+
+                continuation.typedDelegate = typedDelegate;
+                continuation.evt = evt;
+                PlayerLoopHelper.AddContinuation(PlayerLoopTiming.Update, continuation.run);
+            }
+
+            private void Run()
+            {
+                // Reachable only if the player loop ran the same continuation twice; recycling the
+                // entry on that path would double-enqueue it into the pool and corrupt it.
+                if (typedDelegate is not { } invokeTarget)
+                {
+                    ReportHub.LogError(ReportCategory.UNSPECIFIED, "EventBus pooled continuation ran without a stamped delegate: exactly-once scheduling was violated and an event was dropped");
+                    return;
+                }
+
+                T payload = evt;
+                typedDelegate = null;
+                evt = default!;
+                POOL.Enqueue(this);
+
+                invokeTarget.Invoke(payload);
+            }
         }
 
         private class Unsubscriber<T> : IDisposable

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/EventBusShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/EventBusShould.cs
@@ -1,0 +1,204 @@
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Threading;
+using UnityEngine.Profiling;
+using UnityEngine.TestTools;
+
+namespace Utility.Tests
+{
+    public class EventBusShould
+    {
+        private const int WARMUP_PUBLISHES = 20_000;
+        private const int MEASURED_PUBLISHES = 10_000;
+
+        // Rounds published while the main thread is parked (blocked, never yielding): each forces
+        // MEASURED_PUBLISHES continuations in flight simultaneously, priming the pooled-hop free
+        // list to >= the window size. Two rounds are needed because every physical buffer of
+        // UniTask's continuation queue must have grown past the window before measuring,
+        // regardless of how the editor pumped the initial burst.
+        private const int PARKED_ROUNDS = 2;
+
+        // The window counts GC.Alloc profiler samples on the publishing thread — allocation events,
+        // not bytes, because byte counters are unreliable on the Boehm editor runtime
+        // (GC.GetAllocatedBytesForCurrentThread is inert; GC.GetTotalMemory hides small-object
+        // churn behind lazy sweep). The unpooled hop emits 2 events per publish (closure + delegate,
+        // ~20k over the window); the pooled hop emits none — its worst case is ~10 regrowth events
+        // if an unrelated editor continuation forces a queue-buffer regrowth between the parked
+        // rounds; pool misses are impossible because the rounds prime the pool deterministically.
+        // The budget sits between the two, so the assertion discriminates under every editor-pump
+        // schedule.
+        private const int ALLOC_SAMPLE_BUDGET = 2_000;
+
+        // Must all register on the GC.Alloc recorder for the budget assertion to be meaningful.
+        private const int CANARY_ALLOCS = 64;
+
+        private static readonly TimeSpan PUMP_TIMEOUT = TimeSpan.FromSeconds(60);
+
+        private int invoked;
+
+        [UnityTest]
+        public IEnumerator NotAllocatePerOffMainThreadPublish()
+        {
+            //Arrange — a main-thread-invoking bus with one subscriber; publishing from a dedicated
+            // thread guarantees every Publish takes the thread-hop (AddContinuation) branch.
+            invoked = 0;
+            var bus = new EventBus(invokeSubscribersOnMainThread: true);
+            using IDisposable subscription = bus.Subscribe<TestEvent>(_ => Interlocked.Increment(ref invoked));
+
+            var measuredAllocSamples = -1;
+            Exception? threadError = null;
+            var warmupPublished = new ManualResetEventSlim(false);
+            var warmupDrained = new ManualResetEventSlim(false);
+            var roundPublished = new ManualResetEventSlim[PARKED_ROUNDS];
+            var roundDrained = new ManualResetEventSlim[PARKED_ROUNDS];
+
+            for (var i = 0; i < PARKED_ROUNDS; i++)
+            {
+                roundPublished[i] = new ManualResetEventSlim(false);
+                roundDrained[i] = new ManualResetEventSlim(false);
+            }
+
+            var publisher = new Thread(() =>
+            {
+                try
+                {
+                    // Warm-up burst: JITs the publish path; the editor may drain it on any schedule.
+                    for (var i = 0; i < WARMUP_PUBLISHES; i++)
+                        bus.Publish(new TestEvent { Value = i });
+
+                    warmupPublished.Set();
+
+                    if (!warmupDrained.Wait(PUMP_TIMEOUT))
+                        throw new TimeoutException("main thread never drained the warm-up publishes");
+
+                    // Parked rounds: the main thread is blocked (no drains can run), so the whole
+                    // round is in flight at once when it finishes.
+                    for (var round = 0; round < PARKED_ROUNDS; round++)
+                    {
+                        for (var i = 0; i < MEASURED_PUBLISHES; i++)
+                            bus.Publish(new TestEvent { Value = i });
+
+                        roundPublished[round].Set();
+
+                        if (!roundDrained[round].Wait(PUMP_TIMEOUT))
+                            throw new TimeoutException($"main thread never drained parked round {round}");
+                    }
+
+                    // Same recorder pattern as UnityEngine.TestTools' AllocatingGCMemory
+                    // constraint, run on the publishing thread: FilterToCurrentThread binds it to
+                    // this thread and the enabled toggle resets the sample count. The whole window
+                    // sits inside one editor frame because the main thread is parked in Join.
+                    Recorder gcAllocRecorder = Recorder.Get("GC.Alloc");
+                    gcAllocRecorder.FilterToCurrentThread();
+                    gcAllocRecorder.enabled = false;
+                    gcAllocRecorder.enabled = true;
+
+                    // Canary allocations: the budget assertion would be vacuous on a recorder that
+                    // does not register events from this thread.
+                    object? canarySink = null;
+
+                    for (var i = 0; i < CANARY_ALLOCS; i++)
+                        canarySink = new object();
+
+                    for (var i = 0; i < MEASURED_PUBLISHES; i++)
+                        bus.Publish(new TestEvent { Value = i });
+
+                    gcAllocRecorder.enabled = false;
+                    measuredAllocSamples = gcAllocRecorder.sampleBlockCount;
+                    GC.KeepAlive(canarySink);
+                }
+                catch (Exception e) { threadError = e; }
+            });
+
+            try
+            {
+                publisher.Start();
+
+                // Pump the editor loop until the warm-up continuations have all run on the main thread.
+                DateTime deadline = DateTime.UtcNow + PUMP_TIMEOUT;
+
+                while ((!warmupPublished.IsSet || Volatile.Read(ref invoked) < WARMUP_PUBLISHES) && DateTime.UtcNow < deadline)
+                    yield return null;
+
+                Assert.IsNull(threadError, threadError?.ToString());
+
+                Assert.AreEqual(WARMUP_PUBLISHES, Volatile.Read(ref invoked),
+                    "editor loop did not pump the queued main-thread continuations — environment failure, not the allocation regression under test");
+
+                warmupDrained.Set();
+
+                for (var round = 0; round < PARKED_ROUNDS; round++)
+                {
+                    // A blocking Wait (no yield) is what parks the editor loop while the round publishes.
+                    bool roundReady = roundPublished[round].Wait(PUMP_TIMEOUT);
+                    Assert.IsNull(threadError, threadError?.ToString());
+                    Assert.IsTrue(roundReady, $"publisher thread never finished parked round {round}");
+
+                    int expected = WARMUP_PUBLISHES + ((round + 1) * MEASURED_PUBLISHES);
+                    deadline = DateTime.UtcNow + PUMP_TIMEOUT;
+
+                    while (Volatile.Read(ref invoked) < expected && DateTime.UtcNow < deadline)
+                        yield return null;
+
+                    Assert.AreEqual(expected, Volatile.Read(ref invoked),
+                        $"editor loop did not drain parked round {round} — environment failure, not the allocation regression under test");
+
+                    roundDrained[round].Set();
+                }
+
+                //Act — the recorder is bound to the publishing thread and needs no pumping; the bounded
+                // Join parks the main thread so no drain, recycle, or buffer swap can land inside the window.
+                Assert.IsTrue(publisher.Join(PUMP_TIMEOUT), "publisher thread did not finish");
+                Assert.IsNull(threadError, threadError?.ToString());
+
+                //Assert
+                Assert.GreaterOrEqual(measuredAllocSamples, CANARY_ALLOCS,
+                    "GC.Alloc recorder registered fewer events than the canary allocated — environment failure, not the allocation regression under test");
+
+                Assert.Less(measuredAllocSamples, ALLOC_SAMPLE_BUDGET,
+                    $"off-main-thread Publish emitted {measuredAllocSamples} GC.Alloc events over {MEASURED_PUBLISHES} publishes");
+
+                // Drain the measured publishes: exactly-once delivery — nothing lost or duplicated by the hop.
+                const int TOTAL_PUBLISHES = WARMUP_PUBLISHES + ((PARKED_ROUNDS + 1) * MEASURED_PUBLISHES);
+                deadline = DateTime.UtcNow + PUMP_TIMEOUT;
+
+                while (Volatile.Read(ref invoked) < TOTAL_PUBLISHES && DateTime.UtcNow < deadline)
+                    yield return null;
+
+                Assert.AreEqual(TOTAL_PUBLISHES, Volatile.Read(ref invoked));
+            }
+            finally
+            {
+                // Set before Join before Dispose: setting every event releases the publisher from any
+                // Wait it is parked in on an early (assert-failure) exit, and an event may only be
+                // disposed once no other thread can still touch it.
+                warmupPublished.Set();
+                warmupDrained.Set();
+
+                for (var i = 0; i < PARKED_ROUNDS; i++)
+                {
+                    roundPublished[i].Set();
+                    roundDrained[i].Set();
+                }
+
+                if (publisher.IsAlive)
+                    publisher.Join(PUMP_TIMEOUT);
+
+                warmupPublished.Dispose();
+                warmupDrained.Dispose();
+
+                for (var i = 0; i < PARKED_ROUNDS; i++)
+                {
+                    roundPublished[i].Dispose();
+                    roundDrained[i].Dispose();
+                }
+            }
+        }
+
+        private struct TestEvent
+        {
+            public int Value;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/EventBusShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/EventBusShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 25a839409bf3425085142cc70873da27


### PR DESCRIPTION
## Problem

Every `EventBus.Publish<T>` performed off the main thread on a bus constructed with
`invokeSubscribersOnMainThread: true` allocates a closure display class plus an `Action`
delegate - 2 GC allocations per publish - to hop the invocation onto the main thread.
The off-thread publishers are the LiveKit participant-status / connection-state /
block-list callbacks (per-participant-churn frequency in crowded realms; incoming chat
messages already hop via MessagePipe and are not affected). Tracked by the in-code TODO
and tech-debt issue #9182.

## Root cause

The main-thread hop must carry two pieces of state (`typedDelegate`, `evt`) through
`PlayerLoopHelper.AddContinuation(PlayerLoopTiming, Action)`, which accepts only a
stateless `Action` - so the compiler synthesizes a fresh display class + delegate per
publish and nothing recycles them.

## Fix (~45 LOC, single file)

Nested `PooledContinuation<T>` in `EventBus`: a `DCLConcurrentQueue` pool (the repo's WebGL-safe wrapper) of state-carrying
continuations, each with a cached `Action run` delegate. `Schedule(del, evt)` rents (or
creates), stamps the state, and enqueues the cached delegate; `Run()` copies state to
locals, clears the fields (no lifetime extension for class-typed payloads), recycles the
entry, then invokes. Steady state: zero allocations per publish. Semantics preserved
exactly - snapshot-at-publish delegate list, FIFO ordering through UniTask's continuation
queue, by-value struct copy, re-entrancy safe. All four
`invokeSubscribersOnMainThread: true` owners (chat, shared-area chat, communities browser,
emotes) benefit with zero caller changes.

## Test

`EventBusShould.NotAllocatePerOffMainThreadPublish` (EditMode): a background thread
publishes through warm-up, two structurally-parked rounds that deterministically prime the
pool and grow both UniTask continuation-queue buffers, then a measured 10k-publish window
under a thread-filtered GC.Alloc profiler recorder with a 64-alloc liveness canary; asserts
the sample count stays an order of magnitude below the unpooled rate, then drains and
asserts 50 000 exactly-once deliveries. (Byte-based counters proved unusable on the editor
Mono runtime - inert thread counter, lazy-sweep masking - hence the recorder design.)

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL as intended ("off-main-thread
Publish emitted 20064 GC.Alloc events over 10000 publishes; Expected: less than 2000"  - 
exactly 2 allocs per publish + the canary) / GREEN PASS with the fix, canary live and
exactly-once drain verified.

Fixes #9182

Includes inspection-warning cleanup in all touched files.

Fixes #9182