### PR TITLE
feat: target a custom base domain via --base-domain

### DIFF
--- a/Explorer/Assets/DCL/Chat/Commands/ChatEnvironmentValidator.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/ChatEnvironmentValidator.cs
@@ -7,32 +7,28 @@ namespace DCL.Chat.Commands
     public class ChatEnvironmentValidator
     {
         private readonly DecentralandEnvironment dclEnvironment;
+        private readonly IDecentralandUrlsSource decentralandUrlsSource;
 
-        public ChatEnvironmentValidator(DecentralandEnvironment dclEnvironment)
+        public ChatEnvironmentValidator(DecentralandEnvironment dclEnvironment, IDecentralandUrlsSource decentralandUrlsSource)
         {
             this.dclEnvironment = dclEnvironment;
+            this.decentralandUrlsSource = decentralandUrlsSource;
         }
 
         public Result ValidateTeleport(string realmToTeleportTo)
         {
-            switch (dclEnvironment)
-            {
-                case DecentralandEnvironment.Today:
-                    return Result.ErrorResult(
-                        "🔴 Error. You cannot change realms in the Today environment. Please restart DCL with the desired environment");
-                case DecentralandEnvironment.Zone:
-                    return HostHasSuffix(realmToTeleportTo, IDecentralandUrlsSource.ZONE_DOMAIN)
-                        ? Result.SuccessResult()
-                        : Result.ErrorResult(
-                            "🔴 Error. You cannot teleport to other realms that are not Zone in Zone environment. Please restart DCL with the desired environment");
-                case DecentralandEnvironment.Org:
-                    return HostHasSuffix(realmToTeleportTo, IDecentralandUrlsSource.ORG_DOMAIN)
-                        ? Result.SuccessResult()
-                        : Result.ErrorResult(
-                            "🔴 Error. You cannot teleport to other realms that are not Org or World in Org environment. Please restart DCL with the desired environment");
-            }
+            // Today serves part of its hosts from .today and the rest from .org, a split pinned when the url source
+            // is built, so no realm it could move to would be served consistently.
+            if (dclEnvironment == DecentralandEnvironment.Today)
+                return Result.ErrorResult(
+                    "🔴 Error. You cannot change realms in the Today environment. Please restart DCL with the desired environment");
 
-            return Result.SuccessResult();
+            // Every other environment — the decentraland ones and a --base-domain deployment alike — accepts exactly
+            // the realms under its own base domain, so one check covers them all.
+            return HostHasSuffix(realmToTeleportTo, decentralandUrlsSource.BaseDomain)
+                ? Result.SuccessResult()
+                : Result.ErrorResult(
+                    $"🔴 Error. You cannot teleport to realms outside {decentralandUrlsSource.BaseDomain}. Please restart DCL with the desired environment");
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/Chat/Commands/Tests/ChatTeleporterShould.cs
+++ b/Explorer/Assets/DCL/Chat/Commands/Tests/ChatTeleporterShould.cs
@@ -33,6 +33,7 @@ namespace DCL.Chat.Commands.Tests
 
             IDecentralandUrlsSource urlsSource = Substitute.For<IDecentralandUrlsSource>();
             urlsSource.Url(Arg.Any<DecentralandUrl>()).Returns("https://peer.decentraland.org");
+            urlsSource.BaseDomain.Returns(IDecentralandUrlsSource.ORG_DOMAIN);
 
             IReadonlyReactiveProperty<Vector2Int> currentParcel = Substitute.For<IReadonlyReactiveProperty<Vector2Int>>();
             currentParcel.Value.Returns(CURRENT_PARCEL);
@@ -40,7 +41,7 @@ namespace DCL.Chat.Commands.Tests
             IScenesCache scenesCache = Substitute.For<IScenesCache>();
             scenesCache.CurrentParcel.Returns(currentParcel);
 
-            chatTeleporter = new ChatTeleporter(realmNavigator, new ChatEnvironmentValidator(DecentralandEnvironment.Org), urlsSource, scenesCache);
+            chatTeleporter = new ChatTeleporter(realmNavigator, new ChatEnvironmentValidator(DecentralandEnvironment.Org, urlsSource), urlsSource, scenesCache);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Chat/MessageBus/LiveKitChatMessagesBus.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/LiveKitChatMessagesBus.cs
@@ -89,6 +89,11 @@ namespace DCL.Chat.MessageBus
                                    DecentralandEnvironment.Org => "prd",
                                    DecentralandEnvironment.Today => "prd",
                                    DecentralandEnvironment.Zone => "dev",
+
+                                   // A --base-domain deployment is treated as a non-production stack, like zone: its
+                                   // comms-message-sfu has to join as message-router-dev-0 for relayed messages to
+                                   // authenticate. Explicit, so it is not silently routed as a local dev server.
+                                   DecentralandEnvironment.Custom => "dev",
                                    _ => "local",
                                };
 

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Core/ChatReactionsFactory.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Core/ChatReactionsFactory.cs
@@ -170,6 +170,11 @@ namespace DCL.Chat.ChatReactions.Core
                 DecentralandEnvironment.Org => "prd",
                 DecentralandEnvironment.Today => "prd",
                 DecentralandEnvironment.Zone => "dev",
+
+                // A --base-domain deployment is treated as a non-production stack, like zone: its
+                // comms-message-sfu has to join as message-router-dev-0 for relayed reactions to
+                // authenticate. Explicit, so it is not silently routed as a local dev server.
+                DecentralandEnvironment.Custom => "dev",
                 _ => "local",
             };
 

--- a/Explorer/Assets/DCL/Donations/DonationsService.cs
+++ b/Explorer/Assets/DCL/Donations/DonationsService.cs
@@ -82,10 +82,16 @@ namespace DCL.Donations
                         contractAddress = MATIC_CONTRACT_ADDRESS;
                         networkName = MATIC_NETWORK;
                         break;
-                default:
+
+                // Zone, and a --base-domain deployment: only decentraland's own production environments are
+                // treated as mainnet, so an unverified custom deployment can never move real funds.
+                case DecentralandEnvironment.Zone:
+                case DecentralandEnvironment.Custom:
                         contractAddress = AMOY_NET_CONTRACT_ADDRESS;
                         networkName = AMOY_NETWORK;
                         break;
+                default:
+                        throw new ArgumentOutOfRangeException(nameof(dclEnvironment), dclEnvironment, null);
             }
 
             scenesCache.CurrentScene.OnUpdate += OnCurrentSceneChanged;

--- a/Explorer/Assets/DCL/Donations/DonationsService.cs
+++ b/Explorer/Assets/DCL/Donations/DonationsService.cs
@@ -6,6 +6,7 @@ using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.PlacesAPIService;
 using DCL.Utilities;
 using DCL.Web3;
+using DCL.Web3.Chains;
 using DCL.WebRequests;
 using ECS;
 using ECS.SceneLifeCycle;
@@ -63,7 +64,7 @@ namespace DCL.Donations
             IWebRequestController webRequestController,
             IRealmData realmData,
             IPlacesAPIService placesAPIService,
-            DecentralandEnvironment dclEnvironment,
+            EthereumNetwork ethereumNetwork,
             IDecentralandUrlsSource decentralandUrlsSource,
             bool isLocalSceneDevelopmentMode)
         {
@@ -75,23 +76,20 @@ namespace DCL.Donations
             this.manaUsdApiUrl = URLAddress.FromString(decentralandUrlsSource.Url(DecentralandUrl.ManaUsdRateApiUrl));
             this.isLocalSceneDevelopmentMode = isLocalSceneDevelopmentMode;
 
-            switch (dclEnvironment)
+            // The MANA contract follows the resolved network: Polygon pairs with ethereum mainnet, Amoy with
+            // sepolia, so a donation can never move real funds on behalf of a test identity or the reverse.
+            switch (ethereumNetwork)
             {
-                case DecentralandEnvironment.Org:
-                case DecentralandEnvironment.Today:
-                        contractAddress = MATIC_CONTRACT_ADDRESS;
-                        networkName = MATIC_NETWORK;
-                        break;
-
-                // Zone, and a --base-domain deployment: only decentraland's own production environments are
-                // treated as mainnet, so an unverified custom deployment can never move real funds.
-                case DecentralandEnvironment.Zone:
-                case DecentralandEnvironment.Custom:
-                        contractAddress = AMOY_NET_CONTRACT_ADDRESS;
-                        networkName = AMOY_NETWORK;
-                        break;
+                case EthereumNetwork.Mainnet:
+                    contractAddress = MATIC_CONTRACT_ADDRESS;
+                    networkName = MATIC_NETWORK;
+                    break;
+                case EthereumNetwork.Sepolia:
+                    contractAddress = AMOY_NET_CONTRACT_ADDRESS;
+                    networkName = AMOY_NETWORK;
+                    break;
                 default:
-                        throw new ArgumentOutOfRangeException(nameof(dclEnvironment), dclEnvironment, null);
+                    throw new ArgumentOutOfRangeException(nameof(ethereumNetwork), ethereumNetwork, null);
             }
 
             scenesCache.CurrentScene.OnUpdate += OnCurrentSceneChanged;

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -22,6 +22,13 @@ namespace Global.AppArgs
         public const string REALM = "realm";
         public const string COMMS_ADAPTER = "comms-adapter";
         public const string GATEKEEPER_URL = "gatekeeper-url";
+
+        /// <summary>
+        ///     Points every backend host at a deployment served under this base domain instead of
+        ///     decentraland.{org,zone,today}, selecting <c>DecentralandEnvironment.Custom</c>. Command-line only:
+        ///     the value also decides which realm hosts are trusted, so it must never be settable from a deep link.
+        /// </summary>
+        public const string BASE_DOMAIN = "base-domain";
         public const string LOCAL_SCENE = "local-scene";
         public const string POSITION = "position";
         public const string SPAWN_POINT = "spawnpoint";

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -31,6 +31,17 @@ namespace Global.AppArgs
         ///     params, and accepting it in the denied-params dialog has no effect.
         /// </summary>
         public const string BASE_DOMAIN = "base-domain";
+
+        /// <summary>
+        ///     The chain a <c>--base-domain</c> deployment signs and transacts against: "mainnet" or "sepolia", each
+        ///     carrying the polygon network that pairs with it. Defaults to mainnet. Every decentraland environment
+        ///     answers for one chain of its own - org and today mainnet, zone sepolia - and this cannot move them:
+        ///     paired with one of those it is reported and dropped (<c>ChainUtils.ResolveNetwork</c>). Where the value
+        ///     is read, anything not naming a known network ends the launch instead of falling back to the default
+        ///     (<c>MainSceneLoader.CaptureEthNetworkArg</c>). Command line only, like <see cref="BASE_DOMAIN" />.
+        /// </summary>
+        public const string ETH_NETWORK = "eth-network";
+
         public const string LOCAL_SCENE = "local-scene";
         public const string POSITION = "position";
         public const string SPAWN_POINT = "spawnpoint";

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -25,8 +25,10 @@ namespace Global.AppArgs
 
         /// <summary>
         ///     Points every backend host at a deployment served under this base domain instead of
-        ///     decentraland.{org,zone,today}, selecting <c>DecentralandEnvironment.Custom</c>. Command-line only:
-        ///     the value also decides which realm hosts are trusted, so it must never be settable from a deep link.
+        ///     decentraland.{org,zone,today}, selecting <c>DecentralandEnvironment.Custom</c>. Applied from the
+        ///     command line only: it gates which realm hosts are trusted, so it has to be read before a pending deep
+        ///     link is processed. It is denied by <c>DeepLinkAllowlist</c> like the other infrastructure-pointing
+        ///     params, and accepting it in the denied-params dialog has no effect.
         /// </summary>
         public const string BASE_DOMAIN = "base-domain";
         public const string LOCAL_SCENE = "local-scene";

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -165,6 +165,23 @@ namespace Global.AppArgs
         // means loopback-only — the safe default when feature flags are unavailable (e.g. before they are fetched).
         private static HashSet<string> whitelistedWorlds = new();
 
+        // The one base domain a realm has to sit under to carry trust, or null for the decentraland family. Set from
+        // IDecentralandUrlsSource.BaseDomain; see SetTrustedBaseDomain.
+        private static string? trustedBaseDomain;
+
+        /// <summary>
+        ///     Declares the base domain this client is deployed under — pass
+        ///     <see cref="IDecentralandUrlsSource.BaseDomain" />, the single source for it. A domain of the
+        ///     decentraland family keeps the whole family trusted (they are one deployment); any other domain
+        ///     <i>replaces</i> it, because a client pointed at a custom deployment has no reason to trust
+        ///     decentraland-hosted realms. Passing null resets to the decentraland family.
+        /// </summary>
+        public static void SetTrustedBaseDomain(string? baseDomain)
+        {
+            string? domain = baseDomain?.Trim();
+            trustedBaseDomain = domain is { Length: > 0 } && !IsDecentralandDomain(domain) ? domain : null;
+        }
+
         public static bool IsPermitted(string key) =>
             PERMITTED_KEYS.Contains(key);
 
@@ -210,32 +227,51 @@ namespace Global.AppArgs
                 // name is read from the path — handing an attacker the dev params and (worse) a consent-free realm
                 // switch. Uri.Host is the parsed host, so userinfo ("https://x.decentraland.org@evil.example") and port
                 // tricks cannot spoof it.
-                if (!IsDecentralandHost(uri.Host))
+                if (!IsTrustedBaseDomainHost(uri.Host))
                     return false;
             }
 
             return whitelistedWorlds.Count > 0 && whitelistedWorlds.Contains(ExtractWorldName(realm));
         }
 
-        // A subdomain of a Decentraland domain (worlds-content-server.decentraland.org, ...). The '.' boundary check
-        // is what rejects lookalikes such as "decentraland.org.attacker.com" and "evil-decentraland.org".
-        private static bool IsDecentralandHost(string host)
+        // A subdomain of the base domain this client is deployed under (worlds-content-server.decentraland.org,
+        // worlds-content-server.{custom-base-domain}, ...). The '.' boundary check is what rejects lookalikes such as
+        // "decentraland.org.attacker.com" and "evil-decentraland.org".
+        private static bool IsTrustedBaseDomainHost(string host)
+        {
+            if (trustedBaseDomain != null)
+                return IsSubdomainOf(host, trustedBaseDomain);
+
+            // Indexed loop, not foreach: enumerating the IReadOnlyList would allocate an enumerator.
+            IReadOnlyList<string> domains = IDecentralandUrlsSource.ALL_DOMAINS;
+
+            for (var i = 0; i < domains.Count; i++)
+            {
+                if (IsSubdomainOf(host, domains[i]))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsDecentralandDomain(string domain)
         {
             // Indexed loop, not foreach: enumerating the IReadOnlyList would allocate an enumerator.
             IReadOnlyList<string> domains = IDecentralandUrlsSource.ALL_DOMAINS;
 
             for (var i = 0; i < domains.Count; i++)
             {
-                string domain = domains[i];
-
-                if (host.Length > domain.Length
-                    && host[host.Length - domain.Length - 1] == '.'
-                    && host.EndsWith(domain, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(domain, domains[i], StringComparison.OrdinalIgnoreCase))
                     return true;
             }
 
             return false;
         }
+
+        private static bool IsSubdomainOf(string host, string domain) =>
+            host.Length > domain.Length
+            && host[host.Length - domain.Length - 1] == '.'
+            && host.EndsWith(domain, StringComparison.OrdinalIgnoreCase);
 
         // A world realm is either the bare ENS name (e.g. "myworld.dcl.eth") or a worlds-content-server URL whose
         // last path segment is that ENS. We reduce both the configured entries and the realm to that name and match

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -239,15 +239,17 @@ namespace Global.AppArgs
         // "decentraland.org.attacker.com" and "evil-decentraland.org".
         private static bool IsTrustedBaseDomainHost(string host)
         {
+            // Deliberately subdomains only: the registrable domain itself does not host realms, so it carries no
+            // trust here even though it sits under itself.
             if (trustedBaseDomain != null)
-                return IsSubdomainOf(host, trustedBaseDomain);
+                return IDecentralandUrlsSource.IsSubdomainOf(host, trustedBaseDomain);
 
             // Indexed loop, not foreach: enumerating the IReadOnlyList would allocate an enumerator.
             IReadOnlyList<string> domains = IDecentralandUrlsSource.ALL_DOMAINS;
 
             for (var i = 0; i < domains.Count; i++)
             {
-                if (IsSubdomainOf(host, domains[i]))
+                if (IDecentralandUrlsSource.IsSubdomainOf(host, domains[i]))
                     return true;
             }
 
@@ -267,11 +269,6 @@ namespace Global.AppArgs
 
             return false;
         }
-
-        private static bool IsSubdomainOf(string host, string domain) =>
-            host.Length > domain.Length
-            && host[host.Length - domain.Length - 1] == '.'
-            && host.EndsWith(domain, StringComparison.OrdinalIgnoreCase);
 
         // A world realm is either the bare ENS name (e.g. "myworld.dcl.eth") or a worlds-content-server URL whose
         // last path segment is that ENS. We reduce both the configured entries and the realm to that name and match

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -42,7 +42,8 @@ namespace Global.AppArgs
     ///             (<c>creator-hub-bin-path</c>, <c>launch-cdp-monitor-on-start</c> — SEC-005); point the client at
     ///             attacker infrastructure (<c>comms-adapter</c>, <c>gatekeeper-url</c>, <c>friends-api-url</c> —
     ///             SEC-052, <c>feature-flags-url</c>/<c>-hostname</c>, <c>optimized-assets-url</c>,
-    ///             <c>lsd-remote-ab-server</c>/<c>-world</c>, <c>pulse</c>); bypass a version/specs screen
+    ///             <c>lsd-remote-ab-server</c>/<c>-world</c>, <c>pulse</c>); move the client onto another chain
+    ///             (<c>base-domain</c>, <c>eth-network</c>); bypass a version/specs screen
     ///             (<c>skip-version-check</c>, <c>skip-minimum-specs-screen</c>); or enable the remaining dev/test
     ///             modes (<c>debug</c>, <c>autopilot</c>, <c>alttester</c>, <c>simulate*</c>). A whitelisted realm
     ///             does not unlock these: unlike the tier above, a key that is in neither set is dropped for every

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -1,3 +1,4 @@
+using DCL.Multiplayer.Connections.DecentralandUrls;
 using NUnit.Framework;
 using System.Collections.Generic;
 
@@ -10,6 +11,7 @@ namespace Global.AppArgs.Tests
         {
             // Reset the cached/overridden world whitelist so tests don't leak state into one another.
             DeepLinkAllowlist.SetWhitelistedWorlds(null);
+            DeepLinkAllowlist.SetTrustedBaseDomain(null);
         }
 
         [Test]
@@ -279,6 +281,46 @@ namespace Global.AppArgs.Tests
 
             // Act & Assert
             Assert.AreEqual(expected, DeepLinkAllowlist.IsRealmWhitelisted(realm));
+        }
+
+        [TestCase("https://worlds-content-server.interconnected.online/world/test-world.dcl.eth", true, TestName = "a host under the custom base domain is trusted like decentraland's")]
+        [TestCase("https://interconnected.online.attacker.com/world/test-world.dcl.eth", false, TestName = "suffix-lookalike of the custom base domain is rejected")]
+        [TestCase("https://worlds-content-server.decentraland.org/world/test-world.dcl.eth", false, TestName = "a custom deployment does not inherit trust in decentraland hosts")]
+        [TestCase("http://127.0.0.1:8000", true, TestName = "loopback stays trusted")]
+        public void ClassifyRealmAsWhitelistedUnderACustomBaseDomain(string realm, bool expected)
+        {
+            // Arrange
+            DeepLinkAllowlist.SetWhitelistedWorlds(new[] { "test-world.dcl.eth" });
+            DeepLinkAllowlist.SetTrustedBaseDomain("interconnected.online");
+
+            // Act & Assert
+            Assert.AreEqual(expected, DeepLinkAllowlist.IsRealmWhitelisted(realm));
+        }
+
+        [Test]
+        public void KeepTheDecentralandFamilyTrustedWhenTheBaseDomainIsOneOfItsOwn()
+        {
+            // Arrange: passing a decentraland domain must not narrow trust to that single environment.
+            DeepLinkAllowlist.SetWhitelistedWorlds(new[] { "test-world.dcl.eth" });
+            DeepLinkAllowlist.SetTrustedBaseDomain(IDecentralandUrlsSource.ORG_DOMAIN);
+
+            // Act & Assert
+            Assert.IsTrue(DeepLinkAllowlist.IsRealmWhitelisted("https://worlds-content-server.decentraland.org/world/test-world.dcl.eth"));
+            Assert.IsTrue(DeepLinkAllowlist.IsRealmWhitelisted("https://worlds-content-server.decentraland.zone/world/test-world.dcl.eth"));
+        }
+
+        /// <summary>
+        ///     The base domain decides which realm hosts are trusted, so a deep link must never be able to set it:
+        ///     it stays a command-line-only flag, denied (and surfaced for consent) like any other unlisted param.
+        /// </summary>
+        [Test]
+        public void NeverPermitTheBaseDomainFromADeepLink()
+        {
+            Assert.IsFalse(DeepLinkAllowlist.IsPermitted(AppArgsFlags.BASE_DOMAIN));
+            Assert.IsFalse(DeepLinkAllowlist.IsPermittedForWhitelistedRealm(AppArgsFlags.BASE_DOMAIN));
+
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters($"decentraland://?realm=https://peer.decentraland.org&{AppArgsFlags.BASE_DOMAIN}=evil.example");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.BASE_DOMAIN), $"keys: {string.Join(", ", output.Keys)}");
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -323,6 +323,21 @@ namespace Global.AppArgs.Tests
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.BASE_DOMAIN), $"keys: {string.Join(", ", output.Keys)}");
         }
 
+        /// <summary>
+        ///     Which chain the client signs against is not something a link may pick, so it is denied like any other
+        ///     unlisted param. Denial is only half of it: the value is read from the command line before the deep
+        ///     link is processed, so consenting to it in the denied-params dialog does not apply it either.
+        /// </summary>
+        [Test]
+        public void NeverPermitTheEthNetworkFromADeepLink()
+        {
+            Assert.IsFalse(DeepLinkAllowlist.IsPermitted(AppArgsFlags.ETH_NETWORK));
+            Assert.IsFalse(DeepLinkAllowlist.IsPermittedForWhitelistedRealm(AppArgsFlags.ETH_NETWORK));
+
+            Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters($"decentraland://?realm=https://peer.decentraland.org&{AppArgsFlags.ETH_NETWORK}=mainnet");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.ETH_NETWORK), $"keys: {string.Join(", ", output.Keys)}");
+        }
+
         [Test]
         public void DeferDeepLinkUntilInitializeDeepLinksIsCalled()
         {

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
@@ -146,7 +146,7 @@ namespace Global.Dynamic
                 var cdpClient = ChromeDevToolHandler.New(applicationParametersParser.HasFlag(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START));
                 WebRequestsContainer? webRequestsContainer = await WebRequestsContainer.CreateAsync(settingsContainer, identityCache, debugContainer.Builder, decentralandUrlsSource, cdpClient, container.DiagnosticsContainer.SentrySampler, container.RealmClock, ct);
                 container.WebRequestsContainer = webRequestsContainer;
-                var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(webRequestsContainer.WebRequestController), decentralandUrlsSource);
+                var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(webRequestsContainer.WebRequestController, decentralandUrlsSource), decentralandUrlsSource);
 
                 container.Bootstrap = await CreateBootstrapperAsync(debugSettings, debugContainer, applicationParametersParser, splashScreen, realmUrls, diskCache, partialsDiskCache, container, webRequestsContainer, settingsContainer, realmLaunchSettings, world, container.settings.BuildData, dclVersion, ct);
                 container.CompositeWeb3Provider = CreateWeb3Dependencies(sceneLoaderSettings, web3AccountFactory, identityCache, browser, container.Analytics, decentralandUrlsSource, decentralandEnvironment, applicationParametersParser, webRequestsContainer.WebRequestController, container.DeeplinkSigninIdentityId, container.DeeplinkLoginAwaitingSigninRequestId);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
@@ -18,6 +18,7 @@ using DCL.Utility;
 using DCL.Web3.Abstract;
 using DCL.Web3.Accounts.Factory;
 using DCL.Web3.Authenticators;
+using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using DCL.WebRequests;
 using DCL.WebRequests.Analytics;
@@ -64,6 +65,13 @@ namespace Global.Dynamic
         public DecentralandEnvironment Environment { get; private set; }
 
         /// <summary>
+        ///     The chain this run signs and transacts against, resolved once from the environment and
+        ///     <c>--eth-network</c>. Anything needing a chain reads it here instead of deriving one from
+        ///     <see cref="Environment" />.
+        /// </summary>
+        public EthereumNetwork EthereumNetwork { get; private set; }
+
+        /// <summary>
         ///     The loopback endpoint reserved for the local-ab abgen server (the URL sources already point
         ///     at it). Non-null only in local scene development with local asset bundles —
         ///     DynamicWorldContainer registers AbgenSidecarPlugin, which owns the server's whole lifecycle,
@@ -101,6 +109,7 @@ namespace Global.Dynamic
             IDiskCache<PartialLoadingState> partialsDiskCache,
             World world,
             DecentralandEnvironment decentralandEnvironment,
+            EthereumNetwork ethereumNetwork,
             DCLVersion dclVersion,
             string? localAbBaseUrl,
             CancellationToken ct)
@@ -121,6 +130,7 @@ namespace Global.Dynamic
                 DebugSettings = debugSettings,
                 VolumeBus = new VolumeBus(),
                 Environment = decentralandEnvironment,
+                EthereumNetwork = ethereumNetwork,
                 LocalAbBaseUrl = localAbBaseUrl
             };
 
@@ -149,7 +159,7 @@ namespace Global.Dynamic
                 var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(webRequestsContainer.WebRequestController, decentralandUrlsSource), decentralandUrlsSource);
 
                 container.Bootstrap = await CreateBootstrapperAsync(debugSettings, debugContainer, applicationParametersParser, splashScreen, realmUrls, diskCache, partialsDiskCache, container, webRequestsContainer, settingsContainer, realmLaunchSettings, world, container.settings.BuildData, dclVersion, ct);
-                container.CompositeWeb3Provider = CreateWeb3Dependencies(sceneLoaderSettings, web3AccountFactory, identityCache, browser, container.Analytics, decentralandUrlsSource, decentralandEnvironment, applicationParametersParser, webRequestsContainer.WebRequestController, container.DeeplinkSigninIdentityId, container.DeeplinkLoginAwaitingSigninRequestId);
+                container.CompositeWeb3Provider = CreateWeb3Dependencies(sceneLoaderSettings, web3AccountFactory, identityCache, browser, container.Analytics, decentralandUrlsSource, ethereumNetwork, applicationParametersParser, webRequestsContainer.WebRequestController, container.DeeplinkSigninIdentityId, container.DeeplinkLoginAwaitingSigninRequestId);
 
                 void AddIdentityToSentryScope(Scope scope)
                 {
@@ -202,7 +212,7 @@ namespace Global.Dynamic
             UnityAppWebBrowser webBrowser,
             AnalyticsContainer container,
             IDecentralandUrlsSource decentralandUrlsSource,
-            DecentralandEnvironment dclEnvironment,
+            EthereumNetwork ethereumNetwork,
             IAppArgs appArgs,
             IWebRequestController webRequestController,
             ReactiveProperty<string?> deeplinkSigninIdentityId,
@@ -215,7 +225,7 @@ namespace Global.Dynamic
             // Create ThirdWeb authenticator (Email + OTP)
             var thirdWebAuth = new ThirdWebAuthenticator(
                 decentralandUrlsSource,
-                dclEnvironment,
+                ethereumNetwork,
                 new HashSet<string>(sceneLoaderSettings.Web3WhitelistMethods),
                 new HashSet<string>(sceneLoaderSettings.Web3ReadOnlyMethods),
                 web3AccountFactory,
@@ -250,7 +260,7 @@ namespace Global.Dynamic
                 web3AccountFactory,
                 new HashSet<string>(sceneLoaderSettings.Web3WhitelistMethods),
                 new HashSet<string>(sceneLoaderSettings.Web3ReadOnlyMethods),
-                dclEnvironment,
+                ethereumNetwork,
                 identityExpirationDuration
             );
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/ChatContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/ChatContainer.cs
@@ -103,7 +103,7 @@ namespace Global.Dynamic
             var chatHistory = new ChatHistory();
             var chatEventBus = new ChatEventBus();
 
-            var chatTeleporter = new ChatTeleporter(realmNavigator, new ChatEnvironmentValidator(bootstrapContainer.Environment), bootstrapContainer.DecentralandUrlsSource, staticContainer.ScenesCache);
+            var chatTeleporter = new ChatTeleporter(realmNavigator, new ChatEnvironmentValidator(bootstrapContainer.Environment, bootstrapContainer.DecentralandUrlsSource), bootstrapContainer.DecentralandUrlsSource, staticContainer.ScenesCache);
 
             var reloadSceneChatCommand = new ReloadSceneChatCommand(reloadSceneController, globalWorld, playerEntity, staticContainer.ScenesCache, teleportController, localSceneDevelopment);
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -398,7 +398,7 @@ namespace Global.Dynamic
                 staticContainer.WebRequestsContainer.WebRequestController,
                 staticContainer.RealmData,
                 placesAndEventsContainer.PlacesAPIService,
-                bootstrapContainer.Environment,
+                bootstrapContainer.EthereumNetwork,
                 bootstrapContainer.Analytics.Controller,
                 localSceneDevelopment,
                 dynamicWorldParams.EnableAnalytics);
