### PR TITLE
fix: dereference emote assets after promise consumption so memory pressure can unload them

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/EmoteReferences.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/EmoteReferences.cs
@@ -1,8 +1,6 @@
 using DCL.AvatarRendering.Loading.Assets;
 using UnityEngine;
 
-// ReSharper disable InconsistentNaming
-
 namespace DCL.AvatarRendering.Emotes
 {
     public class EmoteReferences : MonoBehaviour
@@ -23,13 +21,13 @@ namespace DCL.AvatarRendering.Emotes
         /// </summary>
         public AttachmentRegularAsset? sourceAsset;
 
-        public void Initialize(AnimationClip? animationClip, AnimationClip? propAnimationClip, Animator? animator, Animation? animation, int propAnimationClipHash, bool legacy)
+        public void Initialize(AnimationClip? animationClip, AnimationClip? propClip, Animator? animatorComp, Animation? animationComp, int propClipHash, bool legacy)
         {
-            avatarClip = animationClip;
-            propClip = propAnimationClip;
-            animatorComp = animator;
-            animationComp = animation;
-            propClipHash = propAnimationClipHash;
+            this.avatarClip = animationClip;
+            this.propClip = propClip;
+            this.animatorComp = animatorComp;
+            this.animationComp = animationComp;
+            this.propClipHash = propClipHash;
             this.legacy = legacy;
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/EmoteReferences.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/EmoteReferences.cs
@@ -1,4 +1,7 @@
+using DCL.AvatarRendering.Loading.Assets;
 using UnityEngine;
+
+// ReSharper disable InconsistentNaming
 
 namespace DCL.AvatarRendering.Emotes
 {
@@ -13,13 +16,20 @@ namespace DCL.AvatarRendering.Emotes
 
         public AudioSource? audioSource;
 
-        public void Initialize(AnimationClip? animationClip, AnimationClip? propClip, Animator? animatorComp, Animation? animationComp, int propClipHash, bool legacy)
+        /// <summary>
+        ///     Pins the source attachment while this instance plays: the instance shares meshes, materials and
+        ///     clips with the source, and the storage disposes assets whose ReferenceCount reaches 0.
+        ///     Set on acquire, dereferenced and cleared on pool release.
+        /// </summary>
+        public AttachmentRegularAsset? sourceAsset;
+
+        public void Initialize(AnimationClip? animationClip, AnimationClip? propAnimationClip, Animator? animator, Animation? animation, int propAnimationClipHash, bool legacy)
         {
-            this.avatarClip = animationClip;
-            this.propClip = propClip;
-            this.animatorComp = animatorComp;
-            this.animationComp = animationComp;
-            this.propClipHash = propClipHash;
+            avatarClip = animationClip;
+            propClip = propAnimationClip;
+            animatorComp = animator;
+            animationComp = animation;
+            propClipHash = propAnimationClipHash;
             this.legacy = legacy;
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/FinalizeEmoteLoadingSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/FinalizeEmoteLoadingSystem.cs
@@ -21,6 +21,8 @@ using AudioPromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoa
 using EmotesFromRealmPromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesDTOList, DCL.AvatarRendering.Emotes.GetEmotesDTOByPointersFromRealmIntention>;
 using EmotePromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution, DCL.AvatarRendering.Emotes.GetEmotesByPointersIntention>;
 using GltfPromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.GLTF.GLTFData, ECS.StreamableLoading.GLTF.GetGLTFIntention>;
+using SceneEmoteFromRealmPromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution, DCL.AvatarRendering.Emotes.GetSceneEmoteFromRealmIntention>;
+using SceneEmoteFromLocalPromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution, DCL.AvatarRendering.Emotes.GetSceneEmoteFromLocalSceneIntention>;
 
 namespace DCL.AvatarRendering.Emotes
 {
@@ -39,6 +41,8 @@ namespace DCL.AvatarRendering.Emotes
             FinalizeGltfLoadingQuery(World);
             FinalizeAudioClipPromiseQuery(World);
             ConsumeAndDisposeFinishedEmotePromiseQuery(World);
+            ConsumeAndDisposeFinishedSceneEmoteFromRealmPromiseQuery(World);
+            ConsumeAndDisposeFinishedSceneEmoteFromLocalPromiseQuery(World);
         }
 
         [Query]
@@ -51,8 +55,8 @@ namespace DCL.AvatarRendering.Emotes
             {
                 if (!promiseResult.Succeeded)
                 {
-                    foreach (var pointerID in promise.LoadingIntention.Pointers)
-                        ReportAndFinalizeWithError(pointerID);
+                    foreach (var pointerId in promise.LoadingIntention.Pointers)
+                        ReportAndFinalizeWithError(pointerId);
                 }
                 else
                     using (var list = promiseResult.Asset.ConsumeAttachments())
@@ -83,7 +87,7 @@ namespace DCL.AvatarRendering.Emotes
                     AssignEmoteResult(emote, bodyShape, regularAssetResult);
                 else
                 {
-                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO.id} failed to load from the AB");
+                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO?.id} failed to load from the AB");
                     AssignFailedEmoteResult(emote, bodyShape);
                 }
 
@@ -108,7 +112,7 @@ namespace DCL.AvatarRendering.Emotes
                     AssignEmoteResult(emote, bodyShape, regularAssetResult);
                 else
                 {
-                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO.id} failed to load from the GLTF");
+                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO?.id} failed to load from the GLTF");
                     AssignFailedEmoteResult(emote, bodyShape);
                 }
 
@@ -134,7 +138,7 @@ namespace DCL.AvatarRendering.Emotes
         {
             var failedResult = new StreamableLoadingResult<AttachmentRegularAsset>(
                 GetReportData(),
-                new Exception($"Emote {emote.DTO.id} failed to load"));
+                new Exception($"Emote {emote.DTO?.id} failed to load"));
 
             if (emote.IsUnisex() && emote.HasSameClipForAllGenders())
             {
@@ -186,12 +190,58 @@ namespace DCL.AvatarRendering.Emotes
         [Query]
         private void ConsumeAndDisposeFinishedEmotePromise(in Entity entity, ref EmotePromise promise)
         {
-            // The result is added into the emote storage at FinalizeEmoteDTO already, no need to do anything else
+            // The loaded emotes stay owned by the emote storage (added at FinalizeEmoteDTO); the promise only
+            // has to return the reference LoadEmotesByPointersSystem added per successful pointer, so the
+            // storage can unload the assets once nothing plays them.
             if (!promise.SafeTryConsume(World, GetReportData(), out StreamableLoadingResult<EmotesResolution> result)) return;
+
+            foreach (URN urn in promise.LoadingIntention.SuccessfulPointers)
+            {
+                if (!storage.TryGetElement(urn, out IEmote emote)) continue;
+
+                emote.AssetResults[promise.LoadingIntention.BodyShape]?.Asset?.Dereference();
+            }
+
+            if (result.Succeeded)
+                result.Asset.ConsumeEmotes().Dispose();
 
             promise.LoadingIntention.Dispose();
 
             World.Destroy(entity);
+        }
+
+        [Query]
+        private void ConsumeAndDisposeFinishedSceneEmoteFromRealmPromise(in Entity entity, ref SceneEmoteFromRealmPromise promise)
+        {
+            if (!promise.SafeTryConsume(World, GetReportData(), out StreamableLoadingResult<EmotesResolution> result)) return;
+
+            DereferenceSceneEmote(promise.LoadingIntention.NewSceneEmoteURN(), promise.LoadingIntention.BodyShape, in result);
+
+            World.Destroy(entity);
+        }
+
+        [Query]
+        private void ConsumeAndDisposeFinishedSceneEmoteFromLocalPromise(in Entity entity, ref SceneEmoteFromLocalPromise promise)
+        {
+            if (!promise.SafeTryConsume(World, GetReportData(), out StreamableLoadingResult<EmotesResolution> result)) return;
+
+            DereferenceSceneEmote(promise.LoadingIntention.NewSceneEmoteURN(), promise.LoadingIntention.BodyShape, in result);
+
+            World.Destroy(entity);
+        }
+
+        /// <summary>
+        ///     Returns the reference LoadSceneEmotesSystem adds when it resolves an intention whose asset
+        ///     loaded successfully; the guard must mirror that condition exactly or the count goes negative.
+        /// </summary>
+        private void DereferenceSceneEmote(URN urn, BodyShape bodyShape, in StreamableLoadingResult<EmotesResolution> result)
+        {
+            if (!result.Succeeded) return;
+
+            if (storage.TryGetElement(urn, out IEmote emote) && emote.AssetResults[bodyShape] is { Succeeded: true } assetResult)
+                assetResult.Asset?.Dereference();
+
+            result.Asset.ConsumeEmotes().Dispose();
         }
 
         private static void ResetEmoteResultOnCancellation(IEmote emote, in BodyShape bodyShape)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/FinalizeEmoteLoadingSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/FinalizeEmoteLoadingSystem.cs
@@ -55,8 +55,8 @@ namespace DCL.AvatarRendering.Emotes
             {
                 if (!promiseResult.Succeeded)
                 {
-                    foreach (var pointerId in promise.LoadingIntention.Pointers)
-                        ReportAndFinalizeWithError(pointerId);
+                    foreach (var pointerID in promise.LoadingIntention.Pointers)
+                        ReportAndFinalizeWithError(pointerID);
                 }
                 else
                     using (var list = promiseResult.Asset.ConsumeAttachments())
@@ -87,7 +87,7 @@ namespace DCL.AvatarRendering.Emotes
                     AssignEmoteResult(emote, bodyShape, regularAssetResult);
                 else
                 {
-                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO?.id} failed to load from the AB");
+                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO.id} failed to load from the AB");
                     AssignFailedEmoteResult(emote, bodyShape);
                 }
 
@@ -112,7 +112,7 @@ namespace DCL.AvatarRendering.Emotes
                     AssignEmoteResult(emote, bodyShape, regularAssetResult);
                 else
                 {
-                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO?.id} failed to load from the GLTF");
+                    ReportHub.LogWarning(GetReportData(), $"The emote {emote.DTO.id} failed to load from the GLTF");
                     AssignFailedEmoteResult(emote, bodyShape);
                 }
 
