### PR TITLE
fix: guard thumbnail disposal on Succeeded so failed results don't NRE and abort cache cleanup

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
@@ -1,10 +1,8 @@
 using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Assets;
-using DCL.AvatarRendering.Wearables.Components;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.StreamableLoading.AudioClips;
 using ECS.StreamableLoading.Common.Components;
-using System;
 using System.Collections.Generic;
 using DCL.AvatarRendering.Wearables.Registry;
 using Utility.Multithreading;
@@ -79,7 +77,7 @@ namespace DCL.AvatarRendering.Emotes
         {
             lock (lockObject)
             {
-                for (LinkedListNode<(URN key, long lastUsedFrame)> node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
+                for (LinkedListNode<(URN key, long lastUsedFrame)>? node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
                 {
                     URN urn = node.Value.key;
 
@@ -139,8 +137,9 @@ namespace DCL.AvatarRendering.Emotes
 
         private static void DisposeThumbnail(IEmote wearable)
         {
-            if (wearable.ThumbnailAssetResult is { IsInitialized: true })
-                wearable.ThumbnailAssetResult.Value.Asset.RemoveReference();
+            // A reference was acquired only if the result succeeded; failed/cancelled results carry a default SpriteData
+            if (wearable.ThumbnailAssetResult is { Succeeded: true } thumbnail)
+                thumbnail.Asset.RemoveReference();
         }
 
         private static void DisposeAudioClips(IEmote emote)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/TrimmedEmoteStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/TrimmedEmoteStorage.cs
@@ -85,8 +85,9 @@ namespace DCL.AvatarRendering.Emotes
 
         private static void DisposeThumbnail(ITrimmedEmote wearable)
         {
-            if (wearable.ThumbnailAssetResult is { IsInitialized: true })
-                wearable.ThumbnailAssetResult.Value.Asset.RemoveReference();
+            // A reference was acquired only if the result succeeded; failed/cancelled results carry a default SpriteData
+            if (wearable.ThumbnailAssetResult is { Succeeded: true } thumbnail)
+                thumbnail.Asset.RemoveReference();
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/TrimmedWearableStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/TrimmedWearableStorage.cs
@@ -86,8 +86,9 @@ namespace DCL.AvatarRendering.Wearables.Helpers
 
         private static void DisposeThumbnail(ITrimmedWearable wearable)
         {
-            if (wearable.ThumbnailAssetResult is { IsInitialized: true })
-                wearable.ThumbnailAssetResult.Value.Asset.RemoveReference();
+            // A reference was acquired only if the result succeeded; failed/cancelled results carry a default SpriteData
+            if (wearable.ThumbnailAssetResult is { Succeeded: true } thumbnail)
+                thumbnail.Asset.RemoveReference();
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableStorage.cs
@@ -14,9 +14,8 @@ namespace DCL.AvatarRendering.Wearables.Helpers
     {
         private readonly LinkedList<(URN key, long lastUsedFrame)> listedCacheKeys = new ();
         private readonly Dictionary<URN, LinkedListNode<(URN key, long lastUsedFrame)>> cacheKeysDictionary = new (new Dictionary<URN, LinkedListNode<(URN key, long lastUsedFrame)>>(), URNIgnoreCaseEqualityComparer.Default);
-        private readonly Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>> ownedNftsRegistry = new (new Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>>(), URNIgnoreCaseEqualityComparer.Default);
 
-        private readonly object lockObject = new ();
+        private new readonly object lockObject = new ();
 
         internal Dictionary<URN, IWearable> wearablesCache { get; } = new (new Dictionary<URN, IWearable>(), URNIgnoreCaseEqualityComparer.Default);
 
@@ -62,7 +61,7 @@ namespace DCL.AvatarRendering.Wearables.Helpers
         {
             lock (lockObject)
             {
-                for (LinkedListNode<(URN key, long lastUsedFrame)> node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
+                for (LinkedListNode<(URN key, long lastUsedFrame)>? node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
                 {
                     URN urn = node.Value.key;
 
@@ -132,8 +131,10 @@ namespace DCL.AvatarRendering.Wearables.Helpers
         private static void DisposeThumbnail(IWearable wearable)
         {
             IAvatarAttachment attachment = wearable;
-            if (attachment.ThumbnailAssetResult is { IsInitialized: true })
-                attachment.ThumbnailAssetResult.Value.Asset.RemoveReference();
+
+            // A reference was acquired only if the result succeeded; failed/cancelled results carry a default SpriteData
+            if (attachment.ThumbnailAssetResult is { Succeeded: true } thumbnail)
+                thumbnail.Asset.RemoveReference();
         }
 
         private void UpdateListedCachePriority(URN @for)

--- a/Explorer/Assets/DCL/ResourcesUnloading/Tests/StorageThumbnailDisposalShould.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/Tests/StorageThumbnailDisposalShould.cs
@@ -1,0 +1,143 @@
+using DCL.AvatarRendering.Emotes;
+using DCL.AvatarRendering.Wearables.Components;
+using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Optimization.PerformanceBudgeting;
+using ECS.StreamableLoading;
+using ECS.StreamableLoading.Common.Components;
+using ECS.StreamableLoading.Textures;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DCL.ResourcesUnloading.Tests
+{
+    /// <summary>
+    ///     Storage Unload must evict entries whose terminal thumbnail result never acquired a
+    ///     refcounted reference (failed/cancelled carry a default <see cref="SpriteData" />),
+    ///     and must release exactly one reference for succeeded thumbnails.
+    /// </summary>
+    public class StorageThumbnailDisposalShould
+    {
+        private const string WEARABLE_URN = "urn:decentraland:matic:collections-v2:0xstoragetest:1";
+        private const string EMOTE_URN = "urn:decentraland:matic:collections-v2:0xstoragetest:2";
+
+        private IReleasablePerformanceBudget budget = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            budget = Substitute.For<IReleasablePerformanceBudget>();
+            budget.TrySpendBudget().Returns(true);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void EvictTrimmedWearableWithUnacquiredThumbnail(bool cancelled)
+        {
+            var storage = new TrimmedWearableStorage();
+            ITrimmedWearable wearable = storage.GetOrAddByDTO(TrimmedWearableDto(WEARABLE_URN));
+            wearable.ThumbnailAssetResult = UnacquiredThumbnail(cancelled);
+
+            Assert.DoesNotThrow(() => storage.Unload(budget));
+
+            Assert.That(storage.TryGetElement(WEARABLE_URN, out _), Is.False);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void EvictWearableWithUnacquiredThumbnail(bool cancelled)
+        {
+            var storage = new WearableStorage();
+            IWearable wearable = storage.AddWearable(WEARABLE_URN, new Wearable(), qualifiedForUnloading: true);
+            wearable.ThumbnailAssetResult = UnacquiredThumbnail(cancelled);
+
+            Assert.DoesNotThrow(() => storage.Unload(budget));
+
+            Assert.That(storage.TryGetElement(WEARABLE_URN, out _), Is.False);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void EvictEmoteWithUnacquiredThumbnail(bool cancelled)
+        {
+            var storage = new MemoryEmotesStorage();
+            IEmote emote = storage.GetOrAddByDTO(EmoteDto(EMOTE_URN));
+            emote.ThumbnailAssetResult = UnacquiredThumbnail(cancelled);
+
+            Assert.DoesNotThrow(() => storage.Unload(budget));
+
+            Assert.That(storage.TryGetElement(EMOTE_URN, out _), Is.False);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void EvictTrimmedEmoteWithUnacquiredThumbnail(bool cancelled)
+        {
+            var storage = new TrimmedEmoteStorage();
+            ITrimmedEmote emote = storage.GetOrAddByDTO(TrimmedEmoteDto(EMOTE_URN));
+            emote.ThumbnailAssetResult = UnacquiredThumbnail(cancelled);
+
+            Assert.DoesNotThrow(() => storage.Unload(budget));
+
+            Assert.That(storage.TryGetElement(EMOTE_URN, out _), Is.False);
+        }
+
+        [Test]
+        public void DereferenceSucceededThumbnailExactlyOnceOnUnload()
+        {
+            var trimmedWearableSpy = new RefCountSpy();
+            var trimmedWearableStorage = new TrimmedWearableStorage();
+            trimmedWearableStorage.GetOrAddByDTO(TrimmedWearableDto(WEARABLE_URN)).ThumbnailAssetResult = SucceededThumbnail(trimmedWearableSpy);
+
+            var wearableSpy = new RefCountSpy();
+            var wearableStorage = new WearableStorage();
+            wearableStorage.AddWearable(WEARABLE_URN, new Wearable(), qualifiedForUnloading: true).ThumbnailAssetResult = SucceededThumbnail(wearableSpy);
+
+            var emoteSpy = new RefCountSpy();
+            var emoteStorage = new MemoryEmotesStorage();
+            emoteStorage.GetOrAddByDTO(EmoteDto(EMOTE_URN)).ThumbnailAssetResult = SucceededThumbnail(emoteSpy);
+
+            var trimmedEmoteSpy = new RefCountSpy();
+            var trimmedEmoteStorage = new TrimmedEmoteStorage();
+            trimmedEmoteStorage.GetOrAddByDTO(TrimmedEmoteDto(EMOTE_URN)).ThumbnailAssetResult = SucceededThumbnail(trimmedEmoteSpy);
+
+            trimmedWearableStorage.Unload(budget);
+            wearableStorage.Unload(budget);
+            emoteStorage.Unload(budget);
+            trimmedEmoteStorage.Unload(budget);
+
+            Assert.That(trimmedWearableSpy.Dereferences, Is.EqualTo(1), nameof(TrimmedWearableStorage));
+            Assert.That(wearableSpy.Dereferences, Is.EqualTo(1), nameof(WearableStorage));
+            Assert.That(emoteSpy.Dereferences, Is.EqualTo(1), nameof(MemoryEmotesStorage));
+            Assert.That(trimmedEmoteSpy.Dereferences, Is.EqualTo(1), nameof(TrimmedEmoteStorage));
+        }
+
+        private static StreamableLoadingResult<SpriteData>.WithFallback UnacquiredThumbnail(bool cancelled) =>
+            cancelled
+                ? StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult()
+                : StreamableLoadingResult<SpriteData>.WithFallback.Failed();
+
+        private static StreamableLoadingResult<SpriteData>.WithFallback SucceededThumbnail(RefCountSpy spy) =>
+            new (new SpriteData(spy, null!));
+
+        private static TrimmedWearableDTO TrimmedWearableDto(string urn) =>
+            new () { metadata = new TrimmedWearableDTO.WearableMetadataDto { id = urn } };
+
+        private static TrimmedEmoteDTO TrimmedEmoteDto(string urn) =>
+            new () { metadata = new TrimmedEmoteDTO.EmoteMetadataDto { id = urn } };
+
+        private static EmoteDTO EmoteDto(string urn) =>
+            new () { metadata = new EmoteDTO.EmoteMetadataDto { id = urn } };
+
+        private class RefCountSpy : IStreamableRefCountData
+        {
+            public int Dereferences { get; private set; }
+
+            public void Dereference()
+            {
+                Dereferences++;
+            }
+
+            public void Dispose() { }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/ResourcesUnloading/Tests/StorageThumbnailDisposalShould.cs.meta
+++ b/Explorer/Assets/DCL/ResourcesUnloading/Tests/StorageThumbnailDisposalShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64652d83fc4d4df893626a58dd5ccc49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Problem

`NullReferenceException` inside `ReleaseMemorySystem` on every unload tick while memory is
low (Sentry UNITY-EXPLORER-P9Q, 541 week-events / 4 users): the low-memory cache cleanup
crashes in `TrimmedWearableStorage.DisposeThumbnail -> SpriteData.RemoveReference`, the
poisoned entry stays at the head of the LRU (so every pass re-crashes), and the abort skips
every cache below it in `CacheCleaner.UnloadCache` - defeating exactly the low-memory
recovery the system exists for.

## Root cause

`DisposeThumbnail` conflates "a terminal result exists" (`IsInitialized`) with "a refcounted
thumbnail reference was acquired" (`Succeeded`). Failed/cancelled thumbnail results are
terminal but carry `Asset == default(SpriteData)` whose `createdFrom` is null, so
`RemoveReference()` NREs. Same pattern at four sites: `WearableStorage`,
`TrimmedWearableStorage`, `MemoryEmotesStorage`, `TrimmedEmoteStorage`.

## Fix (~8 LOC)

Guard on `Succeeded` at all four sites - the exact convention already used by
`MemoryEmotesStorage.DisposeAudioClips` and `WearableStorage.TryUnloadAllWearableAssets`:

```csharp
if (wearable.ThumbnailAssetResult is { Succeeded: true } thumbnail)
    thumbnail.Asset.RemoveReference();
```

Not a defensive null-check: `Failed()`/`CancelledResult()` never acquired a reference, so
skipping them is the semantically correct dereference pairing; succeeded-path behavior is
byte-identical.

## Test

New EditMode `StorageThumbnailDisposalShould` (9 cases): each storage seeded with a
failed/cancelled thumbnail entry must `Unload` without throwing AND actually evict the entry;
plus `DereferenceSucceededThumbnailExactlyOnceOnUnload` guards against over-skipping (a
hand-rolled ref-count spy asserts exactly one dereference).

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 8/8 as intended (all four storages ×
cancelled/failed NRE at `SpriteData.RemoveReference`) + succeeded-path guard PASS at pin as
designed / GREEN PASS 9/9.

Fixes #8884
Related: #9558 (closed as duplicate of #8884, same NRE at TrimmedWearableStorage.cs:90)

Includes inspection-warning cleanup in all touched files.