### PR TITLE
fix: keep checked-out GLTF clones alive when AssetPreLoadCache clears

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
@@ -6,19 +6,21 @@ using ECS.Unity.GLTFContainer.Asset.Cache;
 using ECS.Unity.GLTFContainer.Asset.Components;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ECS.Unity.AssetLoad.Cache
 {
     public class AssetPreLoadCache : IDisposable
     {
         /// <summary>
-        ///     The never-handed-out template plus its live clones, so every copy can be released on teardown.
+        ///     The never-handed-out template. Clones handed out by <see cref="TryGetGltfInstance" /> are owned
+        ///     by the containers that checked them out and are released through
+        ///     <see cref="IGltfContainerAssetsCache.Dereference" /> — this cache must never dispose them.
         /// </summary>
         private sealed class GltfTemplate
         {
             public readonly GltfContainerAsset Template;
             public readonly string Hash;
-            public readonly List<GltfContainerAsset> Copies = new ();
 
             public GltfTemplate(GltfContainerAsset template, string hash)
             {
@@ -47,21 +49,12 @@ namespace ECS.Unity.AssetLoad.Cache
             if (cache.TryGetValue(key, out object? value) && value is GltfTemplate gltfTemplate
                 && Utils.TryDuplicateGltfAssetFromTemplate(gltfTemplate.Template, gltfTemplate.Hash, out GltfContainerAsset? duplicate))
             {
-                gltfTemplate.Copies.Add(duplicate!);
                 instance = duplicate;
                 return true;
             }
 
             instance = null;
             return false;
-        }
-
-        public void ReleaseGltfInstance(string key, GltfContainerAsset instance)
-        {
-            if (cache.TryGetValue(key, out object? value) && value is GltfTemplate gltfTemplate)
-                gltfTemplate.Copies.Remove(instance);
-
-            instance.Dispose();
         }
 
         public bool TryAddVideo(string key, in VideoTemplateData data) =>
@@ -72,7 +65,7 @@ namespace ECS.Unity.AssetLoad.Cache
 
         public bool TryAdd<T>(string key, T asset)
         {
-            if (cache.TryAdd(key, asset))
+            if (asset is not null && cache.TryAdd(key, asset))
             {
                 switch (asset)
                 {
@@ -92,7 +85,7 @@ namespace ECS.Unity.AssetLoad.Cache
             return false;
         }
 
-        public bool TryGet<T>(string key, out T asset)
+        public bool TryGet<T>(string key, [MaybeNullWhen(false)] out T asset)
         {
             if (cache.TryGetValue(key, out object? value) && value is T typedValue)
             {
@@ -112,10 +105,10 @@ namespace ECS.Unity.AssetLoad.Cache
             foreach(var kvp in cache)
                 switch (kvp.Value)
                 {
+                    // Only the never-handed-out template is released. Checked-out clones are owned by
+                    // containers whose lifetime this cache does not control (it is global, Clear runs per
+                    // scene teardown) — disposing them here would destroy live Roots under their owners.
                     case GltfTemplate gltfTemplate:
-                        foreach (GltfContainerAsset copy in gltfTemplate.Copies)
-                            copy.Dispose();
-
                         gltfCache.Dereference(kvp.Key, gltfTemplate.Template, handleAssetLoad: false);
                         break;
                     case AudioClipData audioClipData:

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
@@ -6,7 +6,6 @@ using ECS.Unity.GLTFContainer.Asset.Cache;
 using ECS.Unity.GLTFContainer.Asset.Components;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace ECS.Unity.AssetLoad.Cache
 {
@@ -15,7 +14,7 @@ namespace ECS.Unity.AssetLoad.Cache
         /// <summary>
         ///     The never-handed-out template. Clones handed out by <see cref="TryGetGltfInstance" /> are owned
         ///     by the containers that checked them out and are released through
-        ///     <see cref="IGltfContainerAssetsCache.Dereference" /> — this cache must never dispose them.
+        ///     <see cref="IGltfContainerAssetsCache.Dereference" />; this cache must never dispose them.
         /// </summary>
         private sealed class GltfTemplate
         {
@@ -65,7 +64,7 @@ namespace ECS.Unity.AssetLoad.Cache
 
         public bool TryAdd<T>(string key, T asset)
         {
-            if (asset is not null && cache.TryAdd(key, asset))
+            if (cache.TryAdd(key, asset))
             {
                 switch (asset)
                 {
@@ -85,7 +84,7 @@ namespace ECS.Unity.AssetLoad.Cache
             return false;
         }
 
-        public bool TryGet<T>(string key, [MaybeNullWhen(false)] out T asset)
+        public bool TryGet<T>(string key, out T asset)
         {
             if (cache.TryGetValue(key, out object? value) && value is T typedValue)
             {
@@ -107,7 +106,7 @@ namespace ECS.Unity.AssetLoad.Cache
                 {
                     // Only the never-handed-out template is released. Checked-out clones are owned by
                     // containers whose lifetime this cache does not control (it is global, Clear runs per
-                    // scene teardown) — disposing them here would destroy live Roots under their owners.
+                    // scene teardown); disposing them here would destroy live Roots under their owners.
                     case GltfTemplate gltfTemplate:
                         gltfCache.Dereference(kvp.Key, gltfTemplate.Template, handleAssetLoad: false);
                         break;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c28c5417c3da41ba8cddc2ebced16c1f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoad.Tests.asmref
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoad.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoad.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoad.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 38a45e759c794d46bc0c77979966cdfa
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoadCacheShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoadCacheShould.cs
@@ -1,0 +1,67 @@
+using ECS.StreamableLoading.AssetBundles;
+using ECS.Unity.AssetLoad.Cache;
+using ECS.Unity.GLTFContainer;
+using ECS.Unity.GLTFContainer.Asset.Cache;
+using ECS.Unity.GLTFContainer.Asset.Components;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace ECS.Unity.AssetLoad.Tests
+{
+    [TestFixture]
+    public class AssetPreLoadCacheShould
+    {
+        private const string KEY = "preload-key";
+        private const string HASH = "preload-hash";
+
+        private IGltfContainerAssetsCache gltfCache = null!;
+        private AssetPreLoadCache cache = null!;
+        private GameObject sourceAsset = null!;
+        private AssetBundleData assetBundleData = null!;
+        private GltfContainerAsset template = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            gltfCache = Substitute.For<IGltfContainerAssetsCache>();
+            cache = new AssetPreLoadCache(gltfCache);
+
+            // The template is built the same way the loading pipeline does: from an AssetBundleData
+            // exposing a source GameObject under the asset hash
+            sourceAsset = new GameObject(HASH);
+            assetBundleData = new AssetBundleData(null!, new Object[] { sourceAsset }, typeof(GameObject), Array.Empty<AssetBundleData>());
+            assetBundleData.AcquireRef();
+
+            Assert.That(Utils.TryCreateGltfObject(assetBundleData, HASH, out template), Is.True);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            template.Dispose();
+            Object.DestroyImmediate(sourceAsset);
+        }
+
+        [Test]
+        public void KeepCheckedOutClonesAliveOnClear()
+        {
+            Assert.That(cache.TryAddGltf(KEY, HASH, template), Is.True);
+            Assert.That(cache.TryGetGltfInstance(KEY, out GltfContainerAsset? clone), Is.True);
+
+            cache.Clear();
+
+            // The clone is owned by the container that checked it out; clearing the cache must not
+            // destroy its Root under that owner
+            Assert.That(clone!.Root == null, Is.False, "checked-out clone's Root must survive Clear()");
+
+            // The template itself is released back to the assets cache
+            gltfCache.Received(1).Dereference(KEY, template, false, false);
+            Assert.That(cache.ContainsGltf(KEY), Is.False);
+
+            clone.Dispose();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoadCacheShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoadCacheShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8086f26b5b844d2f8b8b5287a54849d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
@@ -98,7 +98,8 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
 
             if (handleAssetLoad && assetLoadCache != null && assetLoadCache.ContainsGltf(key))
             {
-                assetLoadCache.ReleaseGltfInstance(key, asset);
+                // The template is still cached: destroy the released clone rather than pooling a duplicate
+                asset.Dispose();
                 return;
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
@@ -85,7 +85,7 @@ namespace ECS.Unity.GLTFContainer.Systems
 
                 // A stale result can still reference an asset whose Root was already destroyed (e.g. drained
                 // by cache Unload/Remove). The promise is consumed at this point, so the component must still
-                // reach a terminal state — leaving it Loading would re-enter this query and throw
+                // reach a terminal state; leaving it Loading would re-enter this query and throw
                 // "already consumed" on every subsequent frame.
                 if (result.Asset is not { } asset || asset.Root == null)
                 {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
@@ -2,6 +2,7 @@
 using Arch.System;
 using Arch.SystemGroups;
 using CRDT;
+using DCL.Diagnostics;
 using DCL.ECSComponents;
 using DCL.Interaction.Utility;
 using DCL.Optimization.PerformanceBudgeting;
@@ -82,26 +83,39 @@ namespace ECS.Unity.GLTFContainer.Systems
                     return;
                 }
 
-                ConfigureGltfContainerColliders.SetupColliders(ref component, result.Asset!);
-                ConfigureSceneMaterial.EnableSceneBoundsAndForceCulling(in result.Asset!, in sceneCircumscribedPlanes, sceneHeight);
+                // A stale result can still reference an asset whose Root was already destroyed (e.g. drained
+                // by cache Unload/Remove). The promise is consumed at this point, so the component must still
+                // reach a terminal state — leaving it Loading would re-enter this query and throw
+                // "already consumed" on every subsequent frame.
+                if (result.Asset is not { } asset || asset.Root == null)
+                {
+                    ReportHub.LogError(GetReportData(), $"GltfContainerAsset '{component.Name}' ({component.Hash}) resolved with a destroyed Root");
+                    component.State = LoadingState.FinishedWithError;
+                    component.RootGameObject = null;
+                    eventsBuffer.Add(entity, component);
+                    return;
+                }
+
+                ConfigureGltfContainerColliders.SetupColliders(ref component, asset);
+                ConfigureSceneMaterial.EnableSceneBoundsAndForceCulling(in asset, in sceneCircumscribedPlanes, sceneHeight);
 
                 entityCollidersSceneCache.Associate(in component, entity, sdkEntity);
 
                 // Store reference to the root GameObject
-                component.RootGameObject = result.Asset!.Root;
+                component.RootGameObject = asset.Root;
 
                 // Re-parent to the current transform
-                result.Asset!.Root.transform.SetParent(transformComponent.Transform);
-                result.Asset.Root.transform.ResetLocalTRS();
-                result.Asset.Root.SetActive(true);
+                asset.Root.transform.SetParent(transformComponent.Transform);
+                asset.Root.transform.ResetLocalTRS();
+                asset.Root.SetActive(true);
 
-                result.Asset.SetRenderersActive(true);
-                result.Asset.ToggleAnimationState(true);
+                asset.SetRenderersActive(true);
+                asset.ToggleAnimationState(true);
 
                 component.State = LoadingState.Finished;
                 eventsBuffer.Add(entity, component);
 
-                if (result.Asset!.Animations.Count > 0 && result.Asset!.Animators.Count == 0)
+                if (asset.Animations.Count > 0 && asset.Animators.Count == 0)
                     World.Add(entity, new LegacyGltfAnimation());
             }
         }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
@@ -36,8 +36,8 @@ namespace ECS.Unity.GLTFContainer.Tests
     {
         private readonly GltfContainerTestResources resources = new ();
 
-        private CreateGltfAssetFromAssetBundleSystem createGltfAssetFromAssetBundleSystem = null!;
-        private EntityEventBuffer<GltfContainerComponent> eventBuffer = null!;
+        private CreateGltfAssetFromAssetBundleSystem createGltfAssetFromAssetBundleSystem;
+        private EntityEventBuffer<GltfContainerComponent> eventBuffer;
 
         //Required since all tests invoke TearDown, but not all used resources; therefore it could trigger a negative ref count
         private bool usedResources;
@@ -101,7 +101,7 @@ namespace ECS.Unity.GLTFContainer.Tests
 
             LogAssert.ignoreFailingMessages = true;
 
-            system.Update(0);
+            system!.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
             Assert.That(component.State, Is.EqualTo(LoadingState.FinishedWithError));
@@ -126,7 +126,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             world.Add(component.Promise.Entity, new StreamableLoadingResult<GltfContainerAsset>(asset));
 
             // Without the destroyed-Root guard this throws EcsSystemException (NRE at Root.transform)
-            system.Update(0);
+            system!.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
             Assert.That(component.State, Is.EqualTo(LoadingState.FinishedWithError));
@@ -135,7 +135,7 @@ namespace ECS.Unity.GLTFContainer.Tests
 
             // The consumed promise reached a terminal state: the next frame must be a no-op,
             // not an "AssetPromise is already consumed" throw
-            Assert.DoesNotThrow(() => system.Update(0));
+            Assert.DoesNotThrow(() => system!.Update(0));
         }
 
         [Test]
@@ -184,7 +184,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.RENDERER_WITH_LEGACY_ANIM_HASH });
             AddTransformToEntity(e);
 
-            system.Update(0);
+            system!.Update(0);
 
             Assert.That(world.Get<GltfContainerComponent>(e).State, Is.EqualTo(LoadingState.Finished));
             Assert.That(asset.Renderers, Is.Not.Empty);
@@ -205,18 +205,13 @@ namespace ECS.Unity.GLTFContainer.Tests
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH, IsDirty = true });
             AddTransformToEntity(e);
 
-            system.Update(0);
+            system!.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
+            GltfContainerAsset promiseAsset = component.Promise.Result.Value.Asset;
 
-            if (component.Promise.Result is not { Asset: { DecodedVisibleSDKColliders: { } visibleColliders } })
-            {
-                Assert.Fail("Expected a resolved asset with decoded visible SDK colliders");
-                return;
-            }
-
-            Assert.That(visibleColliders.Count, Is.EqualTo(196));
-            Assert.That(visibleColliders.All(c => c.Collider?.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
+            Assert.That(promiseAsset.DecodedVisibleSDKColliders.Count, Is.EqualTo(196));
+            Assert.That(promiseAsset.DecodedVisibleSDKColliders.All(c => c.Collider.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
         }
 
         [Test]
@@ -234,19 +229,15 @@ namespace ECS.Unity.GLTFContainer.Tests
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH });
             AddTransformToEntity(e);
 
-            system.Update(0);
+            system!.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
 
-            if (component.Promise.Result is not { Asset: { } promiseAsset })
-            {
-                Assert.Fail("Expected a resolved asset");
-                return;
-            }
+            GltfContainerAsset promiseAsset = component.Promise.Result.Value.Asset;
 
             // 1 Collider
             Assert.That(promiseAsset.InvisibleColliders.All(c => c.IsActiveByEntity), Is.True);
-            Assert.That(promiseAsset.InvisibleColliders.All(c => c.Collider?.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
+            Assert.That(promiseAsset.InvisibleColliders.All(c => c.Collider.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
 
             // No visible colliders created
             Assert.That(promiseAsset.DecodedVisibleSDKColliders, Is.Null);

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
@@ -8,6 +8,7 @@ using DCL.Interaction.Utility;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.Abstract;
 using ECS.Prioritization.Components;
+using ECS.StreamableLoading;
 using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.Common;
 using ECS.StreamableLoading.Common.Components;
@@ -35,8 +36,8 @@ namespace ECS.Unity.GLTFContainer.Tests
     {
         private readonly GltfContainerTestResources resources = new ();
 
-        private CreateGltfAssetFromAssetBundleSystem createGltfAssetFromAssetBundleSystem;
-        private EntityEventBuffer<GltfContainerComponent> eventBuffer;
+        private CreateGltfAssetFromAssetBundleSystem createGltfAssetFromAssetBundleSystem = null!;
+        private EntityEventBuffer<GltfContainerComponent> eventBuffer = null!;
 
         //Required since all tests invoke TearDown, but not all used resources; therefore it could trigger a negative ref count
         private bool usedResources;
@@ -100,10 +101,41 @@ namespace ECS.Unity.GLTFContainer.Tests
 
             LogAssert.ignoreFailingMessages = true;
 
-            system!.Update(0);
+            system.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
             Assert.That(component.State, Is.EqualTo(LoadingState.FinishedWithError));
+        }
+
+        [Test]
+        public void FinalizeWithErrorWhenAssetRootDestroyed()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            // A successfully-resolved result can reference an asset whose Root was destroyed
+            // while it awaited consumption
+            var asset = GltfContainerAsset.Create(new GameObject("root"), Substitute.For<IStreamableRefCountData>());
+            UnityEngine.Object.DestroyImmediate(asset.Root);
+
+            var component = new GltfContainerComponent(ColliderLayer.ClPhysics, ColliderLayer.ClPointer,
+                AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(world, new GetGltfContainerAssetIntention(), PartitionComponent.TOP_PRIORITY));
+
+            component.State = LoadingState.Loading;
+
+            Entity e = world.Create(component, new CRDTEntity(100), new TransformComponent(), new PBGltfContainer());
+            world.Add(component.Promise.Entity, new StreamableLoadingResult<GltfContainerAsset>(asset));
+
+            // Without the destroyed-Root guard this throws EcsSystemException (NRE at Root.transform)
+            system.Update(0);
+
+            component = world.Get<GltfContainerComponent>(e);
+            Assert.That(component.State, Is.EqualTo(LoadingState.FinishedWithError));
+            Assert.That(component.RootGameObject, Is.Null);
+            Assert.That(eventBuffer.Relations, Contains.Item(new EntityRelation<GltfContainerComponent>(e, component)));
+
+            // The consumed promise reached a terminal state: the next frame must be a no-op,
+            // not an "AssetPromise is already consumed" throw
+            Assert.DoesNotThrow(() => system.Update(0));
         }
 
         [Test]
@@ -152,7 +184,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.RENDERER_WITH_LEGACY_ANIM_HASH });
             AddTransformToEntity(e);
 
-            system!.Update(0);
+            system.Update(0);
 
             Assert.That(world.Get<GltfContainerComponent>(e).State, Is.EqualTo(LoadingState.Finished));
             Assert.That(asset.Renderers, Is.Not.Empty);
@@ -173,13 +205,18 @@ namespace ECS.Unity.GLTFContainer.Tests
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH, IsDirty = true });
             AddTransformToEntity(e);
 
-            system!.Update(0);
+            system.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
-            GltfContainerAsset promiseAsset = component.Promise.Result.Value.Asset;
 
-            Assert.That(promiseAsset.DecodedVisibleSDKColliders.Count, Is.EqualTo(196));
-            Assert.That(promiseAsset.DecodedVisibleSDKColliders.All(c => c.Collider.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
+            if (component.Promise.Result is not { Asset: { DecodedVisibleSDKColliders: { } visibleColliders } })
+            {
+                Assert.Fail("Expected a resolved asset with decoded visible SDK colliders");
+                return;
+            }
+
+            Assert.That(visibleColliders.Count, Is.EqualTo(196));
+            Assert.That(visibleColliders.All(c => c.Collider?.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
         }
 
         [Test]
@@ -197,15 +234,19 @@ namespace ECS.Unity.GLTFContainer.Tests
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH });
             AddTransformToEntity(e);
 
-            system!.Update(0);
+            system.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
 
-            GltfContainerAsset promiseAsset = component.Promise.Result.Value.Asset;
+            if (component.Promise.Result is not { Asset: { } promiseAsset })
+            {
+                Assert.Fail("Expected a resolved asset");
+                return;
+            }
 
             // 1 Collider
             Assert.That(promiseAsset.InvisibleColliders.All(c => c.IsActiveByEntity), Is.True);
-            Assert.That(promiseAsset.InvisibleColliders.All(c => c.Collider.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
+            Assert.That(promiseAsset.InvisibleColliders.All(c => c.Collider?.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
 
             // No visible colliders created
             Assert.That(promiseAsset.DecodedVisibleSDKColliders, Is.Null);


### PR DESCRIPTION
## Problem

Two coupled Sentry issues in the same sessions: UNITY-EXPLORER-PHE  - 
`EcsSystemException [FinalizeGltfContainerLoadingSystem]` wrapping an NRE on a destroyed
Root GameObject while consuming a successfully-resolved promise - and UNITY-EXPLORER-P8N  - 
"`AssetPromise ... is already consumed`" thrown every subsequent frame once the NRE aborts
`FinalizeLoading` between `TryConsume` and `State = Finished` (~48 events / 17 users past
week combined; scene content also silently vanishes for already-finished containers).

## Root cause

Global-cache/per-scene-lifecycle mismatch → use-after-free. `AssetPreLoadCache` is a global
cache, but `CleanUpAssetPreLoadSystem` is registered per scene world: ANY scene teardown
calls `Clear()`, which disposed every live checked-out clone (`GltfTemplate.Copies`)  - 
destroying the Roots of clones other scenes had placed in-world or were still holding in
unconsumed promise results. The consume side then NREs on the dead Root (PHE), and the
abort leaves a consumed-promise/`Loading` component that throws "already consumed" forever
(P8N). Timeline fits: the clone-on-request mechanism landed in #9001 (2026-06-19); PHE
first appeared v0.158.

## Fix (~30 LOC, two files)

1. `AssetPreLoadCache.Clear()` no longer disposes checked-out clones - clones are owned by
   the containers that checked them out; once the template entry is removed, their normal
   release path routes them into the shared pool, where LRU `Unload` disposes them (no
   leak). The now-dead `Copies` tracking is removed.
2. `FinalizeGltfContainerLoadingSystem`: enforce "consumed ⇒ terminal state" - after a
   successful consume, a destroyed `Root` finishes the component with `FinishedWithError`
   (the exact contract failed loads already use, loudly logged) instead of throwing, so the
   known destroyed-Root NRE can no longer arm the P8N cascade (an exception thrown for a
   different reason between consume and the terminal state would still abort mid-block).

## Test

- `FinalizeGltfContainerLoadingSystemShould.FinalizeWithErrorWhenAssetRootDestroyed`  - 
  reproduces both Sentry issues deterministically at the pin (first update throws the NRE,
  second throws "already consumed").
- New `AssetPreLoadCacheShould.KeepCheckedOutClonesAliveOnClear` - a checked-out clone's
  Root must survive `Clear()`; template dereference still received.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 2/2 as intended (EcsSystemException
on the destroyed GameObject; clone Root destroyed by Clear) / GREEN PASS 2/2.

Fixes #9451
Fixes #9531
Related: #8866, #8291 (older auto-filed dupes of the same system exception), #9001
(context: the clone-on-request mechanism)