@@ -138,7 +138,7 @@ namespace DCL.AvatarRendering.Emotes
         {
             var failedResult = new StreamableLoadingResult<AttachmentRegularAsset>(
                 GetReportData(),
-                new Exception($"Emote {emote.DTO?.id} failed to load"));
+                new Exception($"Emote {emote.DTO.id} failed to load"));
 
             if (emote.IsUnisex() && emote.HasSameClipForAllGenders())
             {

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -460,7 +460,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             in CharacterAnimationComponent animation,
             in StunComponent stun,
             in MovementInputComponent input,
-            in HeadIKComponent headIk,
+            in HeadIKComponent headIK,
             in HandPointAtComponent pointAt)
         {
             var playerState = new NetworkMovementMessage
@@ -476,9 +476,9 @@ namespace DCL.AvatarRendering.Emotes.Play
                 isSliding = animation.States.IsSliding,
                 isPointingAt = pointAt.IsPointing,
                 pointAtWorldHitPoint = pointAt.WorldHitPoint,
-                headIKYawEnabled = headIk.YawEnabled,
-                headIKPitchEnabled = headIk.PitchEnabled,
-                headYawAndPitch = headIk.GetHeadYawAndPitch(),
+                headIKYawEnabled = headIK.YawEnabled,
+                headIKPitchEnabled = headIK.PitchEnabled,
+                headYawAndPitch = headIK.GetHeadYawAndPitch(),
                 movementKind = input.Kind,
                 animState = new AnimationStates
                 {
@@ -538,7 +538,7 @@ namespace DCL.AvatarRendering.Emotes.Play
         private void CleanUp(Profile profile, in DeleteEntityIntention deleteEntityIntention)
         {
             if (!deleteEntityIntention.DeferDeletion)
-                messageBus.OnPlayerRemoved(profile.UserId.Value);
+                messageBus.OnPlayerRemoved(profile.UserId);
         }
 
         // Each promise is wrapped into its own entity so FinalizeEmoteLoadingSystem consumes the

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -341,9 +341,8 @@ namespace DCL.AvatarRendering.Emotes.Play
                         return;
 
                     StreamableLoadingResult<AttachmentRegularAsset> streamableAssetValue = assetResult.Value;
-                    GameObject? mainAsset;
 
-                    if (streamableAssetValue is { Succeeded: false } || (mainAsset = streamableAssetValue.Asset?.MainAsset) == null)
+                    if (streamableAssetValue is { Succeeded: false } || streamableAssetValue.Asset is not { } sourceAsset || sourceAsset.MainAsset == null)
                     {
                         // We can't play emote, remove intent, otherwise there is no place to remove it
                         World.Remove<CharacterEmoteIntent>(entity);
@@ -382,7 +381,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                         emoteComponent.EmoteUrn = emoteId;
                         emoteComponent.Mask = mask;
 
-                        if (!emotePlayer.Play(mainAsset, audioClip, isLooping, spatial, in view, ref emoteComponent))
+                        if (!emotePlayer.Play(sourceAsset, audioClip, isLooping, spatial, in view, ref emoteComponent))
                             ReportHub.LogError(ReportCategory.EMOTE, $"Emote name:{emoteId} cant be played.");
                         else
                         {
@@ -421,7 +420,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                         masked.EmoteUrn = emoteId;
                         masked.Mask = mask;
 
-                        if (!emotePlayer.PlayMasked(mainAsset, audioClip, isLooping, spatial, in view, ref masked))
+                        if (!emotePlayer.PlayMasked(sourceAsset, audioClip, isLooping, spatial, in view, ref masked))
                             ReportHub.LogError(ReportCategory.EMOTE, $"Emote name:{emoteId} cant be played.");
                         else
                         {
@@ -461,7 +460,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             in CharacterAnimationComponent animation,
             in StunComponent stun,
             in MovementInputComponent input,
-            in HeadIKComponent headIK,
+            in HeadIKComponent headIk,
             in HandPointAtComponent pointAt)
         {
             var playerState = new NetworkMovementMessage
@@ -477,9 +476,9 @@ namespace DCL.AvatarRendering.Emotes.Play
                 isSliding = animation.States.IsSliding,
                 isPointingAt = pointAt.IsPointing,
                 pointAtWorldHitPoint = pointAt.WorldHitPoint,
-                headIKYawEnabled = headIK.YawEnabled,
-                headIKPitchEnabled = headIK.PitchEnabled,
-                headYawAndPitch = headIK.GetHeadYawAndPitch(),
+                headIKYawEnabled = headIk.YawEnabled,
+                headIKPitchEnabled = headIk.PitchEnabled,
+                headYawAndPitch = headIk.GetHeadYawAndPitch(),
                 movementKind = input.Kind,
                 animState = new AnimationStates
                 {
@@ -539,9 +538,12 @@ namespace DCL.AvatarRendering.Emotes.Play
         private void CleanUp(Profile profile, in DeleteEntityIntention deleteEntityIntention)
         {
             if (!deleteEntityIntention.DeferDeletion)
-                messageBus.OnPlayerRemoved(profile.UserId);
+                messageBus.OnPlayerRemoved(profile.UserId.Value);
         }
 
+        // Each promise is wrapped into its own entity so FinalizeEmoteLoadingSystem consumes the
+        // resolution and returns the loading-time asset reference; the emote itself is played from
+        // the storage once loaded.
         private void CreateEmotePromise(URN urn, BodyShape bodyShape, AvatarEmoteMask mask)
         {
             loadEmoteBuffer[0] = urn;
@@ -554,9 +556,9 @@ namespace DCL.AvatarRendering.Emotes.Play
                 // Local scene preview path, this is needed if a remote client plays a scene emote this client has not yet played
                 if (localSceneDevelopment && TryResolveLocalSceneEmotePath(scene, emoteHash, out string emotePath))
                 {
-                    SceneEmoteFromLocalPromise.Create(World,
+                    World.Create(SceneEmoteFromLocalPromise.Create(World,
                         new GetSceneEmoteFromLocalSceneIntention(scene.SceneData, emotePath, emoteHash, bodyShape, loop, mask),
-                        PartitionComponent.TOP_PRIORITY);
+                        PartitionComponent.TOP_PRIORITY));
 
                     return;
                 }
@@ -565,14 +567,14 @@ namespace DCL.AvatarRendering.Emotes.Play
                 if (scene.SceneData.SceneEntityDefinition.assetBundleManifestVersion == null)
                     return;
 
-                SceneEmoteFromRealmPromise.Create(World,
+                World.Create(SceneEmoteFromRealmPromise.Create(World,
                     new GetSceneEmoteFromRealmIntention(sceneId, scene.SceneData.SceneEntityDefinition.assetBundleManifestVersion!, emoteHash, loop, bodyShape),
-                    PartitionComponent.TOP_PRIORITY);
+                    PartitionComponent.TOP_PRIORITY));
             }
             else
-                EmotePromise.Create(World,
+                World.Create(EmotePromise.Create(World,
                     EmoteComponentsUtils.CreateGetEmotesByPointersIntention(bodyShape, loadEmoteBuffer),
-                    PartitionComponent.TOP_PRIORITY);
+                    PartitionComponent.TOP_PRIORITY));
         }
 
         private bool TryParseSceneEmoteURN(URN urnToParse, out string sceneId, out string parsedEmoteHash, out bool parsedLoop, out ISceneFacade? resolvedScene, out bool isPortableExperience)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
@@ -274,7 +274,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             if (!emoteReferences) return null;
 
             Transform avatarTransform = view.GetTransform();
-            Transform emoteTransform = emoteReferences.transform;
+            Transform emoteTransform = emoteReferences!.transform;
             emoteTransform.SetParent(avatarTransform, false);
             emoteTransform.localPosition = Vector3.zero;
             emoteTransform.localRotation = Quaternion.identity;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/EmotePlayer.cs
@@ -1,4 +1,5 @@
 using DCL.AvatarRendering.AvatarShape.UnityInterface;
+using DCL.AvatarRendering.Loading.Assets;
 using DCL.Diagnostics;
 using DCL.ECSComponents;
 using DCL.Optimization.Pools;
@@ -8,6 +9,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Pool;
+using Utility;
 using Utility.Animations;
 using Object = UnityEngine.Object;
 
@@ -42,12 +44,16 @@ namespace DCL.AvatarRendering.Emotes.Play
                     audioSourcePool.Release(references.audioSource);
 
                 references.audioSource = null;
+
+                references.sourceAsset?.Dereference();
+                references.sourceAsset = null;
             };
         }
 
-        public bool Play(GameObject mainAsset, AudioClip? audioAsset, bool isLooping, bool isSpatial, in IAvatarView view,
+        public bool Play(AttachmentRegularAsset sourceAsset, AudioClip? audioAsset, bool isLooping, bool isSpatial, in IAvatarView view,
             ref CharacterEmoteComponent emoteComponent)
         {
+            GameObject mainAsset = sourceAsset.MainAsset;
             EmoteReferences? emoteInUse = emoteComponent.CurrentEmoteReference;
 
             if (IsSameLoopingEmote(emoteInUse, mainAsset, emoteComponent.EmoteLoop, isLooping))
@@ -55,6 +61,8 @@ namespace DCL.AvatarRendering.Emotes.Play
 
             EmoteReferences? emoteReferences = AcquireEmoteReferences(mainAsset, audioAsset, isLooping, isSpatial, in view, emoteInUse);
             if (emoteReferences == null) return false;
+
+            PinSourceAsset(emoteReferences, sourceAsset);
 
             emotesInUse.Add(emoteReferences, pools[mainAsset]);
 
@@ -75,9 +83,10 @@ namespace DCL.AvatarRendering.Emotes.Play
             return true;
         }
 
-        public bool PlayMasked(GameObject mainAsset, AudioClip? audioAsset, bool isLooping, bool isSpatial, in IAvatarView view,
+        public bool PlayMasked(AttachmentRegularAsset sourceAsset, AudioClip? audioAsset, bool isLooping, bool isSpatial, in IAvatarView view,
             ref CharacterMaskedEmoteComponent maskedEmote)
         {
+            GameObject mainAsset = sourceAsset.MainAsset;
             EmoteReferences? emoteInUse = maskedEmote.CurrentEmoteReference;
 
             if (IsSameLoopingEmote(emoteInUse, mainAsset, maskedEmote.EmoteLoop, isLooping))
@@ -85,6 +94,8 @@ namespace DCL.AvatarRendering.Emotes.Play
 
             EmoteReferences? emoteReferences = AcquireEmoteReferences(mainAsset, audioAsset, isLooping, isSpatial, in view, emoteInUse);
             if (emoteReferences == null) return false;
+
+            PinSourceAsset(emoteReferences, sourceAsset);
 
             emotesInUse.Add(emoteReferences, pools[mainAsset]);
 
@@ -203,6 +214,40 @@ namespace DCL.AvatarRendering.Emotes.Play
             currentlyLooping &&
             isLooping;
 
+        /// <summary>
+        ///     While an acquired instance exists its source asset must stay referenced, so the storage
+        ///     cannot dispose the shared meshes/materials/clips mid-play. Balanced by the pool's release callback.
+        /// </summary>
+        private static void PinSourceAsset(EmoteReferences references, AttachmentRegularAsset sourceAsset)
+        {
+            sourceAsset.AddReference();
+            references.sourceAsset = sourceAsset;
+        }
+
+        /// <summary>
+        ///     Drops pools keyed by a destroyed source asset, destroying their pooled instances.
+        ///     A destroyed key implies no live instance of that pool exists: every live instance pins
+        ///     its source asset, which keeps the key alive.
+        /// </summary>
+        private void PruneDestroyedPools()
+        {
+            List<GameObject> deadKeys = ListPool<GameObject>.Get();
+
+            foreach (KeyValuePair<GameObject, GameObjectPool<EmoteReferences>> entry in pools)
+                if (!entry.Key)
+                    deadKeys.Add(entry.Key);
+
+            foreach (GameObject deadKey in deadKeys)
+            {
+                GameObjectPool<EmoteReferences> pool = pools[deadKey];
+                pool.Clear();
+                UnityObjectUtils.SafeDestroy(pool.ParentContainer.gameObject);
+                pools.Remove(deadKey);
+            }
+
+            ListPool<GameObject>.Release(deadKeys);
+        }
+
         private EmoteReferences? AcquireEmoteReferences(GameObject mainAsset,
             AudioClip? audioAsset,
             bool isLooping,
@@ -214,6 +259,8 @@ namespace DCL.AvatarRendering.Emotes.Play
                 Stop(emoteInUse);
 
             view.StopLegacyAnimation();
+
+            PruneDestroyedPools();
 
             if (!pools.ContainsKey(mainAsset))
             {
@@ -227,7 +274,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             if (!emoteReferences) return null;
 
             Transform avatarTransform = view.GetTransform();
-            Transform emoteTransform = emoteReferences!.transform;
+            Transform emoteTransform = emoteReferences.transform;
             emoteTransform.SetParent(avatarTransform, false);
             emoteTransform.localPosition = Vector3.zero;
             emoteTransform.localRotation = Quaternion.identity;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/SceneMaskedEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/SceneMaskedEmoteSystem.cs
@@ -149,9 +149,8 @@ namespace DCL.AvatarRendering.Emotes.Play
                 return;
 
             StreamableLoadingResult<AttachmentRegularAsset> streamableAssetValue = emote.AssetResults[bodyShape]!.Value;
-            GameObject? mainAsset;
 
-            if (streamableAssetValue is { Succeeded: false } || (mainAsset = streamableAssetValue.Asset?.MainAsset) == null)
+            if (streamableAssetValue is { Succeeded: false } || streamableAssetValue.Asset is not { } sourceAsset || sourceAsset.MainAsset == null)
             {
                 World.Remove<CharacterEmoteIntent>(entity);
                 return;
@@ -180,7 +179,7 @@ namespace DCL.AvatarRendering.Emotes.Play
 
             bool isLooping = emote.IsLooping();
 
-            if (!emotePlayer.PlayMasked(mainAsset, audioClip, isLooping, emoteIntent.Spatial, in avatarBase, ref masked))
+            if (!emotePlayer.PlayMasked(sourceAsset, audioClip, isLooping, emoteIntent.Spatial, in avatarBase, ref masked))
                 ReportHub.LogError(ReportCategory.EMOTE, $"Emote name:{emoteId} cant be played.");
             else
             {
@@ -237,7 +236,7 @@ namespace DCL.AvatarRendering.Emotes.Play
 
             if (streamableAssetValue is { Succeeded: false } || streamableAssetValue.Asset?.MainAsset == null) return;
 
-            GameObject mainAsset = streamableAssetValue.Asset.MainAsset;
+            AttachmentRegularAsset sourceAsset = streamableAssetValue.Asset;
             StreamableLoadingResult<AudioClipData>? audioAssetResult = emote.AudioAssetResults[bodyShape];
             AudioClip? audioClip = audioAssetResult?.Asset;
 
@@ -245,7 +244,7 @@ namespace DCL.AvatarRendering.Emotes.Play
 
             IAvatarView avatarBase = mainPlayerAvatarBaseProxy.Object!;
 
-            if (!emotePlayer.PlayMasked(mainAsset, audioClip, isLooping: true, isSpatial: true, in avatarBase, ref masked))
+            if (!emotePlayer.PlayMasked(sourceAsset, audioClip, isLooping: true, isSpatial: true, in avatarBase, ref masked))
                 return;
 
             // Reset stored tag so CancelMaskedEmotes doesn't fire on the next frame

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/EmotePlayerShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/EmotePlayerShould.cs
@@ -1,7 +1,10 @@
 using DCL.AvatarRendering.AvatarShape.UnityInterface;
 using DCL.AvatarRendering.Emotes.Play;
+using DCL.AvatarRendering.Loading.Assets;
+using ECS.StreamableLoading;
 using NSubstitute;
 using NUnit.Framework;
+using System.Collections.Generic;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -53,13 +56,85 @@ namespace DCL.AvatarRendering.Emotes.Tests
         public void NotLeakPooledInstanceWhenLegacyEmoteRejected()
         {
             var emoteComponent = new CharacterEmoteComponent();
+            AttachmentRegularAsset sourceAsset = NewSourceAsset(legacyEmoteAsset);
 
-            bool played = emotePlayer.Play(legacyEmoteAsset, null, false, false, in avatarView, ref emoteComponent);
+            bool played = emotePlayer.Play(sourceAsset, null, false, false, in avatarView, ref emoteComponent);
 
             Assert.IsFalse(played);
             Assert.IsNull(emoteComponent.CurrentEmoteReference);
             Assert.IsNull(avatarGameObject.GetComponentInChildren<EmoteReferences>(true),
                 "Rejected legacy emote leaked a pooled instance under the avatar.");
+            Assert.AreEqual(0, sourceAsset.ReferenceCount,
+                "The rejected play must return the reference it took on the source asset.");
+        }
+
+        [Test]
+        public void PinSourceAssetWhilePlayingAndUnpinOnStop()
+        {
+            GameObject mecanimAsset = NewMecanimEmoteAsset("MecanimEmoteAsset");
+            AttachmentRegularAsset sourceAsset = NewSourceAsset(mecanimAsset);
+            var emoteComponent = new CharacterEmoteComponent();
+
+            Assert.IsTrue(emotePlayer.Play(sourceAsset, null, false, false, in avatarView, ref emoteComponent));
+            Assert.AreEqual(1, sourceAsset.ReferenceCount,
+                "A playing emote must keep its source asset referenced, or the storage could dispose it mid-play.");
+
+            emotePlayer.Stop(emoteComponent.CurrentEmoteReference!);
+            emoteComponent.Reset();
+
+            Assert.AreEqual(0, sourceAsset.ReferenceCount,
+                "Releasing the instance back to the pool must return the play-time reference.");
+
+            Object.DestroyImmediate(mecanimAsset);
+        }
+
+        [Test]
+        public void PruneStalePoolWhenSourceAssetDestroyed()
+        {
+            GameObject assetA = NewMecanimEmoteAsset("EmoteAssetA");
+            AttachmentRegularAsset sourceA = NewSourceAsset(assetA);
+            var emoteComponent = new CharacterEmoteComponent();
+
+            Assert.IsTrue(emotePlayer.Play(sourceA, null, false, false, in avatarView, ref emoteComponent));
+            emotePlayer.Stop(emoteComponent.CurrentEmoteReference!);
+            emoteComponent.Reset();
+
+            Assert.AreEqual(1, poolRoot.GetComponentsInChildren<EmoteReferences>(true).Length,
+                "The released instance should be parked under the pool root.");
+
+            // Simulates the storage unloading the emote: its main asset is gone, so the pool keyed
+            // by it can never serve an instance again.
+            Object.DestroyImmediate(assetA);
+
+            GameObject assetB = NewMecanimEmoteAsset("EmoteAssetB");
+            AttachmentRegularAsset sourceB = NewSourceAsset(assetB);
+
+            Assert.IsTrue(emotePlayer.Play(sourceB, null, false, false, in avatarView, ref emoteComponent));
+
+            Assert.AreEqual(0, poolRoot.GetComponentsInChildren<EmoteReferences>(true).Length,
+                "Instances pooled for a destroyed source asset must be destroyed with their pool.");
+
+            emotePlayer.Stop(emoteComponent.CurrentEmoteReference!);
+            Object.DestroyImmediate(assetB);
+        }
+
+        private static GameObject NewMecanimEmoteAsset(string name)
+        {
+            // An Animator without controller and no Animation component resolves to a non-legacy
+            // EmoteReferences with no clips, which the mecanim path plays against the mocked view.
+            var asset = new GameObject(name);
+            asset.AddComponent<Animator>();
+            return asset;
+        }
+
+        private static AttachmentRegularAsset NewSourceAsset(GameObject mainAsset) =>
+            new (mainAsset, new List<AttachmentRegularAsset.RendererInfo>(), new NoopRefCountData());
+
+        private class NoopRefCountData : IStreamableRefCountData
+        {
+            public void Dispose() { }
+
+            public void Dereference() { }
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/FinalizeEmoteLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/FinalizeEmoteLoadingSystemShould.cs
@@ -1,4 +1,5 @@
 using Arch.Core;
+using AssetManagement;
 using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Assets;
 using DCL.AvatarRendering.Loading.Components;
@@ -28,6 +29,7 @@ using UnityEngine.TestTools;
 // Define Promise types as aliases for clarity, similar to the system file
 using AssetBundlePromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.AssetBundles.AssetBundleData, ECS.StreamableLoading.AssetBundles.GetAssetBundleIntention>; // Corrected alias
 using GltfPromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.GLTF.GLTFData, ECS.StreamableLoading.GLTF.GetGLTFIntention>;
+using AssetBundleManifestPromise = ECS.StreamableLoading.Common.AssetPromise<SceneRunner.Scene.SceneAssetBundleManifest, ECS.StreamableLoading.AssetBundles.GetAssetBundleManifestIntention>;
 using AudioPromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.AudioClips.AudioClipData, ECS.StreamableLoading.AudioClips.GetAudioClipIntention>;
 using EmotesFromRealmPromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesDTOList, DCL.AvatarRendering.Emotes.GetEmotesDTOByPointersFromRealmIntention>;
 using EmoteResolutionPromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution, DCL.AvatarRendering.Emotes.GetEmotesByPointersIntention>;
@@ -37,13 +39,13 @@ namespace DCL.AvatarRendering.Emotes.Tests
 {
     public class FinalizeEmoteLoadingSystemShould : UnitySystemTestBase<FinalizeEmoteLoadingSystem>
     {
-        private MockEmoteStorage mockEmoteStorage = null!;
-        private ListObjectPool<URN> urnPool = null!;
+        private MockEmoteStorage mockEmoteStorage;
+        private ListObjectPool<URN> urnPool;
 
         // Shared mock objects for assets
-        private GameObject mockGameObject = null!;
-        private AttachmentRegularAsset mockAttachmentAsset = null!;
-        private MockStreamableDataWithURN mockStreamableData = null!;
+        private GameObject mockGameObject;
+        private AttachmentRegularAsset mockAttachmentAsset;
+        private MockStreamableDataWithURN mockStreamableData;
 
         [SetUp]
         public void SetUp()
@@ -147,7 +149,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Entity emoteEntity = CreateEmoteEntityWithPromise<GLTFData, GetGLTFIntention>(mockEmote, intention, bodyShape, out GltfPromise promise);
 
             // Mocking promise result
-            var gltfData = new GLTFData(null!, mockGameObject);
+            var gltfData = new GLTFData(null, mockGameObject);
             var promiseResult = new StreamableLoadingResult<GLTFData>(gltfData);
             world.Add(promise.Entity, promiseResult);
 
@@ -159,7 +161,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(promise.Entity));
 
             Assert.IsTrue(mockEmote.AssetResults[bodyShape].HasValue);
-            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResults[bodyShape].GetValueOrDefault();
+            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResults[bodyShape].Value;
             Assert.IsTrue(resultValue.Succeeded);
 
             AttachmentRegularAsset? resultingAttachment = resultValue.Asset;
@@ -172,7 +174,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         public void FinalizeGltfEmoteLoadingUnisexCorrectly()
         {
             var emoteURN = new URN("urn:gltf:emote_unisex");
-            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockHasSameClipForAllGendersValue = true };
+            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockIsUnisexValue = true, MockHasSameClipForAllGendersValue = true };
             mockEmote.ApplyAndMarkAsLoaded(CreateEmoteDTO(emoteURN, true)); // Mark as unisex for DTO properties
 
             BodyShape loadingBodyShape = BodyShape.MALE; // System will apply to both if unisex
@@ -180,7 +182,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Entity emoteEntity = CreateEmoteEntityWithPromise<GLTFData, GetGLTFIntention>(mockEmote, intention, loadingBodyShape, out GltfPromise promise);
             Entity resultHolderEntity = promise.Entity;
 
-            var gltfData = new GLTFData(null!, mockGameObject);
+            var gltfData = new GLTFData(null, mockGameObject);
             world.Add(resultHolderEntity, new StreamableLoadingResult<GLTFData>(gltfData));
 
             system.Update(0);
@@ -190,13 +192,13 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
             // Check assets for both body shapes
             Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].HasValue, "Male asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE] is { Succeeded: true }, "Male asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.MALE]?.Asset?.MainAsset, "Male asset game object should match.");
+            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].Value.Succeeded, "Male asset should succeed.");
+            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.MALE].Value.Asset.MainAsset, "Male asset game object should match.");
 
             Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].HasValue, "Female asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE] is { Succeeded: true }, "Female asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.FEMALE]?.Asset?.MainAsset, "Female asset game object should match.");
-            Assert.AreSame(mockEmote.AssetResults[BodyShape.MALE]?.Asset, mockEmote.AssetResults[BodyShape.FEMALE]?.Asset, "Male and Female assets should be the same instance for unisex.");
+            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].Value.Succeeded, "Female asset should succeed.");
+            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset.MainAsset, "Female asset game object should match.");
+            Assert.AreSame(mockEmote.AssetResults[BodyShape.MALE].Value.Asset, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset, "Male and Female assets should be the same instance for unisex.");
 
             Assert.IsFalse(mockEmote.IsLoading, "Emote should not be loading after successful unisex load.");
         }