@@ -440,7 +440,7 @@ namespace Global.Dynamic
             MarketplaceCreditsAPIClient marketplaceCreditsApiClient = new MarketplaceCreditsAPIClient(staticContainer.WebRequestsContainer.WebRequestController, bootstrapContainer.DecentralandUrlsSource);
 
             var marketplaceShopApiClient = new MarketplaceShopAPIClient(staticContainer.WebRequestsContainer.WebRequestController, bootstrapContainer.DecentralandUrlsSource);
-            var creditsChainConfig = new CreditsChainConfig(bootstrapContainer.Environment);
+            var creditsChainConfig = new CreditsChainConfig(bootstrapContainer.EthereumNetwork);
 
             CreditsFeatureAccess.Initialize(new CreditsFeatureAccess(identityCache, ct));
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -69,6 +69,9 @@ namespace Global.Dynamic
         [Space]
         [SerializeField] private DecentralandEnvironment decentralandEnvironment;
 
+        // Non-null only for DecentralandEnvironment.Custom; set from the command line by ApplyBaseDomainArg.
+        private string? customBaseDomain;
+
         [Space]
         [SerializeField] private DebugSettings.DebugSettings debugSettings = new ();
 
@@ -192,8 +195,26 @@ namespace Global.Dynamic
 
         private void ParseEnvironment(string environment)
         {
-            if (Enum.TryParse(environment, true, out DecentralandEnvironment env))
-                decentralandEnvironment = env;
+            // --base-domain already selected Custom, and it is command-line only while --dclenv can arrive from a
+            // deep link. Letting the link win would move the client back onto a decentraland domain behind the
+            // operator's back, so the base domain is authoritative and the mismatch is reported.
+            if (customBaseDomain != null)
+            {
+                ReportHub.Log(ReportCategory.STARTUP, $"Ignoring --{AppArgsFlags.ENVIRONMENT}={environment}: --{AppArgsFlags.BASE_DOMAIN}={customBaseDomain} pins the environment to {nameof(DecentralandEnvironment.Custom)}");
+                return;
+            }
+
+            if (!Enum.TryParse(environment, true, out DecentralandEnvironment env))
+                return;
+
+            // Custom has no domain of its own to derive; only --base-domain can select it.
+            if (env == DecentralandEnvironment.Custom)
+            {
+                ReportHub.LogWarning(ReportCategory.STARTUP, $"Ignoring --{AppArgsFlags.ENVIRONMENT}={environment}: {nameof(DecentralandEnvironment.Custom)} is selected by --{AppArgsFlags.BASE_DOMAIN} instead");
+                return;
+            }
+
+            decentralandEnvironment = env;
         }
 
         private async UniTask InitializeFlowAsync(CancellationToken ct)
@@ -213,6 +234,12 @@ namespace Global.Dynamic
             // initialized until later in bootstrap, so for a deep-link launch we preemptively fetch just the whitelist
             // now (best-effort, fails safe to loopback-only), then process the deep link with it applied.
             IAppArgs applicationParametersParser = ApplicationParametersParser.CreateDeferringDeepLinks(rawApplicationParameters);
+
+            // Read while the deep link is still deferred, so only the command line can supply it: the base domain
+            // decides which realm hosts DeepLinkAllowlist trusts, and a link that could set it would hand an
+            // attacker-chosen domain that trust. It has to be registered before InitializeDeepLinks() evaluates the
+            // pending link's whitelisted-realm params against it.
+            ApplyBaseDomainArg(applicationParametersParser);
 
             if (applicationParametersParser.HasPendingDeepLink)
                 await InitializeDeepLinkWorldWhitelistAsync(applicationParametersParser, ct);
@@ -277,7 +304,8 @@ namespace Global.Dynamic
                 debugSettings.GatekeeperMode,
                 debugSettings.CustomGatekeeperUrl,
                 cliGatekeeperUrl,
-                cliOptimizedAssetsUrl);
+                cliOptimizedAssetsUrl,
+                customBaseDomain);
             DiagnosticInfoUtils.LogEnvironment(decentralandUrlsSource);
 
             splashScreen = await assetsProvisioner.ProvideInstanceAsync(splashScreenRef, ct: ct);
@@ -551,12 +579,28 @@ namespace Global.Dynamic
 #endif
         }
 
+        /// <summary>
+        ///     Applies <see cref="AppArgsFlags.BASE_DOMAIN" />: it selects <see cref="DecentralandEnvironment.Custom" />
+        ///     and, through <see cref="DecentralandUrlsSource.ResolveBaseDomain" />, the domain every backend host and
+        ///     every realm-trust check resolves against.
+        /// </summary>
+        private void ApplyBaseDomainArg(IAppArgs appArgs)
+        {
+            if (appArgs.TryGetValue(AppArgsFlags.BASE_DOMAIN, out string? baseDomainArg) && !string.IsNullOrWhiteSpace(baseDomainArg))
+            {
+                customBaseDomain = baseDomainArg.Trim();
+                decentralandEnvironment = DecentralandEnvironment.Custom;
+            }
+
+            DeepLinkAllowlist.SetTrustedBaseDomain(DecentralandUrlsSource.ResolveBaseDomain(decentralandEnvironment, customBaseDomain));
+        }
+
         private async UniTask InitializeDeepLinkWorldWhitelistAsync(IAppArgs appArgs, CancellationToken ct)
         {
             appArgs.TryGetValue(AppArgsFlags.FeatureFlags.URL, out string? featureFlagsOverride);
 
             string featureFlagsBase = string.IsNullOrEmpty(featureFlagsOverride)
-                ? DecentralandUrlsSource.GetFeatureFlagsUrl(decentralandEnvironment)
+                ? DecentralandUrlsSource.GetFeatureFlagsUrl(decentralandEnvironment, customBaseDomain)
                 : featureFlagsOverride.TrimEnd('/');
 
             IReadOnlyList<string> whitelistedWorlds = await DeepLinkWorldWhitelistProvider.FetchAsync($"{featureFlagsBase}/{FeatureFlagOptions.APP_NAME}.json", ct);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -32,6 +32,8 @@ using DCL.Utilities.Extensions;
 using DCL.Utility;
 using DCL.Utility.Types;
 using DCL.Web3.Accounts.Factory;
+using DCL.Web3.Authenticators;
+using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using DCL.WebRequests;
 using DG.Tweening;
@@ -71,6 +73,10 @@ namespace Global.Dynamic
 
         // Non-null only for DecentralandEnvironment.Custom; set from the command line by ApplyBaseDomainArg.
         private string? customBaseDomain;
+
+        // The validated --eth-network value, or null when it was not passed on the command line. Captured by
+        // CaptureEthNetworkArg and turned into a network by ResolveEthereumNetwork once the environment is settled.
+        private string? ethNetworkArg;
 
         [Space]
         [SerializeField] private DebugSettings.DebugSettings debugSettings = new ();
@@ -240,8 +246,16 @@ namespace Global.Dynamic
             // registered before InitializeDeepLinks() evaluates the pending link's whitelisted-realm params against
             // it. A domain arriving in that same link could not be — its own params would need gating against a domain
             // it has not supplied yet. (base-domain is denied by the allowlist, so a link carrying it still reaches
-            // the consent dialog; WarnIfBaseDomainCameFromTheDeepLink reports that accepting it changes nothing.)
+            // the consent dialog; WarnIfCommandLineOnlyArgCameFromTheDeepLink reports that accepting it changes nothing.)
             ApplyBaseDomainArg(applicationParametersParser);
+
+            // Read while the deep link is still deferred for the same reason as the base domain: which chain the
+            // client signs against is not something a link may pick, not even through the denied-params dialog.
+            if (!CaptureEthNetworkArg(applicationParametersParser))
+            {
+                ExitUtils.Exit();
+                return;
+            }
 
             if (applicationParametersParser.HasPendingDeepLink)
                 await InitializeDeepLinkWorldWhitelistAsync(applicationParametersParser, ct);
@@ -260,7 +274,8 @@ namespace Global.Dynamic
                 return;
             }
 
-            WarnIfBaseDomainCameFromTheDeepLink(applicationParametersParser);
+            WarnIfCommandLineOnlyArgCameFromTheDeepLink(applicationParametersParser, AppArgsFlags.BASE_DOMAIN, customBaseDomain);
+            WarnIfCommandLineOnlyArgCameFromTheDeepLink(applicationParametersParser, AppArgsFlags.ETH_NETWORK, ethNetworkArg);
 
             FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(FeatureFlagsResultDto.Empty));
 
@@ -276,6 +291,10 @@ namespace Global.Dynamic
 
             ApplyConfig(applicationParametersParser);
             launchSettings.ApplyConfig(applicationParametersParser);
+
+            // Resolved after ApplyConfig, not where the arg was captured: --dclenv is able to move the environment up
+            // to this point, and the environment is what decides whether the override is read at all.
+            EthereumNetwork ethereumNetwork = ResolveEthereumNetwork();
 
             NativeWindowManager.Initialize(
                 applicationParametersParser.HasFlag(AppArgsFlags.DISABLE_WINDOW_RESTRICTIONS),
@@ -319,7 +338,7 @@ namespace Global.Dynamic
                 InstantiateAltTester(applicationParametersParser);
 
             var web3AccountFactory = new Web3AccountFactory();
-            var identityCache = new IWeb3IdentityCache.Default(web3AccountFactory, decentralandEnvironment);
+            var identityCache = new IWeb3IdentityCache.Default(web3AccountFactory, ethereumNetwork);
             var debugViewsCatalog = (await assetsProvisioner.ProvideMainAssetAsync(dynamicSettings.DebugViewsCatalog, ct)).Value;
             var debugContainer = DebugUtilitiesContainer.Create(debugViewsCatalog, applicationParametersParser.HasDebugFlag(), applicationParametersParser.HasFlag(AppArgsFlags.LOCAL_SCENE));
 
@@ -341,6 +360,7 @@ namespace Global.Dynamic
                 partialsDiskCache,
                 world,
                 decentralandEnvironment,
+                ethereumNetwork,
                 dclVersion,
                 localAbBaseUrl,
                 destroyCancellationToken
@@ -584,23 +604,78 @@ namespace Global.Dynamic
         }
 
         /// <summary>
+        ///     Reports a value the deep link carried for an arg that was already read from the command line, where
+        ///     the link's own value is therefore not applied - not even after the user accepts it in the
+        ///     denied-params dialog, since nothing reads the arg again. Without this it would sit in the logged args
+        ///     looking applied.
+        /// </summary>
+        private static void WarnIfCommandLineOnlyArgCameFromTheDeepLink(IAppArgs appArgs, string flag, string? commandLineValue)
+        {
+            if (appArgs.TryGetValue(flag, out string? linkValue)
+                && !string.IsNullOrWhiteSpace(linkValue)
+                && !string.Equals(linkValue.Trim(), commandLineValue, StringComparison.OrdinalIgnoreCase))
+                ReportHub.LogWarning(ReportCategory.STARTUP, $"Ignoring --{flag}={linkValue} from the deep link: it is only applied from the command line");
+        }
+
+        /// <summary>
+        ///     Captures <see cref="AppArgsFlags.ETH_NETWORK" /> into <see cref="ethNetworkArg" />, rejecting a value
+        ///     that would otherwise leave the run on the default chain with nothing said. Returns false when the
+        ///     launch must be abandoned; the reason is already reported.
+        ///     <para>
+        ///         Rejecting rather than defaulting is the whole point on a <c>--base-domain</c> deployment: mainnet
+        ///         is the default, so every way of mistyping this flag ends with real contracts and the production
+        ///         identity slot behind an operator who asked for a test chain.
+        ///     </para>
+        /// </summary>
+        private bool CaptureEthNetworkArg(IAppArgs appArgs)
+        {
+            if (!appArgs.TryGetValue(AppArgsFlags.ETH_NETWORK, out string? value))
+                return true;
+
+            // Only a Custom environment reads the value, and only --base-domain selects Custom, so this is already
+            // final here even though --dclenv has not been applied yet.
+            bool valueIsRead = decentralandEnvironment == DecentralandEnvironment.Custom;
+
+            if (valueIsRead && !ChainUtils.TryParseNetwork(value, out _))
+            {
+                ReportHub.LogError(ReportCategory.STARTUP, $"--{AppArgsFlags.ETH_NETWORK} '{value}' names no known network. Expected {ChainUtils.GetNetworkId(EthereumNetwork.Mainnet)} or {ChainUtils.GetNetworkId(EthereumNetwork.Sepolia)}");
+                return false;
+            }
+
+            ethNetworkArg = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+            return true;
+        }
+
+        /// <summary>
+        ///     Turns the captured <see cref="ethNetworkArg" /> into the chain this run uses. Only a
+        ///     <c>--base-domain</c> deployment can answer for its own chain, so an override paired with a
+        ///     decentraland environment is reported and dropped rather than silently having no effect. The rule
+        ///     itself lives in <see cref="ChainUtils.ResolveNetwork" />; this reports what it discarded.
+        /// </summary>
+        private EthereumNetwork ResolveEthereumNetwork()
+        {
+            EthereumNetwork ethereumNetwork = ChainUtils.ResolveNetwork(decentralandEnvironment, ethNetworkArg);
+
+            if (ethNetworkArg != null && ChainUtils.PinnedNetworkOf(decentralandEnvironment) is { } pinned)
+            {
+                if (!ChainUtils.TryParseNetwork(ethNetworkArg, out EthereumNetwork requested))
+                    ReportHub.LogWarning(ReportCategory.STARTUP, $"Ignoring --{AppArgsFlags.ETH_NETWORK}={ethNetworkArg}: it names no known network, and the {decentralandEnvironment} environment runs on {ChainUtils.GetNetworkId(pinned)} regardless");
+                else if (requested != pinned)
+                    ReportHub.LogWarning(ReportCategory.STARTUP, $"Ignoring --{AppArgsFlags.ETH_NETWORK}={ethNetworkArg}: the {decentralandEnvironment} environment always runs on {ChainUtils.GetNetworkId(pinned)}");
+            }
+
+            // Logged unconditionally: a custom deployment defaults to mainnet, which puts the production contracts
+            // and identity slot behind it, and that has to be answerable from a log after the fact.
+            ReportHub.Log(ReportCategory.STARTUP, $"Chain: {ChainUtils.GetNetworkId(ethereumNetwork)} (environment {decentralandEnvironment})");
+
+            return ethereumNetwork;
+        }
+
+        /// <summary>
         ///     Applies <see cref="AppArgsFlags.BASE_DOMAIN" />: it selects <see cref="DecentralandEnvironment.Custom" />
         ///     and, through <see cref="DecentralandUrlsSource.ResolveBaseDomain" />, the domain every backend host and
         ///     every realm-trust check resolves against.
         /// </summary>
-        /// <summary>
-        ///     <see cref="ApplyBaseDomainArg" /> reads the base domain before the deep link is processed, so a value the
-        ///     link carried is not applied — not even after the user accepts it in the denied-params dialog, since
-        ///     nothing reads the arg again. Report that rather than leaving it looking applied in the logged args.
-        /// </summary>
-        private void WarnIfBaseDomainCameFromTheDeepLink(IAppArgs appArgs)
-        {
-            if (appArgs.TryGetValue(AppArgsFlags.BASE_DOMAIN, out string? baseDomainArg)
-                && !string.IsNullOrWhiteSpace(baseDomainArg)
-                && !string.Equals(baseDomainArg!.Trim(), customBaseDomain, StringComparison.OrdinalIgnoreCase))
-                ReportHub.LogWarning(ReportCategory.STARTUP, $"Ignoring --{AppArgsFlags.BASE_DOMAIN}={baseDomainArg} from the deep link: it is only applied from the command line, so the environment stays {decentralandEnvironment}");
-        }
-
         private void ApplyBaseDomainArg(IAppArgs appArgs)
         {
             if (appArgs.TryGetValue(AppArgsFlags.BASE_DOMAIN, out string? baseDomainArg) && !string.IsNullOrWhiteSpace(baseDomainArg))

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -885,6 +885,15 @@ namespace Global.Dynamic
             var uri = new Uri(realm);
             if (uri.Host == "127.0.0.1") return true;
             if (uri.Host == "localhost") return true;
+
+            // A --base-domain deployment owns everything under its domain, so its realms and worlds carry the same
+            // trust the hardcoded decentraland hosts below do. Its worlds server in particular cannot be reached any
+            // other way: the catalyst server list consulted at the end enumerates catalysts, not worlds servers, which
+            // is exactly why decentraland's is hardcoded. Widening trust this way is safe because --base-domain is
+            // command-line only (never accepted from a deep link), so the operator already chose this deployment.
+            if (decentralandEnvironment == DecentralandEnvironment.Custom
+                && IDecentralandUrlsSource.IsHostWithinDomain(uri.Host, dclUrls.BaseDomain))
+                return true;
             if (uri.Host == "sdk-team-cdn." + IDecentralandUrlsSource.ORG_DOMAIN) return true;
             if (uri.Host == "sdk-test-scenes." + IDecentralandUrlsSource.ZONE_DOMAIN) return true;
             if (uri.Host == "realm-provider-ea." + IDecentralandUrlsSource.ORG_DOMAIN) return true;

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -235,10 +235,12 @@ namespace Global.Dynamic
             // now (best-effort, fails safe to loopback-only), then process the deep link with it applied.
             IAppArgs applicationParametersParser = ApplicationParametersParser.CreateDeferringDeepLinks(rawApplicationParameters);
 
-            // Read while the deep link is still deferred, so only the command line can supply it: the base domain
-            // decides which realm hosts DeepLinkAllowlist trusts, and a link that could set it would hand an
-            // attacker-chosen domain that trust. It has to be registered before InitializeDeepLinks() evaluates the
-            // pending link's whitelisted-realm params against it.
+            // Read while the deep link is still deferred, so only the command line can supply it. The ordering is the
+            // reason, not the allowlist: the base domain gates which realms DeepLinkAllowlist trusts, so it has to be
+            // registered before InitializeDeepLinks() evaluates the pending link's whitelisted-realm params against
+            // it. A domain arriving in that same link could not be — its own params would need gating against a domain
+            // it has not supplied yet. (base-domain is denied by the allowlist, so a link carrying it still reaches
+            // the consent dialog; WarnIfBaseDomainCameFromTheDeepLink reports that accepting it changes nothing.)
             ApplyBaseDomainArg(applicationParametersParser);
 
             if (applicationParametersParser.HasPendingDeepLink)
@@ -257,6 +259,8 @@ namespace Global.Dynamic
                 ExitUtils.Exit();
                 return;
             }
+
+            WarnIfBaseDomainCameFromTheDeepLink(applicationParametersParser);
 
             FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(FeatureFlagsResultDto.Empty));
 
@@ -584,6 +588,19 @@ namespace Global.Dynamic
         ///     and, through <see cref="DecentralandUrlsSource.ResolveBaseDomain" />, the domain every backend host and
         ///     every realm-trust check resolves against.
         /// </summary>
+        /// <summary>
+        ///     <see cref="ApplyBaseDomainArg" /> reads the base domain before the deep link is processed, so a value the
+        ///     link carried is not applied — not even after the user accepts it in the denied-params dialog, since
+        ///     nothing reads the arg again. Report that rather than leaving it looking applied in the logged args.
+        /// </summary>
+        private void WarnIfBaseDomainCameFromTheDeepLink(IAppArgs appArgs)
+        {
+            if (appArgs.TryGetValue(AppArgsFlags.BASE_DOMAIN, out string? baseDomainArg)
+                && !string.IsNullOrWhiteSpace(baseDomainArg)
+                && !string.Equals(baseDomainArg!.Trim(), customBaseDomain, StringComparison.OrdinalIgnoreCase))
+                ReportHub.LogWarning(ReportCategory.STARTUP, $"Ignoring --{AppArgsFlags.BASE_DOMAIN}={baseDomainArg} from the deep link: it is only applied from the command line, so the environment stays {decentralandEnvironment}");
+        }
+
         private void ApplyBaseDomainArg(IAppArgs appArgs)
         {
             if (appArgs.TryGetValue(AppArgsFlags.BASE_DOMAIN, out string? baseDomainArg) && !string.IsNullOrWhiteSpace(baseDomainArg))

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -368,13 +368,24 @@ namespace Global.Dynamic
                 var uri = new Uri(realm.Value);
                 hostname = $"{uri.Host}{uri.AbsolutePath}";
             }
+            else if (about.comms != null)
+                hostname = new Uri(realm.Value).Host;
             else
-                hostname = about.comms == null
+            {
+                // Consider it as the "main" realm which shares the comms with many catalysts
+                string realmProviderDomain = environment switch
+                                             {
+                                                 // A custom deployment runs its own realm provider; grouping its comms
+                                                 // under decentraland.org would drop its players into decentraland's
+                                                 // main-realm island.
+                                                 DecentralandEnvironment.Custom => decentralandUrlsSource.BaseDomain,
 
-                    // Consider it as the "main" realm which shares the comms with many catalysts
-                    // TODO: take in consideration the web3-network. If its sepolia then it should be .zone
-                    ? "realm-provider." + IDecentralandUrlsSource.ORG_DOMAIN
-                    : new Uri(realm.Value).Host;
+                                                 // TODO: take in consideration the web3-network. If its sepolia then it should be .zone
+                                                 _ => IDecentralandUrlsSource.ORG_DOMAIN,
+                                             };
+
+                hostname = "realm-provider." + realmProviderDomain;
+            }
 
             return hostname;
         }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmUrl/Names/RealmNamesMap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmUrl/Names/RealmNamesMap.cs
@@ -1,5 +1,6 @@
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
+using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Utilities.Extensions;
 using DCL.WebRequests;
 using System;
@@ -11,12 +12,14 @@ namespace Global.Dynamic.RealmUrl.Names
     public class RealmNamesMap : IRealmNamesMap
     {
         private readonly IWebRequestController webRequestController;
+        private readonly IDecentralandUrlsSource decentralandUrlsSource;
         private readonly Dictionary<string, string> cachedUrlToNameDictionary = new ();
         private IReadOnlyList<NodeDTO>? cachedNodes;
 
-        public RealmNamesMap(IWebRequestController webRequestController)
+        public RealmNamesMap(IWebRequestController webRequestController, IDecentralandUrlsSource decentralandUrlsSource)
         {
             this.webRequestController = webRequestController;
+            this.decentralandUrlsSource = decentralandUrlsSource;
         }
 
         public async UniTask<string> UrlFromNameAsync(string name, CancellationToken token)
@@ -38,7 +41,7 @@ namespace Global.Dynamic.RealmUrl.Names
         {
             if (cachedNodes == null)
             {
-                CommonArguments arguments = "https://peer.decentraland.org/lambdas/contracts/servers";
+                CommonArguments arguments = decentralandUrlsSource.Url(DecentralandUrl.Servers);
 
                 cachedNodes = await webRequestController
                                    .GetAsync(arguments, token, ReportCategory.GENERIC_WEB_REQUEST)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/WorldManifestProvider.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/WorldManifestProvider.cs
@@ -1,19 +1,13 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
-using DCL.AssetsProvision;
 using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.DecentralandUrls;
-using DCL.PluginSystem.Global;
 using DCL.WebRequests;
 using ECS;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Linq;
 using System.Threading;
-using UnityEngine;
-using UnityEngine.AddressableAssets;
-using UnityEngine.Scripting;
 
 namespace Global.Dynamic
 {
@@ -21,10 +15,10 @@ namespace Global.Dynamic
     {
         private readonly IWebRequestController webRequestController;
 
-        private static URLAddress ORG_MANIFEST_URL = URLAddress.FromString("https://places-dcf8abb.s3.amazonaws.com/WorldManifest.json");
-        private static URLAddress ZONE_MANIFEST_URL = URLAddress.FromString("https://places-e22845c.s3.us-east-1.amazonaws.com/WorldManifest.json");
+        private static readonly URLAddress ORG_MANIFEST_URL = URLAddress.FromString("https://places-dcf8abb.s3.amazonaws.com/WorldManifest.json");
+        private static readonly URLAddress ZONE_MANIFEST_URL = URLAddress.FromString("https://places-e22845c.s3.us-east-1.amazonaws.com/WorldManifest.json");
         private static readonly string[] MAIN_REALM_NAMES = { "main", "shiva", "hela", "heimdallr", "baldr", "artemis", "loki", "dg", "hephaestus", "unicorn", "marvel", "nftworld" };
-        private const string dclWorldName = "dcl.eth";
+        private const string DCL_WORLD_NAME = "dcl.eth";
 
         private WorldManifest? cachedMainManifest;
 
@@ -37,10 +31,12 @@ namespace Global.Dynamic
         {
             try
             {
-                if(MAIN_REALM_NAMES.Contains(realmName))
-                    return await FetchGenesisManifestAsync(environment, ct);
+                if (MAIN_REALM_NAMES.Contains(realmName))
+                    return GenesisManifestUrl(environment) is { } genesisManifestUrl
+                        ? await FetchGenesisManifestAsync(genesisManifestUrl, ct)
+                        : WorldManifest.Empty;
 
-                if(realmName.EndsWith(dclWorldName))
+                if(realmName.EndsWith(DCL_WORLD_NAME))
                     return await FetchNonGenesisManifestAsync(assetBundleRegistry, realmName, ct);
 
                 //If its not Genesis or world, nothing we can do
@@ -80,17 +76,31 @@ namespace Global.Dynamic
             }
         }
 
-        private async UniTask<WorldManifest> FetchGenesisManifestAsync(DecentralandEnvironment environment, CancellationToken ct)
+        /// <summary>
+        ///     Where the Genesis City manifest lives, or null for an environment that has none. It is a static S3
+        ///     artifact describing decentraland's own Genesis City, so a <c>--base-domain</c> deployment's realms are
+        ///     not that city even when they reuse its realm names — it has no genesis manifest rather than a
+        ///     differently-hosted one, and applying decentraland's would describe the wrong world.
+        /// </summary>
+        private static URLAddress? GenesisManifestUrl(DecentralandEnvironment environment) =>
+            environment switch
+            {
+                DecentralandEnvironment.Org => ORG_MANIFEST_URL,
+                DecentralandEnvironment.Today => ORG_MANIFEST_URL,
+                DecentralandEnvironment.Zone => ZONE_MANIFEST_URL,
+                DecentralandEnvironment.Custom => null,
+                _ => throw new ArgumentOutOfRangeException(nameof(environment), environment, null),
+            };
+
+        private async UniTask<WorldManifest> FetchGenesisManifestAsync(URLAddress manifestUrl, CancellationToken ct)
         {
             try
             {
                 if (cachedMainManifest.HasValue)
                     return cachedMainManifest.Value;
 
-                URLAddress manifestURL = environment == DecentralandEnvironment.Zone ? ZONE_MANIFEST_URL : ORG_MANIFEST_URL;
-
                 string? result = await webRequestController
-                                      .GetAsync(new CommonArguments(manifestURL), ct,
+                                      .GetAsync(new CommonArguments(manifestUrl), ct,
                                            ReportCategory.REALM)
                                       .StoreTextAsync();
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
@@ -239,7 +239,7 @@ namespace Global
             container.ExposedGlobalDataContainer = exposedGlobalDataContainer;
             container.WebRequestsContainer = webRequestsContainer;
             container.PortableExperiencesController = new ECSPortableExperiencesController(web3IdentityProvider, container.WebRequestsContainer.WebRequestController, container.ScenesCache, launchMode, decentralandUrlsSource);
-            container.SmartWearableCache = new SmartWearableCache(webRequestsContainer.WebRequestController);
+            container.SmartWearableCache = new SmartWearableCache(webRequestsContainer.WebRequestController, decentralandUrlsSource);
             container.ImageControllerProvider = new ImageControllerProvider(globalWorld);
 
             container.FeatureFlagsProvider = new HttpFeatureFlagsProvider(container.WebRequestsContainer.WebRequestController);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/RealmLaunchSettingsShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/RealmLaunchSettingsShould.cs
@@ -25,7 +25,7 @@ namespace Global.Tests.EditMode
             realmLaunchSettings.ApplyConfig(applicationParametersParser);
 
             var dclUrlSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, realmLaunchSettings);
-            var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(IWebRequestController.TEST), dclUrlSource);
+            var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(IWebRequestController.TEST, dclUrlSource), dclUrlSource);
 
             Assert.IsTrue(realmLaunchSettings.CurrentMode is LaunchMode.LocalSceneDevelopment);
             Assert.AreEqual("http://127.0.0.1:8000", realmUrls.LocalSceneDevelopmentRealmBlocking()!);
@@ -46,7 +46,7 @@ namespace Global.Tests.EditMode
             realmLaunchSettings.ApplyConfig(applicationParametersParser);
 
             var dclUrlSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, realmLaunchSettings);
-            var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(IWebRequestController.TEST), dclUrlSource);
+            var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(IWebRequestController.TEST, dclUrlSource), dclUrlSource);
 
             Assert.IsFalse(realmLaunchSettings.CurrentMode is LaunchMode.LocalSceneDevelopment);
             Assert.AreEqual("http://127.0.0.1:8000", realmUrls.StartingRealmBlocking());
@@ -141,7 +141,7 @@ namespace Global.Tests.EditMode
             realmLaunchSettings.ApplyConfig(applicationParametersParser);
 
             var dclUrlSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, realmLaunchSettings);
-            var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(IWebRequestController.TEST), dclUrlSource);
+            var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(IWebRequestController.TEST, dclUrlSource), dclUrlSource);
 
             Assert.AreEqual(realm, realmUrls.StartingRealmBlocking());
         }
