### PR TITLE
fix: resize map render texture when screen resolution changes

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/ConsumerUtils/PixelPerfectMapRendererTextureProvider.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ConsumerUtils/PixelPerfectMapRendererTextureProvider.cs
@@ -10,25 +10,34 @@ namespace DCL.MapRenderer.ConsumerUtils
     public class PixelPerfectMapRendererTextureProvider : MonoBehaviour
     {
         [NonSerialized]
-        private RectTransform cachedRectTransform;
+        private RectTransform? cachedRectTransform;
         private RectTransform rectTransform => cachedRectTransform ??= (RectTransform)transform;
 
-        private RawImage rawImage;
+        private RawImage? rawImage;
         private RawImage targetImage => rawImage ??= GetComponent<RawImage>();
 
-        private IMapCameraController cameraController;
-        private Camera hudCamera;
+        private IMapCameraController? cameraController;
+        private Camera? hudCamera;
+
+        // Resolution last applied to the render texture; seeded in Activate so an unchanged
+        // size never triggers a redundant resize.
+        private Vector2Int lastResolution;
 
         private static Vector3[] worldCorners = new Vector3[4];
 
-        public void Activate(IMapCameraController cameraController)
+        /// <summary>
+        /// Arms pixel-perfect resizing. The controller's render texture must already be sized
+        /// with <see cref="GetPixelPerfectTextureResolution"/> when this is called.
+        /// </summary>
+        public void Activate(IMapCameraController newCameraController)
         {
-            this.cameraController = cameraController;
+            cameraController = newCameraController;
+            lastResolution = GetPixelPerfectTextureResolution();
         }
 
-        public void SetHudCamera(Camera hudCamera)
+        public void SetHudCamera(Camera newHudCamera)
         {
-            this.hudCamera = hudCamera;
+            hudCamera = newHudCamera;
         }
 
         public void Deactivate()
@@ -40,9 +49,6 @@ namespace DCL.MapRenderer.ConsumerUtils
         {
             // assumes CanvasScale Match Height = 1;
 
-            var rectSize = rectTransform.rect.size;
-            var ratio = rectSize.x / rectSize.y;
-
             // translate rect to screen space
             rectTransform.GetWorldCorners(worldCorners);
 
@@ -53,12 +59,31 @@ namespace DCL.MapRenderer.ConsumerUtils
             return new Vector2Int((int) screenSize.x, (int) screenSize.y);
         }
 
+        // Screen-resolution or canvas-scale changes (e.g. windowed -> fullscreen) alter the
+        // on-screen pixel size without changing the rect, so OnRectTransformDimensionsChange
+        // alone cannot keep the render texture pixel-perfect: poll every frame.
+        private void LateUpdate()
+        {
+            ApplyPixelPerfectResolution();
+        }
+
         private void OnRectTransformDimensionsChange()
+        {
+            ApplyPixelPerfectResolution();
+        }
+
+        private void ApplyPixelPerfectResolution()
         {
             if (cameraController == null)
                 return;
 
-            cameraController.ResizeTexture(GetPixelPerfectTextureResolution());
+            Vector2Int resolution = GetPixelPerfectTextureResolution();
+
+            if (resolution == lastResolution)
+                return;
+
+            lastResolution = resolution;
+            cameraController.ResizeTexture(resolution);
 
             targetImage.SetAllDirty();
         }

--- a/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils.meta
+++ b/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42368490db9c4535869fa959000f7998
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils/PixelPerfectMapRendererTextureProviderShould.cs
+++ b/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils/PixelPerfectMapRendererTextureProviderShould.cs
@@ -1,0 +1,104 @@
+﻿using DCL.MapRenderer.ConsumerUtils;
+using DCL.MapRenderer.MapCameraController;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace DCL.MapRenderer.Tests.ConsumerUtils
+{
+    public class PixelPerfectMapRendererTextureProviderShould
+    {
+        private const float RECT_SIZE = 300f;
+
+        private GameObject root = null!;
+        private GameObject providerGo = null!;
+        private PixelPerfectMapRendererTextureProvider provider = null!;
+        private IMapCameraController cameraController = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            root = new GameObject("root", typeof(RectTransform));
+            providerGo = new GameObject("provider", typeof(RectTransform));
+            providerGo.transform.SetParent(root.transform, false);
+            ((RectTransform)providerGo.transform).sizeDelta = new Vector2(RECT_SIZE, RECT_SIZE);
+            providerGo.AddComponent<RawImage>();
+            provider = providerGo.AddComponent<PixelPerfectMapRendererTextureProvider>();
+
+            // Null hud camera = overlay-canvas branch of WorldToScreenPoint: screen size == world size,
+            // deterministic in a headless EditMode run.
+            cameraController = Substitute.For<IMapCameraController>();
+            provider.Activate(cameraController);
+            cameraController.ClearReceivedCalls();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(providerGo);
+            Object.DestroyImmediate(root);
+        }
+
+        private void PumpLateUpdate() =>
+            providerGo.SendMessage("LateUpdate", SendMessageOptions.DontRequireReceiver);
+
+        private void ScaleCanvasBy2()
+        {
+            // Windowed -> fullscreen as production sees it: the scale-with-screen-size canvas absorbs
+            // the new pixel resolution into its scale factor, the provider's own rect (canvas units)
+            // keeps identical dimensions, so Unity never sends OnRectTransformDimensionsChange.
+            root.transform.localScale = 2f * Vector3.one;
+        }
+
+        [Test]
+        public void ResizeWhenScreenSpaceSizeChangesWithoutRectChange()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            ScaleCanvasBy2();
+
+            PumpLateUpdate();
+            PumpLateUpdate();
+
+            cameraController.Received(1).ResizeTexture(new Vector2Int(600, 600));
+        }
+
+        [Test]
+        public void NotResizeWhenScreenSpaceSizeUnchanged()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            PumpLateUpdate();
+            PumpLateUpdate();
+
+            cameraController.DidNotReceive().ResizeTexture(Arg.Any<Vector2Int>());
+        }
+
+        [Test]
+        public void ResizeOnRectDimensionsChangeMessage()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            ScaleCanvasBy2();
+
+            providerGo.SendMessage("OnRectTransformDimensionsChange", SendMessageOptions.DontRequireReceiver);
+
+            cameraController.Received(1).ResizeTexture(new Vector2Int(600, 600));
+        }
+
+        [Test]
+        public void NotResizeAfterDeactivate()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            provider.Deactivate();
+            ScaleCanvasBy2();
+
+            PumpLateUpdate();
+
+            cameraController.DidNotReceive().ResizeTexture(Arg.Any<Vector2Int>());
+        }
+    }
+}