@@ -224,7 +226,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed by AssetPromise framework (even on failure).");
 
             Assert.IsTrue(mockEmote.AssetResults[bodyShape].HasValue, "Asset result should be set to a failed result to prevent retry loops.");
-            Assert.IsTrue(mockEmote.AssetResults[bodyShape] is { Succeeded: false }, "Asset result should be marked as failed.");
+            Assert.IsFalse(mockEmote.AssetResults[bodyShape].Value.Succeeded, "Asset result should be marked as failed.");
             Assert.IsFalse(mockEmote.IsLoading, "Emote should not be loading after a failed asset load attempt (status updated).");
         }
 
@@ -259,7 +261,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             var emoteURN = new URN("urn:ab:emote_female");
             var isUnisex = false;
 
-            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage);
+            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockIsUnisexValue = isUnisex };
             mockEmote.ApplyAndMarkAsLoaded(CreateEmoteDTO(emoteURN, isUnisex));
 
             // Main components needed for the system query to run on the Entity
@@ -268,7 +270,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Entity emoteEntity = CreateEmoteEntityWithPromise<AssetBundleData, GetAssetBundleIntention>(mockEmote, intention, bodyShape, out AssetBundlePromise promise);
 
             // Mocking promise result
-            var assetBundleData = new AssetBundleData(null!, new Object[] { mockGameObject }, null, null!);
+            var assetBundleData = new AssetBundleData(null, new []{mockGameObject}, null, null);
             var promiseResult = new StreamableLoadingResult<AssetBundleData>(assetBundleData);
             world.Add(promise.Entity, promiseResult);
 