@@ -161,7 +161,7 @@ namespace Global.Tests.EditMode
             realmLaunchSettings.ApplyConfig(applicationParametersParser);
 
             var dclUrlSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, realmLaunchSettings);
-            var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(IWebRequestController.TEST), dclUrlSource);
+            var realmUrls = new RealmUrls(realmLaunchSettings, new RealmNamesMap(IWebRequestController.TEST, dclUrlSource), dclUrlSource);
 
             Assert.AreEqual($"https://worlds-content-server.decentraland.org/world/{world}", realmUrls.StartingRealmBlocking());
         }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/WorldManifestProviderShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/WorldManifestProviderShould.cs
@@ -1,0 +1,51 @@
+using CommunicationData.URLHelpers;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.WebRequests;
+using ECS;
+using Global.Dynamic;
+using NSubstitute;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Global.Tests.EditMode
+{
+    public class WorldManifestProviderShould
+    {
+        private static readonly URLDomain ASSET_BUNDLE_REGISTRY = URLDomain.FromString("https://asset-bundle-registry.interconnected.online");
+
+        /// <summary>
+        ///     The genesis manifest is decentraland's own static artifact. A --base-domain deployment's realm can carry
+        ///     one of Genesis City's realm names without being that city, so the fetch must not happen at all — issuing
+        ///     it would describe the wrong world rather than merely waste a request.
+        /// </summary>
+        [TestCase("main")]
+        [TestCase("baldr")]
+        public async Task SkipTheGenesisFetchEntirelyForACustomDeployment(string realmName)
+        {
+            IWebRequestController webRequestController = Substitute.For<IWebRequestController>();
+            var provider = new WorldManifestProvider(webRequestController);
+
+            WorldManifest manifest = await provider.FetchWorldManifestAsync(ASSET_BUNDLE_REGISTRY, realmName, DecentralandEnvironment.Custom, CancellationToken.None);
+
+            Assert.IsTrue(manifest.IsEmpty, "a custom deployment has no genesis manifest");
+            CollectionAssert.IsEmpty(webRequestController.ReceivedCalls(), "no request may be issued for it");
+        }
+
+        /// <summary>
+        ///     A realm that is neither a genesis realm nor a world has no manifest in any environment, so this pins the
+        ///     no-request outcome as the shared baseline rather than something specific to a custom deployment.
+        /// </summary>
+        [Test]
+        public async Task SkipTheFetchForARealmThatIsNeitherGenesisNorAWorld()
+        {
+            IWebRequestController webRequestController = Substitute.For<IWebRequestController>();
+            var provider = new WorldManifestProvider(webRequestController);
+
+            WorldManifest manifest = await provider.FetchWorldManifestAsync(ASSET_BUNDLE_REGISTRY, "some-private-catalyst", DecentralandEnvironment.Org, CancellationToken.None);
+
+            Assert.IsTrue(manifest.IsEmpty);
+            CollectionAssert.IsEmpty(webRequestController.ReceivedCalls());
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/WorldManifestProviderShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/WorldManifestProviderShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ccf354ada154290887f573436836367
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/DecentralandEnvironment.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/DecentralandEnvironment.cs
@@ -4,6 +4,13 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
     {
         Org,
         Zone,
-        Today
+        Today,
+
+        /// <summary>
+        ///     A deployment reachable under a base domain other than <c>decentraland.*</c>, selected with the
+        ///     <c>--base-domain</c> app arg. New values must be appended: the enum is serialized by index on
+        ///     <c>MainSceneLoader</c>.
+        /// </summary>
+        Custom,
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/DecentralandUrl.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/DecentralandUrl.cs
@@ -168,5 +168,11 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
         ReferralProgress = 103,
         IntercomTickets = 104,
         IntercomTicketsOrigin = 105,
+
+        /// <summary>
+        ///     The chain RPC proxy, over https and without a chain path: the embedded-wallet path appends one per
+        ///     chain. Same host as <see cref="ApiRpc" />, which the external-wallet path speaks websocket to.
+        /// </summary>
+        ChainRpc = 106,
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/IDecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/IDecentralandUrlsSource.cs
@@ -30,6 +30,21 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
         const string LOCAL_MCP_ENDPOINT_URL = "http://127.0.0.1:{0}/unity-explorer-mcp";
 
         /// <summary>
+        ///     The base domain every backend host of this client sits under: one of <see cref="ORG_DOMAIN" />,
+        ///     <see cref="ZONE_DOMAIN" />, <see cref="TODAY_DOMAIN" /> or, for
+        ///     <see cref="DecentralandEnvironment.Custom" />, the domain supplied via <c>--base-domain</c>.
+        ///     Anything that needs the domain as a value - a host-trust suffix check, a comms hostname - must read
+        ///     it here rather than restate a literal, so a custom deployment is not silently compared against
+        ///     <c>decentraland.*</c>.
+        ///     <para>
+        ///         <see cref="DecentralandEnvironment.Today" /> reports <see cref="ORG_DOMAIN" />: it serves a handful
+        ///         of endpoints from <see cref="TODAY_DOMAIN" />, which are resolved and pinned while the source is
+        ///         built, and everything after that from org.
+        ///     </para>
+        /// </summary>
+        string BaseDomain { get; }
+
+        /// <summary>
         ///     Get a raw url without caching at any moment (without dependency on FF)
         /// </summary>
         public string Probe(DecentralandUrl decentralandUrl);

--- a/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/IDecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/DecentralandUrls/IDecentralandUrlsSource.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace DCL.Multiplayer.Connections.DecentralandUrls
@@ -17,6 +18,24 @@ namespace DCL.Multiplayer.Connections.DecentralandUrls
         // IReadOnlyList, not string[]: the array contents would otherwise be writable by any caller, and these gate
         // host-trust checks (SEC-019/020).
         static readonly IReadOnlyList<string> ALL_DOMAINS = new[] { ORG_DOMAIN, ZONE_DOMAIN, TODAY_DOMAIN };
+
+        /// <summary>
+        ///     Whether <paramref name="host" /> sits strictly below <paramref name="domain" />
+        ///     ("worlds-content-server.decentraland.org" under "decentraland.org"). The '.' boundary check is what
+        ///     rejects lookalikes such as "decentraland.org.attacker.com" and "evil-decentraland.org". Pass a parsed
+        ///     host — this does no url parsing, so a caller handing it an authority could be spoofed through userinfo.
+        /// </summary>
+        static bool IsSubdomainOf(string host, string domain) =>
+            host.Length > domain.Length
+            && host[host.Length - domain.Length - 1] == '.'
+            && host.EndsWith(domain, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        ///     <see cref="IsSubdomainOf" />, plus the domain itself. Use this where the registrable domain is a host in
+        ///     its own right; prefer <see cref="IsSubdomainOf" /> where only subdomains should carry trust.
+        /// </summary>
+        static bool IsHostWithinDomain(string host, string domain) =>
+            string.Equals(host, domain, StringComparison.OrdinalIgnoreCase) || IsSubdomainOf(host, domain);
 
         const string EXPLORER_LATEST_RELEASE_URL = "https://explorer-artifacts.decentraland.org/@dcl/unity-explorer/releases/latest.json";
         const string LAUNCHER_DOWNLOAD_URL = "https://explorer-artifacts.decentraland.org/launcher-rust";

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Chain/CreditsChainConfig.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Chain/CreditsChainConfig.cs
@@ -1,4 +1,5 @@
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using System;
 
 namespace DCL.MarketplaceCredits.Purchase
 {
@@ -43,21 +44,30 @@ namespace DCL.MarketplaceCredits.Purchase
 
         public CreditsChainConfig(DecentralandEnvironment environment)
         {
-            if (environment is DecentralandEnvironment.Org or DecentralandEnvironment.Today)
+            switch (environment)
             {
-                ChainId = POLYGON_CHAIN_ID;
-                ReadonlyNetwork = POLYGON_READONLY_NETWORK;
-                CreditsManagerAddress = POLYGON_CREDITS_MANAGER_ADDRESS;
-                CollectionStoreAddress = POLYGON_COLLECTION_STORE_ADDRESS;
-                OffChainMarketplaceAddress = POLYGON_OFFCHAIN_MARKETPLACE_ADDRESS;
-            }
-            else
-            {
-                ChainId = AMOY_CHAIN_ID;
-                ReadonlyNetwork = AMOY_READONLY_NETWORK;
-                CreditsManagerAddress = AMOY_CREDITS_MANAGER_ADDRESS;
-                CollectionStoreAddress = AMOY_COLLECTION_STORE_ADDRESS;
-                OffChainMarketplaceAddress = AMOY_OFFCHAIN_MARKETPLACE_ADDRESS;
+                case DecentralandEnvironment.Org:
+                case DecentralandEnvironment.Today:
+                    ChainId = POLYGON_CHAIN_ID;
+                    ReadonlyNetwork = POLYGON_READONLY_NETWORK;
+                    CreditsManagerAddress = POLYGON_CREDITS_MANAGER_ADDRESS;
+                    CollectionStoreAddress = POLYGON_COLLECTION_STORE_ADDRESS;
+                    OffChainMarketplaceAddress = POLYGON_OFFCHAIN_MARKETPLACE_ADDRESS;
+                    break;
+
+                // Only decentraland's own production environments run against Polygon mainnet; zone and a
+                // --base-domain deployment stay on Amoy, so an unverified custom deployment is never handed the
+                // mainnet credits contracts.
+                case DecentralandEnvironment.Zone:
+                case DecentralandEnvironment.Custom:
+                    ChainId = AMOY_CHAIN_ID;
+                    ReadonlyNetwork = AMOY_READONLY_NETWORK;
+                    CreditsManagerAddress = AMOY_CREDITS_MANAGER_ADDRESS;
+                    CollectionStoreAddress = AMOY_COLLECTION_STORE_ADDRESS;
+                    OffChainMarketplaceAddress = AMOY_OFFCHAIN_MARKETPLACE_ADDRESS;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(environment), environment, null);
             }
         }
     }

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Chain/CreditsChainConfig.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Chain/CreditsChainConfig.cs
@@ -1,4 +1,4 @@
-using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Web3.Chains;
 using System;
 
 namespace DCL.MarketplaceCredits.Purchase
@@ -42,24 +42,23 @@ namespace DCL.MarketplaceCredits.Purchase
 
         public string CreditsManagerEip712Version => CREDITS_MANAGER_EIP712_VERSION;
 
-        public CreditsChainConfig(DecentralandEnvironment environment)
+        /// <summary>
+        ///     Polygon is the network that pairs with ethereum mainnet and Amoy the one that pairs with sepolia, so
+        ///     the credits contracts follow the resolved <see cref="EthereumNetwork" /> rather than deciding a chain
+        ///     of their own: an identity signed for one chain can never spend against the other's contracts.
+        /// </summary>
+        public CreditsChainConfig(EthereumNetwork ethereumNetwork)
         {
-            switch (environment)
+            switch (ethereumNetwork)
             {
-                case DecentralandEnvironment.Org:
-                case DecentralandEnvironment.Today:
+                case EthereumNetwork.Mainnet:
                     ChainId = POLYGON_CHAIN_ID;
                     ReadonlyNetwork = POLYGON_READONLY_NETWORK;
                     CreditsManagerAddress = POLYGON_CREDITS_MANAGER_ADDRESS;
                     CollectionStoreAddress = POLYGON_COLLECTION_STORE_ADDRESS;
                     OffChainMarketplaceAddress = POLYGON_OFFCHAIN_MARKETPLACE_ADDRESS;
                     break;
-
-                // Only decentraland's own production environments run against Polygon mainnet; zone and a
-                // --base-domain deployment stay on Amoy, so an unverified custom deployment is never handed the
-                // mainnet credits contracts.
-                case DecentralandEnvironment.Zone:
-                case DecentralandEnvironment.Custom:
+                case EthereumNetwork.Sepolia:
                     ChainId = AMOY_CHAIN_ID;
                     ReadonlyNetwork = AMOY_READONLY_NETWORK;
                     CreditsManagerAddress = AMOY_CREDITS_MANAGER_ADDRESS;
@@ -67,7 +66,7 @@ namespace DCL.MarketplaceCredits.Purchase
                     OffChainMarketplaceAddress = AMOY_OFFCHAIN_MARKETPLACE_ADDRESS;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(environment), environment, null);
+                    throw new ArgumentOutOfRangeException(nameof(ethereumNetwork), ethereumNetwork, null);
             }
         }
     }

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsChainConfigShould.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsChainConfigShould.cs
@@ -1,0 +1,51 @@
+﻿using DCL.Web3.Chains;
+using NUnit.Framework;
+
+namespace DCL.MarketplaceCredits.Purchase.Tests
+{
+    [TestFixture]
+    public class CreditsChainConfigShould
+    {
+        // Pinned rather than derived: these are the addresses real money moves through, and the pairing between an
+        // ethereum network and its polygon counterpart is a convention no compiler enforces. Swapping the two arms
+        // of the switch would otherwise ship silently.
+        [Test]
+        public void PairMainnetWithPolygon()
+        {
+            var config = new CreditsChainConfig(EthereumNetwork.Mainnet);
+
+            Assert.AreEqual(137, config.ChainId);
+            Assert.AreEqual("polygon", config.ReadonlyNetwork);
+            Assert.AreEqual("0x8b3a40ca1b6f5cafc99d112a4d02e897d1fd8cc5", config.CreditsManagerAddress);
+            Assert.AreEqual("0x214ffc0f0103735728dc66b61a22e4f163e275ae", config.CollectionStoreAddress);
+            Assert.AreEqual("0xa40b1d129b8906888720686f3a01921ddf37716f", config.OffChainMarketplaceAddress);
+        }
+
+        [Test]
+        public void PairSepoliaWithAmoy()
+        {
+            var config = new CreditsChainConfig(EthereumNetwork.Sepolia);
+
+            Assert.AreEqual(80002, config.ChainId);
+            Assert.AreEqual("amoy", config.ReadonlyNetwork);
+            Assert.AreEqual("0x8052a560e6e6ac86eeb7e711a4497f639b322fb3", config.CreditsManagerAddress);
+            Assert.AreEqual("0xe36abc9ec616c83caaa386541380829106149d68", config.CollectionStoreAddress);
+            Assert.AreEqual("0x1b67d0e31eeb6b52d8eeed71d3616c2f5b33b8e7", config.OffChainMarketplaceAddress);
+        }
+
+        // Every address above has to belong to exactly one of the two networks; sharing one would mean a test chain
+        // pointing at a production contract or the reverse.
+        [Test]
+        public void ShareNoAddressBetweenTheNetworks()
+        {
+            var mainnet = new CreditsChainConfig(EthereumNetwork.Mainnet);
+            var sepolia = new CreditsChainConfig(EthereumNetwork.Sepolia);
+
+            Assert.AreNotEqual(mainnet.ChainId, sepolia.ChainId);
+            Assert.AreNotEqual(mainnet.ReadonlyNetwork, sepolia.ReadonlyNetwork);
+            Assert.AreNotEqual(mainnet.CreditsManagerAddress, sepolia.CreditsManagerAddress);
+            Assert.AreNotEqual(mainnet.CollectionStoreAddress, sepolia.CollectionStoreAddress);
+            Assert.AreNotEqual(mainnet.OffChainMarketplaceAddress, sepolia.OffChainMarketplaceAddress);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsChainConfigShould.cs.meta
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsChainConfigShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ada77e60fa2241a6999940927fd1ddba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsPurchaseServiceShould.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsPurchaseServiceShould.cs
@@ -1,7 +1,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.FeatureFlags;
-using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Web3;
+using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using NSubstitute;
 using NUnit.Framework;
@@ -64,7 +64,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
             metaTxRelayer = Substitute.For<CreditsManagerMetaTxRelayer>(null, null, null, null);
             settlementPoller = Substitute.For<PolygonSettlementPoller>(null, null);
             manaUsdRateReader = Substitute.For<ManaUsdRateReader>(null, null);
-            chainConfig = new CreditsChainConfig(DecentralandEnvironment.Zone);
+            chainConfig = new CreditsChainConfig(EthereumNetwork.Sepolia);
             identityCache = Substitute.For<IWeb3IdentityCache>();
 
             IWeb3Identity identity = Substitute.For<IWeb3Identity>();

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsTradeEncoderShould.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/CreditsTradeEncoderShould.cs
@@ -1,3 +1,4 @@
+using DCL.Web3.Chains;
 using NUnit.Framework;
 using System;
 using System.Globalization;
@@ -466,7 +467,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
         public void BuildMetaTxTypedDataWithCreditsManagerDomain()
         {
             // Arrange
-            var chainConfig = new CreditsChainConfig(DCL.Multiplayer.Connections.DecentralandUrls.DecentralandEnvironment.Zone);
+            var chainConfig = new CreditsChainConfig(EthereumNetwork.Sepolia);
 
             // Act
             string json = CreditsTradeEncoder.BuildMetaTxTypedDataJson(chainConfig, new BigInteger(7), BUYER, "0x1234");

--- a/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/ManaUsdRateReaderShould.cs
+++ b/Explorer/Assets/DCL/MarketplaceCredits/Purchase/Tests/ManaUsdRateReaderShould.cs
@@ -1,6 +1,6 @@
 using Cysharp.Threading.Tasks;
-using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Web3;
+using DCL.Web3.Chains;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NUnit.Framework;
@@ -38,7 +38,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
         public void SetUp()
         {
             ethereumApi = Substitute.For<IEthereumApi>();
-            reader = new ManaUsdRateReader(ethereumApi, new CreditsChainConfig(DecentralandEnvironment.Zone));
+            reader = new ManaUsdRateReader(ethereumApi, new CreditsChainConfig(EthereumNetwork.Sepolia));
             sentCalldata = new List<string>();
 
             answer = MANA_USD_RATE;
@@ -107,7 +107,7 @@ namespace DCL.MarketplaceCredits.Purchase.Tests
         {
             // Arrange: a zero TTL expires every read; the aggregator address and decimals never change, so
             // only latestRoundData goes back on the wire.
-            reader = new ManaUsdRateReader(ethereumApi, new CreditsChainConfig(DecentralandEnvironment.Zone), TimeSpan.Zero);
+            reader = new ManaUsdRateReader(ethereumApi, new CreditsChainConfig(EthereumNetwork.Sepolia), TimeSpan.Zero);
 
             // Act
             await reader.ReadAsync(MARKETPLACE, CancellationToken.None);

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Demo/ArchipelagoFakeIdentityCache.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Demo/ArchipelagoFakeIdentityCache.cs
@@ -2,6 +2,7 @@ using Cysharp.Threading.Tasks;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Web3.Abstract;
 using DCL.Web3.Authenticators;
+using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using System.Threading;
 
@@ -12,7 +13,7 @@ namespace DCL.Multiplayer.Connections.Demo
         public static async UniTask<IWeb3IdentityCache> NewAsync(
             IDecentralandUrlsSource decentralandUrlsSource,
             IWeb3AccountFactory web3AccountFactory,
-            DecentralandEnvironment dclEnvironment
+            EthereumNetwork ethereumNetwork
         )
         {
             IWeb3IdentityCache identityCache = new ProxyIdentityCache(
@@ -21,13 +22,13 @@ namespace DCL.Multiplayer.Connections.Demo
                     new PlayerPrefsIdentityProvider.DecentralandIdentityWithNethereumAccountJsonSerializer(
                         web3AccountFactory
                     ),
-                    dclEnvironment
+                    ethereumNetwork
                 )
             );
 
             if (identityCache.Identity is null)
             {
-                IWeb3Identity? identity = await new DappWeb3EthereumApi.Default(identityCache, decentralandUrlsSource, web3AccountFactory, dclEnvironment)
+                IWeb3Identity? identity = await new DappWeb3EthereumApi.Default(identityCache, decentralandUrlsSource, web3AccountFactory, ethereumNetwork)
                    .LoginAsync(LoginPayload.ForDappFlow(LoginMethod.ANY), CancellationToken.None);
 
                 identityCache.Identity = identity;

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Demo/ArchipelagoRoomPlayground.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Demo/ArchipelagoRoomPlayground.cs
@@ -10,6 +10,7 @@ using DCL.Multiplayer.Connections.Pools;
 using DCL.RealmNavigation;
 using DCL.Utility;
 using DCL.Web3.Accounts.Factory;
+using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using ECS;
 using ECS.Abstract;
@@ -45,7 +46,7 @@ namespace DCL.Multiplayer.Connections.Demo
                 Debug.Log
             );
 
-            IWeb3IdentityCache? identityCache = await ArchipelagoFakeIdentityCache.NewAsync(DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Zone, ILaunchMode.PLAY), new Web3AccountFactory(), DecentralandEnvironment.Zone);
+            IWeb3IdentityCache? identityCache = await ArchipelagoFakeIdentityCache.NewAsync(DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Zone, ILaunchMode.PLAY), new Web3AccountFactory(), EthereumNetwork.Sepolia);
 
             var archipelagoIslandRoom = new ArchipelagoIslandRoom(
                 loonCharacterObject,

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Demo/GateKeeperRoomPlayground.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Demo/GateKeeperRoomPlayground.cs
@@ -13,6 +13,7 @@ using DCL.Time;
 using DCL.Utility;
 using DCL.Utility.Types;
 using DCL.Web3.Accounts.Factory;
+using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using DCL.WebRequests;
 using DCL.WebRequests.Analytics;
@@ -43,7 +44,7 @@ namespace DCL.Multiplayer.Connections.Demo
             var launchMode = ILaunchMode.PLAY;
             var urlsSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Zone, launchMode);
 
-            IWeb3IdentityCache? identityCache = await ArchipelagoFakeIdentityCache.NewAsync(urlsSource, new Web3AccountFactory(), DecentralandEnvironment.Zone);
+            IWeb3IdentityCache? identityCache = await ArchipelagoFakeIdentityCache.NewAsync(urlsSource, new Web3AccountFactory(), EthereumNetwork.Sepolia);
             var character = new ExposedTransform();
             var totalBudget = 15;
 

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Demo/LocalSceneDevelopmentPlayground.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Demo/LocalSceneDevelopmentPlayground.cs
@@ -13,6 +13,7 @@ using DCL.Time;
 using DCL.Utility;
 using DCL.Utility.Types;
 using DCL.Web3.Accounts.Factory;
+using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using DCL.WebRequests;
 using DCL.WebRequests.Analytics;
@@ -42,7 +43,7 @@ namespace DCL.Multiplayer.Connections.Demo
             var launchMode = ILaunchMode.LOCAL_SCENE_DEVELOPMENT;
             var urlsSource = DecentralandUrlsSource.CreateForTest(DecentralandEnvironment.Org, launchMode);
 
-            IWeb3IdentityCache? identityCache = await ArchipelagoFakeIdentityCache.NewAsync(urlsSource, new Web3AccountFactory(), DecentralandEnvironment.Org);
+            IWeb3IdentityCache? identityCache = await ArchipelagoFakeIdentityCache.NewAsync(urlsSource, new Web3AccountFactory(), EthereumNetwork.Mainnet);
             var totalBudget = 15;
             var webRequests = new WebRequestController(new WebRequestsAnalyticsContainer(null, null), identityCache, new RequestHub(urlsSource), new WebRequestBudget(totalBudget, new ElementBinding<ulong>((ulong)totalBudget)), new RealmClock());
 

--- a/Explorer/Assets/DCL/Navmap/PlaceElementView.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceElementView.cs
@@ -37,6 +37,7 @@ namespace DCL.Navmap
         public GameObject LiveContainer { get; private set; }
 
         private ImageController? imageController;
+        private Sprite? placeholderImage;
 
         public Vector2Int coords;
 
@@ -46,11 +47,14 @@ namespace DCL.Navmap
 
         public void ConfigurePlaceImageController(ImageControllerProvider imageControllerProvider)
         {
+            // The prefab authors the placeholder thumbnail on the image itself; capture it before the first request
+            // overwrites it, so a place carrying no thumbnail url still shows something.
+            placeholderImage = placeImage.ImageSprite;
             imageController = imageControllerProvider.Create(placeImage);
         }
 
         public void SetPlaceImage(string imageUrl) =>
-            imageController?.RequestImage(imageUrl, true);
+            imageController?.RequestImage(imageUrl, true, defaultSprite: placeholderImage);
 
         public void OnPointerEnter(PointerEventData eventData)
         {

--- a/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/PlaceInfoPanelController.cs
@@ -46,6 +46,7 @@ namespace DCL.Navmap
         private readonly GalleryEventBus? galleryEventBus;
         private readonly HomePlaceEventBus homePlaceEventBus;
         private readonly ImageController? thumbnailImage;
+        private readonly Sprite? thumbnailPlaceholder;
         private readonly MultiStateButtonController dislikeButton;
         private readonly MultiStateButtonController likeButton;
         private readonly MultiStateButtonController? homeButton;
@@ -98,6 +99,9 @@ namespace DCL.Navmap
             this.homePlaceEventBus = homePlaceEventBus;
             this.donationsService = donationsService;
 
+            // The prefab authors the placeholder thumbnail on the image itself; capture it before the first request
+            // overwrites it, so a place carrying no thumbnail url still shows something.
+            thumbnailPlaceholder = view.Thumbnail.ImageSprite;
             thumbnailImage = imageControllerProvider.Create(view.Thumbnail);
 
             if (view.CameraReelGalleryView != null)
@@ -188,7 +192,7 @@ namespace DCL.Navmap
             else
                 currentBaseParcel = null;
 
-            thumbnailImage?.RequestImage(placeInfo.image);
+            thumbnailImage?.RequestImage(placeInfo.image, defaultSprite: thumbnailPlaceholder);
             view.PlaceNameLabel.text = placeInfo.title;
             view.CreatorNameLabel.text = $"created by <b>{placeInfo.contact_name}</b>";
             view.LikeRateLabel.text = $"{(placeInfo.LikeRateAsFloat ?? 0) * 100:F0}%";

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -31,18 +31,31 @@ namespace DCL.Browser.DecentralandUrls
             FeatureFlagsDependent = 2,
         }
 
-        protected const string ENV = "{ENV}";
         private const string SCENE_ADAPTER_PATH = "/get-scene-adapter";
 
-        private static readonly string FEATURE_FLAGS_RAW_URL = $"https://feature-flags.decentraland.{ENV}";
+        // The pre-login whitelist fetch resolves this host statically, before any instance exists
+        // (see GetFeatureFlagsUrl), so the subdomain is shared rather than the whole url.
+        private const string FEATURE_FLAGS_SUBDOMAIN = "feature-flags";
+
+        // A base domain feeds host-trust checks, so anything that could turn it into a different authority
+        // (scheme, userinfo, port, path) is rejected rather than silently accepted.
+        private static readonly char[] BASE_DOMAIN_FORBIDDEN_CHARS = { '/', ':', '@', '?', '#', ' ', '\t' };
 
         private readonly Dictionary<DecentralandUrl, UrlData> cache = new ();
         private readonly IRealmData realmData;
         private readonly ILaunchMode launchMode;
-        private readonly string decentralandDomain;
+        private readonly DecentralandEnvironment environment;
         private readonly string? gatekeeperBaseOverride;
         private readonly string? optimizedAssetsBaseOverride;
         private readonly bool isTodayEnvironment;
+
+        /// <summary>
+        ///     The domain <see cref="RawUrl" /> composes every host from. Written only by the constructor — the today
+        ///     environment resolves the handful of hosts it serves from <c>.today</c> and then moves to org for
+        ///     everything resolved afterwards, which is why urls must stay lazily resolved — so it is settled by the
+        ///     time the instance is handed out.
+        /// </summary>
+        public string BaseDomain { get; private set; }
 
         public DecentralandUrlsSource(
             DecentralandEnvironment environment,
@@ -51,9 +64,11 @@ namespace DCL.Browser.DecentralandUrls
             GatekeeperMode gatekeeperMode = GatekeeperMode.Org,
             string customGatekeeperUrl = "",
             string? cliGatekeeperUrl = null,
-            string? cliOptimizedAssetsUrl = null)
+            string? cliOptimizedAssetsUrl = null,
+            string? customBaseDomain = null)
         {
-            decentralandDomain = environment.ToString()!.ToLower();
+            this.environment = environment;
+            BaseDomain = ResolveBaseDomain(environment, customBaseDomain);
             isTodayEnvironment = environment == DecentralandEnvironment.Today;
             this.realmData = realmData;
             this.launchMode = launchMode;
@@ -88,10 +103,44 @@ namespace DCL.Browser.DecentralandUrls
                 Url(DecentralandUrl.BannedUsers);
                 Url(DecentralandUrl.SceneAdmins);
                 Url(DecentralandUrl.RemotePeers);
-                decentralandDomain = nameof(DecentralandEnvironment.Org).ToLower();
+                BaseDomain = IDecentralandUrlsSource.ORG_DOMAIN;
             }
 
             realmData.RealmType.OnUpdate += ResetRealmDependentUrls;
+        }
+
+        /// <summary>
+        ///     The single place the client's base domain is decided. <see cref="DecentralandEnvironment.Custom" /> is
+        ///     the only environment whose domain is not derived from its own name, and the only one that accepts
+        ///     <paramref name="customBaseDomain" />: pairing a base domain with any other environment is a wiring
+        ///     mistake that would leave the client on <c>decentraland.*</c>, so it throws instead of being ignored.
+        /// </summary>
+        public static string ResolveBaseDomain(DecentralandEnvironment environment, string? customBaseDomain)
+        {
+            string? normalized = NormalizeBaseDomain(customBaseDomain);
+
+            if (environment == DecentralandEnvironment.Custom)
+                return normalized ?? throw new ArgumentException($"{nameof(DecentralandEnvironment)}.{nameof(DecentralandEnvironment.Custom)} requires a base domain", nameof(customBaseDomain));
+
+            if (normalized != null)
+                throw new ArgumentException($"A custom base domain ('{normalized}') only applies to {nameof(DecentralandEnvironment)}.{nameof(DecentralandEnvironment.Custom)}, not {environment}", nameof(customBaseDomain));
+
+            return $"decentraland.{environment.ToString()!.ToLower()}";
+        }
+
+        /// <summary>
+        ///     Only a bare registrable domain is accepted - no scheme, userinfo, port or path - because the value
+        ///     becomes a host-trust suffix. Null / blank means "not supplied".
+        /// </summary>
+        private static string? NormalizeBaseDomain(string? customBaseDomain)
+        {
+            if (customBaseDomain?.Trim().Trim('.') is not { Length: > 0 } domain)
+                return null;
+
+            if (domain.IndexOfAny(BASE_DOMAIN_FORBIDDEN_CHARS) >= 0)
+                throw new ArgumentException($"'{domain}' is not a bare domain: a base domain carries no scheme, userinfo, port or path", nameof(customBaseDomain));
+
+            return domain;
         }
 
         private static string? ResolveGatekeeperOverride(GatekeeperMode mode, string customUrl, string? cliOverride, out string source)
@@ -124,18 +173,16 @@ namespace DCL.Browser.DecentralandUrls
         public static DecentralandUrlsSource CreateForTest(DecentralandEnvironment environment, ILaunchMode launchMode) =>
             new (environment, new IRealmData.Fake(), launchMode);
 
+        public static DecentralandUrlsSource CreateForTest(string customBaseDomain, ILaunchMode launchMode) =>
+            new (DecentralandEnvironment.Custom, new IRealmData.Fake(), launchMode, customBaseDomain: customBaseDomain);
+
         public string Probe(DecentralandUrl decentralandUrl)
         {
             if (cache.TryGetValue(decentralandUrl, out UrlData cached))
                 return cached.Url!;
 
-            UrlData rawUrl = RawUrl(decentralandUrl);
-
-            return Probe(rawUrl.ToString(), decentralandDomain);
+            return RawUrl(decentralandUrl).ToString();
         }
-
-        private static string Probe(string rawUrl, string environment) =>
-            rawUrl.Replace(ENV, environment);
 
         public string Url(DecentralandUrl decentralandUrl)
         {
@@ -155,7 +202,7 @@ namespace DCL.Browser.DecentralandUrls
                         return urlData.Url ?? FEATURE_FLAG_DEPENDENT;
 
                     default:
-                        urlData = new UrlData(urlData.Caching, urlData.Url!.Replace(ENV, decentralandDomain));
+                        // RawUrl already composed the host from BaseDomain, so there is nothing left to substitute.
                         cache[decentralandUrl] = urlData;
                         break;
                 }
@@ -193,7 +240,7 @@ namespace DCL.Browser.DecentralandUrls
 
         /// <summary>
         ///     The "--optimized-assets-url" arg or the flag variant payload override the base url, otherwise
-        ///     https://abcdn.decentraland.{ENV}. FeatureFlagsDependent means it is re-resolved (not cached) until flags load.
+        ///     https://abcdn.{BaseDomain}. FeatureFlagsDependent means it is re-resolved (not cached) until flags load.
         /// </summary>
         private UrlData ResolveOptimizedAssetsUrl(string dedicatedHostUrl)
         {
@@ -204,8 +251,8 @@ namespace DCL.Browser.DecentralandUrls
 
             if (featureFlags.IsEmpty)
                 return isTodayEnvironment
-                    ? dedicatedHostUrl // Static — pinned on construction before the domain switches to org
-                    : new UrlData(CacheBehaviour.FeatureFlagsDependent, dedicatedHostUrl.Replace(ENV, decentralandDomain));
+                    ? dedicatedHostUrl // Static — pinned on construction, before the host domain switches to org
+                    : new UrlData(CacheBehaviour.FeatureFlagsDependent, dedicatedHostUrl);
 
             if (!featureFlags.IsEnabled(FeatureFlagsStrings.OPTIMIZED_ASSETS))
                 return dedicatedHostUrl;
@@ -213,115 +260,121 @@ namespace DCL.Browser.DecentralandUrls
             if (featureFlags.TryGetTextPayload(FeatureFlagsStrings.OPTIMIZED_ASSETS, FeatureFlagsStrings.OPTIMIZED_ASSETS_BASE_URL_VARIANT, out string? customBaseUrl) && customBaseUrl is { Length: > 0 })
                 return new UrlData(CacheBehaviour.FeatureFlagsDependent, customBaseUrl.TrimEnd('/'));
 
-            return new UrlData(CacheBehaviour.FeatureFlagsDependent, $"https://abcdn.decentraland.{ENV}");
+            return new UrlData(CacheBehaviour.FeatureFlagsDependent, $"https://abcdn.{BaseDomain}");
         }
 
         /// <summary>Registry-composed endpoints inherit the registry base's caching so a flag-driven base is not cached early.</summary>
         private UrlData ComposeRegistryUrl(string path) =>
             new (RawUrl(DecentralandUrl.AssetBundleRegistry).Caching, $"{Url(DecentralandUrl.AssetBundleRegistry)}{path}");
 
-        public static string GetFeatureFlagsUrl(DecentralandEnvironment env) =>
-            Probe(FEATURE_FLAGS_RAW_URL, env.ToString().ToLower());
+        /// <summary>
+        ///     Composes the feature-flags host before any instance exists (the pre-login whitelist fetch), from the
+        ///     same <see cref="ResolveBaseDomain" /> decision the instance uses, so the two cannot diverge.
+        /// </summary>
+        public static string GetFeatureFlagsUrl(DecentralandEnvironment env, string? customBaseDomain = null) =>
+            $"https://{FEATURE_FLAGS_SUBDOMAIN}.{ResolveBaseDomain(env, customBaseDomain)}";
 
         protected virtual UrlData RawUrl(DecentralandUrl decentralandUrl) =>
             decentralandUrl switch
             {
-                DecentralandUrl.SupportLink => $"https://decentraland.{ENV}/help/",
+                DecentralandUrl.SupportLink => $"https://{BaseDomain}/help/",
                 DecentralandUrl.DiscordDirectLink => "https://discord.gg/decentraland",
                 DecentralandUrl.TwitterLink => "https://x.com/decentraland",
                 DecentralandUrl.TwitterNewPostLink => "https://twitter.com/intent/tweet?text={0}&hashtags={1}&url={2}",
                 DecentralandUrl.NewsletterSubscriptionLink => "https://decentraland.beehiiv.com/?utm_org=dcl&utm_source=client&utm_medium=organic&utm_campaign=marketplacecredits&utm_term=trialend",
-                DecentralandUrl.MarketplaceLink => $"https://decentraland.{ENV}/marketplace",
-                DecentralandUrl.ShopLink => $"https://decentraland.{ENV}/shop",
-                DecentralandUrl.MarketplaceServer => $"https://marketplace-api.decentraland.{ENV}",
-                DecentralandUrl.PrivacyPolicy => $"https://decentraland.{ENV}/privacy",
-                DecentralandUrl.TermsOfUse => $"https://decentraland.{ENV}/terms",
-                DecentralandUrl.ContentPolicy => $"https://decentraland.{ENV}/content",
-                DecentralandUrl.CodeOfEthics => $"https://decentraland.{ENV}/ethics",
-                DecentralandUrl.ApiPlaces => $"https://places.decentraland.{ENV}/api/places",
-                DecentralandUrl.ApiWorlds => $"https://places.decentraland.{ENV}/api/worlds",
-                DecentralandUrl.ApiDestinations => $"https://places.decentraland.{ENV}/api/destinations",
-                DecentralandUrl.ApiAuth => $"https://auth-api.decentraland.{ENV}",
-                DecentralandUrl.ApiRpc => $"wss://rpc.decentraland.{ENV}",
-                DecentralandUrl.MetaTransactionServer => $"https://transactions-api.decentraland.{ENV}/v1/transactions",
-                DecentralandUrl.AuthSignatureWebApp => $"https://decentraland.{ENV}/auth/requests",
-                DecentralandUrl.BuilderApiDtos => $"https://builder-api.decentraland.{ENV}/v1/collections/[COL-ID]/items",
-                DecentralandUrl.BuilderApiContent => $"https://builder-api.decentraland.{ENV}/v1/storage/contents/",
-                DecentralandUrl.BuilderApiNewsletter => $"https://builder-api.decentraland.{ENV}/v1/newsletter",
-                DecentralandUrl.POI => $"https://dcl-lists.decentraland.{ENV}/pois",
-                DecentralandUrl.Map => $"https://places.decentraland.{ENV}/api/map",
-                DecentralandUrl.ContentModerationReport => $"https://places.decentraland.{ENV}/api/report",
-                DecentralandUrl.Gatekeeper => ResolveGatekeeperBaseUrl($"https://comms-gatekeeper.decentraland.{ENV}"),
+                DecentralandUrl.MarketplaceLink => $"https://{BaseDomain}/marketplace",
+                DecentralandUrl.ShopLink => $"https://{BaseDomain}/shop",
+                DecentralandUrl.MarketplaceServer => $"https://marketplace-api.{BaseDomain}",
+                DecentralandUrl.PrivacyPolicy => $"https://{BaseDomain}/privacy",
+                DecentralandUrl.TermsOfUse => $"https://{BaseDomain}/terms",
+                DecentralandUrl.ContentPolicy => $"https://{BaseDomain}/content",
+                DecentralandUrl.CodeOfEthics => $"https://{BaseDomain}/ethics",
+                DecentralandUrl.ApiPlaces => $"https://places.{BaseDomain}/api/places",
+                DecentralandUrl.ApiWorlds => $"https://places.{BaseDomain}/api/worlds",
+                DecentralandUrl.ApiDestinations => $"https://places.{BaseDomain}/api/destinations",
+                DecentralandUrl.ApiAuth => $"https://auth-api.{BaseDomain}",
+                DecentralandUrl.ApiRpc => $"wss://rpc.{BaseDomain}",
+                DecentralandUrl.MetaTransactionServer => $"https://transactions-api.{BaseDomain}/v1/transactions",
+                DecentralandUrl.AuthSignatureWebApp => $"https://{BaseDomain}/auth/requests",
+                DecentralandUrl.BuilderApiDtos => $"https://builder-api.{BaseDomain}/v1/collections/[COL-ID]/items",
+                DecentralandUrl.BuilderApiContent => $"https://builder-api.{BaseDomain}/v1/storage/contents/",
+                DecentralandUrl.BuilderApiNewsletter => $"https://builder-api.{BaseDomain}/v1/newsletter",
+                DecentralandUrl.POI => $"https://dcl-lists.{BaseDomain}/pois",
+                DecentralandUrl.Map => $"https://places.{BaseDomain}/api/map",
+                DecentralandUrl.ContentModerationReport => $"https://places.{BaseDomain}/api/report",
+                DecentralandUrl.Gatekeeper => ResolveGatekeeperBaseUrl($"https://comms-gatekeeper.{BaseDomain}"),
                 DecentralandUrl.GateKeeperSceneAdapter => $"{RawUrl(DecentralandUrl.Gatekeeper).Url!}{SCENE_ADAPTER_PATH}",
-                DecentralandUrl.LocalGateKeeperSceneAdapter => $"{ResolveGatekeeperBaseUrl("https://comms-gatekeeper-local." + IDecentralandUrlsSource.ORG_DOMAIN)}{SCENE_ADAPTER_PATH}",
+                // The local gatekeeper is pinned to org for the decentraland environments (that is where it runs);
+                // a custom deployment runs its own, so it resolves against the base domain instead of reaching for org.
+                DecentralandUrl.LocalGateKeeperSceneAdapter => $"{ResolveGatekeeperBaseUrl("https://comms-gatekeeper-local." + (environment == DecentralandEnvironment.Custom ? BaseDomain : IDecentralandUrlsSource.ORG_DOMAIN))}{SCENE_ADAPTER_PATH}",
                 DecentralandUrl.ChatAdapter => $"{RawUrl(DecentralandUrl.Gatekeeper).Url!}/private-messages/token",
-                DecentralandUrl.ApiEvents => $"https://events.decentraland.{ENV}/api/events",
-                DecentralandUrl.WhatsOnNewEventLink => $"https://decentraland.{ENV}/whats-on/new-event",
-                DecentralandUrl.WhatsOnEventLink => $"https://decentraland.{ENV}/whats-on/?id={{0}}",
-                DecentralandUrl.OpenSea => $"https://opensea.decentraland.{ENV}",
-                DecentralandUrl.Host => $"https://decentraland.{ENV}",
-                DecentralandUrl.ApiChunks => $"https://api.decentraland.{ENV}/v1/map.png",
-                DecentralandUrl.PeerAbout => $"https://peer.decentraland.{ENV}/about",
-                DecentralandUrl.PeerContent => $"https://peer.decentraland.{ENV}/content/contents",
-                DecentralandUrl.RemotePeers => $"https://archipelago-ea-stats.decentraland.{ENV}/comms/peers",
-                DecentralandUrl.RemotePeersWorld => $"https://worlds-content-server.decentraland.{ENV}/wallet/[USER-ID]/connected-world",
-                DecentralandUrl.DAO => $"https://decentraland.{ENV}/dao/",
-                DecentralandUrl.FeatureFlags => FEATURE_FLAGS_RAW_URL,
-                DecentralandUrl.Help => $"https://decentraland.{ENV}/help/",
-                DecentralandUrl.Faqs => $"https://docs.decentraland.{ENV}/faqs/decentraland-101",
-                DecentralandUrl.Discord => $"https://decentraland.{ENV}/discord/",
-                DecentralandUrl.Account => $"https://decentraland.{ENV}/account/",
-                DecentralandUrl.MinimumSpecs => $"https://docs.decentraland.{ENV}/player/FAQs/decentraland-101/#what-hardware-do-i-need-to-run-decentraland",
-                DecentralandUrl.Market => $"https://market.decentraland.{ENV}",
-                DecentralandUrl.AssetBundlesCDN => ResolveOptimizedAssetsUrl($"https://ab-cdn.decentraland.{ENV}"),
-                DecentralandUrl.LodGeneratorCDN => ResolveOptimizedAssetsUrl($"https://lod-generator-unity-cdn.decentraland.{ENV}"),
-                DecentralandUrl.ArchipelagoStatus => $"https://archipelago-ea-stats.decentraland.{ENV}/status",
-                DecentralandUrl.ArchipelagoHotScenes => $"https://archipelago-ea-stats.decentraland.{ENV}/hot-scenes",
+                DecentralandUrl.ApiEvents => $"https://events.{BaseDomain}/api/events",
+                DecentralandUrl.WhatsOnNewEventLink => $"https://{BaseDomain}/whats-on/new-event",
+                DecentralandUrl.WhatsOnEventLink => $"https://{BaseDomain}/whats-on/?id={{0}}",
+                DecentralandUrl.OpenSea => $"https://opensea.{BaseDomain}",
+                DecentralandUrl.Host => $"https://{BaseDomain}",
+                DecentralandUrl.ApiChunks => $"https://api.{BaseDomain}/v1/map.png",
+                DecentralandUrl.PeerAbout => $"https://peer.{BaseDomain}/about",
+                DecentralandUrl.PeerContent => $"https://peer.{BaseDomain}/content/contents",
+                DecentralandUrl.RemotePeers => $"https://archipelago-ea-stats.{BaseDomain}/comms/peers",
+                DecentralandUrl.RemotePeersWorld => $"https://worlds-content-server.{BaseDomain}/wallet/[USER-ID]/connected-world",
+                DecentralandUrl.DAO => $"https://{BaseDomain}/dao/",
+                DecentralandUrl.FeatureFlags => $"https://{FEATURE_FLAGS_SUBDOMAIN}.{BaseDomain}",
+                DecentralandUrl.Help => $"https://{BaseDomain}/help/",
+                DecentralandUrl.Faqs => $"https://docs.{BaseDomain}/faqs/decentraland-101",
+                DecentralandUrl.Discord => $"https://{BaseDomain}/discord/",
+                DecentralandUrl.Account => $"https://{BaseDomain}/account/",
+                DecentralandUrl.MinimumSpecs => $"https://docs.{BaseDomain}/player/FAQs/decentraland-101/#what-hardware-do-i-need-to-run-decentraland",
+                DecentralandUrl.Market => $"https://market.{BaseDomain}",
+                DecentralandUrl.AssetBundlesCDN => ResolveOptimizedAssetsUrl($"https://ab-cdn.{BaseDomain}"),
+                DecentralandUrl.LodGeneratorCDN => ResolveOptimizedAssetsUrl($"https://lod-generator-unity-cdn.{BaseDomain}"),
+                DecentralandUrl.ArchipelagoStatus => $"https://archipelago-ea-stats.{BaseDomain}/status",
+                DecentralandUrl.ArchipelagoHotScenes => $"https://archipelago-ea-stats.{BaseDomain}/hot-scenes",
                 DecentralandUrl.GatekeeperStatus => $"{RawUrl(DecentralandUrl.Gatekeeper).Url!}/status",
-                DecentralandUrl.Genesis => $"https://realm-provider-ea.decentraland.{ENV}/main",
-                DecentralandUrl.Badges => $"https://badges.decentraland.{ENV}",
-                DecentralandUrl.CameraReelUsers => $"https://camera-reel-service.decentraland.{ENV}/api/users",
-                DecentralandUrl.CameraReelImages => $"https://camera-reel-service.decentraland.{ENV}/api/images",
-                DecentralandUrl.CameraReelPlaces => $"https://camera-reel-service.decentraland.{ENV}/api/places",
-                DecentralandUrl.CameraReelLink => $"https://reels.decentraland.{ENV}",
-                DecentralandUrl.Blocklist => $"https://config.decentraland.{ENV}/denylist.json",
-                DecentralandUrl.ApiFriends => $"wss://rpc-social-service-ea.decentraland.{ENV}",
-                DecentralandUrl.AssetBundleRegistry => ResolveOptimizedAssetsUrl($"https://asset-bundle-registry.decentraland.{ENV}"),
+                DecentralandUrl.Genesis => $"https://realm-provider-ea.{BaseDomain}/main",
+                DecentralandUrl.Badges => $"https://badges.{BaseDomain}",
+                DecentralandUrl.CameraReelUsers => $"https://camera-reel-service.{BaseDomain}/api/users",
+                DecentralandUrl.CameraReelImages => $"https://camera-reel-service.{BaseDomain}/api/images",
+                DecentralandUrl.CameraReelPlaces => $"https://camera-reel-service.{BaseDomain}/api/places",
+                DecentralandUrl.CameraReelLink => $"https://reels.{BaseDomain}",
+                DecentralandUrl.Blocklist => $"https://config.{BaseDomain}/denylist.json",
+                DecentralandUrl.ApiFriends => $"wss://rpc-social-service-ea.{BaseDomain}",
+                DecentralandUrl.AssetBundleRegistry => ResolveOptimizedAssetsUrl($"https://asset-bundle-registry.{BaseDomain}"),
 
                 DecentralandUrl.AssetBundleRegistryVersion => ComposeRegistryUrl("/entities/versions"),
-                DecentralandUrl.MarketplaceClaimName => $"https://decentraland.{ENV}/marketplace/names/claim",
-                DecentralandUrl.WorldPermissions => $"https://worlds-content-server.decentraland.{ENV}/world/{{0}}/permissions",
-                DecentralandUrl.WorldComms => $"https://worlds-content-server.decentraland.{ENV}/worlds/{{0}}/comms",
-                DecentralandUrl.WorldServer => $"https://worlds-content-server.decentraland.{ENV}/world",
-                DecentralandUrl.WorldContentServer => $"https://worlds-content-server.decentraland.{ENV}/contents/",
-                DecentralandUrl.Servers => $"https://peer.decentraland.{ENV}/lambdas/contracts/servers",
-                DecentralandUrl.MediaConverter => $"https://metamorph-api.decentraland.{ENV}/convert?url={{0}}",
-                DecentralandUrl.MarketplaceCredits => $"https://credits.decentraland.{ENV}",
-                DecentralandUrl.GoShoppingWithMarketplaceCredits => $"https://decentraland.{ENV}/marketplace/browse?sortBy=newest&status=on_sale&withCredits=true",
-                DecentralandUrl.Notifications => $"https://notifications.decentraland.{ENV}",
-                DecentralandUrl.Communities => $"https://social-api.decentraland.{ENV}/v1/communities",
-                DecentralandUrl.CommunitiesV2 => $"https://social-api.decentraland.{ENV}/v2/communities",
-                DecentralandUrl.ReferralProgress => $"https://social-api.decentraland.{ENV}/v1/referral-progress",
-                DecentralandUrl.CommunityThumbnail => $"https://assets-cdn.decentraland.{ENV}/social/communities/{{0}}/raw-thumbnail.png",
-                DecentralandUrl.Members => $"https://social-api.decentraland.{ENV}/v1/members",
-                DecentralandUrl.MembersV2 => $"https://social-api.decentraland.{ENV}/v2/members",
-                DecentralandUrl.CommunityProfileLink => $"https://decentraland.{ENV}/social/communities/{{0}}?utm_org=dcl&utm_source=explorer&utm_medium=organic&utm_campaign=communities",
+                DecentralandUrl.MarketplaceClaimName => $"https://{BaseDomain}/marketplace/names/claim",
+                DecentralandUrl.WorldPermissions => $"https://worlds-content-server.{BaseDomain}/world/{{0}}/permissions",
+                DecentralandUrl.WorldComms => $"https://worlds-content-server.{BaseDomain}/worlds/{{0}}/comms",
+                DecentralandUrl.WorldServer => $"https://worlds-content-server.{BaseDomain}/world",
+                DecentralandUrl.WorldContentServer => $"https://worlds-content-server.{BaseDomain}/contents/",
+                DecentralandUrl.Servers => $"https://peer.{BaseDomain}/lambdas/contracts/servers",
+                DecentralandUrl.MediaConverter => $"https://metamorph-api.{BaseDomain}/convert?url={{0}}",
+                DecentralandUrl.MarketplaceCredits => $"https://credits.{BaseDomain}",
+                DecentralandUrl.GoShoppingWithMarketplaceCredits => $"https://{BaseDomain}/marketplace/browse?sortBy=newest&status=on_sale&withCredits=true",
+                DecentralandUrl.Notifications => $"https://notifications.{BaseDomain}",
+                DecentralandUrl.Communities => $"https://social-api.{BaseDomain}/v1/communities",
+                DecentralandUrl.CommunitiesV2 => $"https://social-api.{BaseDomain}/v2/communities",
+                DecentralandUrl.ReferralProgress => $"https://social-api.{BaseDomain}/v1/referral-progress",
+                DecentralandUrl.CommunityThumbnail => $"https://assets-cdn.{BaseDomain}/social/communities/{{0}}/raw-thumbnail.png",
+                DecentralandUrl.Members => $"https://social-api.{BaseDomain}/v1/members",
+                DecentralandUrl.MembersV2 => $"https://social-api.{BaseDomain}/v2/members",
+                DecentralandUrl.CommunityProfileLink => $"https://{BaseDomain}/social/communities/{{0}}?utm_org=dcl&utm_source=explorer&utm_medium=organic&utm_campaign=communities",
                 DecentralandUrl.DecentralandWorlds => "https://decentraland.org/blog/about-decentraland/decentraland-worldsTake -your-own-virtual-space?utm_org=dcl&utm_source=explorer&utm_medium=organic",
-                DecentralandUrl.ChatTranslate => $"https://autotranslate-server.decentraland.{ENV}/translate",
-                DecentralandUrl.ActiveCommunityVoiceChats => $"https://social-api.decentraland.{ENV}/v1/community-voice-chats/active",
-                DecentralandUrl.Support => $"https://docs.decentraland.{ENV}/player/support/",
-                DecentralandUrl.CreatorHub => $"https://decentraland.{ENV}/create/",
+                DecentralandUrl.ChatTranslate => $"https://autotranslate-server.{BaseDomain}/translate",
+                DecentralandUrl.ActiveCommunityVoiceChats => $"https://social-api.{BaseDomain}/v1/community-voice-chats/active",
+                DecentralandUrl.Support => $"https://docs.{BaseDomain}/player/support/",
+                DecentralandUrl.CreatorHub => $"https://{BaseDomain}/create/",
                 DecentralandUrl.ManaUsdRateApiUrl => "https://api.coingecko.com/api/v3/simple/price?ids=decentraland&vs_currencies=usd",
-                DecentralandUrl.JumpInGenesisCityLink => $"https://decentraland.{ENV}/jump/?position={{0}},{{1}}",
-                DecentralandUrl.JumpInWorldLink => $"https://decentraland.{ENV}/jump/?realm={{0}}",
-                DecentralandUrl.ReportUserForm => $"https://decentraland.{ENV}/report/players?player_address={{0}}&reported_address={{1}}",
+                DecentralandUrl.JumpInGenesisCityLink => $"https://{BaseDomain}/jump/?position={{0}},{{1}}",
+                DecentralandUrl.JumpInWorldLink => $"https://{BaseDomain}/jump/?realm={{0}}",
+                DecentralandUrl.ReportUserForm => $"https://{BaseDomain}/report/players?player_address={{0}}&reported_address={{1}}",
                 DecentralandUrl.BannedUsers => $"{RawUrl(DecentralandUrl.Gatekeeper).Url!}/users/{{0}}/bans",
                 DecentralandUrl.SceneAdmins => $"{RawUrl(DecentralandUrl.Gatekeeper).Url!}/scene-admin",
-                DecentralandUrl.Pulse => $"pulse-server.decentraland.{ENV}",
+                DecentralandUrl.Pulse => $"pulse-server.{BaseDomain}",
 
                 DecentralandUrl.Profiles => ComposeRegistryUrl("/profiles"),
                 DecentralandUrl.ProfilesMetadata => ComposeRegistryUrl("/profiles/metadata"),
-                DecentralandUrl.WorldCommsAdapter => $"https://worlds-content-server.decentraland.{ENV}/worlds/{{0}}/scenes/{{1}}/comms",
+                DecentralandUrl.WorldCommsAdapter => $"https://worlds-content-server.{BaseDomain}/worlds/{{0}}/scenes/{{1}}/comms",
 
                 DecentralandUrl.EntitiesActive => UrlData.RealmDependent(FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.ASSET_BUNDLE_FALLBACK) && launchMode.CurrentMode != LaunchMode.LocalSceneDevelopment ? $"{Url(DecentralandUrl.AssetBundleRegistry)}/entities/active" :
                     realmData.Configured ? realmData.Ipfs.EntitiesActiveEndpoint.Value : null),
@@ -336,11 +389,11 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.Lambdas => UrlData.RealmDependent(realmData.Configured ? realmData.Ipfs.LambdasBaseUrl.Value : null),
                 DecentralandUrl.Content => UrlData.RealmDependent(realmData.Configured ? realmData.Ipfs.ContentBaseUrl.Value : null),
 
-                DecentralandUrl.SocialServiceMutes => $"https://social-api.decentraland.{ENV}/v1/mutes",
+                DecentralandUrl.SocialServiceMutes => $"https://social-api.{BaseDomain}/v1/mutes",
 
                 // The per-environment proxy only accepts requests whose Origin header matches its environment's web client origin.
-                DecentralandUrl.IntercomTickets => $"https://intercom-proxy.decentraland.{ENV}/intercom/tickets",
-                DecentralandUrl.IntercomTicketsOrigin => $"https://play.decentraland.{ENV}",
+                DecentralandUrl.IntercomTickets => $"https://intercom-proxy.{BaseDomain}/intercom/tickets",
+                DecentralandUrl.IntercomTicketsOrigin => $"https://play.{BaseDomain}",
 
                 _ => throw new ArgumentOutOfRangeException(nameof(decentralandUrl), decentralandUrl, null!),
             };

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -294,6 +294,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.ApiDestinations => $"https://places.{BaseDomain}/api/destinations",
                 DecentralandUrl.ApiAuth => $"https://auth-api.{BaseDomain}",
                 DecentralandUrl.ApiRpc => $"wss://rpc.{BaseDomain}",
+                DecentralandUrl.ChainRpc => $"https://rpc.{BaseDomain}",
                 DecentralandUrl.MetaTransactionServer => $"https://transactions-api.{BaseDomain}/v1/transactions",
                 DecentralandUrl.AuthSignatureWebApp => $"https://{BaseDomain}/auth/requests",
                 DecentralandUrl.BuilderApiDtos => $"https://builder-api.{BaseDomain}/v1/collections/[COL-ID]/items",

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
@@ -14,10 +14,12 @@ namespace DCL.Browser
     public class GatewayUrlsSource : DecentralandUrlsSource
     {
         private const string GATEWAY_SUBDOMAIN = "gateway";
-        private const string TRANSFORMABLE_DOMAIN_MARKER = ".decentraland.";
         private const int HTTPS_PREFIX_LENGTH = 8; // "https://".Length
 
-        private static readonly DecentralandEnvironment[] SUPPORTED_ENVS = { DecentralandEnvironment.Org, DecentralandEnvironment.Zone };
+        // Today is excluded on purpose: its org/today host mixture is pinned at construction and would not survive
+        // the rewrite. Custom is included, but a custom deployment only routes through a gateway when the
+        // "use-gateway" flag its own feature-flags backend serves says so, so opting in stays that deployment's call.
+        private static readonly DecentralandEnvironment[] SUPPORTED_ENVS = { DecentralandEnvironment.Org, DecentralandEnvironment.Zone, DecentralandEnvironment.Custom };
 
         private static readonly HashSet<DecentralandUrl> SUPPORTED_URLS = new (EnumUtils.GetEqualityComparer<DecentralandUrl>())
         {
@@ -74,11 +76,12 @@ namespace DCL.Browser
         };
 
         /// <summary>
-        ///     Routing via the Gateway enables multiplexing over HTTP/2 even for resources originated from the backend services
+        ///     Routing via the Gateway enables multiplexing over HTTP/2 even for resources originated from the backend
+        ///     services. Subdomains, not whole hosts: they are composed against this client's base domain.
         /// </summary>
-        private static readonly HashSet<string> SUPPORTED_URLS_OF_NON_CLIENT_ORIGIN = new (StringComparer.OrdinalIgnoreCase)
+        private static readonly string[] SUPPORTED_SUBDOMAINS_OF_NON_CLIENT_ORIGIN =
         {
-            $"profile-images.decentraland.{ENV}",
+            "profile-images",
         };
 
         private readonly bool envSupported;
@@ -95,26 +98,29 @@ namespace DCL.Browser
             GatekeeperMode gatekeeperMode = GatekeeperMode.Org,
             string customGatekeeperUrl = "",
             string? cliGatekeeperUrl = null,
-            string? cliOptimizedAssetsUrl = null)
-            : base(environment, realmData, launchMode, gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl, cliOptimizedAssetsUrl)
+            string? cliOptimizedAssetsUrl = null,
+            string? customBaseDomain = null)
+            : base(environment, realmData, launchMode, gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl, cliOptimizedAssetsUrl, customBaseDomain)
         {
             envSupported = SUPPORTED_ENVS.Contains(environment);
 
             if (envSupported)
             {
-                string envDomain = environment.ToString()!.ToLower();
-                resolvedNonClientHosts = new List<string>(SUPPORTED_URLS_OF_NON_CLIENT_ORIGIN.Count);
+                resolvedNonClientHosts = new List<string>(SUPPORTED_SUBDOMAINS_OF_NON_CLIENT_ORIGIN.Length);
 
-                foreach (string pattern in SUPPORTED_URLS_OF_NON_CLIENT_ORIGIN)
-                    resolvedNonClientHosts.Add(pattern.Replace(ENV, envDomain));
+                foreach (string subdomain in SUPPORTED_SUBDOMAINS_OF_NON_CLIENT_ORIGIN)
+                    resolvedNonClientHosts.Add($"{subdomain}.{BaseDomain}");
 
-                gatewayPrefix = $"https://{GATEWAY_SUBDOMAIN}.decentraland.{envDomain}/";
-                domainSuffix = $".decentraland.{envDomain}";
+                gatewayPrefix = $"https://{GATEWAY_SUBDOMAIN}.{BaseDomain}/";
+                domainSuffix = $".{BaseDomain}";
             }
         }
 
         public new static GatewayUrlsSource CreateForTest(DecentralandEnvironment environment, ILaunchMode launchMode) =>
             new (environment, new IRealmData.Fake(), launchMode);
+
+        public new static GatewayUrlsSource CreateForTest(string customBaseDomain, ILaunchMode launchMode) =>
+            new (DecentralandEnvironment.Custom, new IRealmData.Fake(), launchMode, customBaseDomain: customBaseDomain);
 
         /// <summary>
         ///     Transforms a 3rd party URL, DecentralandURLs are already transformed by <see cref="RawUrl" />
@@ -157,12 +163,14 @@ namespace DCL.Browser
         }
 
         /// <summary>
-        ///     True only for a bare https://{subdomain}.decentraland.{tld} authority (single-label sub + tld, no port or
-        ///     userinfo); any custom host passes through untouched.
+        ///     True only for a bare <c>https://{subdomain}.{BaseDomain}</c> authority: a single-label subdomain under
+        ///     this client's own base domain, with no port or userinfo. Any other host — a <c>--gatekeeper-url</c>
+        ///     override, a flag-driven assets host, another environment's domain — passes through untouched, because
+        ///     the gateway only fronts this deployment's own services.
         /// </summary>
-        private static bool IsGatewayTransformable(string url)
+        private bool IsGatewayTransformable(string url)
         {
-            if (!url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            if (domainSuffix == null || !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
                 return false;
 
             int hostEnd = url.IndexOf('/', HTTPS_PREFIX_LENGTH);
@@ -171,13 +179,14 @@ namespace DCL.Browser
             if (authority.IndexOfAny(':', '@') >= 0)
                 return false;
 
-            int marker = authority.IndexOf(TRANSFORMABLE_DOMAIN_MARKER.AsSpan(), StringComparison.OrdinalIgnoreCase);
+            ReadOnlySpan<char> suffix = domainSuffix.AsSpan();
 
-            if (marker <= 0 || authority.Slice(0, marker).IndexOf('.') >= 0)
+            if (authority.Length <= suffix.Length || !authority.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
                 return false;
 
-            ReadOnlySpan<char> tld = authority.Slice(marker + TRANSFORMABLE_DOMAIN_MARKER.Length);
-            return tld.Length > 0 && tld.IndexOf('.') < 0;
+            // Single-label subdomain: "peer.decentraland.org" routes, "a.b.decentraland.org" does not.
+            ReadOnlySpan<char> subdomain = authority.Slice(0, authority.Length - suffix.Length);
+            return subdomain.IndexOf('.') < 0;
         }
 
         public override string GetOriginalUrl(string url)

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
@@ -12,6 +12,8 @@ namespace DCL.Browser.DecentralandUrls.Tests
 {
     public class DecentralandUrlsSourceShould
     {
+        private const string CUSTOM_DOMAIN = "interconnected.online";
+
         // The feature-flag singleton takes one Initialize per Reset; clear it around every test
         [SetUp]
         public void SetUp() => FeatureFlagsConfiguration.Reset();
@@ -229,12 +231,132 @@ namespace DCL.Browser.DecentralandUrls.Tests
         [TestCase("https://sub.decentraland.org@evil.example.com")]
         [TestCase("https://x.decentraland.evil.example.com")]
         [TestCase("https://gk.decentraland.org.")]
-        public void KeepNonEnvShapedDecentralandHostsOffTheGateway(string customHost)
+        public void KeepHostsOutsideTheBaseDomainShapeOffTheGateway(string customHost)
         {
             InitializeFeatureFlags(optimizedAssets: false, useGateway: true);
             var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatekeeperUrl: customHost);
 
             Assert.AreEqual($"{customHost}/get-scene-adapter", urlsSource.Url(DecentralandUrl.GateKeeperSceneAdapter));
+        }
+
+        [TestCase(DecentralandEnvironment.Org, IDecentralandUrlsSource.ORG_DOMAIN)]
+        [TestCase(DecentralandEnvironment.Zone, IDecentralandUrlsSource.ZONE_DOMAIN)]
+        [TestCase(DecentralandEnvironment.Today, IDecentralandUrlsSource.TODAY_DOMAIN)]
+        public void SelectTheEnvironmentsOwnDomain(DecentralandEnvironment environment, string expectedBaseDomain)
+        {
+            Assert.AreEqual(expectedBaseDomain, DecentralandUrlsSource.ResolveBaseDomain(environment, null));
+        }
+
+        /// <summary>
+        ///     What a constructed source reports is the domain it resolves urls against, which is not always the
+        ///     domain the environment selects: today pins the handful of hosts it serves from .today while it is being
+        ///     built and serves everything afterwards from org, so org is what it settles on.
+        /// </summary>
+        [TestCase(DecentralandEnvironment.Org, IDecentralandUrlsSource.ORG_DOMAIN)]
+        [TestCase(DecentralandEnvironment.Zone, IDecentralandUrlsSource.ZONE_DOMAIN)]
+        [TestCase(DecentralandEnvironment.Today, IDecentralandUrlsSource.ORG_DOMAIN)]
+        public void ReportTheDomainUrlsResolveAgainst(DecentralandEnvironment environment, string expectedBaseDomain)
+        {
+            InitializeFeatureFlags(optimizedAssets: false);
+            Assert.AreEqual(expectedBaseDomain, DecentralandUrlsSource.CreateForTest(environment, ILaunchMode.PLAY).BaseDomain);
+        }
+
+        [TestCase(CUSTOM_DOMAIN, CUSTOM_DOMAIN)]
+        [TestCase("  " + CUSTOM_DOMAIN + "  ", CUSTOM_DOMAIN)] // padded by a shell or launcher
+        [TestCase("." + CUSTOM_DOMAIN, CUSTOM_DOMAIN)]         // written as a suffix
+        public void TakeBaseDomainFromTheCustomEnvironment(string customBaseDomain, string expectedBaseDomain)
+        {
+            InitializeFeatureFlags(optimizedAssets: false);
+            Assert.AreEqual(expectedBaseDomain, DecentralandUrlsSource.CreateForTest(customBaseDomain, ILaunchMode.PLAY).BaseDomain);
+        }
+
+        [TestCase(DecentralandEnvironment.Custom, null)]                            // Custom has no domain of its own
+        [TestCase(DecentralandEnvironment.Custom, "   ")]
+        [TestCase(DecentralandEnvironment.Custom, "https://" + CUSTOM_DOMAIN)]      // a url, not a domain
+        [TestCase(DecentralandEnvironment.Custom, CUSTOM_DOMAIN + "/path")]
+        [TestCase(DecentralandEnvironment.Custom, CUSTOM_DOMAIN + ":8443")]
+        [TestCase(DecentralandEnvironment.Custom, "evil.example@" + CUSTOM_DOMAIN)] // userinfo smuggled into the domain
+        [TestCase(DecentralandEnvironment.Org, CUSTOM_DOMAIN)]                      // a base domain the environment would ignore
+        [TestCase(DecentralandEnvironment.Zone, CUSTOM_DOMAIN)]
+        public void RejectAMisconfiguredBaseDomain(DecentralandEnvironment environment, string? customBaseDomain)
+        {
+            Assert.Throws<ArgumentException>(() => DecentralandUrlsSource.ResolveBaseDomain(environment, customBaseDomain));
+        }
+
+        [TestCase(DecentralandUrl.Host, "https://" + CUSTOM_DOMAIN)]
+        [TestCase(DecentralandUrl.PeerAbout, "https://peer." + CUSTOM_DOMAIN + "/about")]
+        [TestCase(DecentralandUrl.PeerContent, "https://peer." + CUSTOM_DOMAIN + "/content/contents")]
+        [TestCase(DecentralandUrl.Servers, "https://peer." + CUSTOM_DOMAIN + "/lambdas/contracts/servers")]
+        [TestCase(DecentralandUrl.FeatureFlags, "https://feature-flags." + CUSTOM_DOMAIN)]
+        [TestCase(DecentralandUrl.Gatekeeper, "https://comms-gatekeeper." + CUSTOM_DOMAIN)]
+        [TestCase(DecentralandUrl.GateKeeperSceneAdapter, "https://comms-gatekeeper." + CUSTOM_DOMAIN + "/get-scene-adapter")]
+        [TestCase(DecentralandUrl.LocalGateKeeperSceneAdapter, "https://comms-gatekeeper-local." + CUSTOM_DOMAIN + "/get-scene-adapter")]
+        [TestCase(DecentralandUrl.Genesis, "https://realm-provider-ea." + CUSTOM_DOMAIN + "/main")]
+        [TestCase(DecentralandUrl.WorldServer, "https://worlds-content-server." + CUSTOM_DOMAIN + "/world")]
+        [TestCase(DecentralandUrl.Pulse, "pulse-server." + CUSTOM_DOMAIN)]
+        public void MoveEveryHostOntoTheCustomBaseDomain(DecentralandUrl url, string expected)
+        {
+            InitializeFeatureFlags(optimizedAssets: false);
+            DecentralandUrlsSource urlsSource = DecentralandUrlsSource.CreateForTest(CUSTOM_DOMAIN, ILaunchMode.PLAY);
+
+            Assert.AreEqual(expected, urlsSource.Url(url));
+        }
+
+        /// <summary>
+        ///     The whole point of the base-domain seam: nothing may still resolve to a decentraland host, and no
+        ///     template may leak its unsubstituted token. A new url added with a hand-written domain fails here.
+        /// </summary>
+        [Test]
+        public void LeaveNoDecentralandHostBehindOnACustomBaseDomain()
+        {
+            InitializeFeatureFlags(optimizedAssets: false);
+            var urlsSource = new DecentralandUrlsSource(DecentralandEnvironment.Custom, Substitute.For<IRealmData>(), ILaunchMode.PLAY, customBaseDomain: CUSTOM_DOMAIN);
+
+            foreach (DecentralandUrl url in Enum.GetValues(typeof(DecentralandUrl)))
+            {
+                string resolved = urlsSource.Probe(url);
+
+                // Off-platform links that are decentraland's own marketing surface, not a backend host a custom
+                // deployment could serve.
+                if (url == DecentralandUrl.DecentralandWorlds)
+                    continue;
+
+                foreach (string domain in IDecentralandUrlsSource.ALL_DOMAINS)
+                    Assert.IsTrue(resolved.IndexOf(domain, StringComparison.OrdinalIgnoreCase) < 0, $"{url} still resolves to {domain}: {resolved}");
+            }
+        }
+
+        [TestCase(DecentralandEnvironment.Org, null, "https://feature-flags." + IDecentralandUrlsSource.ORG_DOMAIN)]
+        [TestCase(DecentralandEnvironment.Zone, null, "https://feature-flags." + IDecentralandUrlsSource.ZONE_DOMAIN)]
+        [TestCase(DecentralandEnvironment.Custom, CUSTOM_DOMAIN, "https://feature-flags." + CUSTOM_DOMAIN)]
+        public void ResolveThePreLoginFeatureFlagsHost(DecentralandEnvironment environment, string? customBaseDomain, string expected)
+        {
+            Assert.AreEqual(expected, DecentralandUrlsSource.GetFeatureFlagsUrl(environment, customBaseDomain));
+        }
+
+        [Test]
+        public void RouteACustomBaseDomainThroughItsOwnGateway()
+        {
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: true);
+            GatewayUrlsSource urlsSource = GatewayUrlsSource.CreateForTest(CUSTOM_DOMAIN, ILaunchMode.PLAY);
+
+            Assert.AreEqual("https://gateway." + CUSTOM_DOMAIN + "/auth-api", urlsSource.Url(DecentralandUrl.ApiAuth));
+            Assert.AreEqual("https://gateway." + CUSTOM_DOMAIN + "/comms-gatekeeper/get-scene-adapter", urlsSource.Url(DecentralandUrl.GateKeeperSceneAdapter));
+            Assert.AreEqual("https://gateway." + CUSTOM_DOMAIN + "/comms-gatekeeper/private-messages/token", urlsSource.Url(DecentralandUrl.ChatAdapter));
+
+            // Its host is composed from the base domain like any other, so it routes through the gateway here
+            // exactly as it does on org.
+            Assert.AreEqual("https://gateway." + CUSTOM_DOMAIN + "/comms-gatekeeper-local/get-scene-adapter", urlsSource.Url(DecentralandUrl.LocalGateKeeperSceneAdapter));
+        }
+
+        [Test]
+        public void KeepTheGatekeeperOverrideAboveTheCustomBaseDomain()
+        {
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: true);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Custom, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatekeeperUrl: "https://gk.example.com", customBaseDomain: CUSTOM_DOMAIN);
+
+            Assert.AreEqual("https://gk.example.com/get-scene-adapter", urlsSource.Url(DecentralandUrl.GateKeeperSceneAdapter));
+            Assert.AreEqual("https://gk.example.com/get-scene-adapter", urlsSource.Url(DecentralandUrl.LocalGateKeeperSceneAdapter));
         }
     }
 }

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
@@ -315,6 +315,8 @@ namespace DCL.Browser.DecentralandUrls.Tests
         [TestCase(DecentralandUrl.Genesis, "https://realm-provider-ea." + CUSTOM_DOMAIN + "/main")]
         [TestCase(DecentralandUrl.WorldServer, "https://worlds-content-server." + CUSTOM_DOMAIN + "/world")]
         [TestCase(DecentralandUrl.Pulse, "pulse-server." + CUSTOM_DOMAIN)]
