### PR TITLE
perf: remove per-poll List allocation in notifications polling

### DIFF
--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -43,7 +43,16 @@ namespace DCL.Notifications
             IWeb3IdentityCache web3IdentityCache
         ) : this(webRequestController, urlsSource, web3IdentityCache, NOTIFICATIONS_DELAY) { }
 
-        internal NotificationsRequestController(
+#if UNITY_INCLUDE_TESTS
+        public static NotificationsRequestController CreateForTest(
+            IWebRequestController webRequestController,
+            IDecentralandUrlsSource urlsSource,
+            IWeb3IdentityCache web3IdentityCache,
+            TimeSpan pollInterval) =>
+            new (webRequestController, urlsSource, web3IdentityCache, pollInterval);
+#endif
+
+        private NotificationsRequestController(
             IWebRequestController webRequestController,
             IDecentralandUrlsSource urlsSource,
             IWeb3IdentityCache web3IdentityCache,

--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -20,7 +20,12 @@ namespace DCL.Notifications
 {
     public class NotificationsRequestController
     {
-        private static readonly TimeSpan NOTIFICATIONS_DELAY = TimeSpan.FromSeconds(5);
+#if UNITY_INCLUDE_TESTS
+        // Mutable only in test-including compilations so EditMode tests can shorten the poll cadence
+        public static TimeSpan NotificationsDelay = TimeSpan.FromSeconds(5);
+#else
+        private static readonly TimeSpan NotificationsDelay = TimeSpan.FromSeconds(5);
+#endif
 
         private readonly JsonSerializerSettings serializerSettings;
         private readonly IWebRequestController webRequestController;
@@ -32,7 +37,6 @@ namespace DCL.Notifications
         private readonly URLParameter limitParameter = new ("limit", "50");
         private readonly URLBuilder urlBuilder = new ();
         private readonly URLDomain notificationsUrl;
-        private readonly TimeSpan pollInterval;
         private CommonArguments commonArguments;
         private ulong unixTimestamp;
         private ulong lastPolledTimestamp;
@@ -41,25 +45,8 @@ namespace DCL.Notifications
             IWebRequestController webRequestController,
             IDecentralandUrlsSource urlsSource,
             IWeb3IdentityCache web3IdentityCache
-        ) : this(webRequestController, urlsSource, web3IdentityCache, NOTIFICATIONS_DELAY) { }
-
-#if UNITY_INCLUDE_TESTS
-        public static NotificationsRequestController CreateForTest(
-            IWebRequestController webRequestController,
-            IDecentralandUrlsSource urlsSource,
-            IWeb3IdentityCache web3IdentityCache,
-            TimeSpan pollInterval) =>
-            new (webRequestController, urlsSource, web3IdentityCache, pollInterval);
-#endif
-
-        private NotificationsRequestController(
-            IWebRequestController webRequestController,
-            IDecentralandUrlsSource urlsSource,
-            IWeb3IdentityCache web3IdentityCache,
-            TimeSpan pollInterval
         )
         {
-            this.pollInterval = pollInterval;
             this.webRequestController = webRequestController;
             this.urlsSource = urlsSource;
             this.web3IdentityCache = web3IdentityCache;
@@ -86,7 +73,7 @@ namespace DCL.Notifications
 
         public async UniTask<List<INotification>> GetMostRecentNotificationsAsync(CancellationToken ct)
         {
-            do await UniTask.Delay(pollInterval, DelayType.Realtime, cancellationToken: ct);
+            do await UniTask.Delay(NotificationsDelay, DelayType.Realtime, cancellationToken: ct);
             while (web3IdentityCache.Identity == null || web3IdentityCache.Identity.IsExpired);
 
             urlBuilder.Clear();
@@ -120,7 +107,7 @@ namespace DCL.Notifications
             {
                 try
                 {
-                    await UniTask.Delay(pollInterval, DelayType.Realtime, cancellationToken: ct);
+                    await UniTask.Delay(NotificationsDelay, DelayType.Realtime, cancellationToken: ct);
 
                     if (web3IdentityCache.Identity == null || web3IdentityCache.Identity.IsExpired)
                         continue;

--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -20,11 +20,15 @@ namespace DCL.Notifications
 {
     public class NotificationsRequestController
     {
+        private static readonly TimeSpan NOTIFICATIONS_DELAY = TimeSpan.FromSeconds(5);
+
 #if UNITY_INCLUDE_TESTS
-        // Mutable only in test-including compilations so EditMode tests can shorten the poll cadence
-        public static TimeSpan NotificationsDelay = TimeSpan.FromSeconds(5);
+        // Set by EditMode tests to shorten the poll cadence; null falls back to NOTIFICATIONS_DELAY
+        public static TimeSpan? PollIntervalOverrideForTest;
+
+        private static TimeSpan pollDelay => PollIntervalOverrideForTest ?? NOTIFICATIONS_DELAY;
 #else
-        private static readonly TimeSpan NotificationsDelay = TimeSpan.FromSeconds(5);
+        private static TimeSpan pollDelay => NOTIFICATIONS_DELAY;
 #endif
 
         private readonly JsonSerializerSettings serializerSettings;
@@ -73,7 +77,7 @@ namespace DCL.Notifications
 
         public async UniTask<List<INotification>> GetMostRecentNotificationsAsync(CancellationToken ct)
         {
-            do await UniTask.Delay(NotificationsDelay, DelayType.Realtime, cancellationToken: ct);
+            do await UniTask.Delay(pollDelay, DelayType.Realtime, cancellationToken: ct);
             while (web3IdentityCache.Identity == null || web3IdentityCache.Identity.IsExpired);
 
             urlBuilder.Clear();
@@ -107,7 +111,7 @@ namespace DCL.Notifications
             {
                 try
                 {
-                    await UniTask.Delay(NotificationsDelay, DelayType.Realtime, cancellationToken: ct);
+                    await UniTask.Delay(pollDelay, DelayType.Realtime, cancellationToken: ct);
 
                     if (web3IdentityCache.Identity == null || web3IdentityCache.Identity.IsExpired)
                         continue;

--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -79,7 +79,7 @@ namespace DCL.Notifications
             commonArguments = new CommonArguments(urlBuilder.Build(), RetryPolicy.Enforce());
             unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
-            // Null when the identity disappears between the wait loop above and the signed request: the web request layer returns default without running the op
+            // Null when the identity disappears before the signed request runs
             List<INotification>? notifications =
                 await webRequestController.GetAsync(
                                                commonArguments,
@@ -94,8 +94,7 @@ namespace DCL.Notifications
 
         public async UniTask StartGettingNewNotificationsOverTimeAsync(CancellationToken ct)
         {
-            // Loop-local so a cancelled generation still parsing off-thread can never race the next generation's Clear();
-            // reused across iterations: cleared before each request and never escapes the loop (items are dispatched individually)
+            // Loop-local so a cancelled run can't race the next one's Clear(); reused across iterations and never escapes the loop
             var pollNotificationsBuffer = new List<INotification>();
 
             do
@@ -119,7 +118,7 @@ namespace DCL.Notifications
 
                     pollNotificationsBuffer.Clear();
 
-                    // Null when the identity disappears between the check above and the signed request: the web request layer returns default without running the op
+                    // Null when the identity disappears before the signed request runs
                     List<INotification>? notifications =
                         await webRequestController.GetAsync(
                                                        commonArguments,

--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -22,15 +22,6 @@ namespace DCL.Notifications
     {
         private static readonly TimeSpan NOTIFICATIONS_DELAY = TimeSpan.FromSeconds(5);
 
-#if UNITY_INCLUDE_TESTS
-        // Set by EditMode tests to shorten the poll cadence; null falls back to NOTIFICATIONS_DELAY
-        public static TimeSpan? PollIntervalOverrideForTest;
-
-        private static TimeSpan pollDelay => PollIntervalOverrideForTest ?? NOTIFICATIONS_DELAY;
-#else
-        private static TimeSpan pollDelay => NOTIFICATIONS_DELAY;
-#endif
-
         private readonly JsonSerializerSettings serializerSettings;
         private readonly IWebRequestController webRequestController;
         private readonly IDecentralandUrlsSource urlsSource;
@@ -77,7 +68,7 @@ namespace DCL.Notifications
 
         public async UniTask<List<INotification>> GetMostRecentNotificationsAsync(CancellationToken ct)
         {
-            do await UniTask.Delay(pollDelay, DelayType.Realtime, cancellationToken: ct);
+            do await UniTask.Delay(NOTIFICATIONS_DELAY, DelayType.Realtime, cancellationToken: ct);
             while (web3IdentityCache.Identity == null || web3IdentityCache.Identity.IsExpired);
 
             urlBuilder.Clear();
@@ -111,7 +102,7 @@ namespace DCL.Notifications
             {
                 try
                 {
-                    await UniTask.Delay(pollDelay, DelayType.Realtime, cancellationToken: ct);
+                    await UniTask.Delay(NOTIFICATIONS_DELAY, DelayType.Realtime, cancellationToken: ct);
 
                     if (web3IdentityCache.Identity == null || web3IdentityCache.Identity.IsExpired)
                         continue;

--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -32,6 +32,7 @@ namespace DCL.Notifications
         private readonly URLParameter limitParameter = new ("limit", "50");
         private readonly URLBuilder urlBuilder = new ();
         private readonly URLDomain notificationsUrl;
+        private readonly TimeSpan pollInterval;
         private CommonArguments commonArguments;
         private ulong unixTimestamp;
         private ulong lastPolledTimestamp;
@@ -40,8 +41,16 @@ namespace DCL.Notifications
             IWebRequestController webRequestController,
             IDecentralandUrlsSource urlsSource,
             IWeb3IdentityCache web3IdentityCache
+        ) : this(webRequestController, urlsSource, web3IdentityCache, NOTIFICATIONS_DELAY) { }
+
+        internal NotificationsRequestController(
+            IWebRequestController webRequestController,
+            IDecentralandUrlsSource urlsSource,
+            IWeb3IdentityCache web3IdentityCache,
+            TimeSpan pollInterval
         )
         {
+            this.pollInterval = pollInterval;
             this.webRequestController = webRequestController;
             this.urlsSource = urlsSource;
             this.web3IdentityCache = web3IdentityCache;
@@ -68,7 +77,7 @@ namespace DCL.Notifications
 
         public async UniTask<List<INotification>> GetMostRecentNotificationsAsync(CancellationToken ct)
         {
-            do await UniTask.Delay(NOTIFICATIONS_DELAY, DelayType.Realtime, cancellationToken: ct);
+            do await UniTask.Delay(pollInterval, DelayType.Realtime, cancellationToken: ct);
             while (web3IdentityCache.Identity == null || web3IdentityCache.Identity.IsExpired);
 
             urlBuilder.Clear();
@@ -79,7 +88,8 @@ namespace DCL.Notifications
             commonArguments = new CommonArguments(urlBuilder.Build(), RetryPolicy.Enforce());
             unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
-            List<INotification> notifications =
+            // Null when the identity disappears between the wait loop above and the signed request: the web request layer returns default without running the op
+            List<INotification>? notifications =
                 await webRequestController.GetAsync(
                                                commonArguments,
                                                ct,
@@ -88,7 +98,7 @@ namespace DCL.Notifications
                                                headersInfo: new WebRequestHeadersInfo().WithSign(string.Empty, unixTimestamp))
                                           .CreateFromNewtonsoftJsonAsync<List<INotification>>(serializerSettings: serializerSettings);
 
-            return notifications;
+            return notifications ?? new List<INotification>();
         }
 
         public async UniTask StartGettingNewNotificationsOverTimeAsync(CancellationToken ct)
@@ -101,7 +111,7 @@ namespace DCL.Notifications
             {
                 try
                 {
-                    await UniTask.Delay(NOTIFICATIONS_DELAY, DelayType.Realtime, cancellationToken: ct);
+                    await UniTask.Delay(pollInterval, DelayType.Realtime, cancellationToken: ct);
 
                     if (web3IdentityCache.Identity == null || web3IdentityCache.Identity.IsExpired)
                         continue;
@@ -118,7 +128,8 @@ namespace DCL.Notifications
 
                     pollNotificationsBuffer.Clear();
 
-                    List<INotification> notifications =
+                    // Null when the identity disappears between the check above and the signed request: the web request layer returns default without running the op
+                    List<INotification>? notifications =
                         await webRequestController.GetAsync(
                                                        commonArguments,
                                                        ct,
@@ -127,7 +138,7 @@ namespace DCL.Notifications
                                                        headersInfo: new WebRequestHeadersInfo().WithSign(string.Empty, unixTimestamp))
                                                   .OverwriteFromNewtonsoftJsonAsync(pollNotificationsBuffer, serializerSettings: serializerSettings);
 
-                    if (notifications.Count == 0)
+                    if (notifications == null || notifications.Count == 0)
                         continue;
 
                     lastPolledTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();

--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -31,6 +31,7 @@ namespace DCL.Notifications
         private readonly URLParameter onlyUnreadParameter = new ("onlyUnread", "true");
         private readonly URLParameter limitParameter = new ("limit", "50");
         private readonly URLBuilder urlBuilder = new ();
+        private readonly URLDomain notificationsUrl;
         private CommonArguments commonArguments;
         private ulong unixTimestamp;
         private ulong lastPolledTimestamp;
@@ -52,6 +53,8 @@ namespace DCL.Notifications
 
             lastPolledTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
+            notificationsUrl = URLDomain.FromString($"{urlsSource.Url(DecentralandUrl.Notifications)}/notifications");
+
             commonArgumentsForSetRead = new CommonArguments(
                 new URLBuilder()
                    .AppendDomain(
@@ -70,7 +73,7 @@ namespace DCL.Notifications
 
             urlBuilder.Clear();
 
-            urlBuilder.AppendDomain(URLDomain.FromString($"{urlsSource.Url(DecentralandUrl.Notifications)}/notifications"))
+            urlBuilder.AppendDomain(notificationsUrl)
                       .AppendParameter(limitParameter);
 
             commonArguments = new CommonArguments(urlBuilder.Build(), RetryPolicy.Enforce());
@@ -90,6 +93,10 @@ namespace DCL.Notifications
 
         public async UniTask StartGettingNewNotificationsOverTimeAsync(CancellationToken ct)
         {
+            // Loop-local so a cancelled generation still parsing off-thread can never race the next generation's Clear();
+            // reused across iterations: cleared before each request and never escapes the loop (items are dispatched individually)
+            var pollNotificationsBuffer = new List<INotification>();
+
             do
             {
                 try
@@ -101,7 +108,7 @@ namespace DCL.Notifications
 
                     urlBuilder.Clear();
 
-                    urlBuilder.AppendDomain(URLDomain.FromString($"{urlsSource.Url(DecentralandUrl.Notifications)}/notifications"))
+                    urlBuilder.AppendDomain(notificationsUrl)
                               .AppendParameter(onlyUnreadParameter)
                               .AppendParameter(new URLParameter("from", lastPolledTimestamp.ToString()));
 
@@ -109,7 +116,8 @@ namespace DCL.Notifications
 
                     unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
-                    // TODO remove allocation of List on serialization
+                    pollNotificationsBuffer.Clear();
+
                     List<INotification> notifications =
                         await webRequestController.GetAsync(
                                                        commonArguments,
@@ -117,7 +125,7 @@ namespace DCL.Notifications
                                                        ReportCategory.UI,
                                                        signInfo: WebRequestSignInfo.NewFromUrl(urlsSource.GetOriginalUrl(commonArguments.URL), unixTimestamp, "get"),
                                                        headersInfo: new WebRequestHeadersInfo().WithSign(string.Empty, unixTimestamp))
-                                                  .CreateFromNewtonsoftJsonAsync<List<INotification>>(serializerSettings: serializerSettings);
+                                                  .OverwriteFromNewtonsoftJsonAsync(pollNotificationsBuffer, serializerSettings: serializerSettings);
 
                     if (notifications.Count == 0)
                         continue;

--- a/Explorer/Assets/DCL/Notifications/Tests.meta
+++ b/Explorer/Assets/DCL/Notifications/Tests.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fc1928b0ba9f4aa38be9185acf2140cd
+timeCreated: 1786852140

--- a/Explorer/Assets/DCL/Notifications/Tests/DCL.Notifications.Tests.asmref
+++ b/Explorer/Assets/DCL/Notifications/Tests/DCL.Notifications.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/Notifications/Tests/DCL.Notifications.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/Notifications/Tests/DCL.Notifications.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e566805b12114b19bdf45c17086748d1
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
+++ b/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
@@ -17,8 +17,8 @@ namespace DCL.Notifications.Tests
 {
     public class NotificationsRequestControllerShould
     {
-        private static readonly TimeSpan TEST_POLL_INTERVAL = TimeSpan.FromMilliseconds(10);
-        private static readonly TimeSpan POLL_OBSERVATION_TIMEOUT = TimeSpan.FromSeconds(10);
+        // Two real 5s poll ticks are expected within this window; the loop exits as soon as both are observed
+        private static readonly TimeSpan POLL_OBSERVATION_TIMEOUT = TimeSpan.FromSeconds(30);
 
         private NotificationsRequestController controller = null!;
         private IWebRequestController webRequestController = null!;
@@ -39,8 +39,6 @@ namespace DCL.Notifications.Tests
         [SetUp]
         public void SetUp()
         {
-            NotificationsRequestController.PollIntervalOverrideForTest = TEST_POLL_INTERVAL;
-
             NotificationsBusController.Initialize(new NotificationsBusController());
 
             capturedTargets.Clear();
@@ -77,17 +75,13 @@ namespace DCL.Notifications.Tests
             controller = new NotificationsRequestController(webRequestController, urlsSource, identityCache);
         }
 
-        [TearDown]
-        public void TearDown() =>
-            NotificationsRequestController.PollIntervalOverrideForTest = null;
-
         [Test]
         public async Task ReuseSingleListInstanceAcrossPollIterations()
         {
             var cts = new CancellationTokenSource();
             UniTask loopTask = controller.StartGettingNewNotificationsOverTimeAsync(cts.Token);
 
-            // Two poll iterations at the injected test cadence
+            // Two poll iterations at the loop's realtime 5s cadence
             Stopwatch stopwatch = Stopwatch.StartNew();
 
             while (capturedTargets.Count < 2 && stopwatch.Elapsed < POLL_OBSERVATION_TIMEOUT)

--- a/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
+++ b/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
@@ -12,13 +12,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using UnityEngine.TestTools;
 
 namespace DCL.Notifications.Tests
 {
     public class NotificationsRequestControllerShould
     {
-        private static readonly TimeSpan POLL_OBSERVATION_TIMEOUT = TimeSpan.FromSeconds(15);
+        private static readonly TimeSpan TEST_POLL_INTERVAL = TimeSpan.FromMilliseconds(10);
+        private static readonly TimeSpan POLL_OBSERVATION_TIMEOUT = TimeSpan.FromSeconds(10);
 
         private NotificationsRequestController controller = null!;
         private IWebRequestController webRequestController = null!;
@@ -72,38 +72,32 @@ namespace DCL.Notifications.Tests
                                      return UniTask.FromResult(op.Target);
                                  });
 
-            controller = new NotificationsRequestController(webRequestController, urlsSource, identityCache);
+            controller = new NotificationsRequestController(webRequestController, urlsSource, identityCache, TEST_POLL_INTERVAL);
         }
 
         [Test]
         public async Task ReuseSingleListInstanceAcrossPollIterations()
         {
-            LogAssert.ignoreFailingMessages = true;
+            var cts = new CancellationTokenSource();
+            UniTask loopTask = controller.StartGettingNewNotificationsOverTimeAsync(cts.Token);
 
-            try
-            {
-                var cts = new CancellationTokenSource();
-                UniTask loopTask = controller.StartGettingNewNotificationsOverTimeAsync(cts.Token);
+            // Two poll iterations at the injected test cadence
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
-                // Two poll iterations at the loop's realtime 5s cadence
-                Stopwatch stopwatch = Stopwatch.StartNew();
+            while (capturedTargets.Count < 2 && stopwatch.Elapsed < POLL_OBSERVATION_TIMEOUT)
+                await UniTask.Yield();
 
-                while (capturedTargets.Count < 2 && stopwatch.Elapsed < POLL_OBSERVATION_TIMEOUT)
-                    await UniTask.Yield();
+            cts.Cancel();
+            await loopTask;
 
-                cts.Cancel();
-                await loopTask;
+            Assert.That(capturedTargets.Count, Is.GreaterThanOrEqualTo(2),
+                "the poll loop must parse into a reusable buffer via the Overwrite op instead of allocating a fresh List per poll");
 
-                Assert.That(capturedTargets.Count, Is.GreaterThanOrEqualTo(2),
-                    "the poll loop must parse into a reusable buffer via the Overwrite op instead of allocating a fresh List per poll");
+            Assert.That(capturedTargets[1], Is.SameAs(capturedTargets[0]),
+                "the same buffer instance must be reused across poll iterations");
 
-                Assert.That(capturedTargets[1], Is.SameAs(capturedTargets[0]),
-                    "the same buffer instance must be reused across poll iterations");
-
-                Assert.That(callTimeCounts, Is.All.EqualTo(0),
-                    "the buffer must be cleared before each poll so already-dispatched notifications are not delivered again");
-            }
-            finally { LogAssert.ignoreFailingMessages = false; }
+            Assert.That(callTimeCounts, Is.All.EqualTo(0),
+                "the buffer must be cleared before each poll so already-dispatched notifications are not delivered again");
         }
     }
 }

--- a/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
+++ b/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
@@ -17,7 +17,7 @@ namespace DCL.Notifications.Tests
 {
     public class NotificationsRequestControllerShould
     {
-        // Two real 5s poll ticks are expected within this window; the loop exits as soon as both are observed
+        // Window for two real 5s poll ticks; the wait exits early once both are observed
         private static readonly TimeSpan POLL_OBSERVATION_TIMEOUT = TimeSpan.FromSeconds(30);
 
         private NotificationsRequestController controller = null!;
@@ -81,7 +81,6 @@ namespace DCL.Notifications.Tests
             var cts = new CancellationTokenSource();
             UniTask loopTask = controller.StartGettingNewNotificationsOverTimeAsync(cts.Token);
 
-            // Two poll iterations at the loop's realtime 5s cadence
             Stopwatch stopwatch = Stopwatch.StartNew();
 
             while (capturedTargets.Count < 2 && stopwatch.Elapsed < POLL_OBSERVATION_TIMEOUT)

--- a/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
+++ b/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
@@ -24,6 +24,7 @@ namespace DCL.Notifications.Tests
         private IWebRequestController webRequestController = null!;
         private IWeb3IdentityCache identityCache = null!;
         private IDecentralandUrlsSource urlsSource = null!;
+        private TimeSpan originalNotificationsDelay;
 
         private readonly List<List<INotification>> capturedTargets = new ();
         private readonly List<int> callTimeCounts = new ();
@@ -39,6 +40,9 @@ namespace DCL.Notifications.Tests
         [SetUp]
         public void SetUp()
         {
+            originalNotificationsDelay = NotificationsRequestController.NotificationsDelay;
+            NotificationsRequestController.NotificationsDelay = TEST_POLL_INTERVAL;
+
             NotificationsBusController.Initialize(new NotificationsBusController());
 
             capturedTargets.Clear();
@@ -72,8 +76,12 @@ namespace DCL.Notifications.Tests
                                      return UniTask.FromResult(op.Target);
                                  });
 
-            controller = NotificationsRequestController.CreateForTest(webRequestController, urlsSource, identityCache, TEST_POLL_INTERVAL);
+            controller = new NotificationsRequestController(webRequestController, urlsSource, identityCache);
         }
+
+        [TearDown]
+        public void TearDown() =>
+            NotificationsRequestController.NotificationsDelay = originalNotificationsDelay;
 
         [Test]
         public async Task ReuseSingleListInstanceAcrossPollIterations()

--- a/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
+++ b/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
@@ -1,0 +1,109 @@
+using Cysharp.Threading.Tasks;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.NotificationsBus;
+using DCL.NotificationsBus.NotificationTypes;
+using DCL.Web3.Identities;
+using DCL.WebRequests;
+using ECS.TestSuite;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine.TestTools;
+
+namespace DCL.Notifications.Tests
+{
+    public class NotificationsRequestControllerShould
+    {
+        private static readonly TimeSpan POLL_OBSERVATION_TIMEOUT = TimeSpan.FromSeconds(15);
+
+        private NotificationsRequestController controller = null!;
+        private IWebRequestController webRequestController = null!;
+        private IWeb3IdentityCache identityCache = null!;
+        private IDecentralandUrlsSource urlsSource = null!;
+
+        private readonly List<List<INotification>> capturedTargets = new ();
+        private readonly List<int> callTimeCounts = new ();
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp() =>
+            EcsTestsUtils.SetUpFeaturesRegistry();
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown() =>
+            EcsTestsUtils.TearDownFeaturesRegistry();
+
+        [SetUp]
+        public void SetUp()
+        {
+            NotificationsBusController.Initialize(new NotificationsBusController());
+
+            capturedTargets.Clear();
+            callTimeCounts.Clear();
+
+            urlsSource = Substitute.For<IDecentralandUrlsSource>();
+            urlsSource.Url(DecentralandUrl.Notifications).Returns("https://notifications.test");
+            urlsSource.GetOriginalUrl(Arg.Any<string>()).Returns("https://notifications.test/notifications");
+
+            identityCache = Substitute.For<IWeb3IdentityCache>();
+            IWeb3Identity identity = Substitute.For<IWeb3Identity>();
+            identity.IsExpired.Returns(false);
+            identityCache.Identity.Returns(identity);
+
+            INotification cannedNotification = Substitute.For<INotification>();
+            cannedNotification.Id.Returns("notification-1");
+
+            webRequestController = Substitute.For<IWebRequestController>();
+
+            webRequestController.SendAsync<GenericGetRequest, GenericGetArguments, GenericDownloadHandlerUtils.OverwriteFromJsonAsyncOp<List<INotification>, GenericGetRequest>, List<INotification>>(
+                                     Arg.Any<RequestEnvelope<GenericGetRequest, GenericGetArguments>>(),
+                                     Arg.Any<GenericDownloadHandlerUtils.OverwriteFromJsonAsyncOp<List<INotification>, GenericGetRequest>>())!
+                                .Returns(callInfo =>
+                                 {
+                                     GenericDownloadHandlerUtils.OverwriteFromJsonAsyncOp<List<INotification>, GenericGetRequest> op =
+                                         callInfo.ArgAt<GenericDownloadHandlerUtils.OverwriteFromJsonAsyncOp<List<INotification>, GenericGetRequest>>(1);
+
+                                     capturedTargets.Add(op.Target);
+                                     callTimeCounts.Add(op.Target.Count);
+                                     op.Target.Add(cannedNotification);
+                                     return UniTask.FromResult(op.Target);
+                                 });
+
+            controller = new NotificationsRequestController(webRequestController, urlsSource, identityCache);
+        }
+
+        [Test]
+        public async Task ReuseSingleListInstanceAcrossPollIterations()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            try
+            {
+                var cts = new CancellationTokenSource();
+                UniTask loopTask = controller.StartGettingNewNotificationsOverTimeAsync(cts.Token);
+
+                // Two poll iterations at the loop's realtime 5s cadence
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
+                while (capturedTargets.Count < 2 && stopwatch.Elapsed < POLL_OBSERVATION_TIMEOUT)
+                    await UniTask.Yield();
+
+                cts.Cancel();
+                await loopTask;
+
+                Assert.That(capturedTargets.Count, Is.GreaterThanOrEqualTo(2),
+                    "the poll loop must parse into a reusable buffer via the Overwrite op instead of allocating a fresh List per poll");
+
+                Assert.That(capturedTargets[1], Is.SameAs(capturedTargets[0]),
+                    "the same buffer instance must be reused across poll iterations");
+
+                Assert.That(callTimeCounts, Is.All.EqualTo(0),
+                    "the buffer must be cleared before each poll so already-dispatched notifications are not delivered again");
+            }
+            finally { LogAssert.ignoreFailingMessages = false; }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
+++ b/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
@@ -24,7 +24,6 @@ namespace DCL.Notifications.Tests
         private IWebRequestController webRequestController = null!;
         private IWeb3IdentityCache identityCache = null!;
         private IDecentralandUrlsSource urlsSource = null!;
-        private TimeSpan originalNotificationsDelay;
 
         private readonly List<List<INotification>> capturedTargets = new ();
         private readonly List<int> callTimeCounts = new ();
@@ -40,8 +39,7 @@ namespace DCL.Notifications.Tests
         [SetUp]
         public void SetUp()
         {
-            originalNotificationsDelay = NotificationsRequestController.NotificationsDelay;
-            NotificationsRequestController.NotificationsDelay = TEST_POLL_INTERVAL;
+            NotificationsRequestController.PollIntervalOverrideForTest = TEST_POLL_INTERVAL;
 
             NotificationsBusController.Initialize(new NotificationsBusController());
 
@@ -81,7 +79,7 @@ namespace DCL.Notifications.Tests
 
         [TearDown]
         public void TearDown() =>
-            NotificationsRequestController.NotificationsDelay = originalNotificationsDelay;
+            NotificationsRequestController.PollIntervalOverrideForTest = null;
 
         [Test]
         public async Task ReuseSingleListInstanceAcrossPollIterations()

--- a/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
+++ b/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
@@ -72,7 +72,7 @@ namespace DCL.Notifications.Tests
                                      return UniTask.FromResult(op.Target);
                                  });
 
-            controller = new NotificationsRequestController(webRequestController, urlsSource, identityCache, TEST_POLL_INTERVAL);
+            controller = NotificationsRequestController.CreateForTest(webRequestController, urlsSource, identityCache, TEST_POLL_INTERVAL);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs.meta
+++ b/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9bfc0940c4e54a24b9b0ac066c7b7456
+timeCreated: 1786852140

--- a/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
@@ -212,8 +212,9 @@ namespace DCL.WebRequests
             public async UniTask<T?> ExecuteAsync(TRequest request, CancellationToken ct)
             {
                 DownloadHandler downloadHandler = request.UnityWebRequest.downloadHandler;
-                string text = string.Empty;
-                var textWasRead = false;
+
+                // Captured only on the text-based branch: Newtonsoft streaming failures rethrow raw, without the custom exception wrapper
+                string? text = null;
 
                 try
                 {
@@ -224,7 +225,6 @@ namespace DCL.WebRequests
                         )
                     {
                         text = downloadHandler.text;
-                        textWasRead = true;
 
                         if ((threadFlags & WRThreadFlags.SwitchToThreadPool) != 0)
                             await DCLTask.SwitchToThreadPool();
@@ -255,7 +255,7 @@ namespace DCL.WebRequests
                 }
                 catch (Exception ex)
                 {
-                    if (createCustomExceptionOnFailure != null && textWasRead)
+                    if (createCustomExceptionOnFailure != null && text != null)
                         throw createCustomExceptionOnFailure(ex, text);
                     else
                         throw;
@@ -273,6 +273,14 @@ namespace DCL.WebRequests
         ///     consults converters registered for the root type, so a matching root-level converter must be routed manually,
         ///     receiving <paramref name="target" /> as its existing value to populate in place.
         /// </summary>
+        /// <remarks>
+        ///     Root-converter routing deliberately diverges from Newtonsoft's full resolution semantics:
+        ///     only <see cref="JsonSerializer.Converters" /> are consulted (attribute- and contract-level converters on
+        ///     <typeparamref name="T" /> are not), the first converter with <see cref="JsonConverter.CanRead" /> that matches wins,
+        ///     matching is against the static <typeparamref name="T" /> (a buffer typed as a base or interface will not match a
+        ///     converter for the concrete type), and a matching converter that allocates a fresh result instead of filling
+        ///     <paramref name="target" /> throws rather than silently discarding data.
+        /// </remarks>
         public static void PopulateInto<T>(JsonReader reader, T target, JsonSerializer serializer)
         {
             IList<JsonConverter> converters = serializer.Converters;
@@ -283,9 +291,10 @@ namespace DCL.WebRequests
 
                 if (converter.CanRead && converter.CanConvert(typeof(T)))
                 {
-                    // Converters expect the reader positioned at the value's first token, matching Newtonsoft's own invocation contract
-                    if (reader.TokenType == JsonToken.None)
-                        reader.Read();
+                    // Converters expect the reader positioned at the value's first token, matching Newtonsoft's own invocation contract.
+                    // An empty body has no first token: overwrite semantics make that a no-op that leaves the target untouched
+                    if (reader.TokenType == JsonToken.None && !reader.Read())
+                        return;
 
                     // A null result (e.g. a null token) legitimately leaves the target untouched; anything else must be the target itself or data is silently lost
                     if (converter.ReadJson(reader, typeof(T), target, serializer) is { } result && !ReferenceEquals(result, target))
@@ -319,8 +328,9 @@ namespace DCL.WebRequests
             public async UniTask<T?> ExecuteAsync(TRequest request, CancellationToken ct)
             {
                 DownloadHandler downloadHandler = request.UnityWebRequest.downloadHandler;
-                string text = string.Empty;
-                var textWasRead = false;
+
+                // Captured only on the text-based branch: Newtonsoft streaming failures rethrow raw, without the custom exception wrapper
+                string? text = null;
 
                 try
                 {
@@ -331,7 +341,6 @@ namespace DCL.WebRequests
                         )
                     {
                         text = downloadHandler.text;
-                        textWasRead = true;
 
                         if ((threadFlags & WRThreadFlags.SwitchToThreadPool) != 0)
                             await DCLTask.SwitchToThreadPool();
@@ -362,7 +371,7 @@ namespace DCL.WebRequests
                 }
                 catch (Exception ex)
                 {
-                    if (createCustomExceptionOnFailure != null && textWasRead)
+                    if (createCustomExceptionOnFailure != null && text != null)
                         throw createCustomExceptionOnFailure(ex, text);
                     else
                         throw;

--- a/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
@@ -212,7 +212,8 @@ namespace DCL.WebRequests
             public async UniTask<T?> ExecuteAsync(TRequest request, CancellationToken ct)
             {
                 DownloadHandler downloadHandler = request.UnityWebRequest.downloadHandler;
-                string text = null;
+                string text = string.Empty;
+                var textWasRead = false;
 
                 try
                 {
@@ -223,6 +224,7 @@ namespace DCL.WebRequests
                         )
                     {
                         text = downloadHandler.text;
+                        textWasRead = true;
 
                         if ((threadFlags & WRThreadFlags.SwitchToThreadPool) != 0)
                             await DCLTask.SwitchToThreadPool();
@@ -253,7 +255,7 @@ namespace DCL.WebRequests
                 }
                 catch (Exception ex)
                 {
-                    if (createCustomExceptionOnFailure != null && text != null)
+                    if (createCustomExceptionOnFailure != null && textWasRead)
                         throw createCustomExceptionOnFailure(ex, text);
                     else
                         throw;
@@ -264,6 +266,36 @@ namespace DCL.WebRequests
                         await UniTask.SwitchToMainThread();
                 }
             }
+        }
+
+        /// <summary>
+        ///     <see cref="JsonSerializer.Populate(JsonReader, object)" /> resolves the target's contract directly and never
+        ///     consults converters registered for the root type, so a matching root-level converter must be routed manually,
+        ///     receiving <paramref name="target" /> as its existing value to populate in place.
+        /// </summary>
+        public static void PopulateInto<T>(JsonReader reader, T target, JsonSerializer serializer)
+        {
+            IList<JsonConverter> converters = serializer.Converters;
+
+            for (var i = 0; i < converters.Count; i++)
+            {
+                JsonConverter converter = converters[i];
+
+                if (converter.CanRead && converter.CanConvert(typeof(T)))
+                {
+                    // Converters expect the reader positioned at the value's first token, matching Newtonsoft's own invocation contract
+                    if (reader.TokenType == JsonToken.None)
+                        reader.Read();
+
+                    // A null result (e.g. a null token) legitimately leaves the target untouched; anything else must be the target itself or data is silently lost
+                    if (converter.ReadJson(reader, typeof(T), target, serializer) is { } result && !ReferenceEquals(result, target))
+                        throw new JsonSerializationException($"{converter.GetType().Name} did not populate the existing value in place; its result would be discarded.");
+
+                    return;
+                }
+            }
+
+            serializer.Populate(reader, target);
         }
 
         public struct OverwriteFromJsonAsyncOp<T, TRequest> : IWebRequestOp<TRequest, T> where TRequest: struct, ITypedWebRequest, IGenericDownloadHandlerRequest
@@ -287,7 +319,8 @@ namespace DCL.WebRequests
             public async UniTask<T?> ExecuteAsync(TRequest request, CancellationToken ct)
             {
                 DownloadHandler downloadHandler = request.UnityWebRequest.downloadHandler;
-                string text = null;
+                string text = string.Empty;
+                var textWasRead = false;
 
                 try
                 {
@@ -298,6 +331,7 @@ namespace DCL.WebRequests
                         )
                     {
                         text = downloadHandler.text;
+                        textWasRead = true;
 
                         if ((threadFlags & WRThreadFlags.SwitchToThreadPool) != 0)
                             await DCLTask.SwitchToThreadPool();
@@ -322,13 +356,13 @@ namespace DCL.WebRequests
 
                             using var textReader = new StreamReader(stream, Encoding.UTF8);
                             using var jsonReader = new JsonTextReader(textReader);
-                            serializer.Populate(jsonReader, Target);
+                            PopulateInto(jsonReader, Target, serializer);
                         }
                     }
                 }
                 catch (Exception ex)
                 {
-                    if (createCustomExceptionOnFailure != null && text != null)
+                    if (createCustomExceptionOnFailure != null && textWasRead)
                         throw createCustomExceptionOnFailure(ex, text);
                     else
                         throw;

--- a/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
@@ -213,7 +213,7 @@ namespace DCL.WebRequests
             {
                 DownloadHandler downloadHandler = request.UnityWebRequest.downloadHandler;
 
-                // Captured only on the text-based branch: Newtonsoft streaming failures rethrow raw, without the custom exception wrapper
+                // Non-null only on the text-based branch; streaming failures rethrow raw
                 string? text = null;
 
                 try
@@ -274,12 +274,8 @@ namespace DCL.WebRequests
         ///     receiving <paramref name="target" /> as its existing value to populate in place.
         /// </summary>
         /// <remarks>
-        ///     Root-converter routing deliberately diverges from Newtonsoft's full resolution semantics:
-        ///     only <see cref="JsonSerializer.Converters" /> are consulted (attribute- and contract-level converters on
-        ///     <typeparamref name="T" /> are not), the first converter with <see cref="JsonConverter.CanRead" /> that matches wins,
-        ///     matching is against the static <typeparamref name="T" /> (a buffer typed as a base or interface will not match a
-        ///     converter for the concrete type), and a matching converter that allocates a fresh result instead of filling
-        ///     <paramref name="target" /> throws rather than silently discarding data.
+        ///     Only <see cref="JsonSerializer.Converters" /> are consulted, matched against the static <typeparamref name="T" />;
+        ///     a matching converter that returns a fresh result instead of filling <paramref name="target" /> throws.
         /// </remarks>
         public static void PopulateInto<T>(JsonReader reader, T target, JsonSerializer serializer)
         {
@@ -291,8 +287,7 @@ namespace DCL.WebRequests
 
                 if (converter.CanRead && converter.CanConvert(typeof(T)))
                 {
-                    // Converters expect the reader positioned at the value's first token, matching Newtonsoft's own invocation contract.
-                    // An empty body has no first token: overwrite semantics make that a no-op that leaves the target untouched
+                    // Converters expect the reader at the value's first token; an empty body has none and is a no-op
                     if (reader.TokenType == JsonToken.None && !reader.Read())
                         return;
 
@@ -329,7 +324,7 @@ namespace DCL.WebRequests
             {
                 DownloadHandler downloadHandler = request.UnityWebRequest.downloadHandler;
 
-                // Captured only on the text-based branch: Newtonsoft streaming failures rethrow raw, without the custom exception wrapper
+                // Non-null only on the text-based branch; streaming failures rethrow raw
                 string? text = null;
 
                 try

--- a/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs
+++ b/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs
@@ -84,6 +84,19 @@ namespace DCL.WebRequests.Tests
         }
 
         [Test]
+        public void LeaveBufferEmptyOnEmptyBody()
+        {
+            var buffer = new List<INotification>();
+            JsonSerializer serializer = NewNotificationsSerializer();
+
+            using var textReader = new StringReader(string.Empty);
+            using var jsonReader = new JsonTextReader(textReader);
+            GenericDownloadHandlerUtils.PopulateInto(jsonReader, buffer, serializer);
+
+            Assert.That(buffer, Is.Empty);
+        }
+
+        [Test]
         public void FallBackToPopulateWhenNoConverterMatchesRootType()
         {
             var target = new PlainDto();

--- a/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs
+++ b/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs
@@ -1,0 +1,126 @@
+using DCL.Notifications.Serialization;
+using DCL.NotificationsBus.NotificationTypes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace DCL.WebRequests.Tests
+{
+    public class GenericDownloadHandlerPopulateIntoShould
+    {
+        private const string NOTIFICATIONS_PAYLOAD =
+            "{\"notifications\":[{\"id\":\"n-1\",\"type\":\"events_started\"},{\"id\":\"n-2\",\"type\":\"badge_granted\"}]}";
+
+        private static JsonSerializer NewNotificationsSerializer() =>
+            JsonSerializer.CreateDefault(new JsonSerializerSettings
+            {
+                Converters = new JsonConverter[] { new NotificationJsonDtoConverter(true) },
+            });
+
+        private static void PopulateIntoBuffer(List<INotification> buffer, JsonSerializer serializer)
+        {
+            using var textReader = new StringReader(NOTIFICATIONS_PAYLOAD);
+            using var jsonReader = new JsonTextReader(textReader);
+            GenericDownloadHandlerUtils.PopulateInto(jsonReader, buffer, serializer);
+        }
+
+        [Test]
+        public void RouteRootLevelConverterIntoProvidedBuffer()
+        {
+            var buffer = new List<INotification>();
+            JsonSerializer serializer = NewNotificationsSerializer();
+
+            PopulateIntoBuffer(buffer, serializer);
+
+            Assert.That(buffer.Count, Is.EqualTo(2));
+            Assert.That(buffer[0], Is.InstanceOf<EventStartedNotification>());
+            Assert.That(buffer[1], Is.InstanceOf<BadgeGrantedNotification>());
+            Assert.That(buffer[0].Id, Is.EqualTo("n-1"));
+        }
+
+        [Test]
+        public void NotDuplicateItemsWhenBufferIsClearedBetweenReuses()
+        {
+            var buffer = new List<INotification>();
+            JsonSerializer serializer = NewNotificationsSerializer();
+
+            PopulateIntoBuffer(buffer, serializer);
+            buffer.Clear();
+            PopulateIntoBuffer(buffer, serializer);
+
+            Assert.That(buffer.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void ThrowWhenConverterReturnsFreshInstanceInsteadOfPopulatingTarget()
+        {
+            var buffer = new List<INotification>();
+
+            JsonSerializer serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings
+            {
+                Converters = new JsonConverter[] { new FreshInstanceListConverter() },
+            });
+
+            using var textReader = new StringReader(NOTIFICATIONS_PAYLOAD);
+            using var jsonReader = new JsonTextReader(textReader);
+
+            Assert.Throws<JsonSerializationException>(() => GenericDownloadHandlerUtils.PopulateInto(jsonReader, buffer, serializer));
+        }
+
+        [Test]
+        public void LeaveBufferEmptyOnNullBodyViaConverterNullGuard()
+        {
+            var buffer = new List<INotification>();
+            JsonSerializer serializer = NewNotificationsSerializer();
+
+            using var textReader = new StringReader("null");
+            using var jsonReader = new JsonTextReader(textReader);
+            GenericDownloadHandlerUtils.PopulateInto(jsonReader, buffer, serializer);
+
+            Assert.That(buffer, Is.Empty);
+        }
+
+        [Test]
+        public void FallBackToPopulateWhenNoConverterMatchesRootType()
+        {
+            var target = new PlainDto();
+            JsonSerializer serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings
+            {
+                Converters = new JsonConverter[] { new NotificationJsonDtoConverter(true) },
+            });
+
+            using var textReader = new StringReader("{\"value\":42,\"name\":\"populated\"}");
+            using var jsonReader = new JsonTextReader(textReader);
+            GenericDownloadHandlerUtils.PopulateInto(jsonReader, target, serializer);
+
+            Assert.That(target.value, Is.EqualTo(42));
+            Assert.That(target.name, Is.EqualTo("populated"));
+        }
+
+        // The standard converter shape: allocates a fresh result instead of filling existingValue
+        private class FreshInstanceListConverter : JsonConverter<List<INotification>>
+        {
+            public override List<INotification>? ReadJson(JsonReader reader, Type objectType, List<INotification>? existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                JObject.Load(reader);
+                return new List<INotification>();
+            }
+
+            public override void WriteJson(JsonWriter writer, List<INotification>? value, JsonSerializer serializer) =>
+                throw new NotSupportedException();
+        }
+
+        private class PlainDto
+        {
+            // Field names mirror the JSON wire format
+            // ReSharper disable InconsistentNaming
+            public int value;
+            public string? name;
+
+            // ReSharper restore InconsistentNaming
+        }
+    }
+}

--- a/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs.meta
+++ b/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5b2189c09e6d4c4ab1647eb6a42b58b4
+timeCreated: 1786852140


### PR DESCRIPTION
## Problem

The notifications poller allocates a fresh `List<INotification>` plus a full Newtonsoft
LINQ-to-JSON object graph every 5 seconds for the entire app lifetime, even when zero
notifications arrive - steady-state GC churn on the hottest always-on polling loop in the
client. Tracked by the in-code TODO and tech-debt issue #9263.

## Root cause

Newtonsoft's `JsonSerializer.Populate` never consults root-level `JsonConverter`s, and the
notifications payload is an object wrapping an interface-typed list only
`NotificationJsonDtoConverter` can parse - so the existing reuse path
(`OverwriteFromNewtonsoftJsonAsync`) was unusable for this endpoint and the poll loop was
stuck on the allocating create-op. The converter's own `existingValue` support was dead
code.

## Fix (~30 LOC)

- `GenericDownloadHandlerUtils`: new `PopulateInto<T>(JsonReader, T target, JsonSerializer)`
  - routes the first matching registered converter with the target as `existingValue`,
  falling back to `serializer.Populate` (existing behavior). The Overwrite op's Newtonsoft
  branch now uses it, making converter-aware reuse available to every poller.
- `NotificationsRequestController`: a reusable `pollNotificationsBuffer` cleared per
  iteration + `OverwriteFromNewtonsoftJsonAsync`; the per-poll URL interpolation is hoisted
  to a ctor-built field. `GetMostRecentNotificationsAsync` is deliberately not pooled (its
  list escapes to the panel controller).

Contract blast radius: behavior changes only when a registered converter matches the ROOT
target type of an Overwrite call - a combination that today either throws or silently
ignores the converter; all existing callers audited unaffected.

## Test

- `NotificationsRequestControllerShould.ReuseSingleListInstanceAcrossPollIterations`  - 
  drives two poll iterations against a stubbed web controller; asserts the overwrite op is
  used, the same `Target` instance is passed both iterations, and the buffer is empty at
  delivery (the re-dispatch hazard).
- `GenericDownloadHandlerPopulateIntoShould` (3 tests) - converter-routed populate in
  place, no duplication after `Clear()`, and the no-matching-converter fallback.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 1/1 as intended (overwrite op
received 0 calls at pin - the loop allocates a fresh list per poll) / GREEN PASS 4/4.
Side-find from validation (separate issue): a real wire "events_ended" notification would
throw `JsonSerializationException` in production `ReadJson` - `NotificationType` has no
matching enum member.

Fixes #9263

Includes inspection-warning cleanup in all touched files.

Fixes #9263