@@ -280,7 +282,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(promise.Entity));
 
             Assert.IsTrue(mockEmote.AssetResults[bodyShape].HasValue);
-            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResults[bodyShape].GetValueOrDefault();
+            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResults[bodyShape].Value;
             Assert.IsTrue(resultValue.Succeeded);
 
             AttachmentRegularAsset? resultingAttachment = resultValue.Asset;
@@ -293,7 +295,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         public void FinalizeAssetBundleEmoteLoadingUnisexCorrectly()
         {
             var emoteURN = new URN("urn:ab:emote_unisex");
-            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockHasSameClipForAllGendersValue = true };
+            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockIsUnisexValue = true, MockHasSameClipForAllGendersValue = true };
             mockEmote.ApplyAndMarkAsLoaded(CreateEmoteDTO(emoteURN, true));
 
             BodyShape loadingBodyShape = BodyShape.FEMALE; // System will apply to both if unisex
@@ -301,7 +303,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Entity emoteEntity = CreateEmoteEntityWithPromise<AssetBundleData, GetAssetBundleIntention>(mockEmote, intention, loadingBodyShape, out AssetBundlePromise promise);
             Entity resultHolderEntity = promise.Entity;
 
-            var assetBundleData = new AssetBundleData(null!, new Object[] { mockGameObject }, null, null!);
+            var assetBundleData = new AssetBundleData(null, new []{mockGameObject}, null, null);
             world.Add(resultHolderEntity, new StreamableLoadingResult<AssetBundleData>(assetBundleData));
 
             system.Update(0);