+        [TestCase(DecentralandUrl.ApiRpc, "wss://rpc." + CUSTOM_DOMAIN)]
+        [TestCase(DecentralandUrl.ChainRpc, "https://rpc." + CUSTOM_DOMAIN)]
         public void MoveEveryHostOntoTheCustomBaseDomain(DecentralandUrl url, string expected)
         {
             InitializeFeatureFlags(optimizedAssets: false);

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
@@ -261,6 +261,27 @@ namespace DCL.Browser.DecentralandUrls.Tests
             Assert.AreEqual(expectedBaseDomain, DecentralandUrlsSource.CreateForTest(environment, ILaunchMode.PLAY).BaseDomain);
         }
 
+        [TestCase("worlds-content-server." + CUSTOM_DOMAIN, true)]
+        [TestCase("a.b." + CUSTOM_DOMAIN, true)]                  // nested subdomains are still below it
+        [TestCase(CUSTOM_DOMAIN, false)]                          // the domain itself is not a subdomain of itself
+        [TestCase(CUSTOM_DOMAIN + ".attacker.com", false)]        // suffix-spoof
+        [TestCase("evil-" + CUSTOM_DOMAIN, false)]                // no '.' boundary
+        [TestCase("online", false)]                               // shorter than the domain
+        public void MatchOnlySubdomainsOfADomain(string host, bool expected)
+        {
+            Assert.AreEqual(expected, IDecentralandUrlsSource.IsSubdomainOf(host, CUSTOM_DOMAIN), host);
+        }
+
+        [TestCase("worlds-content-server." + CUSTOM_DOMAIN, true)]
+        [TestCase(CUSTOM_DOMAIN, true)]                           // the domain is a host in its own right here
+        [TestCase("WORLDS-CONTENT-SERVER.INTERCONNECTED.ONLINE", true)]
+        [TestCase(CUSTOM_DOMAIN + ".attacker.com", false)]
+        [TestCase("evil-" + CUSTOM_DOMAIN, false)]
+        public void MatchAnyHostWithinADomain(string host, bool expected)
+        {
+            Assert.AreEqual(expected, IDecentralandUrlsSource.IsHostWithinDomain(host, CUSTOM_DOMAIN), host);
+        }
+
         [TestCase(CUSTOM_DOMAIN, CUSTOM_DOMAIN)]
         [TestCase("  " + CUSTOM_DOMAIN + "  ", CUSTOM_DOMAIN)] // padded by a shell or launcher
         [TestCase("." + CUSTOM_DOMAIN, CUSTOM_DOMAIN)]         // written as a suffix

