### PR TITLE
fix: fall back to unconverted textures when the ktx native decoder cannot load

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/NFTShapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/NFTShapePlugin.cs
@@ -23,8 +23,6 @@ using ECS.LifeCycle.Systems;
 using ECS.StreamableLoading.Cache;
 using ECS.StreamableLoading.NFTShapes;
 using ECS.StreamableLoading.NFTShapes.URNs;
-using ECS.StreamableLoading.Textures;
-using System;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -77,7 +75,8 @@ namespace DCL.PluginSystem.World
         {
             var buffer = sharedDependencies.EntityEventsBuilder.Rent<NftShapeRendererComponent>();
 
-            bool isKtxEnabled = FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.KTX2_CONVERSION);
+            // A converter content-info result is only meaningful when the native decoder can actually run.
+            bool isKtxEnabled = FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.KTX2_CONVERSION) && KtxNativeSupport.IsSupported;
 
             LoadNFTTypeSystem.InjectToWorld(ref builder, NoCache<NftTypeResult, GetNFTTypeIntention>.INSTANCE, webRequestController, isKtxEnabled, decentralandUrlsSource);
             LoadCycleNftShapeSystem.InjectToWorld(ref builder, new BasedURNSource(decentralandUrlsSource), mediaFactory.CreateForScene(builder.World, sharedDependencies, systemsDependencies.RoomHub, placeholderSource: null));

--- a/Explorer/Assets/DCL/PluginSystem/World/NFTShapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/NFTShapePlugin.cs
@@ -23,6 +23,8 @@ using ECS.LifeCycle.Systems;
 using ECS.StreamableLoading.Cache;
 using ECS.StreamableLoading.NFTShapes;
 using ECS.StreamableLoading.NFTShapes.URNs;
+using ECS.StreamableLoading.Textures;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 

--- a/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceBenchmark.cs
+++ b/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceBenchmark.cs
@@ -30,7 +30,7 @@ namespace DCL.Tests.PlayMode.PerformanceTests
         protected SampleGroup? iterationDownloadedData;
 
         protected IWebRequestController? controller;
-        protected PerformanceTestWebRequestsAnalytics analytics = null!;
+        protected PerformanceTestWebRequestsAnalytics analytics;
 
         private MockedReportScope? reportScope;
 
@@ -49,7 +49,7 @@ namespace DCL.Tests.PlayMode.PerformanceTests
         }
 
         [OneTimeSetUp]