@@ -310,13 +312,13 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed.");
 
             Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].HasValue, "Male asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE] is { Succeeded: true }, "Male asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.MALE]?.Asset?.MainAsset, "Male asset game object should match.");
+            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].Value.Succeeded, "Male asset should succeed.");
+            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.MALE].Value.Asset.MainAsset, "Male asset game object should match.");
 
             Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].HasValue, "Female asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE] is { Succeeded: true }, "Female asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.FEMALE]?.Asset?.MainAsset, "Female asset game object should match.");
-            Assert.AreSame(mockEmote.AssetResults[BodyShape.MALE]?.Asset, mockEmote.AssetResults[BodyShape.FEMALE]?.Asset, "Male and Female assets should be the same instance for unisex.");
+            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].Value.Succeeded, "Female asset should succeed.");
+            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset.MainAsset, "Female asset game object should match.");
+            Assert.AreSame(mockEmote.AssetResults[BodyShape.MALE].Value.Asset, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset, "Male and Female assets should be the same instance for unisex.");
 
             Assert.IsFalse(mockEmote.IsLoading, "Emote should not be loading after successful unisex load.");
         }
@@ -345,7 +347,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed (even on failure).");
 
             Assert.IsTrue(mockEmote.AssetResults[bodyShape].HasValue, "Asset result should be set to a failed result to prevent retry loops.");
-            Assert.IsTrue(mockEmote.AssetResults[bodyShape] is { Succeeded: false }, "Asset result should be marked as failed.");
+            Assert.IsFalse(mockEmote.AssetResults[bodyShape].Value.Succeeded, "Asset result should be marked as failed.");
             Assert.IsFalse(mockEmote.IsLoading, "Emote loading status should be false after failure.");
         }
 
@@ -381,7 +383,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage);
             BodyShape bodyShape = BodyShape.MALE;
             var intention = new GetAudioClipIntention { CommonArguments = new CommonLoadingArguments(URLAddress.EMPTY) };
-            var audioClipData = new AudioClipData(null!); // Mock AudioClipData
+            var audioClipData = new AudioClipData(null); // Mock AudioClipData
 
             Entity targetEntity = world.Create(mockEmote, bodyShape);
             var promise = AudioPromise.Create(world, intention, PartitionComponent.TOP_PRIORITY);
@@ -393,8 +395,8 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(targetEntity));
             Assert.IsFalse(world.IsAlive(promise.Entity));
             Assert.IsTrue(mockEmote.AudioAssetResults[bodyShape].HasValue);
-            Assert.IsTrue(mockEmote.AudioAssetResults[bodyShape] is { Succeeded: true });
-            Assert.AreSame(audioClipData, mockEmote.AudioAssetResults[bodyShape]?.Asset);
+            Assert.IsTrue(mockEmote.AudioAssetResults[bodyShape].Value.Succeeded);
+            Assert.AreSame(audioClipData, mockEmote.AudioAssetResults[bodyShape].Value.Asset);
         }
 
         [Test]
@@ -561,7 +563,8 @@ namespace DCL.AvatarRendering.Emotes.Tests
         {
             public readonly Dictionary<URN, IEmote> Emotes = new ();
             public readonly List<URN> GetOrAddByDTOCalls = new ();
-            public Action<MockEmote, bool>? OnUpdateLoadingStatusCalled;
+            public readonly List<URN> TryGetElementCalls = new ();
+            public Action<MockEmote, bool> OnUpdateLoadingStatusCalled;
             public IReadOnlyList<URN> BaseEmotesUrns => throw new NotImplementedException();
 
             public IEmote GetOrAddByDTO(EmoteDTO dto, bool isDefault)
@@ -579,6 +582,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
             public bool TryGetElement(URN urn, out IEmote element)
             {
+                TryGetElementCalls.Add(urn);
                 return Emotes.TryGetValue(urn, out element);
             }
 
@@ -614,7 +618,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 throw new NotImplementedException();
             }
 
-            public IReadOnlyDictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>> AllOwnedNftRegistry => throw new NotImplementedException();
+            public IReadOnlyDictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>> AllOwnedNftRegistry { get; }
 
             public void SetBaseEmotesUrns(IReadOnlyCollection<URN> urns) =>
                 throw new NotImplementedException();
@@ -622,12 +626,14 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
         public class MockEmote : IEmote
         {
-            public readonly MockEmoteStorage? StorageRef;
+            public readonly MockEmoteStorage storageRef;
             public URN Urn { get; }
             public StreamableLoadingResult<SceneAssetBundleManifest>? ManifestResult { get; set; }
             public StreamableLoadingResult<AttachmentRegularAsset>?[] AssetResults { get; }
+            public StreamableLoadingResult<AudioClipData>?[] SocialEmoteOutcomeAudioAssetResults { get; set; }
+            public bool IsSocial { get; }
             public int Amount { get; set; }
-            public TrimmedEmoteDTO TrimmedDTO => throw new NotImplementedException();
+            public TrimmedEmoteDTO TrimmedDTO { get; }
 
             TrimmedAvatarAttachmentDTO ITrimmedAvatarAttachment.TrimmedDTO => TrimmedDTO;
 
@@ -637,33 +643,34 @@ namespace DCL.AvatarRendering.Emotes.Tests
             }
 
             public StreamableLoadingResult<AudioClipData>?[] AudioAssetResults { get; }
-            public EmoteDTO? DTO { get; private set; }
+            public EmoteDTO DTO { get; private set; }
             public bool IsLoading { get; set; }
             public int ApplyAndMarkAsLoadedCallCount { get; private set; }
