### PR TITLE
feat: add emote preview on click in passport

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenCharacterPreviewController.cs
@@ -39,7 +39,7 @@ namespace DCL.AuthenticationScreenFlow
             PlayEmote(settings.IntroEmoteURN);
         }
 
-        public new void OnHide(bool triggerOnHideBusEvent = true)
+        public override void OnHide(bool triggerOnHideBusEvent = true)
         {
             playEmotesCts.SafeCancelAndDispose();
             base.OnHide(triggerOnHideBusEvent);
@@ -47,7 +47,7 @@ namespace DCL.AuthenticationScreenFlow
             view.gameObject.SetActive(false);
         }
 
-        public new void Dispose()
+        public override void Dispose()
         {
             playEmotesCts.SafeCancelAndDispose();
             base.Dispose();

--- a/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
@@ -77,7 +77,7 @@ namespace DCL.Backpack.CharacterPreview
             }
         }
 
-        public new void Dispose()
+        public override void Dispose()
         {
             base.Dispose();
 

--- a/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
+++ b/Explorer/Assets/DCL/Character/CharacterPreview/CharacterPreviewControllerBase.cs
@@ -119,7 +119,7 @@ namespace DCL.CharacterPreview
             OnModelUpdated();
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             initialized = false;
             previewController?.Dispose();
@@ -223,7 +223,7 @@ namespace DCL.CharacterPreview
         /// Hides the character preview.
         /// </summary>
         /// <param name="triggerOnHideBusEvent">True for keeping the rest of preview controllers informed about this hiding.</param>
-        public void OnHide(bool triggerOnHideBusEvent = true)
+        public virtual void OnHide(bool triggerOnHideBusEvent = true)
         {
             if (initialized)
             {

--- a/Explorer/Assets/DCL/Passport/Fields/EquippedItemPassportFieldView.cs
+++ b/Explorer/Assets/DCL/Passport/Fields/EquippedItemPassportFieldView.cs
@@ -3,6 +3,7 @@ using Cysharp.Threading.Tasks;
 using DCL.Audio;
 using DCL.UI;
 using DG.Tweening;
+using System;
 using System.Threading;
 using TMPro;
 using UnityEngine;
@@ -12,7 +13,7 @@ using Utility;
 
 namespace DCL.Passport.Fields
 {
-    public class EquippedItemPassportFieldView : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+    public class EquippedItemPassportFieldView : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerClickHandler
     {
         private readonly Vector3 hoveredScale = new (1.1f,1.1f,1.1f);
         private const float ANIMATION_TIME = 0.1f;
@@ -73,6 +74,10 @@ namespace DCL.Passport.Fields
 
         public URN ItemId { get; set; }
 
+        public Action<URN>? EmoteClicked;
+
+        public Action? WearableClicked;
+
         private CancellationTokenSource cts;
 
         private void Awake()
@@ -90,6 +95,15 @@ namespace DCL.Passport.Fields
         public void OnPointerExit(PointerEventData eventData)
         {
             AnimateExit();
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (eventData.button != PointerEventData.InputButton.Left)
+                return;
+
+            EmoteClicked?.Invoke(ItemId);
+            WearableClicked?.Invoke();
         }
 
         public void SetAsLoading(bool isLoading)

--- a/Explorer/Assets/DCL/Passport/Modules/EquippedItemsPassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/EquippedItemsPassportModuleController.cs
@@ -52,6 +52,8 @@ namespace DCL.Passport.Modules
         private readonly IObjectPool<EquippedItemPassportFieldView> emptyItemsPool;
         private readonly List<EquippedItemPassportFieldView> instantiatedEmptyItems = new ();
         private readonly CreditPurchaseBuyHandler creditPurchaseBuyHandler;
+        private readonly Action<URN> onEmoteClicked;
+        private readonly Action onWearableClicked;
         private readonly List<(EquippedItemPassportFieldView view, string urn)> primaryListingCandidates = new ();
         private readonly HashSet<string> onSaleUrns = new (StringComparer.OrdinalIgnoreCase);
 
@@ -69,7 +71,9 @@ namespace DCL.Passport.Modules
             IThumbnailProvider thumbnailProvider,
             IDecentralandUrlsSource decentralandUrlsSource,
             PassportErrorsController passportErrorsController,
-            CreditPurchaseBuyHandler creditPurchaseBuyHandler)
+            CreditPurchaseBuyHandler creditPurchaseBuyHandler,
+            Action<URN> onEmoteClicked,
+            Action onWearableClicked)
         {
             this.view = view;
             this.world = world;
@@ -82,6 +86,8 @@ namespace DCL.Passport.Modules
             this.decentralandUrlsSource = decentralandUrlsSource;
             this.passportErrorsController = passportErrorsController;
             this.creditPurchaseBuyHandler = creditPurchaseBuyHandler;
+            this.onEmoteClicked = onEmoteClicked;
+            this.onWearableClicked = onWearableClicked;
 
             loadingItemsPool = new ObjectPool<EquippedItemPassportFieldView>(
                 InstantiateEquippedItemPrefab,
@@ -112,6 +118,8 @@ namespace DCL.Passport.Modules
                     equippedItemView.gameObject.SetActive(false);
                     equippedItemView.BuyButton.onClick.RemoveAllListeners();
                     equippedItemView.ViewButton.onClick.RemoveAllListeners();
+                    equippedItemView.EmoteClicked = null;
+                    equippedItemView.WearableClicked = null;
                 });
 
             emptyItemsPool = new ObjectPool<EquippedItemPassportFieldView>(
@@ -217,6 +225,7 @@ namespace DCL.Passport.Modules
                 string wearableUrn = wearable.GetUrn();
                 var wearableItemView = equippedWearableItem;
                 equippedWearableItem.BuyButton.onClick.AddListener(() => OnBuyClicked(wearableItemView, wearableUrn, marketPlaceLink, rarityName, raritySprite, rarityColor));
+                equippedWearableItem.WearableClicked = onWearableClicked;
 
                 if (wearable.IsOnChain() && marketPlaceLink != string.Empty)
                 {
@@ -251,6 +260,7 @@ namespace DCL.Passport.Modules
                 string emoteUrn = emote.GetUrn();
                 var emoteItemView = equippedWearableItem;
                 equippedWearableItem.BuyButton.onClick.AddListener(() => OnBuyClicked(emoteItemView, emoteUrn, marketPlaceLink, rarityName, raritySprite, rarityColor));
+                equippedWearableItem.EmoteClicked = onEmoteClicked;
 
                 if (emote.IsOnChain() && rarityName != "base" && marketPlaceLink != string.Empty)
                 {

--- a/Explorer/Assets/DCL/Passport/PassportCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportCharacterPreviewController.cs
@@ -1,8 +1,13 @@
 using Arch.Core;
 using CommunicationData.URLHelpers;
+using Cysharp.Threading.Tasks;
 using DCL.CharacterPreview;
+using DCL.Diagnostics;
+using System;
 using System.Collections.Generic;
+using System.Threading;
 using UnityEngine;
+using Utility;
 using Avatar = DCL.Profiles.Avatar;
 
 namespace DCL.Passport
@@ -10,6 +15,9 @@ namespace DCL.Passport
     public class PassportCharacterPreviewController : CharacterPreviewControllerBase
     {
         private readonly List<URN> shortenedWearables = new ();
+
+        private CancellationTokenSource? emotePreviewCts;
+        private bool isEmoteLoading;
 
         public PassportCharacterPreviewController(CharacterPreviewView view, ICharacterPreviewFactory previewFactory, World world, CharacterPreviewEventBus characterPreviewEventBus)
             : base(view, previewFactory, world, false, characterPreviewEventBus) { }
@@ -25,6 +33,60 @@ namespace DCL.Passport
 
             base.Initialize(avatar, position);
             PlayEmote("wave");
+        }
+
+        public void PlayEmoteClicked(URN emoteUrn)
+        {
+            emotePreviewCts = emotePreviewCts.SafeRestart();
+            EnsureEmoteLoadedAndPlayAsync(emoteUrn.Shorten(), emotePreviewCts.Token).Forget();
+        }
+
+        public void StopEmotePreview()
+        {
+            bool restoreAfterCancelledLoad = isEmoteLoading;
+
+            emotePreviewCts.SafeCancelAndDispose();
+            StopEmotes();
+
+            if (restoreAfterCancelledLoad)
+                OnModelUpdated();
+        }
+
+        public new void OnHide(bool triggerOnHideBusEvent = true)
+        {
+            emotePreviewCts.SafeCancelAndDispose();
+            base.OnHide(triggerOnHideBusEvent);
+        }
+
+        public new void Dispose()
+        {
+            emotePreviewCts.SafeCancelAndDispose();
+            base.Dispose();
+        }
+
+        private async UniTaskVoid EnsureEmoteLoadedAndPlayAsync(URN urn, CancellationToken ct)
+        {
+            previewAvatarModel.Emotes ??= new HashSet<URN>();
+
+            if (!previewAvatarModel.Emotes.Contains(urn))
+            {
+                previewAvatarModel.Emotes.Add(urn);
+                isEmoteLoading = true;
+
+                try { await ShowLoadingSpinnerAndUpdateAvatarAsync(ct); }
+                catch (OperationCanceledException) { }
+                catch (Exception e) { ReportHub.LogException(e, ReportCategory.EMOTE); }
+                finally
+                {
+                    previewAvatarModel.Emotes.Remove(urn);
+                    isEmoteLoading = false;
+                }
+            }
+
+            if (ct.IsCancellationRequested)
+                return;
+
+            PlayEmote(urn);
         }
     }
 }

--- a/Explorer/Assets/DCL/Passport/PassportCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportCharacterPreviewController.cs
@@ -52,13 +52,13 @@ namespace DCL.Passport
                 OnModelUpdated();
         }
 
-        public new void OnHide(bool triggerOnHideBusEvent = true)
+        public override void OnHide(bool triggerOnHideBusEvent = true)
         {
             emotePreviewCts.SafeCancelAndDispose();
             base.OnHide(triggerOnHideBusEvent);
         }
 
-        public new void Dispose()
+        public override void Dispose()
         {
             emotePreviewCts.SafeCancelAndDispose();
             base.Dispose();

--- a/Explorer/Assets/DCL/Passport/PassportCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportCharacterPreviewController.cs
@@ -74,8 +74,12 @@ namespace DCL.Passport
                 isEmoteLoading = true;
 
                 try { await ShowLoadingSpinnerAndUpdateAvatarAsync(ct); }
-                catch (OperationCanceledException) { }
-                catch (Exception e) { ReportHub.LogException(e, ReportCategory.EMOTE); }
+                catch (OperationCanceledException) { return; }
+                catch (Exception e)
+                {
+                    ReportHub.LogException(e, ReportCategory.EMOTE);
+                    return;
+                }
                 finally
                 {
                     previewAvatarModel.Emotes.Remove(urn);

--- a/Explorer/Assets/DCL/Passport/PassportController.cs
+++ b/Explorer/Assets/DCL/Passport/PassportController.cs
@@ -280,11 +280,6 @@ namespace DCL.Passport
 
             passportErrorsController = new PassportErrorsController(viewInstance!.ErrorNotification);
 
-            characterPreviewController = new PassportCharacterPreviewController(viewInstance.CharacterPreviewView,
-                characterPreviewFactory,
-                world,
-                characterPreviewEventBus);
-
             characterPreviewController = new PassportCharacterPreviewController(
                 viewInstance.CharacterPreviewView,
                 characterPreviewFactory,
@@ -337,7 +332,9 @@ namespace DCL.Passport
                 thumbnailProvider,
                 decentralandUrlsSource,
                 passportErrorsController,
-                creditPurchaseBuyHandler));
+                creditPurchaseBuyHandler,
+                characterPreviewController.PlayEmoteClicked,
+                characterPreviewController.StopEmotePreview));
 
             overviewPassportModules.Add(new BadgesOverviewPassportModuleController(
                 viewInstance.BadgesOverviewModuleView,


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #9789 
This PR allows previewing emotes in a user passport by clicking on them

## Test Instructions

### Test Steps
1. Open the client
2. Open a user passport
3. Check his equipped emotes
4. Click on one of them
5. Verify that the character preview plays the emote (if stuff is still loading around it could take a couple of seconds to load the emote the first time)

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
