### PR TITLE
fix: resolve private conversation user state without friends service

### DIFF
--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/GetUserCallStatusCommand.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/GetUserCallStatusCommand.cs
@@ -22,6 +22,10 @@ namespace DCL.Chat.ChatCommands
                                                .SuppressCancellationThrow()
                                                .SuppressToResultAsync(ReportCategory.CHAT_MESSAGES);
 
+            // result.Value is default on cancellation or failure and must not be decoded as a user state
+            if (ct.IsCancellationRequested || !result.Success)
+                return CallButtonPresenter.OtherUserCallStatus.UserOffline;
+
             switch (result.Value.Result.ChatUserState)
             {
                 case PrivateConversationUserStateService.ChatUserState.Connected:

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -4,11 +4,8 @@ using DCL.Diagnostics;
 using DCL.Friends;
 using DCL.Friends.UserBlocking;
 using DCL.Multiplayer.Connections.RoomHubs;
-using DCL.Multiplayer.Profiles.Poses;
 using DCL.Optimization.Pools;
-using DCL.Profiles;
 using DCL.Settings.Settings;
-using DCL.Utilities;
 using DCL.Utility;
 using DCL.LiveKit.Public;
 using LiveKit.Rooms;
@@ -16,10 +13,11 @@ using LiveKit.Rooms.Participants;
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using LiveKit.Proto;
 using System.Linq;
 using UnityEngine;
 using Utility;
+
+// ReSharper disable InconsistentNaming
 
 namespace DCL.Chat.ChatServices
 {
@@ -175,7 +173,11 @@ namespace DCL.Chat.ChatServices
         {
             string lowerUserId = userId.ToLower();
 
-            FriendshipStatus friendshipStatus = await friendsService!.GetFriendshipStatusAsync(userId, ct);
+            // friendsService is null when the Friends feature is disabled (e.g. local scene development):
+            // every user resolves as a non-friend and the flow below handles them through the non-friend branches
+            FriendshipStatus friendshipStatus = friendsService != null
+                ? await friendsService.GetFriendshipStatusAsync(userId, ct)
+                : FriendshipStatus.None;
             bool isUserConnected = UserIsConsideredAsOnline(userId);
 
             //If it's a friend we just return its connection status
@@ -285,7 +287,7 @@ namespace DCL.Chat.ChatServices
         }
 
         private void OnYouUnblockedProfile(BlockedProfile profile) =>
-            CheckOnlineStatusAndNotify(profile.Profile.UserId);
+            CheckOnlineStatusAndNotify(profile.Profile.UserId.Value);
 
         private void OnYouBlockedByUser(string userId)
         {
@@ -295,7 +297,7 @@ namespace DCL.Chat.ChatServices
         }
 
         private void OnYouBlockedProfile(BlockedProfile profile) =>
-            CheckOnlineStatusAndNotify(profile.Profile.UserId);
+            CheckOnlineStatusAndNotify(profile.Profile.UserId.Value);
 
         /// <summary>
         /// Determines if a given user should be considered "online"

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests.meta
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a871751de6bc41fe865bf48679055a14
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/PrivateConversationUserStateServiceShould.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/PrivateConversationUserStateServiceShould.cs
@@ -1,0 +1,86 @@
+using Cysharp.Threading.Tasks;
+using DCL.Chat.ChatCommands;
+using DCL.Friends;
+using DCL.Friends.UserBlocking;
+using DCL.Multiplayer.Connections.RoomHubs;
+using DCL.Multiplayer.Connections.Rooms;
+using DCL.Settings.Settings;
+using DCL.SocialService;
+using DCL.VoiceChat;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace DCL.Chat.ChatServices.Tests
+{
+    [TestFixture]
+    public class PrivateConversationUserStateServiceShould
+    {
+        private IUserBlockingCache userBlockingCache = null!;
+        private ChatSettingsAsset settingsAsset = null!;
+        private PrivateConversationUserStateService service = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            userBlockingCache = Substitute.For<IUserBlockingCache>();
+            settingsAsset = ScriptableObject.CreateInstance<ChatSettingsAsset>();
+
+            IRoomHub roomHub = Substitute.For<IRoomHub>();
+            roomHub.ChatRoom().Returns(NullRoom.INSTANCE);
+
+            // friendsService: null mirrors sessions where the Friends feature is force-disabled (local scene development)
+            service = new PrivateConversationUserStateService(
+                new CurrentChannelService(),
+                new ChatEventBus(),
+                userBlockingCache,
+                friendsService: null,
+                settingsAsset,
+                new RPCChatPrivacyService(Substitute.For<IRPCSocialServices>(), settingsAsset),
+                Substitute.For<IFriendsEventBus>(),
+                roomHub);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UnityEngine.Object.DestroyImmediate(settingsAsset);
+        }
+
+        [Test]
+        public void ResolveUserStateWithoutFriendsService()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            // The path has no pending awaits when friendsService is null, so the task completes synchronously
+            UniTask<PrivateConversationUserStateService.UserState> task = service.GetChatUserStateAsync("0xabc", CancellationToken.None);
+
+            Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
+
+            PrivateConversationUserStateService.UserState state = task.GetAwaiter().GetResult();
+
+            Assert.That(state.IsConsideredOnline, Is.False);
+            Assert.That(state.ChatUserState, Is.EqualTo(PrivateConversationUserStateService.ChatUserState.Disconnected));
+        }
+
+        [Test]
+        public void ReportCallStatusOfflineWhenResolutionFails()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            userBlockingCache.UserIsBlocked(Arg.Any<string>()).Returns(_ => throw new InvalidOperationException("blocking cache unavailable"));
+
+            var command = new GetUserCallStatusCommand(service);
+
+            UniTask<CallButtonPresenter.OtherUserCallStatus> task = command.ExecuteAsync("0xabc", CancellationToken.None);
+
+            Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
+            Assert.That(task.GetAwaiter().GetResult(), Is.EqualTo(CallButtonPresenter.OtherUserCallStatus.UserOffline));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/PrivateConversationUserStateServiceShould.cs.meta
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/PrivateConversationUserStateServiceShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e5c5d1edcdec493aacd9955cc452df2d

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/UserStateService.Tests.asmref
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/UserStateService.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/UserStateService.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/UserStateService.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1f67717920be42d88d6babbb7788072d
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Tests/Editor/DCL.EditMode.Tests.asmdef
+++ b/Explorer/Assets/DCL/Tests/Editor/DCL.EditMode.Tests.asmdef
@@ -65,7 +65,8 @@
         "GUID:f254b2009e854709a0ef0022a7ca697c",
         "GUID:4d072b9bce344c9bbcff885117cf1e6f",
         "GUID:d9709898aa920584a8d1613950e6a7f5",
-        "GUID:63cde67b4a5d47449392dfc49fc0c3ed"
+        "GUID:63cde67b4a5d47449392dfc49fc0c3ed",
+        "GUID:1d75b3d8691c845b1a51082e81433dfc"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
## Problem

`NullReferenceException` in `PrivateConversationUserStateService.GetChatUserStateAsync`  - 
5 Sentry groups, ~21 events / 9 users past week, all local-scene-development / creator-hub
sessions. The call button additionally shows a bogus "available" affordance whenever state
resolution fails.

## Root cause

`PrivateConversationUserStateService.cs:178` dereferences the declared-nullable
`IFriendsService?` with null-forgiveness (`friendsService!`). `FeaturesRegistry`
force-disables Friends under local scene development, so `ChatPlugin` constructs the
service with `friendsService: null` - a mode the class explicitly supports (nullable ctor
param, the LSD catch in `InitializeAsync`). This is a nullability-contract violation inside
the class, not a missing defensive check; same defect class as pre-refactor #4343,
regressed by the `_Refactor` rewrite. Secondary defect in the same stack:
`GetUserCallStatusCommand.ExecuteAsync` ignores `result.Success`, and a failed `Result`'s
default value decodes to `UserAvailable`.

## Fix (~9 LOC, 2 files)

- `PrivateConversationUserStateService`: honor the declared degraded mode  - 
  `friendsService != null ? await ... : FriendshipStatus.None`, which routes into the
  existing non-friend flow (block cache, OtherClient detection, privacy checks all keep
  working). Bit-identical behavior when the service is present.
- `GetUserCallStatusCommand`: mirror the sibling command's guard  - 
  failure/cancellation → `UserOffline`.

## Test

New EditMode `PrivateConversationUserStateServiceShould` building the real service with
`friendsService: null`: `ResolveUserStateWithoutFriendsService` (pin: task faults with the
NRE; fix: completes `Disconnected` synchronously) and
`ReportCallStatusOfflineWhenResolutionFails` (pin: failed Result decodes `UserAvailable`).

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 2/2 as intended ("Expected:
Succeeded But was: Faulted"; "Expected: UserOffline But was: UserAvailable") / GREEN PASS 2/2.

Fixes #9447
Related: #9483 (closed, same signature), #4343 (closed precedent - pre-refactor
ChatUserStateUpdater LSD failures)

Includes inspection-warning cleanup in all touched files.

Fixes #9447