--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIResponse.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIResponse.cs
@@ -80,7 +80,9 @@ namespace DCL.PlacesAPIService
                 id = EMPTY_PLACE_ID;
                 title = "Empty place";
                 description = "No description";
-                image = "https://peer.decentraland.org/content/contents/bafkreidj26s7aenyxfthfdibnqonzqm5ptc4iamml744gmcyuokewkr76y";
+                // Carries no thumbnail: the only default available was a content hash pinned to
+                // peer.decentraland.org, which a deployment under another base domain cannot serve.
+                image = string.Empty;
                 owner = "no owner";
                 tags = Array.Empty<string>();
                 world_name = "";

--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIResponse.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIResponse.cs
@@ -80,9 +80,7 @@ namespace DCL.PlacesAPIService
                 id = EMPTY_PLACE_ID;
                 title = "Empty place";
                 description = "No description";
-                // Carries no thumbnail: the only default available was a content hash pinned to
-                // peer.decentraland.org, which a deployment under another base domain cannot serve.
-                image = string.Empty;
+                image = "https://peer.decentraland.org/content/contents/bafkreidj26s7aenyxfthfdibnqonzqm5ptc4iamml744gmcyuokewkr76y";
                 owner = "no owner";
                 tags = Array.Empty<string>();
                 world_name = "";

--- a/Explorer/Assets/DCL/PluginSystem/Global/SocialServicesContainer.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/SocialServicesContainer.cs
@@ -12,6 +12,7 @@ using DCL.SocialService;
 using DCL.Utilities;
 using DCL.Utilities.Extensions;
 using DCL.Web3;
+using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using DCL.WebRequests;
 using ECS;
@@ -45,7 +46,7 @@ namespace DCL.PluginSystem.Global
             IWebRequestController webRequestController,
             IRealmData realmData,
             IPlacesAPIService placesAPIService,
-            DecentralandEnvironment environment,
+            EthereumNetwork ethereumNetwork,
             IAnalyticsController analyticsController,
             bool localSceneDevelopment,
             bool enableAnalytics)
@@ -64,7 +65,7 @@ namespace DCL.PluginSystem.Global
             socialServicesRPC = new RPCSocialServices(GetApiUrl(), web3IdentityCache, EventBus);
 
             DonationsService = CreateDonationsService(scenesCache, ethereumApi, webRequestController, realmData, placesAPIService,
-                environment, dclUrlSource, localSceneDevelopment, analyticsController, enableAnalytics);
+                ethereumNetwork, dclUrlSource, localSceneDevelopment, analyticsController, enableAnalytics);
         }
 
         private static IDonationsService CreateDonationsService(
@@ -73,7 +74,7 @@ namespace DCL.PluginSystem.Global
             IWebRequestController webRequestController,
             IRealmData realmData,
             IPlacesAPIService placesAPIService,
-            DecentralandEnvironment environment,
+            EthereumNetwork ethereumNetwork,
             IDecentralandUrlsSource urlsSource,
             bool localSceneDevelopment,
             IAnalyticsController analyticsController,
@@ -83,7 +84,7 @@ namespace DCL.PluginSystem.Global
                 return new DonationsServiceDisabled();
 
             IDonationsService core = new DonationsService(scenesCache, ethereumApi, webRequestController, realmData,
-                placesAPIService, environment, urlsSource, localSceneDevelopment);
+                placesAPIService, ethereumNetwork, urlsSource, localSceneDevelopment);
 
             return enableAnalytics ? new DonationsServiceAnalyticsDecorator(core, analyticsController) : core;
         }

--- a/Explorer/Assets/DCL/SmartWearables/SmartWearableCache.cs
+++ b/Explorer/Assets/DCL/SmartWearables/SmartWearableCache.cs
@@ -4,6 +4,7 @@ using DCL.AvatarRendering.Loading.Components;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.Diagnostics;
 using DCL.Ipfs;
+using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.SmartWearables;
 using DCL.WebRequests;
 using ECS.StreamableLoading.Common.Components;
@@ -29,12 +30,14 @@ namespace Runtime.Wearables
         private const string NULL_DTO_WEARABLE_ID = "null-dto-wearable-id";
 
         private readonly IWebRequestController webRequestController;
+        private readonly IDecentralandUrlsSource decentralandUrlsSource;
 
         private readonly Dictionary<string, CacheItem> cache = new ();
 
-        public SmartWearableCache(IWebRequestController webRequestController)
+        public SmartWearableCache(IWebRequestController webRequestController, IDecentralandUrlsSource decentralandUrlsSource)
         {
             this.webRequestController = webRequestController;
+            this.decentralandUrlsSource = decentralandUrlsSource;
         }
 
         public bool CurrentSceneAllowsSmartWearables { get; set; }
@@ -168,9 +171,8 @@ namespace Runtime.Wearables
 
         private string GetContentUrl(IWearable smartWearable)
         {
-            const string DEFAULT_CONTENT_URL = "https://peer.decentraland.org/content/contents/";
             string? dtoContentUrl = smartWearable.DTO.ContentDownloadUrl;
-            return string.IsNullOrEmpty(dtoContentUrl) ? DEFAULT_CONTENT_URL : dtoContentUrl;
+            return string.IsNullOrEmpty(dtoContentUrl) ? $"{decentralandUrlsSource.Url(DecentralandUrl.PeerContent)}/" : dtoContentUrl;
         }
 
         private class CacheItem

