### PR TITLE
fix: discard duplicate scene facade for already-cached parcels and serialize realm changes

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -31,6 +31,7 @@ using Unity.Mathematics;
 using UnityEngine;
 using DCL.UserInAppInitializationFlow.StartupOperations;
 using Utility;
+using Utility.Multithreading;
 
 namespace Global.Dynamic
 {
@@ -51,6 +52,7 @@ namespace Global.Dynamic
 
         private readonly List<ISceneFacade> allScenes = new (PoolConstants.SCENES_COUNT);
         private readonly ServerAbout serverAbout = new ();
+        private readonly DCLSemaphoreSlim realmChangeSemaphore = new ();
         private readonly IWebRequestController webRequestController;
         private readonly IReadOnlyList<int2> staticLoadPositions;
         private readonly RealmData realmData;
@@ -121,6 +123,17 @@ namespace Global.Dynamic
         }
 
         public async UniTask SetRealmAsync(URLDomain realm, CancellationToken ct)
+        {
+            // Realm changes must be mutually exclusive: each one relies on its unload phase leaving no
+            // realm entity alive, so that at most one realm entity (and one ProcessedScenePointers
+            // scene-pointer dedup pipeline) exists afterwards
+            await realmChangeSemaphore.WaitAsync(ct);
+
+            try { await SetRealmExclusiveAsync(realm, ct); }
+            finally { realmChangeSemaphore.Release(); }
+        }
+
+        private async UniTask SetRealmExclusiveAsync(URLDomain realm, CancellationToken ct)
         {
             World world = globalWorld!.EcsWorld;
 
@@ -197,12 +210,10 @@ namespace Global.Dynamic
 
         public async UniTask<List<SceneEntityDefinition>> WaitForFixedScenePromisesAsync(CancellationToken ct)
         {
-            FixedScenePointers fixedScenePointers = default;
-
-            await UniTask.WaitUntil(() => GlobalWorld.EcsWorld.TryGet(realmEntity, out fixedScenePointers)
+            await UniTask.WaitUntil(() => GlobalWorld.EcsWorld.TryGet(realmEntity, out FixedScenePointers fixedScenePointers)
                                           && fixedScenePointers.AllPromisesResolved, cancellationToken: ct);
 
-            return fixedScenePointers.SceneResults;
+            return GlobalWorld.EcsWorld.Get<FixedScenePointers>(realmEntity).SceneResults;
         }
 
         public async UniTask<SceneDefinitions?> WaitForStaticScenesEntityDefinitionsAsync(CancellationToken ct)
@@ -310,19 +321,19 @@ namespace Global.Dynamic
             return parsed;
         }
 
-        private void ComplimentWithVolatilePointers(World world, Entity realmEntity)
+        private void ComplimentWithVolatilePointers(World world, Entity targetRealmEntity)
         {
-            world.Add(realmEntity, VolatileScenePointers.Create(partitionComponentPool.Get()));
+            world.Add(targetRealmEntity, VolatileScenePointers.Create(partitionComponentPool.Get()));
         }
 
-        private bool ComplimentWithStaticPointers(World world, Entity realmEntity)
+        private bool ComplimentWithStaticPointers(World world, Entity targetRealmEntity)
         {
             IReadOnlyList<int2> positions = localSceneParcels.Count > 0 ? localSceneParcels : staticLoadPositions;
 
             if (positions is { Count: > 0 })
             {
                 // Static scene pointers don't replace the logic of fixed pointers loading but compliment it
-                world.Add(realmEntity, new StaticScenePointers(positions));
+                world.Add(targetRealmEntity, new StaticScenePointers(positions));
                 return true;
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
@@ -12,7 +12,9 @@ using ECS.SceneLifeCycle.Reporting;
 using ECS.SceneLifeCycle.SceneDefinition;
 using SceneRunner.Scene;
 using System;
+using System.Collections.Generic;
 using System.Threading;
+using UnityEngine;
 using ScenePromise = ECS.StreamableLoading.Common.AssetPromise<SceneRunner.Scene.ISceneFacade, ECS.SceneLifeCycle.Components.GetSceneFacadeIntention>;
 using Utility.Multithreading;
 
@@ -54,7 +56,7 @@ namespace ECS.SceneLifeCycle.Systems
 
         protected override void Update(float t)
         {
-            ChangeSceneFPSQuery(World);
+            ChangeSceneFpsQuery(World);
             HandleNotCreatedScenesQuery(World);
             HandleSmartWearableScenesQuery(World);
         }
@@ -76,9 +78,28 @@ namespace ECS.SceneLifeCycle.Systems
             if (!promise.TryConsume(World, out var result) || !result.Succeeded) return;
 
             ISceneFacade scene = result.Asset!;
+
+            // At most one facade may own a parcel: a duplicate definition entity is left facade-less
+            // so its unload cannot remove the live scene's parcel mappings from the cache
+            if (!definitionComponent.IsPortableExperience && AnyParcelHasLiveScene(definitionComponent.Parcels))
+            {
+                ReportHub.LogWarning(GetReportData(), $"Duplicate scene definition for '{definitionComponent.Definition.GetLogSceneName()}': discarding its facade");
+                scene.DisposeAsync().Forget();
+                return;
+            }
+
             StartAndUpdateSceneAsync(definitionComponent, partition, scene).Forget();
 
             World.Add(entity, scene);
+        }
+
+        private bool AnyParcelHasLiveScene(IReadOnlyList<Vector2Int> parcels)
+        {
+            for (var i = 0; i < parcels.Count; i++)
+                if (scenesCache.TryGetByParcel(parcels[i], out _))
+                    return true;
+
+            return false;
         }
 
         [Query]
@@ -93,7 +114,7 @@ namespace ECS.SceneLifeCycle.Systems
 
         [Query]
         [None(typeof(DeleteEntityIntention))]
-        private void ChangeSceneFPS(ref ISceneFacade sceneFacade, in PartitionComponent partition)
+        private void ChangeSceneFps(ref ISceneFacade sceneFacade, in PartitionComponent partition)
         {
             if (!partition.IsDirty) return;
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ControlSceneUpdateLoopSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ControlSceneUpdateLoopSystemShould.cs
@@ -1,7 +1,9 @@
 ﻿using Arch.Core;
+using Cysharp.Threading.Tasks;
 using DCL.Ipfs;
 using DCL.Utilities;
 using ECS;
+using ECS.LifeCycle.Components;
 using ECS.Prioritization;
 using ECS.Prioritization.Components;
 using ECS.SceneLifeCycle;
@@ -62,7 +64,7 @@ namespace DCL.SceneLifeCycle.Tests
 
             Entity e = world.Create(promise, PartitionComponent.TOP_PRIORITY, sceneDefinitionComponent);
 
-            system?.Update(0f);
+            system.Update(0f);
 
             // let the system switch to the thread pool
             await Task.Delay(100);
@@ -72,7 +74,7 @@ namespace DCL.SceneLifeCycle.Tests
         }
 
         [Test]
-        public async Task StartSceneWithCorrectFPS()
+        public async Task StartSceneWithCorrectFps()
         {
             ISceneFacade scene = Substitute.For<ISceneFacade>();
 
@@ -93,7 +95,7 @@ namespace DCL.SceneLifeCycle.Tests
             Entity e = world.Create(promise, partition, sceneDefinitionComponent);
             realmPartitionSettings.GetSceneUpdateFrequency(in partition).Returns(15);
 
-            system?.Update(0f);
+            system.Update(0f);
 
             // let the system switch to the thread pool
             await Task.Delay(100);
@@ -107,7 +109,7 @@ namespace DCL.SceneLifeCycle.Tests
         {
             ISceneFacade scene = CreateWorldScenePendingStart(isRoomSettled: false, hasReadinessReport: true);
 
-            system?.Update(0f);
+            system.Update(0f);
 
             // let the system switch to the thread pool
             await Task.Delay(100);
@@ -120,7 +122,7 @@ namespace DCL.SceneLifeCycle.Tests
         {
             ISceneFacade scene = CreateWorldScenePendingStart(isRoomSettled: true, hasReadinessReport: true);
 
-            system?.Update(0f);
+            system.Update(0f);
 
             // let the system switch to the thread pool
             await Task.Delay(100);
@@ -133,7 +135,7 @@ namespace DCL.SceneLifeCycle.Tests
         {
             ISceneFacade scene = CreateWorldScenePendingStart(isRoomSettled: false, hasReadinessReport: false);
 
-            system?.Update(0f);
+            system.Update(0f);
 
             // let the system switch to the thread pool
             await Task.Delay(100);
@@ -142,7 +144,7 @@ namespace DCL.SceneLifeCycle.Tests
         }
 
         [Test]
-        public void ChangeSceneFPS()
+        public void ChangeSceneFps()
         {
             ISceneFacade scene = Substitute.For<ISceneFacade>();
 
@@ -151,9 +153,98 @@ namespace DCL.SceneLifeCycle.Tests
 
             world.Create(scene, partition, new SceneDefinitionComponent());
 
-            system?.Update(0f);
+            system.Update(0f);
 
             scene.Received(1).SetTargetFPS(15);
+        }
+
+        [Test]
+        public async Task DiscardDuplicateSceneForSameParcelsKeepingLiveFacade()
+        {
+            var scenesCache = new ScenesCache();
+
+            system = new ControlSceneUpdateLoopSystem(world, realmPartitionSettings, CancellationToken.None, scenesCache, sceneReadinessReportQueue,
+                realmData, sceneRoomStatus);
+
+            ISceneFacade scene1 = Substitute.For<ISceneFacade>();
+            ISceneFacade scene2 = Substitute.For<ISceneFacade>();
+
+            Entity e1 = CreateResolvedSceneEntity(scene1);
+            Entity e2 = CreateResolvedSceneEntity(scene2);
+
+            // a structural World.Add during query iteration can defer the sibling entity to the next update
+            system.Update(0f);
+            system.Update(0f);
+
+            // let the started scene switch to the thread pool
+            await Task.Delay(100);
+
+            // whichever entity was consumed first owns the parcel; the sibling must be discarded
+            bool firstEntityKept = world.Has<ISceneFacade>(e1);
+            (Entity discardedEntity, ISceneFacade keptScene, ISceneFacade discardedScene) = firstEntityKept ? (e2, scene1, scene2) : (e1, scene2, scene1);
+
+            Assert.That(world.Has<ISceneFacade>(discardedEntity), Is.False);
+
+            discardedScene.Received(1).DisposeAsync().Forget();
+            await discardedScene.DidNotReceive().StartUpdateLoopAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            keptScene.DidNotReceive().DisposeAsync().Forget();
+            await keptScene.Received(1).StartUpdateLoopAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            Assert.That(scenesCache.Scenes.Count, Is.EqualTo(1));
+            Assert.That(scenesCache.TryGetByParcel(Vector3.zero.ToParcel(), out ISceneFacade cached), Is.True);
+            Assert.That(cached, Is.SameAs(keptScene));
+        }
+
+        [Test]
+        public async Task KeepLiveSceneCacheMappingWhenDuplicateEntityUnloads()
+        {
+            var scenesCache = new ScenesCache();
+
+            system = new ControlSceneUpdateLoopSystem(world, realmPartitionSettings, CancellationToken.None, scenesCache, sceneReadinessReportQueue,
+                realmData, sceneRoomStatus);
+
+            ISceneFacade scene1 = Substitute.For<ISceneFacade>();
+            ISceneFacade scene2 = Substitute.For<ISceneFacade>();
+
+            Entity e1 = CreateResolvedSceneEntity(scene1);
+            Entity e2 = CreateResolvedSceneEntity(scene2);
+
+            // a structural World.Add during query iteration can defer the sibling entity to the next update
+            system.Update(0f);
+            system.Update(0f);
+
+            // let the started scene switch to the thread pool
+            await Task.Delay(100);
+
+            bool firstEntityKept = world.Has<ISceneFacade>(e1);
+            (Entity discardedEntity, ISceneFacade keptScene) = firstEntityKept ? (e2, scene1) : (e1, scene2);
+
+            var unloadSystem = new UnloadSceneSystem(world, scenesCache, false);
+            world.Add(discardedEntity, new DeleteEntityIntention());
+            unloadSystem.Update(0f);
+
+            Assert.That(scenesCache.TryGetByParcel(Vector3.zero.ToParcel(), out ISceneFacade cached), Is.True);
+            Assert.That(cached, Is.SameAs(keptScene));
+            Assert.That(scenesCache.Scenes.Count, Is.EqualTo(1));
+        }
+
+        private Entity CreateResolvedSceneEntity(ISceneFacade scene)
+        {
+            var promise = AssetPromise<ISceneFacade, GetSceneFacadeIntention>.Create(world, new GetSceneFacadeIntention(), PartitionComponent.TOP_PRIORITY);
+
+            SceneDefinitionComponent sceneDefinitionComponent = SceneDefinitionComponentFactory.CreateFromDefinition(new SceneEntityDefinition
+            {
+                metadata = new SceneMetadata
+                {
+                    scene = new SceneMetadataScene
+                        { DecodedParcels = new[] { Vector3.zero.ToParcel() } },
+                },
+            }, new IpfsPath());
+
+            world.Add(promise.Entity, new StreamableLoadingResult<ISceneFacade>(scene));
+
+            return world.Create(promise, PartitionComponent.TOP_PRIORITY, sceneDefinitionComponent);
         }
 
         private ISceneFacade CreateWorldScenePendingStart(bool isRoomSettled, bool hasReadinessReport)


### PR DESCRIPTION
## Problem

`ArgumentException: An item with the same key has already been added. Key: (2, -4)` from
`ScenesCache.Add` (Sentry UNITY-EXPLORER-PA9, 75 events / 8 users, ongoing since v0.150).
The crash is the visible tip: session breadcrumbs show every scene loading twice from
session start, zombie facades ripping the live scene's cache mappings on unload, and a
~1.5 s dispose/re-create churn loop under the player.

## Root cause

Two composing defects. (1) `RealmController.SetRealmAsync` has no re-entrancy guard: two
overlapping calls both pass the unload phase and both create a realm entity → two
independent scene-pointer pipelines mint every scene-definition entity twice for the whole
session. (2) The consume path assumes the one-entity-per-parcel invariant instead of
enforcing it: the duplicate consume's `Dictionary.Add` throw is swallowed, but
`World.Add(entity, scene)` still runs - the duplicate keeps a zombie facade that never
started, and its eventual unload removes whatever facade owns the parcel, i.e. the live
scene's cache entries.

## Fix (~30 LOC, two loci)

- A (invariant at the single cache writer): `ControlSceneUpdateLoopSystem.HandleNotCreatedScenes`
  detects a parcel collision after a successful consume (plain for-loop, non-PX only), logs
  a warning, disposes the duplicate facade, and returns without attaching it - the duplicate
  entity stays inert and its unload takes the promise-only path, which cannot touch the live
  scene's mappings. Keep-first is correct (in-session duplicates are always the same scene id).
- B (close the mint): `SetRealmAsync` serialized behind a `DCLSemaphoreSlim(1,1)` (the
  repo's WebGL-safe wrapper; raw SemaphoreSlim is lint-forbidden) - overlapping realm
  changes now execute sequentially, restoring the at-most-one-realm-entity invariant all
  pointer dedup relies on.

## Test

Two new EditMode tests in the existing `ControlSceneUpdateLoopSystemShould` harness:
`DiscardDuplicateSceneForSameParcelsKeepingLiveFacade` (duplicate disposed exactly once,
never started, exactly one facade attached, cache holds the kept facade, no error log) and
`KeepLiveSceneCacheMappingWhenDuplicateEntityUnloads` (cascade guard through a real
`UnloadSceneSystem`). Fix B validated by review (mocking the /about + WorldManifest stack
is out of proportion).

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 2/2 as intended (both failed via
the unhandled same-key ArgumentException surfacing through LogAssert) / GREEN PASS 2/2.

Fixes #8911
Related: #8883, #8720, #8492/#8441/#8183 (closed same-key family in sibling subsystems,
context for the defect class)

Includes inspection-warning cleanup in all touched files.

Fixes #8720