-            public EmoteDTO? LastAppliedDTO { get; private set; }
+            public EmoteDTO LastAppliedDTO { get; private set; }
+            public bool MockIsUnisexValue { get; set; }
             public bool MockHasSameClipForAllGendersValue { get; set; }
             public StreamableLoadingResult<EmoteDTO> Model { get; set; }
             public StreamableLoadingResult<TrimmedEmoteDTO> TrimmedModel { get; set; }
             public StreamableLoadingResult<SpriteData>.WithFallback? ThumbnailAssetResult { get; set; }
 
-            AvatarAttachmentDTO? IAvatarAttachment.DTO => DTO;
+            AvatarAttachmentDTO IAvatarAttachment.DTO => DTO;
 
-            public MockEmote(URN urn, MockEmoteStorage? storage = null)
+            public MockEmote(URN urn, MockEmoteStorage storage = null)
             {
                 Urn = urn;
-                StorageRef = storage;
+                storageRef = storage;
                 AssetResults = new StreamableLoadingResult<AttachmentRegularAsset>?[BodyShape.COUNT];
                 AudioAssetResults = new StreamableLoadingResult<AudioClipData>?[BodyShape.COUNT];
                 IsLoading = true;
             }
 
             public bool IsLooping() =>
-                DTO?.metadata.emoteDataADR74.loop ?? false;
+                DTO?.metadata?.emoteDataADR74?.loop ?? false;
 
             public void UpdateLoadingStatus(bool newStatus)
             {
                 IsLoading = newStatus;
-                StorageRef?.OnUpdateLoadingStatusCalled?.Invoke(this, newStatus);
+                storageRef?.OnUpdateLoadingStatusCalled?.Invoke(this, newStatus);
             }
 
             public void ApplyAndMarkAsLoaded(EmoteDTO dto)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/FinalizeEmoteLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/FinalizeEmoteLoadingSystemShould.cs
@@ -1,5 +1,4 @@
 using Arch.Core;
-using AssetManagement;
 using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Assets;
 using DCL.AvatarRendering.Loading.Components;
@@ -29,7 +28,6 @@ using UnityEngine.TestTools;
 // Define Promise types as aliases for clarity, similar to the system file
 using AssetBundlePromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.AssetBundles.AssetBundleData, ECS.StreamableLoading.AssetBundles.GetAssetBundleIntention>; // Corrected alias
 using GltfPromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.GLTF.GLTFData, ECS.StreamableLoading.GLTF.GetGLTFIntention>;
-using AssetBundleManifestPromise = ECS.StreamableLoading.Common.AssetPromise<SceneRunner.Scene.SceneAssetBundleManifest, ECS.StreamableLoading.AssetBundles.GetAssetBundleManifestIntention>;
 using AudioPromise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.AudioClips.AudioClipData, ECS.StreamableLoading.AudioClips.GetAudioClipIntention>;
 using EmotesFromRealmPromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesDTOList, DCL.AvatarRendering.Emotes.GetEmotesDTOByPointersFromRealmIntention>;
 using EmoteResolutionPromise = ECS.StreamableLoading.Common.AssetPromise<DCL.AvatarRendering.Emotes.EmotesResolution, DCL.AvatarRendering.Emotes.GetEmotesByPointersIntention>;
@@ -39,13 +37,13 @@ namespace DCL.AvatarRendering.Emotes.Tests
 {
     public class FinalizeEmoteLoadingSystemShould : UnitySystemTestBase<FinalizeEmoteLoadingSystem>
     {
-        private MockEmoteStorage mockEmoteStorage;
-        private ListObjectPool<URN> urnPool;
+        private MockEmoteStorage mockEmoteStorage = null!;
+        private ListObjectPool<URN> urnPool = null!;
 
         // Shared mock objects for assets
-        private GameObject mockGameObject;
-        private AttachmentRegularAsset mockAttachmentAsset;
-        private MockStreamableDataWithURN mockStreamableData;
+        private GameObject mockGameObject = null!;
+        private AttachmentRegularAsset mockAttachmentAsset = null!;
+        private MockStreamableDataWithURN mockStreamableData = null!;
 
         [SetUp]
         public void SetUp()
@@ -149,7 +147,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Entity emoteEntity = CreateEmoteEntityWithPromise<GLTFData, GetGLTFIntention>(mockEmote, intention, bodyShape, out GltfPromise promise);
 
             // Mocking promise result
-            var gltfData = new GLTFData(null, mockGameObject);
+            var gltfData = new GLTFData(null!, mockGameObject);
             var promiseResult = new StreamableLoadingResult<GLTFData>(gltfData);
             world.Add(promise.Entity, promiseResult);
 
@@ -161,7 +159,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(promise.Entity));
 
             Assert.IsTrue(mockEmote.AssetResults[bodyShape].HasValue);
-            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResults[bodyShape].Value;
+            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResults[bodyShape].GetValueOrDefault();
             Assert.IsTrue(resultValue.Succeeded);
 
             AttachmentRegularAsset? resultingAttachment = resultValue.Asset;
@@ -174,7 +172,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         public void FinalizeGltfEmoteLoadingUnisexCorrectly()
         {
             var emoteURN = new URN("urn:gltf:emote_unisex");
-            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockIsUnisexValue = true, MockHasSameClipForAllGendersValue = true };
+            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockHasSameClipForAllGendersValue = true };
             mockEmote.ApplyAndMarkAsLoaded(CreateEmoteDTO(emoteURN, true)); // Mark as unisex for DTO properties
 
             BodyShape loadingBodyShape = BodyShape.MALE; // System will apply to both if unisex
@@ -182,7 +180,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Entity emoteEntity = CreateEmoteEntityWithPromise<GLTFData, GetGLTFIntention>(mockEmote, intention, loadingBodyShape, out GltfPromise promise);
             Entity resultHolderEntity = promise.Entity;
 
-            var gltfData = new GLTFData(null, mockGameObject);
+            var gltfData = new GLTFData(null!, mockGameObject);
             world.Add(resultHolderEntity, new StreamableLoadingResult<GLTFData>(gltfData));
 
             system.Update(0);
@@ -192,13 +190,13 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
             // Check assets for both body shapes
             Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].HasValue, "Male asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].Value.Succeeded, "Male asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.MALE].Value.Asset.MainAsset, "Male asset game object should match.");
+            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE] is { Succeeded: true }, "Male asset should succeed.");
+            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.MALE]?.Asset?.MainAsset, "Male asset game object should match.");
 
             Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].HasValue, "Female asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].Value.Succeeded, "Female asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset.MainAsset, "Female asset game object should match.");
-            Assert.AreSame(mockEmote.AssetResults[BodyShape.MALE].Value.Asset, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset, "Male and Female assets should be the same instance for unisex.");
+            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE] is { Succeeded: true }, "Female asset should succeed.");
+            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.FEMALE]?.Asset?.MainAsset, "Female asset game object should match.");
+            Assert.AreSame(mockEmote.AssetResults[BodyShape.MALE]?.Asset, mockEmote.AssetResults[BodyShape.FEMALE]?.Asset, "Male and Female assets should be the same instance for unisex.");
 
             Assert.IsFalse(mockEmote.IsLoading, "Emote should not be loading after successful unisex load.");
         }
@@ -226,7 +224,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed by AssetPromise framework (even on failure).");
 
             Assert.IsTrue(mockEmote.AssetResults[bodyShape].HasValue, "Asset result should be set to a failed result to prevent retry loops.");
-            Assert.IsFalse(mockEmote.AssetResults[bodyShape].Value.Succeeded, "Asset result should be marked as failed.");
+            Assert.IsTrue(mockEmote.AssetResults[bodyShape] is { Succeeded: false }, "Asset result should be marked as failed.");
             Assert.IsFalse(mockEmote.IsLoading, "Emote should not be loading after a failed asset load attempt (status updated).");
         }
 
@@ -261,7 +259,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             var emoteURN = new URN("urn:ab:emote_female");
             var isUnisex = false;
 
-            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockIsUnisexValue = isUnisex };
+            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage);
             mockEmote.ApplyAndMarkAsLoaded(CreateEmoteDTO(emoteURN, isUnisex));
 
             // Main components needed for the system query to run on the Entity
@@ -270,7 +268,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Entity emoteEntity = CreateEmoteEntityWithPromise<AssetBundleData, GetAssetBundleIntention>(mockEmote, intention, bodyShape, out AssetBundlePromise promise);
 
             // Mocking promise result
-            var assetBundleData = new AssetBundleData(null, new []{mockGameObject}, null, null);
+            var assetBundleData = new AssetBundleData(null!, new Object[] { mockGameObject }, null, null!);
             var promiseResult = new StreamableLoadingResult<AssetBundleData>(assetBundleData);
             world.Add(promise.Entity, promiseResult);
 
@@ -282,7 +280,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(promise.Entity));
 
             Assert.IsTrue(mockEmote.AssetResults[bodyShape].HasValue);
