### PR TITLE
fix: left-pad private key bytes to 32 before rust sign-server init

### DIFF
--- a/Explorer/Assets/DCL/Web3/Accounts/RustEthereumAccount.cs
+++ b/Explorer/Assets/DCL/Web3/Accounts/RustEthereumAccount.cs
@@ -8,6 +8,8 @@ namespace DCL.Web3.Accounts
 {
     public class RustEthereumAccount : IWeb3Account
     {
+        private const int PRIVATE_KEY_SIZE = 32;
+
         private readonly IWeb3Account verifierAccount;
 
         public Web3Address Address { get; }
@@ -18,12 +20,27 @@ namespace DCL.Web3.Accounts
         {
             verifierAccount = NethereumAccount.CreateForVerifyOnly(key);
 
-            PrivateKey = key.GetPrivateKey().EnsureNotNull();
             Address = new Web3Address(key.GetPublicAddress()!);
-            byte[] bytes = key.GetPrivateKeyAsBytes().EnsureNotNull();
+
+            // secp256k1 private keys are 32-byte big-endian scalars; Nethereum's
+            // GetPrivateKeyAsBytes() returns the scalar unsigned-trimmed, without leading
+            // zero bytes, while RustEthSignServer.Initialize demands exactly 32 bytes.
+            byte[] bytes = LeftPad(key.GetPrivateKeyAsBytes().EnsureNotNull(), PRIVATE_KEY_SIZE);
+            PrivateKey = ToHex(bytes, true);
 
             if (!RustEthSignServer.Initialize(bytes))
                 throw new Exception("Failed to initialize sign server");
+        }
+
+        private static byte[] LeftPad(byte[] value, int size)
+        {
+            if (value.Length == size)
+                return value;
+
+            // Fresh array: the input is cached inside EthECKey and must not be mutated.
+            var padded = new byte[size];
+            Buffer.BlockCopy(value, 0, padded, size - value.Length, value.Length);
+            return padded;
         }
 
         public string Sign(string message) =>

--- a/Explorer/Assets/DCL/Web3/Tests/RustEthereumAccountShould.cs
+++ b/Explorer/Assets/DCL/Web3/Tests/RustEthereumAccountShould.cs
@@ -1,0 +1,39 @@
+using DCL.Web3.Abstract;
+using DCL.Web3.Accounts.Factory;
+using Nethereum.Signer;
+using NUnit.Framework;
+
+namespace DCL.Web3.Tests
+{
+    [TestFixture]
+    public class RustEthereumAccountShould
+    {
+        // Scalar with a 0x00 top byte: Nethereum's GetPrivateKeyAsBytes() returns the
+        // scalar unsigned-trimmed, so this key materializes as 31 bytes (~1/256 of keys).
+        private const string LEADING_ZERO_PRIVATE_KEY = "0x0011223344556677889900112233445566778899001122334455667788990011";
+
+        [Test]
+        public void CreateAccountWhenPrivateKeyHasLeadingZeroByte()
+        {
+            var key = new EthECKey(LEADING_ZERO_PRIVATE_KEY);
+            Assume.That(key.GetPrivateKeyAsBytes()!.Length, Is.LessThan(32));
+
+            IWeb3Account account = new Web3AccountFactory().CreateAccount(key);
+
+            Assert.That(account.Address.ToString(), Is.EqualTo(key.GetPublicAddress()).IgnoreCase);
+
+            string signature = account.Sign("hello");
+            Assert.That(account.Verify("hello", signature), Is.True);
+        }
+
+        [Test]
+        public void ExposeCanonicalPaddedPrivateKeyHex()
+        {
+            var key = new EthECKey(LEADING_ZERO_PRIVATE_KEY);
+
+            IWeb3Account account = new Web3AccountFactory().CreateAccount(key);
+
+            Assert.That(account.PrivateKey, Is.EqualTo(LEADING_ZERO_PRIVATE_KEY));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Web3/Tests/RustEthereumAccountShould.cs.meta
+++ b/Explorer/Assets/DCL/Web3/Tests/RustEthereumAccountShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 500d4d1ce171409e9a0f5cdf21d8319f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Problem

Deep-link sign-in aborts with `ArgumentException: private key must be 32 bytes` from
`RustEthSignServer.Initialize` (Sentry UNITY-EXPLORER-PMW). The auth server's ephemeral key
for a given sign-in identity is fixed, so an affected identity fails deterministically on
every retry.

## Root cause

Nethereum's `EthECKey.GetPrivateKeyAsBytes()` returns the key scalar as BouncyCastle
`BigInteger.ToByteArrayUnsigned()` - big-endian with leading zero bytes stripped (verified
by decompiling the exact DLL at the pin). ~1/256 of uniformly random secp256k1 keys have a
0x00 top byte and yield 31 bytes; the rust signer correctly demands exactly 32. The same
latent 1/256 flake exists for every `CreateRandomAccount()` ephemeral (guest/random/
ThirdWeb flows). Single call site: `RustEthereumAccount`'s constructor.

## Fix (~12 LOC, one file)

`RustEthereumAccount.cs`: left-pad the scalar to 32 bytes (fresh array - never resize the
array cached inside `EthECKey`) before handing it to the native signer, and derive
`PrivateKey` hex from the padded bytes so persisted identities are canonical 64-hex.
Previously stored 62-char values keep loading (both forms parse to the same scalar). A
zero/invalid scalar still fails via the existing `Initialize == false` path.

## Test

New EditMode `RustEthereumAccountShould`:

- `CreateAccountWhenPrivateKeyHasLeadingZeroByte` - a key whose scalar trims below 32
  bytes; pin: the ctor throws before the P/Invoke. With the fix, a Sign/Verify ECRecover
  round-trip through the native lib proves padding preserved the scalar.
- `ExposeCanonicalPaddedPrivateKeyHex` - pins the persisted-identity normalization.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 2/2 as intended (both hit
"private key must be 32 bytes") / GREEN PASS 2/2 (including the native-signer round-trip).

No tracking issue exists for this signature (searched issue name/content for "private
key", "32 bytes", "RustEthSignServer"); Sentry UNITY-EXPLORER-PMW is the source.