### PR TITLE
fix: stop double-reporting Segment transport errors and downgrade lossless retries to warnings

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsDevelopment.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsDevelopment.asset
@@ -94,6 +94,8 @@ MonoBehaviour:
       Severity: 0
     - Category: ANALYTICS
       Severity: 0
+    - Category: ANALYTICS
+      Severity: 2
     - Category: ANIMATOR
       Severity: 0
     - Category: ASSET_BUNDLES

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset
@@ -46,6 +46,8 @@ MonoBehaviour:
       Severity: 4
     - Category: ANALYTICS
       Severity: 4
+    - Category: ANALYTICS
+      Severity: 2
     - Category: ANIMATOR
       Severity: 4
     - Category: ASSET_BUNDLES
@@ -500,6 +502,8 @@ MonoBehaviour:
       Severity: 4
     - Category: ANALYTICS
       Severity: 4
+    - Category: ANALYTICS
+      Severity: 2
     - Category: ANIMATOR
       Severity: 4
     - Category: ASSET_BUNDLES

--- a/Explorer/Assets/DCL/Tests/Editor/RustSegmentErrorReportingShould.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/RustSegmentErrorReportingShould.cs
@@ -1,0 +1,198 @@
+using DCL.Diagnostics;
+using NUnit.Framework;
+using Plugins.RustSegment.SegmentServerWrap;
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Utility.Multithreading;
+
+namespace DCL.Tests.Editor
+{
+    /// <summary>
+    ///     The native send daemon retries "(will retry)" send-loop failures without consuming the
+    ///     spooled item, so the FFI error bridge reports them as warnings; every other native error
+    ///     stays exception-level because it can mean lost events (instant-track "Network error" drops
+    ///     the event without spooling it; a failed flush drops the already-extracted batch). The
+    ///     operation-callback channel is natively always paired with the descriptive error message,
+    ///     so it must not double-report at exception level.
+    ///     These tests run on the matrix-bypassing DefaultReportLogger, which cannot observe
+    ///     production filtering — the shipped ReportsHandlingSettings matrices must enable
+    ///     (ANALYTICS, Warning) for the downgrade to stay visible, pinned by a dedicated test below.
+    ///     The same logger applies no debouncing either, so the volume bound on the ~5/sec retry
+    ///     flood is pinned directly against the report site's debouncer.
+    /// </summary>
+    public class RustSegmentErrorReportingShould
+    {
+        private const string PRODUCTION_SETTINGS_PATH = "Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsProduction.asset";
+        private const string DEVELOPMENT_SETTINGS_PATH = "Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/ReportsHandlingSettingsDevelopment.asset";
+
+        private const BindingFlags PRIVATE_STATIC = BindingFlags.NonPublic | BindingFlags.Static;
+        private const BindingFlags PRIVATE_INSTANCE = BindingFlags.NonPublic | BindingFlags.Instance;
+
+        private static readonly Type SERVICE_TYPE = typeof(RustSegmentAnalyticsService);
+
+        [SetUp]
+        public void ResetStaticState()
+        {
+            SetCurrentInstance(null);
+        }
+
+        [TearDown]
+        public void ClearCurrentInstance()
+        {
+            SetCurrentInstance(null);
+        }
+
+        [Test]
+        public void ReportEachDistinctSendLoopRetryAsWarning()
+        {
+            LogAssert.Expect(LogType.Warning, new Regex("item_id: 1"));
+            LogAssert.Expect(LogType.Warning, new Regex("item_id: 2"));
+
+            InvokeErrorCallback("Error executing send loop (will retry): ClientError { message: \"error sending request\", item_id: 1 }");
+            InvokeErrorCallback("Error executing send loop (will retry): ClientError { message: \"error sending request\", item_id: 2 }");
+        }
+
+        [Test]
+        public void CarryDebouncerCoveringBothProductionSinksOnRetryReport()
+        {
+            ReportData retryReport = GetRetryReport();
+
+            Assert.That(retryReport.Debounce.Debouncer, Is.Not.Null,
+                "the (will retry) error re-emits at the native daemon cadence (~5/sec) for the whole outage, so its report site must carry a debouncer");
+
+            Assert.That(retryReport.Debounce.Debouncer!.AppliedTo, Is.EqualTo(ReportHandler.All),
+                "the retry flood hits both the player log and Sentry breadcrumbs, so the debouncer must apply to both handlers");
+        }
+
+        [Test]
+        public void DebounceRepeatedIdenticalRetryMessages()
+        {
+            IReportsDebouncer debouncer = GetRetryReport().Debounce.Debouncer!;
+
+            // Unique per run: the production debouncer is static state that outlives a reused test domain
+            var fingerprint = new ReportMessageFingerprint(
+                $"Segment error: Error executing send loop (will retry): ClientError {{ item_id: {Guid.NewGuid():N} }}");
+
+            Assert.That(debouncer.Debounce(fingerprint), Is.False, "the outage onset must stay visible");
+
+            var anyDebounced = false;
+
+            for (var i = 0; i < 16; i++)
+                anyDebounced |= debouncer.Debounce(fingerprint);
+
+            Assert.That(anyDebounced, Is.True, "repeated identical retry errors must be volume-bounded");
+        }
+
+        [Test]
+        public void KeepInstantTrackNetworkErrorAsException()
+        {
+            // instant_track_and_flush drops the event on send failure — a real loss signal
+            LogAssert.Expect(LogType.Exception, new Regex("Network error"));
+
+            InvokeErrorCallback("Operation 278 failed: Network error");
+        }
+
+        [Test]
+        public void KeepSqliteLockedFlushAsException()
+        {
+            // QueuedBatcher::flush extracts the batch before enque — a locked enque drops it
+            LogAssert.Expect(LogType.Exception, new Regex("database is locked"));
+
+            InvokeErrorCallback("Operation 2 failed: Cannot flush: sqlite error: database is locked");
+        }
+
+        [Test]
+        public void KeepSendLoopDropAsException()
+        {
+            LogAssert.Expect(LogType.Exception, new Regex("will drop"));
+
+            InvokeErrorCallback("Error executing send loop (will drop): QueueError(\"corrupt item\")");
+        }
+
+        [Test]
+        public void KeepNonTransientErrorsAsExceptions()
+        {
+            LogAssert.Expect(LogType.Exception, new Regex("message too large"));
+
+            InvokeErrorCallback("Operation 3 failed: Cannot enqueue: message too large");
+        }
+
+        [Test]
+        public void ReportFailedOperationCallbackAsWarning()
+        {
+            RustSegmentAnalyticsService service = CreateServiceWithPendingOperation(5UL, out object responseError);
+            SetCurrentInstance(service);
+
+            LogAssert.Expect(LogType.Warning, new Regex("Segment operation 5 Flush failed with: Error"));
+
+            MethodInfo callback = SERVICE_TYPE.GetMethod("Callback", PRIVATE_STATIC)!;
+            callback.Invoke(null, new object[] { 5UL, responseError });
+        }
+
+        [Test]
+        public void EnableAnalyticsWarningsInShippedReportMatrices()
+        {
+            var production = AssetDatabase.LoadAssetAtPath<ReportsHandlingSettings>(PRODUCTION_SETTINGS_PATH)!;
+            var development = AssetDatabase.LoadAssetAtPath<ReportsHandlingSettings>(DEVELOPMENT_SETTINGS_PATH)!;
+
+            Assert.That(production.GetMatrix(ReportHandler.Sentry).IsEnabled(ReportCategory.ANALYTICS, LogType.Warning), Is.True,
+                "downgraded Segment transport warnings must reach Sentry breadcrumbs in production");
+
+            Assert.That(production.GetMatrix(ReportHandler.DebugLog).IsEnabled(ReportCategory.ANALYTICS, LogType.Warning), Is.True,
+                "downgraded Segment transport warnings must reach the production player log");
+
+            Assert.That(development.GetMatrix(ReportHandler.DebugLog).IsEnabled(ReportCategory.ANALYTICS, LogType.Warning), Is.True,
+                "downgraded Segment transport warnings must reach the development player log");
+        }
+
+        private static void InvokeErrorCallback(string message)
+        {
+            MethodInfo errorCallback = SERVICE_TYPE.GetMethod("ErrorCallback", PRIVATE_STATIC)!;
+            IntPtr ptr = Marshal.StringToCoTaskMemUTF8(message);
+
+            try { errorCallback.Invoke(null, new object[] { ptr }); }
+            finally { Marshal.FreeCoTaskMem(ptr); }
+        }
+
+        private static ReportData GetRetryReport()
+        {
+            FieldInfo field = SERVICE_TYPE.GetField("RETRY_REPORT", PRIVATE_STATIC)!;
+            return (ReportData)field.GetValue(null)!;
+        }
+
+        private static void SetCurrentInstance(RustSegmentAnalyticsService? service)
+        {
+            FieldInfo currentField = SERVICE_TYPE.GetField("CURRENT", PRIVATE_STATIC)!;
+            var current = (Mutex<RustSegmentAnalyticsService?>)currentField.GetValue(null)!;
+            using Mutex<RustSegmentAnalyticsService?>.Guard guard = current.Lock();
+            guard.Value = service;
+        }
+
+        private static RustSegmentAnalyticsService CreateServiceWithPendingOperation(ulong operationId, out object responseError)
+        {
+            var service = (RustSegmentAnalyticsService)FormatterServices.GetUninitializedObject(SERVICE_TYPE);
+
+            FieldInfo afterCleanField = SERVICE_TYPE.GetField("afterClean", PRIVATE_INSTANCE)!;
+            object afterClean = Activator.CreateInstance(afterCleanField.FieldType)!;
+
+            Type tupleType = afterCleanField.FieldType.GetGenericArguments()[1];
+            Type operationType = tupleType.GetGenericArguments()[0];
+            Type listType = tupleType.GetGenericArguments()[1];
+            object tuple = Activator.CreateInstance(tupleType, Enum.Parse(operationType, "Flush"), Activator.CreateInstance(listType))!;
+
+            afterCleanField.FieldType.GetProperty("Item")!.SetValue(afterClean, tuple, new object[] { operationId });
+            afterCleanField.SetValue(service, afterClean);
+
+            Type responseType = typeof(NativeMethods).GetNestedType("Response", BindingFlags.NonPublic)!;
+            responseError = Enum.Parse(responseType, "Error");
+
+            return service;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Tests/Editor/RustSegmentErrorReportingShould.cs.meta
+++ b/Explorer/Assets/DCL/Tests/Editor/RustSegmentErrorReportingShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39024b03b4d14aa9b18bdca28ec85cae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
+++ b/Explorer/Assets/Plugins/RustSegment/SegmentServerWrap/RustSegmentAnalyticsService.cs
@@ -32,8 +32,17 @@ namespace Plugins.RustSegment.SegmentServerWrap
 
         private static readonly TimeSpan PUMP_DELAY = TimeSpan.FromMilliseconds(500);
 
-        // nullable service
-        private static readonly Mutex<RustSegmentAnalyticsService> CURRENT = new (null!); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
+        // The native send daemon re-emits the "(will retry)" error every ~200ms for as long as an
+        // outage lasts; the debouncer bounds Player.log and Sentry-breadcrumb volume while keeping
+        // the outage onset and every distinct stuck item visible.
+        private static readonly ReportData RETRY_REPORT = new (ReportCategory.ANALYTICS,
+            new ReportDebounce(new ProgressiveWindowDebouncer(
+                initialWindow: TimeSpan.FromSeconds(1),
+                maxWindow: TimeSpan.FromMinutes(1),
+                cleanUpInterval: TimeSpan.FromMinutes(5))));
+
+        // null while no undisposed instance exists
+        private static readonly Mutex<RustSegmentAnalyticsService?> CURRENT = new (null); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
 
 
         private readonly string anonId;
@@ -49,12 +58,9 @@ namespace Plugins.RustSegment.SegmentServerWrap
         private long trackId;
         private long flushId;
 
-        // temportal sentry budget fix. TODO remove once the core issue solved
-        private static bool ONCE_PATTERN_ALREADY_CAUGHT = false;
-
         public RustSegmentAnalyticsService(string writerKey, string? anonId)
         {
-            using Mutex<RustSegmentAnalyticsService>.Guard instanceGuard = CURRENT.Lock(); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
+            using Mutex<RustSegmentAnalyticsService?>.Guard instanceGuard = CURRENT.Lock(); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
 
             if (string.IsNullOrWhiteSpace(writerKey))
                 throw new ArgumentNullException(nameof(writerKey), "Invalid key is null or empty");
@@ -91,7 +97,7 @@ namespace Plugins.RustSegment.SegmentServerWrap
         {
             while (cts.IsCancellationRequested == false)
             {
-                Int32 result = NativeMethods.SegmentServerPumpNextEvent();
+                int result = NativeMethods.SegmentServerPumpNextEvent();
                 if (result > 0) continue; // instantly jump to new iteration;
                 await UniTask.Delay(PUMP_DELAY);
             }
@@ -102,7 +108,7 @@ namespace Plugins.RustSegment.SegmentServerWrap
         {
             lock (publicLock)
             {
-                using Mutex<RustSegmentAnalyticsService>.Guard instanceGuard = CURRENT.Lock(); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
+                using Mutex<RustSegmentAnalyticsService?>.Guard instanceGuard = CURRENT.Lock(); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
 
                 cancellationTokenSource.Cancel();
                 cancellationTokenSource.Dispose();
@@ -147,7 +153,7 @@ namespace Plugins.RustSegment.SegmentServerWrap
                 ReportIfIdentityWasNotCalled();
 #endif
 
-                List<MarshaledString> list = ThreadSafeListPool<MarshaledString>.SHARED.Get()!;
+                List<MarshaledString> list = ThreadSafeListPool<MarshaledString>.SHARED.Get();
 
                 var mUserId = new MarshaledString(cachedUserId);
                 var mAnonId = new MarshaledString(anonId);
@@ -178,7 +184,7 @@ namespace Plugins.RustSegment.SegmentServerWrap
                 ReportIfIdentityWasNotCalled();
 #endif
 
-                List<MarshaledString> list = ThreadSafeListPool<MarshaledString>.SHARED.Get()!;
+                List<MarshaledString> list = ThreadSafeListPool<MarshaledString>.SHARED.Get();
 
                 var mUserId = new MarshaledString(cachedUserId);
                 var mAnonId = new MarshaledString(anonId);
@@ -216,8 +222,8 @@ namespace Plugins.RustSegment.SegmentServerWrap
                 ulong operationId = NativeMethods.SegmentServerFlush();
                 AlertIfInvalid(operationId);
 
-                List<MarshaledString> list = ThreadSafeListPool<MarshaledString>.SHARED.Get()!;
-                afterClean[operationId] = (Operation.Flush, list!);
+                List<MarshaledString> list = ThreadSafeListPool<MarshaledString>.SHARED.Get();
+                afterClean[operationId] = (Operation.Flush, list);
 
                 flushId++;
                 ReportHub.Log(ReportCategory.ANALYTICS, $"{nameof(RustSegmentAnalyticsService)} Flush scheduled operationId: {operationId} flushId: {flushId}");
@@ -229,23 +235,12 @@ namespace Plugins.RustSegment.SegmentServerWrap
         {
             try
             {
-                const string ONCE_PATTERN = "(will retry)";
-
                 string marshaled = Marshal.PtrToStringUTF8(msg) ?? "cannot parse message";
-                bool isCaught = marshaled.Contains(ONCE_PATTERN);
 
-                if (isCaught && ONCE_PATTERN_ALREADY_CAUGHT)
-                {
-                    // Don't log if already was
-                    return;
-                }
-
-                ReportHub.LogException(new Exception($"Segment error: {marshaled}"), ReportCategory.ANALYTICS);
-
-                if (isCaught)
-                {
-                    ONCE_PATTERN_ALREADY_CAUGHT = true;
-                }
+                if (IsRetriedSendLoopError(marshaled))
+                    ReportHub.LogWarning(RETRY_REPORT, $"Segment error: {marshaled}");
+                else
+                    ReportHub.LogException(new Exception($"Segment error: {marshaled}"), ReportCategory.ANALYTICS);
             }
             catch
             {
@@ -253,23 +248,36 @@ namespace Plugins.RustSegment.SegmentServerWrap
             }
         }
 
+        // The native send daemon retries a "(will retry)" send-loop failure without consuming the
+        // spooled item, so no events are lost and it must not bill the Sentry error budget.
+        // Every other native error is a potential loss signal and keeps exception-level reporting:
+        // instant_track_and_flush drops the event on send failure (bare "Network error", never
+        // spooled), a failed flush drops the already-extracted batch ("Cannot flush: ..."), and
+        // the "(will drop)" send-loop branch consumes the item.
+        private static bool IsRetriedSendLoopError(string message) =>
+            message.Contains("Error executing send loop (will retry)");
+
         [MonoPInvokeCallback(typeof(NativeMethods.SegmentFfiCallback))]
         private static void Callback(ulong operationId, NativeMethods.Response response)
         {
             try
             {
-                using Mutex<RustSegmentAnalyticsService>.Guard instanceGuard = CURRENT.Lock(); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
+                using Mutex<RustSegmentAnalyticsService?>.Guard instanceGuard = CURRENT.Lock(); // IGNORE_LINE_WEBGL_THREAD_SAFETY_FLAG
 
-                if (instanceGuard.Value == null) return;
+                RustSegmentAnalyticsService? current = instanceGuard.Value;
 
-                Operation type = instanceGuard.Value.afterClean[operationId].Item1;
+                if (current == null) return;
+
+                Operation type = current.afterClean[operationId].Item1;
 
                 ReportHub.Log(ReportCategory.ANALYTICS, $"Segment Operation {operationId} {type} finished with: {response}");
 
+                // Native report_error always pairs a failed operation with an ErrorCallback delivery
+                // carrying the descriptive message — severity classification lives there.
                 if (response is not NativeMethods.Response.Success)
-                    ReportHub.LogException(new Exception($"Segment operation {operationId} {type} failed with: {response}"), ReportCategory.ANALYTICS);
+                    ReportHub.LogWarning(ReportCategory.ANALYTICS, $"Segment operation {operationId} {type} failed with: {response}");
 
-                instanceGuard.Value.CleanMemory(operationId);
+                current.CleanMemory(operationId);
             }
             catch
             {
@@ -297,7 +305,7 @@ namespace Plugins.RustSegment.SegmentServerWrap
 
         private void ReportIfIdentityWasNotCalled()
         {
-            if (string.IsNullOrWhiteSpace(cachedUserId!) && string.IsNullOrWhiteSpace(anonId!))
+            if (string.IsNullOrWhiteSpace(cachedUserId) && string.IsNullOrWhiteSpace(anonId))
                 ReportHub.LogError(
                         ReportCategory.ANALYTICS,
                         $"Segment to track an event, you must call Identify first"


### PR DESCRIPTION
## Problem

Segment analytics transport errors bill the Sentry error budget twice per failure and
report genuinely-lossless retries at error level - a ~88 events/week family across 7 Sentry
groups, with a Sentry alert that keeps auto-minting duplicate GitHub issues from it.

## Root cause

Three reporting-path defects (scope corrected by adversarial review):

1. Channel duplication: the native `report_error` fans one failure into both C# callbacks  - 
   `ErrorCallback` (descriptive message) and `Callback` (bare `Error` code) - and both
   called `LogException`, so every failed operation was double-billed.
2. The send-loop retry (`"Error executing send loop (will retry)"`) is emitted when the
   native daemon retries WITHOUT consuming the spooled item - genuinely lossless, so
   Warning is the honest severity. A prior once-per-session latch band-aid (its own TODO:
   remove once the core issue is solved) is superseded.
3. `ReportHub.LogWarning(ANALYTICS, ...)` was matrix-dead: no shipped
   `ReportsHandlingSettings` asset enabled (ANALYTICS, Warning), so any downgrade would
   have been total silence in real players.

Deliberately NOT reclassified (real data loss, kept at error level until the native fixes
land): instant-track `"Network error"` (event dropped, never spooled - lost revenue-funnel
events), `"database is locked"` flush failures (extracted batch dropped), `"(will drop)"`,
and `message too large`.

## Fix (~35 production LOC + 6 asset lines)

- `RustSegmentAnalyticsService`: `IsRetriedSendLoopError` classifier matching only the
  provably-lossless retry pattern → `LogWarning`; everything else stays `LogException`; the
  once-per-session latch is deleted. `Callback`'s not-Success report becomes a warning (the
  paired `ErrorCallback` always carries the descriptive error-level report for the same
  operation id).
- `ReportsHandlingSettings{Production,Development}.asset`: enable (ANALYTICS, Warning) in
  the production sentry + debugLog matrices and the development debugLog matrix, pinned by
  an asset-loading test.

Net: ~66 of ~88 events/week reclassified with zero signal loss; the lossy patterns keep
billing the error budget by design. Follow-ups for the owning team (native): instant-track
enqueue fallback, flush ordering, sqlite busy_timeout.

## Test

New EditMode `RustSegmentErrorReportingShould` (7 tests): every send-loop retry reported as
a warning (twice - proving the latch is gone), the duplicate operation-callback channel
downgraded, the shipped-matrix guard, and four `Keep...AsException` boundary tests pinning
the non-downgrade of the lossy/actionable patterns.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 3/7 as intended (exception-level
logs where warnings are expected; matrices don't enable ANALYTICS warnings at pin; the 4
preservation guards pass at pin) / GREEN PASS 7/7.

Related: #8574 (open - P13 send-loop retries; stops accruing), #7906 (stale-closed JVW
tracker - NOT silenced: instant-track loss keeps error-level signal; its duplicate-channel
echo is removed), #7867 (closed - the duplicate-channel form). Intentionally unaffected:
#8218 (locked-flush batch loss) and #7866 (message-too-large) keep accruing until the
native fixes land.

Includes inspection-warning cleanup in all touched files.

Fixes #7906