--- a/Explorer/Assets/DCL/TeleportPrompt/TeleportPromptController.cs
+++ b/Explorer/Assets/DCL/TeleportPrompt/TeleportPromptController.cs
@@ -111,7 +111,7 @@ namespace DCL.TeleportPrompt
         private void SetPlaceInfo(PlacesData.PlaceInfo placeInfo)
         {
             SetPopupAsLoading(false);
-            placeImageController.RequestImage(placeInfo.image);
+            placeImageController.RequestImage(placeInfo.image, defaultSprite: viewInstance.defaultImage);
             viewInstance.placeName.text = placeInfo.title;
             viewInstance.placeCreator.text = $"created by <b>{placeInfo.contact_name}</b>";
             viewInstance.location.text = placeInfo.base_position;

--- a/Explorer/Assets/DCL/Tests/Editor/ChatEnvironmentValidatorShould.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/ChatEnvironmentValidatorShould.cs
@@ -1,31 +1,59 @@
 using DCL.Chat.Commands;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace DCL.Tests.Editor
 {
     public class ChatEnvironmentValidatorShould
     {
-        [TestCase("https://peer.decentraland.org", true)]
-        [TestCase("https://worlds-content-server.decentraland.org/world/x.dcl.eth", true)]
-        [TestCase("https://evil.example/org", false)]              // substring "org" no longer passes
-        [TestCase("https://decentraland.org.attacker.com", false)] // suffix-spoof
-        [TestCase("https://attacker-decentraland.org", false)]     // not a real subdomain boundary
-        [TestCase("https://decentraland.org@evil.com", false)]      // userinfo spoof — real host is evil.com
-        [TestCase("https://decentraland.org:1234@evil.com", false)] // colon-before-@ userinfo spoof (real host evil.com)
-        [TestCase("https://peer.decentraland.org:443", true)]       // legit host with an explicit port
-        public void ValidateOrgBySuffix(string realm, bool expectSuccess)
+        private const string CUSTOM_DOMAIN = "interconnected.online";
+
+        // Org
+        [TestCase(DecentralandEnvironment.Org, IDecentralandUrlsSource.ORG_DOMAIN, "https://peer.decentraland.org", true)]
+        [TestCase(DecentralandEnvironment.Org, IDecentralandUrlsSource.ORG_DOMAIN, "https://worlds-content-server.decentraland.org/world/x.dcl.eth", true)]
+        [TestCase(DecentralandEnvironment.Org, IDecentralandUrlsSource.ORG_DOMAIN, "https://peer.decentraland.org:443", true)]       // legit host with an explicit port
+        [TestCase(DecentralandEnvironment.Org, IDecentralandUrlsSource.ORG_DOMAIN, "https://evil.example/org", false)]              // substring "org" does not pass
+        [TestCase(DecentralandEnvironment.Org, IDecentralandUrlsSource.ORG_DOMAIN, "https://decentraland.org.attacker.com", false)] // suffix-spoof
+        [TestCase(DecentralandEnvironment.Org, IDecentralandUrlsSource.ORG_DOMAIN, "https://attacker-decentraland.org", false)]     // not a real subdomain boundary
+        [TestCase(DecentralandEnvironment.Org, IDecentralandUrlsSource.ORG_DOMAIN, "https://decentraland.org@evil.com", false)]      // userinfo spoof — real host is evil.com
+        [TestCase(DecentralandEnvironment.Org, IDecentralandUrlsSource.ORG_DOMAIN, "https://decentraland.org:1234@evil.com", false)] // colon-before-@ userinfo spoof (real host evil.com)
+
+        // Zone
+        [TestCase(DecentralandEnvironment.Zone, IDecentralandUrlsSource.ZONE_DOMAIN, "https://peer.decentraland.zone", true)]
+        [TestCase(DecentralandEnvironment.Zone, IDecentralandUrlsSource.ZONE_DOMAIN, "https://evil.example/zone", false)]
+        [TestCase(DecentralandEnvironment.Zone, IDecentralandUrlsSource.ZONE_DOMAIN, "https://peer.decentraland.org", false)] // another environment's domain is foreign
+
+        // A --base-domain deployment: its own domain is accepted, decentraland's is as foreign to it as it is to them
+        [TestCase(DecentralandEnvironment.Custom, CUSTOM_DOMAIN, "https://" + CUSTOM_DOMAIN, true)]
+        [TestCase(DecentralandEnvironment.Custom, CUSTOM_DOMAIN, "https://peer." + CUSTOM_DOMAIN, true)]
+        [TestCase(DecentralandEnvironment.Custom, CUSTOM_DOMAIN, "https://worlds-content-server." + CUSTOM_DOMAIN + "/world/x.dcl.eth", true)]
+        [TestCase(DecentralandEnvironment.Custom, CUSTOM_DOMAIN, "https://peer.decentraland.org", false)]
+        [TestCase(DecentralandEnvironment.Custom, CUSTOM_DOMAIN, "https://" + CUSTOM_DOMAIN + ".attacker.com", false)] // suffix-spoof
+        [TestCase(DecentralandEnvironment.Custom, CUSTOM_DOMAIN, "https://" + CUSTOM_DOMAIN + "@evil.com", false)]     // userinfo spoof
+        public void AcceptOnlyRealmsUnderTheBaseDomain(DecentralandEnvironment environment, string baseDomain, string realm, bool expectSuccess)
         {
-            var validator = new ChatEnvironmentValidator(DecentralandEnvironment.Org);
+            var validator = new ChatEnvironmentValidator(environment, UrlsSourceWithBaseDomain(baseDomain));
             Assert.AreEqual(expectSuccess, validator.ValidateTeleport(realm).Success, realm);
         }
 
-        [TestCase("https://peer.decentraland.zone", true)]
-        [TestCase("https://evil.example/zone", false)]
-        public void ValidateZoneBySuffix(string realm, bool expectSuccess)
+        /// <summary>
+        ///     Today is the one environment that cannot follow a realm change at all, so even a host under its own
+        ///     base domain is rejected.
+        /// </summary>
+        [TestCase("https://peer.decentraland.today")]
+        [TestCase("https://peer.decentraland.org")]
+        public void RejectEveryRealmInTheTodayEnvironment(string realm)
         {
-            var validator = new ChatEnvironmentValidator(DecentralandEnvironment.Zone);
-            Assert.AreEqual(expectSuccess, validator.ValidateTeleport(realm).Success, realm);
+            var validator = new ChatEnvironmentValidator(DecentralandEnvironment.Today, UrlsSourceWithBaseDomain(IDecentralandUrlsSource.TODAY_DOMAIN));
+            Assert.IsFalse(validator.ValidateTeleport(realm).Success, realm);
+        }
+
+        private static IDecentralandUrlsSource UrlsSourceWithBaseDomain(string baseDomain)
+        {
+            IDecentralandUrlsSource urlsSource = Substitute.For<IDecentralandUrlsSource>();
+            urlsSource.BaseDomain.Returns(baseDomain);
+            return urlsSource;
         }
     }
 }

--- a/Explorer/Assets/DCL/UI/ImageController.cs
+++ b/Explorer/Assets/DCL/UI/ImageController.cs
@@ -59,6 +59,14 @@ namespace DCL.UI
 
                 view.IsLoading = true;
 
+                // Nothing to fetch (e.g. a place that carries no thumbnail url): show the placeholder rather than
+                // firing a request that can only fail.
+                if (string.IsNullOrEmpty(uri))
+                {
+                    TryApplyDefaultSprite(defaultSprite, fitAndCenterImage);
+                    return;
+                }
+
                 Sprite? sprite = null;
 
                 var textureRef = await imageControllerProvider.LoadTextureAsync(uri, ct);

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3EthereumApi.Default.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3EthereumApi.Default.cs
@@ -3,6 +3,7 @@ using Cysharp.Threading.Tasks;
 using DCL.Browser;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Web3.Abstract;
+using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using System.Collections.Generic;
 using System.Threading;
@@ -15,7 +16,7 @@ namespace DCL.Web3.Authenticators
         {
             private readonly DappWeb3EthereumApi origin;
 
-            public Default(IWeb3IdentityCache identityCache, IDecentralandUrlsSource decentralandUrlsSource, IWeb3AccountFactory web3AccountFactory, DecentralandEnvironment environment)
+            public Default(IWeb3IdentityCache identityCache, IDecentralandUrlsSource decentralandUrlsSource, IWeb3AccountFactory web3AccountFactory, EthereumNetwork ethereumNetwork)
             {
                 URLAddress authApiUrl = URLAddress.FromString(decentralandUrlsSource.Url(DecentralandUrl.ApiAuth));
                 URLAddress signatureUrl = URLAddress.FromString(decentralandUrlsSource.Url(DecentralandUrl.AuthSignatureWebApp));
@@ -51,7 +52,7 @@ namespace DCL.Web3.Authenticators
                         "eth_getTransactionCount",
                         "eth_getBlockByNumber", "eth_getCode"
                     },
-                    environment
+                    ethereumNetwork
                 );
             }
 

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3EthereumApi.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3EthereumApi.cs
@@ -1,7 +1,6 @@
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Browser;
-using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Web3.Abstract;
 using DCL.Web3.Chains;
 using DCL.Web3.Identities;
@@ -35,7 +34,7 @@ namespace DCL.Web3.Authenticators
         private readonly IWeb3AccountFactory web3AccountFactory;
         private readonly HashSet<string> whitelistMethods;
         private readonly HashSet<string> readOnlyMethods;
-        private readonly DecentralandEnvironment environment;
+        private readonly EthereumNetwork ethereumNetwork;
         private readonly int? identityExpirationDuration;
 
         // Allow only one web3 operation at a time
@@ -57,7 +56,7 @@ namespace DCL.Web3.Authenticators
             IWeb3AccountFactory web3AccountFactory,
             HashSet<string> whitelistMethods,
             HashSet<string> readOnlyMethods,
-            DecentralandEnvironment environment,
+            EthereumNetwork ethereumNetwork,
             int? identityExpirationDuration = null)
         {
             this.webBrowser = webBrowser;
@@ -68,7 +67,7 @@ namespace DCL.Web3.Authenticators
             this.web3AccountFactory = web3AccountFactory;
             this.whitelistMethods = whitelistMethods;
             this.readOnlyMethods = readOnlyMethods;
-            this.environment = environment;
+            this.ethereumNetwork = ethereumNetwork;
             this.identityExpirationDuration = identityExpirationDuration;
         }
 
@@ -104,7 +103,7 @@ namespace DCL.Web3.Authenticators
 
             if (string.Equals(request.method, "eth_chainId"))
             {
-                string chainId = ChainUtils.GetChainId(environment);
+                string chainId = ChainUtils.GetChainId(ethereumNetwork);
 
                 return new EthApiResponse
                 {
@@ -116,7 +115,7 @@ namespace DCL.Web3.Authenticators
 
             if (string.Equals(request.method, "net_version"))
             {
-                string netVersion = ChainUtils.GetNetVersion(environment);
+                string netVersion = ChainUtils.GetNetVersion(ethereumNetwork);
 
                 return new EthApiResponse
                 {
@@ -239,7 +238,7 @@ namespace DCL.Web3.Authenticators
 
                 await UniTask.SwitchToMainThread(ct);
 
-                await ConnectToRpcAsync(request.readonlyNetwork ?? ChainUtils.GetNetworkId(environment), ct)
+                await ConnectToRpcAsync(request.readonlyNetwork ?? ChainUtils.GetNetworkId(ethereumNetwork), ct)
                    .Timeout(TimeSpan.FromSeconds(TIMEOUT_SECONDS));
 
                 var response = await RequestEthMethodWithoutSignatureAsync(request, ct)

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/ThirdWeb/ThirdWebAuthenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/ThirdWeb/ThirdWebAuthenticator.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Web3.Abstract;
+using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using DCL.WebRequests;
 using System;
@@ -47,7 +48,7 @@ namespace DCL.Web3.Authenticators
 
         internal ThirdWebAuthenticator(
             IDecentralandUrlsSource decentralandUrlsSource,
-            DecentralandEnvironment environment,
+            EthereumNetwork ethereumNetwork,
             HashSet<string> whitelistMethods,
             HashSet<string> readOnlyMethods,
             IWeb3AccountFactory web3AccountFactory,
@@ -66,7 +67,7 @@ namespace DCL.Web3.Authenticators
             );
 
             loginService = new ThirdWebLoginService(thirdwebClient, web3AccountFactory, identityExpirationDuration);
-            ethereumApi = new ThirdWebEthereumApi(thirdwebClient, whitelistMethods, readOnlyMethods, decentralandUrlsSource, environment, RPC_OVERRIDES);
+            ethereumApi = new ThirdWebEthereumApi(thirdwebClient, whitelistMethods, readOnlyMethods, decentralandUrlsSource, ethereumNetwork, RPC_OVERRIDES);
         }
 
         public void Dispose()

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/ThirdWeb/ThirdWebAuthenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/ThirdWeb/ThirdWebAuthenticator.cs
@@ -19,22 +19,6 @@ namespace DCL.Web3.Authenticators
         private const string BUNDLE_ID = "com.Decentraland";
         private const string SDK_VERSION = "6.0.5";
 
-        /// <summary>
-        ///     RPC overrides for different chains. Uses Decentraland RPC endpoints.
-        /// </summary>
-        private static readonly Dictionary<BigInteger, string> RPC_OVERRIDES = new ()
-        {
-            { 1, "https://rpc.decentraland.org/mainnet" }, // Ethereum Mainnet
-            { 11155111, "https://rpc.decentraland.org/sepolia" }, // Ethereum Sepolia
-            { 137, "https://rpc.decentraland.org/polygon" }, // Polygon Mainnet
-            { 80002, "https://rpc.decentraland.org/amoy" }, // Polygon Amoy
-            { 42161, "https://rpc.decentraland.org/arbitrum" }, // Arbitrum Mainnet
-            { 10, "https://rpc.decentraland.org/optimism" }, // Optimism Mainnet
-            { 43114, "https://rpc.decentraland.org/avalanche" }, // Avalanche Mainnet
-            { 56, "https://rpc.decentraland.org/binance" }, // BSC Mainnet
-            { 250, "https://rpc.decentraland.org/fantom" }, // Fantom Mainnet
-        };
-
         private readonly ThirdWebLoginService loginService;
         private readonly ThirdWebEthereumApi ethereumApi;
 
@@ -55,6 +39,8 @@ namespace DCL.Web3.Authenticators
             IWebRequestController webRequestController,
             int? identityExpirationDuration = null)
         {
+            Dictionary<BigInteger, string> rpcOverrides = ChainRpcOverrides(decentralandUrlsSource);
+
             var thirdwebClient = ThirdwebClient.Create(
                 CLIENT_ID,
                 bundleId: BUNDLE_ID,
@@ -63,11 +49,40 @@ namespace DCL.Web3.Authenticators
                 sdkOs: Application.platform.ToString(),
                 sdkPlatform: "unity",
                 sdkVersion: SDK_VERSION,
-                rpcOverrides: RPC_OVERRIDES
+                rpcOverrides: rpcOverrides
             );
 
             loginService = new ThirdWebLoginService(thirdwebClient, web3AccountFactory, identityExpirationDuration);
-            ethereumApi = new ThirdWebEthereumApi(thirdwebClient, whitelistMethods, readOnlyMethods, decentralandUrlsSource, ethereumNetwork, RPC_OVERRIDES);
+            ethereumApi = new ThirdWebEthereumApi(thirdwebClient, whitelistMethods, readOnlyMethods, decentralandUrlsSource, ethereumNetwork, rpcOverrides);
+        }
+
+        /// <summary>
+        ///     Where the embedded wallet reaches each chain it may transact on, keyed by chain id. These are
+        ///     Decentraland's own RPC proxy rather than a chain's public node, so they follow the base domain like
+        ///     every other backend host: a <c>--base-domain</c> deployment serves its chains from
+        ///     <c>rpc.&lt;its domain&gt;</c>.
+        ///     <para>
+        ///         Probed rather than resolved through <c>Url</c> so the endpoint stays the RPC host itself. It is a
+        ///         single-label subdomain, which would otherwise be rewritten to the gateway once that flag is on -
+        ///         a change of route for every chain call, on the default environments too.
+        ///     </para>
+        /// </summary>
+        private static Dictionary<BigInteger, string> ChainRpcOverrides(IDecentralandUrlsSource decentralandUrlsSource)
+        {
+            string chainRpc = decentralandUrlsSource.Probe(DecentralandUrl.ChainRpc);
+
+            return new Dictionary<BigInteger, string>
+            {
+                { 1, $"{chainRpc}/mainnet" }, // Ethereum Mainnet
+                { 11155111, $"{chainRpc}/sepolia" }, // Ethereum Sepolia
+                { 137, $"{chainRpc}/polygon" }, // Polygon Mainnet
+                { 80002, $"{chainRpc}/amoy" }, // Polygon Amoy
+                { 42161, $"{chainRpc}/arbitrum" }, // Arbitrum Mainnet
+                { 10, $"{chainRpc}/optimism" }, // Optimism Mainnet
+                { 43114, $"{chainRpc}/avalanche" }, // Avalanche Mainnet
+                { 56, $"{chainRpc}/binance" }, // BSC Mainnet
+                { 250, $"{chainRpc}/fantom" }, // Fantom Mainnet
+            };
         }
 
         public void Dispose()

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/ThirdWeb/ThirdWebEthereumApi.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/ThirdWeb/ThirdWebEthereumApi.cs
@@ -2,6 +2,7 @@ using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Web3.Chains;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -36,7 +37,7 @@ namespace DCL.Web3.Authenticators
             HashSet<string> whitelistMethods,
             HashSet<string> readOnlyMethods,
             IDecentralandUrlsSource decentralandUrlsSource,
-            DecentralandEnvironment environment,
+            EthereumNetwork ethereumNetwork,
             Dictionary<BigInteger, string> rpcOverrides)
         {
             this.client = client;
@@ -44,7 +45,7 @@ namespace DCL.Web3.Authenticators
             this.readOnlyMethods = readOnlyMethods;
             this.rpcOverrides = rpcOverrides;
 
-            chainId = ChainUtils.GetChainIdAsInt(environment);
+            chainId = ChainUtils.GetChainIdAsInt(ethereumNetwork);
 
             metaTxService = new ThirdWebMetaTxService(client, URLDomain.FromString(decentralandUrlsSource.Url(DecentralandUrl.MetaTransactionServer)), (request, targetChainId) => SendRpcRequestAsync(request, targetChainId, CancellationToken.None));
         }

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/ThirdWeb/ThirdWebEthereumApi.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/ThirdWeb/ThirdWebEthereumApi.cs
@@ -55,7 +55,7 @@ namespace DCL.Web3.Authenticators
             if (rpcOverrides.TryGetValue(chainId, out string? rpcUrl))
                 return rpcUrl;
 
-            throw new Web3Exception($"No RPC endpoint configured for chain {chainId}. Add it to RPC_OVERRIDES in ThirdWebAuthenticator.");
+            throw new Web3Exception($"No RPC endpoint configured for chain {chainId}. Add it to ChainRpcOverrides in ThirdWebAuthenticator.");
         }
 
         public async UniTask<EthApiResponse> SendAsync(IThirdwebWallet? wallet, EthApiRequest request, Web3RequestSource source, CancellationToken ct)

--- a/Explorer/Assets/DCL/Web3/Chains/ChainUtils.cs
+++ b/Explorer/Assets/DCL/Web3/Chains/ChainUtils.cs
@@ -1,4 +1,5 @@
 ﻿using DCL.Multiplayer.Connections.DecentralandUrls;
+using System;
 using System.Numerics;
 
 namespace DCL.Web3.Authenticators
@@ -19,16 +20,31 @@ namespace DCL.Web3.Authenticators
         private const string SEPOLIA_CHAIN_ID = "0xaa36a7";
 
         public static string GetNetVersion(DecentralandEnvironment env) =>
-            env is DecentralandEnvironment.Org or DecentralandEnvironment.Today ? MAINNET_NET_VERSION : SEPOLIA_NET_VERSION;
+            IsMainnet(env) ? MAINNET_NET_VERSION : SEPOLIA_NET_VERSION;
 
         public static string GetChainId(DecentralandEnvironment env) =>
-            env is DecentralandEnvironment.Org or DecentralandEnvironment.Today ? MAINNET_CHAIN_ID : SEPOLIA_CHAIN_ID;
+            IsMainnet(env) ? MAINNET_CHAIN_ID : SEPOLIA_CHAIN_ID;
 
         public static BigInteger GetChainIdAsInt(DecentralandEnvironment environment) =>
-            environment is DecentralandEnvironment.Org or DecentralandEnvironment.Today ? new BigInteger(MAINNET_NET_VERSION_INT) : new BigInteger(SEPOLIA_NET_VERSION_INT);
+            IsMainnet(environment) ? new BigInteger(MAINNET_NET_VERSION_INT) : new BigInteger(SEPOLIA_NET_VERSION_INT);
 
         public static string GetNetworkId(DecentralandEnvironment env) =>
-            env is DecentralandEnvironment.Org or DecentralandEnvironment.Today ? NETWORK_MAINNET : NETWORK_SEPOLIA;
+            IsMainnet(env) ? NETWORK_MAINNET : NETWORK_SEPOLIA;
+
+        /// <summary>
+        ///     The one place the ethereum network is decided, so the four accessors above cannot drift apart. Only
+        ///     decentraland's own production environments are mainnet: a <c>--base-domain</c> deployment is an
+        ///     alternate, unverified stack, and signing its requests against mainnet would put real assets behind it.
+        /// </summary>
+        private static bool IsMainnet(DecentralandEnvironment env) =>
+            env switch
+            {
+                DecentralandEnvironment.Org => true,
+                DecentralandEnvironment.Today => true,
+                DecentralandEnvironment.Zone => false,
+                DecentralandEnvironment.Custom => false,
+                _ => throw new ArgumentOutOfRangeException(nameof(env), env, null),
+            };
 
         public static string GetNetworkNameById(int chainId) =>
             chainId switch