-            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResults[bodyShape].Value;
+            StreamableLoadingResult<AttachmentRegularAsset> resultValue = mockEmote.AssetResults[bodyShape].GetValueOrDefault();
             Assert.IsTrue(resultValue.Succeeded);
 
             AttachmentRegularAsset? resultingAttachment = resultValue.Asset;
@@ -295,7 +293,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         public void FinalizeAssetBundleEmoteLoadingUnisexCorrectly()
         {
             var emoteURN = new URN("urn:ab:emote_unisex");
-            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockIsUnisexValue = true, MockHasSameClipForAllGendersValue = true };
+            IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage) { MockHasSameClipForAllGendersValue = true };
             mockEmote.ApplyAndMarkAsLoaded(CreateEmoteDTO(emoteURN, true));
 
             BodyShape loadingBodyShape = BodyShape.FEMALE; // System will apply to both if unisex
@@ -303,7 +301,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Entity emoteEntity = CreateEmoteEntityWithPromise<AssetBundleData, GetAssetBundleIntention>(mockEmote, intention, loadingBodyShape, out AssetBundlePromise promise);
             Entity resultHolderEntity = promise.Entity;
 
-            var assetBundleData = new AssetBundleData(null, new []{mockGameObject}, null, null);
+            var assetBundleData = new AssetBundleData(null!, new Object[] { mockGameObject }, null, null!);
             world.Add(resultHolderEntity, new StreamableLoadingResult<AssetBundleData>(assetBundleData));
 
             system.Update(0);
@@ -312,13 +310,13 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed.");
 
             Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].HasValue, "Male asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE].Value.Succeeded, "Male asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.MALE].Value.Asset.MainAsset, "Male asset game object should match.");
+            Assert.IsTrue(mockEmote.AssetResults[BodyShape.MALE] is { Succeeded: true }, "Male asset should succeed.");
+            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.MALE]?.Asset?.MainAsset, "Male asset game object should match.");
 
             Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].HasValue, "Female asset should be set for unisex.");
-            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE].Value.Succeeded, "Female asset should succeed.");
-            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset.MainAsset, "Female asset game object should match.");
-            Assert.AreSame(mockEmote.AssetResults[BodyShape.MALE].Value.Asset, mockEmote.AssetResults[BodyShape.FEMALE].Value.Asset, "Male and Female assets should be the same instance for unisex.");
+            Assert.IsTrue(mockEmote.AssetResults[BodyShape.FEMALE] is { Succeeded: true }, "Female asset should succeed.");
+            Assert.AreSame(mockGameObject, mockEmote.AssetResults[BodyShape.FEMALE]?.Asset?.MainAsset, "Female asset game object should match.");
+            Assert.AreSame(mockEmote.AssetResults[BodyShape.MALE]?.Asset, mockEmote.AssetResults[BodyShape.FEMALE]?.Asset, "Male and Female assets should be the same instance for unisex.");
 
             Assert.IsFalse(mockEmote.IsLoading, "Emote should not be loading after successful unisex load.");
         }
@@ -347,7 +345,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(resultHolderEntity), "Result-holder entity should be destroyed (even on failure).");
 
             Assert.IsTrue(mockEmote.AssetResults[bodyShape].HasValue, "Asset result should be set to a failed result to prevent retry loops.");
-            Assert.IsFalse(mockEmote.AssetResults[bodyShape].Value.Succeeded, "Asset result should be marked as failed.");
+            Assert.IsTrue(mockEmote.AssetResults[bodyShape] is { Succeeded: false }, "Asset result should be marked as failed.");
             Assert.IsFalse(mockEmote.IsLoading, "Emote loading status should be false after failure.");
         }
 
@@ -383,7 +381,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             IEmote mockEmote = new MockEmote(emoteURN, mockEmoteStorage);
             BodyShape bodyShape = BodyShape.MALE;
             var intention = new GetAudioClipIntention { CommonArguments = new CommonLoadingArguments(URLAddress.EMPTY) };
-            var audioClipData = new AudioClipData(null); // Mock AudioClipData
+            var audioClipData = new AudioClipData(null!); // Mock AudioClipData
 
             Entity targetEntity = world.Create(mockEmote, bodyShape);
             var promise = AudioPromise.Create(world, intention, PartitionComponent.TOP_PRIORITY);
@@ -395,8 +393,8 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsFalse(world.IsAlive(targetEntity));
             Assert.IsFalse(world.IsAlive(promise.Entity));
             Assert.IsTrue(mockEmote.AudioAssetResults[bodyShape].HasValue);
-            Assert.IsTrue(mockEmote.AudioAssetResults[bodyShape].Value.Succeeded);
-            Assert.AreSame(audioClipData, mockEmote.AudioAssetResults[bodyShape].Value.Asset);
+            Assert.IsTrue(mockEmote.AudioAssetResults[bodyShape] is { Succeeded: true });
+            Assert.AreSame(audioClipData, mockEmote.AudioAssetResults[bodyShape]?.Asset);
         }
 
         [Test]
@@ -484,6 +482,37 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsTrue(cts.IsCancellationRequested, "Intention CTS should be cancelled after disposal.");
         }
 