--- a/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils/PixelPerfectMapRendererTextureProviderShould.cs.meta
+++ b/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils/PixelPerfectMapRendererTextureProviderShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11ab2bebbfe549679281d63a2b7ab104
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Problem

The minimap (and the navmap satellite view) renders pixelated after switching from windowed
to fullscreen, and stays pixelated until restart. Slack #bug-reporting 2026-08-12, repro
10/10, QA-confirmed STR; GitHub #9692.

## Root cause

The map camera's RenderTexture is sized once at rent time from
`GetPixelPerfectTextureResolution()` and the only resize trigger in the product is
`OnRectTransformDimensionsChange()`. On a windowed→fullscreen switch the screen pixel
resolution changes but the minimap RectTransform's rect (canvas units) does not - the
scale-with-screen-size CanvasScaler absorbs the change into the canvas scaleFactor - so the
event never fires and the RT stays at the boot-time pixel size (e.g. ~225 px tall from a
720p window) drawn over ~2x the physical pixels with point filtering. A missing-trigger
defect: the resolution math itself is already correct at any time.

## Fix (~25 LOC, single file shared by all three consumers)

`PixelPerfectMapRendererTextureProvider.cs`: cache `lastResolution` (seeded in `Activate()`),
add a `LateUpdate()` poll that computes the pixel-perfect resolution and calls
`ResizeTexture` only when it changed, and funnel `OnRectTransformDimensionsChange()` through
the same debounced apply-path (which also removes the previously unconditional per-frame RT
realloc during rect animations). Zero allocations per frame; navmap satellite and street
view are fixed for free; the downscale direction (fullscreen→windowed) also starts working,
shrinking VRAM.

## Test

New EditMode `PixelPerfectMapRendererTextureProviderShould` (4 tests): the repro simulates
fullscreen exactly as production experiences it (root localScale ×2 - a canvas-scale-only
change that never raises the rect-dimensions event) and asserts exactly one
`ResizeTexture((600,600))`; guards cover the no-change debounce, the legacy rect-change
path, and the deactivated state.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 1/1 as intended (no resize observed
at pin on a scale-only change) + 3 guards PASS at pin / GREEN PASS 4/4.

Fixes #9692
Related: #4474 (minimap image distortion, plausibly the same staleness), #2665 (map zoom
fidelity, context)

Includes inspection-warning cleanup in all touched files.

Fixes #9692