### PR TITLE
fix: abandon the parked connect await when an unestablished close aborts

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
@@ -4,15 +4,24 @@ using Cysharp.Threading.Tasks;
 
 namespace Utility.Networking
 {
-    // Desktop / WebGL friendly implementation
+    /// <summary>
+    ///     Desktop / WebGL friendly implementation. CloseAsync, Abort and Dispose may run on a
+    ///     different thread than a pending ConnectAsync await; failing a pending connection
+    ///     completes that await instead of leaving it parked.
+    /// </summary>
     public class DCLWebSocket : IDisposable
     {
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
         private DCL.WebSockets.JS.WebGLWebSocket ws = new ();
 #else
         private System.Net.WebSockets.ClientWebSocket ws = new ();
-#endif
 
+        // Failing a pending connection requires abandoning the connect await: once the TCP
+        // connect succeeds, mono's ClientWebSocket keeps no registration that can unpark the
+        // HTTP-upgrade read, so neither Abort() nor a CancellationToken completes a parked
+        // ConnectAsync.
+        private readonly CancellationTokenSource connectAbort = new ();
+#endif
 
         public WebSocketState State
         {
@@ -28,7 +37,12 @@ namespace Utility.Networking
 
         public void Dispose()
         {
+#if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
             ws.Dispose();
+#else
+            connectAbort.SafeCancelAndDispose();
+            ws.Dispose();
+#endif
         }
 
         public async UniTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
@@ -79,7 +93,24 @@ namespace Utility.Networking
         {
             try
             {
+#if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
                 await ws.ConnectAsync(uri, cancellationToken);
+#else
+                // AttachExternalCancellation completes this await when connectAbort fires even
+                // though the BCL task stays parked; the abandoned task's outcome must not
+                // surface as an unobserved fault.
+                //
+                // The receive loop that consumes this connection is started in this continuation, so
+                // the continuation must resume on the thread the connect was issued from. A connecting
+                // thread that has a SynchronizationContext (the Unity main thread, whose social/comms
+                // receive loops feed main-thread-only UI) keeps it so the loop stays on that thread; a
+                // connecting thread without one (the V8 script-invoke thread) skips it, since
+                // TaskScheduler.FromCurrentSynchronizationContext() throws with no current context
+                // (see DCLSemaphoreSlim.WaitAsync).
+                bool marshalBackToIssuingContext = SynchronizationContext.Current != null;
+                using CancellationTokenSource linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, connectAbort.Token);
+                await ws.ConnectAsync(uri, linked.Token).AsUniTask(useCurrentSynchronizationContext: marshalBackToIssuingContext).AttachExternalCancellation(linked.Token);
+#endif
             }
             catch (System.Net.WebSockets.WebSocketException e)
             {
@@ -87,7 +118,7 @@ namespace Utility.Networking
             }
         }
 
-        public async UniTask CloseAsync(WebSocketCloseStatus status, String? description, CancellationToken cancellationToken)
+        public async UniTask CloseAsync(WebSocketCloseStatus status, string? description, CancellationToken cancellationToken)
         {
             try
             {
@@ -95,6 +126,17 @@ namespace Utility.Networking
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
                 await ws.CloseAsync(status, description, cancellationToken);
 #else
+                // A close handshake requires an established connection: mono's ClientWebSocket marks
+                // itself connected internally before the upgrade completes and its close path derefs an
+                // inner socket that only exists after a successful upgrade, so closing a pending or
+                // already torn-down connection must abort it instead (WHATWG close() during CONNECTING
+                // fails the connection; close() on a closed socket is a no-op).
+                if (State is not (WebSocketState.Open or WebSocketState.CloseReceived or WebSocketState.CloseSent))
+                {
+                    Abort();
+                    return;
+                }
+
                 System.Net.WebSockets.WebSocketCloseStatus statusType = (System.Net.WebSockets.WebSocketCloseStatus)status;
                 await ws.CloseAsync(statusType, description, cancellationToken);
 #endif
@@ -110,6 +152,15 @@ namespace Utility.Networking
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
             // Ignore, WebGL doesn't expose raw TCP sockets to hard interrupt
 #else
+            // Cancelling connectAbort is what completes a parked connect await; ws.Abort() alone
+            // leaves it hanging on mono. Cancelling after a completed connect is inert (the
+            // linked registration is gone once ConnectAsync returns).
+            try { connectAbort.Cancel(); }
+            catch (ObjectDisposedException)
+            {
+                // Abort must tolerate a racing Dispose() (scene teardown vs a JS close())
+            }
+
             ws.Abort();
 #endif
         }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
@@ -16,10 +16,7 @@ namespace Utility.Networking
 #else
         private System.Net.WebSockets.ClientWebSocket ws = new ();
 
-        // Failing a pending connection requires abandoning the connect await: once the TCP
-        // connect succeeds, mono's ClientWebSocket keeps no registration that can unpark the
-        // HTTP-upgrade read, so neither Abort() nor a CancellationToken completes a parked
-        // ConnectAsync.
+        // Once TCP connects, neither Abort() nor a CancellationToken unparks mono's ConnectAsync, so failing a pending connection means abandoning its await via this token.
         private readonly CancellationTokenSource connectAbort = new ();
 #endif
 
@@ -30,7 +27,7 @@ namespace Utility.Networking
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
                 return ws.State;
 #else
-                return (WebSocketState) ws.State; // Direct mapping
+                return (WebSocketState) ws.State;
 #endif
             }
         }
@@ -96,19 +93,11 @@ namespace Utility.Networking
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
                 await ws.ConnectAsync(uri, cancellationToken);
 #else
-                // AttachExternalCancellation completes this await when connectAbort fires even
-                // though the BCL task stays parked; the abandoned task's outcome must not
-                // surface as an unobserved fault.
-                //
-                // The receive loop that consumes this connection is started in this continuation, so
-                // the continuation must resume on the thread the connect was issued from. A connecting
-                // thread that has a SynchronizationContext (the Unity main thread, whose social/comms
-                // receive loops feed main-thread-only UI) keeps it so the loop stays on that thread; a
-                // connecting thread without one (the V8 script-invoke thread) skips it, since
-                // TaskScheduler.FromCurrentSynchronizationContext() throws with no current context
-                // (see DCLSemaphoreSlim.WaitAsync).
+                // Main-thread callers need the continuation back on their context (their receive loops feed main-thread-only UI); context-less ones (the V8 script-invoke thread) would throw in TaskScheduler.FromCurrentSynchronizationContext.
                 bool marshalBackToIssuingContext = SynchronizationContext.Current != null;
                 using CancellationTokenSource linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, connectAbort.Token);