-        public void SetupFeatureFlags()
+        public void SetupFF()
         {
             FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(new FeatureFlagsResultDto
             {
@@ -59,7 +59,7 @@ namespace DCL.Tests.PlayMode.PerformanceTests
         }
 
         [OneTimeTearDown]
-        public void ResetFeatureFlags()
+        public void ResetFF()
         {
             FeatureFlagsConfiguration.Reset();
         }

--- a/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceBenchmark.cs
+++ b/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceBenchmark.cs
@@ -30,7 +30,7 @@ namespace DCL.Tests.PlayMode.PerformanceTests
         protected SampleGroup? iterationDownloadedData;
 
         protected IWebRequestController? controller;
-        protected PerformanceTestWebRequestsAnalytics analytics;
+        protected PerformanceTestWebRequestsAnalytics analytics = null!;
 
         private MockedReportScope? reportScope;
 
@@ -40,10 +40,16 @@ namespace DCL.Tests.PlayMode.PerformanceTests
             iterationTotalTime = new SampleGroup("Iteration Total Time", SampleUnit.Microsecond);
             iterationDownloadedData = new SampleGroup("Iteration Downloaded Data", SampleUnit.Megabyte);
             reportScope = new MockedReportScope();
+
+            // Benchmarks measure request routing, not machine capability: pinning the probe keeps
+            // SetKTXEnabled(true) deterministic on every machine and keeps the real probe (and any
+            // native-lib console logging) out of the test runner.
+            KtxNativeSupport.Reset();
+            KtxNativeSupport.probeOverride = static () => true;
         }
 
         [OneTimeSetUp]
-        public void SetupFF()
+        public void SetupFeatureFlags()
         {
             FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(new FeatureFlagsResultDto
             {
@@ -53,14 +59,17 @@ namespace DCL.Tests.PlayMode.PerformanceTests
         }
 
         [OneTimeTearDown]
-        public void ResetFF()
+        public void ResetFeatureFlags()
         {
             FeatureFlagsConfiguration.Reset();
         }
 
         [TearDown]
-        public void TearDown() =>
+        public void TearDown()
+        {
             reportScope?.Dispose();
+            KtxNativeSupport.Reset();
+        }
 
         protected void EnableErrors()
         {

--- a/Explorer/Assets/DCL/WebRequests/RequestsHub/RequestHub.cs
+++ b/Explorer/Assets/DCL/WebRequests/RequestsHub/RequestHub.cs
@@ -55,14 +55,14 @@ namespace DCL.WebRequests.RequestsHub
 
         public IDecentralandUrlsSource UrlsSource { get; }
 
-        private void Add<T, TWebRequest>(IDictionary<Key, object> map, InitializeRequest<T, TWebRequest> requestDelegate)
+        private void Add<T, TWebRequest>(IDictionary<Key, object> mutableMap, InitializeRequest<T, TWebRequest> requestDelegate)
             where T: struct
             where TWebRequest: struct, ITypedWebRequest
         {
             InitializeRequest<T, TWebRequest> invokeWithTransformedUrl
                 = (string url, ref T arguments) => requestDelegate.Invoke(UrlsSource.TransformUrl(url), ref arguments);
 
-            map.Add(Key.NewKey<T, TWebRequest>(), invokeWithTransformedUrl);
+            mutableMap.Add(Key.NewKey<T, TWebRequest>(), invokeWithTransformedUrl);
         }
 
         public InitializeRequest<T, TWebRequest> RequestDelegateFor<T, TWebRequest>()
@@ -77,7 +77,9 @@ namespace DCL.WebRequests.RequestsHub
 
         public void SetKTXEnabled(bool enabled)
         {
-            ktxEnabled = enabled;
+            // The flag comes from a remote source that cannot know whether this machine can load the
+            // ktx_unity native plugin; short-circuiting keeps the probe lazy while the feature is off.
+            ktxEnabled = enabled && KtxNativeSupport.IsSupported;
         }
     }
 }

--- a/Explorer/Assets/DCL/WebRequests/RequestsHub/RequestHub.cs
+++ b/Explorer/Assets/DCL/WebRequests/RequestsHub/RequestHub.cs
@@ -55,14 +55,14 @@ namespace DCL.WebRequests.RequestsHub
 
         public IDecentralandUrlsSource UrlsSource { get; }
 
-        private void Add<T, TWebRequest>(IDictionary<Key, object> mutableMap, InitializeRequest<T, TWebRequest> requestDelegate)
+        private void Add<T, TWebRequest>(IDictionary<Key, object> map, InitializeRequest<T, TWebRequest> requestDelegate)
             where T: struct
             where TWebRequest: struct, ITypedWebRequest
         {
             InitializeRequest<T, TWebRequest> invokeWithTransformedUrl
                 = (string url, ref T arguments) => requestDelegate.Invoke(UrlsSource.TransformUrl(url), ref arguments);
 
-            mutableMap.Add(Key.NewKey<T, TWebRequest>(), invokeWithTransformedUrl);
+            map.Add(Key.NewKey<T, TWebRequest>(), invokeWithTransformedUrl);
         }
 
         public InitializeRequest<T, TWebRequest> RequestDelegateFor<T, TWebRequest>()

--- a/Explorer/Assets/DCL/WebRequests/Tests/KtxNativeSupportShould.cs
+++ b/Explorer/Assets/DCL/WebRequests/Tests/KtxNativeSupportShould.cs
@@ -1,0 +1,114 @@
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.WebRequests.RequestsHub;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using UnityEngine.Networking;
+
+namespace DCL.WebRequests.Tests
+{
+    // Regression coverage for UNITY-EXPLORER-NQS (#7832): KTX2 conversion is enabled by a remote feature
+    // flag, so a machine whose OS cannot open the ktx_unity native plugin must route texture requests to
+    // the original URL instead of the media converter.
+    public class KtxNativeSupportShould
+    {
+        private const string ORIGINAL_URL = "https://peer.decentraland.org/content/contents/bafytexture";
+        private const string CONVERTER_URL_PREFIX = "https://converter.invalid/convert?url=";
+        private const string CONVERTER_URL_TEMPLATE = CONVERTER_URL_PREFIX + "{0}";
+
+        private IDecentralandUrlsSource urlsSource = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            KtxNativeSupport.Reset();
+
+            urlsSource = Substitute.For<IDecentralandUrlsSource>();
+            urlsSource.TransformUrl(Arg.Any<string>()).Returns(callInfo => callInfo.Arg<string>());
+            urlsSource.Url(DecentralandUrl.MediaConverter).Returns(CONVERTER_URL_TEMPLATE);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            KtxNativeSupport.Reset();
+        }
+
+        [Test]
+        public void RouteToOriginalUrl_WhenKtxNativeUnavailable()
+        {
+            KtxNativeSupport.probeOverride = static () => false;
+
+            var hub = new RequestHub(urlsSource);
+            hub.SetKTXEnabled(true);
+
+            using UnityWebRequest request = CreateTextureRequest(hub);
+
+            Assert.That(request.url, Is.EqualTo(ORIGINAL_URL));
+        }
+
+        [Test]
+        public void RouteToConverter_WhenKtxNativeAvailable()
+        {
+            KtxNativeSupport.probeOverride = static () => true;
+
+            var hub = new RequestHub(urlsSource);
+            hub.SetKTXEnabled(true);
+
+            using UnityWebRequest request = CreateTextureRequest(hub);
+
+            Assert.That(request.url, Does.StartWith(CONVERTER_URL_PREFIX));
+        }
+
+        [Test]
+        public void CacheProbeResult_AcrossReads()
+        {
+            var probeCalls = 0;
+
+            KtxNativeSupport.probeOverride = () =>
+            {
+                probeCalls++;
+                return true;
+            };
+
+            Assert.That(KtxNativeSupport.IsSupported, Is.True);
+            Assert.That(KtxNativeSupport.IsSupported, Is.True);
+            Assert.That(probeCalls, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ReportUnsupported_WhenProbeThrowsDllNotFound()
+        {
+            KtxNativeSupport.probeOverride = static () => throw new DllNotFoundException("ktx_unity");
+
+            Assert.That(KtxNativeSupport.IsSupported, Is.False);
+        }
+
+        [Test]
+        public void ReportUnsupported_WhenProbeThrowsUnexpectedException()
+        {
+            KtxNativeSupport.probeOverride = static () => throw new InvalidOperationException("corrupted install");
+
+            Assert.That(KtxNativeSupport.IsSupported, Is.False);
+        }
+
+        [Test]
+        public void StayUnsupported_AfterRuntimeTrip()
+        {
+            KtxNativeSupport.probeOverride = static () => true;
+
+            Assert.That(KtxNativeSupport.IsSupported, Is.True);
+
+            KtxNativeSupport.MarkUnsupported();
+
+            Assert.That(KtxNativeSupport.IsSupported, Is.False);
+        }
+
+        private static UnityWebRequest CreateTextureRequest(RequestHub hub)
+        {
+            InitializeRequest<GetTextureArguments, GetTextureWebRequest> initialize = hub.RequestDelegateFor<GetTextureArguments, GetTextureWebRequest>();
+            var arguments = new GetTextureArguments(TextureType.Albedo, useKtx: true);
+            return initialize(ORIGINAL_URL, ref arguments).UnityWebRequest;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/WebRequests/Tests/KtxNativeSupportShould.cs.meta
+++ b/Explorer/Assets/DCL/WebRequests/Tests/KtxNativeSupportShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f917208b7cf84094ad62c6b3e2f68425
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
@@ -37,7 +37,7 @@ namespace DCL.WebRequests
 
         internal static GetTextureWebRequest Initialize(string url, GetTextureArguments textureArguments, IDecentralandUrlsSource urlsSource, bool ktxEnabled)
         {
-            bool useKtx = textureArguments.UseKtx && ktxEnabled && !WebRequestUtils.IsLocalhost(url);
+            bool useKtx = textureArguments.UseKtx && ktxEnabled && KtxNativeSupport.IsSupported && !WebRequestUtils.IsLocalhost(url);
             string requestUrl = useKtx ? string.Format(urlsSource.Url(DecentralandUrl.MediaConverter), Uri.EscapeDataString(url)) : url;
             UnityWebRequest webRequest = UnityWebRequest.Get(requestUrl);
 
@@ -59,10 +59,10 @@ namespace DCL.WebRequests
             {
                 string? contentType = webRequest.UnityWebRequest.GetResponseHeader("Content-Type");
 
-                return contentType == "image/ktx2" ? ExecuteKtxAsync(webRequest, ct) : ExecuteNoCompressionAsync(webRequest, ct);
+                return contentType == "image/ktx2" ? ExecuteKtxAsync(webRequest) : ExecuteNoCompressionAsync(webRequest);
             }
 
-            private UniTask<Texture2D> ExecuteNoCompressionAsync(GetTextureWebRequest webRequest, CancellationToken ct)
+            private UniTask<Texture2D?> ExecuteNoCompressionAsync(GetTextureWebRequest webRequest)
             {
                 Texture2D texture;
 
@@ -86,10 +86,10 @@ namespace DCL.WebRequests
                 texture.filterMode = filterMode;
                 texture.SetDebugName(webRequest.url);
                 ProfilingCounters.TexturesAmount.Value++;
-                return UniTask.FromResult(texture);
+                return UniTask.FromResult<Texture2D?>(texture);
             }
 
-            private async UniTask<Texture2D> ExecuteKtxAsync(GetTextureWebRequest webRequest, CancellationToken ct)
+            private async UniTask<Texture2D?> ExecuteKtxAsync(GetTextureWebRequest webRequest)
             {
                 // TODO: .data creates an array
                 var data = webRequest.UnityWebRequest.downloadHandler?.data;
@@ -101,8 +101,16 @@ namespace DCL.WebRequests
 
                 var ktxTexture = new KtxTexture();
 
-                // Open() can throw before allocating native state; keep it outside the try so Dispose only runs once that state exists.
-                var openResult = ktxTexture.Open(bufferWrapped.nativeArray.AsReadOnly());
+                // Open() can throw before allocating native state; keep it outside the try/finally so Dispose only runs once that state exists.
+                ErrorCode openResult;
+
+                try { openResult = ktxTexture.Open(bufferWrapped.nativeArray.AsReadOnly()); }
+                catch (DllNotFoundException)
+                {
+                    // The OS failing to open the native plugin is per-machine-permanent, not transient.
+                    KtxNativeSupport.MarkUnsupported();
+                    throw;
+                }
 
                 try
                 {

--- a/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
@@ -105,9 +105,9 @@ namespace DCL.WebRequests
                 ErrorCode openResult;
 
                 try { openResult = ktxTexture.Open(bufferWrapped.nativeArray.AsReadOnly()); }
-                catch (DllNotFoundException)
+                catch (Exception e) when (e is DllNotFoundException or EntryPointNotFoundException)
                 {
-                    // The OS failing to open the native plugin is per-machine-permanent, not transient.
+                    // The OS failing to open the native plugin (or resolve a symbol in it) is per-machine-permanent, not transient.
                     KtxNativeSupport.MarkUnsupported();
                     throw;
                 }

--- a/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
@@ -59,10 +59,10 @@ namespace DCL.WebRequests
             {
                 string? contentType = webRequest.UnityWebRequest.GetResponseHeader("Content-Type");
 
-                return contentType == "image/ktx2" ? ExecuteKtxAsync(webRequest) : ExecuteNoCompressionAsync(webRequest);
+                return contentType == "image/ktx2" ? ExecuteKtxAsync(webRequest, ct) : ExecuteNoCompressionAsync(webRequest, ct);
             }
 
-            private UniTask<Texture2D?> ExecuteNoCompressionAsync(GetTextureWebRequest webRequest)
+            private UniTask<Texture2D> ExecuteNoCompressionAsync(GetTextureWebRequest webRequest, CancellationToken ct)
             {
                 Texture2D texture;
 
@@ -86,10 +86,10 @@ namespace DCL.WebRequests
                 texture.filterMode = filterMode;
                 texture.SetDebugName(webRequest.url);
                 ProfilingCounters.TexturesAmount.Value++;
-                return UniTask.FromResult<Texture2D?>(texture);
+                return UniTask.FromResult(texture);
             }
 
-            private async UniTask<Texture2D?> ExecuteKtxAsync(GetTextureWebRequest webRequest)
+            private async UniTask<Texture2D> ExecuteKtxAsync(GetTextureWebRequest webRequest, CancellationToken ct)
             {
                 // TODO: .data creates an array
                 var data = webRequest.UnityWebRequest.downloadHandler?.data;

--- a/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs
@@ -58,20 +58,10 @@ namespace DCL.WebRequests
                 // Garbage input makes Open return an error code without throwing when the native library is
                 // loadable, so the throw below is the only unsupported signal; Dispose must not run if Open threw
                 // because native state only exists once Open returns. The error code is the expected healthy-lib
-                // outcome, but the package logs it at Error level; logging is paused so the deliberate garbage
-                // probe emits no error. The pause is a blanket logEnabled toggle because Unity's filterLogType
-                // ranks Error above every other type and cannot mute errors alone; the blast radius is one
-                // synchronous sub-millisecond Open call on the main thread.
-                UnityEngine.ILogger unityLogger = UnityEngine.Debug.unityLogger;
-                bool logWasEnabled = unityLogger.logEnabled;
-                unityLogger.logEnabled = false;
-
-                try
-                {
-                    ktxTexture.Open(probeBuffer.AsReadOnly());
-                    ktxTexture.Dispose();
-                }
-                finally { unityLogger.logEnabled = logWasEnabled; }
+                // outcome; the package logs it at Error level only under #if DEBUG (editor and development builds),
+                // where the "KTX error code" line from this deliberate garbage probe is expected and harmless.
+                ktxTexture.Open(probeBuffer.AsReadOnly());
+                ktxTexture.Dispose();
 
                 return true;
             }

--- a/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs
@@ -1,0 +1,85 @@
+using DCL.Diagnostics;
+using KtxUnity;
+using System;
+using Unity.Collections;
+
+namespace DCL.WebRequests
+{
+    /// <summary>
+    ///     Local capability check for the ktx_unity native decoder. KTX2 conversion is toggled by a remote feature
+    ///     flag, so machines where the OS cannot open the native plugin (AV quarantine, missing VC++ runtime,
+    ///     corrupted install) must degrade to unconverted texture URLs instead of failing every converted request
+    ///     with <see cref="DllNotFoundException" />.
+    ///     Not thread-safe: all reads and writes are expected on the main thread; a racing double probe is
+    ///     benign (same cached result).
+    /// </summary>
+    public static class KtxNativeSupport
+    {
+        private const int PROBE_BUFFER_SIZE = 16;
+
+        internal static Func<bool>? probeOverride;
+
+        private static bool? isSupported;
+
+        public static bool IsSupported
+        {
+            get
+            {
+                isSupported ??= Probe();
+                return isSupported.Value;
+            }
+        }
+
+        /// <summary>
+        ///     A native load failure observed at runtime is per-machine-permanent: the capability stays off for the
+        ///     rest of the session.
+        /// </summary>
+        internal static void MarkUnsupported()
+        {
+            isSupported = false;
+        }
+
+        internal static void Reset()
+        {
+            isSupported = null;
+            probeOverride = null;
+        }
+
+        private static bool Probe()
+        {
+            try
+            {
+                if (probeOverride != null)
+                    return probeOverride();
+
+                using var probeBuffer = new NativeArray<byte>(PROBE_BUFFER_SIZE, Allocator.Temp);
+                var ktxTexture = new KtxTexture();
+
+                // Garbage input makes Open return an error code without throwing when the native library is
+                // loadable, so the throw below is the only unsupported signal; Dispose must not run if Open threw
+                // because native state only exists once Open returns. The error code is the expected healthy-lib
+                // outcome, but the package logs it at Error level; logging is paused so the deliberate garbage
+                // probe emits no error.
+                UnityEngine.ILogger unityLogger = UnityEngine.Debug.unityLogger;
+                bool logWasEnabled = unityLogger.logEnabled;
+                unityLogger.logEnabled = false;
+
+                try
+                {
+                    ktxTexture.Open(probeBuffer.AsReadOnly());
+                    ktxTexture.Dispose();
+                }
+                finally { unityLogger.logEnabled = logWasEnabled; }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                // A broken native install can fail in shapes beyond DllNotFound; the probe never throws and
+                // fails closed instead, with the exception type named in the warning to keep it visible.
+                ReportHub.LogWarning(ReportCategory.TEXTURE_WEB_REQUEST, $"ktx_unity probe failed ({e.GetType().Name}: {e.Message}); KTX2 conversion is disabled and textures fall back to unconverted URLs");
+                return false;
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs
@@ -59,7 +59,9 @@ namespace DCL.WebRequests
                 // loadable, so the throw below is the only unsupported signal; Dispose must not run if Open threw
                 // because native state only exists once Open returns. The error code is the expected healthy-lib
                 // outcome, but the package logs it at Error level; logging is paused so the deliberate garbage
-                // probe emits no error.
+                // probe emits no error. The pause is a blanket logEnabled toggle because Unity's filterLogType
+                // ranks Error above every other type and cannot mute errors alone; the blast radius is one
+                // synchronous sub-millisecond Open call on the main thread.
                 UnityEngine.ILogger unityLogger = UnityEngine.Debug.unityLogger;
                 bool logWasEnabled = unityLogger.logEnabled;
                 unityLogger.logEnabled = false;

--- a/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs.meta
+++ b/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d8e603bf2d342fdaebe70c49bcc8118
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Problem

`DllNotFoundException: Unable to load DLL 'ktx_unity'` from
`KtxNativeInstance.CertifySupportedPlatform` whenever a texture arrives from the
media-converter as `image/ktx2` on a machine where the native plugin (or a transitive DLL
dependency) cannot be opened - AV quarantine, missing VC++ runtime, corrupted install.
Sentry UNITY-EXPLORER-NQS: 235 events past week, ongoing. Every KTX2 texture load on that
machine fails for the whole session, session after session, with no fallback.

## Root cause

The KTX2-conversion pipeline is enabled based solely on the remote `ktx2-conversion`
feature flag, with no verification that the native decoder is actually loadable on this
machine and no fallback when it is not - a missing local capability probe for a
remotely-toggled native-dependent feature. The DLL load failure itself is environmental and
unfixable client-side; the permanent per-machine breakage is not.

## Fix (~60 production LOC)

- New `KtxNativeSupport`: cached static capability probe (`KtxTexture.Open` on garbage
  bytes - returns `ErrorCode.LoadingFailed` on a healthy lib, throws on a broken one);
  catches `DllNotFoundException | EntryPointNotFoundException | NotSupportedException`;
  one-time warning when unsupported; internal probe-override test seam +
  `MarkUnsupported()`.
- `RequestHub.SetKTXEnabled`: `enabled && KtxNativeSupport.IsSupported` - probe runs lazily,
  only when the flag is on.
- `GetTextureWebRequest`: same gate in `Initialize`; a mid-session `DllNotFoundException`
  in `ExecuteKtxAsync` trips `MarkUnsupported()` and rethrows - subsequent requests
  self-heal onto the direct-URL path.
- `NFTShapePlugin`: same gate, keeping the NFT content-info fetch consistent.
- `PerformanceBenchmark` pins the probe true per-test (review finding: the real probe's
  debug-only error log would trip UTF's unexpected-error check in the perf lane).

Result: affected machines degrade gracefully to unconverted originals (more bandwidth, zero
user-visible breakage) instead of failing outright.

## Test

New EditMode `KtxNativeSupportShould` (5 tests): routing to the original URL when the probe
reports unavailable (the repro), routing to the converter when available (over-disable
guard), probe caching, DllNotFound-in-probe handling, and the `MarkUnsupported` runtime trip.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 1/5 as intended (request routed to
the converter URL at pin despite the failing probe; 4 by-construction guards passed) /
GREEN PASS 5/5.

Fixes #7832
Related: #5150 (autoclosed original of this signature, still occurring), #7634 (closed
duplicate), #9064 (context: registry-resolved com.unity.cloud.ktx 3.6.3)


Fixes #5150