--- a/Explorer/Assets/DCL/Web3/Chains/ChainUtils.cs
+++ b/Explorer/Assets/DCL/Web3/Chains/ChainUtils.cs
@@ -1,10 +1,10 @@
 ﻿using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Web3.Chains;
 using System;
 using System.Numerics;
 
 namespace DCL.Web3.Authenticators
 {
-    // TODO: this is a temporary thing until we solve the network in a better way (probably it should be parametrized)
     public static class ChainUtils
     {
         private const string NETWORK_MAINNET = "mainnet";
@@ -19,31 +19,103 @@ namespace DCL.Web3.Authenticators
         private const string MAINNET_CHAIN_ID = "0x1";
         private const string SEPOLIA_CHAIN_ID = "0xaa36a7";
 
-        public static string GetNetVersion(DecentralandEnvironment env) =>
-            IsMainnet(env) ? MAINNET_NET_VERSION : SEPOLIA_NET_VERSION;
-
-        public static string GetChainId(DecentralandEnvironment env) =>
-            IsMainnet(env) ? MAINNET_CHAIN_ID : SEPOLIA_CHAIN_ID;
-
-        public static BigInteger GetChainIdAsInt(DecentralandEnvironment environment) =>
-            IsMainnet(environment) ? new BigInteger(MAINNET_NET_VERSION_INT) : new BigInteger(SEPOLIA_NET_VERSION_INT);
-
-        public static string GetNetworkId(DecentralandEnvironment env) =>
-            IsMainnet(env) ? NETWORK_MAINNET : NETWORK_SEPOLIA;
+        /// <summary>
+        ///     What a <c>--base-domain</c> deployment runs on when <c>--eth-network</c> says nothing: it stands in
+        ///     for a production stack of its own, so an operator running a test deployment names sepolia explicitly.
+        /// </summary>
+        private const EthereumNetwork CUSTOM_DEFAULT_NETWORK = EthereumNetwork.Mainnet;
 
         /// <summary>
-        ///     The one place the ethereum network is decided, so the four accessors above cannot drift apart. Only
-        ///     decentraland's own production environments are mainnet: a <c>--base-domain</c> deployment is an
-        ///     alternate, unverified stack, and signing its requests against mainnet would put real assets behind it.
+        ///     The one place the network is decided. Where <see cref="PinnedNetworkOf" /> names a network the
+        ///     environment holds it and <paramref name="ethNetworkArg" /> is discarded, so no argument can move a
+        ///     decentraland environment off its own chain. Only a <c>--base-domain</c> deployment reads the
+        ///     override, and defaults to <see cref="CUSTOM_DEFAULT_NETWORK" /> without one. There, a value naming no
+        ///     known network throws rather than falling back: a misspelt override must not quietly put the run on a
+        ///     chain nobody asked for.
         /// </summary>
-        private static bool IsMainnet(DecentralandEnvironment env) =>
-            env switch
+        public static EthereumNetwork ResolveNetwork(DecentralandEnvironment environment, string? ethNetworkArg)
+        {
+            if (PinnedNetworkOf(environment) is { } pinned)
+                return pinned;
+
+            if (string.IsNullOrWhiteSpace(ethNetworkArg))
+                return CUSTOM_DEFAULT_NETWORK;
+
+            if (TryParseNetwork(ethNetworkArg, out EthereumNetwork network))
+                return network;
+
+            throw new ArgumentException($"Unknown ethereum network '{ethNetworkArg}', expected '{NETWORK_MAINNET}' or '{NETWORK_SEPOLIA}'", nameof(ethNetworkArg));
+        }
+
+        /// <summary>
+        ///     Reads an <c>--eth-network</c> value, accepting either network's own id from
+        ///     <see cref="GetNetworkId" /> in any casing and with surrounding whitespace. False for null, blank and
+        ///     anything else. Non-throwing so a caller can reject a bad value where it can still report and exit
+        ///     cleanly, instead of letting <see cref="ResolveNetwork" /> throw somewhere it cannot.
+        /// </summary>
+        public static bool TryParseNetwork(string? value, out EthereumNetwork network)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
             {
-                DecentralandEnvironment.Org => true,
-                DecentralandEnvironment.Today => true,
-                DecentralandEnvironment.Zone => false,
-                DecentralandEnvironment.Custom => false,
-                _ => throw new ArgumentOutOfRangeException(nameof(env), env, null),
+                string trimmed = value.Trim();
+
+                if (string.Equals(trimmed, NETWORK_MAINNET, StringComparison.OrdinalIgnoreCase))
+                {
+                    network = EthereumNetwork.Mainnet;
+                    return true;
+                }
+
+                if (string.Equals(trimmed, NETWORK_SEPOLIA, StringComparison.OrdinalIgnoreCase))
+                {
+                    network = EthereumNetwork.Sepolia;
+                    return true;
+                }
+            }
+
+            network = default(EthereumNetwork);
+            return false;
+        }
+
+        /// <summary>
+        ///     The network an environment is fixed to, or null where the environment does not decide. Decentraland's
+        ///     own environments each answer for exactly one chain - org and today for mainnet, zone for sepolia -
+        ///     and that is not negotiable: their contracts, identities and backends are all on that chain, so a
+        ///     client pointed at one of them signing against the other is simply wrong. A <c>--base-domain</c>
+        ///     deployment is the only case the client knows nothing about, which is why it is the only one
+        ///     <c>--eth-network</c> speaks for.
+        /// </summary>
+        public static EthereumNetwork? PinnedNetworkOf(DecentralandEnvironment environment) =>
+            environment switch
+            {
+                DecentralandEnvironment.Org => EthereumNetwork.Mainnet,
+                DecentralandEnvironment.Today => EthereumNetwork.Mainnet,
+                DecentralandEnvironment.Zone => EthereumNetwork.Sepolia,
+                DecentralandEnvironment.Custom => null,
+                _ => throw new ArgumentOutOfRangeException(nameof(environment), environment, null),
+            };
+
+        public static string GetNetVersion(EthereumNetwork network) =>
+            IsMainnet(network) ? MAINNET_NET_VERSION : SEPOLIA_NET_VERSION;
+
+        public static string GetChainId(EthereumNetwork network) =>
+            IsMainnet(network) ? MAINNET_CHAIN_ID : SEPOLIA_CHAIN_ID;
+
+        public static BigInteger GetChainIdAsInt(EthereumNetwork network) =>
+            IsMainnet(network) ? new BigInteger(MAINNET_NET_VERSION_INT) : new BigInteger(SEPOLIA_NET_VERSION_INT);
+
+        public static string GetNetworkId(EthereumNetwork network) =>
+            IsMainnet(network) ? NETWORK_MAINNET : NETWORK_SEPOLIA;
+
+        /// <summary>
+        ///     The one place a network turns into ids, so the four accessors above cannot drift apart. Exhaustive on
+        ///     purpose: a network added later has to be given its own ids instead of silently answering as sepolia.
+        /// </summary>
+        private static bool IsMainnet(EthereumNetwork network) =>
+            network switch
+            {
+                EthereumNetwork.Mainnet => true,
+                EthereumNetwork.Sepolia => false,
+                _ => throw new ArgumentOutOfRangeException(nameof(network), network, null),
             };
 
         public static string GetNetworkNameById(int chainId) =>

--- a/Explorer/Assets/DCL/Web3/Chains/EthereumNetwork.cs
+++ b/Explorer/Assets/DCL/Web3/Chains/EthereumNetwork.cs
@@ -1,0 +1,18 @@
+﻿namespace DCL.Web3.Chains
+{
+    /// <summary>
+    ///     The chain this run signs and transacts against, resolved once by <c>ChainUtils.ResolveNetwork</c> from the
+    ///     environment and the <c>--eth-network</c> override.
+    ///     <para>
+    ///         Each value names an ethereum network only. Consumers that need the polygon side pair one with it by
+    ///         convention - Polygon with mainnet, Amoy with sepolia - because a deployment is on both or neither: an
+    ///         identity signed for mainnet has no business spending against test credits contracts, and a test
+    ///         identity has no business against the real ones.
+    ///     </para>
+    /// </summary>
+    public enum EthereumNetwork
+    {
+        Mainnet,
+        Sepolia,
+    }
+}

--- a/Explorer/Assets/DCL/Web3/Chains/EthereumNetwork.cs.meta
+++ b/Explorer/Assets/DCL/Web3/Chains/EthereumNetwork.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ada2934859ca4c848e5e85a587ba50b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/IWeb3IdentityCache.cs
@@ -1,6 +1,6 @@
-using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Web3.Abstract;
 using DCL.Web3.Accounts.Factory;
+using DCL.Web3.Chains;
 using System;
 
 namespace DCL.Web3.Identities
@@ -53,7 +53,7 @@ namespace DCL.Web3.Identities
         {
             private readonly IWeb3IdentityCache origin;
 
-            public Default(IWeb3AccountFactory? web3AccountFactory = null, DecentralandEnvironment dclEnv = DecentralandEnvironment.Org)
+            public Default(IWeb3AccountFactory? web3AccountFactory = null, EthereumNetwork ethereumNetwork = EthereumNetwork.Mainnet)
             {
                 origin = new LogWeb3IdentityCache(
                     new ProxyIdentityCache(
@@ -62,7 +62,7 @@ namespace DCL.Web3.Identities
                             new PlayerPrefsIdentityProvider.DecentralandIdentityWithNethereumAccountJsonSerializer(
                                 web3AccountFactory ?? new Web3AccountFactory()
                             ),
-                            dclEnv
+                            ethereumNetwork
                         )
                     )
                 );

--- a/Explorer/Assets/DCL/Web3/Identities/PlayerPrefsIdentityProvider.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/PlayerPrefsIdentityProvider.cs
@@ -12,12 +12,20 @@ namespace DCL.Web3.Identities
         public event Action? OnIdentityCleared;
         public event Action? OnIdentityChanged;
 
-        private string GetIdentityKey()
-        {
-            return dclEnv == DecentralandEnvironment.Zone
-                ? DCLPrefKeys.WEB3_IDENTITY_ZONE
-                : DCLPrefKeys.WEB3_IDENTITY;
-        }
+        /// <summary>
+        ///     The stored identity is chain-scoped, so the key follows <c>ChainUtils</c>: the mainnet environments
+        ///     share one slot and the sepolia ones the other. A <c>--base-domain</c> deployment signs against
+        ///     sepolia, so it must not overwrite the mainnet identity.
+        /// </summary>
+        private string GetIdentityKey() =>
+            dclEnv switch
+            {
+                DecentralandEnvironment.Org => DCLPrefKeys.WEB3_IDENTITY,
+                DecentralandEnvironment.Today => DCLPrefKeys.WEB3_IDENTITY,
+                DecentralandEnvironment.Zone => DCLPrefKeys.WEB3_IDENTITY_ZONE,
+                DecentralandEnvironment.Custom => DCLPrefKeys.WEB3_IDENTITY_ZONE,
+                _ => throw new ArgumentOutOfRangeException(nameof(dclEnv), dclEnv, null),
+            };
 
         public IWeb3Identity? Identity
         {

--- a/Explorer/Assets/DCL/Web3/Identities/PlayerPrefsIdentityProvider.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/PlayerPrefsIdentityProvider.cs
@@ -1,5 +1,5 @@
-using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Prefs;
+using DCL.Web3.Chains;
 using System;
 
 namespace DCL.Web3.Identities
@@ -7,24 +7,22 @@ namespace DCL.Web3.Identities
     public partial class PlayerPrefsIdentityProvider : IWeb3IdentityCache
     {
         private readonly IWeb3IdentityJsonSerializer identitySerializer;
-        private readonly DecentralandEnvironment dclEnv;
+        private readonly EthereumNetwork ethereumNetwork;
 
         public event Action? OnIdentityCleared;
         public event Action? OnIdentityChanged;
 
         /// <summary>
-        ///     The stored identity is chain-scoped, so the key follows <c>ChainUtils</c>: the mainnet environments
-        ///     share one slot and the sepolia ones the other. A <c>--base-domain</c> deployment signs against
-        ///     sepolia, so it must not overwrite the mainnet identity.
+        ///     The stored identity is chain-scoped, so it gets a slot per network: an identity signed for one chain
+        ///     must not overwrite the identity signed for the other. Two networks, two slots - the sepolia slot
+        ///     keeps its legacy "zone" key.
         /// </summary>
         private string GetIdentityKey() =>
-            dclEnv switch
+            ethereumNetwork switch
             {
-                DecentralandEnvironment.Org => DCLPrefKeys.WEB3_IDENTITY,
-                DecentralandEnvironment.Today => DCLPrefKeys.WEB3_IDENTITY,
-                DecentralandEnvironment.Zone => DCLPrefKeys.WEB3_IDENTITY_ZONE,
-                DecentralandEnvironment.Custom => DCLPrefKeys.WEB3_IDENTITY_ZONE,
-                _ => throw new ArgumentOutOfRangeException(nameof(dclEnv), dclEnv, null),
+                EthereumNetwork.Mainnet => DCLPrefKeys.WEB3_IDENTITY,
+                EthereumNetwork.Sepolia => DCLPrefKeys.WEB3_IDENTITY_ZONE,
+                _ => throw new ArgumentOutOfRangeException(nameof(ethereumNetwork), ethereumNetwork, null),
             };
 
         public IWeb3Identity? Identity
@@ -50,10 +48,10 @@ namespace DCL.Web3.Identities
             }
         }
 
-        public PlayerPrefsIdentityProvider(IWeb3IdentityJsonSerializer identitySerializer, DecentralandEnvironment dclEnv)
+        public PlayerPrefsIdentityProvider(IWeb3IdentityJsonSerializer identitySerializer, EthereumNetwork ethereumNetwork)
         {
             this.identitySerializer = identitySerializer;
-            this.dclEnv = dclEnv;
+            this.ethereumNetwork = ethereumNetwork;
         }
 
         public void Dispose()

--- a/Explorer/Assets/DCL/Web3/Tests/ChainUtilsShould.cs
+++ b/Explorer/Assets/DCL/Web3/Tests/ChainUtilsShould.cs
@@ -1,0 +1,115 @@
+﻿using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Web3.Authenticators;
+using DCL.Web3.Chains;
+using NUnit.Framework;
+using System;
+
+namespace DCL.Web3.Tests
+{
+    [TestFixture]
+    public class ChainUtilsShould
+    {
+        [TestCase(DecentralandEnvironment.Org, EthereumNetwork.Mainnet, TestName = "org is mainnet")]
+        [TestCase(DecentralandEnvironment.Today, EthereumNetwork.Mainnet, TestName = "today is mainnet")]
+        [TestCase(DecentralandEnvironment.Zone, EthereumNetwork.Sepolia, TestName = "zone is sepolia")]
+        public void PinDecentralandsOwnEnvironmentsToTheirChain(DecentralandEnvironment environment, EthereumNetwork expected)
+        {
+            Assert.AreEqual(expected, ChainUtils.PinnedNetworkOf(environment));
+            Assert.AreEqual(expected, ChainUtils.ResolveNetwork(environment, null));
+        }
+
+        // The whole point of pinning: no argument moves a decentraland environment onto the other chain, whether it
+        // names the other network, a network that does not exist, or nonsense.
+        [TestCase(DecentralandEnvironment.Org, "sepolia", EthereumNetwork.Mainnet, TestName = "org asked for sepolia")]
+        [TestCase(DecentralandEnvironment.Today, "sepolia", EthereumNetwork.Mainnet, TestName = "today asked for sepolia")]
+        [TestCase(DecentralandEnvironment.Zone, "mainnet", EthereumNetwork.Sepolia, TestName = "zone asked for mainnet")]
+        [TestCase(DecentralandEnvironment.Org, "MAINNET", EthereumNetwork.Mainnet, TestName = "org asked for the chain it already runs on")]
+        [TestCase(DecentralandEnvironment.Zone, "amoy", EthereumNetwork.Sepolia, TestName = "zone asked for a network this flag does not name")]
+        [TestCase(DecentralandEnvironment.Org, "sepolai", EthereumNetwork.Mainnet, TestName = "org asked for a misspelt network")]
+        public void DiscardTheOverrideOnAPinnedEnvironment(DecentralandEnvironment environment, string ethNetworkArg, EthereumNetwork expected)
+        {
+            Assert.AreEqual(expected, ChainUtils.ResolveNetwork(environment, ethNetworkArg));
+        }
+
+        [Test]
+        public void LeaveACustomBaseDomainUnpinned()
+        {
+            Assert.IsNull(ChainUtils.PinnedNetworkOf(DecentralandEnvironment.Custom));
+        }
+
+        // Blank reads as "not supplied" here. That is only safe because MainSceneLoader.CaptureEthNetworkArg
+        // refuses to pass a blank value through on a custom deployment - reaching the default by mistyping the flag
+        // is what would be dangerous, not the default itself.
+        [TestCase(null, TestName = "absent")]
+        [TestCase("", TestName = "empty")]
+        [TestCase("   ", TestName = "blank")]
+        public void DefaultACustomBaseDomainToMainnet(string? ethNetworkArg)
+        {
+            Assert.AreEqual(EthereumNetwork.Mainnet, ChainUtils.ResolveNetwork(DecentralandEnvironment.Custom, ethNetworkArg));
+        }
+
+        [TestCase("mainnet", EthereumNetwork.Mainnet, TestName = "mainnet")]
+        [TestCase("sepolia", EthereumNetwork.Sepolia, TestName = "sepolia")]
+        [TestCase("  SEPOLIA  ", EthereumNetwork.Sepolia, TestName = "padded and uppercase")]
+        public void ParseAKnownNetwork(string value, EthereumNetwork expected)
+        {
+            Assert.IsTrue(ChainUtils.TryParseNetwork(value, out EthereumNetwork network));
+            Assert.AreEqual(expected, network);
+        }
+
+        // The startup path validates through this before it decides whether to launch, so it must never report
+        // success for something it cannot map - a false with a defaulted out value would resolve to mainnet.
+        [TestCase(null, TestName = "null")]
+        [TestCase("", TestName = "empty")]
+        [TestCase("   ", TestName = "blank")]
+        [TestCase("amoy", TestName = "a polygon network")]
+        [TestCase("sepolai", TestName = "misspelt sepolia")]
+        [TestCase("main net", TestName = "an inner space")]
+        public void FailToParseAnythingElse(string? value)
+        {
+            Assert.IsFalse(ChainUtils.TryParseNetwork(value, out _));
+        }
+
+        [TestCase("sepolia", EthereumNetwork.Sepolia, TestName = "sepolia")]
+        [TestCase("mainnet", EthereumNetwork.Mainnet, TestName = "mainnet")]
+        [TestCase("SEPOLIA", EthereumNetwork.Sepolia, TestName = "uppercase")]
+        [TestCase("Sepolia", EthereumNetwork.Sepolia, TestName = "capitalized")]
+        [TestCase("  sepolia  ", EthereumNetwork.Sepolia, TestName = "surrounded by whitespace")]
+        public void LetACustomBaseDomainNameItsNetwork(string ethNetworkArg, EthereumNetwork expected)
+        {
+            Assert.AreEqual(expected, ChainUtils.ResolveNetwork(DecentralandEnvironment.Custom, ethNetworkArg));
+        }
+
+        // Only where the value is actually read does a bad one matter, and there it must not resolve to anything:
+        // falling back to the default would put the deployment on mainnet after asking for a test chain.
+        [TestCase("sepolai", TestName = "misspelt sepolia")]
+        [TestCase("polygon", TestName = "a polygon network, which is derived rather than named here")]
+        [TestCase("amoy", TestName = "amoy")]
+        [TestCase("1", TestName = "a chain id")]
+        [TestCase("goerli", TestName = "a retired testnet")]
+        [TestCase("mainnet sepolia", TestName = "two networks at once")]
+        public void RejectAnUnknownNetworkOnACustomBaseDomain(string ethNetworkArg)
+        {
+            Assert.Throws<ArgumentException>(() => ChainUtils.ResolveNetwork(DecentralandEnvironment.Custom, ethNetworkArg));
+        }
+
+        [TestCase(EthereumNetwork.Mainnet, "1", "0x1", "mainnet", TestName = "mainnet ids")]
+        [TestCase(EthereumNetwork.Sepolia, "11155111", "0xaa36a7", "sepolia", TestName = "sepolia ids")]
+        public void MapANetworkToItsChainIds(EthereumNetwork network, string netVersion, string chainId, string networkId)
+        {
+            Assert.AreEqual(netVersion, ChainUtils.GetNetVersion(network));
+            Assert.AreEqual(chainId, ChainUtils.GetChainId(network));
+            Assert.AreEqual(networkId, ChainUtils.GetNetworkId(network));
+            Assert.AreEqual(netVersion, ChainUtils.GetChainIdAsInt(network).ToString());
+        }
+
+        // The accepted --eth-network values and the network ids the client reports have to stay the same strings, so
+        // an operator can read a network out of a log or an error message and pass it straight back to the flag.
+        [TestCase(EthereumNetwork.Mainnet, TestName = "mainnet")]
+        [TestCase(EthereumNetwork.Sepolia, TestName = "sepolia")]
+        public void AcceptItsOwnNetworkIdAsAnOverride(EthereumNetwork network)
+        {
+            Assert.AreEqual(network, ChainUtils.ResolveNetwork(DecentralandEnvironment.Custom, ChainUtils.GetNetworkId(network)));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Web3/Tests/ChainUtilsShould.cs.meta
+++ b/Explorer/Assets/DCL/Web3/Tests/ChainUtilsShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28a301ce43034064ad525833435dfd08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Explorer.sln.DotSettings
+++ b/Explorer/Explorer.sln.DotSettings
@@ -544,6 +544,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Prewarmed/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reloader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=screencapture/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sepolia/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=teleporter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=thirdweb/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=UISFX/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Welcome to the official documentation for Unity Explorer — the Decentraland cl
 - **[Feature Flags](feature-flags.md)** — Fetching and checking feature flags at runtime
 - **[Features Registry](features-registry.md)** — Centralized feature state registry
 - **[App Arguments](app-arguments.md)** — Command-line flags and launch parameters
+- **[Custom Base Domain](custom-base-domain.md)** — Targeting a non-`decentraland.*` deployment with `--base-domain`
 
 ## Core Systems
 - **[Asset Promises](asset-promises.md)** — Asynchronous asset loading with ECS promises

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -97,11 +97,24 @@ For embedded links you will need to place value after `=` sign, instead of space
 
 ### `dclenv`
 **Type:** String
-**Description:** Sets the Decentraland environment (e.g., `org`, `zone`, `today`). Determines which API endpoints and services the application connects to.
+**Description:** Sets the Decentraland environment (e.g., `org`, `zone`, `today`). Determines which API endpoints and services the application connects to. `custom` is not accepted here — it is selected by [`base-domain`](#base-domain), which also supplies the domain it needs.
 
 **Usage:**
 ```bash
 --dclenv org
+```
+
+---
+
+### `base-domain`
+**Type:** String (bare domain)
+**Description:** Targets a deployment served under a base domain other than `decentraland.{org,zone,today}` — every backend host resolves under it (`peer.<domain>`, `comms-gatekeeper.<domain>`, `feature-flags.<domain>`, …). It selects the `Custom` environment, which is treated as a non-production stack: sepolia / Amoy chains, the sepolia identity slot, and `message-router-dev-0` as the community-message router identity. See [Custom base domain](custom-base-domain.md).
+
+The value must be a bare domain — no scheme, port or path — and it takes precedence over `dclenv`. Hosts under it are trusted for deep-link realm switching, so it is **command-line only**: it is never accepted from a `decentraland://` link.
+
+**Usage:**
+```bash
+--base-domain interconnected.online
 ```
 
 ---

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -108,13 +108,28 @@ For embedded links you will need to place value after `=` sign, instead of space
 
 ### `base-domain`
 **Type:** String (bare domain)
-**Description:** Targets a deployment served under a base domain other than `decentraland.{org,zone,today}` — every backend host resolves under it (`peer.<domain>`, `comms-gatekeeper.<domain>`, `feature-flags.<domain>`, …). It selects the `Custom` environment, which is treated as a non-production stack: sepolia / Amoy chains, the sepolia identity slot, and `message-router-dev-0` as the community-message router identity. See [Custom base domain](custom-base-domain.md).
+**Description:** Targets a deployment served under a base domain other than `decentraland.{org,zone,today}` — every backend host resolves under it (`peer.<domain>`, `comms-gatekeeper.<domain>`, `feature-flags.<domain>`, …). It selects the `Custom` environment, whose chain is mainnet unless [`eth-network`](#eth-network) says otherwise, and whose community-message router identity is `message-router-dev-0`. See [Custom base domain](custom-base-domain.md).
 
 The value must be a bare domain — no scheme, port or path — and it takes precedence over `dclenv`. Hosts under it are trusted for deep-link realm switching, so it is **command-line only**: it is never accepted from a `decentraland://` link.
 
 **Usage:**
 ```bash
 --base-domain interconnected.online
+```
+
+---
+
+### `eth-network`
+**Type:** String (`mainnet` | `sepolia`)
+**Description:** The chain a [`base-domain`](#base-domain) deployment signs and transacts against. Each value carries the polygon network that pairs with it — `mainnet` with Polygon, `sepolia` with Amoy — because the identity, the credits contracts and the donation contract all have to sit on one chain. It also picks which stored-identity slot the session uses. Defaults to `mainnet`.
+
+Decentraland's own environments each answer for one chain — org and today mainnet, zone sepolia — and this flag **cannot move them**: paired with `--dclenv`, it is reported in the log and dropped.
+
+On a `base-domain` deployment, where the value *is* read, anything that does not name a known network makes the client report the problem and exit rather than fall back to the default. Command-line only: denied from `decentraland://` links, and accepting it in the denied-params dialog does not apply it.
+
+**Usage:**
+```bash
+--base-domain interconnected.online --eth-network sepolia
 ```
 
 ---

--- a/docs/custom-base-domain.md
+++ b/docs/custom-base-domain.md
@@ -1,0 +1,85 @@
+# Custom base domain
+
+The client can target a deployment served under a base domain other than
+`decentraland.{org,zone,today}` — an independent catalyst stack, for example
+`interconnected.online` — by passing the [`--base-domain`](app-arguments.md#base-domain)
+app arg.
+
+`--base-domain` selects a fourth environment, `DecentralandEnvironment.Custom`. Modelling
+it as an environment rather than as a silent override is deliberate: the domain is only
+one of the things an environment decides, and every other decision (chain, identity
+storage, message routing) gets an explicit arm for `Custom` instead of falling into a
+`default` branch whose value nobody chose.
+
+## The domain seam
+
+`DecentralandUrlsSource.ResolveBaseDomain(environment, customBaseDomain)` is the single
+place the base domain is decided, and `IDecentralandUrlsSource.BaseDomain` is the single
+place to read it. Anything needing the domain as a *value* — a host-trust suffix, a comms
+hostname — reads it there rather than restating a literal.
+
+The domain is **composed into** each url rather than substituted afterwards: every template
+in `RawUrl` interpolates the `hostDomain` field (`$"https://peer.{hostDomain}/about"`), so
+there is no `decentraland.` literal repeated across the table, no placeholder token, and no
+replace pass on resolution. `Url()` only caches what `RawUrl` produced.
+
+`hostDomain` equals `BaseDomain` except in the today environment, which resolves the handful
+of hosts it serves from `.today` in its constructor and then flips the field to org for
+everything resolved afterwards. That is the one reason urls must stay lazily resolved, and
+the one case where `BaseDomain` names the environment rather than where every host lives.
+
+`ResolveBaseDomain` rejects a `Custom` environment without a domain, a domain paired with
+any other environment, and anything that is not a bare domain (scheme, userinfo, port or
+path) — the value feeds host-trust checks, so a url smuggled in as a domain must not be
+accepted. `DecentralandUrlsSourceShould.LeaveNoDecentralandHostBehindOnACustomBaseDomain`
+walks every `DecentralandUrl` and fails if one still resolves to a decentraland host, so a
+newly added url with a hand-written domain is caught.
+
+## What follows the base domain
+
+- **Every backend url** (`DecentralandUrlsSource`), including the pre-login feature-flag
+  host (`GetFeatureFlagsUrl`), the catalyst server list (`RealmNamesMap`) and the
+  smart-wearable content fallback (`SmartWearableCache`).
+- **Gateway routing** (`GatewayUrlsSource`): supported hosts route through
+  `gateway.<base-domain>/…`. `IsGatewayTransformable` accepts exactly a single-label
+  subdomain under this client's own `BaseDomain`, so an overridden or flag-driven host — or
+  another environment's domain — passes through untouched. It only engages when the
+  `use-gateway` flag served by *that deployment's* feature-flags backend enables it.
+- **Teleport validation** (`ChatEnvironmentValidator`): realms must sit under the base
+  domain — a custom deployment neither rejects its own realms nor accepts decentraland
+  ones.
+- **Deep-link realm trust** (`DeepLinkAllowlist.SetTrustedBaseDomain`): hosts under the
+  custom base domain are trusted for realm switching exactly like `decentraland.*` hosts,
+  and *instead of* them. Because that grants trust, the value is read while the deep link
+  is still deferred, so only the command line can set it.
+- **The main-realm comms hostname** (`RealmController`): a custom deployment groups under
+  its own `realm-provider.<base-domain>` rather than decentraland's main-realm island.
+- **comms-gatekeeper** stays independently overridable through `--gatekeeper-url`, which
+  outranks both the base domain and gateway routing, for the main and the local scene
+  adapter alike.
+
+## What `Custom` explicitly does *not* change
+
+These decisions are not domain-derived, and each carries an explicit `Custom` arm:
+
+| Decision | `Custom` resolves to | Why |
+| --- | --- | --- |
+| Ethereum network (`ChainUtils`) | sepolia | A `--base-domain` stack is unverified; mainnet would put real assets behind it. |
+| Marketplace credits (`CreditsChainConfig`), donations (`DonationsService`) | Amoy | Same reason: no mainnet contracts. |
+| Stored identity slot (`PlayerPrefsIdentityProvider`) | the sepolia slot | The key is chain-scoped, so it must not overwrite the mainnet identity. |
+| Community-message router (`LiveKitChatMessagesBus`, `ChatReactionsFactory`) | `message-router-dev-0` | A custom deployment's comms-message-sfu has to join under this identity for relayed messages to authenticate. |
+| Genesis City manifest (`WorldManifestProvider`) | the production manifest | A static S3 artifact, not a host under the base domain. |
+
+A deployment that mirrors *mainnet* is therefore out of scope for this flag.
+
+## Not covered
+
+- The `MainSceneLoader` trusted-realm fast-path still lists decentraland hosts
+  explicitly. A custom realm is not short-circuited there and is validated against the
+  deployment's own catalyst server list instead (which does follow the base domain), so
+  the flow works — it just costs one request.
+- `LoadHybridSceneSystemLogic` / `IGetHash` (legacy SDK6 hybrid-scene content) and
+  `LocalIpfsRealm` (reached only by the test `IRealmData.Fake`) keep their decentraland
+  constants.
+- Intentionally decentraland: `ThirdWebAuthenticator` RPC endpoints, the goerli /
+  test-scene constants, and the marketplace / blog / docs links.

--- a/docs/custom-base-domain.md
+++ b/docs/custom-base-domain.md
@@ -18,15 +18,15 @@ place the base domain is decided, and `IDecentralandUrlsSource.BaseDomain` is th
 place to read it. Anything needing the domain as a *value* — a host-trust suffix, a comms
 hostname — reads it there rather than restating a literal.
 
-The domain is **composed into** each url rather than substituted afterwards: every template
-in `RawUrl` interpolates the `hostDomain` field (`$"https://peer.{hostDomain}/about"`), so
-there is no `decentraland.` literal repeated across the table, no placeholder token, and no
-replace pass on resolution. `Url()` only caches what `RawUrl` produced.
+The domain is **composed into** each url rather than substituted afterwards: every template in
+`RawUrl` interpolates `BaseDomain` (`$"https://peer.{BaseDomain}/about"`), so there is no
+`decentraland.` literal repeated across the table, no placeholder token, and no replace pass on
+resolution. `Url()` only caches what `RawUrl` produced.
 
-`hostDomain` equals `BaseDomain` except in the today environment, which resolves the handful
-of hosts it serves from `.today` in its constructor and then flips the field to org for
-everything resolved afterwards. That is the one reason urls must stay lazily resolved, and
-the one case where `BaseDomain` names the environment rather than where every host lives.
+`BaseDomain` is written only by the constructor, and the today environment is the reason it is
+writable at all: it resolves the handful of hosts it serves from `.today` while being built and
+then moves to org for everything resolved afterwards, so it reports org and urls must stay lazily
+resolved.
 
 `ResolveBaseDomain` rejects a `Custom` environment without a domain, a domain paired with
 any other environment, and anything that is not a bare domain (scheme, userinfo, port or
@@ -50,8 +50,7 @@ newly added url with a hand-written domain is caught.
   ones.
 - **Deep-link realm trust** (`DeepLinkAllowlist.SetTrustedBaseDomain`): hosts under the
   custom base domain are trusted for realm switching exactly like `decentraland.*` hosts,
-  and *instead of* them. Because that grants trust, the value is read while the deep link
-  is still deferred, so only the command line can set it.
+  and *instead of* them.
 - **The startup trusted-realm gate** (`MainSceneLoader.IsTrustedRealmAsync`): every host
   under the custom base domain is trusted, so a `--realm` on that deployment — catalyst or
   world — connects without the untrusted-realm confirmation. See below for why.
@@ -91,10 +90,19 @@ otherwise use — the deployment's catalyst server list — enumerates catalysts
 servers. That is why decentraland's `worlds-content-server` is hardcoded there; without the
 domain rule a custom deployment's worlds would prompt for confirmation on every launch.
 
-Widening trust this way is safe because `--base-domain` is **command-line only** and never
-accepted from a deep link, so reaching these gates already required the operator to point the
-client at that deployment. The deep-link gate stays deliberately stricter — subdomains only,
-and still flag-gated on the world name — because the realm there is attacker-supplied.
+Widening trust this way costs nothing, because whoever sets the base domain has already
+redirected *every* backend host — profiles, content, comms, feature flags. Trusting realms under
+that same domain adds no capability on top of that. The deep-link gate stays deliberately
+stricter — subdomains only, and still flag-gated on the world name — because the realm *it* sees
+is attacker-supplied while the base domain is not.
+
+`--base-domain` itself is applied from the command line only. That is an ordering constraint
+rather than a trust boundary: the domain gates which realms `DeepLinkAllowlist` trusts, so it
+must be registered before `InitializeDeepLinks()` evaluates a pending link's whitelisted-realm
+params — a domain arriving in that same link could not be, since the link's own params would
+need gating against a domain it has not supplied yet. The allowlist denies `base-domain` like
+the other infrastructure-pointing params, so a link carrying it still reaches the consent
+dialog; accepting it changes nothing, and the client logs a warning saying so.
 
 `IDecentralandUrlsSource.IsSubdomainOf` / `IsHostWithinDomain` hold the `.`-boundary check
 these gates share, so the rule that rejects `interconnected.online.attacker.com` and
@@ -102,12 +110,13 @@ these gates share, so the rule that rejects `interconnected.online.attacker.com`
 
 ## Not covered
 
-- The `MainSceneLoader` trusted-realm fast-path still lists decentraland hosts
-  explicitly. A custom realm is not short-circuited there and is validated against the
-  deployment's own catalyst server list instead (which does follow the base domain), so
-  the flow works — it just costs one request.
-- `LoadHybridSceneSystemLogic` / `IGetHash` (legacy SDK6 hybrid-scene content) and
-  `LocalIpfsRealm` (reached only by the test `IRealmData.Fake`) keep their decentraland
-  constants.
-- Intentionally decentraland: `ThirdWebAuthenticator` RPC endpoints, the goerli /
-  test-scene constants, and the marketplace / blog / docs links.
+- `LoadHybridSceneSystemLogic` / `IGetHash` (legacy SDK6 hybrid-scene content) keep static
+  goerli-plaza / genesis content urls, so SDK6 hybrid content still loads from decentraland.
+  Each needs the url source threaded into a static context.
+- `LocalIpfsRealm` keeps its hardcoded lambdas url; it is only ever constructed by
+  `IRealmData.Fake`, so it never runs in a shipped client.
+- Intentionally decentraland: `ThirdWebAuthenticator`'s `rpc.decentraland.org/{network}`
+  endpoints (decentraland's proxy to the actual chains — a custom deployment has no Ethereum of
+  its own), the goerli / test-scene constants, the off-platform links (Discord, X, the
+  newsletter, CoinGecko) and the `DecentralandWorlds` blog link. The marketplace, shop, docs and
+  help links are templated and *do* follow the base domain.

--- a/docs/custom-base-domain.md
+++ b/docs/custom-base-domain.md
@@ -173,15 +173,8 @@ dialog; accepting it changes nothing, and the client logs a warning saying so.
 these gates share, so the rule that rejects `interconnected.online.attacker.com` and
 `evil-interconnected.online` lives in one place.
 
-## Not covered
+## Stays on decentraland
 
-- `LoadHybridSceneSystemLogic` / `IGetHash` (legacy SDK6 hybrid-scene content) keep static
-  goerli-plaza / genesis content urls, so SDK6 hybrid content still loads from decentraland.
-  Each needs the url source threaded into a static context.
-- `LocalIpfsRealm` keeps its hardcoded lambdas url; it is only ever constructed by
-  `IRealmData.Fake`, so it never runs in a shipped client.
-- Intentionally decentraland: `ThirdWebAuthenticator`'s `rpc.decentraland.org/{network}`
-  endpoints (decentraland's proxy to the actual chains — a custom deployment has no Ethereum of
-  its own), the goerli / test-scene constants, the off-platform links (Discord, X, the
-  newsletter, CoinGecko) and the `DecentralandWorlds` blog link. The marketplace, shop, docs and
-  help links are templated and *do* follow the base domain.
+The off-platform links — Discord, X, the newsletter, CoinGecko — and the `DecentralandWorlds`
+blog link are decentraland's own surfaces and keep pointing there. The marketplace, shop, docs
+and help links *do* follow the base domain.

--- a/docs/custom-base-domain.md
+++ b/docs/custom-base-domain.md
@@ -7,9 +7,10 @@ app arg.
 
 `--base-domain` selects a fourth environment, `DecentralandEnvironment.Custom`. Modelling
 it as an environment rather than as a silent override is deliberate: the domain is only
-one of the things an environment decides, and every other decision (chain, identity
-storage, message routing) gets an explicit arm for `Custom` instead of falling into a
-`default` branch whose value nobody chose.
+one of the things an environment decides, and every other decision gets an explicit arm
+for `Custom` instead of falling into a `default` branch whose value nobody chose. Where
+the domain cannot imply the answer — the chain — there is a flag for it rather than a
+guess.
 
 ## The domain seam
 
@@ -60,19 +61,66 @@ newly added url with a hand-written domain is caught.
   outranks both the base domain and gateway routing, for the main and the local scene
   adapter alike.
 
+## The chain
+
+A base domain says where the hosts are; it says nothing about which chain they are on, and
+nothing in a domain name can. So the chain is named, by
+[`--eth-network`](app-arguments.md#eth-network) — `mainnet` or `sepolia`, defaulting to
+mainnet.
+
+`ChainUtils.ResolveNetwork` is the single place it is decided, and the resolved
+`EthereumNetwork` is what everything downstream is handed. Four decisions used to make it
+separately from `DecentralandEnvironment`; none of them does now, so they cannot disagree:
+
+| Decision | Follows the resolved network |
+| --- | --- |
+| Ethereum net version / chain id / network id (`ChainUtils`) | mainnet or sepolia |
+| Marketplace credits (`CreditsChainConfig`) | Polygon with mainnet, Amoy with sepolia |
+| Donations MANA contract (`DonationsService`) | Polygon with mainnet, Amoy with sepolia |
+| Stored identity slot (`PlayerPrefsIdentityProvider`) | one slot per network |
+
+Each ethereum network carries exactly one polygon network because a deployment is on both or
+neither: an identity signed for mainnet has no business spending against test credits
+contracts, and a test identity has no business against the real ones.
+
+**Decentraland's own environments cannot be moved.** `ChainUtils.PinnedNetworkOf` fixes org
+and today to mainnet and zone to sepolia; `--eth-network` paired with one of them is reported
+in the log and dropped. Their contracts, identities and backends are all on that one chain, so
+a client pointed at zone signing against mainnet is simply wrong — there is no deployment for
+which that combination is what the operator meant. A custom base domain is the only stack the
+client knows nothing about, and the only one the flag speaks for.
+
+**A value the client cannot map is refused rather than defaulted**, because the default is
+mainnet: reaching it by accident is what puts real contracts and the production identity behind
+an operator who asked for a test chain. `--eth-network sepolai`, or the flag with no value at
+all, reports the problem and exits instead of launching. As everywhere in this client, the value
+is a separate token — `--eth-network sepolia`, never `--eth-network=sepolia`.
+
+Like `--base-domain`, it is applied **from the command line only**: a `decentraland://` link
+carrying it is denied, and accepting it in the denied-params dialog does not apply it (the
+client logs a warning saying so). A link is attacker-supplied and a consent dialog is a weak
+place to decide which chain a wallet signs for.
+
+**Open: the identity slot is keyed by chain, so a mainnet custom deployment shares the
+mainnet slot with org.** A session on either can reuse an identity signed on the other, and a
+login on either replaces it — so logging in to a custom deployment logs you out of org.
+`--eth-network sepolia` moves it to the sepolia slot, which zone also uses.
+
+This is not a property of the identity, which is a wallet signature over a locally generated
+ephemeral key and is not chain-scoped at all; the slot key just happens to be named by
+environment, and before the chain became explicit it stood in for *which stack minted the
+identity*. Scoping the slot by stack — a slot of its own for `Custom`, or one per base domain —
+would separate them again without touching which chain the deployment runs on. Worth deciding
+before a custom deployment is used against a signed-in production session.
+
 ## What `Custom` explicitly does *not* change
 
 These decisions are not domain-derived, and each carries an explicit `Custom` arm:
 
 | Decision | `Custom` resolves to | Why |
 | --- | --- | --- |
-| Ethereum network (`ChainUtils`) | sepolia | A `--base-domain` stack is unverified; mainnet would put real assets behind it. |
-| Marketplace credits (`CreditsChainConfig`), donations (`DonationsService`) | Amoy | Same reason: no mainnet contracts. |
-| Stored identity slot (`PlayerPrefsIdentityProvider`) | the sepolia slot | The key is chain-scoped, so it must not overwrite the mainnet identity. |
 | Community-message router (`LiveKitChatMessagesBus`, `ChatReactionsFactory`) | `message-router-dev-0` | A custom deployment's comms-message-sfu has to join under this identity for relayed messages to authenticate. |
 | Genesis City manifest (`WorldManifestProvider`) | *no manifest* — the fetch is skipped | It describes decentraland's own Genesis City; a custom realm reusing one of its realm names is a different world. |
-
-A deployment that mirrors *mainnet* is therefore out of scope for this flag.
 
 ## World manifest, parcel loading and roads
 
@@ -141,9 +189,8 @@ over wss on the deployment, while the embedded-wallet path keeps reaching decent
 proxy — which is arguably right (a custom deployment has no Ethereum of its own) but means the
 two disagree about where a chain lives.
 
-Two consequences of `Custom` being a non-production stack (see above): signatures are produced
-for **sepolia**, and the identity is stored in the **sepolia slot**, which zone also uses — so a
-custom session and a zone session share one cached identity.
+Which chain those signatures are produced for, and which stored-identity slot the session uses,
+follow [the chain](#the-chain) — mainnet unless `--eth-network sepolia` says otherwise.
 
 The signin deep link is unchanged: the `decentraland://` scheme is registered by the client, so
 a custom deployment's auth website must emit that same scheme with `signin` and `authRequestId`.

--- a/docs/custom-base-domain.md
+++ b/docs/custom-base-domain.md
@@ -180,14 +180,21 @@ The login handshake follows the base domain, and both wallet paths are built on 
 | `ApiAuth` | `auth-api.<base-domain>` |
 | `AuthSignatureWebApp` | `https://<base-domain>/auth/requests` |
 | `ApiRpc` (external-wallet dapp path) | `wss://rpc.<base-domain>` |
-| `ThirdWebAuthenticator`'s chain RPC map | **unchanged** — `rpc.decentraland.org/{network}` |
+| `ChainRpc` (embedded-wallet chain map) | `https://rpc.<base-domain>/{network}` |
 
 So a custom deployment **must** serve the auth API and the signing web app, or login cannot
-complete. The chain RPC is deliberately inconsistent between the two paths and worth a
-decision: `DappWeb3EthereumApi` resolves `ApiRpc` and therefore needs `rpc.<base-domain>`
-over wss on the deployment, while the embedded-wallet path keeps reaching decentraland's chain
-proxy — which is arguably right (a custom deployment has no Ethereum of its own) but means the
-two disagree about where a chain lives.
+complete — and, if the embedded wallet is used, the chain RPC too.
+
+Both wallet paths reach the same RPC host over different transports: `DappWeb3EthereumApi`
+resolves `ApiRpc` over websocket, and `ThirdWebAuthenticator`'s per-chain map is built from
+`ChainRpc` over https, one entry per chain the client may transact on (mainnet, sepolia,
+polygon, amoy, arbitrum, optimism, avalanche, binance, fantom). One dependency configured
+twice, not two — so both follow the base domain and cannot disagree about where a chain lives.
+
+The chain map is `Probe`d rather than resolved through `Url`, so it stays the RPC host itself.
+`rpc` is a single-label subdomain, which gateway routing would otherwise rewrite to
+`gateway.<domain>/rpc` once that flag is on — a change of route for every chain call, on the
+default environments too. That is a separate decision from this one.
 
 Which chain those signatures are produced for, and which stored-identity slot the session uses,
 follow [the chain](#the-chain) — mainnet unless `--eth-network sepolia` says otherwise.

--- a/docs/custom-base-domain.md
+++ b/docs/custom-base-domain.md
@@ -76,9 +76,22 @@ A deployment that mirrors *mainnet* is therefore out of scope for this flag.
 
 ## World manifest, parcel loading and roads
 
-`RealmKind` is derived from the realm's own `/about`, not from decentraland: no fixed scene
-URNs means `GenesisCity`, otherwise `World` (`RealmData.Reconfigure`). A custom deployment's
-catalyst realm therefore classifies as `GenesisCity`, and two things follow from that.
+Two independent signals decide that a realm *is Genesis City*, and they key off different
+things — which matters because only one of them responds to how the deployment names its realm.
+
+**The manifest path is chosen by realm name, matched against decentraland's own list.**
+`WorldManifestProvider.MAIN_REALM_NAMES` is a hardcoded set — `main`, `baldr`, `hela`,
+`heimdallr`, `shiva`, `artemis`, `loki`, `dg`, `hephaestus`, `unicorn`, `marvel`, `nftworld` —
+compared against `configurations.realmName` from the deployment's `/about`. A custom deployment
+calling its main realm `main` collides with that list and takes the genesis branch; calling it
+anything else takes neither the genesis nor the `.dcl.eth` world branch. Both end at
+`WorldManifest.Empty` today, so the name does not change the outcome — but the list is
+decentraland's naming, and a deployment cannot opt out of matching it.
+
+**`RealmKind` ignores the name.** It comes from whether `/about` lists fixed scene URNs: none
+means `GenesisCity`, otherwise `World` (`RealmData.Reconfigure`). A custom catalyst realm
+therefore classifies as `GenesisCity` whatever it is called — so renaming away from `main` does
+not change what follows.
 
 **Roads.** `RoadsPresence` switches instanced road rendering purely on
 `RealmKind == GenesisCity`, and the geometry comes from `RoadSettingsAsset` — a local

--- a/docs/custom-base-domain.md
+++ b/docs/custom-base-domain.md
@@ -52,6 +52,9 @@ newly added url with a hand-written domain is caught.
   custom base domain are trusted for realm switching exactly like `decentraland.*` hosts,
   and *instead of* them. Because that grants trust, the value is read while the deep link
   is still deferred, so only the command line can set it.
+- **The startup trusted-realm gate** (`MainSceneLoader.IsTrustedRealmAsync`): every host
+  under the custom base domain is trusted, so a `--realm` on that deployment — catalyst or
+  world — connects without the untrusted-realm confirmation. See below for why.
 - **The main-realm comms hostname** (`RealmController`): a custom deployment groups under
   its own `realm-provider.<base-domain>` rather than decentraland's main-realm island.
 - **comms-gatekeeper** stays independently overridable through `--gatekeeper-url`, which
@@ -68,9 +71,34 @@ These decisions are not domain-derived, and each carries an explicit `Custom` ar
 | Marketplace credits (`CreditsChainConfig`), donations (`DonationsService`) | Amoy | Same reason: no mainnet contracts. |
 | Stored identity slot (`PlayerPrefsIdentityProvider`) | the sepolia slot | The key is chain-scoped, so it must not overwrite the mainnet identity. |
 | Community-message router (`LiveKitChatMessagesBus`, `ChatReactionsFactory`) | `message-router-dev-0` | A custom deployment's comms-message-sfu has to join under this identity for relayed messages to authenticate. |
-| Genesis City manifest (`WorldManifestProvider`) | the production manifest | A static S3 artifact, not a host under the base domain. |
+| Genesis City manifest (`WorldManifestProvider`) | *no manifest* — the fetch is skipped | It describes decentraland's own Genesis City; a custom realm reusing one of its realm names is a different world. |
 
 A deployment that mirrors *mainnet* is therefore out of scope for this flag.
+
+## Realm trust under a custom base domain
+
+Three separate gates decide whether a realm is trusted, and all three treat the custom base
+domain the way they treat `decentraland.*`:
+
+| Gate | Rule |
+| --- | --- |
+| `MainSceneLoader.IsTrustedRealmAsync` (startup `--realm`) | any host under `BaseDomain` |
+| `DeepLinkAllowlist.IsRealmWhitelisted` (deep-link dev params) | any *subdomain* of `BaseDomain`, and the world must also be flag-whitelisted |
+| `ChatEnvironmentValidator` (in-session teleport) | any host under `BaseDomain` |
+
+The startup gate needs the domain rule rather than a host list because the fallback it would
+otherwise use — the deployment's catalyst server list — enumerates catalysts, not worlds
+servers. That is why decentraland's `worlds-content-server` is hardcoded there; without the
+domain rule a custom deployment's worlds would prompt for confirmation on every launch.
+
+Widening trust this way is safe because `--base-domain` is **command-line only** and never
+accepted from a deep link, so reaching these gates already required the operator to point the
+client at that deployment. The deep-link gate stays deliberately stricter — subdomains only,
+and still flag-gated on the world name — because the realm there is attacker-supplied.
+
+`IDecentralandUrlsSource.IsSubdomainOf` / `IsHostWithinDomain` hold the `.`-boundary check
+these gates share, so the rule that rejects `interconnected.online.attacker.com` and
+`evil-interconnected.online` lives in one place.
 
 ## Not covered
 

--- a/docs/custom-base-domain.md
+++ b/docs/custom-base-domain.md
@@ -74,6 +74,71 @@ These decisions are not domain-derived, and each carries an explicit `Custom` ar
 
 A deployment that mirrors *mainnet* is therefore out of scope for this flag.
 
+## World manifest, parcel loading and roads
+
+`RealmKind` is derived from the realm's own `/about`, not from decentraland: no fixed scene
+URNs means `GenesisCity`, otherwise `World` (`RealmData.Reconfigure`). A custom deployment's
+catalyst realm therefore classifies as `GenesisCity`, and two things follow from that.
+
+**Roads.** `RoadsPresence` switches instanced road rendering purely on
+`RealmKind == GenesisCity`, and the geometry comes from `RoadSettingsAsset` — a local
+Addressable baked from decentraland's Genesis City layout by `RoadParser`. So a custom
+deployment's genesis realm gets **decentraland's road network drawn over its parcels**,
+regardless of what its own content looks like. Nothing here changes that: it is driven by
+`RealmKind` and a client-side asset, and `--base-domain` only makes it reachable. Correct for
+a deployment that mirrors Genesis City, wrong for one with its own layout — fixing it means
+gating roads on something other than `RealmKind`, or shipping per-deployment road data.
+
+**Manifest.** `Custom` resolves to no genesis manifest (above), so `WorldManifest.IsEmpty`:
+
+- `LoadPointersByIncreasingRadiusSystem` only filters by occupied parcels when the manifest
+  is non-empty, so a custom genesis realm requests pointers for every parcel in radius rather
+  than only occupied ones. An optimisation lost, not a break.
+- `LoadFixedPointersSystem` and `Landscape`/`TerrainGenerator` take their empty-manifest
+  paths, so there is no manifest-derived terrain or spawn coordinate.
+- `RealmData.SingleScene` is unaffected for genesis realms (it returns before consulting the
+  manifest), but a custom *world* without a manifest is treated as single-scene — i.e. as
+  having no gatekeeper-per-room.
+
+Skipping is still the right trade: the alternative was applying decentraland's occupied-parcel
+set to a foreign realm, which would filter *out* that deployment's real parcels and silently
+fail to load scenes wherever decentraland has none.
+
+The forward path is per-deployment manifests. `FetchNonGenesisManifestAsync` already reads
+`{assetBundleRegistry}/worlds/{realmName}/manifest` and the registry follows the base domain,
+so a custom deployment can serve manifests for its own worlds today. Only the *genesis*
+manifest has no per-deployment source, because it is a static S3 artifact rather than a
+registry endpoint.
+
+## Authentication
+
+The login handshake follows the base domain, and both wallet paths are built on it:
+
+| Endpoint | Under a custom base domain |
+| --- | --- |
+| `ApiAuth` | `auth-api.<base-domain>` |
+| `AuthSignatureWebApp` | `https://<base-domain>/auth/requests` |
+| `ApiRpc` (external-wallet dapp path) | `wss://rpc.<base-domain>` |
+| `ThirdWebAuthenticator`'s chain RPC map | **unchanged** — `rpc.decentraland.org/{network}` |
+
+So a custom deployment **must** serve the auth API and the signing web app, or login cannot
+complete. The chain RPC is deliberately inconsistent between the two paths and worth a
+decision: `DappWeb3EthereumApi` resolves `ApiRpc` and therefore needs `rpc.<base-domain>`
+over wss on the deployment, while the embedded-wallet path keeps reaching decentraland's chain
+proxy — which is arguably right (a custom deployment has no Ethereum of its own) but means the
+two disagree about where a chain lives.
+
+Two consequences of `Custom` being a non-production stack (see above): signatures are produced
+for **sepolia**, and the identity is stored in the **sepolia slot**, which zone also uses — so a
+custom session and a zone session share one cached identity.
+
+The signin deep link is unchanged: the `decentraland://` scheme is registered by the client, so
+a custom deployment's auth website must emit that same scheme with `signin` and `authRequestId`.
+
+Whoever sets `--base-domain` controls the page the user signs on. That is inherent to
+redirecting the auth host rather than something this flag adds, and it is why the value is
+operator-supplied.
+
 ## Realm trust under a custom base domain
 
 Three separate gates decide whether a realm is trusted, and all three treat the custom base


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Adds `--base-domain <domain>`, which points every backend host at a deployment served under a domain other than `decentraland.{org,zone,today}` (e.g. `interconnected.online`). It selects a new `DecentralandEnvironment.Custom`.

Adds `--eth-network <mainnet|sepolia>`, which names the chain that deployment is on — a base domain cannot imply it, and nothing else can tell the client.

**The url table no longer repeats the domain.** `RawUrl` composes each host from `BaseDomain` (`$"https://peer.{BaseDomain}/about"`), replacing 85 `decentraland.{ENV}` templates and the `Replace` pass that resolved them — `ENV`, `DOMAIN_TOKEN` and `ResolveDomain` are gone, `Url()` only caches. A custom domain is a different value in one field, not a second code path.

`DecentralandUrlsSource.ResolveBaseDomain` is the single place the domain is decided; `IDecentralandUrlsSource.BaseDomain` the single place to read it. A value that isn't a bare domain, `Custom` without one, or one paired with another environment all throw rather than being ignored.

Following the resolved domain: the pre-login feature-flag host, the catalyst server list, the smart-wearable content fallback, gateway routing, teleport validation, deep-link realm trust, the main-realm comms hostname, and both wallet paths' chain RPC. `--gatekeeper-url` still outranks all of it.

`--base-domain` is applied **from the command line only**, and outranks a deep-link `--dclenv`. That is an ordering constraint rather than a trust boundary: the domain gates which realms `DeepLinkAllowlist` trusts, so it must be registered before `InitializeDeepLinks()` evaluates a pending link's whitelisted-realm params — a domain arriving in that same link could not be, since the link's own params would need gating against a domain it has not supplied yet. The allowlist denies `base-domain` like the other infrastructure-pointing params, so a link carrying it still reaches the consent dialog; accepting it changes nothing and the client now logs a warning saying so, instead of leaving the value looking applied in the logged args.

Docs: [`docs/custom-base-domain.md`](../blob/feat/custom-base-domain/docs/custom-base-domain.md).

### ⚠️ Design-dependent: which chain the client is on

`--base-domain` says where the hosts are; it says nothing about which chain they are on, and no domain name can. So `--eth-network` names it: `mainnet` or `sepolia`, defaulting to mainnet.

**The chain used to be derived from `DecentralandEnvironment` in four independent places.** An override applied to one of them would have let them disagree — a mainnet identity spending against test credits contracts, or the reverse — so all four now take the resolved `EthereumNetwork` and none re-derives a chain of its own:

| Decision | Follows the resolved network |
|---|---|
| Ethereum net version / chain id / network id (`ChainUtils`) | mainnet or sepolia |
| Marketplace credits (`CreditsChainConfig`) | Polygon with mainnet, Amoy with sepolia |
| Donations MANA contract (`DonationsService`) | Polygon with mainnet, Amoy with sepolia |
| Stored identity slot (`PlayerPrefsIdentityProvider`) | one slot per network |

Each ethereum network carries exactly one polygon network because a deployment is on both or neither.

**Decentraland's own environments cannot be moved.** `ChainUtils.PinnedNetworkOf` fixes org and today to mainnet and zone to sepolia; `--eth-network` paired with one of them is reported in the log and dropped. Their contracts, identities and backends are all on that one chain, so there is no deployment for which the other combination is what the operator meant. A custom base domain is the only stack the client knows nothing about, and the only one the flag speaks for.

**Where the value is read, a value naming no known network ends the launch** rather than falling back to the default. Reaching mainnet by mistyping the flag is exactly what would put real contracts and the production identity slot behind an operator who asked for a test chain. Like `--base-domain`, it is captured while the deep link is still deferred, so a link cannot pick the chain — not even through the denied-params dialog.

**Consequence: a deployment mirroring *mainnet* is now in scope**, which it was not when `Custom` was hardcoded to sepolia.

### ⚠️ Needs a decision: the identity slot is shared with org

The stored identity is keyed by chain, so a custom deployment defaulting to mainnet **shares the mainnet slot with org**: a session on either can reuse an identity signed on the other, and logging in to a custom deployment logs you out of production. `--eth-network sepolia` moves it to the sepolia slot, which zone also uses.

This is not a property of the identity — it is a wallet signature over a locally generated ephemeral key, not chain-scoped at all. The slot key just happens to be named by environment, and it stood in for *which stack minted the identity*. Scoping the slot by stack (a slot of its own for `Custom`, or one per base domain) would separate them again without touching which chain the deployment runs on. Not done here; worth deciding before a custom deployment is used against a signed-in production session.

### ⚠️ Design-dependent: chat message-router identity

Community messages and chat reactions are relayed through comms-message-sfu, and the router's participant identity is the only thing that authenticates a relayed message's `ForwardedFrom` stamp. The identity is derived from the environment (`message-router-{env}-0`), and `Custom` resolves to **`dev`**, consistent with treating it as a non-production stack:

- `LiveKitChatMessagesBus` → `message-router-dev-0`
- `ChatReactionsFactory` → `message-router-dev-0`

**A custom deployment's comms-message-sfu must join rooms under `message-router-dev-0`.** If it joins under anything else, relayed community messages and reactions are attributed to the router instead of their sender rather than being accepted incorrectly — it fails closed, but it fails.

### ⚠️ Design-dependent: how a custom deployment looks in-world

Two client behaviours decide that a realm *is Genesis City*, and neither can tell that the deployment is not decentraland. **They key off different signals, which matters because only one of them can be influenced by naming.**

**The land description is chosen by realm name, against decentraland's own list.** The client recognises genesis realms by a hardcoded set of names read from the deployment's `/about` — `main`, `baldr`, `hela`, `heimdallr`, `shiva`, `artemis`, `loki`, `dg`, `hephaestus`, `unicorn`, `marvel`, `nftworld`. A custom deployment that calls its main realm **`main`** — the obvious choice — collides with that list and is routed down the Genesis City path; one that calls it anything else is routed down neither the genesis nor the world path. Today both end up with no land description, so the name does not change what a player sees — but the list is decentraland's naming rather than a general concept, and a deployment cannot opt out of matching it.

**Roads ignore the name entirely.** They switch on for any realm whose `/about` lists no fixed scenes, which is what a catalyst realm looks like. **So renaming the realm away from `main` does not turn roads off.**

What a player would notice:

- **Decentraland's roads run through the world.** Road geometry ships *inside the client*, pinned to Genesis City's coordinates. Right for a deployment mirroring Genesis City; wrong for one with its own layout — and there is no switch to disable it.
- **Loading does more work in open space.** Normally the client knows which parcels hold content and skips the rest; here it does not, so it asks about every parcel around the player. Less efficient, nothing fails.
- **Ground and spawn point fall back to client defaults**, rather than coming from the deployment describing itself.
- **A custom world is treated as a single scene**, so it gets one comms room instead of per-scene rooms.

**Why not just reuse decentraland's description of Genesis City?** Because that is worse than having none. The client would treat the deployment's real parcels as empty land anywhere decentraland has none, and silently not load the scenes there — missing content with no error. No description degrades gracefully; the wrong description does not.

**What a deployment can already fix:** it can describe its own worlds today — the client reads world manifests from the deployment's own asset registry, which follows the base domain. It cannot describe its *main* realm, because that description is a static file on decentraland's side rather than a per-deployment endpoint.

**Open decisions:** whether the genesis realm-name list should be per-deployment rather than hardcoded, and whether roads should follow the deployment rather than the client. Out of scope here; `--base-domain` only makes the existing behaviour reachable.

### ⚠️ Design-dependent: authentication

The login handshake follows the base domain, and both wallet paths are built on it:

| Endpoint | Under a custom base domain |
|---|---|
| `ApiAuth` | `auth-api.<base-domain>` |
| `AuthSignatureWebApp` | `https://<base-domain>/auth/requests` |
| `ApiRpc` (external-wallet dapp path) | `wss://rpc.<base-domain>` |
| `ChainRpc` (embedded-wallet chain map) | `https://rpc.<base-domain>/{network}` |

**A custom deployment must serve the auth API and the signing web app**, or login cannot complete — and the chain RPC too, if the embedded wallet is used.

**Both wallet paths now reach the same RPC host.** `ThirdWebAuthenticator` held a hardcoded table of `rpc.decentraland.org/{network}` for nine chains while `DappWeb3EthereumApi` resolved `ApiRpc`, so the two disagreed about where a chain lives on a custom deployment. They are one dependency configured twice — the same host over websocket and https — so the map is now built per instance from a new `DecentralandUrl.ChainRpc` and every chain follows the base domain.

The map is `Probe`d rather than resolved through `Url`: `rpc` is a single-label subdomain, so gateway routing would rewrite it to `gateway.<domain>/rpc` once that flag is on — a change of route for every chain call, on the default environments too, and a separate decision from this one.

Which chain those signatures are produced for, and which stored-identity slot the session uses, follow [the chain](#-design-dependent-which-chain-the-client-is-on) — mainnet unless `--eth-network sepolia` says otherwise. See the identity-slot decision above.

The signin deep link is unchanged: `decentraland://` is registered by the client, so a custom deployment's auth website must emit that same scheme with `signin` and `authRequestId`. And whoever sets `--base-domain` controls the page the user signs on — inherent to redirecting the auth host, and why the value is operator-supplied.

### ⚠️ Design-dependent: which realms are trusted

Three gates decide whether a realm is trusted, and all three now treat the custom base domain the way they treat `decentraland.*`:

| Gate | Rule under a custom base domain |
|---|---|
| `MainSceneLoader.IsTrustedRealmAsync` (startup `--realm`) | any host under `BaseDomain` |
| `DeepLinkAllowlist.IsRealmWhitelisted` (deep-link dev params) | any *subdomain* of `BaseDomain`, **and** the world must still be flag-whitelisted |
| `ChatEnvironmentValidator` (in-session teleport) | any host under `BaseDomain` |

The startup gate needs a domain rule rather than a host list: its fallback is the deployment's catalyst server list, which enumerates catalysts and **not** worlds servers — exactly why decentraland's `worlds-content-server` is hardcoded there. Without it, a custom deployment's world realm would raise the untrusted-realm confirmation on every launch.

**Widening trust this way costs nothing**: whoever sets the base domain has already redirected *every* backend host — profiles, content, comms, feature flags — so trusting realms under that same domain adds no capability on top. The deep-link gate stays deliberately stricter — subdomains only, still gated on the flag-whitelisted world name — because the realm *it* sees is attacker-supplied while the base domain is not.

`IDecentralandUrlsSource.IsSubdomainOf` / `IsHostWithinDomain` now hold the `.`-boundary check these gates share (replacing a private copy in `DeepLinkAllowlist`, semantics unchanged), so the rule rejecting `interconnected.online.attacker.com` and `evil-interconnected.online` lives in one tested place.

### Every other environment decision

Each carries an explicit `Custom` arm with a throwing `default`, so a new environment cannot be silently swallowed. That also removed a permissive fallthrough in teleport validation, where an unhandled environment previously accepted *every* realm.

Gateway routing is enabled for `Custom`, double-gated by the `use-gateway` flag that deployment's own feature-flags backend serves — keeping those flags correct is the deployment maintainer's responsibility.

### Related

A `--base-domain` deployment whose feature-flags backend does not publish `minimum_requirements` currently throws out of `HasMinimumSpecs()` at startup. Fixed separately in #9827 — a prerequisite for booting against such a deployment.

## Test Instructions

Default behaviour is expected to be **byte-identical** — every url on org/zone/today resolves exactly as before. Full automated testing should show no change.

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**: no behavioural change on the default environment.

**Steps (custom base domain)**: launch with `--base-domain interconnected.online` (or another catalyst deployment) and confirm the client resolves its hosts under that domain — `peer.<domain>`, `comms-gatekeeper.<domain>`, `feature-flags.<domain>` — connects, and can teleport between that deployment's own realms.

### Prerequisites
- [ ] For the custom-domain run: a reachable non-`decentraland.*` catalyst deployment
- [ ] Its feature-flags backend should publish `minimum_requirements`, or apply #9827 first

### Test Steps
1. Run the default environment and confirm nothing changed (realms, chat, marketplace links, thumbnails).
2. Relaunch with `--base-domain <domain>` and confirm every backend host resolves under it.
3. Teleport between realms of that deployment — allowed; teleporting to a `decentraland.*` realm — rejected.
4. Add `--eth-network sepolia` and confirm the marketplace-credits and donation flows use the Amoy contracts, and that login lands in a different stored-identity slot than a mainnet run.
5. Confirm the chain RPC resolves under the deployment (`rpc.<domain>`) on the embedded-wallet login path.
6. Launch with `--base-domain <domain> --realm=https://worlds-content-server.<domain>/world/<a-world>` and confirm it connects with **no** untrusted-realm confirmation.
7. Confirm `--gatekeeper-url` still overrides the gatekeeper host under `--base-domain`.

### Additional Testing Notes
- A `decentraland://…&base-domain=…` link surfaces it as a denied param. Accepting it in the consent dialog does **not** apply it (it is command-line only) — the client logs a warning to that effect. Same for `eth-network`.
- `--dclenv=custom` is rejected; only `--base-domain` selects that environment.
- `--dclenv zone --eth-network mainnet` logs `Ignoring --eth-network=mainnet: the Zone environment always runs on sepolia` and stays on sepolia. `--dclenv org --eth-network mainnet` is silent (it restates the pinned chain).
- `--base-domain <domain> --eth-network sepolai` exits at startup with the accepted values, rather than launching on the mainnet default.
- Every launch logs the resolved chain (`Chain: mainnet (environment Custom)`).
- Empty places carry no thumbnail under a custom domain (the old default was a content hash pinned to `peer.decentraland.org`); views fall back to the placeholder sprite their prefab ships.

## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

Verified locally: Unity batch compile clean (0 `error CS`); the touched fixtures **237/237** (`DecentralandUrlsSourceShould` 68, `AppArgsTest` 54, `ChainUtilsShould` 37, `CreditsPurchaseServiceShould` 28, `ChatEnvironmentValidatorShould` 19, `CreditsTradeEncoderShould` 16, `ManaUsdRateReaderShould` 9, `CreditsChainConfigShould` 3, `WorldManifestProviderShould` 3); earlier full EditMode suite 25,308/25,328 with all failures pre-existing or environmental; ReSharper InspectCode reports nothing in any file added or rewritten here.

New/extended tests: a characterization sweep that walks **every** `DecentralandUrl` under a custom domain and fails if one still resolves to a decentraland host (so a future url with a hand-written domain is caught), base-domain validation, gateway routing, teleport validation, deep-link realm trust, the skipped genesis fetch (asserting zero requests, verified red/green), network resolution and pinning, non-throwing network parsing, and both credits chains pinned by chain id and contract address — every existing credits fixture only ever built the test chain, so swapping the two arms of that switch would have shipped silently.

Known gap: `PlayerPrefsIdentityProvider.GetIdentityKey` decides an on-disk key and has no test — reaching it needs either reflection into `DCLPlayerPrefs`'s private in-memory init or widening an unrelated class.

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting.