+
+                // Only AttachExternalCancellation can complete this await once the BCL task parks mid-upgrade (see connectAbort).
                 await ws.ConnectAsync(uri, linked.Token).AsUniTask(useCurrentSynchronizationContext: marshalBackToIssuingContext).AttachExternalCancellation(linked.Token);
 #endif
             }
@@ -126,11 +115,7 @@ namespace Utility.Networking
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
                 await ws.CloseAsync(status, description, cancellationToken);
 #else
-                // A close handshake requires an established connection: mono's ClientWebSocket marks
-                // itself connected internally before the upgrade completes and its close path derefs an
-                // inner socket that only exists after a successful upgrade, so closing a pending or
-                // already torn-down connection must abort it instead (WHATWG close() during CONNECTING
-                // fails the connection; close() on a closed socket is a no-op).
+                // Mono's close path derefs an inner socket that only exists after a successful upgrade; per WHATWG, close() outside an established connection aborts instead.
                 if (State is not (WebSocketState.Open or WebSocketState.CloseReceived or WebSocketState.CloseSent))
                 {
                     Abort();
@@ -150,15 +135,13 @@ namespace Utility.Networking
         public void Abort()
         {
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
-            // Ignore, WebGL doesn't expose raw TCP sockets to hard interrupt
+            // WebGL doesn't expose raw TCP sockets to hard-interrupt.
 #else
-            // Cancelling connectAbort is what completes a parked connect await; ws.Abort() alone
-            // leaves it hanging on mono. Cancelling after a completed connect is inert (the
-            // linked registration is gone once ConnectAsync returns).
+            // ws.Abort() alone leaves a parked connect hanging on mono; cancelling after a completed connect is inert.
             try { connectAbort.Cancel(); }
             catch (ObjectDisposedException)
             {
-                // Abort must tolerate a racing Dispose() (scene teardown vs a JS close())
+                // A racing Dispose() (scene teardown vs a JS close()) may have already disposed the CTS.
             }
 
             ws.Abort();

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs
@@ -14,11 +14,9 @@ using Utility.Networking;
 namespace Utility.Tests
 {
     /// <summary>
-    ///     The JS WebSocket polyfill allows close() while the socket is still CONNECTING (WHATWG:
-    ///     close() during the handshake fails the connection). mono's ClientWebSocket reports itself
-    ///     Connected before the HTTP upgrade completes while its close path derefs an inner socket
-    ///     that only exists after a successful upgrade, so CloseAsync on a pending (or never started)
-    ///     connection must abort instead of entering the close handshake.
+    ///     The JS WebSocket polyfill allows close() while still CONNECTING (WHATWG: it fails the
+    ///     connection), but mono's close path derefs an inner socket that only exists after a
+    ///     successful upgrade — so CloseAsync on a pending connection must abort, not handshake.
     /// </summary>
     [TestFixture]
     public class DCLWebSocketCloseAsyncShould
@@ -29,8 +27,7 @@ namespace Utility.Tests
         public async Task AbortInsteadOfThrowingWhenClosedDuringHandshake()
         {
             // Arrange
-            // Accepts the TCP connection but never answers the HTTP upgrade, so the client
-            // stays parked mid-handshake with its inner managed socket unassigned.
+            // Never answering the HTTP upgrade parks the client mid-handshake with its inner managed socket unassigned.
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
             int port = ((IPEndPoint)listener.LocalEndpoint).Port;
@@ -43,8 +40,7 @@ namespace Utility.Tests
             {
                 Task connectTask = webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None).AsTask();
 
-                // The parked connect surfaces its abort on a background continuation; observe it there
-                // so no unobserved fault leaks past this test.
+                // Observe the abandoned connect's fault so it can't surface as unobserved.
                 Task connectObserved = connectTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
 
                 Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
@@ -75,9 +71,7 @@ namespace Utility.Tests
         public async Task UnparkAPendingConnectWhenAborted()
         {
             // Arrange
-            // Accepts the TCP connection but never answers the HTTP upgrade, so the client
-            // stays parked mid-handshake; the public Abort() must fail that pending connection
-            // the same way the CloseAsync gate does.
+            // Never answering the HTTP upgrade parks the client mid-handshake.
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
             int port = ((IPEndPoint)listener.LocalEndpoint).Port;
@@ -90,8 +84,7 @@ namespace Utility.Tests
             {
                 Task connectTask = webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None).AsTask();
 
-                // The parked connect surfaces its abort on a background continuation; observe it there
-                // so no unobserved fault leaks past this test.
+                // Observe the abandoned connect's fault so it can't surface as unobserved.
                 Task connectObserved = connectTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
 
                 Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
@@ -119,9 +112,7 @@ namespace Utility.Tests
         public async Task ConnectFromAThreadWithoutSynchronizationContext()
         {
             // Arrange
-            // The production caller is the ClearScript/V8 script-invoke thread, which carries no
-            // TaskScheduler-compatible SynchronizationContext, so the whole connect/close path must
-            // work with SynchronizationContext.Current == null.
+            // The production caller, the ClearScript/V8 script-invoke thread, carries no SynchronizationContext.
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
             int port = ((IPEndPoint)listener.LocalEndpoint).Port;
@@ -210,7 +201,7 @@ namespace Utility.Tests
             int port = ((IPEndPoint)listener.LocalEndpoint).Port;
             Task serverTask = ServeUpgradeThenEchoCloseAsync(listener);
 
-            // Observed on a background continuation so no unobserved fault leaks if the test fails early
+            // Observed on a background continuation so no unobserved fault leaks if the test fails early.
             _ = serverTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
 
             var webSocket = new DCLWebSocket();
@@ -243,11 +234,7 @@ namespace Utility.Tests
         public async Task ResumeOnTheCallerSynchronizationContextAfterConnecting()
         {
             // Arrange
-            // The social/comms RPC transports start their receive loop in the connect continuation,
-            // and that loop hands every incoming message to main-thread-only UI handlers. A connect
-            // issued on a SynchronizationContext (the Unity main thread in production) must therefore
-            // resume back on it, not on the socket's completion thread, or the loop and its handlers
-            // run off the main thread.
+            // The connect continuation starts receive loops that feed main-thread-only UI, so a connect issued on a SynchronizationContext must resume on it.
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
             int port = ((IPEndPoint)listener.LocalEndpoint).Port;
@@ -264,7 +251,6 @@ namespace Utility.Tests
             {
                 var done = new TaskCompletionSource<bool>();
 
-                // Drive the connect from the dedicated context thread and record where it resumes.
                 context.Post(_ =>
                 {
                     ConnectAndCaptureAsync().Forget();
@@ -335,8 +321,7 @@ namespace Utility.Tests
 
             await stream.WriteAsync(response, 0, response.Length);
 
-            // Client close frame: FIN+opcode 0x8, masked payload. Echo the unmasked payload back
-            // so the client-side close handshake can complete.
+            // Echoing the client's masked close frame (FIN+opcode 0x8) back unmasked lets the client-side close handshake complete.
             var header = new byte[2];
             await ReadExactAsync(stream, header, header.Length);
             int payloadLength = header[1] & 0x7F;
@@ -392,9 +377,8 @@ namespace Utility.Tests
         }
 
         /// <summary>
-        ///     A pumped SynchronizationContext backed by one dedicated thread, standing in for Unity's
-        ///     single-threaded main-thread context: continuations posted to it run on that one thread,
-        ///     so a test can assert an await resumed on the context it was issued from.
+        ///     Stands in for Unity's single-threaded main-thread context: continuations posted here run
+        ///     on one dedicated thread, so a test can assert an await resumed where it was issued.
         /// </summary>
         private sealed class SingleThreadSynchronizationContext : SynchronizationContext, IDisposable
         {

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs
@@ -1,0 +1,430 @@
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Utility.Networking;
+
+namespace Utility.Tests
+{
+    /// <summary>
+    ///     The JS WebSocket polyfill allows close() while the socket is still CONNECTING (WHATWG:
+    ///     close() during the handshake fails the connection). mono's ClientWebSocket reports itself
+    ///     Connected before the HTTP upgrade completes while its close path derefs an inner socket
+    ///     that only exists after a successful upgrade, so CloseAsync on a pending (or never started)
+    ///     connection must abort instead of entering the close handshake.
+    /// </summary>
+    [TestFixture]
+    public class DCLWebSocketCloseAsyncShould
+    {
+        private const int TIMEOUT_MS = 10_000;
+
+        [Test]
+        public async Task AbortInsteadOfThrowingWhenClosedDuringHandshake()
+        {
+            // Arrange
+            // Accepts the TCP connection but never answers the HTTP upgrade, so the client
+            // stays parked mid-handshake with its inner managed socket unassigned.
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task<Socket> serverAccept = listener.AcceptSocketAsync();
+            Task acceptObserved = serverAccept.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+            var webSocket = new DCLWebSocket();
+
+            try
+            {
+                Task connectTask = webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None).AsTask();
+
+                // The parked connect surfaces its abort on a background continuation; observe it there
+                // so no unobserved fault leaks past this test.
+                Task connectObserved = connectTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
+                    "Precondition: the socket must be observed mid-handshake (the JS readyState CONNECTING window)");
+
+                // Act
+                Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
+
+                // Assert
+                Assert.That(thrown, Is.Null,
+                    $"CloseAsync during the connect handshake must fail the connection, not throw, but threw {thrown?.GetType()}: {thrown?.Message}");
+
+                Task completed = await Task.WhenAny(connectObserved, Task.Delay(TIMEOUT_MS));
+                Assert.That(completed, Is.SameAs(connectObserved), "The aborted connect must complete instead of hanging");
+            }
+            finally
+            {
+                webSocket.Dispose();
+                listener.Stop();
+                await Task.WhenAny(acceptObserved, Task.Delay(TIMEOUT_MS));
+
+                if (serverAccept.Status == TaskStatus.RanToCompletion)
+                    serverAccept.Result.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task UnparkAPendingConnectWhenAborted()
+        {
+            // Arrange
+            // Accepts the TCP connection but never answers the HTTP upgrade, so the client
+            // stays parked mid-handshake; the public Abort() must fail that pending connection
+            // the same way the CloseAsync gate does.
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task<Socket> serverAccept = listener.AcceptSocketAsync();
+            Task acceptObserved = serverAccept.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+            var webSocket = new DCLWebSocket();
+
+            try
+            {
+                Task connectTask = webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None).AsTask();
+
+                // The parked connect surfaces its abort on a background continuation; observe it there
+                // so no unobserved fault leaks past this test.
+                Task connectObserved = connectTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
+                    "Precondition: the socket must be observed mid-handshake");
+
+                // Act
+                webSocket.Abort();
+
+                // Assert
+                Task completed = await Task.WhenAny(connectObserved, Task.Delay(TIMEOUT_MS));
+                Assert.That(completed, Is.SameAs(connectObserved), "Abort() must complete a parked connect instead of leaving it hanging");
+            }
+            finally
+            {
+                webSocket.Dispose();
+                listener.Stop();
+                await Task.WhenAny(acceptObserved, Task.Delay(TIMEOUT_MS));
+
+                if (serverAccept.Status == TaskStatus.RanToCompletion)
+                    serverAccept.Result.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task ConnectFromAThreadWithoutSynchronizationContext()
+        {
+            // Arrange
+            // The production caller is the ClearScript/V8 script-invoke thread, which carries no
+            // TaskScheduler-compatible SynchronizationContext, so the whole connect/close path must
+            // work with SynchronizationContext.Current == null.
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task<Socket> serverAccept = listener.AcceptSocketAsync();
+            Task acceptObserved = serverAccept.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+            var webSocket = new DCLWebSocket();
+
+            try
+            {
+                Task? connectTask = null;
+                Exception? synchronousThrow = null;
+
+                // Act
+                await Task.Run(() =>
+                {
+                    SynchronizationContext.SetSynchronizationContext(null);
+
+                    try { connectTask = webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None).AsTask(); }
+                    catch (Exception e) { synchronousThrow = e; }
+                });
+
+                // Assert
+                Assert.That(synchronousThrow, Is.Null,
+                    $"ConnectAsync must not throw on a thread without a SynchronizationContext, but threw {synchronousThrow?.GetType()}: {synchronousThrow?.Message}");
+
+                Task connectObserved = connectTask!.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+                Assert.That(connectTask.IsFaulted, Is.False,
+                    $"ConnectAsync must not fault on a thread without a SynchronizationContext, but faulted with {connectTask.Exception?.GetBaseException().GetType()}: {connectTask.Exception?.GetBaseException().Message}");
+
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
+                    "Precondition: the socket must be observed mid-handshake");
+
+                // Act
+                Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
+
+                // Assert
+                Assert.That(thrown, Is.Null,
+                    $"CloseAsync after an off-context connect must fail the connection, not throw, but threw {thrown?.GetType()}: {thrown?.Message}");
+
+                Task completed = await Task.WhenAny(connectObserved, Task.Delay(TIMEOUT_MS));
+                Assert.That(completed, Is.SameAs(connectObserved), "The aborted connect must complete instead of hanging");
+            }
+            finally
+            {
+                webSocket.Dispose();
+                listener.Stop();
+                await Task.WhenAny(acceptObserved, Task.Delay(TIMEOUT_MS));
+
+                if (serverAccept.Status == TaskStatus.RanToCompletion)
+                    serverAccept.Result.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task CompleteCleanlyOnANeverConnectedSocket()
+        {
+            // Arrange
+            var webSocket = new DCLWebSocket();
+
+            try
+            {
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.None),
+                    "Precondition: no connect attempt was started");
+
+                // Act
+                Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
+
+                // Assert
+                Assert.That(thrown, Is.Null,
+                    $"CloseAsync on a never-connected socket must be a no-op abort, but threw {thrown?.GetType()}: {thrown?.Message}");
+            }
+            finally
+            {
+                webSocket.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task StillPerformTheCloseHandshakeOnAnOpenSocket()
+        {
+            // Arrange
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task serverTask = ServeUpgradeThenEchoCloseAsync(listener);
+
+            // Observed on a background continuation so no unobserved fault leaks if the test fails early
+            _ = serverTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+            var webSocket = new DCLWebSocket();
+
+            try
+            {
+                await AwaitWithTimeoutAsync(webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None).AsTask(), "connect");
+
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Open), "Precondition: the upgrade completed");
+
+                // Act
+                Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
+
+                // Assert
+                Assert.That(thrown, Is.Null,
+                    $"CloseAsync on an open socket must run the close handshake, but threw {thrown?.GetType()}: {thrown?.Message}");
+
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Closed), "The close handshake must complete both ways");
+
+                await AwaitWithTimeoutAsync(serverTask, "server close echo");
+            }
+            finally
+            {
+                webSocket.Dispose();
+                listener.Stop();
+            }
+        }
+
+        [Test]
+        public async Task ResumeOnTheCallerSynchronizationContextAfterConnecting()
+        {
+            // Arrange
+            // The social/comms RPC transports start their receive loop in the connect continuation,
+            // and that loop hands every incoming message to main-thread-only UI handlers. A connect
+            // issued on a SynchronizationContext (the Unity main thread in production) must therefore
+            // resume back on it, not on the socket's completion thread, or the loop and its handlers
+            // run off the main thread.
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task serverTask = ServeUpgradeThenEchoCloseAsync(listener);
+            _ = serverTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+            using var context = new SingleThreadSynchronizationContext();
+            var webSocket = new DCLWebSocket();
+
+            var resumeThreadId = 0;
+            Exception? failure = null;
+
+            try
+            {
+                var done = new TaskCompletionSource<bool>();
+
+                // Drive the connect from the dedicated context thread and record where it resumes.
+                context.Post(_ =>
+                {
+                    ConnectAndCaptureAsync().Forget();
+                    return;
+
+                    async UniTaskVoid ConnectAndCaptureAsync()
+                    {
+                        try
+                        {
+                            await webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None);
+                            resumeThreadId = Thread.CurrentThread.ManagedThreadId;
+                        }
+                        catch (Exception e) { failure = e; }
+                        finally { done.TrySetResult(true); }
+                    }
+                }, null);
+
+                await AwaitWithTimeoutAsync(done.Task, "connect on a SynchronizationContext");
+
+                // Assert
+                Assert.That(failure, Is.Null, $"ConnectAsync on a SynchronizationContext must not fault, but threw {failure?.GetType()}: {failure?.Message}");
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Open), "Precondition: the upgrade completed");
+                Assert.That(resumeThreadId, Is.EqualTo(context.ThreadId),
+                    "ConnectAsync must resume on the caller's SynchronizationContext so the receive loop it starts stays on that thread");
+            }
+            finally
+            {
+                webSocket.Dispose();
+                listener.Stop();
+                await Task.WhenAny(serverTask, Task.Delay(TIMEOUT_MS));
+            }
+        }
+
+        private static async Task<Exception?> CaptureAsync(Func<UniTask> operation)
+        {
+            try { await operation(); }
+            catch (Exception e) { return e; }
+
+            return null;
+        }
+
+        private static async Task AwaitWithTimeoutAsync(Task task, string what)
+        {
+            Task completed = await Task.WhenAny(task, Task.Delay(TIMEOUT_MS));
+            Assert.That(completed, Is.SameAs(task), $"{what} did not complete within {TIMEOUT_MS}ms");
+            await task;
+        }
+
+        private static async Task ServeUpgradeThenEchoCloseAsync(TcpListener listener)
+        {
+            using Socket socket = await listener.AcceptSocketAsync();
+            using var stream = new NetworkStream(socket, ownsSocket: false);
+
+            string request = await ReadHeadersAsync(stream);
+            var key = string.Empty;
+
+            foreach (string line in request.Split(new[] { "\r\n" }, StringSplitOptions.None))
+                if (line.StartsWith("Sec-WebSocket-Key:", StringComparison.OrdinalIgnoreCase))
+                    key = line.Substring("Sec-WebSocket-Key:".Length).Trim();
+
+            string acceptKey;
+
+            using (var sha1 = SHA1.Create())
+                acceptKey = Convert.ToBase64String(sha1.ComputeHash(Encoding.ASCII.GetBytes(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")));
+
+            byte[] response = Encoding.ASCII.GetBytes(
+                $"HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Accept: {acceptKey}\r\n\r\n");
+
+            await stream.WriteAsync(response, 0, response.Length);
+
+            // Client close frame: FIN+opcode 0x8, masked payload. Echo the unmasked payload back
+            // so the client-side close handshake can complete.
+            var header = new byte[2];
+            await ReadExactAsync(stream, header, header.Length);
+            int payloadLength = header[1] & 0x7F;
+            var maskAndPayload = new byte[4 + payloadLength];
+            await ReadExactAsync(stream, maskAndPayload, maskAndPayload.Length);
+
+            var closeReply = new byte[2 + payloadLength];
+            closeReply[0] = 0x88;
+            closeReply[1] = (byte)payloadLength;
+
+            for (var i = 0; i < payloadLength; i++)
+                closeReply[2 + i] = (byte)(maskAndPayload[4 + i] ^ maskAndPayload[i % 4]);
+
+            await stream.WriteAsync(closeReply, 0, closeReply.Length);
+        }
+
+        private static async Task<string> ReadHeadersAsync(NetworkStream stream)
+        {
+            var builder = new StringBuilder();
+            var single = new byte[1];
+
+            while (!EndsWithHeaderTerminator(builder))
+            {
+                int read = await stream.ReadAsync(single, 0, 1);
+
+                if (read == 0)
+                    throw new IOException("Connection closed before the upgrade request completed");
+
+                builder.Append((char)single[0]);
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool EndsWithHeaderTerminator(StringBuilder builder) =>
+            builder.Length >= 4
+            && builder[builder.Length - 4] == '\r' && builder[builder.Length - 3] == '\n'
+            && builder[builder.Length - 2] == '\r' && builder[builder.Length - 1] == '\n';
+
+        private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, int count)
+        {
+            var offset = 0;
+
+            while (offset < count)
+            {
+                int read = await stream.ReadAsync(buffer, offset, count - offset);
+
+                if (read == 0)
+                    throw new IOException("Connection closed mid-frame");
+
+                offset += read;
+            }
+        }
+
+        /// <summary>
+        ///     A pumped SynchronizationContext backed by one dedicated thread, standing in for Unity's
+        ///     single-threaded main-thread context: continuations posted to it run on that one thread,
+        ///     so a test can assert an await resumed on the context it was issued from.
+        /// </summary>
+        private sealed class SingleThreadSynchronizationContext : SynchronizationContext, IDisposable
+        {
+            private readonly BlockingCollection<(SendOrPostCallback callback, object? state)> queue = new ();
+            private readonly Thread thread;
+
+            public int ThreadId => thread.ManagedThreadId;
+
+            public SingleThreadSynchronizationContext()
+            {
+                thread = new Thread(Pump) { IsBackground = true, Name = nameof(SingleThreadSynchronizationContext) };
+                thread.Start();
+            }
+
+            public override void Post(SendOrPostCallback d, object? state) =>
+                queue.Add((d, state));
+
+            public override void Send(SendOrPostCallback d, object? state) =>
+                throw new NotSupportedException();
+
+            public void Dispose() =>
+                queue.CompleteAdding();
+
+            private void Pump()
+            {
+                SetSynchronizationContext(this);
+
+                foreach ((SendOrPostCallback callback, object? state) in queue.GetConsumingEnumerable())
+                    callback(state);
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6f9ee9ed9db437fb0a1ce1946f06c42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
@@ -39,6 +39,7 @@ namespace DCL.Tests
         private static readonly string[] WEBGL_THREAD_SAFETY_EXCLUDED_PATHS = {
             "Assets/DCL/Input/UnityInputSystem/DCLInput.cs", // cause it's autogen
             "Assets/Plugins/UUAV/Packages/UUAV/Runtime/UUAVPlayer.cs", // desktop-only native plugin; Interlocked guards FFI callback state and the assembly never targets WebGL
+            "Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs", // desktop-only; SynchronizationContext.Current gates the connect continuation's thread affinity
         };
 
         private static readonly string[] WEB_SOCKETS_EXCLUDED_PATHS = {
@@ -200,6 +201,7 @@ namespace DCL.Tests
                 "Assets/DCL/Infrastructure/Utility/Multithreading/DCLConcurrentDictionary.cs",
                 "Assets/DCL/Infrastructure/Utility/Multithreading/DCLConcurrentBag.cs",
                 "Assets/DCL/Infrastructure/Utility/Multithreading/DCLConcurrentQueue.cs",
+                "Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs", // test-only SynchronizationContext pump uses BlockingCollection
             };
             ValidateNoForbiddenApiUsed(PATTERN, "Use DCLConcurrent insteat version instead.", ignorePaths);
         }


### PR DESCRIPTION
> **Thread-affinity correction (post-consolidation):** the original fix forced
> `useCurrentSynchronizationContext: false` on every `ConnectAsync`, which dropped the
> connecting thread's `SynchronizationContext`. The social-service RPC transport starts its
> receive loop in the connect continuation, so a main-thread connect that lost its context
> moved every RPC response - and the passport friendship-status continuation that flips UI
> buttons active - onto a background thread, faulting Unity graphics ("Graphics device is
> null") and crashing natively. Now marshals back only when a `SynchronizationContext` exists
> (`marshalBackToIssuingContext = SynchronizationContext.Current != null`), restoring the
> main-thread receive loop for social/comms transports while preserving the no-throw behaviour
> on the context-less V8 script-invoke thread. Regression test
> `ResumeOnTheCallerSynchronizationContextAfterConnecting`; v16 EditMode RED 6/1-fail → GREEN 6/6.

## Problem

Scene WebSocket closes race the connect handshake: mono's `ClientWebSocket.CloseAsync` NREs
mid-handshake (Sentry UNITY-EXPLORER-PNT, 624 events) and throws
`InvalidOperationException: The WebSocket is not connected` on a never-connected socket.
Both surface out of `DCLWebSocket.CloseAsync`/`Dispose` on the desktop path.

## Root cause

Two layers. (1) `CloseAsync` called the inner close handshake regardless of connection
state. (2) Deeper - verified against the corefx source Unity's mono ships: a `ConnectAsync`
parked on an unanswered HTTP upgrade read is structurally unreachable from outside - the
socket-dispose cancellation registrations are scoped to `ConnectSocketAsync` only (gone once
TCP connects), the upgrade-read loop's `NetworkStream.ReadAsync` ignores its token once the
read is pending, and handle-level `Abort()` mid-handshake only cancels a source nothing
listens to at that stage. No fix shape that keeps awaiting the BCL task can work.

## Fix

`DCLWebSocket` (desktop branch): `CloseAsync` gates on the public state machine - when
`State is not (Open or CloseReceived or CloseSent)` it takes an abort path instead of the
inner close: it calls `Abort()`, which owns the abort pair (cancel the per-socket
`connectAbort` CTS, then `ws.Abort()`) so aborting mid-handshake through either public API
unparks the connect. `Dispose()` tears the CTS down via the existing
`SafeCancelAndDispose()` and stays idempotent. `ConnectAsync`
awaits the BCL connect via `.AsUniTask().AttachExternalCancellation(linked.Token)` (caller
token + `connectAbort.Token`), abandoning the parked BCL task; AttachExternalCancellation
observes and discards the abandoned task's eventual outcome (double-completion of the
vendored `UniTaskCompletionSourceCore` is a verified silent no-op). The caller-visible
contract matches WHATWG "fail the connection": connect completes canceled, onerror/onclose
fire. Residual: the abandoned BCL task parks until the TCP peer dies - same as pin behavior
for an unanswered server.

## Behavior notes

- `WebSocketArchipelagoLiveConnection.DisconnectAsync` on a never-connected socket now
  returns `SuccessResult` where mono previously threw `InvalidOperationException` →
  `ErrorResult`. Callers treat disconnect failure as log-only today; disconnecting an
  unconnected connection reporting success is the more correct contract, but it is a flip.
- `DCLWebSocket.Dispose()` remains idempotent: the added CTS teardown goes through the
  existing `SafeCancelAndDispose()`, so a second `Dispose()` (scene-teardown rental loop)
  stays a no-op instead of throwing `ObjectDisposedException`.

## Test

New EditMode `Utility.Tests.DCLWebSocketCloseAsyncShould` (5 tests):
`AbortInsteadOfThrowingWhenClosedDuringHandshake` (pin: NRE),
`CompleteCleanlyOnANeverConnectedSocket` (pin: InvalidOperationException),
`UnparkAPendingConnectWhenAborted` (public `Abort()` mid-handshake must complete the parked
connect), `ConnectFromAThreadWithoutSynchronizationContext` (the V8-thread constraint), and
an open-socket guard proving the real close handshake still runs.

## Validation

Windows Unity 6000.4 EditMode lane at the pin: RED FAIL 2/3 as intended (the exact NRE and
InvalidOperationException signatures; guard passed) / GREEN PASS 3/3. Two earlier fix
shapes (state guard alone; linked-CTS into `ws.ConnectAsync`) deterministically failed the
hang-guard on the same lane - the parked-read analysis above is validation-driven, not
theoretical.

Note: the initial adversarial review covered the state-guard shape; the connect-abandon
mechanism was added in the validation repair round and needs a re-review before merge.

Related: Sentry UNITY-EXPLORER-PNT (close-during-handshake NRE), UNITY-EXPLORER-PK9
(CloseAsync WebSocketException on dropped sockets, expected to collapse with this)

Includes inspection-warning cleanup in all touched files.