### PR TITLE
fix: dispose never-shown AuthenticationScreenController without NRE

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -81,16 +81,17 @@ namespace DCL.AuthenticationScreenFlow
         // misclassifying returning users whose cached identity expired.
         public bool IsCurrentlyNewAccount { get; internal set; }
 
-        public event Action DiscordButtonClicked;
-        public event Action<string, bool> OTPVerified;
-        public event Action OTPResend;
-        public event Action ProfileFinalized;
+        public event Action? DiscordButtonClicked;
+        public event Action<string, bool>? OTPVerified;
+        public event Action? OTPResend;
+        public event Action? ProfileFinalized;
 
         internal void RaiseProfileFinalized() =>
             ProfileFinalized?.Invoke();
 
-        private MVCStateMachine<AuthStateBase> fsm;
-        private AuthenticationScreenAudio audio;
+        // Null until OnViewInstantiated: the view is created lazily on first Show and may never be instantiated.
+        private MVCStateMachine<AuthStateBase>? fsm;
+        private AuthenticationScreenAudio? audio;
 
         public AuthenticationScreenController(
             ViewFactoryMethod viewFactory,
@@ -138,8 +139,8 @@ namespace DCL.AuthenticationScreenFlow
             characterPreviewController?.Dispose();
 
             CancelLoginProcess();
-            audio.Dispose();
-            fsm.Dispose();
+            audio?.Dispose();
+            fsm?.Dispose();
         }
 
         protected override void OnViewInstantiated()
@@ -191,6 +192,7 @@ namespace DCL.AuthenticationScreenFlow
         protected override void OnBeforeViewShow()
         {
             base.OnBeforeViewShow();
+
             // Force to re-login if the identity will expire in 24hs or less, so we mitigate the chances on
             // getting the identity expired while in-world, provoking signed-fetch requests to fail
             IWeb3Identity? storedIdentity = storedIdentityProvider.Identity;
@@ -203,7 +205,7 @@ namespace DCL.AuthenticationScreenFlow
             }
             else
             {
-                fsm.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
+                fsm!.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
             }
         }
 
@@ -214,10 +216,10 @@ namespace DCL.AuthenticationScreenFlow
                 bool autoLoginSuccess = await web3Authenticator.TryAutoLoginAsync(ct);
 
                 if (autoLoginSuccess)
-                    fsm.Enter<ProfileFetchingAuthState, ProfileFetchingPayload>(new (storedIdentity, storedIdentity.Source != IWeb3Identity.Web3IdentitySource.TokenFile, ct));
+                    fsm!.Enter<ProfileFetchingAuthState, ProfileFetchingPayload>(new (storedIdentity, storedIdentity.Source != IWeb3Identity.Web3IdentitySource.TokenFile, ct));
                 else
                 {
-                    fsm.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
+                    fsm!.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
                 }
             }
             catch (OperationCanceledException)
@@ -226,7 +228,7 @@ namespace DCL.AuthenticationScreenFlow
             catch (Exception e)
             {
                 ReportHub.LogException(e, new ReportData(ReportCategory.AUTHENTICATION));
-                fsm.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
+                fsm!.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.IN, true);
             }
         }
 
@@ -235,18 +237,18 @@ namespace DCL.AuthenticationScreenFlow
             base.OnViewShow();
 
             BlockUnwantedInputs();
-            audio.OnShow();
+            audio!.OnShow();
         }
 
         protected override void OnViewClose()
         {
             base.OnViewClose();
 
-            fsm.CurrentState?.Exit();
+            fsm!.CurrentState?.Exit();
             CancelLoginProcess();
 
             UnblockUnwantedInputs();
-            audio.OnHide();
+            audio!.OnHide();
         }
 
         protected override async UniTask WaitForCloseIntentAsync(CancellationToken ct)
@@ -285,7 +287,7 @@ namespace DCL.AuthenticationScreenFlow
 
                 await web3Authenticator.LogoutAsync(ct);
 
-                fsm.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.SLIDE, true);
+                fsm!.Enter<LoginSelectionAuthState, int>(UIAnimationHashes.SLIDE, true);
             }
         }
 

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -81,10 +81,10 @@ namespace DCL.AuthenticationScreenFlow
         // misclassifying returning users whose cached identity expired.
         public bool IsCurrentlyNewAccount { get; internal set; }
 
-        public event Action? DiscordButtonClicked;
-        public event Action<string, bool>? OTPVerified;
-        public event Action? OTPResend;
-        public event Action? ProfileFinalized;
+        public event Action DiscordButtonClicked;
+        public event Action<string, bool> OTPVerified;
+        public event Action OTPResend;
+        public event Action ProfileFinalized;
 
         internal void RaiseProfileFinalized() =>
             ProfileFinalized?.Invoke();