+        [Test]
+        public void DereferenceResolutionReferenceWhenConsumingFinishedEmotePromise()
+        {
+            var emoteURN = new URN("urn:resolution:emote_referenced");
+            BodyShape bodyShape = BodyShape.MALE;
+
+            IEmote emote = new MockEmote(emoteURN, mockEmoteStorage) { IsLoading = false };
+            emote.AssetResults[bodyShape] = new StreamableLoadingResult<AttachmentRegularAsset>(mockAttachmentAsset);
+            mockEmoteStorage.Set(emoteURN, emote);
+
+            // LoadEmotesByPointersSystem adds one reference per pointer it marks successful; the consumer
+            // owns that reference and must return it, otherwise the storage can never unload the emote
+            // (MemoryEmotesStorage.Unload only disposes assets whose ReferenceCount is 0).
+            mockAttachmentAsset.AddReference();
+            Assert.AreEqual(1, mockAttachmentAsset.ReferenceCount);
+
+            var pointers = new List<URN> { emoteURN };
+            var intention = new GetEmotesByPointersIntention(pointers, bodyShape);
+            intention.SuccessfulPointers.Add(emoteURN);
+
+            var promise = EmoteResolutionPromise.Create(world, intention, PartitionComponent.TOP_PRIORITY);
+            Entity promiseCarrierEntity = world.Create(promise);
+            world.Add(promise.Entity, new StreamableLoadingResult<EmotesResolution>(new EmotesResolution(RepoolableList<IEmote>.FromElement(emote), 1)));
+
+            system.Update(0);
+
+            Assert.IsFalse(world.IsAlive(promiseCarrierEntity), "Carrier entity should be destroyed by the system.");
+            Assert.AreEqual(0, mockAttachmentAsset.ReferenceCount,
+                "Consuming the finished promise must dereference the asset referenced at resolution time.");
+        }
+
         private Entity CreateEmoteEntityWithPromise<TAsset, TIntention>(
             IEmote mockEmote,
             TIntention intention,
@@ -532,8 +561,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         {
             public readonly Dictionary<URN, IEmote> Emotes = new ();
             public readonly List<URN> GetOrAddByDTOCalls = new ();
-            public readonly List<URN> TryGetElementCalls = new ();
-            public Action<MockEmote, bool> OnUpdateLoadingStatusCalled;
+            public Action<MockEmote, bool>? OnUpdateLoadingStatusCalled;
             public IReadOnlyList<URN> BaseEmotesUrns => throw new NotImplementedException();
 
             public IEmote GetOrAddByDTO(EmoteDTO dto, bool isDefault)
@@ -551,7 +579,6 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
             public bool TryGetElement(URN urn, out IEmote element)
             {
-                TryGetElementCalls.Add(urn);
                 return Emotes.TryGetValue(urn, out element);
             }
 
@@ -587,7 +614,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 throw new NotImplementedException();
             }
 
-            public IReadOnlyDictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>> AllOwnedNftRegistry { get; }
+            public IReadOnlyDictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>> AllOwnedNftRegistry => throw new NotImplementedException();
 
             public void SetBaseEmotesUrns(IReadOnlyCollection<URN> urns) =>
                 throw new NotImplementedException();
@@ -595,14 +622,12 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
         public class MockEmote : IEmote
         {
-            public readonly MockEmoteStorage storageRef;
+            public readonly MockEmoteStorage? StorageRef;
             public URN Urn { get; }
             public StreamableLoadingResult<SceneAssetBundleManifest>? ManifestResult { get; set; }
             public StreamableLoadingResult<AttachmentRegularAsset>?[] AssetResults { get; }
-            public StreamableLoadingResult<AudioClipData>?[] SocialEmoteOutcomeAudioAssetResults { get; set; }
-            public bool IsSocial { get; }
             public int Amount { get; set; }
-            public TrimmedEmoteDTO TrimmedDTO { get; }
+            public TrimmedEmoteDTO TrimmedDTO => throw new NotImplementedException();
 
             TrimmedAvatarAttachmentDTO ITrimmedAvatarAttachment.TrimmedDTO => TrimmedDTO;
 
@@ -612,34 +637,33 @@ namespace DCL.AvatarRendering.Emotes.Tests
             }
 
             public StreamableLoadingResult<AudioClipData>?[] AudioAssetResults { get; }
-            public EmoteDTO DTO { get; private set; }
+            public EmoteDTO? DTO { get; private set; }
             public bool IsLoading { get; set; }
             public int ApplyAndMarkAsLoadedCallCount { get; private set; }
-            public EmoteDTO LastAppliedDTO { get; private set; }
-            public bool MockIsUnisexValue { get; set; }
+            public EmoteDTO? LastAppliedDTO { get; private set; }
             public bool MockHasSameClipForAllGendersValue { get; set; }
             public StreamableLoadingResult<EmoteDTO> Model { get; set; }
             public StreamableLoadingResult<TrimmedEmoteDTO> TrimmedModel { get; set; }
             public StreamableLoadingResult<SpriteData>.WithFallback? ThumbnailAssetResult { get; set; }
 
-            AvatarAttachmentDTO IAvatarAttachment.DTO => DTO;
+            AvatarAttachmentDTO? IAvatarAttachment.DTO => DTO;
 
-            public MockEmote(URN urn, MockEmoteStorage storage = null)
+            public MockEmote(URN urn, MockEmoteStorage? storage = null)
             {
                 Urn = urn;
-                storageRef = storage;
+                StorageRef = storage;
                 AssetResults = new StreamableLoadingResult<AttachmentRegularAsset>?[BodyShape.COUNT];
                 AudioAssetResults = new StreamableLoadingResult<AudioClipData>?[BodyShape.COUNT];
                 IsLoading = true;
             }
 
             public bool IsLooping() =>
-                DTO?.metadata?.emoteDataADR74?.loop ?? false;
+                DTO?.metadata.emoteDataADR74.loop ?? false;
 
             public void UpdateLoadingStatus(bool newStatus)
             {
                 IsLoading = newStatus;
-                storageRef?.OnUpdateLoadingStatusCalled?.Invoke(this, newStatus);
+                StorageRef?.OnUpdateLoadingStatusCalled?.Invoke(this, newStatus);
             }
 
             public void ApplyAndMarkAsLoaded(EmoteDTO dto)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/MemoryEmotesStorageShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/MemoryEmotesStorageShould.cs
@@ -1,0 +1,94 @@
+using CommunicationData.URLHelpers;
+using DCL.AvatarRendering.Loading.Assets;
+using DCL.AvatarRendering.Loading.Components;
+using DCL.Optimization.PerformanceBudgeting;
+using ECS.StreamableLoading;
+using ECS.StreamableLoading.Common.Components;
+using NUnit.Framework;
+using System.Collections.Generic;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace DCL.AvatarRendering.Emotes.Tests
+{
+    public class MemoryEmotesStorageShould
+    {
+        private MemoryEmotesStorage storage = null!;
+        private GameObject mainAsset = null!;
+        private CountingRefCountData refCountData = null!;
+        private AttachmentRegularAsset asset = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            storage = new MemoryEmotesStorage();
+            mainAsset = new GameObject("EmoteMainAsset");
+            refCountData = new CountingRefCountData();
+            asset = new AttachmentRegularAsset(mainAsset, new List<AttachmentRegularAsset.RendererInfo>(), refCountData);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (mainAsset != null) Object.DestroyImmediate(mainAsset);
+        }
+
+        [Test]
+        public void KeepReferencedEmoteAssetsOnUnload()
+        {
+            var urn = new URN("urn:test:emote:referenced");
+            IEmote emote = AddEmoteWithAsset(urn);
+
+            asset.AddReference();
+
+            storage.Unload(new NullPerformanceBudget());
+
+            Assert.IsTrue(storage.TryGetElement(urn, out _), "A referenced emote must survive the unload pass.");
+            Assert.IsNotNull(emote.AssetResults[BodyShape.MALE], "A referenced asset must not be discarded.");
+            Assert.AreEqual(0, refCountData.DereferenceCount, "A referenced asset must not be disposed.");
+        }
+
+        [Test]
+        public void DisposeAndEvictUnreferencedEmoteOnUnload()
+        {
+            var urn = new URN("urn:test:emote:unreferenced");
+            IEmote emote = AddEmoteWithAsset(urn);
+
+            // First pass disposes the unreferenced asset and clears its slot; the second pass
+            // (all slots empty by then) evicts the emote from the storage.
+            storage.Unload(new NullPerformanceBudget());
+
+            Assert.AreEqual(1, refCountData.DereferenceCount, "An unreferenced asset must be disposed under memory pressure.");
+            Assert.IsNull(emote.AssetResults[BodyShape.MALE], "The disposed asset slot must be cleared.");
+
+            storage.Unload(new NullPerformanceBudget());
+
+            Assert.IsFalse(storage.TryGetElement(urn, out _), "A fully unloaded emote must be evicted from the storage.");
+        }
+
+        private IEmote AddEmoteWithAsset(URN urn)
+        {
+            var dto = new EmoteDTO
+            {
+                id = urn.ToString(),
+                metadata = new EmoteDTO.EmoteMetadataDto
+                {
+                    id = urn.ToString(),
+                },
+            };
+
+            IEmote emote = storage.GetOrAddByDTO(dto);
+            emote.AssetResults[BodyShape.MALE] = new StreamableLoadingResult<AttachmentRegularAsset>(asset);
+            return emote;
+        }
+
+        private class CountingRefCountData : IStreamableRefCountData
+        {
+            public int DereferenceCount { get; private set; }
+
+            public void Dispose() { }
+
+            public void Dereference() => DereferenceCount++;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/MemoryEmotesStorageShould.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/MemoryEmotesStorageShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9bbac0c70b048f3bd9a3d2d095ed65e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Problem

RAM climbs continuously to ~99% while idling in Genesis Plaza; growth rate scales with the
number of nearby emoting avatars (100% repro on a 32 GB Windows 11 rig, GitHub #9665;
#9440 is the same growth class on Mac).

## Root cause

Emote asset ref-counting is add-only. `LoadEmotesByPointersSystem`/`LoadSceneEmotesSystem`
`AddReference()` on every resolved intention, but a repo-wide search finds zero
`Dereference()` calls on `emote.AssetResults[*].Asset` - so `MemoryEmotesStorage.Unload`'s
`ReferenceCount == 0` gate can never pass and the LRU unloader re-scans pinned emotes
fruitlessly on every pressure cycle. Every distinct emote played by anyone nearby is
retained forever. (Wearables balance the identical resolution-time ref via avatar release  - 
emotes had no balancing owner.) Secondary defects in the same locus: `CharacterEmoteSystem`
discarded promise entities without wrapping them for the consumer (one leaked entity per
uncached emote request), and `EmotePlayer.pools` was never pruned.

## Fix (~120 LOC)

1. `FinalizeEmoteLoadingSystem` balances the resolution ref per successful pointer on the
   intention's body-shape slot (exact mirror of the AddReference guard, so unisex
   double-slot sharing stays balanced) and disposes the resolution's `RepoolableList`.
2. `CharacterEmoteSystem.CreateEmotePromise` wraps all three promise kinds in
   `World.Create(...)`; new consume-and-dispose queries balance the scene-emote refs.
3. Play-time pinning: `EmotePlayer.Play/PlayMasked` take the `AttachmentRegularAsset`,
   `AddReference()` on acquire, dereference in the pool's release callback - a playing emote
   cannot be unloaded out from under the avatar once refcounts can reach 0.
4. `EmotePlayer.PruneDestroyedPools()` drops pool entries whose source asset was destroyed.

`CharacterPreviewController` flows through the fixed consumer for free;
`EquippedItemsPassportModuleController` remains self-consumed (smaller pre-existing leak,
follow-up material).

## Test

EditMode, in the existing emote test suites:

- `FinalizeEmoteLoadingSystemShould.DereferenceResolutionReferenceWhenConsumingFinishedEmotePromise`
  - RED at pin (RC stays 1), GREEN with fix.
- `MemoryEmotesStorageShould` - characterizes the unload gate (RC > 0 survives, RC 0 is
  disposed and evicted).
- `EmotePlayerShould` - play-time pin/unpin and stale-pool pruning (fix-coupled, new `Play`
  signature).

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 1/1 as intended ("Expected: 0 But
was: 1" - the leaked resolution reference) + 2 characterization guards PASS at pin / GREEN
PASS 5/5 including the fix-side pool-pinning tests.

Fixes #9665
Related: #9440 (Mac Genesis Plaza memory growth, same retention class)

Includes inspection-warning cleanup in all touched files.

Fixes #9665