@@ -192,7 +192,6 @@ namespace DCL.AuthenticationScreenFlow
         protected override void OnBeforeViewShow()
         {
             base.OnBeforeViewShow();
-
             // Force to re-login if the identity will expire in 24hs or less, so we mitigate the chances on
             // getting the identity expired while in-world, provoking signed-fetch requests to fail
             IWeb3Identity? storedIdentity = storedIdentityProvider.Identity;

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/AuthenticationScreenControllerShould.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/AuthenticationScreenControllerShould.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+
+namespace DCL.AuthenticationScreenFlow.Tests
+{
+    [TestFixture]
+    public class AuthenticationScreenControllerShould
+    {
+        [Test]
+        public void NotThrowOnDisposeWhenViewWasNeverShown()
+        {
+            // Registered-but-never-shown lifecycle: the view factory is never invoked, so
+            // OnViewInstantiated never runs and the lazily-created members stay null
+            // (sessions with --skip-auth-screen + a valid cached identity).
+            // The constructor only stores its dependencies; none are dereferenced before the view exists.
+            var controller = new AuthenticationScreenController(
+                () => null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                string.Empty,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!);
+
+            Assert.DoesNotThrow(controller.Dispose);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/AuthenticationScreenControllerShould.cs.meta
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/AuthenticationScreenControllerShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66373631147046cd8f17228cbe05ddba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
@@ -37,7 +37,12 @@ namespace MVC
         public void Dispose()
         {
             foreach (IController controllersValue in controllers.Values)
-                controllersValue.Dispose();
+            {
+                // One controller's failing Dispose must not abort disposal of the remaining
+                // controllers, the destruction CTS and the windows stack.
+                try { controllersValue.Dispose(); }
+                catch (Exception e) { ReportHub.LogException(e, ReportCategory.MVC); }
+            }
 
             destructionCancellationTokenSource.SafeCancelAndDispose();
             windowsStackManager.Dispose();

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerDisposeShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerDisposeShould.cs
@@ -1,0 +1,52 @@
+using MVC.PopupsController.PopupCloser;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using UnityEngine.TestTools;
+
+namespace MVC.Tests
+{
+    [TestFixture]
+    public class MVCManagerDisposeShould
+    {
+        private IWindowsStackManager windowsStackManager = null!;
+        private MVCManager mvcManager = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            windowsStackManager = Substitute.For<IWindowsStackManager>();
+            mvcManager = new MVCManager(windowsStackManager, new CancellationTokenSource(), Substitute.For<IPopupCloserView>());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            LogAssert.ignoreFailingMessages = false;
+        }
+
+        [Test]
+        public void DisposeRemainingControllersAndStackWhenOneControllerThrows()
+        {
+            // The guarded disposal loop reports the throwing controller via ReportHub (error-level log).
+            LogAssert.ignoreFailingMessages = true;
+
+            IController<ITestView, TestInputData> throwingController = Substitute.For<IController<ITestView, TestInputData>>();
+            throwingController.When(c => c.Dispose()).Do(_ => throw new InvalidOperationException("dispose failure"));
+            IController<IOtherTestView, TestInputData> otherController = Substitute.For<IController<IOtherTestView, TestInputData>>();
+
+            mvcManager.RegisterController(throwingController);
+            mvcManager.RegisterController(otherController);
+
+            Assert.DoesNotThrow(mvcManager.Dispose);
+
+            // Order-independent: whichever controller is disposed first, both must be reached
+            // and the windows stack must be disposed after the loop.
+            otherController.Received(1).Dispose();
+            windowsStackManager.Received(1).Dispose();
+        }
+    }
+
+    public interface IOtherTestView : IView { }
+}

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerDisposeShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerDisposeShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1019d41ca774ef9a96de237c26e737b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Problem

At app exit, `MainSceneLoader.Shutdown` logs "`MainUIPlugin`'s thrown an exception on
disposal" with an inner `NullReferenceException` from
`AuthenticationScreenController.Dispose` (Sentry UNITY-EXPLORER-PC4, 44 events / 8 users
past week). Worse than the log line: the first throwing controller aborts
`MVCManager.Dispose`'s loop, so every controller registered after it (~200 total) leaks its
disposal - event unsubscribes, CTS cancels - on every affected exit.

## Root cause

`AuthenticationScreenController.Dispose` unconditionally disposes `fsm` and `audio`, which
are only assigned in `OnViewInstantiated()` - and view instantiation is lazy and optional.
Sessions started with `--skip-auth-screen` plus a valid cached identity (the Creator Hub
preview flow) never show the auth screen, so both fields are still null at shutdown. The
field annotations lied about the lifecycle: null-until-shown is the real invariant.

## Fix (~21 LOC, 2 files)

1. `AuthenticationScreenController`: declare `fsm`/`audio` nullable with the
   null-until-shown invariant; `Dispose()` uses `audio?.Dispose(); fsm?.Dispose();`
   (mirroring the adjacent `characterPreviewController?.Dispose()`); post-instantiation
   lifecycle sites use `!.` per the trust-nullability convention (ControllerBase guarantees
   show-lifecycle callbacks run only after `OnViewInstantiated`). An annotation correction,
   not a defensive null-check.
2. `MVCManager.Dispose` (defect-class hardening): per-controller try/catch +
   `ReportHub.LogException(..., ReportCategory.MVC)` so one throwing controller can no
   longer truncate disposal of the remaining controllers, the destruction CTS, and the
   windows stack.

## Test

- `AuthenticationScreenControllerShould.NotThrowOnDisposeWhenViewWasNeverShown` - constructs
  the controller with a never-invoked view factory and disposes; RED at pin (NRE from
  `audio.Dispose()`).
- `MVCManagerDisposeShould.DisposeRemainingControllersAndStackWhenOneControllerThrows`  - 
  order-independent: a throwing controller must not prevent the other controller and the
  windows stack from being disposed.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 2/2 as intended (NRE at
`AuthenticationScreenController.Dispose`; the substitute's exception aborting
`MVCManager.Dispose`) / GREEN PASS 2/2.

Related: #9030 (stale-closed tracker for this exact Sentry issue, still occurring), #8972
(same defect, earlier symbolication), #6942 (closed umbrella for the shutdown-disposal
class)

